### PR TITLE
Druid 'Shapeshifting' Columns

### DIFF
--- a/benchmarks/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
+++ b/benchmarks/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.apache.druid.benchmark.EncodingSizeProfiler

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/BaseColumnarIntsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/BaseColumnarIntsBenchmark.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.data.ColumnarInts;
+import org.apache.druid.segment.data.CompressedVSizeColumnarIntsSupplier;
+import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.data.IndexedInts;
+import org.apache.druid.segment.data.ShapeShiftingColumnarIntsSerializer;
+import org.apache.druid.segment.data.ShapeShiftingColumnarIntsSupplier;
+import org.apache.druid.segment.data.VSizeColumnarInts;
+import org.apache.druid.segment.data.codecs.ints.BytePackedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.CompressedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.IntCodecs;
+import org.apache.druid.segment.data.codecs.ints.IntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.LemireIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.RunLengthBytePackedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.UnencodedIntFormEncoder;
+import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.util.BitSet;
+import java.util.Map;
+import java.util.Random;
+
+@State(Scope.Benchmark)
+public class BaseColumnarIntsBenchmark
+{
+  static int encodeToFile(int[] vals, int minValue, int maxValue, String encoding, FileChannel output)
+      throws IOException
+  {
+    int numBytes = VSizeColumnarInts.getNumBytesForMax(maxValue);
+
+    ByteOrder byteOrder = ByteOrder.LITTLE_ENDIAN;
+
+    IndexSpec.ShapeShiftBlockSize blockSizeEnum = encoding.endsWith("-13")
+                                                ? IndexSpec.ShapeShiftBlockSize.MIDDLE
+                                                : encoding.endsWith("-12")
+                                                  ? IndexSpec.ShapeShiftBlockSize.SMALL
+                                                  : IndexSpec.ShapeShiftBlockSize.LARGE;
+    byte blockSize = (byte) (blockSizeEnum.getLogBlockSize() - 2);
+    IndexSpec.ShapeShiftOptimizationTarget optimizationTarget =
+        IndexSpec.ShapeShiftOptimizationTarget.FASTBUTSMALLISH;
+
+
+    try (SegmentWriteOutMedium writeOutMedium = new OnHeapMemorySegmentWriteOutMedium()) {
+
+      ByteBuffer uncompressedDataBuffer =
+          CompressionStrategy.LZ4.getCompressor()
+                                 .allocateInBuffer(8 + ((1 << blockSize) * Integer.BYTES), writeOutMedium.getCloser())
+                                 .order(byteOrder);
+      ByteBuffer compressedDataBuffer =
+          CompressionStrategy.LZ4.getCompressor()
+                                 .allocateOutBuffer(
+                                     ((1 << blockSize) * Integer.BYTES) + 1024,
+                                     writeOutMedium.getCloser()
+                                 );
+      switch (encoding) {
+        case "vsize-byte":
+          final VSizeColumnarInts vsize = VSizeColumnarInts.fromArray(vals);
+          vsize.writeTo(output, null);
+          return (int) vsize.getSerializedSize();
+        case "compressed-vsize-byte":
+          final CompressedVSizeColumnarIntsSupplier compressed = CompressedVSizeColumnarIntsSupplier.fromList(
+              IntArrayList.wrap(vals),
+              Math.max(maxValue - 1, 1),
+              CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForBytes(numBytes),
+              ByteOrder.nativeOrder(),
+              CompressionStrategy.LZ4,
+              Closer.create()
+          );
+          compressed.writeTo(output, null);
+          return (int) compressed.getSerializedSize();
+        case "compressed-vsize-big-endian":
+          final CompressedVSizeColumnarIntsSupplier compressedBigEndian = CompressedVSizeColumnarIntsSupplier.fromList(
+              IntArrayList.wrap(vals),
+              Math.max(maxValue - 1, 1),
+              CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForBytes(numBytes),
+              ByteOrder.BIG_ENDIAN,
+              CompressionStrategy.LZ4,
+              Closer.create()
+          );
+          compressedBigEndian.writeTo(output, null);
+          return (int) compressedBigEndian.getSerializedSize();
+        case "shapeshift-unencoded":
+          final IntFormEncoder[] ssucodecs = new IntFormEncoder[]{
+              new UnencodedIntFormEncoder(
+                  blockSize,
+                  byteOrder
+              )
+          };
+          final ShapeShiftingColumnarIntsSerializer ssunencodedSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  ssucodecs,
+                  optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          ssunencodedSerializer.open();
+          for (int val : vals) {
+            ssunencodedSerializer.addValue(val);
+          }
+          ssunencodedSerializer.writeTo(output, null);
+          return (int) ssunencodedSerializer.getSerializedSize();
+        case "shapeshift-bytepack":
+          final IntFormEncoder[] ssbytepackcodecs = new IntFormEncoder[]{
+              new BytePackedIntFormEncoder(
+                  blockSize,
+                  byteOrder
+              )
+          };
+          final ShapeShiftingColumnarIntsSerializer ssbytepackSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  ssbytepackcodecs,
+                  optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          ssbytepackSerializer.open();
+          for (int val : vals) {
+            ssbytepackSerializer.addValue(val);
+          }
+          ssbytepackSerializer.writeTo(output, null);
+          return (int) ssbytepackSerializer.getSerializedSize();
+        case "shapeshift-rle-bytepack":
+          final IntFormEncoder[] ssrbytepackcodecs = new IntFormEncoder[]{
+              new RunLengthBytePackedIntFormEncoder(
+                  blockSize,
+                  byteOrder
+              )
+          };
+          final ShapeShiftingColumnarIntsSerializer ssrbytepackSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  ssrbytepackcodecs,
+                  optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          ssrbytepackSerializer.open();
+          for (int val : vals) {
+            ssrbytepackSerializer.addValue(val);
+          }
+          ssrbytepackSerializer.writeTo(output, null);
+          return (int) ssrbytepackSerializer.getSerializedSize();
+        case "shapeshift-lz4-bytepack":
+          final IntFormEncoder[] sslzcodecs = new IntFormEncoder[]{
+              new CompressedIntFormEncoder(
+                  blockSize,
+                  byteOrder,
+                  CompressionStrategy.LZ4,
+                  new BytePackedIntFormEncoder(blockSize, byteOrder),
+                  uncompressedDataBuffer,
+                  compressedDataBuffer
+                  )
+          };
+          final ShapeShiftingColumnarIntsSerializer sslzSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  sslzcodecs,
+                  optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          sslzSerializer.open();
+          for (int val : vals) {
+            sslzSerializer.addValue(val);
+          }
+          sslzSerializer.writeTo(output, null);
+          return (int) sslzSerializer.getSerializedSize();
+        case "shapeshift-lz4-rle-bytepack":
+          final IntFormEncoder[] sslzrlecodecs = new IntFormEncoder[]{
+              new CompressedIntFormEncoder(
+                  blockSize,
+                  byteOrder,
+                  CompressionStrategy.LZ4,
+                  new RunLengthBytePackedIntFormEncoder(blockSize, byteOrder),
+                  uncompressedDataBuffer,
+                  compressedDataBuffer
+              )
+          };
+          final ShapeShiftingColumnarIntsSerializer sslzrleSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  sslzrlecodecs,
+                  optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          sslzrleSerializer.open();
+          for (int val : vals) {
+            sslzrleSerializer.addValue(val);
+          }
+          sslzrleSerializer.writeTo(output, null);
+          return (int) sslzrleSerializer.getSerializedSize();
+        case "shapeshift-fastpfor":
+          final IntFormEncoder[] dfastcodecs = new IntFormEncoder[]{
+              new LemireIntFormEncoder(
+                  blockSize,
+                  IntCodecs.FASTPFOR,
+                  "fastpfor",
+                  byteOrder
+              )
+          };
+          final ShapeShiftingColumnarIntsSerializer ssfastPforSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  dfastcodecs,
+                  optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          ssfastPforSerializer.open();
+          for (int val : vals) {
+            ssfastPforSerializer.addValue(val);
+          }
+          ssfastPforSerializer.writeTo(output, null);
+          return (int) ssfastPforSerializer.getSerializedSize();
+        case "shapeshift":
+        case "shapeshift-13":
+        case "shapeshift-12":
+        case "shapeshift-lazy":
+        case "shapeshift-eager":
+        case "shapeshift-faster":
+        case "shapeshift-faster-13":
+        case "shapeshift-faster-12":
+        case "shapeshift-smaller":
+        case "shapeshift-smaller-13":
+        case "shapeshift-smaller-12":
+          final IntFormEncoder[] sscodecs = ShapeShiftingColumnarIntsSerializer.getDefaultIntFormEncoders(
+              blockSizeEnum,
+              CompressionStrategy.LZ4,
+              writeOutMedium.getCloser(),
+              byteOrder
+          );
+          final ShapeShiftingColumnarIntsSerializer ssSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  sscodecs,
+                  encoding.contains("shapeshift-smaller")
+                  ? IndexSpec.ShapeShiftOptimizationTarget.SMALLER
+                  : encoding.contains("shapeshift-faster")
+                    ? IndexSpec.ShapeShiftOptimizationTarget.FASTER
+                    : optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          ssSerializer.open();
+          for (int val : vals) {
+            ssSerializer.addValue(val);
+          }
+          ssSerializer.writeTo(output, null);
+          return (int) ssSerializer.getSerializedSize();
+        case "shapeshift-lz4-only":
+          final IntFormEncoder[] sslzNewcodecs = new IntFormEncoder[]{
+              new CompressedIntFormEncoder(
+                  blockSize,
+                  byteOrder,
+                  CompressionStrategy.LZ4,
+                  new RunLengthBytePackedIntFormEncoder(blockSize, byteOrder),
+                  uncompressedDataBuffer,
+                  compressedDataBuffer
+              ),
+              new CompressedIntFormEncoder(
+                  blockSize,
+                  byteOrder,
+                  CompressionStrategy.LZ4,
+                  new BytePackedIntFormEncoder(blockSize, byteOrder),
+                  uncompressedDataBuffer,
+                  compressedDataBuffer
+              ),
+              };
+          final ShapeShiftingColumnarIntsSerializer sslzNewSerializer =
+              new ShapeShiftingColumnarIntsSerializer(
+                  writeOutMedium,
+                  sslzNewcodecs,
+                  optimizationTarget,
+                  blockSizeEnum,
+                  byteOrder
+              );
+          sslzNewSerializer.open();
+          for (int val : vals) {
+            sslzNewSerializer.addValue(val);
+          }
+          sslzNewSerializer.writeTo(output, null);
+          return (int) sslzNewSerializer.getSerializedSize();
+      }
+      throw new IllegalArgumentException("unknown encoding");
+    }
+  }
+
+  static ColumnarInts createIndexedInts(String encoding, ByteBuffer buffer, int size)
+  {
+    ByteOrder byteOrder = ByteOrder.LITTLE_ENDIAN;
+    switch (encoding) {
+      case "vsize-byte":
+        return VSizeColumnarInts.readFromByteBuffer(buffer);
+      case "compressed-vsize-byte":
+        return CompressedVSizeColumnarIntsSupplier.fromByteBuffer(buffer, ByteOrder.nativeOrder()).get();
+      case "compressed-vsize-big-endian":
+        return CompressedVSizeColumnarIntsSupplier.fromByteBuffer(buffer, ByteOrder.BIG_ENDIAN).get();
+      case "shapeshift":
+      case "shapeshift-unencoded":
+      case "shapeshift-fastpfor":
+      case "shapeshift-bytepack":
+      case "shapeshift-lz4-bytepack":
+      case "shapeshift-rle-bytepack":
+      case "shapeshift-lz4-rle-bytepack":
+      case "shapeshift-lz4-only":
+      case "shapeshift-smaller":
+      case "shapeshift-faster":
+      case "shapeshift-13":
+      case "shapeshift-smaller-13":
+      case "shapeshift-faster-13":
+      case "shapeshift-12":
+      case "shapeshift-smaller-12":
+      case "shapeshift-faster-12":
+        return ShapeShiftingColumnarIntsSupplier.fromByteBuffer(buffer, byteOrder).get();
+      case "shapeshift-lazy":
+        return ShapeShiftingColumnarIntsSupplier.fromByteBuffer(
+            buffer,
+            byteOrder,
+            ShapeShiftingColumnarIntsSupplier.ShapeShiftingColumnarIntsDecodeOptimization.MIXED
+        ).get();
+      case "shapeshift-eager":
+        return ShapeShiftingColumnarIntsSupplier.fromByteBuffer(
+            buffer,
+            byteOrder,
+            ShapeShiftingColumnarIntsSupplier.ShapeShiftingColumnarIntsDecodeOptimization.BLOCK
+        ).get();
+    }
+    throw new IllegalArgumentException("unknown encoding");
+  }
+
+  // for debugging: validate that all encoders read the same values
+  static void checkSanity(Map<String, ColumnarInts> encoders, ImmutableList<String> encodings, int rows)
+      throws Exception
+  {
+    for (int i = 0; i < rows; i++) {
+      checkRowSanity(encoders, encodings, i);
+    }
+  }
+
+  static void checkRowSanity(Map<String, ColumnarInts> encoders, ImmutableList<String> encodings, int row)
+      throws Exception
+  {
+    if (encodings.size() > 1) {
+      for (int i = 0; i < encodings.size() - 1; i++) {
+        String currentKey = encodings.get(i);
+        String nextKey = encodings.get(i + 1);
+        IndexedInts current = encoders.get(currentKey);
+        IndexedInts next = encoders.get(nextKey);
+        int vCurrent = current.get(row);
+        int vNext = next.get(row);
+        if (vCurrent != vNext) {
+          throw new Exception("values do not match at row "
+                              + row
+                              + " - "
+                              + currentKey
+                              + ":"
+                              + vCurrent
+                              + " "
+                              + nextKey
+                              + ":"
+                              + vNext);
+        }
+      }
+    }
+  }
+
+  //@Param({"shapeshift-bytepack", "shapeshift-rle-bytepack", "shapeshift-fastpfor", "shapeshift-lz4-bytepack", "shapeshift-lz4-rle-bytepack", "compressed-vsize-byte"})
+  @Param({"compressed-vsize-byte", "shapeshift"})
+  String encoding;
+
+  Random rand = new Random(0);
+
+  int[] vals;
+
+  int minValue;
+  int maxValue;
+  BitSet filter;
+
+  void setupFilters(int rows, double filteredRowCountPercetnage)
+  {
+    // todo: save and read from file for stable filter set..
+    // todo: also maybe filter set distributions to simulate different select patterns?
+    // (because benchmarks don't take long enough already..)
+    filter = null;
+    final int filteredRowCount = (int) Math.floor(rows * filteredRowCountPercetnage);
+
+    if (filteredRowCount < rows) {
+      // setup bitset filter
+      filter = new BitSet();
+      for (int i = 0; i < filteredRowCount; i++) {
+        int rowToAccess = rand.nextInt(rows);
+        // Skip already selected rows if any
+        while (filter.get(rowToAccess)) {
+          rowToAccess = (rowToAccess + 1) % rows;
+        }
+        filter.set(rowToAccess);
+      }
+    }
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/BaseColumnarIntsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/BaseColumnarIntsFromGeneratorBenchmark.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.google.common.collect.ImmutableList;
+import io.netty.util.SuppressForbidden;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.generator.ColumnValueGenerator;
+import org.apache.druid.segment.generator.GeneratorColumnSchema;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+@State(Scope.Benchmark)
+public class BaseColumnarIntsFromGeneratorBenchmark extends BaseColumnarIntsBenchmark
+{
+  static ColumnValueGenerator makeGenerator(
+      String distribution,
+      int bits,
+      int bound,
+      int cardinality,
+      int rows
+  )
+  {
+    switch (distribution) {
+      case "enumerated":
+        ImmutableList<Object> enumerated;
+        ImmutableList<Double> probability;
+
+        switch (bits) {
+          case 1:
+            enumerated = ImmutableList.of(0, 1);
+            probability = ImmutableList.of(0.95, 0.001);
+            break;
+          case 2:
+            enumerated = ImmutableList.of(0, 1, 2, 3);
+            probability = ImmutableList.of(0.95, 0.001, 0.0189, 0.03);
+            break;
+          default:
+            enumerated = ImmutableList.of(0, 1, bound / 4, bound / 2, 3 * bound / 4, bound);
+            probability = ImmutableList.of(0.90, 0.001, 0.0189, 0.03, 0.0001, 0.025);
+            break;
+        }
+        GeneratorColumnSchema enumeratedSchema = GeneratorColumnSchema.makeEnumerated(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            enumerated,
+            probability
+        );
+        return enumeratedSchema.makeGenerator(1);
+      case "zipfLow":
+        GeneratorColumnSchema zipfLowSchema = GeneratorColumnSchema.makeZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            Math.max(bound - cardinality, 0),
+            bound,
+            1d
+        );
+        return zipfLowSchema.makeGenerator(1);
+      case "lazyZipfLow":
+        GeneratorColumnSchema lzipfLowSchema = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            Math.max(bound - cardinality, 0),
+            bound,
+            1d
+        );
+        return lzipfLowSchema.makeGenerator(1);
+      case "zipfHi":
+        GeneratorColumnSchema zipfHighSchema = GeneratorColumnSchema.makeZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return zipfHighSchema.makeGenerator(1);
+      case "lazyZipfHi":
+        GeneratorColumnSchema lzipfHighSchema = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return lzipfHighSchema.makeGenerator(1);
+      case "nullp50zipfLow":
+        GeneratorColumnSchema nullp50ZipfLow = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.5,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return nullp50ZipfLow.makeGenerator(1);
+      case "nullp75zipfLow":
+        GeneratorColumnSchema nullp75ZipfLow = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.75,
+            Math.max(bound - cardinality, 0),
+            bound,
+            1d
+        );
+        return nullp75ZipfLow.makeGenerator(1);
+      case "nullp90zipfLow":
+        GeneratorColumnSchema nullp90ZipfLow = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.9,
+            Math.max(bound - cardinality, 0),
+            bound,
+            1d
+        );
+        return nullp90ZipfLow.makeGenerator(1);
+      case "nullp95zipfLow":
+        GeneratorColumnSchema nullp95ZipfLow = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.95,
+            Math.max(bound - cardinality, 0),
+            bound,
+            1d
+        );
+        return nullp95ZipfLow.makeGenerator(1);
+      case "nullp99zipfLow":
+        GeneratorColumnSchema nullp99ZipfLow = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.99,
+            Math.max(bound - cardinality, 0),
+            bound,
+            1d
+        );
+        return nullp99ZipfLow.makeGenerator(1);
+      case "nullp50zipfHi":
+        GeneratorColumnSchema nullp50ZipfHi = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.5,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return nullp50ZipfHi.makeGenerator(1);
+      case "nullp75zipfHi":
+        GeneratorColumnSchema nullp75ZipfHi = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.75,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return nullp75ZipfHi.makeGenerator(1);
+      case "nullp90zipfHi":
+        GeneratorColumnSchema nullp90ZipfHi = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.9,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return nullp90ZipfHi.makeGenerator(1);
+      case "nullp95zipfHi":
+        GeneratorColumnSchema nullp95ZipfHi = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.95,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return nullp95ZipfHi.makeGenerator(1);
+      case "nullp99zipfHi":
+        GeneratorColumnSchema nullp99ZipfHi = GeneratorColumnSchema.makeLazyZipf(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0.99,
+            Math.max(bound - cardinality, 0),
+            bound,
+            3d
+        );
+        return nullp99ZipfHi.makeGenerator(1);
+      case "sequential":
+        GeneratorColumnSchema sequentialSchema = GeneratorColumnSchema.makeSequential(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            Math.max(bound - rows, 0),
+            bound
+        );
+        return sequentialSchema.makeGenerator(1);
+      case "sequential-skip":
+        GeneratorColumnSchema sequentialSkipSchema = GeneratorColumnSchema.makeSequential(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            0,
+            bound
+        );
+        return sequentialSkipSchema.makeGenerator(1);
+      case "uniform":
+        GeneratorColumnSchema uniformSchema = GeneratorColumnSchema.makeDiscreteUniform(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            Math.max(bound - cardinality, 0),
+            bound
+        );
+        return uniformSchema.makeGenerator(1);
+      case "lazyUniform":
+        GeneratorColumnSchema lazyUniformSchema = GeneratorColumnSchema.makeLazyDiscreteUniform(
+            "",
+            ValueType.INT,
+            true,
+            1,
+            0d,
+            Math.max(bound - cardinality, 0),
+            bound
+        );
+        return lazyUniformSchema.makeGenerator(1);
+    }
+    throw new IllegalArgumentException("unknown distribution");
+  }
+
+  //@Param({"3", "9", "18", "27"})
+  @Param({"27"})
+  int bits;
+
+  @Param({"3000000"})
+  int rows;
+
+  //@Param({"lazyZipfLow", "lazyZipfHi", "nullp50zipfLow", "nullp75zipfLow", "nullp90zipfLow", "nullp95zipfLow", "nullp99zipfLow", "lazyUniform", "random"})
+  @Param({"nullp95zipfHi"})
+  String distribution;
+
+  @Param("150000000")
+  int cardinality;
+
+  int bound;
+
+  @SuppressForbidden(reason = "System#out")
+  void initializeValues() throws IOException
+  {
+    final String filename = getGeneratorValueFilename(distribution, cardinality, bits, rows);
+    File dir = getTmpDir();
+    File dataFile = new File(dir, filename);
+
+    vals = new int[rows];
+    bound = 1 << bits;
+
+    if (dataFile.exists()) {
+      System.out.println("Data files already exist, re-using\n");
+      try (BufferedReader br = Files.newBufferedReader(dataFile.toPath(), StandardCharsets.UTF_8)) {
+        int lineNum = 0;
+        String line;
+        while ((line = br.readLine()) != null) {
+          vals[lineNum] = Integer.parseInt(line);
+          if (vals[lineNum] < minValue) {
+            minValue = vals[lineNum];
+          }
+          if (vals[lineNum] > maxValue) {
+            maxValue = vals[lineNum];
+          }
+          lineNum++;
+        }
+      }
+    } else {
+      try (Writer writer = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8)) {
+        int atLeastOneMustBeAsLargeAsBound = rand.nextInt(rows);
+        if ("random".equals(distribution)) {
+          for (int i = 0; i < vals.length; ++i) {
+            vals[i] = rand.nextInt(bound);
+            if (i == atLeastOneMustBeAsLargeAsBound) {
+              vals[i] = bound;
+            }
+            if (vals[i] < minValue) {
+              minValue = vals[i];
+            }
+            if (vals[i] > maxValue) {
+              maxValue = vals[i];
+            }
+            writer.write(vals[i] + "\n");
+          }
+        } else {
+          ColumnValueGenerator valueGenerator = makeGenerator(distribution, bits, bound, cardinality, rows);
+
+          for (int i = 0; i < vals.length; ++i) {
+            int value;
+            Object rowValue = valueGenerator.generateRowValue();
+            value = rowValue != null ? (int) rowValue : 0;
+            if (i == atLeastOneMustBeAsLargeAsBound) {
+              value = bound;
+            } else if ("sequential-skip".equals(distribution) && bits > 1) {
+              int skip = Math.max(bound / cardinality, 1);
+              for (int burn = 0; burn < skip; burn++) {
+                value = (int) valueGenerator.generateRowValue();
+              }
+            }
+            vals[i] = value;
+            if (vals[i] < minValue) {
+              minValue = vals[i];
+            }
+            if (vals[i] > maxValue) {
+              maxValue = vals[i];
+            }
+            writer.write(vals[i] + "\n");
+          }
+        }
+      }
+    }
+  }
+
+  static String getGeneratorValueFilename(String distribution, int cardinality, int bits, int rows)
+  {
+    return "values-" + distribution + "-" + cardinality + "-" + bits + "-" + rows + ".bin";
+  }
+
+  static String getGeneratorEncodedFilename(String encoding, int bits, String distribution, int rows, int cardinality)
+  {
+    return encoding + "-" + bits + "-" + distribution + "-" + rows + "-" + cardinality + ".bin";
+  }
+
+  static File getTmpDir()
+  {
+    final String dirPath = "tmp/encoding/ints/";
+    File dir = new File(dirPath);
+    dir.mkdirs();
+    return dir;
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/BaseColumnarIntsFromSegmentsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/BaseColumnarIntsFromSegmentsBenchmark.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterables;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.IndexIO;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.DictionaryEncodedColumn;
+import org.apache.druid.segment.column.ValueType;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+@State(Scope.Benchmark)
+public class BaseColumnarIntsFromSegmentsBenchmark extends BaseColumnarIntsBenchmark
+{
+  //CHECKSTYLE.OFF: Regexp
+  // wiki columns
+  @Param({
+      "channel",
+      "cityName",
+      "comment",
+      "commentLength",
+      "countryIsoCode",
+      "countryName",
+      "deltaBucket",
+      "diffUrl",
+      "flags",
+      "isAnonymous",
+      "isMinor",
+      "isNew",
+      "isRobot",
+      "isUnpatrolled",
+      "metroCode",
+      "namespace",
+      "page",
+      "regionIsoCode",
+      "regionName",
+      "user"
+  })
+
+  // twitter columns
+//  @Param({
+//    "geo",
+//    "lang",
+//    "retweet",
+//    "screen_name",
+//    "source",
+//    "text",
+//    "utc_offset",
+//    "verified"
+//  })
+
+  // clarity columns
+//  @Param({
+//    "bufferpoolName",
+//    "clarityTopic",
+//    "clarityUser",
+//    "context",
+//    "dataSource",
+//    "description",
+//    "dimension",
+//    "duration",
+//    "feed",
+//    "gcGen",
+//    "gcGenSpaceName",
+//    "gcName",
+//    "hasFilters",
+//    "host",
+//    "id",
+//    "identity",
+//    "implyCluster",
+//    "implyDruidVersion",
+//    "implyNodeType",
+//    "implyVersion",
+//    "memKind",
+//    "memcached txt",
+//    "metric",
+//    "numComplexMetrics",
+//    "numDimensions",
+//    "numMetrics",
+//    "poolKind",
+//    "poolName",
+//    "priority",
+//    "remoteAddr",
+//    "remoteAddress",
+//    "server",
+//    "service",
+//    "severity",
+//    "success",
+//    "taskId",
+//    "taskStatus",
+//    "taskType",
+//    "threshold",
+//    "tier",
+//    "type",
+//    "version"
+//  })
+
+  // lineitem columns
+//  @Param({
+//      "l_comment",
+//      "l_commitdate",
+//      "l_linenumber",
+//      "l_linestatus",
+//      "l_orderkey",
+//      "l_partkey",
+//      "l_receiptdate",
+//      "l_returnflag",
+//      "l_shipinstruct",
+//      "l_shipmode",
+//      "l_suppkey"
+//  })
+  String columnName;
+
+//  @Param({"533652"})        // wiki
+  @Param({"3537476"})        // wiki-2
+//  @Param({"3259585"})       // twitter
+//  @Param({"3783642"})       // clarity
+//  @Param({"6001215"})         // tpch-lineitem-1g
+  int rows;
+
+
+//  @Param({"tmp/segments/wiki-1/"})
+  @Param({"tmp/segments/wiki-2/"})
+//  @Param({"tmp/segments/twitter-1/"})
+//  @Param({"tmp/segments/clarity-1/"})
+//  @Param({"tmp/segments/tpch-lineitem-1/"})
+  String segmentPath;
+
+//  @Param({"wikiticker"})
+  @Param({"wikiticker-2"})
+//  @Param({"twitter"})
+//  @Param({"clarity"})
+//  @Param({"tpch-lineitem"})
+  String segmentName;
+
+
+  private static IndexIO INDEX_IO;
+  public static ObjectMapper JSON_MAPPER;
+
+  //CHECKSTYLE.ON: Regexp
+
+  /**
+   * read column intermediary values into integer array
+   *
+   * @throws IOException
+   */
+  void initializeValues() throws IOException
+  {
+    initializeSegmentValueIntermediaryFile();
+    File dir = getTmpDir();
+    File dataFile = new File(dir, getColumnDataFileName(segmentName, columnName));
+
+    ArrayList<Integer> values = new ArrayList<>();
+    try (BufferedReader br = Files.newBufferedReader(dataFile.toPath(), StandardCharsets.UTF_8)) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        int value = Integer.parseInt(line);
+        if (value < minValue) {
+          minValue = value;
+        }
+        if (value > maxValue) {
+          maxValue = value;
+        }
+        values.add(value);
+        rows++;
+      }
+    }
+
+    vals = values.stream().mapToInt(i -> i).toArray();
+  }
+
+  String getColumnDataFileName(String segmentName, String columnName)
+  {
+    return StringUtils.format("%s-ints-%s.txt", segmentName, columnName);
+  }
+
+  String getColumnEncodedFileName(String encoding, String segmentName, String columnName)
+  {
+    return StringUtils.format("%s-%s-ints-%s.bin", encoding, segmentName, columnName);
+  }
+
+  File getTmpDir()
+  {
+    final String dirPath = StringUtils.format("tmp/encoding/%s", segmentName);
+    File dir = new File(dirPath);
+    dir.mkdirs();
+    return dir;
+  }
+
+  /**
+   * writes column values to text file, 1 per line
+   *
+   * @throws IOException
+   */
+  void initializeSegmentValueIntermediaryFile() throws IOException
+  {
+    File dir = getTmpDir();
+    File dataFile = new File(dir, getColumnDataFileName(segmentName, columnName));
+
+    if (!dataFile.exists()) {
+      JSON_MAPPER = new DefaultObjectMapper();
+      INDEX_IO = new IndexIO(
+          JSON_MAPPER,
+          () -> 0
+      );
+      try (final QueryableIndex index = INDEX_IO.loadIndex(new File(segmentPath))) {
+        final Set<String> columnNames = new HashSet<>();
+        columnNames.add(ColumnHolder.TIME_COLUMN_NAME);
+        Iterables.addAll(columnNames, index.getColumnNames());
+        final ColumnHolder column = index.getColumnHolder(columnName);
+        final ColumnCapabilities capabilities = column.getCapabilities();
+        final ValueType columnType = capabilities.getType();
+        try (Writer writer = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8)) {
+          if (columnType != ValueType.STRING) {
+            throw new RuntimeException("Invalid column type, expected 'String'");
+          }
+          DictionaryEncodedColumn<String> theColumn = (DictionaryEncodedColumn<String>) column.getColumn();
+
+          if (theColumn.hasMultipleValues()) {
+            throw new RuntimeException("Multi-int benchmarks are not current supported");
+          }
+
+          for (int i = 0; i < theColumn.length(); i++) {
+            int value = theColumn.getSingleValueRow(i);
+            writer.write(value + "\n");
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsEncodeDataFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsEncodeDataFromGeneratorBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 1)
+public class ColumnarIntsEncodeDataFromGeneratorBenchmark extends BaseColumnarIntsFromGeneratorBenchmark
+{
+  @Setup
+  public void setup() throws Exception
+  {
+    initializeValues();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void encodeColumn(Blackhole blackhole) throws IOException
+  {
+    File dir = getTmpDir();
+    File columnDataFile = new File(dir, getGeneratorEncodedFilename(encoding, bits, distribution, rows, cardinality));
+    columnDataFile.delete();
+    FileChannel output =
+        FileChannel.open(columnDataFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+    int size = encodeToFile(vals, minValue, maxValue, encoding, output);
+    EncodingSizeProfiler.encodedSize = size;
+    blackhole.consume(size);
+    output.close();
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(ColumnarIntsEncodeDataFromGeneratorBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-ints-encode-speed.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsEncodeDataFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsEncodeDataFromSegmentBenchmark.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 3)
+public class ColumnarIntsEncodeDataFromSegmentBenchmark extends BaseColumnarIntsFromSegmentsBenchmark
+{
+  @Setup
+  public void setup() throws Exception
+  {
+    initializeValues();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void encodeColumn(Blackhole blackhole) throws IOException
+  {
+    File dir = getTmpDir();
+    File columnDataFile = new File(dir, getColumnEncodedFileName(encoding, segmentName, columnName));
+    columnDataFile.delete();
+    FileChannel output =
+        FileChannel.open(columnDataFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+    int size = BaseColumnarIntsBenchmark.encodeToFile(vals, minValue, maxValue, encoding, output);
+    EncodingSizeProfiler.encodedSize = size;
+    blackhole.consume(size);
+    output.close();
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(ColumnarIntsEncodeDataFromSegmentBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-ints-encode-speed-segments.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}
+

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsSelectRowsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsSelectRowsFromGeneratorBenchmark.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.google.common.io.Files;
+import org.apache.druid.segment.data.ColumnarInts;
+import org.apache.druid.segment.data.IndexedInts;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+public class ColumnarIntsSelectRowsFromGeneratorBenchmark extends BaseColumnarIntsFromGeneratorBenchmark
+{
+  private Map<String, ColumnarInts> encoders;
+  private Map<String, Integer> encodedSize;
+
+  // Number of rows to read, the test will read random rows
+  @Param({"0.01", "0.1", "0.33", "0.66", "0.95", "1.0"})
+  private double filteredRowCountPercentage;
+
+  @Setup
+  public void setup() throws Exception
+  {
+    encoders = new HashMap<>();
+    encodedSize = new HashMap<>();
+
+    setupFilters(rows, filteredRowCountPercentage);
+    setupFromFile(encoding);
+
+    // uncomment me to load multiple encoded files for sanity check
+    //CHECKSTYLE.OFF: Regexp
+//    ImmutableList<String> all = ImmutableList.of("compressed-vsize-byte", "shapeshift-fastpfor");
+//    for (String _enc : all) {
+//      if (!_enc.equalsIgnoreCase(encoding)) {
+//        setupFromFile(_enc);
+//      }
+//    }
+//
+//    checkSanity(encoders, all, rows);
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  @TearDown
+  public void teardown() throws Exception
+  {
+    for (ColumnarInts ints : encoders.values()) {
+      ints.close();
+    }
+  }
+
+  private void setupFromFile(String encoding) throws IOException
+  {
+    File dir = getTmpDir();
+    File compFile = new File(dir, getGeneratorEncodedFilename(encoding, bits, distribution, rows, cardinality));
+    ByteBuffer buffer = Files.map(compFile);
+
+    int size = (int) compFile.length();
+    encodedSize.put(encoding, size);
+    ColumnarInts data = createIndexedInts(encoding, buffer, size);
+    encoders.put(encoding, data);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void selectRows(Blackhole blackhole)
+  {
+    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+    IndexedInts encoder = encoders.get(encoding);
+    if (filter == null) {
+      for (int i = 0; i < rows; i++) {
+        blackhole.consume(encoder.get(i));
+      }
+    } else {
+      for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
+        blackhole.consume(encoder.get(i));
+      }
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(ColumnarIntsSelectRowsFromGeneratorBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-ints-select-speed.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsSelectRowsFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ColumnarIntsSelectRowsFromSegmentBenchmark.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import org.apache.druid.segment.data.ColumnarInts;
+import org.apache.druid.segment.data.IndexedInts;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+public class ColumnarIntsSelectRowsFromSegmentBenchmark extends BaseColumnarIntsFromSegmentsBenchmark
+{
+  private Map<String, ColumnarInts> encoders;
+  private Map<String, Integer> encodedSize;
+
+  // Number of rows to read, the test will read random rows
+  @Param({"0.01", "0.1", "0.33", "0.66", "0.95", "1.0"})
+  private double filteredRowCountPercentage;
+
+  Random rand = new Random(0);
+
+  @Setup
+  public void setup() throws Exception
+  {
+    encoders = new HashMap<>();
+    encodedSize = new HashMap<>();
+    setupFilters(rows, filteredRowCountPercentage);
+
+    setupFromFile(encoding);
+
+
+    // uncomment me to load some encoding files to cross reference values for sanity check
+    //CHECKSTYLE.OFF: Regexp
+    ImmutableList<String> all = ImmutableList.of("compressed-vsize-byte", "shapeshift");
+    for (String _enc : all) {
+      if (!_enc.equals(encoding)) {
+        setupFromFile(_enc);
+      }
+    }
+    checkSanity(encoders, all, rows);
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  @TearDown
+  public void teardown() throws Exception
+  {
+    for (ColumnarInts ints : encoders.values()) {
+      ints.close();
+    }
+  }
+
+  private void setupFromFile(String encoding) throws IOException
+  {
+    File dir = getTmpDir();
+    File compFile = new File(dir, getColumnEncodedFileName(encoding, segmentName, columnName));
+    ByteBuffer buffer = Files.map(compFile);
+
+    int size = (int) compFile.length();
+    encodedSize.put(encoding, size);
+    ColumnarInts data = BaseColumnarIntsBenchmark.createIndexedInts(encoding, buffer, size);
+    encoders.put(encoding, data);
+  }
+
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void selectRows(Blackhole blackhole)
+  {
+    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+    IndexedInts encoder = encoders.get(encoding);
+    if (filter == null) {
+      for (int i = 0; i < rows; i++) {
+        blackhole.consume(encoder.get(i));
+      }
+    } else {
+      for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
+        blackhole.consume(encoder.get(i));
+      }
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(ColumnarIntsSelectRowsFromSegmentBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-ints-select-speed-segments.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/EncodingSizeProfiler.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/EncodingSizeProfiler.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ScalarResult;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class EncodingSizeProfiler implements InternalProfiler
+{
+  public static int encodedSize;
+
+  @Override
+  public void beforeIteration(
+      BenchmarkParams benchmarkParams,
+      IterationParams iterationParams
+  )
+  {
+  }
+
+  @Override
+  public Collection<? extends Result> afterIteration(
+      BenchmarkParams benchmarkParams,
+      IterationParams iterationParams,
+      IterationResult result
+  )
+  {
+    return Collections.singletonList(
+        new ScalarResult("encoded size", (double) encodedSize, "bytes", AggregationPolicy.MAX)
+    );
+  }
+
+  @Override
+  public String getDescription()
+  {
+    return "super janky encoding size result collector";
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
@@ -124,7 +124,7 @@ public class GroupByBenchmark
   @Param({"4"})
   private int numSegments;
 
-  @Param({"2", "4"})
+  @Param({"2"})
   private int numProcessingThreads;
 
   @Param({"-1"})
@@ -133,10 +133,10 @@ public class GroupByBenchmark
   @Param({"100000"})
   private int rowsPerSegment;
 
-  @Param({"basic.A", "basic.nested"})
+  @Param({"basic.nested"})
   private String schemaAndQuery;
 
-  @Param({"v1", "v2"})
+  @Param({"v2"})
   private String defaultStrategy;
 
   @Param({"all", "day"})

--- a/pom.xml
+++ b/pom.xml
@@ -921,6 +921,12 @@
                 <version>0.8.11</version>
             </dependency>
             <dependency>
+                <groupId>me.lemire.integercompression</groupId>
+                <artifactId>JavaFastPFOR</artifactId>
+                <version>0.1.11</version>
+                <!--<version>0.1.12-SNAPSHOT</version>-->
+            </dependency>
+            <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
                 <version>7.1</version>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -76,6 +76,10 @@
             <artifactId>RoaringBitmap</artifactId>
         </dependency>
         <dependency>
+            <groupId>me.lemire.integercompression</groupId>
+            <artifactId>JavaFastPFOR</artifactId>
+        </dependency>
+        <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
         </dependency>

--- a/processing/src/main/java/org/apache/druid/segment/IndexSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexSpec.java
@@ -21,9 +21,11 @@ package org.apache.druid.segment;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.data.BitmapSerde;
 import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.CompressionFactory;
@@ -46,6 +48,8 @@ public class IndexSpec
   public static final CompressionStrategy DEFAULT_METRIC_COMPRESSION = CompressionStrategy.DEFAULT_COMPRESSION_STRATEGY;
   public static final CompressionStrategy DEFAULT_DIMENSION_COMPRESSION = CompressionStrategy.DEFAULT_COMPRESSION_STRATEGY;
   public static final CompressionFactory.LongEncodingStrategy DEFAULT_LONG_ENCODING = CompressionFactory.DEFAULT_LONG_ENCODING_STRATEGY;
+  public static final ColumnEncodingStrategy DEFAULT_INT_ENCODING_STRATEGY =
+      new ColumnEncodingStrategy(EncodingStrategy.COMPRESSION, null, null);
 
   private static final Set<CompressionStrategy> METRIC_COMPRESSION = Sets.newHashSet(
       Arrays.asList(CompressionStrategy.values())
@@ -64,6 +68,7 @@ public class IndexSpec
   private final CompressionStrategy metricCompression;
   private final CompressionFactory.LongEncodingStrategy longEncoding;
 
+  private final ColumnEncodingStrategy intEncodingStrategy;
   @Nullable
   private final SegmentizerFactory segmentLoader;
 
@@ -72,7 +77,7 @@ public class IndexSpec
    */
   public IndexSpec()
   {
-    this(null, null, null, null, null);
+    this(null, null, null, null, null, null);
   }
 
   @VisibleForTesting
@@ -83,16 +88,15 @@ public class IndexSpec
       @Nullable CompressionFactory.LongEncodingStrategy longEncoding
   )
   {
-    this(bitmapSerdeFactory, dimensionCompression, metricCompression, longEncoding, null);
+    this(bitmapSerdeFactory, dimensionCompression, metricCompression, longEncoding, null, null);
   }
 
   /**
    * Creates an IndexSpec with the given storage format settings.
    *
-   *
-   * @param bitmapSerdeFactory type of bitmap to use (e.g. roaring or concise), null to use the default.
-   *                           Defaults to the bitmap type specified by the (deprecated) "druid.processing.bitmap.type"
-   *                           setting, or, if none was set, uses the default defined in {@link BitmapSerde}
+   * @param bitmapSerdeFactory   type of bitmap to use (e.g. roaring or concise), null to use the default.
+   *                             Defaults to the bitmap type specified by the (deprecated) "druid.processing.bitmap.type"
+   *                             setting, or, if none was set, uses the default defined in {@link BitmapSerde}
    *
    * @param dimensionCompression compression format for dimension columns, null to use the default.
    *                             Defaults to {@link CompressionStrategy#DEFAULT_COMPRESSION_STRATEGY}
@@ -102,6 +106,8 @@ public class IndexSpec
    *
    * @param longEncoding encoding strategy for metric and dimension columns with type long, null to use the default.
    *                     Defaults to {@link CompressionFactory#DEFAULT_LONG_ENCODING_STRATEGY}
+   *
+   * @param intEncodingStrategy     encoding strategy for integer columns
    */
   @JsonCreator
   public IndexSpec(
@@ -109,17 +115,27 @@ public class IndexSpec
       @JsonProperty("dimensionCompression") @Nullable CompressionStrategy dimensionCompression,
       @JsonProperty("metricCompression") @Nullable CompressionStrategy metricCompression,
       @JsonProperty("longEncoding") @Nullable CompressionFactory.LongEncodingStrategy longEncoding,
-      @JsonProperty("segmentLoader") @Nullable SegmentizerFactory segmentLoader
+      @JsonProperty("segmentLoader") @Nullable SegmentizerFactory segmentLoader,
+      @JsonProperty("intEncodingStrategy") @Nullable ColumnEncodingStrategy intEncodingStrategy
   )
   {
-    Preconditions.checkArgument(dimensionCompression == null || DIMENSION_COMPRESSION.contains(dimensionCompression),
-                                "Unknown compression type[%s]", dimensionCompression);
+    Preconditions.checkArgument(
+        dimensionCompression == null || DIMENSION_COMPRESSION.contains(dimensionCompression),
+        "Unknown compression type[%s]",
+        dimensionCompression
+    );
 
-    Preconditions.checkArgument(metricCompression == null || METRIC_COMPRESSION.contains(metricCompression),
-                                "Unknown compression type[%s]", metricCompression);
+    Preconditions.checkArgument(
+        metricCompression == null || METRIC_COMPRESSION.contains(metricCompression),
+        "Unknown compression type[%s]",
+        metricCompression
+    );
 
-    Preconditions.checkArgument(longEncoding == null || LONG_ENCODING_NAMES.contains(longEncoding),
-                                "Unknown long encoding type[%s]", longEncoding);
+    Preconditions.checkArgument(
+        longEncoding == null || LONG_ENCODING_NAMES.contains(longEncoding),
+        "Unknown long encoding type[%s]",
+        longEncoding
+    );
 
     this.bitmapSerdeFactory = bitmapSerdeFactory != null
                               ? bitmapSerdeFactory
@@ -128,6 +144,7 @@ public class IndexSpec
     this.metricCompression = metricCompression == null ? DEFAULT_METRIC_COMPRESSION : metricCompression;
     this.longEncoding = longEncoding == null ? DEFAULT_LONG_ENCODING : longEncoding;
     this.segmentLoader = segmentLoader;
+    this.intEncodingStrategy = intEncodingStrategy == null ? DEFAULT_INT_ENCODING_STRATEGY : intEncodingStrategy;
   }
 
   @JsonProperty("bitmap")
@@ -161,6 +178,12 @@ public class IndexSpec
     return segmentLoader;
   }
 
+  @JsonProperty
+  public ColumnEncodingStrategy getIntEncodingStrategy()
+  {
+    return intEncodingStrategy;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -175,13 +198,21 @@ public class IndexSpec
            dimensionCompression == indexSpec.dimensionCompression &&
            metricCompression == indexSpec.metricCompression &&
            longEncoding == indexSpec.longEncoding &&
-           Objects.equals(segmentLoader, indexSpec.segmentLoader);
+           Objects.equals(segmentLoader, indexSpec.segmentLoader) &&
+           intEncodingStrategy.equals(indexSpec.intEncodingStrategy);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(bitmapSerdeFactory, dimensionCompression, metricCompression, longEncoding, segmentLoader);
+    return Objects.hash(
+        bitmapSerdeFactory,
+        dimensionCompression,
+        metricCompression,
+        longEncoding,
+        segmentLoader,
+        intEncodingStrategy
+    );
   }
 
   @Override
@@ -193,6 +224,193 @@ public class IndexSpec
            ", metricCompression=" + metricCompression +
            ", longEncoding=" + longEncoding +
            ", segmentLoader=" + segmentLoader +
+           ", intEncodingStrategy=" + intEncodingStrategy +
            '}';
+  }
+
+  /**
+   * Encapsulate column encoding strategy options
+   */
+  public static class ColumnEncodingStrategy
+  {
+    private static final EncodingStrategy DEFAULT_ENCODING_STRATEGY = EncodingStrategy.COMPRESSION;
+    private static final ShapeShiftOptimizationTarget DEFAULT_OPTIMIZATION_TARGET = ShapeShiftOptimizationTarget.FASTBUTSMALLISH;
+    private static final ShapeShiftBlockSize DEFAULT_BLOCK_SIZE = ShapeShiftBlockSize.LARGE;
+    private static final Set<EncodingStrategy> ENCODING_STRATEGIES = Sets.newHashSet(
+        Arrays.asList(EncodingStrategy.values())
+    );
+    private static final Set<ShapeShiftOptimizationTarget> OPTIMIZATION_TARGETS = Sets.newHashSet(
+        Arrays.asList(ShapeShiftOptimizationTarget.values())
+    );
+    private static final Set<ShapeShiftBlockSize> BLOCK_SIZES = Sets.newHashSet(
+        Arrays.asList(ShapeShiftBlockSize.values())
+    );
+
+    private final EncodingStrategy strategy;
+    private final ShapeShiftOptimizationTarget optimizationTarget;
+    private final ShapeShiftBlockSize blockSize;
+
+    @JsonCreator
+    public ColumnEncodingStrategy(
+        @JsonProperty("strategy") EncodingStrategy strategy,
+        @JsonProperty("optimizationTarget") ShapeShiftOptimizationTarget optimizationTarget,
+        @JsonProperty("blockSize") ShapeShiftBlockSize blockSize
+    )
+    {
+      Preconditions.checkArgument(strategy == null || ENCODING_STRATEGIES.contains(strategy),
+                                  "Unknown encoding strategy[%s]", strategy
+      );
+      Preconditions.checkArgument(optimizationTarget == null || OPTIMIZATION_TARGETS.contains(optimizationTarget),
+                                  "Unknown shapeshift optimization target[%s]", optimizationTarget
+      );
+      Preconditions.checkArgument(blockSize == null || BLOCK_SIZES.contains(blockSize),
+                                  "Unknown shapeshift block size[%s]", blockSize
+      );
+      this.strategy = strategy == null ? DEFAULT_ENCODING_STRATEGY : strategy;
+      this.optimizationTarget = optimizationTarget == null ? DEFAULT_OPTIMIZATION_TARGET : optimizationTarget;
+      this.blockSize = blockSize == null ? DEFAULT_BLOCK_SIZE : blockSize;
+    }
+
+    @JsonProperty
+    public EncodingStrategy getStrategy()
+    {
+      return strategy;
+    }
+
+    @JsonProperty
+    public ShapeShiftOptimizationTarget getOptimizationTarget()
+    {
+      return optimizationTarget;
+    }
+
+    @JsonProperty
+    public ShapeShiftBlockSize getBlockSize()
+    {
+      return blockSize;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ColumnEncodingStrategy that = (ColumnEncodingStrategy) o;
+      return strategy == that.strategy &&
+             optimizationTarget == that.optimizationTarget &&
+             blockSize == that.blockSize;
+    }
+
+    @Override
+    public int hashCode()
+    {
+
+      return Objects.hash(strategy, optimizationTarget, blockSize);
+    }
+
+    @Override
+    public String toString()
+    {
+      return "ColumnEncodingStrategy{" +
+             "strategy=" + strategy +
+             ", optimizationTarget=" + optimizationTarget +
+             ", blockSize=" + blockSize +
+             '}';
+    }
+  }
+
+
+  public enum EncodingStrategy
+  {
+    COMPRESSION,
+    SHAPESHIFT;
+
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(this.name());
+    }
+
+    @JsonCreator
+    public static EncodingStrategy fromString(String name)
+    {
+      return valueOf(StringUtils.toUpperCase(name));
+    }
+  }
+
+  /**
+   * Log base 2 values per chunk in shapeshift encoding
+   */
+  public enum ShapeShiftBlockSize
+  {
+    /**
+     * Shapeshift will encode blocks of 2^16 bytes. This puts the most memory pressure at indexing and query time in
+     * exchange for the potential to reduce encoded size. Approximate footprint is 64k off heap for decompression buffer
+     * and 129k on heap for value arrays
+     */
+    LARGE(16),
+    /**
+     * Shapeshift will encode blocks of 2^15 bytes. Approximate footprint is 32k off heap for decompression buffer
+     * and 65k on heap for value arrays
+     */
+    MIDDLE(15),
+    /**
+     * Shapeshift will encode blocks of 2^14 bytes. This approach is very conservative and uses less overall memory
+     * than {@link IndexSpec.EncodingStrategy#COMPRESSION} in exchange for increased encoding size overhead and
+     * potentially smaller gains in overall encoded size. Approximate footprint is 16k off heap for decompression buffer
+     * and 33k on heap for value arrays.
+     */
+    SMALL(14);
+
+    int logBlockSize;
+
+    ShapeShiftBlockSize(int blockSize)
+    {
+      this.logBlockSize = blockSize;
+    }
+
+    public byte getLogBlockSize()
+    {
+      return (byte) this.logBlockSize;
+    }
+
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(this.name());
+    }
+
+    @JsonCreator
+    public static ShapeShiftBlockSize fromString(String name)
+    {
+      return valueOf(StringUtils.toUpperCase(name));
+    }
+  }
+
+  public enum ShapeShiftOptimizationTarget
+  {
+    SMALLER,
+    FASTBUTSMALLISH,
+    FASTER;
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(this.name());
+    }
+
+    @JsonCreator
+    public static ShapeShiftOptimizationTarget fromString(String name)
+    {
+      return valueOf(StringUtils.toUpperCase(name));
+    }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/DoublesColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/DoublesColumn.java
@@ -86,4 +86,9 @@ public class DoublesColumn implements NumericColumn
   {
     inspector.visit("column", column);
   }
+
+  public ColumnarDoubles getColumn()
+  {
+    return column;
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/FloatsColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/FloatsColumn.java
@@ -86,4 +86,9 @@ public class FloatsColumn implements NumericColumn
   {
     inspector.visit("column", column);
   }
+
+  public ColumnarFloats getColumn()
+  {
+    return column;
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/ValueType.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ValueType.java
@@ -90,6 +90,13 @@ public enum ValueType
       return new SettableLongColumnValueSelector();
     }
   },
+  INT { // todo: lame, this is for benchmark value generation
+    @Override
+    public SettableColumnValueSelector makeNewSettableColumnValueSelector()
+    {
+      return new SettableDimensionValueSelector();
+    }
+  },
   STRING {
     @Override
     public SettableColumnValueSelector makeNewSettableColumnValueSelector()

--- a/processing/src/main/java/org/apache/druid/segment/data/ColumnarMultiIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ColumnarMultiIntsSerializer.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 /**
  * Serializer that produces {@link ColumnarMultiInts}.
  */
-public abstract class ColumnarMultiIntsSerializer implements ColumnarIntsSerializer
+public interface ColumnarMultiIntsSerializer extends ColumnarIntsSerializer
 {
-  public abstract void addValues(IndexedInts ints) throws IOException;
+  void addValues(IndexedInts ints) throws IOException;
 }

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializer.java
@@ -33,7 +33,7 @@ import java.nio.channels.WritableByteChannel;
 /**
  * Streams array of integers out in the binary format described by {@link CompressedColumnarIntsSupplier}
  */
-public class CompressedColumnarIntsSerializer extends SingleValueColumnarIntsSerializer
+public class CompressedColumnarIntsSerializer implements SingleValueColumnarIntsSerializer
 {
   private static final byte VERSION = CompressedColumnarIntsSupplier.VERSION;
 

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializer.java
@@ -35,7 +35,7 @@ import java.nio.channels.WritableByteChannel;
 /**
  * Streams array of integers out in the binary format described by {@link CompressedVSizeColumnarIntsSupplier}
  */
-public class CompressedVSizeColumnarIntsSerializer extends SingleValueColumnarIntsSerializer
+public class CompressedVSizeColumnarIntsSerializer implements SingleValueColumnarIntsSerializer
 {
   private static final byte VERSION = CompressedVSizeColumnarIntsSupplier.VERSION;
 

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
@@ -309,7 +309,7 @@ public class CompressedVSizeColumnarIntsSupplier implements WritableSupplier<Col
     }
   }
 
-  private class CompressedVSizeColumnarInts implements ColumnarInts
+  protected class CompressedVSizeColumnarInts implements ColumnarInts
   {
     final Indexed<ResourceHolder<ByteBuffer>> singleThreadedBuffers = baseBuffers.singleThreaded();
 

--- a/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingBlockColumnarInts.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingBlockColumnarInts.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import org.apache.druid.segment.data.codecs.ConstantFormDecoder;
+import org.apache.druid.segment.data.codecs.FormDecoder;
+
+import java.util.Arrays;
+
+/**
+ * Variant of {@link ShapeShiftingColumnarInts} that is optimized for eagerly decoding all column values, allowing
+ * {@link ShapeShiftingColumnarInts#get(int)} to be implemented directly as a masked array access.
+ * This optimization will be produced by {@link ShapeShiftingColumnarIntsSupplier} if
+ */
+public final class ShapeShiftingBlockColumnarInts extends ShapeShiftingColumnarInts
+{
+  public ShapeShiftingBlockColumnarInts(
+      ShapeShiftingColumnData sourceData,
+      Byte2ObjectMap<FormDecoder<ShapeShiftingColumnarInts>> decoders
+  )
+  {
+    super(sourceData, decoders);
+  }
+
+  @Override
+  public int get(final int index)
+  {
+    final int desiredChunk = index >> logValuesPerChunk;
+
+    if (desiredChunk != currentChunk) {
+      loadChunk(desiredChunk);
+    }
+
+    return decodedValues[index & chunkIndexMask];
+  }
+
+  @Override
+  public void transform(FormDecoder<ShapeShiftingColumnarInts> nextForm)
+  {
+    nextForm.transform(this);
+    if (nextForm instanceof ConstantFormDecoder) {
+      Arrays.fill(getDecodedValues(), 0, currentChunkNumValues, getCurrentConstant());
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumn.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.CompressedPools;
+import org.apache.druid.segment.data.codecs.FormDecoder;
+import sun.misc.Unsafe;
+import sun.nio.ch.DirectBuffer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Base type for reading 'shape shifting' columns, which divide row values into chunks sized to a power of 2, each
+ * potentially encoded with a different algorithm which was chosen as optimal for size and speed for the given values
+ * at indexing time. This class generically provides common structure for loading and decoding chunks of values for
+ * all shape shifting column implementations, with the help of matching {@link FormDecoder<TShapeShiftImpl>}. Like
+ * some other column decoding strategies, shape shifting columns operate with a 'currentChunk' which is loaded when
+ * a 'get' operation for a row index is done, and remains until a row index on a different chunk is requested, so
+ * performs best of row selection is done in an ordered manner.
+ *
+ * Shape shifting columns are designed to place row retrieval functions within the column implementation for optimal
+ * performance with the jvm. Each chunk has a byte header that uniquely maps to a {@link FormDecoder}, andChunks are
+ * decoded by passing them column into {@link FormDecoder} which are tightly coupled to know how to mutate the
+ * implementation so row values can be retrieved. What this means is implementation specific, but for the sake of
+ * example, could be decoding all values of the chunk to a primitive array or setting offsets to read values directly
+ * from a {@link ByteBuffer}. See specific implementations for further details.
+ *
+ * @param <TShapeShiftImpl> type of {@link ShapeShiftingColumn} implementation to strongly associate {@link FormDecoder}
+ */
+public abstract class ShapeShiftingColumn<TShapeShiftImpl extends ShapeShiftingColumn> implements Closeable
+{
+  public static Unsafe getTheUnsafe()
+  {
+    try {
+      Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+      theUnsafe.setAccessible(true);
+      return (Unsafe) theUnsafe.get(null);
+    }
+    catch (Exception e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  final ByteBuffer buffer;
+  final int numChunks;
+  final int numValues;
+  final byte logValuesPerChunk;
+  final int valuesPerChunk;
+  final int chunkIndexMask;
+  final ByteOrder byteOrder;
+  // shared chunk data areas for decoders that need space
+  ResourceHolder<ByteBuffer> bufHolder;
+  private final Supplier<ByteBuffer> decompressedDataBuffer;
+
+  protected int currentChunk = -1;
+  protected ByteBuffer currentValueBuffer;
+  protected ByteBuffer currentMetadataBuffer;
+  protected long currentValuesAddress;
+  protected int currentValuesStartOffset;
+  protected int currentChunkStartOffset;
+  protected int currentChunkSize;
+  protected int currentChunkNumValues;
+
+  protected final Byte2ObjectMap<FormDecoder<TShapeShiftImpl>> decoders;
+  final ShapeShiftingColumnData columnData;
+
+  public ShapeShiftingColumn(ShapeShiftingColumnData sourceData, Byte2ObjectMap<FormDecoder<TShapeShiftImpl>> decoders)
+  {
+    this.buffer = sourceData.getBaseBuffer();
+    this.numChunks = sourceData.getNumChunks();
+    this.numValues = sourceData.getNumValues();
+    this.logValuesPerChunk = sourceData.getLogValuesPerChunk();
+    this.valuesPerChunk = 1 << logValuesPerChunk;
+    this.chunkIndexMask = valuesPerChunk - 1;
+    this.byteOrder = sourceData.getByteOrder();
+    this.decoders = decoders;
+    this.columnData = sourceData;
+
+    // todo: meh side effects...
+    this.decompressedDataBuffer = Suppliers.memoize(() -> {
+      this.bufHolder = CompressedPools.getShapeshiftDecodedValuesBuffer(
+          logValuesPerChunk + sourceData.getLogBytesPerValue(),
+          byteOrder
+      );
+      return this.bufHolder.get();
+    });
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (bufHolder != null) {
+      bufHolder.close();
+    }
+  }
+
+  /**
+   * This method loads and decodes a chunk of values, and should be called in column 'get' methods to change the current
+   * chunk
+   *
+   * @param desiredChunk
+   */
+  final void loadChunk(int desiredChunk)
+  {
+    // todo: needed?
+    //CHECKSTYLE.OFF: Regexp
+//      Preconditions.checkArgument(
+//          desiredChunk < numChunks,
+//          "desiredChunk[%s] < numChunks[%s]",
+//          desiredChunk,
+//          numChunks
+//      );
+    //CHECKSTYLE.ON: Regexp
+
+    currentValueBuffer = buffer;
+    currentMetadataBuffer = buffer;
+    currentValuesAddress = -1;
+    currentValuesStartOffset = -1;
+    currentChunkStartOffset = -1;
+    currentChunk = -1;
+    currentChunkSize = -1;
+
+    if (desiredChunk == numChunks - 1) {
+      currentChunkNumValues = (numValues - ((numChunks - 1) * valuesPerChunk));
+    } else {
+      currentChunkNumValues = valuesPerChunk;
+    }
+
+    final ShapeShiftingColumnData.ChunkPosition position = columnData.getChunkPosition(desiredChunk);
+    final int chunkStartByte = columnData.getValueChunksStartOffset() + position.getStartOffset();
+    final int chunkEndByte = columnData.getValueChunksStartOffset() + position.getEndOffset();
+    final byte chunkCodec = buffer.get(chunkStartByte);
+
+    FormDecoder<TShapeShiftImpl> nextForm = getFormDecoder(chunkCodec);
+
+    currentChunkStartOffset = chunkStartByte + 1;
+    currentValuesStartOffset = currentChunkStartOffset + nextForm.getMetadataSize();
+    currentChunkSize = chunkEndByte - currentValuesStartOffset;
+    if (buffer.isDirect() && byteOrder.equals(ByteOrder.nativeOrder())) {
+      currentValuesAddress = (((DirectBuffer) buffer).address() + currentValuesStartOffset);
+    }
+
+    transform(nextForm);
+
+    currentChunk = desiredChunk;
+  }
+
+  public void inspectRuntimeShape(final RuntimeShapeInspector inspector)
+  {
+    // todo: idk
+    inspector.visit("decompressedDataBuffer", decompressedDataBuffer);
+  }
+
+  /**
+   * Transform this shapeshifting column to be able to read row values for the specified chunk
+   *
+   * @param nextForm decoder for the form of the next chunk of values
+   */
+  public abstract void transform(FormDecoder<TShapeShiftImpl> nextForm);
+
+  /**
+   * Get form decoder mapped to chunk header, used to transform this column to prepare for value reading
+   *
+   * @param header
+   *
+   * @return
+   */
+  public FormDecoder<TShapeShiftImpl> getFormDecoder(byte header)
+  {
+    return decoders.get(header);
+  }
+
+  /**
+   * Get underlying column buffer sliced from mapped smoosh
+   *
+   * @return
+   */
+  public ByteBuffer getBuffer()
+  {
+    return this.buffer;
+  }
+
+  /**
+   * Get shared bytebuffer for decompression
+   *
+   * @return
+   */
+  public ByteBuffer getDecompressedDataBuffer()
+  {
+    return this.decompressedDataBuffer.get();
+  }
+
+  /**
+   * Get current {@link ByteBuffer} to read row values from
+   *
+   * @return
+   */
+  public final ByteBuffer getCurrentValueBuffer()
+  {
+    return currentValueBuffer;
+  }
+
+  /**
+   * Set bytebuffer to read row values from
+   *
+   * @param currentValueBuffer
+   */
+  public void setCurrentValueBuffer(ByteBuffer currentValueBuffer)
+  {
+    this.currentValueBuffer = currentValueBuffer;
+  }
+
+  /**
+   * Get 'unsafe' memory address of current value chunk direct buffer
+   *
+   * @return
+   */
+  public final long getCurrentValuesAddress()
+  {
+    return currentValuesAddress;
+  }
+
+  /**
+   * Set 'unsafe' memory address of current value chunk direct buffer
+   *
+   * @param currentValuesAddress
+   */
+  public final void setCurrentValuesAddress(long currentValuesAddress)
+  {
+    this.currentValuesAddress = currentValuesAddress;
+  }
+
+  /**
+   * Get buffer offset of base column buffer for values of current chunk. If chunk has it's own encoding metadata, this
+   * may be offset from the start of the chunk itself.
+   *
+   * @return
+   */
+  public final int getCurrentValuesStartOffset()
+  {
+    return currentValuesStartOffset;
+  }
+
+  /**
+   * Set buffer offset of base column buffer for current value chunk. If chunk has it's own encoding metadata, this
+   * may be offset from the start of the chunk itself
+   */
+  public final void setCurrentValuesStartOffset(int currentValuesStartOffset)
+  {
+    this.currentValuesStartOffset = currentValuesStartOffset;
+  }
+
+  /**
+   * Get buffer offset of base column buffer for start of current chunk.
+   *
+   * @return
+   */
+  public int getCurrentChunkStartOffset()
+  {
+    return currentChunkStartOffset;
+  }
+
+  /**
+   * Set buffer offset of base column buffer for current chunk.
+   *
+   * @param currentChunkStartOffset
+   */
+  public void setCurrentChunkStartOffset(int currentChunkStartOffset)
+  {
+    this.currentChunkStartOffset = currentChunkStartOffset;
+  }
+
+  /**
+   * Get size in bytes of current chunk
+   *
+   * @return
+   */
+  public int getCurrentChunkSize()
+  {
+    return currentChunkSize;
+  }
+
+  /**
+   * Set size in bytes of current chunk
+   *
+   * @param currentChunkSize
+   */
+  public void setCurrentChunkSize(int currentChunkSize)
+  {
+    this.currentChunkSize = currentChunkSize;
+  }
+
+  /**
+   * Get number of rows in current chunk
+   *
+   * @return
+   */
+  public int getCurrentChunkNumValues()
+  {
+    return currentChunkNumValues;
+  }
+
+  /**
+   * Set number of rows in current chunk
+   *
+   * @param currentChunkNumValues
+   */
+  public void setCurrentChunkNumValues(int currentChunkNumValues)
+  {
+    this.currentChunkNumValues = currentChunkNumValues;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnData.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnData.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import it.unimi.dsi.fastutil.bytes.Byte2IntArrayMap;
+import it.unimi.dsi.fastutil.bytes.Byte2IntMap;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Materialized version of outer buffer contents of a {@link ShapeShiftingColumn}, extracting all header information
+ * as well as a sliced buffer, prepared for reading, allowing suppliers a tidy structure to instantiate
+ * {@link ShapeShiftingColumn} objects.
+ *
+ * layout:
+ * | version (byte) | headerSize (int) | numValues (int) | numChunks (int) | logValuesPerChunk (byte) | offsetsSize (int) |  compositionSize (int) | composition | offsets | values |
+ */
+public class ShapeShiftingColumnData
+{
+  private final int headerSize;
+  private final int numValues;
+  private final int numChunks;
+  private final byte logValuesPerChunk;
+  private final byte logBytesPerValue;
+  private final int compositionOffset;
+  private final int compositionSize;
+  private final int offsetsOffset;
+  private final int offsetsSize;
+  private final Byte2IntArrayMap composition;
+  private final ChunkPosition[] chunkPositions;
+  private final ByteBuffer baseBuffer;
+  private final ByteOrder byteOrder;
+
+  public ShapeShiftingColumnData(ByteBuffer buffer, byte logBytesPerValue, ByteOrder byteOrder)
+  {
+    this(buffer, logBytesPerValue, byteOrder, false);
+  }
+
+  public ShapeShiftingColumnData(
+      ByteBuffer buffer,
+      byte logBytesPerValue,
+      ByteOrder byteOrder,
+      boolean moveSourceBufferPosition
+  )
+  {
+    ByteBuffer ourBuffer = buffer.slice().order(byteOrder);
+    int position = 0;
+    this.byteOrder = byteOrder;
+    this.logBytesPerValue = logBytesPerValue;
+    this.headerSize = ourBuffer.getInt(++position);
+    this.numValues = ourBuffer.getInt(position += Integer.BYTES);
+    this.numChunks = ourBuffer.getInt(position += Integer.BYTES);
+    this.logValuesPerChunk = ourBuffer.get(position += Integer.BYTES);
+    this.compositionOffset = ourBuffer.getInt(++position);
+    this.compositionSize = ourBuffer.getInt(position += Integer.BYTES);
+    this.offsetsOffset = ourBuffer.getInt(position += Integer.BYTES);
+    this.offsetsSize = ourBuffer.getInt(position += Integer.BYTES);
+
+    this.composition = new Byte2IntArrayMap();
+    // 5 bytes per composition entry
+    for (int i = 0; i < compositionSize; i += 5) {
+      byte header = ourBuffer.get(compositionOffset + i);
+      int count = ourBuffer.getInt(compositionOffset + i + 1);
+      composition.put(header, count);
+    }
+
+    this.chunkPositions = new ChunkPosition[numChunks];
+    int prevOffset = 0;
+    for (int chunk = 0, chunkOffset = 0; chunk < numChunks; chunk++, chunkOffset += Integer.BYTES) {
+      int chunkStart = ourBuffer.getInt(offsetsOffset + chunkOffset);
+      int chunkEnd = ourBuffer.getInt(offsetsOffset + chunkOffset + Integer.BYTES);
+      chunkPositions[chunk] = new ChunkPosition(chunkStart, chunkEnd);
+      prevOffset = chunkEnd;
+    }
+
+    ourBuffer.limit(getValueChunksStartOffset() + prevOffset);
+
+    if (moveSourceBufferPosition) {
+      buffer.position(buffer.position() + ourBuffer.remaining());
+    }
+
+    this.baseBuffer = ourBuffer.slice().order(byteOrder);
+  }
+
+  /**
+   * Total 'header' size, to future proof by allowing us to always be able to find offsets and values sections offsets,
+   * but stuffing any additional data into the header.
+   *
+   * @return
+   */
+  public int getHeaderSize()
+  {
+    return headerSize;
+  }
+
+  /**
+   * Total number of rows in this column
+   *
+   * @return
+   */
+  public int getNumValues()
+  {
+    return numValues;
+  }
+
+  /**
+   * Number of 'chunks' of values this column is divided into
+   *
+   * @return
+   */
+  public int getNumChunks()
+  {
+    return numChunks;
+  }
+
+  /**
+   * log base 2 max number of values per chunk
+   *
+   * @return
+   */
+  public byte getLogValuesPerChunk()
+  {
+    return logValuesPerChunk;
+  }
+
+  /**
+   * log base 2 number of bytes per value
+   *
+   * @return
+   */
+  public byte getLogBytesPerValue()
+  {
+    return logBytesPerValue;
+  }
+
+  /**
+   * Size in bytes of chunk offset data
+   *
+   * @return
+   */
+  public int getOffsetsSize()
+  {
+    return offsetsSize;
+  }
+
+  /**
+   * Size in bytes of composition data
+   *
+   * @return
+   */
+  public int getCompositionSize()
+  {
+    return compositionSize;
+  }
+
+  /**
+   * Get composition of codecs used in column and their counts, allowing column suppliers to optimize at query time.
+   * Note that 'compressed' blocks are counted twice, once as compression and once as inner codec, so the total
+   * count here may not match {@link ShapeShiftingColumnData#numChunks}
+   *
+   * @return
+   */
+  public Byte2IntMap getComposition()
+  {
+    return composition;
+  }
+
+  /**
+   * get start and end offset of chunk in {@link ShapeShiftingColumnData#baseBuffer}
+   * @param chunk index of chunk
+   * @return
+   */
+  public ChunkPosition getChunkPosition(int chunk)
+  {
+    return chunkPositions[chunk];
+  }
+
+  /**
+   * Start offset of {@link ShapeShiftingColumnData#baseBuffer} for the 'chunk values' section
+   *
+   * @return
+   */
+  public int getValueChunksStartOffset()
+  {
+    return headerSize;
+  }
+
+  /**
+   * {@link ByteBuffer} View of column data, sliced from underlying mapped segment smoosh buffer.
+   *
+   * @return
+   */
+  public ByteBuffer getBaseBuffer()
+  {
+    return baseBuffer;
+  }
+
+  /**
+   * Column byte order
+   *
+   * @return
+   */
+  public ByteOrder getByteOrder()
+  {
+    return byteOrder;
+  }
+
+  public static class ChunkPosition
+  {
+    private final int startOffset;
+    private final int endOffset;
+
+    public ChunkPosition(int startOffset, int endOffset)
+    {
+      this.startOffset = startOffset;
+      this.endOffset = endOffset;
+    }
+
+    public int getStartOffset()
+    {
+      return startOffset;
+    }
+
+    public int getEndOffset()
+    {
+      return endOffset;
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnSerializer.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Ints;
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.data.codecs.CompressedFormEncoder;
+import org.apache.druid.segment.data.codecs.FormEncoder;
+import org.apache.druid.segment.data.codecs.FormMetrics;
+import org.apache.druid.segment.serde.Serializer;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+import java.util.Map;
+
+/**
+ * Base serializer for {@link ShapeShiftingColumn} implementations, providing most common functionality such as headers,
+ * value-chunking, encoder selection, and writing out values.
+ *
+ * Encoding Selection:
+ * The intention of this base structure is that implementors of this class will analyze incoming values and aggregate
+ * facts about the data which matching {@link FormEncoder} implementations might find interesting, while storing raw,
+ * unencoded values in {@link ShapeShiftingColumnSerializer#currentChunk}. When the threshold of
+ * {@link ShapeShiftingColumnSerializer#valuesPerChunk} is reached, {@link ShapeShiftingColumnSerializer} will attempt
+ * to find the "best" encoding by first computing the encoded size with
+ * {@link FormEncoder#getEncodedSize} and then applying a modifier to scale this value in order to influence behavior
+ * when sizes are relatively close according to the chosen {@link IndexSpec.ShapeShiftOptimizationTarget}. This
+ * effectively sways the decision towards using encodings with faster decoding speed or smaller encoded size as
+ * appropriate. Note that very often the best encoding is unambiguous and these settings don't matter, the nuanced
+ * differences of behavior of {@link IndexSpec.ShapeShiftOptimizationTarget} mainly come into play when things are
+ * close.
+ *
+ * Implementors need only supply an initialize method to allocate storage for {@code <TChunk>}, an add value method to
+ * populate {@code <TChunk>}, a reset method to prepare {@code <TChunkMetrics>} for the next chunk after a flush, and
+ * of course, matching {@link FormEncoder} implementations to perform actual value encoding. Generic compression is
+ * available to {@link FormEncoder} implementations by implementing
+ * {@link org.apache.druid.segment.data.codecs.CompressibleFormEncoder} and wrapping in a
+ * {@link CompressedFormEncoder} in the codec list passed to the serializer.
+ *
+ * layout:
+ * | version (byte) | headerSize (int) | numValues (int) | numChunks (int) | logValuesPerChunk (byte) |  compositionOffset (int) | compositionSize (int) | offsetsOffset (int) | offsetsSize (int) | composition | offsets | values |
+ *
+ * @param <TChunk>
+ * @param <TChunkMetrics>
+ */
+public abstract class ShapeShiftingColumnSerializer<TChunk, TChunkMetrics extends FormMetrics> implements Serializer
+{
+  /**
+   * | version (byte) | headerSize (int) | numValues (int) | numChunks (int) | logValuesPerChunk (byte) | compositionOffset (int) | compositionSize (int) |  offsetsOffset (int) | offsetsSize (int) |
+   */
+  private static final int BASE_HEADER_BYTES = 1 + (3 * Integer.BYTES) + 1 + (4 * Integer.BYTES);
+
+  private static Logger log = new Logger(ShapeShiftingColumnSerializer.class);
+
+  protected final SegmentWriteOutMedium segmentWriteOutMedium;
+  protected final FormEncoder<TChunk, TChunkMetrics>[] codecs;
+  protected final byte version;
+  protected final byte logValuesPerChunk;
+  protected final int valuesPerChunk;
+  protected final ByteBuffer intToBytesHelperBuffer;
+  protected final Object2IntMap<FormEncoder> composition;
+  protected final IndexSpec.ShapeShiftOptimizationTarget optimizationTarget;
+  protected WriteOutBytes offsetsOut;
+  protected WriteOutBytes valuesOut;
+  protected boolean wroteFinalOffset = false;
+  protected TChunkMetrics chunkMetrics;
+  protected TChunk currentChunk;
+  protected int currentChunkPos = 0;
+  protected int numChunks = 0;
+  protected int numValues = 0;
+
+  public ShapeShiftingColumnSerializer(
+      final SegmentWriteOutMedium segmentWriteOutMedium,
+      final FormEncoder<TChunk, TChunkMetrics>[] codecs,
+      final IndexSpec.ShapeShiftOptimizationTarget optimizationTarget,
+      final IndexSpec.ShapeShiftBlockSize blockSize,
+      final int logBytesPerValue,
+      final byte version,
+      @Nullable final ByteOrder overrideByteOrder,
+      @Nullable final Byte overrideLogValuesPerChunk
+  )
+  {
+    Preconditions.checkArgument(codecs.length > 0, "must have at least one encoder");
+    this.segmentWriteOutMedium = Preconditions.checkNotNull(segmentWriteOutMedium, "segmentWriteOutMedium");
+    this.version = version;
+    this.logValuesPerChunk = overrideLogValuesPerChunk != null
+                             ? overrideLogValuesPerChunk
+                             : (byte) (blockSize.getLogBlockSize() - logBytesPerValue);
+    this.valuesPerChunk = 1 << logValuesPerChunk;
+    this.codecs = codecs;
+    this.optimizationTarget = optimizationTarget;
+    ByteOrder byteOrder = overrideByteOrder == null ? ByteOrder.nativeOrder() : overrideByteOrder;
+    this.intToBytesHelperBuffer = ByteBuffer.allocate(Integer.BYTES).order(byteOrder);
+    this.composition = new Object2IntArrayMap<>();
+  }
+
+  public void open() throws IOException
+  {
+    offsetsOut = segmentWriteOutMedium.makeWriteOutBytes();
+    valuesOut = segmentWriteOutMedium.makeWriteOutBytes();
+    initializeChunk();
+    resetChunkCollector();
+  }
+
+  /**
+   * Initialize/allocate {@link ShapeShiftingColumnSerializer#currentChunk} to hold unencoded chunk values until
+   * {@link ShapeShiftingColumnSerializer#flushCurrentChunk()} is performed.
+   */
+  public abstract void initializeChunk();
+
+  /**
+   * Reset {@link ShapeShiftingColumnSerializer#chunkMetrics} to prepare for analyzing the next incoming chunk of data
+   * after performing {@link ShapeShiftingColumnSerializer#flushCurrentChunk()}
+   */
+  public abstract void resetChunkCollector();
+
+  @Override
+  public long getSerializedSize() throws IOException
+  {
+    if (currentChunkPos > 0) {
+      flushCurrentChunk();
+    }
+
+    writeFinalOffset();
+
+    return getHeaderSize() + valuesOut.size();
+  }
+
+  @Override
+  public void writeTo(
+      final WritableByteChannel channel,
+      final FileSmoosher smoosher
+  ) throws IOException
+  {
+    if (currentChunkPos > 0) {
+      flushCurrentChunk();
+    }
+
+    writeShapeShiftHeader(channel);
+    valuesOut.writeTo(channel);
+  }
+
+
+  protected ByteBuffer toBytes(final int n)
+  {
+    intToBytesHelperBuffer.putInt(0, n);
+    intToBytesHelperBuffer.rewind();
+    return intToBytesHelperBuffer;
+  }
+
+  /**
+   * Encode values of {@link ShapeShiftingColumnSerializer#currentChunk} with the 'best' available {@link FormEncoder}
+   * given the information collected in {@link ShapeShiftingColumnSerializer#chunkMetrics}. The best is chosen by
+   * computing the smallest 'modified' size, where {@link FormEncoder#getModifiedEncodedSize} is tuned based
+   * on decoding speed for each encoding in relation to all other available encodings.
+   *
+   * @throws IOException
+   */
+  protected void flushCurrentChunk() throws IOException
+  {
+    Preconditions.checkState(!wroteFinalOffset, "!wroteFinalOffset");
+    Preconditions.checkState(currentChunkPos > 0, "currentChunkPos > 0");
+    Preconditions.checkState(offsetsOut.isOpen(), "offsetsOut.isOpen");
+    Preconditions.checkState(valuesOut.isOpen(), "valuesOut.isOpen");
+
+    offsetsOut.write(toBytes(Ints.checkedCast(valuesOut.size())));
+
+    int bestSize = Integer.MAX_VALUE;
+    FormEncoder<TChunk, TChunkMetrics> bestCodec = null;
+    if (codecs.length > 1) {
+      for (FormEncoder<TChunk, TChunkMetrics> codec : codecs) {
+        double modifiedSize = codec.getModifiedEncodedSize(currentChunk, currentChunkPos, chunkMetrics);
+        if (modifiedSize < bestSize) {
+          bestCodec = codec;
+          bestSize = (int) modifiedSize;
+        }
+      }
+    } else {
+      bestCodec = codecs[0];
+    }
+
+    if (bestCodec == null) {
+      throw new RuntimeException("WTF? Unable to select an encoder.");
+    }
+
+    if (!composition.containsKey(bestCodec)) {
+      composition.put(bestCodec, 0);
+    }
+    composition.computeIfPresent(bestCodec, (k, v) -> v + 1);
+    if (bestCodec instanceof CompressedFormEncoder) {
+      FormEncoder inner = ((CompressedFormEncoder) bestCodec).getInnerEncoder();
+      if (!composition.containsKey(inner)) {
+        composition.put(inner, 0);
+      }
+      composition.computeIfPresent(inner, (k, v) -> v + 1);
+    }
+    valuesOut.write(new byte[]{bestCodec.getHeader()});
+    bestCodec.encode(valuesOut, currentChunk, currentChunkPos, chunkMetrics);
+
+    numChunks++;
+    resetChunk();
+  }
+
+  private void resetChunk()
+  {
+    currentChunkPos = 0;
+    resetChunkCollector();
+  }
+
+
+  private int getHeaderSize() throws IOException
+  {
+    return BASE_HEADER_BYTES + (composition.size() * 5) + Ints.checkedCast(offsetsOut.size());
+  }
+
+
+  private void writeFinalOffset() throws IOException
+  {
+    if (!wroteFinalOffset) {
+      offsetsOut.write(toBytes(Ints.checkedCast(valuesOut.size())));
+      wroteFinalOffset = true;
+    }
+  }
+
+  private void writeShapeShiftHeader(WritableByteChannel channel) throws IOException
+  {
+    writeFinalOffset();
+
+    int compositionSizeBytes = composition.entrySet().size() * 5;
+    int offsetsSizeBytes = Ints.checkedCast(offsetsOut.size());
+    int headerSizeBytes = BASE_HEADER_BYTES + compositionSizeBytes + offsetsSizeBytes;
+
+    channel.write(ByteBuffer.wrap(new byte[]{version}));
+    channel.write(toBytes(headerSizeBytes));
+    channel.write(toBytes(numValues));
+    channel.write(toBytes(numChunks));
+    channel.write(ByteBuffer.wrap(new byte[]{logValuesPerChunk}));
+    channel.write(toBytes(BASE_HEADER_BYTES));
+    channel.write(toBytes(compositionSizeBytes));
+    channel.write(toBytes(BASE_HEADER_BYTES + compositionSizeBytes));
+    channel.write(toBytes(offsetsSizeBytes));
+
+    // write composition map
+    for (Map.Entry<FormEncoder, Integer> enc : composition.entrySet()) {
+      channel.write(ByteBuffer.wrap(new byte[]{enc.getKey().getHeader()}));
+      channel.write(toBytes(enc.getValue()));
+      log.info(enc.getKey().getName() + ": " + enc.getValue());
+    }
+
+    // write offsets
+    offsetsOut.writeTo(channel);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnarInts.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnarInts.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.CompressedPools;
+import org.apache.druid.segment.data.codecs.ArrayFormDecoder;
+import org.apache.druid.segment.data.codecs.CompressedFormDecoder;
+import org.apache.druid.segment.data.codecs.FormDecoder;
+import org.apache.druid.segment.data.codecs.ints.BytePackedIntFormDecoder;
+import sun.misc.Unsafe;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class ShapeShiftingColumnarInts extends ShapeShiftingColumn<ShapeShiftingColumnarInts> implements ColumnarInts
+{
+  public static final byte VERSION = 0x4; // todo: idk..
+
+  protected static final Unsafe unsafe = getTheUnsafe();
+
+  protected final GetIntBuffer getInt24;
+  protected final GetIntUnsafe getInt24Unsafe;
+  ResourceHolder<int[]> decodedValuesHolder;
+
+  private final Supplier<int[]> decodedValuesSupplier;
+
+  protected int[] tmp;
+  protected int[] decodedValues;
+  protected DecodeIndex currentForm;
+  protected int currentBytesPerValue = 4;
+  protected int currentConstant = 0;
+
+  public ShapeShiftingColumnarInts(
+      ShapeShiftingColumnData sourceData,
+      Byte2ObjectMap<FormDecoder<ShapeShiftingColumnarInts>> decoders
+  )
+  {
+    super(sourceData, decoders);
+    this.decodedValuesSupplier = Suppliers.memoize(() -> {
+      decodedValuesHolder = CompressedPools.getShapeshiftIntsDecodedValuesArray(logValuesPerChunk);
+      return decodedValuesHolder.get();
+    });
+
+    getInt24 = byteOrder.equals(ByteOrder.LITTLE_ENDIAN)
+                      ? (_buffer, pos) -> _buffer.getInt(pos) & BytePackedIntFormDecoder.LITTLE_ENDIAN_INT_24_MASK
+                      : (_buffer, pos) -> _buffer.getInt(pos) >>> BytePackedIntFormDecoder.BIG_ENDIAN_INT_24_SHIFT;
+    getInt24Unsafe = byteOrder.equals(ByteOrder.LITTLE_ENDIAN)
+                            ? (pos) -> unsafe.getInt(pos) & BytePackedIntFormDecoder.LITTLE_ENDIAN_INT_24_MASK
+                            : (pos) -> unsafe.getInt(pos) >>> BytePackedIntFormDecoder.BIG_ENDIAN_INT_24_SHIFT;
+  }
+
+  @Override
+  public int size()
+  {
+    return numValues;
+  }
+
+  @Override
+  public void inspectRuntimeShape(final RuntimeShapeInspector inspector)
+  {
+    // todo: idk
+    super.inspectRuntimeShape(inspector);
+    inspector.visit("decodedValues", decodedValuesSupplier);
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    super.close();
+    if (decodedValuesHolder != null) {
+      decodedValuesHolder.close();
+    }
+  }
+
+  @Override
+  public int get(final int index)
+  {
+    final int desiredChunk = index >> logValuesPerChunk;
+
+    if (desiredChunk != currentChunk) {
+      loadChunk(desiredChunk);
+    }
+
+    return currentForm.decode(index & chunkIndexMask);
+  }
+
+  /**
+   * integer array sized to number of values, to allow {@link FormDecoder} a place for fully
+   * decoded values upon transformation
+   *
+   * @return
+   */
+  public final int[] getDecodedValues()
+  {
+    return decodedValues = decodedValuesSupplier.get();
+  }
+
+  /**
+   * current 'constant' value, for constant chunk transformations
+   *
+   * @return
+   */
+  public final int getCurrentConstant()
+  {
+    return currentConstant;
+  }
+
+  /**
+   * Allows {@link FormDecoder} to set current 'constant' value during a transformation.
+   *
+   * @param currentConstant
+   */
+  public final void setCurrentConstant(int currentConstant)
+  {
+    this.currentConstant = currentConstant;
+  }
+
+  /**
+   * Get current number of bytes used per value for random access transformations.
+   *
+   * @return
+   */
+  public int getCurrentBytesPerValue()
+  {
+    return currentBytesPerValue;
+  }
+
+  /**
+   * Allows {@link FormDecoder} to set current number of bytes for value, for random access transformations
+   *
+   * @param currentBytesPerValue
+   */
+  public void setCurrentBytesPerValue(int currentBytesPerValue)
+  {
+    this.currentBytesPerValue = currentBytesPerValue;
+  }
+
+  /**
+   * Transform {@link ShapeShiftingColumnarInts} to the form of the requested chunk, which may either be eagerly
+   * decoded entirely to {@link ShapeShiftingColumnarInts#decodedValuesSupplier} with values retrieved by
+   * {@link ShapeShiftingColumnarInts#decodeBlockForm(int)}, or randomly accessible, which may set
+   * {@link ShapeShiftingColumnarInts#currentValuesAddress}, {@link ShapeShiftingColumnarInts#currentValuesStartOffset},
+   * {@link ShapeShiftingColumnarInts#currentBytesPerValue}, {@link ShapeShiftingColumnarInts#currentConstant} and be
+   * decoded by {@link ShapeShiftingColumnarInts#decodeBufferForm(int)}.
+   *
+   * @param nextForm
+   */
+  @Override
+  public void transform(FormDecoder<ShapeShiftingColumnarInts> nextForm)
+  {
+    currentBytesPerValue = 4;
+    currentConstant = 0;
+
+    nextForm.transform(this);
+    if (nextForm instanceof ArrayFormDecoder) {
+      currentForm = this::decodeBlockForm;
+    } else if (!(nextForm instanceof CompressedFormDecoder)) {
+      if (getCurrentValueBuffer().isDirect() && byteOrder.equals(ByteOrder.nativeOrder())) {
+        currentForm = this::decodeUnsafeForm;
+      } else {
+        currentForm = this::decodeBufferForm;
+      }
+    }
+  }
+
+  /**
+   * get value at index produced {@link FormDecoder} transformation
+   *
+   * @param index masked index into the chunk array (index & {@link ShapeShiftingColumnarInts#chunkIndexMask})
+   *
+   * @return decoded row value at index
+   */
+  private int decodeBlockForm(int index)
+  {
+    return decodedValues[index];
+  }
+
+  /**
+   * get value (unsafe) at index produced by {@link FormDecoder} transformation
+   *
+   * @param index masked index into the chunk array (index & {@link ShapeShiftingColumnarInts#chunkIndexMask})
+   *
+   * @return decoded row value at index
+   */
+  private int decodeUnsafeForm(int index)
+  {
+    final long pos = currentValuesAddress + (index * currentBytesPerValue);
+    switch (currentBytesPerValue) {
+      case 1:
+        return unsafe.getByte(pos) & 0xFF;
+      case 2:
+        return unsafe.getShort(pos) & 0xFFFF;
+      case 3:
+        return getInt24Unsafe.getInt(pos);
+      case 4:
+        return unsafe.getInt(pos);
+      default:
+        return currentConstant;
+    }
+  }
+
+  /**
+   * get value at index produced by {@link FormDecoder} transformation
+   *
+   * @param index masked index into the chunk array (index & {@link ShapeShiftingColumnarInts#chunkIndexMask})
+   *
+   * @return decoded row value at index
+   */
+  private int decodeBufferForm(int index)
+  {
+    final int pos = getCurrentValuesStartOffset() + (index * currentBytesPerValue);
+    final ByteBuffer buffer = getCurrentValueBuffer();
+    switch (currentBytesPerValue) {
+      case 1:
+        return buffer.get(pos) & 0xFF;
+      case 2:
+        return buffer.getShort(pos) & 0xFFFF;
+      case 3:
+        return getInt24.getInt(buffer, pos);
+      case 4:
+        return buffer.getInt(pos);
+      default:
+        return currentConstant;
+    }
+  }
+
+  @FunctionalInterface
+  public interface DecodeIndex
+  {
+    int decode(int index);
+  }
+
+  @FunctionalInterface
+  protected interface GetIntUnsafe
+  {
+    int getInt(long index);
+  }
+
+  @FunctionalInterface
+  protected interface GetIntBuffer
+  {
+    int getInt(ByteBuffer buffer, int index);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnarIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnarIntsSerializer.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.CompressedPools;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.data.codecs.ints.BytePackedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.CompressedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.CompressibleIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.ConstantIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.IntCodecs;
+import org.apache.druid.segment.data.codecs.ints.IntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.IntFormMetrics;
+import org.apache.druid.segment.data.codecs.ints.LemireIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.RunLengthBytePackedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.UnencodedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.ZeroIntFormEncoder;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+/**
+ * {@link ShapeShiftingColumnSerializer} implementation for {@link ShapeShiftingColumnarInts}, using
+ * {@link IntFormEncoder} to encode values and {@link IntFormMetrics} to analyze them and assist with decisions of how
+ * the value chunks will be encoded when 'flushed' to the {@link SegmentWriteOutMedium}.
+ */
+public class ShapeShiftingColumnarIntsSerializer
+    extends ShapeShiftingColumnSerializer<int[], IntFormMetrics>
+    implements SingleValueColumnarIntsSerializer
+{
+  private ResourceHolder<int[]> unencodedValuesHolder;
+
+  private final boolean enableEncoderOptOut;
+
+  public static IntFormEncoder[] getDefaultIntFormEncoders(
+      IndexSpec.ShapeShiftBlockSize blockSize,
+      CompressionStrategy compressionStrategy,
+      Closer closer,
+      ByteOrder byteOrder
+  )
+  {
+    byte intBlockSize = (byte) (blockSize.getLogBlockSize() - 2);
+
+    ByteBuffer uncompressedDataBuffer =
+        compressionStrategy.getCompressor()
+                               .allocateInBuffer(8 + ((1 << intBlockSize) * Integer.BYTES), closer)
+                               .order(byteOrder);
+    ByteBuffer compressedDataBuffer =
+        compressionStrategy.getCompressor()
+                               .allocateOutBuffer(((1 << intBlockSize) * Integer.BYTES) + 1024, closer);
+
+    final CompressibleIntFormEncoder rle = new RunLengthBytePackedIntFormEncoder(
+        intBlockSize,
+        byteOrder
+    );
+    final CompressibleIntFormEncoder bytepack = new BytePackedIntFormEncoder(intBlockSize, byteOrder);
+
+    final IntFormEncoder[] defaultCodecs = new IntFormEncoder[]{
+        new ZeroIntFormEncoder(intBlockSize, byteOrder),
+        new ConstantIntFormEncoder(intBlockSize, byteOrder),
+        new UnencodedIntFormEncoder(intBlockSize, byteOrder),
+        rle,
+        bytepack,
+        new CompressedIntFormEncoder(
+            intBlockSize,
+            byteOrder,
+            compressionStrategy,
+            rle,
+            uncompressedDataBuffer,
+            compressedDataBuffer
+        ),
+        new CompressedIntFormEncoder(
+            intBlockSize,
+            byteOrder,
+            compressionStrategy,
+            bytepack,
+            uncompressedDataBuffer,
+            compressedDataBuffer
+        ),
+        new LemireIntFormEncoder(intBlockSize, IntCodecs.FASTPFOR, "fastpfor", byteOrder)
+    };
+
+    return defaultCodecs;
+  }
+
+  public ShapeShiftingColumnarIntsSerializer(
+      final SegmentWriteOutMedium segmentWriteOutMedium,
+      final IntFormEncoder[] codecs,
+      final IndexSpec.ShapeShiftOptimizationTarget optimizationTarget,
+      final IndexSpec.ShapeShiftBlockSize blockSize,
+      @Nullable final ByteOrder overrideByteOrder
+  )
+  {
+    this(
+        segmentWriteOutMedium,
+        codecs,
+        optimizationTarget,
+        blockSize,
+        overrideByteOrder,
+        null
+    );
+  }
+
+  @VisibleForTesting
+  public ShapeShiftingColumnarIntsSerializer(
+      final SegmentWriteOutMedium segmentWriteOutMedium,
+      final IntFormEncoder[] codecs,
+      final IndexSpec.ShapeShiftOptimizationTarget optimizationTarget,
+      final IndexSpec.ShapeShiftBlockSize blockSize,
+      @Nullable final ByteOrder overrideByteOrder,
+      @Nullable final Byte overrideLogValuesPerChunk
+  )
+  {
+    super(
+        segmentWriteOutMedium,
+        codecs,
+        optimizationTarget,
+        blockSize,
+        2,
+        ShapeShiftingColumnarInts.VERSION,
+        overrideByteOrder,
+        overrideLogValuesPerChunk
+    );
+
+    Closer closer = segmentWriteOutMedium.getCloser();
+    if (closer != null) {
+      closer.register(() -> {
+        if (unencodedValuesHolder != null) {
+          unencodedValuesHolder.close();
+        }
+      });
+    }
+
+    // enable optimization of encoders such as rle if there are additional non-zero and non-constant encoders.
+    this.enableEncoderOptOut =
+        Arrays.stream(codecs)
+              .filter(e -> !(e instanceof ZeroIntFormEncoder) && !(e instanceof ConstantIntFormEncoder))
+              .count() > 1;
+  }
+
+  @Override
+  public void initializeChunk()
+  {
+    unencodedValuesHolder = CompressedPools.getShapeshiftIntsDecodedValuesArray(logValuesPerChunk);
+    currentChunk = unencodedValuesHolder.get();
+  }
+
+  @Override
+  public void resetChunkCollector()
+  {
+    chunkMetrics = new IntFormMetrics(optimizationTarget, this.enableEncoderOptOut);
+  }
+
+  /**
+   * Adds a value to the current chunk of ints, stored in an array, analyzing values with {@link IntFormMetrics}, and
+   * flushing to the {@link SegmentWriteOutMedium} if the current chunk is full.
+   *
+   * @param val
+   *
+   * @throws IOException
+   */
+  @Override
+  public void addValue(int val) throws IOException
+  {
+    if (currentChunkPos == valuesPerChunk) {
+      flushCurrentChunk();
+    }
+
+    chunkMetrics.processNextRow(val);
+
+    currentChunk[currentChunkPos++] = val;
+    numValues++;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnarIntsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ShapeShiftingColumnarIntsSupplier.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.bytes.Byte2IntMap;
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.segment.data.codecs.ConstantFormDecoder;
+import org.apache.druid.segment.data.codecs.DirectFormDecoder;
+import org.apache.druid.segment.data.codecs.FormDecoder;
+import org.apache.druid.segment.data.codecs.ints.IntCodecs;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Reads mapped buffer contents into {@link ShapeShiftingColumnData} to supply {@link ShapeShiftingColumnarInts}
+ */
+public class ShapeShiftingColumnarIntsSupplier implements WritableSupplier<ColumnarInts>
+{
+  private static Logger log = new Logger(ShapeShiftingColumnarIntsSupplier.class);
+
+  private final ShapeShiftingColumnData columnData;
+  // null = default, false = force ShapeShiftingColumnarInts, true = force ShapeShiftingBlockColumnarInts
+  private final ShapeShiftingColumnarIntsDecodeOptimization overrideOptimization;
+
+  private ShapeShiftingColumnarIntsSupplier(
+      ShapeShiftingColumnData columnData,
+      @Nullable ShapeShiftingColumnarIntsDecodeOptimization overrideOptimization
+  )
+  {
+    this.columnData = columnData;
+    this.overrideOptimization = overrideOptimization;
+  }
+
+  /**
+   * Create a new instance from a {@link ByteBuffer} with position set to the start of a
+   * {@link ShapeShiftingColumnarInts}
+   *
+   * @param buffer
+   * @param byteOrder
+   *
+   * @return
+   */
+  public static ShapeShiftingColumnarIntsSupplier fromByteBuffer(
+      final ByteBuffer buffer,
+      final ByteOrder byteOrder
+  )
+  {
+    ShapeShiftingColumnData columnData =
+        new ShapeShiftingColumnData(buffer, (byte) 2, byteOrder, true);
+
+    return new ShapeShiftingColumnarIntsSupplier(columnData, null);
+  }
+
+  /**
+   * Create a new instance from a {@link ByteBuffer} with position set to the start of a
+   * {@link ShapeShiftingColumnarInts}
+   *
+   * @param buffer
+   * @param byteOrder
+   *
+   * @return
+   */
+  @VisibleForTesting
+  public static ShapeShiftingColumnarIntsSupplier fromByteBuffer(
+      final ByteBuffer buffer,
+      final ByteOrder byteOrder,
+      ShapeShiftingColumnarIntsDecodeOptimization overrideOptimization
+  )
+  {
+    ShapeShiftingColumnData columnData =
+        new ShapeShiftingColumnData(buffer, (byte) 2, byteOrder, true);
+
+    return new ShapeShiftingColumnarIntsSupplier(columnData, overrideOptimization);
+  }
+
+  /**
+   * Supply a {@link ShapeShiftingColumnarInts}
+   *
+   * @return
+   */
+  @Override
+  public ColumnarInts get()
+  {
+    Byte2IntMap composition = columnData.getComposition();
+
+    Byte2ObjectMap<FormDecoder<ShapeShiftingColumnarInts>> decoders = IntCodecs.getDecoders(
+        composition.keySet(),
+        columnData.getLogValuesPerChunk(),
+        columnData.getByteOrder()
+    );
+
+    ShapeShiftingColumnarIntsDecodeOptimization optimization =
+        overrideOptimization != null
+        ? overrideOptimization
+        : ShapeShiftingColumnarIntsDecodeOptimization.fromComposition(columnData, decoders);
+
+    switch (optimization) {
+      case BLOCK:
+        return new ShapeShiftingBlockColumnarInts(columnData, decoders);
+      case MIXED:
+      default:
+        return new ShapeShiftingColumnarInts(columnData, decoders);
+    }
+  }
+
+  @Override
+  public long getSerializedSize() throws IOException
+  {
+    return columnData.getBaseBuffer().remaining();
+  }
+
+  @Override
+  public void writeTo(
+      final WritableByteChannel channel,
+      final FileSmoosher smoosher
+  ) throws IOException
+  {
+        // todo: idk
+    //    ByteBuffer intToBytesHelperBuffer = ByteBuffer.allocate(Integer.BYTES).order(columnData.getByteOrder());
+
+    //    ShapeShiftingColumnSerializer.writeShapeShiftHeader(
+    //        channel,
+    //        intToBytesHelperBuffer,
+    //        ShapeShiftingColumnarInts.VERSION,
+    //        columnData.getNumChunks(),
+    //        columnData.getNumValues(),
+    //        columnData.getLogValuesPerChunk(),
+    //        columnData.getCompositionSize(),
+    //        columnData.getOffsetsSize()
+    //    );
+    channel.write(columnData.getBaseBuffer());
+  }
+
+  public enum ShapeShiftingColumnarIntsDecodeOptimization
+  {
+    MIXED,
+    BLOCK;
+
+    public static ShapeShiftingColumnarIntsDecodeOptimization fromComposition(
+        ShapeShiftingColumnData columnData,
+        Byte2ObjectMap<FormDecoder<ShapeShiftingColumnarInts>> decoders
+    )
+    {
+      int numDirectAccess = 0;
+      int preferDirectAccess = 0;
+      final Byte2IntMap composition = columnData.getComposition();
+      for (Byte2ObjectMap.Entry<FormDecoder<ShapeShiftingColumnarInts>> intDecoderEntry : decoders.byte2ObjectEntrySet()) {
+        final FormDecoder<ShapeShiftingColumnarInts> intDecoder = intDecoderEntry.getValue();
+        if (intDecoder instanceof DirectFormDecoder) {
+          final int count = composition.get(intDecoderEntry.getByteKey());
+          numDirectAccess += count;
+          if (!(intDecoder instanceof ConstantFormDecoder)) {
+            preferDirectAccess += count;
+          }
+        }
+      }
+
+      if (preferDirectAccess == 0) {
+        log.info(
+            "Using block optimized strategy, %d:%d have random access, %d prefer random access",
+            numDirectAccess,
+            columnData.getNumChunks(),
+            preferDirectAccess
+        );
+        return BLOCK;
+      } else {
+        log.info(
+            "Using mixed access strategy, %d:%d have random access, %d prefer random access",
+            numDirectAccess,
+            columnData.getNumChunks(),
+            preferDirectAccess
+        );
+        return MIXED;
+      }
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/SingleValueColumnarIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/SingleValueColumnarIntsSerializer.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 /**
  * Serializer that produces {@link ColumnarInts}.
  */
-public abstract class SingleValueColumnarIntsSerializer implements ColumnarIntsSerializer
+public interface SingleValueColumnarIntsSerializer extends ColumnarIntsSerializer
 {
-  public abstract void addValue(int val) throws IOException;
+  void addValue(int val) throws IOException;
 }

--- a/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializer.java
@@ -31,7 +31,7 @@ import java.nio.channels.WritableByteChannel;
 /**
  * Streams array of integers out in the binary format described by {@link V3CompressedVSizeColumnarMultiIntsSupplier}
  */
-public class V3CompressedVSizeColumnarMultiIntsSerializer extends ColumnarMultiIntsSerializer
+public class V3CompressedVSizeColumnarMultiIntsSerializer implements ColumnarMultiIntsSerializer
 {
   private static final byte VERSION = V3CompressedVSizeColumnarMultiIntsSupplier.VERSION;
 

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeColumnarIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeColumnarIntsSerializer.java
@@ -35,7 +35,7 @@ import java.nio.channels.WritableByteChannel;
 /**
  * Streams integers out in the binary format described by {@link VSizeColumnarInts}
  */
-public class VSizeColumnarIntsSerializer extends SingleValueColumnarIntsSerializer
+public class VSizeColumnarIntsSerializer implements SingleValueColumnarIntsSerializer
 {
   private static final byte VERSION = VSizeColumnarInts.VERSION;
 

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeColumnarMultiIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeColumnarMultiIntsSerializer.java
@@ -34,7 +34,7 @@ import java.nio.channels.WritableByteChannel;
 /**
  * Streams arrays of objects out in the binary format described by {@link VSizeColumnarMultiInts}.
  */
-public class VSizeColumnarMultiIntsSerializer extends ColumnarMultiIntsSerializer
+public class VSizeColumnarMultiIntsSerializer implements ColumnarMultiIntsSerializer
 {
   private static final byte VERSION = 0x1;
 

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ArrayFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ArrayFormDecoder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+
+public interface ArrayFormDecoder<TColumn extends ShapeShiftingColumn> extends FormDecoder<TColumn>
+{
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/BaseFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/BaseFormDecoder.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+
+import java.nio.ByteOrder;
+
+/**
+ * Common base type for {@link FormDecoder} implementations of any type of {@link ShapeShiftingColumn}
+ *
+ * @param <TColumn>
+ */
+public abstract class BaseFormDecoder<TColumn extends ShapeShiftingColumn> implements FormDecoder<TColumn>
+{
+  protected final byte logValuesPerChunk;
+  protected final int valuesPerChunk;
+  protected final ByteOrder byteOrder;
+
+  public BaseFormDecoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    this.logValuesPerChunk = logValuesPerChunk;
+    this.valuesPerChunk = 1 << logValuesPerChunk;
+    this.byteOrder = byteOrder;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/BaseFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/BaseFormEncoder.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumnSerializer;
+
+import java.nio.ByteOrder;
+
+/**
+ * Common base type for {@link FormEncoder} implementations of any type of
+ * {@link ShapeShiftingColumnSerializer}
+ *
+ * @param <TChunk>
+ * @param <TChunkMetrics>
+ */
+public abstract class BaseFormEncoder<TChunk, TChunkMetrics extends FormMetrics>
+    implements FormEncoder<TChunk, TChunkMetrics>
+{
+  protected final byte logValuesPerChunk;
+  protected final int valuesPerChunk;
+  protected final ByteOrder byteOrder;
+  protected final boolean isBigEndian;
+
+  public BaseFormEncoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    this.logValuesPerChunk = logValuesPerChunk;
+    this.valuesPerChunk = 1 << logValuesPerChunk;
+    this.byteOrder = byteOrder;
+    this.isBigEndian = byteOrder.equals(ByteOrder.BIG_ENDIAN);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/CompressedFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/CompressedFormDecoder.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+import sun.nio.ch.DirectBuffer;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Generic Shapeshifting form decoder for chunks that are block compressed using any of {@link CompressionStrategy}.
+ * Data is decompressed to 'decompressedDataBuffer' to be further decoded by another {@link BaseFormDecoder},
+ * via calling 'transform' again on the decompressed chunk.
+ */
+public final class CompressedFormDecoder<TShapeShiftImpl extends ShapeShiftingColumn<TShapeShiftImpl>>
+    extends BaseFormDecoder<TShapeShiftImpl>
+{
+  private final byte header;
+
+  public CompressedFormDecoder(byte logValuesPerChunk, ByteOrder byteOrder, byte header)
+  {
+    super(logValuesPerChunk, byteOrder);
+    this.header = header;
+  }
+
+  @Override
+  public void transform(TShapeShiftImpl shapeshiftingColumn)
+  {
+    final ByteBuffer buffer = shapeshiftingColumn.getBuffer();
+    final ByteBuffer decompressed = shapeshiftingColumn.getDecompressedDataBuffer();
+    int startOffset = shapeshiftingColumn.getCurrentChunkStartOffset();
+    int endOffset = startOffset + shapeshiftingColumn.getCurrentChunkSize();
+    decompressed.clear();
+
+    final CompressionStrategy.Decompressor decompressor =
+        CompressionStrategy.forId(buffer.get(startOffset++)).getDecompressor();
+
+    // metadata for inner encoding is stored outside of the compressed values chunk, so set column metadata offsets
+    // accordingly
+    final byte chunkCodec = buffer.get(startOffset++);
+    shapeshiftingColumn.setCurrentChunkStartOffset(startOffset);
+    FormDecoder<TShapeShiftImpl> innerForm = shapeshiftingColumn.getFormDecoder(chunkCodec);
+    startOffset += innerForm.getMetadataSize();
+    final int size = endOffset - startOffset;
+
+    decompressor.decompress(buffer, startOffset, size, decompressed);
+    shapeshiftingColumn.setCurrentValueBuffer(decompressed);
+    shapeshiftingColumn.setCurrentValuesStartOffset(0);
+    if (decompressed.isDirect()) {
+      shapeshiftingColumn.setCurrentValuesAddress(((DirectBuffer) decompressed).address());
+    }
+    // transform again, this time using the inner form against the the decompressed buffer
+    shapeshiftingColumn.transform(innerForm);
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return header;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/CompressedFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/CompressedFormEncoder.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Generic compression encoder that can wrap {@link CompressibleFormEncoder} to provide any of the compression
+ * algorithms available in {@link CompressionStrategy}
+ *
+ * @param <TChunk>
+ * @param <TChunkMetrics>
+ */
+public abstract class CompressedFormEncoder<TChunk, TChunkMetrics extends FormMetrics>
+    extends BaseFormEncoder<TChunk, TChunkMetrics>
+{
+  private final CompressibleFormEncoder<TChunk, TChunkMetrics> formEncoder;
+  private final CompressionStrategy compressionStrategy;
+  private final CompressionStrategy.Compressor compressor;
+  private final ByteBuffer uncompressedDataBuffer;
+  private final ByteBuffer compressedDataBuffer;
+  private ByteBuffer compressed;
+
+  public CompressedFormEncoder(
+      byte logValuesPerChunk,
+      ByteOrder byteOrder,
+      CompressionStrategy strategy,
+      CompressibleFormEncoder<TChunk, TChunkMetrics> encoder,
+      ByteBuffer uncompressedDataBuffer,
+      ByteBuffer compressedDataBuffer
+  )
+  {
+    super(logValuesPerChunk, byteOrder);
+    this.formEncoder = encoder;
+    this.compressionStrategy = strategy;
+    this.compressor = compressionStrategy.getCompressor();
+    this.compressedDataBuffer = compressedDataBuffer;
+    this.uncompressedDataBuffer = uncompressedDataBuffer;
+  }
+
+  @Override
+  public int getEncodedSize(
+      TChunk values,
+      int numValues,
+      TChunkMetrics metrics
+  ) throws IOException
+  {
+    if (!formEncoder.shouldAttemptCompression(metrics)) {
+      return Integer.MAX_VALUE;
+    }
+
+    metrics.setCompressionBufferHolder(formEncoder.getHeader());
+    uncompressedDataBuffer.clear();
+    compressedDataBuffer.clear();
+    formEncoder.encodeToBuffer(uncompressedDataBuffer, values, numValues, metrics);
+    compressed = compressor.compress(uncompressedDataBuffer, compressedDataBuffer);
+    // compressionId | inner encoding header | inner encoding metadata | compressed values
+    return 1 + 1 + formEncoder.getMetadataSize() + compressed.remaining();
+  }
+
+  @Override
+  public double getModifiedEncodedSize(
+      TChunk values,
+      int numValues,
+      TChunkMetrics metrics
+  ) throws IOException
+  {
+    int encodedSize = getEncodedSize(values, numValues, metrics);
+    switch (metrics.getOptimizationTarget()) {
+      case FASTER:
+        return encodedSize * formEncoder.getSpeedModifier(metrics) * 1.30;
+      case SMALLER:
+        return encodedSize * formEncoder.getSpeedModifier(metrics);
+      case FASTBUTSMALLISH:
+      default:
+        return encodedSize * formEncoder.getSpeedModifier(metrics) * 1.05;
+    }
+  }
+
+  @Override
+  public void encode(
+      WriteOutBytes valuesOut,
+      TChunk values,
+      int numValues,
+      TChunkMetrics metrics
+  ) throws IOException
+  {
+    if (metrics.getCompressionBufferHolder() == formEncoder.getHeader()) {
+      valuesOut.write(new byte[]{compressionStrategy.getId(), formEncoder.getHeader()});
+      formEncoder.encodeCompressionMetadata(valuesOut, values, numValues, metrics);
+      valuesOut.write(compressedDataBuffer);
+    } else {
+      uncompressedDataBuffer.clear();
+      compressedDataBuffer.clear();
+      formEncoder.encodeToBuffer(uncompressedDataBuffer, values, numValues, metrics);
+      valuesOut.write(new byte[]{compressionStrategy.getId(), formEncoder.getHeader()});
+      formEncoder.encodeCompressionMetadata(valuesOut, values, numValues, metrics);
+      valuesOut.write(compressor.compress(uncompressedDataBuffer, compressedDataBuffer));
+    }
+  }
+
+  @Override
+  public String getName()
+  {
+    return StringUtils.format("%s [%s]", compressionStrategy.toString(), formEncoder.getName());
+  }
+
+  public FormEncoder<TChunk, TChunkMetrics> getInnerEncoder()
+  {
+    return formEncoder;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/CompressibleFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/CompressibleFormEncoder.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumnSerializer;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A CompressibleFormEncoder extends {@link FormEncoder} to allow composition with a {@link CompressedFormEncoder},
+ * to further compress encoded values at the byte level in a value agnostic manner using any
+ * {@link org.apache.druid.segment.data.CompressionStrategy}.
+ *
+ * @param <TChunk>
+ * @param <TChunkMetrics>
+ */
+public interface CompressibleFormEncoder<TChunk, TChunkMetrics extends FormMetrics>
+    extends FormEncoder<TChunk, TChunkMetrics>
+{
+  /**
+   * Encode values to a temporary buffer to stage for compression by the
+   * {@link org.apache.druid.segment.data.CompressionStrategy} in use by {@link CompressedFormEncoder}
+   *
+   * @param buffer
+   * @param values
+   * @param numValues
+   * @param metadata
+   *
+   * @throws IOException
+   */
+  void encodeToBuffer(
+      ByteBuffer buffer,
+      TChunk values,
+      int numValues,
+      TChunkMetrics metadata
+  ) throws IOException;
+
+  /**
+   * Encode any metadata, not including the encoding header byte, to {@link WriteOutBytes}, which will preceede
+   * compressed values
+   *
+   * @param valuesOut
+   * @param values
+   * @param numValues
+   * @param metrics
+   *
+   * @throws IOException
+   */
+  default void encodeCompressionMetadata(
+      WriteOutBytes valuesOut,
+      TChunk values,
+      int numValues,
+      TChunkMetrics metrics
+  ) throws IOException
+  {
+  }
+
+  /**
+   * Get size of any encoding metadata, not including header byte.
+   *
+   * @return
+   */
+  default int getMetadataSize()
+  {
+    return 0;
+  }
+
+  /**
+   * To be chill, implementations can suggest that
+   * {@link ShapeShiftingColumnSerializer} should not attempt compression since it can be very
+   * expensive in terms of compute time, skipping this encoding for consideration for a block of values.
+   *
+   * @param hints
+   *
+   * @return
+   */
+  default boolean shouldAttemptCompression(TChunkMetrics hints)
+  {
+    return true;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ConstantFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ConstantFormDecoder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+
+public interface ConstantFormDecoder<TColumn extends ShapeShiftingColumn> extends FormDecoder<TColumn>
+{
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/DirectFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/DirectFormDecoder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+
+public interface DirectFormDecoder<TColumn extends ShapeShiftingColumn> extends FormDecoder<TColumn>
+{
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/FormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/FormDecoder.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+
+/**
+ * Interface describing value decoders for {@link ShapeShiftingColumn} implmentations. {@link ShapeShiftingColumn}
+ * operate on principle of being mutated by {@link FormDecoder} to load a chunk of values, preparing it to be able to
+ * read row values for indexes that fall within that chunk.
+ *
+ * @param <TColumn>
+ */
+public interface FormDecoder<TColumn extends ShapeShiftingColumn>
+{
+  /**
+   * Transform {@link ShapeShiftingColumn} to be able to read values for this decoder.
+   *
+   * @param column
+   */
+  void transform(TColumn column);
+
+  /**
+   * Size of any chunk specific metadata stored at the start of a chunk, to calculate offset of values from chunk start
+   * in underlying buffer
+   *
+   * @return
+   */
+  default int getMetadataSize()
+  {
+    return 0;
+  }
+
+  byte getHeader();
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/FormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/FormEncoder.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+import org.apache.druid.segment.data.ShapeShiftingColumnSerializer;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+
+/**
+ * Interface describing value encoders for use with {@link ShapeShiftingColumnSerializer}
+ *
+ * @param <TChunk>        Type of value chunk, i.e. {@code int[]}, {@code long[]}, etc.
+ * @param <TChunkMetrics> Type of {@link FormMetrics} that the encoder cosumes
+ */
+public interface FormEncoder<TChunk, TChunkMetrics extends FormMetrics>
+{
+  /**
+   * Get size in bytes if the values were encoded with this encoder
+   *
+   * @param values
+   * @param numValues
+   * @param metrics
+   *
+   * @return
+   *
+   * @throws IOException
+   */
+  int getEncodedSize(
+      TChunk values,
+      int numValues,
+      TChunkMetrics metrics
+  ) throws IOException;
+
+  default double getSpeedModifier(TChunkMetrics metrics)
+  {
+    return 1.0;
+  }
+
+  default double getModifiedEncodedSize(
+      TChunk values,
+      int numValues,
+      TChunkMetrics metrics
+  ) throws IOException
+  {
+    return getSpeedModifier(metrics) * getEncodedSize(values, numValues, metrics);
+  }
+
+  /**
+   * Encode the values to the supplied {@link WriteOutBytes}
+   *
+   * @param valuesOut
+   * @param values
+   * @param numValues
+   * @param metrics
+   *
+   * @throws IOException
+   */
+  void encode(
+      WriteOutBytes valuesOut,
+      TChunk values,
+      int numValues,
+      TChunkMetrics metrics
+  ) throws IOException;
+
+  /**
+   * Byte value to write as first byte to indicate the type of encoder used for this chunk. This value must be distinct
+   * for all encoding/decoding strategies tied to a specific implementation of
+   * {@link ShapeShiftingColumnSerializer} and {@link ShapeShiftingColumn}
+   *
+   * @return
+   */
+  byte getHeader();
+
+  /**
+   * Get friendly name of this encoder
+   *
+   * @return
+   */
+  String getName();
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/FormMetrics.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/FormMetrics.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs;
+
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.data.ShapeShiftingColumnSerializer;
+
+/**
+ * Base type for collecting statistics about a block of values for
+ * {@link ShapeShiftingColumnSerializer} to provide to {@link FormEncoder} implementations to
+ * make decisions about what encoding to employ.
+ */
+public abstract class FormMetrics
+{
+  private IndexSpec.ShapeShiftOptimizationTarget optimizationTarget;
+  private boolean enableEncoderOptOut;
+
+  private byte compressionBufferHolder = -1;
+
+  public FormMetrics(IndexSpec.ShapeShiftOptimizationTarget optimizationTarget, boolean enableEncoderOptOut)
+  {
+    this.optimizationTarget = optimizationTarget;
+    this.enableEncoderOptOut = enableEncoderOptOut;
+  }
+
+  /**
+   * Get {@link IndexSpec.ShapeShiftOptimizationTarget}, useful for {@link FormEncoder}
+   * implementations to adapt their calculations to the supplied indexing preference
+   *
+   * @return
+   */
+  public IndexSpec.ShapeShiftOptimizationTarget getOptimizationTarget()
+  {
+    return this.optimizationTarget;
+  }
+
+  /**
+   * When multiple 'complete' encoders are being employed, allow encoders which 'think' they will perform poorly for a
+   * given block to opt out of being used, which in some cases can save expensive calculations
+   * @return
+   */
+  public boolean isEnableEncoderOptOut()
+  {
+    return enableEncoderOptOut;
+  }
+
+  /**
+   * Total number of rows processed for this block of values
+   *
+   * @return
+   */
+  public abstract int getNumValues();
+
+  /**
+   * byte header value of last encoder to use compressed bytebuffer, allowing re-use if encoder is chosen rather than
+   * recompressing
+   *
+   * @return
+   */
+  public byte getCompressionBufferHolder()
+  {
+    return compressionBufferHolder;
+  }
+
+  /**
+   * Set encoder header as holder of compression buffers
+   *
+   * @param encoder
+   */
+  public void setCompressionBufferHolder(byte encoder)
+  {
+    this.compressionBufferHolder = encoder;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/BaseIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/BaseIntFormEncoder.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.codecs.BaseFormEncoder;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Base type for {@link IntFormEncoder} implementations, provides int to byte helper methods
+ */
+abstract class BaseIntFormEncoder extends BaseFormEncoder<int[], IntFormMetrics> implements IntFormEncoder
+{
+  private final ByteBuffer intToBytesHelperBuffer;
+
+  BaseIntFormEncoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+    intToBytesHelperBuffer = ByteBuffer.allocate(Integer.BYTES).order(byteOrder);
+  }
+
+  /**
+   * Write integer value to helper buffer
+   *
+   * @param n
+   *
+   * @return
+   */
+  protected final ByteBuffer toBytes(final int n)
+  {
+    intToBytesHelperBuffer.putInt(0, n);
+    intToBytesHelperBuffer.rewind();
+    return intToBytesHelperBuffer;
+  }
+
+  /**
+   * Write integer {@param value} byte packed into {@param numBytes} bytes to {@link WriteOutBytes} output
+   *
+   * @param valuesOut
+   * @param numBytes
+   * @param value
+   *
+   * @throws IOException
+   */
+  final void writeOutValue(WriteOutBytes valuesOut, int numBytes, int value) throws IOException
+  {
+    intToBytesHelperBuffer.putInt(0, value);
+    intToBytesHelperBuffer.position(0);
+    if (isBigEndian) {
+      valuesOut.write(intToBytesHelperBuffer.array(), Integer.BYTES - numBytes, numBytes);
+    } else {
+      valuesOut.write(intToBytesHelperBuffer.array(), 0, numBytes);
+    }
+  }
+
+  /**
+   * Write integer {@param value} byte packed into {@param numBytes} bytes to {@link ByteBuffer} output
+   *
+   * @param valuesOut
+   * @param numBytes
+   * @param value
+   */
+  final void writeOutValue(ByteBuffer valuesOut, int numBytes, int value)
+  {
+    intToBytesHelperBuffer.putInt(0, value);
+    intToBytesHelperBuffer.position(0);
+    if (isBigEndian) {
+      valuesOut.put(intToBytesHelperBuffer.array(), Integer.BYTES - numBytes, numBytes);
+    } else {
+      valuesOut.put(intToBytesHelperBuffer.array(), 0, numBytes);
+    }
+  }
+
+  @FunctionalInterface
+  interface WriteOutFunction
+  {
+    void write(int value) throws IOException;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/BytePackedIntFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/BytePackedIntFormDecoder.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.ShapeShiftingColumnarInts;
+import org.apache.druid.segment.data.codecs.BaseFormDecoder;
+import org.apache.druid.segment.data.codecs.DirectFormDecoder;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Byte packed integer decoder based on
+ * {@link org.apache.druid.segment.data.CompressedVSizeColumnarIntsSupplier} implementations
+ *
+ * layout:
+ * | header: IntCodecs.BYTEPACK (byte) | numBytes (byte) | encoded values  (numValues * numBytes) |
+ */
+public final class BytePackedIntFormDecoder extends BaseFormDecoder<ShapeShiftingColumnarInts>
+    implements DirectFormDecoder<ShapeShiftingColumnarInts>
+{
+  public static final int BIG_ENDIAN_INT_24_SHIFT = Integer.SIZE - 24;
+  public static final int LITTLE_ENDIAN_INT_24_MASK = (int) ((1L << 24) - 1);
+
+  public BytePackedIntFormDecoder(final byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  /**
+   * Eagerly get all values into value array of shapeshifting int column
+   *
+   * @param columnarInts
+   */
+  @Override
+  public void transform(ShapeShiftingColumnarInts columnarInts)
+  {
+    // metadata is always in base buffer at current chunk start offset
+    final ByteBuffer metaBuffer = columnarInts.getBuffer();
+    final int metaOffset = columnarInts.getCurrentChunkStartOffset();
+    final byte numBytes = metaBuffer.get(metaOffset);
+    columnarInts.setCurrentBytesPerValue(numBytes);
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.BYTEPACK;
+  }
+
+  @Override
+  public int getMetadataSize()
+  {
+    return 1;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/BytePackedIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/BytePackedIntFormEncoder.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Byte packing integer encoder based on {@link org.apache.druid.segment.data.CompressedVSizeColumnarIntsSerializer}. This
+ * encoder is a {@link CompressibleIntFormEncoder} and can be compressed with any
+ * {@link org.apache.druid.segment.data.CompressionStrategy}.
+ *
+ * layout:
+ * | header: IntCodecs.BYTEPACK (byte) | numBytes (byte) | encoded values  (numValues * numBytes) |
+ */
+public class BytePackedIntFormEncoder extends CompressibleIntFormEncoder
+{
+  public BytePackedIntFormEncoder(final byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  // todo: oh hey, it's me.. ur copy pasta
+  public static byte getNumBytesForMax(int maxValue)
+  {
+    if (maxValue < 0) {
+      throw new IAE("maxValue[%s] must be positive", maxValue);
+    }
+    if (maxValue <= 0xFF) {
+      return 1;
+    } else if (maxValue <= 0xFFFF) {
+      return 2;
+    } else if (maxValue <= 0xFFFFFF) {
+      return 3;
+    }
+    return 4;
+  }
+
+  @Override
+  public int getEncodedSize(
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    final int numBytes = getNumBytesForMax(metrics.getMaxValue());
+    return (numValues * numBytes) + Integer.BYTES - numBytes;
+  }
+
+  @Override
+  public void encode(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  ) throws IOException
+  {
+    final byte numBytes = getNumBytesForMax(metrics.getMaxValue());
+    valuesOut.write(new byte[]{numBytes});
+    WriteOutFunction writer = (value) -> writeOutValue(valuesOut, numBytes, value);
+    encodeValues(writer, values, numValues);
+    valuesOut.write(new byte[Integer.BYTES - numBytes]);
+  }
+
+  @Override
+  public void encodeToBuffer(
+      ByteBuffer buffer,
+      int[] values,
+      int numValues,
+      IntFormMetrics metadata
+  ) throws IOException
+  {
+    final byte numBytes = BytePackedIntFormEncoder.getNumBytesForMax(metadata.getMaxValue());
+    WriteOutFunction writer = (value) -> writeOutValue(buffer, numBytes, value);
+    encodeValues(writer, values, numValues);
+    buffer.put(new byte[Integer.BYTES - numBytes]);
+    buffer.flip();
+  }
+
+  @Override
+  public void encodeCompressionMetadata(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  ) throws IOException
+  {
+    final byte numBytes = getNumBytesForMax(metrics.getMaxValue());
+    valuesOut.write(new byte[]{numBytes});
+  }
+
+  @Override
+  public int getMetadataSize()
+  {
+    return 1;
+  }
+
+
+  private void encodeValues(
+      WriteOutFunction writer,
+      int[] values,
+      int numValues
+  ) throws IOException
+  {
+    for (int i = 0; i < numValues; i++) {
+      writer.write(values[i]);
+    }
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.BYTEPACK;
+  }
+
+  @Override
+  public String getName()
+  {
+    return "bytepack";
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/CompressedIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/CompressedIntFormEncoder.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.data.codecs.CompressedFormEncoder;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Int typed {@link CompressedFormEncoder} for compressing a {@link CompressibleIntFormEncoder} with a
+ * {@link CompressionStrategy}. The inner encoder encodes to a temporary data buffer, and then data is compressed to
+ * the compression buffer.
+ *
+ * layout:
+ * | header: IntCodecs.COMPRESSED (byte) | compressed data (compressedDataBuffer.remaining()) |
+ */
+public final class CompressedIntFormEncoder extends CompressedFormEncoder<int[], IntFormMetrics>
+    implements IntFormEncoder
+{
+  public CompressedIntFormEncoder(
+      byte logValuesPerChunk,
+      ByteOrder byteOrder,
+      CompressionStrategy strategy,
+      CompressibleIntFormEncoder encoder,
+      ByteBuffer uncompressedDataBuffer,
+      ByteBuffer compressedDataBuffer
+  )
+  {
+    super(logValuesPerChunk, byteOrder, strategy, encoder, uncompressedDataBuffer, compressedDataBuffer);
+  }
+
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.COMPRESSED;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/CompressibleIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/CompressibleIntFormEncoder.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.codecs.CompressibleFormEncoder;
+
+import java.nio.ByteOrder;
+
+/**
+ * Base type for {@link IntFormEncoder} implementations which also implement {@link CompressibleFormEncoder} and are
+ * compressible with a {@link org.apache.druid.segment.data.CompressionStrategy}
+ */
+public abstract class CompressibleIntFormEncoder extends BaseIntFormEncoder
+    implements CompressibleFormEncoder<int[], IntFormMetrics>
+{
+  CompressibleIntFormEncoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ConstantIntFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ConstantIntFormDecoder.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.ShapeShiftingColumnarInts;
+import org.apache.druid.segment.data.codecs.BaseFormDecoder;
+import org.apache.druid.segment.data.codecs.ConstantFormDecoder;
+import org.apache.druid.segment.data.codecs.DirectFormDecoder;
+
+import java.nio.ByteOrder;
+
+/**
+ * Decoder used if all values are the same within a chunk are constant.
+ *
+ * layout:
+ * | header: IntCodecs.CONSTANT (byte) | constant value (int) |
+ */
+public final class ConstantIntFormDecoder extends BaseFormDecoder<ShapeShiftingColumnarInts>
+    implements ConstantFormDecoder<ShapeShiftingColumnarInts>, DirectFormDecoder<ShapeShiftingColumnarInts>
+{
+  public ConstantIntFormDecoder(final byte logValuesPerChunk, final ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  @Override
+  public void transform(ShapeShiftingColumnarInts columnarInts)
+  {
+    final int startOffset = columnarInts.getCurrentValuesStartOffset();
+    final int currentConstant = columnarInts.getCurrentValueBuffer().getInt(startOffset);
+    columnarInts.setCurrentBytesPerValue(0);
+    columnarInts.setCurrentConstant(currentConstant);
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.CONSTANT;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ConstantIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ConstantIntFormEncoder.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+
+/**
+ * Encoding optimization used if all values are the same within a chunk are constant, using 5 bytes total, including
+ * the header.
+ *
+ * layout:
+ * | header: IntCodecs.CONSTANT (byte) | constant value (int) |
+ */
+public class ConstantIntFormEncoder extends BaseIntFormEncoder
+{
+  public ConstantIntFormEncoder(final byte logValuesPerChunk, final ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  @Override
+  public int getEncodedSize(
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    if (metrics.isConstant()) {
+      return Integer.BYTES;
+    }
+    return Integer.MAX_VALUE;
+  }
+
+  @Override
+  public double getModifiedEncodedSize(
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    if (metrics.isConstant()) {
+      // count as 1 byte for sake of comparison, iow, never replace zero, but prefer this over 2 bpv rle
+      return 1;
+    }
+    return Integer.MAX_VALUE;
+  }
+
+
+  @Override
+  public void encode(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  ) throws IOException
+  {
+    valuesOut.write(toBytes(metrics.getMaxValue()));
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.CONSTANT;
+  }
+
+  @Override
+  public String getName()
+  {
+    return "constant";
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/IntCodecs.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/IntCodecs.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectArrayMap;
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import it.unimi.dsi.fastutil.bytes.ByteSet;
+import org.apache.druid.java.util.common.RE;
+import org.apache.druid.segment.data.ShapeShiftingColumnarInts;
+import org.apache.druid.segment.data.codecs.CompressedFormDecoder;
+import org.apache.druid.segment.data.codecs.FormDecoder;
+
+import java.nio.ByteOrder;
+
+public class IntCodecs
+{
+  public static final byte ZERO = 0x00;
+  public static final byte CONSTANT = 0x01;
+  public static final byte UNENCODED = 0x02;
+  public static final byte BYTEPACK = 0x03;
+  public static final byte RLE_BYTEPACK = 0x04;
+  public static final byte COMPRESSED = 0x05;
+  public static final byte FASTPFOR = 0x06;
+
+
+  public static Byte2ObjectMap<FormDecoder<ShapeShiftingColumnarInts>> getDecoders(
+      ByteSet composition,
+      byte logValuesPerChunk,
+      ByteOrder byteOrder
+  )
+  {
+    Byte2ObjectArrayMap compositionMap = new Byte2ObjectArrayMap(composition.size());
+    for (byte b : composition) {
+      compositionMap.put(b, getDecoder(b, logValuesPerChunk, byteOrder));
+    }
+    return compositionMap;
+  }
+
+  public static FormDecoder<ShapeShiftingColumnarInts> getDecoder(
+      byte header,
+      byte logValuesPerChunk,
+      ByteOrder byteOrder
+  )
+  {
+    switch (header) {
+      case ZERO:
+        return new ZeroIntFormDecoder(logValuesPerChunk, byteOrder);
+      case CONSTANT:
+        return new ConstantIntFormDecoder(logValuesPerChunk, byteOrder);
+      case UNENCODED:
+        return new UnencodedIntFormDecoder(logValuesPerChunk, byteOrder);
+      case BYTEPACK:
+        return new BytePackedIntFormDecoder(logValuesPerChunk, byteOrder);
+      case RLE_BYTEPACK:
+        return new RunLengthBytePackedIntFormDecoder(logValuesPerChunk, byteOrder);
+      case FASTPFOR:
+        return new LemireIntFormDecoder(logValuesPerChunk, IntCodecs.FASTPFOR, byteOrder);
+      case COMPRESSED:
+        return new CompressedFormDecoder<>(logValuesPerChunk, byteOrder, IntCodecs.COMPRESSED);
+    }
+
+    throw new RE("Unknown decoder[%d]", (int) header);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/IntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/IntFormEncoder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.codecs.FormEncoder;
+
+public interface IntFormEncoder extends FormEncoder<int[], IntFormMetrics>
+{
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/IntFormMetrics.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/IntFormMetrics.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.data.ShapeShiftingColumnarIntsSerializer;
+import org.apache.druid.segment.data.codecs.FormMetrics;
+
+/**
+ * Aggregates statistics about blocks of integer values, such as total number of values processed, minimum and maximum
+ * values encountered, if the chunk is constant or all zeros, and various facts about data which is repeated more than
+ * twice ('runs') including number of distinct runs, longest run length, and total number of runs. This information is
+ * collected by {@link ShapeShiftingColumnarIntsSerializer} which processing row values, and is
+ * provided to {@link IntFormEncoder} implementations to do anything from estimate encoded size to influencing how
+ * {@link ShapeShiftingColumnarIntsSerializer} decides whether or not to employ that particular
+ * encoding.
+ */
+public class IntFormMetrics extends FormMetrics
+{
+  private int minValue = Integer.MAX_VALUE;
+  private int maxValue = Integer.MIN_VALUE;
+  private int numRunValues = 0;
+  private int numDistinctRuns = 0;
+  private int longestRun;
+  private int currentRun;
+  private int previousValue;
+  private int numValues = 0;
+  private boolean isFirstValue = true;
+
+  public IntFormMetrics(IndexSpec.ShapeShiftOptimizationTarget target, boolean enableEncoderOptOut)
+  {
+    super(target, enableEncoderOptOut);
+  }
+
+  @Override
+  public int getNumValues()
+  {
+    return numValues;
+  }
+
+  /**
+   * Minimum integer value encountered in the block of values
+   *
+   * @return
+   */
+  public int getMinValue()
+  {
+    return minValue;
+  }
+
+  /**
+   * Maximum integer value encountered in the block of values
+   *
+   * @return
+   */
+  public int getMaxValue()
+  {
+    return maxValue;
+  }
+
+  /**
+   * Total count of values which are part of a 'run', or a repitition of a value 3 or more times
+   *
+   * @return
+   */
+  public int getNumRunValues()
+  {
+    return numRunValues;
+  }
+
+  /**
+   * Count of distinct of 'runs', or values which are repeated more than 2 times
+   *
+   * @return
+   */
+  public int getNumDistinctRuns()
+  {
+    return numDistinctRuns;
+  }
+
+  /**
+   * Count of longest continuous sequence of repeated values
+   *
+   * @return
+   */
+  public int getLongestRun()
+  {
+    return longestRun;
+  }
+
+  /**
+   * All block values are a constant
+   *
+   * @return
+   */
+  public boolean isConstant()
+  {
+    return minValue == maxValue;
+  }
+
+  /**
+   * All block values are zero
+   *
+   * @return
+   */
+  public boolean isZero()
+  {
+    return minValue == 0 && minValue == maxValue;
+  }
+
+
+  /**
+   * This method is called for every {@link ShapeShiftingColumnarIntsSerializer#addValue(int)} to
+   * aggregate details about a chunk of values.
+   *
+   * @param val row value
+   */
+  public void processNextRow(int val)
+  {
+    if (isFirstValue) {
+      isFirstValue = false;
+      previousValue = val;
+      currentRun = 1;
+      longestRun = 1;
+    } else {
+      if (val == previousValue) {
+        currentRun++;
+        if (currentRun > 2) {
+          numRunValues++;
+        }
+      } else {
+        previousValue = val;
+        if (currentRun > 2) {
+          numDistinctRuns++;
+        }
+        currentRun = 1;
+      }
+    }
+
+    if (currentRun > longestRun) {
+      longestRun = currentRun;
+    }
+    if (val < minValue) {
+      minValue = val;
+    }
+    if (val > maxValue) {
+      maxValue = val;
+    }
+    numValues++;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/LemireIntFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/LemireIntFormDecoder.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import me.lemire.integercompression.IntWrapper;
+import me.lemire.integercompression.SkippableIntegerCODEC;
+import org.apache.druid.collections.NonBlockingPool;
+import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.segment.CompressedPools;
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+import org.apache.druid.segment.data.ShapeShiftingColumnarInts;
+import org.apache.druid.segment.data.codecs.ArrayFormDecoder;
+import org.apache.druid.segment.data.codecs.BaseFormDecoder;
+import sun.misc.Unsafe;
+import sun.nio.ch.DirectBuffer;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Integer form decoder using {@link <a href="https://github.com/lemire/JavaFastPFOR">JavaFastPFOR</a>}. Any
+ * {@link SkippableIntegerCODEC} will work, but currently only {@link me.lemire.integercompression.FastPFOR} is
+ * setup as a known encoding in {@link IntCodecs} as {@link IntCodecs#FASTPFOR}.
+ * Eagerly decodes all values to {@link ShapeShiftingColumnarInts#decodedValues}.
+ *
+ * layout:
+ * | header (byte) | encoded values  (numOutputInts * Integer.BYTES) |
+ */
+public final class LemireIntFormDecoder extends BaseFormDecoder<ShapeShiftingColumnarInts>
+    implements ArrayFormDecoder<ShapeShiftingColumnarInts>
+{
+  private static final Unsafe unsafe = ShapeShiftingColumn.getTheUnsafe();
+  private final NonBlockingPool<SkippableIntegerCODEC> codecPool;
+  private final byte header;
+
+  public LemireIntFormDecoder(
+      byte logValuesPerChunk,
+      byte header,
+      ByteOrder byteOrder
+  )
+  {
+    super(logValuesPerChunk, byteOrder);
+    this.header = header;
+    this.codecPool = CompressedPools.getShapeshiftLemirePool(header, logValuesPerChunk);
+  }
+
+  /**
+   * Eagerly decode all values into value array of shapeshifting int column
+   *
+   * @param columnarInts
+   */
+  @Override
+  public void transform(ShapeShiftingColumnarInts columnarInts)
+  {
+    final int numValues = columnarInts.getCurrentChunkNumValues();
+    final int startOffset = columnarInts.getCurrentValuesStartOffset();
+    final int endOffset = startOffset + columnarInts.getCurrentChunkSize();
+    final ByteBuffer buffer = columnarInts.getCurrentValueBuffer();
+    final int[] decodedChunk = columnarInts.getDecodedValues();
+
+    final int chunkSizeBytes = endOffset - startOffset;
+
+    // todo: needed?
+    //CHECKSTYLE.OFF: Regexp
+//    if (chunkSizeBytes % Integer.BYTES != 0) {
+//      throw new ISE(
+//          "Expected to read a whole number of integers, but got[%d] to [%d] for chunk",
+//          startOffset,
+//          endOffset
+//      );
+//    }
+    //CHECKSTYLE.ON: Regexp
+
+    // Copy chunk into an int array.
+    final int chunkSizeAsInts = chunkSizeBytes >> 2;
+
+    try (
+        ResourceHolder<int[]> tmpHolder = CompressedPools.getShapeshiftIntsEncodedValuesArray(logValuesPerChunk);
+        ResourceHolder<SkippableIntegerCODEC> codecHolder = codecPool.take()
+    ) {
+      final int[] tmp = tmpHolder.get();
+      final SkippableIntegerCODEC codec = codecHolder.get();
+
+      if (buffer.isDirect() && byteOrder.equals(ByteOrder.nativeOrder())) {
+        long addr = ((DirectBuffer) buffer).address() + startOffset;
+        for (int i = 0; i < chunkSizeAsInts; i++, addr += Integer.BYTES) {
+          tmp[i] = unsafe.getInt(addr);
+        }
+      } else {
+        for (int i = 0, bufferPos = startOffset; i < chunkSizeAsInts; i += 1, bufferPos += Integer.BYTES) {
+          tmp[i] = buffer.getInt(bufferPos);
+        }
+      }
+
+      // Decompress the chunk.
+      final IntWrapper inPos = new IntWrapper(0);
+      final IntWrapper outPos = new IntWrapper(0);
+
+      // this will unpack encodedValuesTmp to decodedValues
+      codec.headlessUncompress(
+          tmp,
+          inPos,
+          chunkSizeAsInts,
+          decodedChunk,
+          outPos,
+          numValues
+      );
+    }
+
+    // todo: needed?
+    // Sanity checks.
+    //CHECKSTYLE.OFF: Regexp
+//    if (inPos.get() != chunkSizeAsInts) {
+//      throw new ISE(
+//          "Expected to read[%d] ints but actually read[%d]",
+//          chunkSizeAsInts,
+//          inPos.get()
+//      );
+//    }
+//
+//    if (outPos.get() != numValues) {
+//      throw new ISE("Expected to get[%d] ints but actually got[%d]", numValues, outPos.get());
+//    }
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return header;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/LemireIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/LemireIntFormEncoder.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import me.lemire.integercompression.IntWrapper;
+import me.lemire.integercompression.SkippableIntegerCODEC;
+import org.apache.druid.collections.NonBlockingPool;
+import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.segment.CompressedPools;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+
+/**
+ * Integer form encoder using {@link <a href="https://github.com/lemire/JavaFastPFOR">JavaFastPFOR</a>}. Any
+ * {@link SkippableIntegerCODEC} should work, but currently only {@link me.lemire.integercompression.FastPFOR} is
+ * setup as a known encoding in {@link IntCodecs} as {@link IntCodecs#FASTPFOR}.
+ *
+ * layout:
+ * | header (byte) | encoded values  (numOutputInts * Integer.BYTES) |
+ */
+public final class LemireIntFormEncoder extends BaseIntFormEncoder
+{
+  private final NonBlockingPool<SkippableIntegerCODEC> codecPool;
+  private final byte header;
+  private final String name;
+  private int numOutputInts;
+
+  public LemireIntFormEncoder(
+      byte logValuesPerChunk,
+      byte header,
+      String name,
+      ByteOrder byteOrder
+  )
+  {
+    super(logValuesPerChunk, byteOrder);
+    this.header = header;
+    this.name = name;
+    this.codecPool = CompressedPools.getShapeshiftLemirePool(header, logValuesPerChunk);
+  }
+
+  @Override
+  public int getEncodedSize(
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    try (ResourceHolder<int[]> tmpHolder = CompressedPools.getShapeshiftIntsEncodedValuesArray(logValuesPerChunk)) {
+      final int[] encodedValuesTmp = tmpHolder.get();
+      numOutputInts = doEncode(values, encodedValuesTmp, numValues);
+      return numOutputInts * Integer.BYTES;
+    }
+  }
+
+  @Override
+  public void encode(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  ) throws IOException
+  {
+    try (ResourceHolder<int[]> tmpHolder = CompressedPools.getShapeshiftIntsEncodedValuesArray(logValuesPerChunk)) {
+      final int[] encodedValuesTmp = tmpHolder.get();
+      numOutputInts = doEncode(values, encodedValuesTmp, numValues);
+      for (int i = 0; i < numOutputInts; i++) {
+        valuesOut.write(toBytes(encodedValuesTmp[i]));
+      }
+    }
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return header;
+  }
+
+  @Override
+  public String getName()
+  {
+    return name;
+  }
+
+  private int doEncode(int[] values, int[] encodedValuesTmp, final int numValues)
+  {
+    final IntWrapper inPos = new IntWrapper(0);
+    final IntWrapper outPos = new IntWrapper(0);
+
+    try (ResourceHolder<SkippableIntegerCODEC> codecHolder = codecPool.take()) {
+      final SkippableIntegerCODEC codec = codecHolder.get();
+      codec.headlessCompress(values, inPos, numValues, encodedValuesTmp, outPos);
+    }
+
+    if (inPos.get() != numValues) {
+      throw new ISE("Expected to compress[%d] ints, but read[%d]", numValues, inPos.get());
+    }
+
+    return outPos.get();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/RunLengthBytePackedIntFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/RunLengthBytePackedIntFormDecoder.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.ShapeShiftingColumn;
+import org.apache.druid.segment.data.ShapeShiftingColumnarInts;
+import org.apache.druid.segment.data.codecs.ArrayFormDecoder;
+import org.apache.druid.segment.data.codecs.BaseFormDecoder;
+import sun.misc.Unsafe;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * layout:
+ * | header: IntCodecs.RLE_BYTEPACK (byte) | numBytes (byte) | encoded values ((2 * numDistinctRuns * numBytes) + (numSingleValues * numBytes)) |
+ */
+public final class RunLengthBytePackedIntFormDecoder extends BaseFormDecoder<ShapeShiftingColumnarInts>
+    implements ArrayFormDecoder<ShapeShiftingColumnarInts>
+{
+  static final int value_mask_int8 = 0x7F;
+  static final int value_mask_int16 = 0x7FFF;
+  static final int value_mask_int24 = 0x7FFFFF;
+  static final int value_mask_int32 = 0x7FFFFFFF;
+
+  static final int run_mask_int8 = 0x80;
+  static final int run_mask_int16 = 0x8000;
+  static final int run_mask_int24 = 0x800000;
+  static final int run_mask_int32 = 0x80000000;
+
+  private static final Unsafe unsafe = ShapeShiftingColumn.getTheUnsafe();
+
+  public RunLengthBytePackedIntFormDecoder(final byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  @Override
+  public void transform(ShapeShiftingColumnarInts columnarInts)
+  {
+    final ByteBuffer buffer = columnarInts.getCurrentValueBuffer();
+    // metadata is always in base buffer at current chunk start offset
+    final ByteBuffer metaBuffer = columnarInts.getBuffer();
+    final int metaOffset = columnarInts.getCurrentChunkStartOffset();
+    final byte numBytes = metaBuffer.get(metaOffset);
+    final int[] decodedChunk = columnarInts.getDecodedValues();
+    final int numValues = columnarInts.getCurrentChunkNumValues();
+    final int startOffset = columnarInts.getCurrentValuesStartOffset();
+
+    if (buffer.isDirect() && byteOrder.equals(ByteOrder.nativeOrder())) {
+      final long addr = columnarInts.getCurrentValuesAddress();
+      decodeIntsUnsafe(addr, numValues, decodedChunk, numBytes, byteOrder);
+    } else {
+      decodeIntsBuffer(buffer, startOffset, numValues, decodedChunk, numBytes, byteOrder);
+    }
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.RLE_BYTEPACK;
+  }
+
+  @Override
+  public int getMetadataSize()
+  {
+    return 1;
+  }
+
+  private static void decodeIntsUnsafe(
+      long addr,
+      final int numValues,
+      final int[] decodedValues,
+      final int bytePerValue,
+      final ByteOrder byteOrder
+  )
+  {
+    int runCount;
+    int runValue;
+
+    final boolean isBigEndian = byteOrder.equals(ByteOrder.BIG_ENDIAN);
+    final DecodeAddressFunction decode;
+    final int runMask;
+    final int valueMask;
+    switch (bytePerValue) {
+      case 1:
+        decode = RunLengthBytePackedIntFormDecoder::decodeInt8Unsafe;
+        runMask = run_mask_int8;
+        valueMask = value_mask_int8;
+        break;
+      case 2:
+        decode = RunLengthBytePackedIntFormDecoder::decodeInt16Unsafe;
+        runMask = run_mask_int16;
+        valueMask = value_mask_int16;
+        break;
+      case 3:
+        decode = isBigEndian
+                 ? RunLengthBytePackedIntFormDecoder::decodeBigEndianInt24Unsafe
+                 : RunLengthBytePackedIntFormDecoder::decodeInt24Unsafe;
+        runMask = run_mask_int24;
+        valueMask = value_mask_int24;
+        break;
+      default:
+        decode = RunLengthBytePackedIntFormDecoder::decodeInt32Unsafe;
+        runMask = run_mask_int32;
+        valueMask = value_mask_int32;
+        break;
+    }
+
+    for (int i = 0; i < numValues; i++) {
+      final int nextVal = decode.get(addr);
+      addr += bytePerValue;
+      if ((nextVal & runMask) == 0) {
+        decodedValues[i] = nextVal;
+      } else {
+        runCount = nextVal & valueMask;
+        runValue = decode.get(addr);
+        addr += bytePerValue;
+        do {
+          decodedValues[i] = runValue;
+        } while (--runCount > 0 && ++i < numValues);
+      }
+    }
+  }
+
+
+  private static int decodeInt8Unsafe(long addr)
+  {
+    return unsafe.getByte(addr) & 0xFF;
+  }
+
+  private static int decodeInt16Unsafe(long addr)
+  {
+    return unsafe.getShort(addr) & 0xFFFF;
+  }
+
+  private static int decodeBigEndianInt24Unsafe(long addr)
+  {
+    // big-endian:    0x000c0b0a stored 0c 0b 0a XX, read 0x0c0b0aXX >>> 8
+    return unsafe.getInt(addr) >>> BytePackedIntFormDecoder.BIG_ENDIAN_INT_24_SHIFT;
+  }
+
+  private static int decodeInt24Unsafe(long addr)
+  {
+    // little-endian: 0x000c0b0a stored 0a 0b 0c XX, read 0xXX0c0b0a & 0x00FFFFFF
+    return unsafe.getInt(addr) & BytePackedIntFormDecoder.LITTLE_ENDIAN_INT_24_MASK;
+  }
+
+  private static int decodeInt32Unsafe(long addr)
+  {
+    return unsafe.getInt(addr);
+  }
+
+  public static void decodeIntsBuffer(
+      ByteBuffer buffer,
+      final int startOffset,
+      final int numValues,
+      final int[] decodedValues,
+      final int bytePerValue,
+      final ByteOrder byteOrder
+  )
+  {
+
+    int bufferPosition = startOffset;
+    int runCount;
+    int runValue;
+
+    final boolean isBigEndian = byteOrder.equals(ByteOrder.BIG_ENDIAN);
+    final DecodeBufferFunction decode;
+    final int runMask;
+    final int valueMask;
+    switch (bytePerValue) {
+      case 1:
+        decode = RunLengthBytePackedIntFormDecoder::decodeInt8;
+        runMask = run_mask_int8;
+        valueMask = value_mask_int8;
+        break;
+      case 2:
+        decode = RunLengthBytePackedIntFormDecoder::decodeInt16;
+        runMask = run_mask_int16;
+        valueMask = value_mask_int16;
+        break;
+      case 3:
+        decode = isBigEndian
+                 ? RunLengthBytePackedIntFormDecoder::decodeBigEndianInt24
+                 : RunLengthBytePackedIntFormDecoder::decodeInt24;
+        runMask = run_mask_int24;
+        valueMask = value_mask_int24;
+        break;
+      default:
+        decode = RunLengthBytePackedIntFormDecoder::decodeInt32;
+        runMask = run_mask_int32;
+        valueMask = value_mask_int32;
+        break;
+    }
+
+    for (int i = 0; i < numValues; i++) {
+      final int nextVal = decode.get(buffer, bufferPosition);
+      bufferPosition += bytePerValue;
+      if ((nextVal & runMask) == 0) {
+        decodedValues[i] = nextVal;
+      } else {
+        runCount = nextVal & valueMask;
+        runValue = decode.get(buffer, bufferPosition);
+        bufferPosition += bytePerValue;
+        do {
+          decodedValues[i] = runValue;
+        } while (--runCount > 0 && ++i < numValues);
+      }
+    }
+  }
+
+  private static int decodeInt8(
+      final ByteBuffer buffer,
+      final int offset
+  )
+  {
+    return buffer.get(offset) & 0xFF;
+  }
+
+  private static int decodeInt16(
+      final ByteBuffer buffer,
+      final int offset
+  )
+  {
+    return buffer.getShort(offset) & 0xFFFF;
+  }
+
+  private static int decodeBigEndianInt24(
+      final ByteBuffer buffer,
+      final int offset
+  )
+  {
+    // big-endian:    0x000c0b0a stored 0c 0b 0a XX, read 0x0c0b0aXX >>> 8
+    return buffer.getInt(offset) >>> BytePackedIntFormDecoder.BIG_ENDIAN_INT_24_SHIFT;
+  }
+
+  private static int decodeInt24(
+      final ByteBuffer buffer,
+      final int offset
+  )
+  {
+    // little-endian: 0x000c0b0a stored 0a 0b 0c XX, read 0xXX0c0b0a & 0x00FFFFFF
+    return buffer.getInt(offset) & BytePackedIntFormDecoder.LITTLE_ENDIAN_INT_24_MASK;
+  }
+
+  private static int decodeInt32(
+      final ByteBuffer buffer,
+      final int offset
+  )
+  {
+    return buffer.getInt(offset);
+  }
+
+  @FunctionalInterface
+  public interface DecodeBufferFunction
+  {
+    int get(ByteBuffer buffer, int offset);
+  }
+
+  @FunctionalInterface
+  public interface DecodeAddressFunction
+  {
+    int get(long address);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/RunLengthBytePackedIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/RunLengthBytePackedIntFormEncoder.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Simple run-length encoding implementation which uses a bytepacking strategy similar to
+ * {@link BytePackedIntFormEncoder}, where the maximum run length and maximum row value are analzyed to choose a
+ * number of bytes which both the row values and run counts can be encoded, using the high bit to indicate if the
+ * bytes represent a run or a single value. A run is encoded with 2 values sized with the chosen number of bytes,
+ * the first with the high bit set and the run length encoded, the 2nd with the value that is repeated. A single
+ * value is packed into numBytes with the high bit not set.
+ *
+ * layout:
+ * | header: IntCodecs.RLE_BYTEPACK (byte) | numBytes (byte) | encoded values ((2 * numDistinctRuns * numBytes) + (numSingleValues * numBytes)) |
+ */
+public class RunLengthBytePackedIntFormEncoder extends CompressibleIntFormEncoder
+{
+  public RunLengthBytePackedIntFormEncoder(final byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  private static int applyRunMask(int runLength, int numBytes)
+  {
+    switch (numBytes) {
+      case 1:
+        return runLength | RunLengthBytePackedIntFormDecoder.run_mask_int8;
+      case 2:
+        return runLength | RunLengthBytePackedIntFormDecoder.run_mask_int16;
+      case 3:
+        return runLength | RunLengthBytePackedIntFormDecoder.run_mask_int24;
+      default:
+        return runLength | RunLengthBytePackedIntFormDecoder.run_mask_int32;
+    }
+  }
+
+  private static byte getNumBytesForMax(int maxValue, int maxRun)
+  {
+    if (maxValue < 0) {
+      throw new IAE("maxValue[%s] must be positive", maxValue);
+    }
+    int toConsider = maxValue > maxRun ? maxValue : maxRun;
+    if (toConsider <= RunLengthBytePackedIntFormDecoder.value_mask_int8) {
+      return 1;
+    } else if (toConsider <= RunLengthBytePackedIntFormDecoder.value_mask_int16) {
+      return 2;
+    } else if (toConsider <= RunLengthBytePackedIntFormDecoder.value_mask_int24) {
+      return 3;
+    }
+    return 4;
+  }
+
+  @Override
+  public int getEncodedSize(
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    return computeSize(metrics);
+  }
+
+  /**
+   * Run length speed modifier is dependent on how effective run length encoding is on the data itself if the
+   * optimization strategy is not {@link IndexSpec.ShapeShiftOptimizationTarget#SMALLER}, since
+   * decode performance is not great if run count is small, but approaching 1.0 as the values become constant.
+   *
+   * @param metrics
+   *
+   * @return
+   */
+  @Override
+  public double getSpeedModifier(IntFormMetrics metrics)
+  {
+    // rle is pretty slow when not in a situation where it is appropriate, penalize if big gains are not projected
+    final byte numBytesBytepack = BytePackedIntFormEncoder.getNumBytesForMax(metrics.getMaxValue());
+    final int bytepackSize = numBytesBytepack * metrics.getNumValues();
+    final int size = computeSize(metrics);
+    // don't bother if not smaller than bytepacking
+    if (size >= bytepackSize) {
+      return 10.0;
+    }
+    double modifier;
+    switch (metrics.getOptimizationTarget()) {
+      case SMALLER:
+        modifier = 1.0;
+        break;
+      default:
+        modifier = (((double) bytepackSize - (double) size)) / (double) bytepackSize;
+        break;
+    }
+    return Math.max(2.0 - modifier, 1.0);
+  }
+
+  @Override
+  public void encode(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  ) throws IOException
+  {
+    final byte numBytes = getNumBytesForMax(metrics.getMaxValue(), metrics.getLongestRun());
+    valuesOut.write(new byte[]{numBytes});
+
+    final WriteOutFunction writer = (value) -> writeOutValue(valuesOut, numBytes, value);
+
+    encodeValues(writer, values, numValues, numBytes);
+
+    // pad if int24, it reads values with buffer.getInt and either masks or shifts as appropriate for endian-ness
+    // other sizes have native read methods and don't require padding
+    if (numBytes == 3) {
+      valuesOut.write(new byte[]{0});
+    }
+  }
+
+  @Override
+  public void encodeToBuffer(
+      ByteBuffer buffer,
+      int[] values,
+      int numValues,
+      IntFormMetrics metadata
+  ) throws IOException
+  {
+    final byte numBytes =
+        RunLengthBytePackedIntFormEncoder.getNumBytesForMax(metadata.getMaxValue(), metadata.getLongestRun());
+
+    final WriteOutFunction writer = (value) -> writeOutValue(buffer, numBytes, value);
+
+    encodeValues(writer, values, numValues, numBytes);
+
+    // pad if int24, it reads values with buffer.getInt and either masks or shifts as appropriate for endian-ness
+    // other sizes have native read methods and don't require padding
+    if (numBytes == 3) {
+      buffer.put((byte) 0);
+    }
+    buffer.flip();
+  }
+
+  @Override
+  public void encodeCompressionMetadata(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  ) throws IOException
+  {
+    final byte numBytes = getNumBytesForMax(metrics.getMaxValue(), metrics.getLongestRun());
+    valuesOut.write(new byte[]{numBytes});
+  }
+
+  @Override
+  public int getMetadataSize()
+  {
+    return 1;
+  }
+
+  @Override
+  public boolean shouldAttemptCompression(IntFormMetrics hints)
+  {
+    if (!hints.isEnableEncoderOptOut()) {
+      return true;
+    }
+
+    // if not very many runs, cheese it out of here since i am expensive-ish
+    // todo: this is totally scientific. 100%. If we don't have at least 3/4 runs, then bail on trying compression since expensive
+    if ((hints.getOptimizationTarget() != IndexSpec.ShapeShiftOptimizationTarget.SMALLER) &&
+        (hints.getNumRunValues() < (3 * (hints.getNumValues() / 4)))) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.RLE_BYTEPACK;
+  }
+
+  @Override
+  public String getName()
+  {
+    return "rle-bytepack";
+  }
+
+  private void encodeValues(WriteOutFunction writer, int[] values, int numValues, int numBytes) throws IOException
+  {
+    int runCounter = 1;
+
+    for (int current = 1; current < numValues; current++) {
+      final int prev = current - 1;
+      final int next = current + 1;
+      // if previous value equals current value, we are in a run, continue accumulating
+      if (values[prev] == values[current]) {
+        runCounter++;
+        if (next < numValues) {
+          continue;
+        }
+      }
+      // if we get here we are either previously encountered a single value,
+      // or we are at the end of a run and the current value is the start of a new run or a single value,
+      // so write out the previous value
+      if (runCounter > 1) {
+        if (runCounter > 2) {
+          // if a run, encode with 2 values, the first masked to indicate that it is a run length, followed by the
+          // value itself
+          int maskedCounter = RunLengthBytePackedIntFormEncoder.applyRunMask(runCounter, numBytes);
+          writer.write(maskedCounter);
+          writer.write(values[prev]);
+          runCounter = 1;
+        } else {
+          // a run of 2 is lame, and no smaller than encoding directly and avoid entering the inner "run" unrolling
+          // loop during decoding
+          //CHECKSTYLE.OFF: duplicateLine
+          writer.write(values[prev]);
+          writer.write(values[prev]);
+          //CHECKSTYLE.ON: duplicateLine
+          runCounter = 1;
+        }
+      } else {
+        // non runs are written directly
+        writer.write(values[prev]);
+      }
+      // write out the last value if not part of a run
+      if (next == numValues && values[current] != values[prev]) {
+        writer.write(values[current]);
+      }
+    }
+  }
+
+  private int computeSize(IntFormMetrics metadata)
+  {
+    final byte numBytes = getNumBytesForMax(metadata.getMaxValue(), metadata.getLongestRun());
+    int size = numBytes * metadata.getNumValues();
+    size -= (numBytes * metadata.getNumRunValues());
+    size += (2 * numBytes * metadata.getNumDistinctRuns());
+    return size;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/UnencodedIntFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/UnencodedIntFormDecoder.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.ShapeShiftingColumnarInts;
+import org.apache.druid.segment.data.codecs.BaseFormDecoder;
+import org.apache.druid.segment.data.codecs.DirectFormDecoder;
+
+import java.nio.ByteOrder;
+
+/**
+ * "Unencoded" decoder, reads full sized integer values from shapeshifting int column read buffer.
+ *
+ * layout:
+ * | header: IntCodecs.UNENCODED (byte) | values  (numValues * Integer.BYTES) |
+ */
+public final class UnencodedIntFormDecoder extends BaseFormDecoder<ShapeShiftingColumnarInts>
+    implements DirectFormDecoder<ShapeShiftingColumnarInts>
+{
+  public UnencodedIntFormDecoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  @Override
+  public void transform(ShapeShiftingColumnarInts columnarInts)
+  {
+    columnarInts.setCurrentBytesPerValue(Integer.BYTES);
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.UNENCODED;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/UnencodedIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/UnencodedIntFormEncoder.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Unencoded integer encoder that writes full sized integer values as is.
+ *
+ * layout:
+ * | header: IntCodecs.UNENCODED (byte) | values  (numValues * Integer.BYTES) |
+ */
+public class UnencodedIntFormEncoder extends CompressibleIntFormEncoder
+{
+  public UnencodedIntFormEncoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  @Override
+  public int getEncodedSize(
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    return numValues * Integer.BYTES;
+  }
+
+  @Override
+  public void encode(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  ) throws IOException
+  {
+    WriteOutFunction writer = (value) -> valuesOut.write(toBytes(value));
+    encodeValues(writer, values, numValues);
+  }
+
+  @Override
+  public void encodeToBuffer(
+      ByteBuffer buffer,
+      int[] values,
+      int numValues,
+      IntFormMetrics metadata
+  ) throws IOException
+  {
+    WriteOutFunction writer = (value) -> buffer.putInt(value);
+    encodeValues(writer, values, numValues);
+    buffer.flip();
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.UNENCODED;
+  }
+
+  @Override
+  public String getName()
+  {
+    return "unencoded";
+  }
+
+  private void encodeValues(WriteOutFunction writer, int[] values, int numValues) throws IOException
+  {
+    for (int i = 0; i < numValues; i++) {
+      writer.write(values[i]);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ZeroIntFormDecoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ZeroIntFormDecoder.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.data.ShapeShiftingColumnarInts;
+import org.apache.druid.segment.data.codecs.BaseFormDecoder;
+import org.apache.druid.segment.data.codecs.ConstantFormDecoder;
+import org.apache.druid.segment.data.codecs.DirectFormDecoder;
+
+import java.nio.ByteOrder;
+
+/**
+ * Decoder used if all values are the same within a chunk are zero.
+ *
+ * layout:
+ * | header: IntCodecs.ZERO (byte) |
+ */
+public final class ZeroIntFormDecoder extends BaseFormDecoder<ShapeShiftingColumnarInts>
+    implements ConstantFormDecoder<ShapeShiftingColumnarInts>, DirectFormDecoder<ShapeShiftingColumnarInts>
+{
+  public ZeroIntFormDecoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  /**
+   * Fill shapeshifting int column chunk values array with zeros
+   *
+   * @param columnarInts
+   */
+  @Override
+  public void transform(ShapeShiftingColumnarInts columnarInts)
+  {
+    columnarInts.setCurrentBytesPerValue(0);
+    columnarInts.setCurrentConstant(0);
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.ZERO;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ZeroIntFormEncoder.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/codecs/ints/ZeroIntFormEncoder.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data.codecs.ints;
+
+import org.apache.druid.segment.writeout.WriteOutBytes;
+
+import java.nio.ByteOrder;
+
+/**
+ * Encoding optimization used if all values are the same within a chunk are zero, using 1 byte total, including
+ * the header.
+ *
+ * layout:
+ * | header: IntCodecs.ZERO (byte) |
+ */
+public class ZeroIntFormEncoder extends BaseIntFormEncoder
+{
+  public ZeroIntFormEncoder(byte logValuesPerChunk, ByteOrder byteOrder)
+  {
+    super(logValuesPerChunk, byteOrder);
+  }
+
+  @Override
+  public int getEncodedSize(
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    if (metrics.isZero()) {
+      return 0;
+    }
+    return Integer.MAX_VALUE;
+  }
+
+  @Override
+  public void encode(
+      WriteOutBytes valuesOut,
+      int[] values,
+      int numValues,
+      IntFormMetrics metrics
+  )
+  {
+    // do nothing!
+  }
+
+  @Override
+  public byte getHeader()
+  {
+    return IntCodecs.ZERO;
+  }
+
+  @Override
+  public String getName()
+  {
+    return "zero";
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/generator/ColumnValueGenerator.java
+++ b/processing/src/main/java/org/apache/druid/segment/generator/ColumnValueGenerator.java
@@ -131,6 +131,13 @@ public class ColumnValueGenerator
           ret = Float.parseFloat(input.toString());
         }
         break;
+      case INT:
+        if (input instanceof Number) {
+          ret = ((Number) input).intValue();
+        } else {
+          ret = Integer.parseInt(input.toString());
+        }
+        break;
       default:
         throw new UnsupportedOperationException("Unknown data type: " + type);
     }

--- a/processing/src/test/java/org/apache/druid/segment/CustomSegmentizerFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CustomSegmentizerFactoryTest.java
@@ -87,6 +87,7 @@ public class CustomSegmentizerFactoryTest extends InitializedNullHandlingTest
             null,
             null,
             null,
+            null,
             null
         ),
         null
@@ -112,7 +113,8 @@ public class CustomSegmentizerFactoryTest extends InitializedNullHandlingTest
             null,
             null,
             null,
-            new CustomSegmentizerFactory()
+            new CustomSegmentizerFactory(),
+            null
         ),
         null
     );

--- a/processing/src/test/java/org/apache/druid/segment/IndexSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexSpecTest.java
@@ -42,6 +42,37 @@ public class IndexSpecTest
     Assert.assertEquals(CompressionStrategy.LZ4, spec.getDimensionCompression());
     Assert.assertEquals(CompressionStrategy.LZF, spec.getMetricCompression());
     Assert.assertEquals(CompressionFactory.LongEncodingStrategy.AUTO, spec.getLongEncoding());
+    Assert.assertEquals(IndexSpec.EncodingStrategy.COMPRESSION, spec.getIntEncodingStrategy().getStrategy());
+    Assert.assertEquals(
+        IndexSpec.ShapeShiftOptimizationTarget.FASTBUTSMALLISH,
+        spec.getIntEncodingStrategy().getOptimizationTarget()
+    );
+    Assert.assertEquals(IndexSpec.ShapeShiftBlockSize.LARGE, spec.getIntEncodingStrategy().getBlockSize());
+
+    Assert.assertEquals(spec, objectMapper.readValue(objectMapper.writeValueAsBytes(spec), IndexSpec.class));
+  }
+
+
+  @Test
+  public void testSerdeShapeshift() throws Exception
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    final String json = "{ \"bitmap\" : { \"type\" : \"roaring\" }, \"dimensionCompression\" : \"lz4\", "
+                        + "\"metricCompression\" : \"lzf\", \"longEncoding\" : \"auto\", \"intEncodingStrategy\" : { "
+                        + "\"strategy\" : \"shapeshift\", \"optimizationTarget\" : \"faster\", "
+                        + "\"blockSize\" : \"small\"}}";
+
+    final IndexSpec spec = objectMapper.readValue(json, IndexSpec.class);
+    Assert.assertEquals(new RoaringBitmapSerdeFactory(null), spec.getBitmapSerdeFactory());
+    Assert.assertEquals(CompressionStrategy.LZ4, spec.getDimensionCompression());
+    Assert.assertEquals(CompressionStrategy.LZF, spec.getMetricCompression());
+    Assert.assertEquals(CompressionFactory.LongEncodingStrategy.AUTO, spec.getLongEncoding());
+    Assert.assertEquals(IndexSpec.EncodingStrategy.SHAPESHIFT, spec.getIntEncodingStrategy().getStrategy());
+    Assert.assertEquals(
+        IndexSpec.ShapeShiftOptimizationTarget.FASTER,
+        spec.getIntEncodingStrategy().getOptimizationTarget()
+    );
+    Assert.assertEquals(IndexSpec.ShapeShiftBlockSize.SMALL, spec.getIntEncodingStrategy().getBlockSize());
 
     Assert.assertEquals(spec, objectMapper.readValue(objectMapper.writeValueAsBytes(spec), IndexSpec.class));
   }

--- a/processing/src/test/java/org/apache/druid/segment/data/ShapeShiftingColumnarIntsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/ShapeShiftingColumnarIntsSerdeTest.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.guava.CloseQuietly;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.data.codecs.CompressedFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.BytePackedIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.IntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.LemireIntFormEncoder;
+import org.apache.druid.segment.data.codecs.ints.RunLengthBytePackedIntFormEncoder;
+import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.Channels;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+@RunWith(Parameterized.class)
+public class ShapeShiftingColumnarIntsSerdeTest
+{
+
+  @Parameterized.Parameters(name = "{index}: blockSize={0}, optimizationTarget={1}, byteOrder={2}, encoderSet={3}")
+  public static List<Object[]> blockSizesOptimizationTargetsAndByteOrders()
+  {
+    Set<List<Object>> combinations = Sets.cartesianProduct(
+        Sets.newHashSet(IndexSpec.ShapeShiftBlockSize.values()),
+        Sets.newHashSet(IndexSpec.ShapeShiftOptimizationTarget.values()),
+        Sets.newHashSet(ByteOrder.LITTLE_ENDIAN, ByteOrder.BIG_ENDIAN),
+        Sets.newHashSet("bytepack", "rle-bytepack", "fastpfor", "lz4-bytepack", "lz4-rle-bytepack", "lz4", "default")
+    );
+
+    return combinations.stream()
+                       .map(input -> new Object[]{input.get(0), input.get(1), input.get(2), input.get(3)})
+                       .collect(Collectors.toList());
+  }
+
+  private final IndexSpec.ShapeShiftBlockSize blockSize;
+  private final IndexSpec.ShapeShiftOptimizationTarget optimizationTarget;
+  private final ByteOrder byteOrder;
+  private final String encoderSet;
+
+  private Closer closer;
+  private ColumnarInts columnarInts;
+  private ShapeShiftingColumnarIntsSupplier supplier;
+  private int[] vals;
+
+  public ShapeShiftingColumnarIntsSerdeTest(
+      IndexSpec.ShapeShiftBlockSize blockSize,
+      IndexSpec.ShapeShiftOptimizationTarget optimizationTarget,
+      ByteOrder byteOrder,
+      String encoderSet
+  )
+  {
+    this.blockSize = blockSize;
+    this.optimizationTarget = optimizationTarget;
+    this.byteOrder = byteOrder;
+    this.encoderSet = encoderSet;
+  }
+
+  @Before
+  public void setUp()
+  {
+    closer = Closer.create();
+    CloseQuietly.close(columnarInts);
+    columnarInts = null;
+    supplier = null;
+    vals = null;
+  }
+
+  @After
+  public void tearDown() throws Exception
+  {
+    columnarInts.close();
+    closer.close();
+  }
+  
+  @Test
+  public void testFidelity() throws Exception
+  {
+    int intChunkSize = 1 << (blockSize.getLogBlockSize() - 2);
+
+    seedAndEncodeData(10 * intChunkSize);
+
+    assertIndexMatchesVals();
+  }
+
+
+  // cargo cult test, this guy is everywhere so why not here too
+  @Test
+  public void testConcurrentThreadReads() throws Exception
+  {
+    int intChunkSize = 1 << (blockSize.getLogBlockSize() - 2);
+    seedAndEncodeData(3 * intChunkSize);
+
+    final AtomicReference<String> reason = new AtomicReference<>("none");
+
+    final int numRuns = 1000;
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    final CountDownLatch stopLatch = new CountDownLatch(2);
+    final AtomicBoolean failureHappened = new AtomicBoolean(false);
+    new Thread(() -> {
+      try {
+        startLatch.await();
+      }
+      catch (InterruptedException e) {
+        failureHappened.set(true);
+        reason.set("interrupt.");
+        stopLatch.countDown();
+        return;
+      }
+
+      try {
+        for (int i = 0; i < numRuns; ++i) {
+          for (int j = 0, size = columnarInts.size(); j < size; ++j) {
+            final long val = vals[j];
+            final long indexedVal = columnarInts.get(j);
+            if (Longs.compare(val, indexedVal) != 0) {
+              failureHappened.set(true);
+              reason.set(StringUtils.format("Thread1[%d]: %d != %d", j, val, indexedVal));
+              stopLatch.countDown();
+              return;
+            }
+          }
+        }
+      }
+      catch (Exception e) {
+        e.printStackTrace();
+        failureHappened.set(true);
+        reason.set(e.getMessage());
+      }
+
+      stopLatch.countDown();
+    }).start();
+
+    final ColumnarInts columnarInts2 = supplier.get();
+    try {
+      new Thread(() -> {
+        try {
+          startLatch.await();
+        }
+        catch (InterruptedException e) {
+          stopLatch.countDown();
+          return;
+        }
+
+        try {
+          for (int i = 0; i < numRuns; ++i) {
+            for (int j = columnarInts2.size() - 1; j >= 0; --j) {
+              final long val = vals[j];
+              final long indexedVal = columnarInts2.get(j);
+              if (Longs.compare(val, indexedVal) != 0) {
+                failureHappened.set(true);
+                reason.set(StringUtils.format("Thread2[%d]: %d != %d", j, val, indexedVal));
+                stopLatch.countDown();
+                return;
+              }
+            }
+          }
+        }
+        catch (Exception e) {
+          e.printStackTrace();
+          reason.set(e.getMessage());
+          failureHappened.set(true);
+        }
+
+        stopLatch.countDown();
+      }).start();
+
+      startLatch.countDown();
+
+      stopLatch.await();
+    }
+    finally {
+      CloseQuietly.close(columnarInts2);
+    }
+
+    if (failureHappened.get()) {
+      Assert.fail("Failure happened.  Reason: " + reason.get());
+    }
+  }
+
+  private void serializeAndGetSupplier() throws IOException
+  {
+    SegmentWriteOutMedium writeOutMedium = new OnHeapMemorySegmentWriteOutMedium();
+
+    final SegmentWriteOutMedium segmentWriteOutMedium = new OnHeapMemorySegmentWriteOutMedium();
+    IntFormEncoder[] encoders = ShapeShiftingColumnarIntsSerializer.getDefaultIntFormEncoders(
+      blockSize,
+      CompressionStrategy.LZ4,
+      writeOutMedium.getCloser(),
+      byteOrder
+    );
+
+    List<IntFormEncoder> encoderList = Arrays.asList(encoders);
+
+    // todo: probably a better way to do this...
+    switch (encoderSet) {
+      case "bytepack":
+        encoders = encoderList.stream()
+                              .filter(e -> e instanceof BytePackedIntFormEncoder)
+                              .toArray(IntFormEncoder[]::new);
+        break;
+      case "rle-bytepack":
+        encoders = encoderList.stream()
+                              .filter(e -> e instanceof RunLengthBytePackedIntFormEncoder)
+                              .toArray(IntFormEncoder[]::new);
+        break;
+      case "fastpfor":
+        encoders = encoderList.stream()
+                              .filter(e -> e instanceof LemireIntFormEncoder)
+                              .toArray(IntFormEncoder[]::new);
+        break;
+      case "lz4-bytepack":
+        encoders =
+            encoderList.stream()
+                       .filter(e -> e instanceof CompressedFormEncoder &&
+                                    ((CompressedFormEncoder) e).getInnerEncoder() instanceof BytePackedIntFormEncoder
+                       ).toArray(IntFormEncoder[]::new);
+        break;
+      case "lz4-rle-bytepack":
+        encoders =
+            encoderList.stream()
+                       .filter(e -> e instanceof CompressedFormEncoder &&
+                                    ((CompressedFormEncoder) e).getInnerEncoder() instanceof RunLengthBytePackedIntFormEncoder
+                       ).toArray(IntFormEncoder[]::new);
+        break;
+      case "lz4":
+        encoders =
+            encoderList.stream().filter(e -> e instanceof CompressedFormEncoder).toArray(IntFormEncoder[]::new);
+        break;
+    }
+
+    ShapeShiftingColumnarIntsSerializer serializer = new ShapeShiftingColumnarIntsSerializer(
+        segmentWriteOutMedium,
+        encoders,
+        optimizationTarget,
+        blockSize,
+        byteOrder
+    );
+    serializer.open();
+    for (int val : vals) {
+      serializer.addValue(val);
+    }
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    serializer.writeTo(Channels.newChannel(baos), null);
+
+    writeOutMedium.close();
+    final byte[] bytes = baos.toByteArray();
+    Assert.assertEquals(serializer.getSerializedSize(), bytes.length);
+
+    supplier = ShapeShiftingColumnarIntsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), byteOrder);
+    columnarInts = supplier.get();
+  }
+
+
+  private void seedAndEncodeData(final int totalSize) throws IOException
+  {
+    int intChunkSize = 1 << (blockSize.getLogBlockSize() - 2);
+
+    vals = new int[totalSize];
+    Random rand = new Random(0);
+    boolean isZero = false;
+    boolean isConstant = false;
+    int constant = 0;
+
+    for (int i = 0; i < vals.length; ++i) {
+      // occasionally write a zero or constant block for funsies
+      if (i != 0 && (i % intChunkSize == 0)) {
+        isZero = false;
+        isConstant = false;
+        int rando = rand.nextInt(3);
+        switch (rando) {
+          case 0:
+            isZero = true;
+            break;
+          case 1:
+            isConstant = true;
+            constant = rand.nextInt((1 << 31) - 1);
+            break;
+
+        }
+      }
+
+      if (isZero) {
+        vals[i] = 0;
+      } else if (isConstant) {
+        vals[i] = constant;
+      } else {
+        vals[i] = rand.nextInt((1 << 31) - 1);
+      }
+    }
+
+    serializeAndGetSupplier();
+  }
+
+
+  // todo: copy pasta, maybe should share these validation methods between tests
+  private void assertIndexMatchesVals()
+  {
+    Assert.assertEquals(vals.length, columnarInts.size());
+
+    // sequential access
+    int[] indices = new int[vals.length];
+    for (int i = 0, size = columnarInts.size(); i < size; i++) {
+      Assert.assertEquals("row mismatch at " + i, vals[i], columnarInts.get(i), 0.0);
+      indices[i] = i;
+    }
+
+    // random access, limited to 1000 elements for large lists (every element would take too long)
+    IntArrays.shuffle(indices, ThreadLocalRandom.current());
+    final int limit = Math.min(columnarInts.size(), 1000);
+    for (int i = 0; i < limit; ++i) {
+      int k = indices[i];
+      Assert.assertEquals(vals[k], columnarInts.get(k), 0.0);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new approach to representing numerical columns in which row values are split into varyingly _encoded_ blocks, dubbed _shape-shifting_ columns for [obvious](https://rpg.stackexchange.com/questions/112244/is-the-shapeshifting-druid-an-original-dd-invention), [druid](https://wow.gamepedia.com/Druid_Shapeshift_forms) reasons. In other words, we are trading a bit extra compute and memory at indexing time to analyze each block of values and find the most appropriate encoding, in exchange for potential increased decoding speed and decreased encoded size on the query side. The end result is _hopefully_ faster performance in most cases.

Included in this PR is the base generic structure for creating and reading `ShapeShiftingColumn` as well as an implementation for the integer column part of dictionary encoded columns, `ShapeShiftingColumnarInts`. I have an additional branch in development with an implementation for long columns which was done as a reference to make sure the generic base structure is workable and will follow on the tail of this PR, as well as some experiments I would like to do with floats/doubles, so they hopefully won't be far behind either. For ints at least, the result is something that in many cases will decode as fast or faster and be as small or smaller `CompressedVSizeColumnarInts` with lz4.

## tl;dr
### The good
This PR can _likely_ make your queries faster, and maybe, your data smaller. Based on observations thus far, I would advocate making this the default in whatever major version + 1 this PR makes it into (if it continues to perform well in the wild of course), but the intention for now is to be an optional/experimental feature specified at indexing time. You will mainly see two types of plots generated from benchmarks in this writeup comparing `ShapeShiftingColumnarInts` to `CompressedVSizeColumnarInts` trying to convince you of this, one of which is a summary of encoded sizes by column and for the whole segment:

![wiki-2-size-summary](https://user-images.githubusercontent.com/1577461/42849111-c36bfcfc-89d6-11e8-9fea-7b16bb36136c.gif)

and the other which has a line chart of 'time to select n rows' where 'time to select' is the y axis and 'n' as a fraction of total rows in the column is the x axis:

![wiki-2-select-speed](https://user-images.githubusercontent.com/1577461/42849138-e1b27880-89d6-11e8-8946-289a1ef7c11f.gif)

as well as 2 bar charts, one showing encoded size comparison, the other encoding speed comparison. Most of these are animations which show each column. The dip at the end is actually a cliff caused by the benchmark iterating the column without a simulated filter, to get raw total scan speed for the entire column. Beyond benchmarks, there is a bunch of design description and background of how things ended up how they are, to hopefully make review easier.

### The bad
This isn't currently better 100% of the time, specifically in the case of low cardinality dimensions that have a semi-random distribution without a lot of repeated values. The reason shape-shifting columns perform worse in this case is due to fixed using block sizes that are decided prior to indexing, where `CompressedVSizeColumnarIntsSerializer` byte packs on the fly until a fixed size buffer is full, effectively allowing it to vary block size to have up to 4 times as many values per block as the current largest block size setting provided for the shape-shifting serializer, allowing lz4 to take advantage of having more values to work with per run. There is nothing preventing the use of varying sized blocks for shape-shifting columns, so this could likely be overcome in one way or another. I am just currently erring on the side of caution to attempt to limit heap pressure that this PR already introduces where there previously was none, which makes me nervous but has seemed ok so far while running on a test cluster. Additionally, because these columns have a different memory profile than `CompressedVSizeColumnarInts` for both indexing and query, jvm configuration adjustments will likely need to be made, especially if your cluster is tuned to effectively use most of it's resources. See the 'Memory Footprint' section of the design section for more details. Overall indexing time might also change, sometimes faster, sometimes slower, encode speed is dependent on value composition so can range quite a lot between columns.

## Design

On the query side, `ShapeShiftingColumn` implementations are designed to implement the actual logic to get values for row indices within the column implementation, which through meticulous benchmarking has proven to be the maximally performant arrangement I could find and do the things we are doing here. This is an alternative approach to pushing down reads into a decoder type, as is done in the `BlockLayout...`  `EntireLayout...` implementations for long columns. To put row reads _in_ the column, a `ShapeShiftingColumn` implementation operates on a slightly unintuitive pattern, that for each block it will pass itself into a decoder which knows how to mutate _things_ the column such that the column's 'get' function will produce the correct data for the row index. Vague, I know, but we'll get there. Sticking with the theme, these phase changes between the chunks of the data while reading are called _transformations_. This design is a bit less straightforward than I was hoping to end up with, but this inversion of responsibility allows the implementation beat the performance penalty that faces the `BlockLayout...`  `EntireLayout...` with `EncodingReader` pattern which is [vaguely alluded to here](https://github.com/druid-io/druid/blob/master/processing/src/main/java/io/druid/segment/data/BlockLayoutColumnarLongsSupplier.java#L60). More on this later (and pictures). 

### Background
##### FastPFOR
The works produced in this PR actually began life as a follow up [investigation to using the FastPFOR algorithm](https://github.com/druid-io/druid/issues/4080) to encode integer value columns, writing additional benchmarks to expand upon the random valued columns tested in that thread to use the column value generators to compare FastPFOR against `CompressedVSizeColumnarInts` across a wide variety of column value distributions. Things looked really good in early tests, FastPFOR was doing very well, often outperforming the lz4 bytepacking across the board on encoding speed, encoded size, and decoding speed. 

![generator-fastpfor-select-speed](https://user-images.githubusercontent.com/1577461/42849186-10f087e0-89d7-11e8-9bbf-43d2df8823ad.gif)

From there, benchmarks were expanded to test against actual integer columns from actual segments, where FastPFOR was initially looking even better as a standalone option.

![wiki-2-all-fastpfor-size-summary](https://user-images.githubusercontent.com/1577461/42849208-26fb8148-89d7-11e8-9f90-e9dafb7cba03.gif)

![wiki-2-fastpfor-select-speed](https://user-images.githubusercontent.com/1577461/42849211-2ba44392-89d7-11e8-98d8-e82ed1b8f35e.gif)

However, once I began looking at one of our 'metrics-like' data sets, where the encoded size using FastPFOR was on the order of double the size of using the existing lz4 bytepacking.

![clarity-1-fastpfor-size-summary](https://user-images.githubusercontent.com/1577461/42849238-424ed9ea-89d7-11e8-88ec-64871b27ec3c.gif)

Examining more metrics datasources produced similar results. Many columns decoded faster, but the increased size cost was too much to be something that we could consider making the default, greatly reducing the utility of this feature if it were to require cluster operators to experiment with segments by hand to compare FastPFOR and lz4 bytepacking to see which performed better with their columns. Note that this is unrelated to the previous mentioned block size issue, increased block size had little effect on overall encoded size, it's more a case of being a data distribution which fastpfor overall does pretty poorly with compared to lz4.

Thinking that the sparse nature of many metrics datasets might be the cause, I made a 'RunFastPFOR' version of the column that eliminated blocks that were entirely zeros or a constant value by putting a byte header in each chunk to indicate if a block was zero, constant, or FastPFOR encoded, which helped a bit but still couldn't compete with the existing implementation. Noting that encoding speed for FastPFOR being so much faster than lz4, we considered a system that would try both and use whichever was better (similar to the intermediary column approach with longs), and also looked into introducing a run length encoding into the mix to see how much repeated values played a role in how well lz4 was doing comparatively. Searching for some reading about run length encoding, I came across some Apache ORC encoding docs (the original link is dead, but most of the content is contained [here](https://orc.apache.org/specification/ORCv2/)) which upon reading, caused something to click, realizing my earlier 'RunFastPFOR' sketch was maybe on to something, but to try _all_ encodings and vary per block. This is similar to the 'auto' idea via intermediary columns used in longs, but can much better capitalize on encodings that do well in specialized circumstances, since an encoding doesn't have to do well for the entire column at once. 'Shape-shifting' columns were born and I finally had something that was competitive even on metrics like datasets. Sizes still come out occasionally larger in some cases, due to differences in block sizes used between the 2 strategies, but in observations so far it has been able to achieve acceptable sizes.

##### Column Structure
Concurrent with experimentations with FastPFOR, I was also investigating how to best wire it into the current segment structure, should it prove itself useful. [Previous efforts](https://github.com/druid-io/druid/pull/3148) had done work to introduce the structure to have a variety of encodings for longs, floats, and double columns, so I began there. I created `EntireLayoutColumnarInts` and `BlockLayoutColumnarInts` in the pattern that was done with longs, and ported the byte packing algorithm we currently employ for ints into the `EncodingReader` and `EncodingWriter` pattern used by `ColumnarLongs`. Benchmarking it however (`bytepacked` in the chart below), showed a performance slowdown compared to the existing implementation (`vsize-byte` aka `VSizeColumnarInts`).

![entire-layout](https://user-images.githubusercontent.com/1577461/42849361-bfc56a24-89d7-11e8-8648-50c9a4d92f1f.png)

This is the performance drop in action from the overhead of these additional layers of indirection mentioned above. It is also apparent in the long implementation:

![long-auto](https://user-images.githubusercontent.com/1577461/42849379-d1483132-89d7-11e8-8cdd-2382690d70b6.gif)

where at low row selection `lz4-auto` wins because it's decompressing a smaller volume of data, but when reading more values `lz4-longs`, which optimizes out the encoding reader entirely, becomes faster.

After it became apparent that FastPFOR alone was not a sufficient replacement for lz4 bytepacking, I sketched a couple of competing implementations of `ShapeShiftingColumnarInts` to try to both have a mechanism to abstract decoding and reading values from column implementation, but not suffer the same performance drop of the earlier approach. One was a simpler 'block' based approach that always eagerly decoded everything into an array, on the hope that because row gets are just an array access if on the same chunk, it could keep up with `CompressedVSizeColumnarInts` which eagerly decompresses but supports random access to individual row values unpacking bytes on the fly. The other approach was attempting to support random access for encodings that supported it, similar in spirit to the `BlockLayout` approach, but with one less layer of indirection. It had more overhead than the array based approach since it had a set of decoder objects and pushed reads down into them, but less than . Initial results were as expected, random access did better for a smaller number of rows selection, but was slower for a large scan than the array based approach, and both did reasonable compared to `CompressedVSizeColumnarInts`. In the following plots, `shapeshift` is the random access approach, `shapeshift-block` is the array based approach.

![shapeshift-ok](https://user-images.githubusercontent.com/1577461/42849404-ecdb538e-89d7-11e8-97e6-41c3b1bf8657.png)

However I eventually ran into a degradation similar in nature to what I saw with the `BlockLayout`/`EntireLayout` approach with my random access implementation, but it only happened when more than 2 encodings were used for a column. 

![shapeshift-sad](https://user-images.githubusercontent.com/1577461/42849424-f82f6dec-89d7-11e8-857c-38638977ca36.png)

I refactored a handful of times to try and outsmart the jvm, but as far as I can tell from running with print inlining and assembly output enabled, I was running into a similar issue with byte-code getting too large to inline. However random access did quite a lot better for low selectivity in benchmarks, so I continued experimentation to try and get the best of both worlds, which led me to where things are now - decoders that mutate the column to either read 'directly' from memory, or to populate an int array. 

I suspect even this implementation is dancing perilously close to going off the rails in the same way, so care should be definitely be taken when making any changes. However, this is true of everything in this area of the code, I find it impressively easy to just flat out wreck performance with the smallest of changes, so this is always a concern. My standard practice while working on this PR has been to fire off a full regression of benchmarks on a test machine with nearly every change I've make, and have run thousands of hours of them at this point.

### `ShapeShiftingColumn` Encoding
The generic base types for producing a `ShapeShiftingColumn` are 
* `abstract class ShapeShiftingColumnSerializer<TChunk, TChunkMetrics extends FormMetrics>` - base column serializer which has parameters to specify the type of chunks to be encoded (e.g. `int[]` or `long[]`), and the type of _metrics_ that are collected about that chunk used during encoding selection. 
* `interface FormEncoder<TChunk, TChunkMetrics extends FormMetrics>` is the interface describing... encoders, and it has generic parameters to match that of the `ShapeShiftingColumnSerializer`. 
* `abstract class FormMetrics` - the base type for the data collected about the current chunk during indexing, the `ShapeShiftingColumnSerializer` metric type generic parameter must extend this class.

`ShapeShiftingColumnSerializer` provides all typical column serialization facilities for writing to `SegmentWriteOutMedium`, and provides a method for 'flushing' chunks to the medium, `flushCurrentChunk`, which is where encoding selection is performed. Implementors must implement 2 methods, `initializeChunk` and `resetChunkCollector` which allocate the chunk storage and reset the metrics collected about a chunk respectively. It's not perfectly automatic - implementors must manually add values to the current chunk, track when to call the flush mechanism, and ensure that the `FormMetrics` are updated, all within the 'add' method of the column type serializer interface the column implements. For ints, it looks like this

```java
@Override  
public void addValue(int val) throws IOException  
{  
  if (currentChunkPos == valuesPerChunk) {  
    flushCurrentChunk();  
  }  
  
  chunkMetrics.processNextRow(val);  
  
  currentChunk[currentChunkPos++] = val;  
  numValues++;  
}
```
I blame this shortcoming more on Java generics not working with value types than anything else, as repeated near identical structure across column types is pretty common in this area of the code.

#### Encoding Selection
Encoding selection is probably the most 'magical' part of this setup. The column serializer will iterate over all available `FormEncoder` implementations, which must be able to estimate their encoded size, as well as provide a 'scaling' factor that correlates to _decoding speed relative to all other decoders_ and adjusted for the _optimization target_. The 'lowest' value is the best encoder, and is used to encode that block of values to the write out medium. This is the icky part, in that relatively thorough performance analysis must be done to see how encoding speeds relate to each other, and tune the responses of the scaling function accordingly. 

![lineitem-1-shapeshift-breakdown-size-summary](https://user-images.githubusercontent.com/1577461/42849472-2e809718-89d8-11e8-90a0-2ddd79276b31.gif)

![lineitem-1-shapeshift-breakdown-select-speed](https://user-images.githubusercontent.com/1577461/42849523-663a9d52-89d8-11e8-99f0-f685482662ba.gif)


The optimization target is to allow some _subtle_ control over behavior: 
* `ShapeShiftingOptimizationTarget.SMALLER` - "make my data as small as possible"
* `ShapeShiftingOptimizationTarget.FASTBUTSMALLISH` - "make my data small, but be chill if a way faster encoding is close in size" (default)
* `ShapeShiftingOptimizationTarget.FASTER` - "I'm willing to trade some reasonable amount of size if it means more of my queries will be faster"

I think there is a lot of room for improvement here, and I don't know how scalable this will be. However, if the general idea is workable I would rather build improvements as an additional PR since this is already quite expansive. A very easy one would be noticing 'zero' and 'constant' blocks (if encodings exist) and short circuiting general encoding selection, since those will always be the fastest and smallest choices, if available.

Compression is provided generically, since it operates at the byte level in a value agnostic way, and is available for any encoder that implements `CompressibleFormEncoder`. Implementing this interface allows encoding to a temporary `ByteBuffer` to be compressed at indexing time. However, compression very dramatically increases encoding time because it requires actually encoding and compressing the values to determine the encoded size, so we need to be very considerate about what algorithms we attempt to compress. We at least preserve the temporary buffer, so if the last compressed encoding strategy to be used is selected it does not have to be re-encoded. It would probably be legitimate to just make all encoders compressible and get rid of the extra interface, but I haven't done that at this time.

#### `ShapeShiftingColumn` byte layout
Due to shared based serializer, all `ShapeShiftingColumn` implementations have the following byte layout, consisting of 2 major parts: the header, and the data.

| version | headerSize | numValues | numChunks | logValuesPerChunk | compositionOffset | compositionSize | offsetsOffset | offsetsSize | composition | offsets | values |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | 
| byte | int | int | int | byte | int | int | `compositionOffset` | `compositionSize` | `offsetsOffset` |`offsetsOutSize` | remaining |

##### Header
* version - byte indicating column version
* headerSize - size of header, to future proof header changes
* numValues - total number of rows in the column
* numChunks - number of value chunks in the column
* logValuesPerChunk - log base 2 of chunk size
* compositionOffset - starting byte position of variable sized composition header section
* compositionSize - size in bytes of the column composition section
* offsetsOffset - starting byte position of variable sized offset header section
* offsetsOutSize - size in bytes of the 'offsets' section
* composition - count metrics for all chunk codecs
* offsets - in order _starting_ offsets into the base `ByteBuffer` for each chunk, with 'final' offset indicating end of final chunk.

##### Data
* The data section stores the actual encoded chunks, pointed to by the offsets.

The column structure is similar in many ways to `GenericIndexed`, but tailored to this specific purpose (and I was afraid to touch that, since it's everywhere).


### `ShapeShiftingColumn` Decoding
`ShapeShiftingColumn` and `FormDecoder` are the generic structure on the decoding side.
* `abstract class ShapeShiftingColumn<TShapeShiftImpl extends ShapeShiftingColumn>` - Base type for reading shapeshifting columns, uses the 'curiously recurring template' pattern to be able to share this common structure and flow, and has a generic parameter is to grant type the corresponding `FormDecoder` implementations. To read row values for a block of data, the `ShapeShiftingColumn` first reads a byte header which corresponds to a `FormDecoder` implementation, and then calls the decoder `transform` method to decode values and prepare for reading.
* `interface FormDecoder<TColumn extends ShapeShiftingColumn>` - Mutates `ShapeShiftingColumn` with a `transform` method to allow reading row values for that block of data. What exactly _transformation_ entails is column implementation specific, as these types are tightly coupled, but can include setting the decoding values into a buffer and setting it as the columns read buffer, populating a primitive value array provided by the column, and the like. The two primary models of column reads I had in mind are 'direct' reads from a `ByteBuffer` and array reads where row values for a chunk are eagerly decoded to a primitive array, which was what I needed to support both `CompressionStrategy` and `FastPFOR`.

Decompression is provided generically here too for any `ShapeShiftingColumn` through `CompressedFormDecoder`, which will decompress the data from the buffer and `transform` again using the inner decoder pointed at the decompressed data buffer. While transformation is implementation specific, raw chunk loading is not since it's just offsets on the base buffer, so `ShapeShiftingColumn` provides a `loadChunk(int chunkNumber)` that will jump to the correct offset of the requested chunk and call `transform` to prepare for value reading.

Similar to the shortcomings on the serializer side of things, implementors of `ShapeShiftingColumn` will also need to manually handle chunk loading based on block size in the row index `get` method. For integers, it looks like this:
```java
@Override  
public int get(final int index)  
{  
  final int desiredChunk = index >> logValuesPerChunk;  
  if (desiredChunk != currentChunk) {  
    loadChunk(desiredChunk);  
  }  
  return currentForm.decode(index & chunkIndexMask);  
}
```
where `currentForm` is a function that either reads a value from an array, or reads a value direct from a `ByteBuffer`, which is selected by it's implementation of `transform`.

#### Memory access
Currently, reads prefer to use `Unsafe` if the underlying column is stored in native order on a direct buffer for better performance due to lack of bounds checking on the 'get' method, and for non-native or non-direct reads, tracks offsets into the base `ByteBuffer` instead of slicing or creating any sort of other view. I know there is [an initiative to move to `Memory`](https://github.com/apache/incubator-druid/issues/3892), both of these approaches can be folded into that model. During experimentation I used `Memory` to see how it did, and without a `CompressionStrategy` it performance was closer to `Unsafe` than `ByteBuffer`, but with compression the overhead of wrapping made it slightly slower than just using `ByteBuffer`. That said, once compression supports `Memory` it should be a relatively straightforward change, and will reduce the duplicate unsafe/buffer versions of everything that currently exist. Additionally, JVM9+ claims to have performance improvements for direct byte buffers and maybe other stuff worth investigating.


## Shape-shifting integer columns
`ShapeShiftingColumnarInts` can be enabled via a new option on `IndexingSpec`

#### `IndexSpec.ColumnEncodingStrategy`
| property | type | default  | description |
| --- | --- | --- | --- | 
| strategy | string (`IndexSpec.EncodingStrategy`)| `compression`  | `(compression|shapeshift)` `compression` will result in current behavior and use the `CompressionStrategy` defined on `indexSpec.dimensionCompression`, while `shapeshift` will use `ShapeShiftingColumnarIntsSerializer`.|
| optimizationTarget | string (`IndexSpec.ShapeShiftingOptimizationTarget`)| `fastbutsmallish` | `(smaller|fastbutsmallish|faster)` see previous description of optimization target value meanings above.|
| blockSize | string (`IndexSpec.ShapeShiftingBlockSize`)| `large` | `(large|middle|small)` Set shape shifting column block sizes, corresponding to 2^16, 2^15, and 2^14 bytes, which for ints are blocks of 16k values, 8k values, and 4k values respectively for ints. Smaller block sizes put have lower memory pressure and potentially faster low selectivity scan times, but will likely produce larger overall columns sizes due to more encoding overhead.
##### example
```json
"indexSpec": {
  "dimensionCompression":"lz4",
  "intEncodingStrategy": {
    "strategy": "shapeshift",
    "optimizationTarget":"fastbutsmallish",
    "blockSize":"large"
  }
}
```
`optimizationTarget` and `blockSize` have a very subtle effect, as quite often the best codec for a given block is unambiguous. In essence, it provides control to sway the decisions when there are multiple options that are very close in terms of encoded size.

Optimization targets:

![wiki-2-optimize-size-summary](https://user-images.githubusercontent.com/1577461/42849622-cb492290-89d8-11e8-82ee-9ec7ba465935.gif)

![wiki-2-optimize-select-speed](https://user-images.githubusercontent.com/1577461/42849625-d1a344ae-89d8-11e8-8cfa-10b92b849179.gif)

Block sizes:

![wiki-2-blocks-size-summary](https://user-images.githubusercontent.com/1577461/42849632-d925555a-89d8-11e8-81f9-468a0236462a.gif)

![wiki-2-blocks-select-speed](https://user-images.githubusercontent.com/1577461/42849635-def4ea86-89d8-11e8-923b-d5e0f99c407f.gif)

Given how similar the outcomes are, it may make sense to not expose one or both of these configuration settings at all, but on the other hand it seems useful to be able to influence in the manner that best suits the use case, no matter how minor the difference. 

### Codecs

#### FastPFOR
The initial algorithm investigation that started this whole endeavor, FastPFOR is available via this [Java FastPFOR implementation](https://github.com/lemire/JavaFastPFOR) and does really well in a lot of cases.
##### layout
| header | encoded values |
| :---: | :---: |
| byte | `numOutputInts*Integer.BYTES` |

#### Bytepacking
Our old friend, byte packed integers, ported from the algorithm used by `CompressedVSizeColumnarInts`. Since values are analyzed on the fly, the number of bytes that values are packed into can vary on a chunk by chunk basis to be suited to the values. In some cases this can result in smaller column sizes than `CompressedVSizeColumnarInts`.

##### layout
| header | numBytes | encoded values |
| :---: | :---: | :---: |
| byte | byte | `numValues*numBytes`

#### Run Length Bytepacking
A simple run length encoding that uses the same byte packing strategy for integers, but uses the high bit to indicate if a value is a 'run' length or a single non-repeating value. The high bit set indicates that the value is a run length, and the next value is the value that is repeated that many times. There is very likely a better run-length implementation out there, I busted this out more or less from scratch based on the other byte packing algorithm to see how well a simple run length encoding would perform when thrown into the mix. The answer is pretty decent, situationally dependent, but I imagine there is a lot of opportunity for improvement here.
##### layout
| header | numBytes  | encoded values |
| :---: | :---: | :---: |
| byte | byte | `((2*numDistinctRuns*numBytes) + (numSingleValues*numBytes))`|

#### Unencoded
Like the name says, full 4 byte ints - more for testing and reference, I have yet to see it used in the experiments conducted so far.

##### layout
| header | values |
| :---: | :---: |
| byte | `numValues*Integer.BYTES` |

#### Zero
This encoding is an optimization to employ if a chunk of values is all zero, allowing the chunk to be represented solely with the header byte. As you can imagine, this and constant encoding can _dramatically_ reduce column size for really sparse columns.

![zero-encoding](https://user-images.githubusercontent.com/1577461/42849662-fb6a8a4a-89d8-11e8-9b2d-c808e0beaa5d.png)


##### layout
| header |
| :---: |
| byte |

#### Constant
This encoding is an optimization to employ if a chunk of values is a non-zero constant, allowing the chunk to be represented with a header byte. Like zero, this can also have a very dramatic reduction of column size.
##### layout
| header | constant |
| :---: | :---: |
| byte | int |

#### Compression
Compression algorithms from `CompressionStrategy` are available to wrap 'compressible' encodings. Out of the box, integers uses lz4 with byte-packing, run length byte-packing. Unencoded is also compressible, but is not enabled by default to reduce overall indexing time. The metadata size is to account for things like the number of bytes stored in the header of a bytepacking chunk, etc.

##### layout
| header | inner codec header | inner codec metadata | compressed data |
| :---: | :---: | :---: | :---: |
| byte | byte | `innerForm.getMetadataSize()` | remaining chunk size |


### Encoding
`ShapeShiftingColumnarIntsSerializer` is a `ShapeShiftingColumnSerializer` with `int[]` chunk type and `IntFormMetrics` to collect chunk metrics, which tracks minimum and maximum values, number of unique 'runs', the longest 'run', and the total number of values which are part of a 'run'. 

### Decoding
`ShapeShiftingColumnarInts` is a `ShapeShiftingColumn<ShapeShiftingColumnarInts>` using `FormDecoder<ShapeShiftingColumnarInts>` to decode values. `ShapeShiftingColumnarInts` decodes values in one of two basic ways depending on the encoding used, either eagerly decoding all values into an `int[]` provided by the column, or by reading values directly from a `ByteBuffer`. For buffer reads, `ShapeShiftingColumnarInts` cheats (as we must whenever possible), and natively knows of the byte packing algorithm used by `VSizeColumnarInts` and `CompressedVSizeColumnarInts` as well as constants. The base transform for int columns is to decode values into `int[]` - all decoders must currently support this, and may also implement a 'direct' transformation if the encoding supports it. I don't think it is strictly necessary that all decoders need to be able to produce to an array, admittedly this is more of an artifact of the journey that got me here and probably worth discussing.

#### Memory Footprint
`ShapeShiftingColumnarInts` does have a larger memory footprint than `CompressedVSizeColumnarInts`, having up to 64KB direct buffer, a 64KB on heap primitive 'decoded' value array, 65KB on heap primitive 'encoded' values array, depending on block size. The `FastPFOR` encoder/decoder object is an additional 1MB on heap and 200KB off heap direct buffer. With a small patch to allow setting 'page size', the FastPFOR object heap usage could be ~1/4 of it's current size, since the largest shape-shift block currently allowed is 16k values. All of the objects are pooled in `CompressedPools` and lazy allocated by the column, the on heap objects with a maximum cache size so they don't grow unbounded during spikes of load (this might need to be a config option). Pooling both prevents merely materializing the column from taking up unnecessary space (i.e. during merging at indexing time) and is also much faster since large on heap allocations can be rather slow. These sizes can be reduced by using a smaller `blockSize` on the indexing spec, which will use correctly sized direct buffers and heap arrays.

The 64KB direct buffer and 64KB on heap array are the primary memory vessels for the column, and are allocated from the pool for the lifetime of the column if they are required. They are both lazy allocated when a transformation that requires the space is encountered, so it's possible that only one or even (less commonly) none of them will be required. The 65KB 'encoded' values buffer is allocated and released for a very short time, only during a transformation for decoders that need to copy values to a `int[]` before decoding (e.g. `FastPFOR`). The `FastPFOR` pool is used in the same manner, very short lifetime during transformation, and then released back to the pool.

A downside of the current pooling approach I have in place is that each different block size has it's own set of pools to support it, so if multiple block sizes are used in practice, it will be a larger amount of heap and direct overhead. 

#### Encoding Selection
Encoding selection for `ShapeShiftingColumnarIntsSerializer` was tuned by extensively benchmarking each encoding in a standalone manner and coming up with a selection speed ranking to properly weight the scaling factor of each `IntFormEncoder` implementation.

![wiki-1-shapeshift-breakdown-size-summary](https://user-images.githubusercontent.com/1577461/42849692-33aa0a84-89d9-11e8-8ac1-171b5ca5a526.gif)

![wiki-1-shapeshift-breakdown-select-speed](https://user-images.githubusercontent.com/1577461/42849699-3968e12a-89d9-11e8-8a8e-32311c129c9d.gif)

'zero' and 'constant' are the fastest, followed by 'bytepacking', with 'FastPFOR' very close behind and finally 'lz4 bytepacking'. Run length encoding performance seems very contextual, it can be quite slow if there are not a lot of runs, but can be very quick if there are many repeated values, so it's scaling value adjusts based on the data collected `IntFormMetrics`, and compression is not attempted at all if not enough of the overall values are 'runs'.

## Benchmarks
All benchmarks were generated on a `c5.large` and corroborated on my macbook pro with the new benchmarks introduced in this PR. You can even try at home with your own segments in a semi manual way, replacing the segments referenced (but not supplied) by `BaseColumnarIntsFromSegmentsBenchmark` by setting the parameters `columnName`, `rows`, `segmentPath` which points to the segment file, and `segmentName`. Benchmarks are run in 2 phases, the first to encode the columns with each encoding specified in `BaseColumnarIntsBenchmark`, then to select values out of each column. To run, from the root druid source directory use these commands
```
$ java -server -cp benchmarks/target/benchmarks.jar io.druid.benchmark.ColumnarIntsEncodeDataFromSegmentBenchmark
...
$ java -server -cp benchmarks/target/benchmarks.jar io.druid.benchmark.ColumnarIntsSelectRowsFromSegmentBenchmark
...
```
and the results will be written to `column-ints-encode-speed-segments.csv` and `column-ints-select-speed-segments.csv` respectively.

I've also attached the R code I used to generate all of these plots, which you can feed the csv output into like so:
```R
source("./path/to/plot-column-bench.R")

wikiSize = 533652 # number of rows in segment
wiki1SelectSpeed1 = read.csv("./path/to/column-ints-select-speed-segments.csv")
wiki1EncodeSpeed1 = read.csv("./path/to/column-ints-encode-speed-segments.csv")

# to generate gif images:
animatePlot(plotIntSegBench(wiki1SelectSpeed1, wiki1EncodeSpeed1, wikiSize), "wiki-1-1.gif")
animatePlot(plotIntSegSizeSummary(wiki1EncodeSpeed1, wikiSize), "wiki-1-summary-1.gif")

# or just generate plots in R studio:
plotIntSegBench(wiki1SelectSpeed1, wiki1EncodeSpeed1, wikiSize)
plotIntSegSizeSummary(wiki1EncodeSpeed1, wikiSize)
```

### Segments
##### Datasource: 'Wikiticker'
The `wikiticker` dataset is a relatively small volume realtime datasource on our test cluster that scrapes wikipedia edits from irc to feed into kafka for ingestion. Realtime segments are quite small, so I focused on compacted segments for benchmarks to be more in line with 'recommended' segment sizes, one partially compacted, with 500,000 rows and another fully compacted to ~3.5 million rows. In my observations `shapeshift` reduces int column sizes by 10-15%, with a notably faster scan time.
Column sizes:

![wiki-1-size-summary](https://user-images.githubusercontent.com/1577461/42849737-64bb12f8-89d9-11e8-9916-a013d6cae4a0.gif)

Row select speed:

![wiki-1-select-speed](https://user-images.githubusercontent.com/1577461/42849719-5a4c0e80-89d9-11e8-8b92-f6bb66161a2f.gif)


Query metrics collected on our test cluster corroborate with these lower level benchmark results, showing respectably better query speeds. To get a baseline I repeated the same set of queries every minute against the same datasources.

<img width="1445" alt="wiki-shapeshift-metrics" src="https://user-images.githubusercontent.com/1577461/42849938-3af69248-89da-11e8-9f55-05cc42c3c81d.png">


The segments were not exactly identical, but similar enough for comparison. The int column portion of wiki segments ranges from 5-15% of total smoosh size in my observations, and overall size reduction seems to be in the 1-5% range.

##### Datasource: 'Twitter'
Similar to 'wikiticker', the 'twitter' dataset is a realtime stream of twitter activity using the kafka indexing service. This dataset has smaller gains with shape shifting columns than wikipedia, but it still outperforms `CompressedVSizeColumnarInts` much of the time, even if only slightly.
Column sizes:

![twitter-1-size-summary](https://user-images.githubusercontent.com/1577461/42850319-e0c01c8e-89db-11e8-9356-8451abd44a4f.gif)

Row select speed:

![twitter-1-select-speed](https://user-images.githubusercontent.com/1577461/42850330-f3c73bc8-89db-11e8-84d0-493adc2b41e6.gif)


##### Datasource: 'TPC-H Lineitem (1GB)'
Segment created by ingesting 1GB of 'lineitem' schema adapted from the [tpc-h dataset](http://www.tpc.org/tpch/). This was a rather large segment with just over 6 million rows, and shape-shift does quite well here.
Column sizes:

![lineitem-1-size-summary](https://user-images.githubusercontent.com/1577461/42850347-05fa8b7e-89dc-11e8-9036-4ad5d550ce71.gif)

Row select speed:

![lineitem-1-select-speed](https://user-images.githubusercontent.com/1577461/42850357-0eb106a8-89dc-11e8-9f90-9699333a65c2.gif)


Integer columns overall are 15% smaller, and for many of the columns, select speeds are generally significantly faster. However, a few of the columns are marginally slower at low selectivity levels.

##### Datasource: 'Clarity' (metrics-like)
The 'clarity' dataset is one of our druid metrics datasources. Overall column size is actually larger here by 0.5%, but many of the columns have faster select speed.
Column sizes:

![clarity-1-size-summary](https://user-images.githubusercontent.com/1577461/42850374-262aebd2-89dc-11e8-855a-375cbe2d20e4.gif)

Row select speed:

![clarity-1-select-speed](https://user-images.githubusercontent.com/1577461/42850382-310e2050-89dc-11e8-9192-a5747ee3b03c.gif)

Testing out a larger block size than is included in this PR, (64k values per block), this strategy can beat `CompressedVSizeColumnarInts` in overall encoded size: 

![clarity-mega-size-summary](https://user-images.githubusercontent.com/1577461/42850439-770ca9aa-89dc-11e8-9caf-2373744857c7.gif)

but I'm on the fence about the memory footprint on blocks this large, and have not tested select speed.


## What's left
There are still a handful of things left to do, but don't anticipate any major changes and would welcome feedback on this. Thanks for sticking with it if you made it this far, I know this is absurdly long for a PR description 😜 

### Todo:
- [ ] Tighten up configuration and control knobs
- [ ] Clean up 'todo' comments in code
- [ ] More thorough unit tests
- [ ] Test more segments from more datasources
- [ ] Stress test a test cluster to find where stuff falls over. We've had this PR running in our test cluster for over a month mirror indexing a few datasources, but have yet to really hammer it.
- [ ] Convince other people to test their own segments to confirm my results
- [ ] Seriously, convince more people to test segments

## Future Work
* Extend strategy to all numerical columns
* Smarter StupidPool that adapts object max cache size to load (or external library)
* More experiments with encoding types, JNI based decoder experiments using native versions of eager decoded algorithms like fastpfor and rle, to see if performance can be increased and column structure simplified by avoid the need for primitive arrays
* Encoders/decoders as extension points
* Collect metrics about encoded column composition
* Investigation if a sort of metrics feedback loop could help reduce encoding time by eliminating encoders which will likely perform poorly or any other enhancements to make indexing smarter and more efficient


[plot-column-bench.R.zip](https://github.com/apache/incubator-druid/files/2203886/plot-column-bench.R.zip)

