### PR TITLE
do not watch unwanted tier's data node in HttpServerInventoryView

### DIFF
--- a/server/src/main/java/org/apache/druid/client/BrokerServerView.java
+++ b/server/src/main/java/org/apache/druid/client/BrokerServerView.java
@@ -113,6 +113,10 @@ public class BrokerServerView implements TimelineServerView
           return false;
         }
 
+        if (input.rhs == null) {
+          return true;
+        }
+
         if (segmentWatcherConfig.getWatchedDataSources() != null
             && !segmentWatcherConfig.getWatchedDataSources().contains(input.rhs.getDataSource())) {
           return false;

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -390,6 +390,10 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
     synchronized (servers) {
       DruidServerHolder holder = servers.get(server.getName());
       if (holder == null) {
+        if (!finalPredicate.apply(Pair.of(server.getMetadata(), null))) {
+          log.debug("Server[%s] is not added due to not match filter.", server.getName());
+          return;
+        }
         log.info("Server[%s] appeared.", server.getName());
         holder = new DruidServerHolder(server);
         servers.put(server.getName(), holder);

--- a/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
@@ -178,7 +178,7 @@ public class HttpServerInventoryViewTest
         jsonMapper,
         httpClient,
         druidNodeDiscoveryProvider,
-        (pair) -> !pair.rhs.getDataSource().equals("non-loading-datasource"),
+        (pair) -> pair.rhs == null || !pair.rhs.getDataSource().equals("non-loading-datasource"),
         new HttpServerInventoryViewConfig(null, null, null)
     );
 


### PR DESCRIPTION
broker should not connect to realtime/historical node if node's tier is not in broker's watching tiers. Currently, broker will connect to every compute node, and do the filter in addSegment(), which is too late and is big waste, we should do the filter early in serverAdded().

would you like to review this? @himanshug 