### PR TITLE
 Avoid file rename when pushing segments with HDFSDataPusher

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -121,28 +121,13 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
     log.info("Compressing files from[%s] to [%s]", inDir, outIndexFile);
 
     final long size;
-    try (FSDataOutputStream out = fs.create(outIndexFile)) {
+    try (FSDataOutputStream out = fs.create(outIndexFile, false)) {
       size = CompressionUtils.zip(inDir, out);
     }
 
     return segment.withLoadSpec(makeLoadSpec(outIndexFile.toUri()))
                   .withSize(size)
                   .withBinaryVersion(SegmentUtils.getVersionFromDir(inDir));
-  }
-
-  private void copyFilesWithChecks(final FileSystem fs, final Path from, final Path to) throws IOException
-  {
-    if (!HadoopFsWrapper.rename(fs, from, to)) {
-      if (fs.exists(to)) {
-        log.info(
-            "Unable to rename temp file [%s] to segment path [%s], it may have already been pushed by a replica task.",
-            from,
-            to
-        );
-      } else {
-        throw new IOE("Failed to rename temp file [%s] and final segment path [%s] is not present.", from, to);
-      }
-    }
   }
 
   @Override

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -25,7 +25,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.SegmentUtils;
@@ -35,7 +34,6 @@ import org.apache.druid.utils.CompressionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.HadoopFsWrapper;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.format.ISODateTimeFormat;
 

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
@@ -249,13 +249,16 @@ public class HdfsDataSegmentPusherTest
 
       // push twice will fail and temp dir cleaned
       File outDir = new File(StringUtils.format("%s/%s", config.getStorageDirectory(), segmentPath));
+      Exception ex = null;
       outDir.setReadOnly();
       try {
         pusher.push(segmentDir, segments[i], false);
       }
       catch (IOException e) {
-        Assert.fail("should not throw exception");
+        ex = e;
       }
+      // Should throw exception when pushing segment twice.
+      Assert.assertNotNull(ex);
     }
   }
 
@@ -324,13 +327,16 @@ public class HdfsDataSegmentPusherTest
 
     // push twice will fail and temp dir cleaned
     File outDir = new File(StringUtils.format("%s/%s", config.getStorageDirectory(), segmentPath));
+    Exception ex = null;
     outDir.setReadOnly();
     try {
       pusher.push(segmentDir, segmentToPush, false);
     }
     catch (IOException e) {
-      Assert.fail("should not throw exception");
+      ex = e;
     }
+    // Should throw exception when pushing segment twice.
+    Assert.assertNotNull(ex);
   }
 
   public static class TestObjectMapper extends ObjectMapper

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -453,7 +453,7 @@ public class RealtimePlumber implements Plumber
               DataSegment segment = dataSegmentPusher.push(
                   mergedFile,
                   sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes)),
-                  true
+                  false
               );
               log.info("Inserting [%s] to the metadata store", sink.getSegment().getId());
               segmentPublisher.publishSegment(segment);

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -453,7 +453,7 @@ public class RealtimePlumber implements Plumber
               DataSegment segment = dataSegmentPusher.push(
                   mergedFile,
                   sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes)),
-                  false
+                  true
               );
               log.info("Inserting [%s] to the metadata store", sink.getSegment().getId());
               segmentPublisher.publishSegment(segment);


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/7532

In HdfsDataSegmentPusher, a push to temporary location and a copy is not required as we can safely rely on the useUniquePath flag to avoid path conflicts of multiple tasks.

This PR removes the un-necessary writing to a temp file and copy. 