### PR TITLE
hll sketch to accept array as input

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregator.java
@@ -107,6 +107,12 @@ public class HllSketchBuildAggregator implements Aggregator
       for (String v : list) {
         sketch.update(v.toCharArray());
       }
+    } else if (value instanceof String[]) {
+      // noinspection unchecked
+      String[] list = (String[]) value;
+      for (String v : list) {
+        sketch.update(v.toCharArray());
+      }
     } else if (value instanceof char[]) {
       sketch.update((char[]) value);
     } else if (value instanceof byte[]) {

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -127,7 +127,7 @@ public class HllSketchAggregatorTest
             ImmutableList.of(
                 new ExpressionTransform(
                     "multiDim",
-                    "array_append(multiDim, '0')",
+                    "array_append(multiDim, 0)",
                     ExprMacroTable.nil()
                 )
             )

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -127,7 +127,7 @@ public class HllSketchAggregatorTest
             ImmutableList.of(
                 new ExpressionTransform(
                     "multiDimAppended",
-                    "array_append(multiDim, '0')",
+                    "array_append(multiDim, '15')",
                     ExprMacroTable.nil()
                 )
             )

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -259,7 +259,7 @@ public class HllSketchAggregatorTest
       List<ExpressionTransform> transforms
   )
   {
-    List<Map<String, String>> transformsObjects = transforms.stream().map( transform ->
+    List<Map<String, String>> transformsObjects = transforms.stream().map(transform ->
         ImmutableMap.of(
             "type", "expression",
             "name", transform.getName(),

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -290,7 +290,7 @@ public class HllSketchAggregatorTest
     Map<String, Object> object = ImmutableMap.of(
         "type", "string",
         "parseSpec", parseSpec,
-        "transformationSpec", transformsObject
+        "transformSpec", transformsObject
     );
     return toJson(object);
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -141,7 +141,7 @@ public class HllSketchAggregatorTest
     List<ResultRow> results = seq.toList();
     Assert.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(200, (double) row.get(0), 0.1);
+    Assert.assertEquals(15, (double) row.get(0), 0.1);
   }
 
   @Test
@@ -183,7 +183,7 @@ public class HllSketchAggregatorTest
     List<ResultRow> results = seq.toList();
     Assert.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(15, (double) row.get(0), 0.1);
+    Assert.assertEquals(14, (double) row.get(0), 0.1);
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -126,13 +126,13 @@ public class HllSketchAggregatorTest
             Arrays.asList("timestamp", "dim", "multiDim", "id"),
             ImmutableList.of(
                 new ExpressionTransform(
-                    "multiDim",
-                    "array_append(multiDim, 0)",
+                    "multiDimAppended",
+                    "array_append(multiDim, '0')",
                     ExprMacroTable.nil()
                 )
             )
         ),
-        buildAggregatorJson("HLLSketchBuild", "multiDim", !ROUND),
+        buildAggregatorJson("HLLSketchBuild", "multiDimAppended", !ROUND),
         0, // minTimestamp
         Granularities.NONE,
         200, // maxRowCount


### PR DESCRIPTION
Fixes #8613.

### Description

Adds `String[]` support for HLL sketches generation.

This fix lets customers use results of transformation as input for HLL Build aggregation.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added integration tests.

<hr>

##### Key changed/added classes in this PR
 * `HllSketchBuildAggregator`