### PR TITLE
resolve resolveip command not found issue in integration test

### DIFF
--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -86,4 +86,4 @@ EXPOSE 8300 8301 8302 8303 8304 8305
 EXPOSE 9092 9093
 
 WORKDIR /var/lib/druid
-ENTRYPOINT export HOST_IP="$(resolveip -s $HOSTNAME)" && /tls/generate-server-certs-and-keystores.sh && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+ENTRYPOINT export HOST_IP="$(curl ifconfig.me)" && /tls/generate-server-certs-and-keystores.sh && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/integration-tests/docker/tls/generate-expired-client-cert.sh
+++ b/integration-tests/docker/tls/generate-expired-client-cert.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+export DOCKER_HOST_IP=$(curl ifconfig.me)
 
 cat <<EOT > expired_csr.conf
 [req]

--- a/integration-tests/docker/tls/generate-good-client-cert.sh
+++ b/integration-tests/docker/tls/generate-good-client-cert.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+export DOCKER_HOST_IP=$(curl ifconfig.me)
 
 cat <<EOT > csr.conf
 [req]

--- a/integration-tests/docker/tls/generate-incorrect-hostname-client-cert.sh
+++ b/integration-tests/docker/tls/generate-incorrect-hostname-client-cert.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+export DOCKER_HOST_IP=$(curl ifconfig.me)
 
 # Generate a client cert with an incorrect hostname for testing
 cat <<EOT > invalid_hostname_csr.conf

--- a/integration-tests/docker/tls/generate-invalid-intermediate-client-cert.sh
+++ b/integration-tests/docker/tls/generate-invalid-intermediate-client-cert.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+export DOCKER_HOST_IP=$(curl ifconfig.me)
 
 cat <<EOT > invalid_ca_intermediate.conf
 [req]

--- a/integration-tests/docker/tls/generate-to-be-revoked-client-cert.sh
+++ b/integration-tests/docker/tls/generate-to-be-revoked-client-cert.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+export DOCKER_HOST_IP=$(curl ifconfig.me)
 
 # Generate a client cert that will be revoked
 cat <<EOT > revoked_csr.conf

--- a/integration-tests/docker/tls/generate-untrusted-root-client-cert.sh
+++ b/integration-tests/docker/tls/generate-untrusted-root-client-cert.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+export DOCKER_HOST_IP=$(curl ifconfig.me)
 
 cat <<EOT > csr_another_root.conf
 [req]

--- a/integration-tests/docker/tls/generate-valid-intermediate-client-cert.sh
+++ b/integration-tests/docker/tls/generate-valid-intermediate-client-cert.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+export DOCKER_HOST_IP=$(curl ifconfig.me)
 
 cat <<EOT > ca_intermediate.conf
 [req]


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes (partially) #7842 .

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
We use `resolveip` to get the hose ip address when generating the keys and certs, which command not necessary already installed/worked well on that platform where user run the integration test. This would cause the integration test fail. Replacing `resolveip` with `curl ifconfig.me` to get the host ip address will be more robust and prevent the integration test fail.

However, I'm still getting below error after this issue is resolved: `java.net.ConnectException: Connection refused: /192.168.99.100:8081` Coordinator does not start up in time for some reason, which requires more research.



