### PR TITLE
bug fix for unit test

### DIFF
--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -613,6 +613,9 @@ public class DruidCoordinatorBalancerTest
     @Override
     public BalancerSegmentHolder pickSegmentToMove(List<ServerHolder> serverHolders)
     {
+      if (serverHolders.size() == 0) {
+        return null;
+      }
       return pickOrder.get(pickCounter.getAndIncrement() % pickOrder.size());
     }
 


### PR DESCRIPTION
Unit test fix for DruidCoordinatorBalancerTest

### Description
Some of current unit test will go thought decommissioning logic, but it should test general balance feature.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.


<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.server.coordinator.DruidCoordinatorBalancerTest`