### PR TITLE
add explodeSpec

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/FlattenJSONBenchmarkUtil.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/FlattenJSONBenchmarkUtil.java
@@ -57,6 +57,7 @@ public class FlattenJSONBenchmarkUtil
         new TimestampSpec("ts", "iso", null),
         new DimensionsSpec(null, null, null),
         null,
+        null,
         null
     );
     return spec.makeParser();
@@ -71,6 +72,7 @@ public class FlattenJSONBenchmarkUtil
         new TimestampSpec("ts", "iso", null),
         new DimensionsSpec(null, null, null),
         flattenSpec,
+        null,
         null
     );
 
@@ -114,6 +116,7 @@ public class FlattenJSONBenchmarkUtil
         new TimestampSpec("ts", "iso", null),
         new DimensionsSpec(null, null, null),
         flattenSpec,
+        null,
         null
     );
 
@@ -157,6 +160,7 @@ public class FlattenJSONBenchmarkUtil
         new TimestampSpec("ts", "iso", null),
         new DimensionsSpec(null, null, null),
         flattenSpec,
+        null,
         null
     );
 
@@ -198,6 +202,7 @@ public class FlattenJSONBenchmarkUtil
         new TimestampSpec("ts", "iso", null),
         new DimensionsSpec(null, null, null),
         flattenSpec,
+        null,
         null
     );
 

--- a/core/src/main/java/org/apache/druid/data/input/impl/ParseSpec.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/ParseSpec.java
@@ -28,6 +28,7 @@ import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.java.util.common.parsers.Parser;
 
 import java.util.List;
+import java.util.Objects;
 
 @ExtensionPoint
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "format")
@@ -98,12 +99,10 @@ public abstract class ParseSpec
 
     ParseSpec parseSpec = (ParseSpec) o;
 
-    if (timestampSpec != null ? !timestampSpec.equals(parseSpec.timestampSpec) : parseSpec.timestampSpec != null) {
+    if (!Objects.equals(timestampSpec, parseSpec.timestampSpec)) {
       return false;
     }
-    return !(dimensionsSpec != null
-             ? !dimensionsSpec.equals(parseSpec.dimensionsSpec)
-             : parseSpec.dimensionsSpec != null);
+    return !(!Objects.equals(dimensionsSpec, parseSpec.dimensionsSpec));
 
   }
 

--- a/core/src/main/java/org/apache/druid/data/input/impl/StringInputRowParser.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/StringInputRowParser.java
@@ -36,10 +36,12 @@ import java.nio.charset.Charset;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 /**
+ *
  */
 public class StringInputRowParser implements ByteBufferInputRowParser
 {
@@ -140,6 +142,15 @@ public class StringInputRowParser implements ByteBufferInputRowParser
   {
     initializeParser();
     parser.startFileFromBeginning();
+  }
+
+
+  public List<InputRow> parseBatch(@Nullable String input)
+  {
+    initializeParser();
+    List<InputRow> returnList = new ArrayList<>();
+    parser.parseToMapList(input).forEach(e -> returnList.add(parseMap(e)));
+    return returnList;
   }
 
   @Nullable

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/AbstractFlatTextFormatParser.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/AbstractFlatTextFormatParser.java
@@ -127,6 +127,12 @@ public abstract class AbstractFlatTextFormatParser implements Parser<String, Obj
   }
 
   @Override
+  public List<Map<String, Object>> parseToMapList(final String input)
+  {
+    return Utils.nullableListOf(parseToMap(input));
+  }
+
+  @Override
   public Map<String, Object> parseToMap(final String input)
   {
     if (!supportSkipHeaderRows && (hasHeaderRow || maxSkipHeaderRows > 0)) {

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONExplodeSpec.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONExplodeSpec.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common.parsers;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class JSONExplodeSpec
+{
+  public static final JSONExplodeSpec DEFAULT =
+      new JSONExplodeSpec(null, null);
+
+  private final String explodePath;
+  private final String type;
+
+  @JsonCreator
+  public JSONExplodeSpec(
+      @JsonProperty("path") String explodePath,
+      @JsonProperty("type") String type
+  )
+  {
+    this.explodePath = explodePath;
+    this.type = type;
+  }
+
+  @JsonProperty
+  public String getExplodePath()
+  {
+    return explodePath;
+  }
+
+  @JsonProperty
+  public String getType()
+  {
+    return type;
+  }
+
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JSONExplodeSpec that = (JSONExplodeSpec) o;
+    return explodePath.equals(that.explodePath) &&
+           type.equals(that.type);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(explodePath, type);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "JSONExplodeSpec{" +
+           "explodePath=" + explodePath +
+           ", type=" + type +
+           '}';
+  }
+}
+

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONExplodeSpec.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONExplodeSpec.java
@@ -29,23 +29,23 @@ public class JSONExplodeSpec
   public static final JSONExplodeSpec DEFAULT =
       new JSONExplodeSpec(null, null);
 
-  private final String explodePath;
+  private final String path;
   private final String type;
 
   @JsonCreator
   public JSONExplodeSpec(
-      @JsonProperty("path") String explodePath,
+      @JsonProperty("path") String path,
       @JsonProperty("type") String type
   )
   {
-    this.explodePath = explodePath;
+    this.path = path;
     this.type = type;
   }
 
   @JsonProperty
-  public String getExplodePath()
+  public String getPath()
   {
-    return explodePath;
+    return path;
   }
 
   @JsonProperty
@@ -65,21 +65,21 @@ public class JSONExplodeSpec
       return false;
     }
     final JSONExplodeSpec that = (JSONExplodeSpec) o;
-    return explodePath.equals(that.explodePath) &&
+    return path.equals(that.path) &&
            type.equals(that.type);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(explodePath, type);
+    return Objects.hash(path, type);
   }
 
   @Override
   public String toString()
   {
     return "JSONExplodeSpec{" +
-           "explodePath=" + explodePath +
+           "path=" + path +
            ", type=" + type +
            '}';
   }

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONExploderMaker.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONExploderMaker.java
@@ -64,7 +64,7 @@ public class JSONExploderMaker implements ObjectExploders.ExploderMaker<JsonNode
   }
 
   @Override
-  public JsonNode setObj(final JsonNode node, Object value, String expr)
+  public JsonNode setNodeWithValue(final JsonNode node, Object value, String expr)
   {
     final JsonPath jsonPath = JsonPath.compile(expr);
     JsonNode replica = node.deepCopy();

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectExploder.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectExploder.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common.parsers;
+
+import java.util.List;
+
+public interface ObjectExploder<T>
+{
+  List<T> explode(List<T> obj);
+}

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectExploders.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectExploders.java
@@ -46,11 +46,11 @@ public class ObjectExploders
         List<T> allObjs = obj;
         for (JSONExplodeSpec explodeSpec : explodeSpecList) {
           List<T> newAllObjs = new ArrayList<>();
-          final String path = explodeSpec.getExplodePath();
+          final String path = explodeSpec.getPath();
           for (T curObj : allObjs) {
             List<Object> arrayToExplode = exploderMaker.getExplodeArray(curObj, path);
             for (Object entry : arrayToExplode) {
-              T newObj = exploderMaker.setObj(curObj, entry, path);
+              T newObj = exploderMaker.setNodeWithValue(curObj, entry, path);
               newAllObjs.add(newObj);
             }
           }
@@ -69,7 +69,7 @@ public class ObjectExploders
   {
     List<Object> getExplodeArray(T node, String expr);
 
-    T setObj(T node, Object value, String expr);
+    T setNodeWithValue(T node, Object value, String expr);
 
     Object valueConversionFunction(JsonNode val);
 

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectExploders.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectExploders.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common.parsers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ObjectExploders
+{
+  private ObjectExploders()
+  {
+    // No instantiation.
+  }
+
+  public static <T> ObjectExploder<T> create(
+      final List<JSONExplodeSpec> explodeSpecList,
+      final ExploderMaker<T> exploderMaker
+  )
+  {
+
+    return new ObjectExploder<T>()
+    {
+
+      @Override
+      public List<T> explode(final List<T> obj)
+      {
+        List<T> allObjs = obj;
+        for (JSONExplodeSpec explodeSpec : explodeSpecList) {
+          List<T> newAllObjs = new ArrayList<>();
+          final String path = explodeSpec.getExplodePath();
+          for (T curObj : allObjs) {
+            List<Object> arrayToExplode = exploderMaker.getExplodeArray(curObj, path);
+            for (Object entry : arrayToExplode) {
+              T newObj = exploderMaker.setObj(curObj, entry, path);
+              newAllObjs.add(newObj);
+            }
+          }
+          allObjs = newAllObjs;
+        }
+        List<T> retval = new ArrayList<>();
+        for (T curObj : allObjs) {
+          retval.add(curObj);
+        }
+        return retval;
+      }
+    };
+  }
+
+  public interface ExploderMaker<T>
+  {
+    List<Object> getExplodeArray(T node, String expr);
+
+    T setObj(T node, Object value, String expr);
+
+    Object valueConversionFunction(JsonNode val);
+
+  }
+}

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/Parser.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/Parser.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.java.util.common.parsers;
 
+import org.apache.druid.java.util.common.collect.Utils;
+
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +46,18 @@ public interface Parser<K, V>
    */
   @Nullable
   Map<K, V> parseToMap(String input);
+
+
+  /**
+   * Parse a String into a List of Maps.  The result can be null which means the given input string will be ignored.
+   *
+   * @throws ParseException if the String cannot be parsed
+   */
+  @Nullable
+  default List<Map<K, V>> parseToMapList(String input)
+  {
+    return Utils.nullableListOf();
+  }
 
   /**
    * Set the fieldNames that you expect to see in parsed Maps. Deprecated; Parsers should not, in general, be

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/RegexParser.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/RegexParser.java
@@ -23,6 +23,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.druid.java.util.common.collect.Utils;
@@ -108,6 +109,12 @@ public class RegexParser implements Parser<String, Object>
     catch (Exception e) {
       throw new ParseException(e, "Unable to parse row [%s]", input);
     }
+  }
+
+  @Override
+  public List<Map<String, Object>> parseToMapList(String input)
+  {
+    return ImmutableList.of(parseToMap(input));
   }
 
   @Override

--- a/core/src/test/java/org/apache/druid/data/input/impl/InputRowParserSerdeTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/InputRowParserSerdeTest.java
@@ -52,6 +52,7 @@ public class InputRowParserSerdeTest
             new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), null, null),
             null,
+            null,
             null
         ),
         null
@@ -98,6 +99,7 @@ public class InputRowParserSerdeTest
                 null
             ),
             null,
+            null,
             null
         )
     );
@@ -130,6 +132,7 @@ public class InputRowParserSerdeTest
                 ImmutableList.of("toobig", "value"),
                 null
             ),
+            null,
             null,
             null
         )
@@ -167,6 +170,7 @@ public class InputRowParserSerdeTest
         new JSONParseSpec(
             new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("foo", "bar")), null, null),
+            null,
             null,
             null
         ),
@@ -208,6 +212,7 @@ public class InputRowParserSerdeTest
             new TimestampSpec("timestamp", "iso", null),
             new DimensionsSpec(null, null, null),
             flattenSpec,
+            null,
             null
         ),
         null

--- a/core/src/test/java/org/apache/druid/data/input/impl/JSONParseSpecTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JSONParseSpecTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.TestObjectMapper;
+import org.apache.druid.java.util.common.parsers.JSONExplodeSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class JSONParseSpecTest
@@ -57,6 +59,7 @@ public class JSONParseSpecTest
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
             )
         ),
+        null,
         null
     );
 
@@ -95,6 +98,7 @@ public class JSONParseSpecTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "bar", "$.[?(@.something_else)].something_else.foo")
             )
         ),
+        null,
         null
     );
 
@@ -119,6 +123,7 @@ public class JSONParseSpecTest
         new TimestampSpec("timestamp", "iso", null),
         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
         null,
+        null,
         feature
     );
 
@@ -132,4 +137,269 @@ public class JSONParseSpecTest
     Assert.assertEquals(Arrays.asList("bar", "foo"), serde.getDimensionsSpec().getDimensionNames());
     Assert.assertEquals(feature, serde.getFeatureSpec());
   }
+
+
+  @Test
+  public void testParseNoExplode()
+  {
+    final JSONParseSpec parseSpec = new JSONParseSpec(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
+        null,
+        null,
+        null
+    );
+
+    final String input = "{\"time\":\"2014-01-01T00:00:10Z\",\"dim\":\"a\",\"dimLong\":2,\"dimFloat\":3.0,\"val\":1}\n";
+    final Map<String, Object> explodeMap1 = new HashMap<>();
+
+    explodeMap1.put("time", "2014-01-01T00:00:10Z");
+    explodeMap1.put("dim", "a");
+    explodeMap1.put("dimLong", (long) 2);
+    explodeMap1.put("dimFloat", 3.0);
+    explodeMap1.put("val", (long) 1);
+
+
+    final Parser<String, Object> parser = parseSpec.makeParser();
+    final List<Map<String, Object>> parsedRows = parser.parseToMapList(input);
+
+    Assert.assertNotNull(parsedRows);
+    Assert.assertTrue(explodeMap1.equals(parsedRows.get(0)));
+    final Map<String, Object> parsedRow1 = parsedRows.get(0);
+
+    Assert.assertNull(parsedRow1.get("jq_omg2"));
+    Assert.assertNull(parsedRow1.get("path_omg2"));
+  }
+
+  @Test
+  public void testParseSimpleExplodeNoFlatten()
+  {
+    final JSONParseSpec parseSpec = new JSONParseSpec(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
+        null,
+        ImmutableList.of(
+            new JSONExplodeSpec("$.bidders", null)
+        ),
+        null
+    );
+
+    final String input = "{\"bidders\":[\"Baron\",\"Caro\",\"Daro\"]}";
+    final Map<String, Object> explodeMap1 = new HashMap<>();
+    final Map<String, Object> explodeMap2 = new HashMap<>();
+    final Map<String, Object> explodeMap3 = new HashMap<>();
+
+    explodeMap1.put("bidders", "Baron");
+    explodeMap2.put("bidders", "Caro");
+    explodeMap3.put("bidders", "Daro");
+
+    final List<Map<String, Object>> expectedRows = ImmutableList.of(explodeMap1, explodeMap2, explodeMap3);
+
+
+    final Parser<String, Object> parser = parseSpec.makeParser();
+    final List<Map<String, Object>> parsedRows = parser.parseToMapList(input);
+    Assert.assertNotNull(parsedRows);
+
+    for (int i = 0; i < parsedRows.size(); i++) {
+      Assert.assertTrue(expectedRows.get(i).equals(parsedRows.get(i)));
+    }
+    Assert.assertTrue(expectedRows.equals(parsedRows));
+    final Map<String, Object> parsedRow1 = parsedRows.get(0);
+    final Map<String, Object> parsedRow2 = parsedRows.get(1);
+
+    Assert.assertNull(parsedRow1.get("jq_omg2"));
+    Assert.assertNull(parsedRow1.get("path_omg2"));
+    Assert.assertNull(parsedRow2.get("bar"));
+    Assert.assertNull(parsedRow2.get("buzz"));
+  }
+
+  @Test
+  public void testParseSimpleExplodeFlatten()
+  {
+    final JSONParseSpec parseSpec = new JSONParseSpec(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
+        new JSONPathSpec(
+            true,
+            ImmutableList.of(
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_bidder", "$.bids.bidder"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_bid", "$.bids.bid"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_valid", "$.bids.valid"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_winner", "$.bids.winner")
+            )
+        ),
+        ImmutableList.of(
+            new JSONExplodeSpec("$.bids", null)
+        ),
+        null
+    );
+
+    final String input = "{\"bids\":[{\"bidder\":\"Caroline\",\"bid\":28.00,\"valid\":true,\"winner\":false},{\"bidder\":\"Robert\",\"bid\":30.00,\"valid\":true,\"winner\":true}]}";
+    final Map<String, Object> explodeMap1 = new HashMap<>();
+    final Map<String, Object> explodeMap2 = new HashMap<>();
+
+    explodeMap1.put("bids_bidder", "Caroline");
+    explodeMap1.put("bids_bid", 28.00);
+    explodeMap1.put("bids_valid", true);
+    explodeMap1.put("bids_winner", false);
+
+    explodeMap2.put("bids_bidder", "Robert");
+    explodeMap2.put("bids_bid", 30.00);
+    explodeMap2.put("bids_valid", true);
+    explodeMap2.put("bids_winner", true);
+
+    final List<Map<String, Object>> expectedRows = ImmutableList.of(explodeMap1, explodeMap2);
+
+
+    final Parser<String, Object> parser = parseSpec.makeParser();
+    final List<Map<String, Object>> parsedRows = parser.parseToMapList(input);
+    Assert.assertNotNull(parsedRows);
+
+    for (int i = 0; i < parsedRows.size(); i++) {
+      Assert.assertTrue(expectedRows.get(i).equals(parsedRows.get(i)));
+    }
+    Assert.assertTrue(expectedRows.equals(parsedRows));
+    final Map<String, Object> parsedRow1 = parsedRows.get(0);
+    final Map<String, Object> parsedRow2 = parsedRows.get(1);
+
+    Assert.assertNull(parsedRow1.get("jq_omg2"));
+    Assert.assertNull(parsedRow1.get("path_omg2"));
+    Assert.assertNull(parsedRow2.get("bar"));
+    Assert.assertNull(parsedRow2.get("buzz"));
+  }
+
+  @Test
+  public void testParseNestedExplode()
+  {
+    final JSONParseSpec parseSpec = new JSONParseSpec(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
+        new JSONPathSpec(
+            true,
+            ImmutableList.of(
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_bidder", "$.data.bids.bidder"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_bid", "$.data.bids.bid"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_valid", "$.data.bids.valid"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_winner", "$.data.bids.winner"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_info_bst", "$.data.bids.info.bidStartTime"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_info_round", "$.data.bids.info.round")
+            )
+        ),
+        ImmutableList.of(
+            new JSONExplodeSpec("$.data.bids", null),
+            new JSONExplodeSpec("$.data.bids.info", null)
+        ),
+        null
+    );
+
+    final String input = "{\"data\":{\"bids\":[{\"bidder\":\"Caroline\",\"bid\":28.00,\"valid\":true,\"winner\":false,\"info\":[{\"bidStartTime\":\"2019-05-08T11:35:00\",\"round\":\"1\"}]},{\"bidder\":\"Robert\",\"bid\":30.00,\"valid\":true,\"winner\":false,\"info\":[{\"bidStartTime\":\"2019-05-08T11:36:00\",\"round\":\"2\"}]}]}}";
+    final Map<String, Object> explodeMap1 = new HashMap<>();
+    final Map<String, Object> explodeMap2 = new HashMap<>();
+
+    explodeMap1.put("bids_bidder", "Caroline");
+    explodeMap1.put("bids_bid", 28.00);
+    explodeMap1.put("bids_valid", true);
+    explodeMap1.put("bids_winner", false);
+    explodeMap1.put("bids_info_bst", "2019-05-08T11:35:00");
+    explodeMap1.put("bids_info_round", "1");
+
+    explodeMap2.put("bids_bidder", "Robert");
+    explodeMap2.put("bids_bid", 30.00);
+    explodeMap2.put("bids_valid", true);
+    explodeMap2.put("bids_winner", false);
+    explodeMap2.put("bids_info_bst", "2019-05-08T11:36:00");
+    explodeMap2.put("bids_info_round", "2");
+
+    final List<Map<String, Object>> expectedRows = ImmutableList.of(explodeMap1, explodeMap2);
+
+    final Parser<String, Object> parser = parseSpec.makeParser();
+    final List<Map<String, Object>> parsedRows = parser.parseToMapList(input);
+
+    Assert.assertNotNull(parsedRows);
+
+    for (int i = 0; i < parsedRows.size(); i++) {
+      Assert.assertTrue(expectedRows.get(i).equals(parsedRows.get(i)));
+    }
+    Assert.assertTrue(expectedRows.equals(parsedRows));
+    final Map<String, Object> parsedRow1 = parsedRows.get(0);
+    final Map<String, Object> parsedRow2 = parsedRows.get(1);
+
+    Assert.assertNull(parsedRow1.get("jq_omg2"));
+    Assert.assertNull(parsedRow1.get("path_omg2"));
+    Assert.assertNull(parsedRow2.get("bar"));
+    Assert.assertNull(parsedRow2.get("buzz"));
+  }
+
+  @Test
+  public void testParseNestedExplodeImbalaced()
+  {
+    final JSONParseSpec parseSpec = new JSONParseSpec(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")), null, null),
+        new JSONPathSpec(
+            true,
+            ImmutableList.of(
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_bidder", "$.data.bids.bidder"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_bid", "$.data.bids.bid"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_valid", "$.data.bids.valid"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_winner", "$.data.bids.winner"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_info_bst", "$.data.bids.info.bidStartTime"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "bids_info_round", "$.data.bids.info.round")
+            )
+        ),
+        ImmutableList.of(
+            new JSONExplodeSpec("$.data.bids", null),
+            new JSONExplodeSpec("$.data.bids.info", null)
+        ),
+        null
+    );
+    final String input = "{\"data\":{\"bids\":[{\"bidder\":\"Caroline\",\"bid\":28.00,\"valid\":true,\"winner\":false,"
+                         + "\"info\":[{\"bidStartTime\":\"2019-05-08T11:35:00\",\"round\":\"1\"}]},{\"bidder\":"
+                         + "\"Robert\",\"bid\":30.00,\"valid\":true,\"winner\":false,\"info\":[{\"bidStartTime\":"
+                         + "\"2019-05-08T11:36:00\",\"round\":\"2\"},{\"bidStartTime\":\"2019-05-08T11:36:00\","
+                         + "\"round\":\"3\"}]}]}}";
+    final Map<String, Object> explodeMap1 = new HashMap<>();
+    final Map<String, Object> explodeMap2 = new HashMap<>();
+    final Map<String, Object> explodeMap3 = new HashMap<>();
+
+    explodeMap1.put("bids_bidder", "Caroline");
+    explodeMap1.put("bids_bid", 28.00);
+    explodeMap1.put("bids_valid", true);
+    explodeMap1.put("bids_winner", false);
+    explodeMap1.put("bids_info_bst", "2019-05-08T11:35:00");
+    explodeMap1.put("bids_info_round", "1");
+
+    explodeMap2.put("bids_bidder", "Robert");
+    explodeMap2.put("bids_bid", 30.00);
+    explodeMap2.put("bids_valid", true);
+    explodeMap2.put("bids_winner", false);
+    explodeMap2.put("bids_info_bst", "2019-05-08T11:36:00");
+    explodeMap2.put("bids_info_round", "2");
+
+    explodeMap3.put("bids_bidder", "Robert");
+    explodeMap3.put("bids_bid", 30.00);
+    explodeMap3.put("bids_valid", true);
+    explodeMap3.put("bids_winner", false);
+    explodeMap3.put("bids_info_bst", "2019-05-08T11:36:00");
+    explodeMap3.put("bids_info_round", "3");
+
+    final List<Map<String, Object>> expectedRows = ImmutableList.of(explodeMap1, explodeMap2, explodeMap3);
+
+    final Parser<String, Object> parser = parseSpec.makeParser();
+    final List<Map<String, Object>> parsedRows = parser.parseToMapList(input);
+    Assert.assertNotNull(parsedRows);
+
+    for (int i = 0; i < parsedRows.size(); i++) {
+      Assert.assertTrue(expectedRows.get(i).equals(parsedRows.get(i)));
+    }
+    Assert.assertTrue(expectedRows.equals(parsedRows));
+    final Map<String, Object> parsedRow1 = parsedRows.get(0);
+    final Map<String, Object> parsedRow2 = parsedRows.get(1);
+
+    Assert.assertNull(parsedRow1.get("jq_omg2"));
+    Assert.assertNull(parsedRow1.get("path_omg2"));
+    Assert.assertNull(parsedRow2.get("bar"));
+    Assert.assertNull(parsedRow2.get("buzz"));
+  }
 }
+

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/JSONPathParserTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/JSONPathParserTest.java
@@ -56,7 +56,7 @@ public class JSONPathParserTest
   public void testSimple()
   {
     List<JSONPathFieldSpec> fields = new ArrayList<>();
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null, null);
     final Map<String, Object> jsonMap = jsonParser.parseToMap(JSON);
     Assert.assertEquals(
         "jsonMap",
@@ -69,7 +69,7 @@ public class JSONPathParserTest
   public void testWithNumbers()
   {
     List<JSONPathFieldSpec> fields = new ArrayList<>();
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null, null);
     final Map<String, Object> jsonMap = jsonParser.parseToMap(NUMBERS_JSON);
     Assert.assertEquals(
         "jsonMap",
@@ -82,7 +82,7 @@ public class JSONPathParserTest
   public void testWithWhackyCharacters()
   {
     List<JSONPathFieldSpec> fields = new ArrayList<>();
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null, null);
     final Map<String, Object> jsonMap = jsonParser.parseToMap(WHACKY_CHARACTER_JSON);
     Assert.assertEquals(
         "jsonMap",
@@ -112,7 +112,7 @@ public class JSONPathParserTest
     fields.add(new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq-met-array", ".met.a"));
 
 
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null, null);
     final Map<String, Object> jsonMap = jsonParser.parseToMap(NESTED_JSON);
 
     // Root fields
@@ -173,7 +173,7 @@ public class JSONPathParserTest
     fields.add(new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq-heybarx0", ".hey[0].barx"));
     fields.add(new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq-met-array", ".met.a"));
 
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(false, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(false, fields), null, null);
     final Map<String, Object> jsonMap = jsonParser.parseToMap(NESTED_JSON);
 
     // Root fields
@@ -210,7 +210,7 @@ public class JSONPathParserTest
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Cannot have duplicate field definition: met-array");
 
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(false, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(false, fields), null, null);
     jsonParser.parseToMap(NESTED_JSON);
   }
 
@@ -224,7 +224,7 @@ public class JSONPathParserTest
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Cannot have duplicate field definition: met-array");
 
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(false, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(false, fields), null, null);
     jsonParser.parseToMap(NESTED_JSON);
   }
 
@@ -236,7 +236,7 @@ public class JSONPathParserTest
     thrown.expect(ParseException.class);
     thrown.expectMessage("Unable to parse row [" + NOT_JSON + "]");
 
-    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null);
+    final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(true, fields), null, null);
     jsonParser.parseToMap(NOT_JSON);
   }
 }

--- a/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftInputRowParserTest.java
+++ b/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftInputRowParserTest.java
@@ -68,7 +68,9 @@ public class ThriftInputRowParserTest
                                           new JSONPathFieldSpec(JSONPathFieldType.ROOT, "title", "title"),
                                           new JSONPathFieldSpec(JSONPathFieldType.PATH, "lastName", "$.author.lastName")
                                       )
-                                  ), null
+                                  ),
+                                  null,
+                                  null
     );
   }
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
@@ -82,6 +82,7 @@ public class KafkaSamplerSpecTest
                       null
                   ),
                   new JSONPathSpec(true, ImmutableList.of()),
+                  null,
                   ImmutableMap.of()
               ),
               StandardCharsets.UTF_8.name()

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -3518,6 +3518,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
                         null
                     ),
                     new JSONPathSpec(true, ImmutableList.of()),
+                    null,
                     ImmutableMap.of()
                 ),
                 StandardCharsets.UTF_8.name()

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -182,7 +182,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   private AppenderatorsManager appenderatorsManager;
   private final Set<Integer> checkpointRequestsHash = new HashSet<>();
   private RowIngestionMetersFactory rowIngestionMetersFactory;
-
+  
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
@@ -87,6 +87,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
                       null
                   ),
                   new JSONPathSpec(true, ImmutableList.of()),
+                  null,
                   ImmutableMap.of()
               ),
               StandardCharsets.UTF_8.name()

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -4991,6 +4991,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
                         null
                     ),
                     new JSONPathSpec(true, ImmutableList.of()),
+                    null,
                     ImmutableMap.of()
                 ),
                 StandardCharsets.UTF_8.name()

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespace.java
@@ -540,6 +540,7 @@ public class UriExtractionNamespace implements ExtractionNamespace
                       new JSONPathFieldSpec(JSONPathFieldType.ROOT, valueFieldName, valueFieldName)
                   )
               ),
+              null,
               jsonMapper.copy()
           ),
           keyFieldName,

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParserTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParserTest.java
@@ -71,7 +71,9 @@ public class ProtobufInputRowParserTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "foobar", "$.foo.bar"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "bar0", "$.bar[0].bar")
             )
-        ), null
+        ),
+        null,
+        null
     );
 
   }
@@ -81,7 +83,7 @@ public class ProtobufInputRowParserTest
   {
     //configure parser with desc file, and specify which file name to use
     @SuppressWarnings("unused") // expected to create parser without exception
-    ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "prototest.desc", "ProtoTestEvent");
+        ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "prototest.desc", "ProtoTestEvent");
     parser.initDescriptor();
   }
 
@@ -91,7 +93,11 @@ public class ProtobufInputRowParserTest
   {
     //configure parser with desc file, and specify which file name to use
     @SuppressWarnings("unused") // expected to create parser without exception
-    ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "prototest.desc", "prototest.ProtoTestEvent");
+        ProtobufInputRowParser parser = new ProtobufInputRowParser(
+        parseSpec,
+        "prototest.desc",
+        "prototest.ProtoTestEvent"
+    );
     parser.initDescriptor();
   }
 
@@ -101,7 +107,7 @@ public class ProtobufInputRowParserTest
   {
     //configure parser with desc file
     @SuppressWarnings("unused") // expected exception
-    ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "prototest.desc", "BadName");
+        ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "prototest.desc", "BadName");
     parser.initDescriptor();
   }
 
@@ -110,7 +116,7 @@ public class ProtobufInputRowParserTest
   {
     //configure parser with non existent desc file
     @SuppressWarnings("unused") // expected exception
-    ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "file:/nonexist.desc", "BadName");
+        ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "file:/nonexist.desc", "BadName");
     parser.initDescriptor();
   }
 
@@ -119,7 +125,7 @@ public class ProtobufInputRowParserTest
   {
     // For the backward compatibility, protoMessageType allows null when the desc file has only one message type.
     @SuppressWarnings("unused") // expected to create parser without exception
-    ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "prototest.desc", null);
+        ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, "prototest.desc", null);
     parser.initDescriptor();
   }
 

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerMapperTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerMapperTest.java
@@ -70,6 +70,7 @@ public class HadoopDruidIndexerMapperTest
                       null
                   ),
                   new JSONPathSpec(true, ImmutableList.of()),
+                  null,
                   ImmutableMap.of()
               )
           ),

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
@@ -338,6 +338,7 @@ public class IndexGeneratorJobTest
                         new TimestampSpec("ts", "yyyyMMddHH", null),
                         new DimensionsSpec(null, null, null),
                         null,
+                        null,
                         null
                     ),
                     null
@@ -370,6 +371,7 @@ public class IndexGeneratorJobTest
                     new JSONParseSpec(
                         new TimestampSpec("ts", "yyyyMMddHH", null),
                         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("B", "F", "M", "Q", "X", "Y")), null, null),
+                        null,
                         null,
                         null
                     ),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -708,7 +708,6 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
     try (
         final Firehose firehose = firehoseFactory.connect(ingestionSchema.getDataSchema().getParser(), firehoseTempDir)
     ) {
-
       while (firehose.hasMore()) {
         try {
           final InputRow inputRow = firehose.nextRow();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/FirehoseSampler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/FirehoseSampler.java
@@ -88,6 +88,13 @@ public class FirehoseSampler
               throw new ParseException(null);
             }
 
+
+            @Override
+            public List<Map<String, Object>> parseToMapList(String input)
+            {
+              throw new ParseException(null);
+            }
+
             @Override
             public void setFieldNames(Iterable<String> fieldNames)
             {
@@ -162,7 +169,6 @@ public class FirehoseSampler
     if (samplerConfig == null) {
       samplerConfig = SamplerConfig.empty();
     }
-
     final InputRowParser parser = dataSchema.getParser() != null
                                   ? dataSchema.getParser()
                                   : (firehoseFactory instanceof AbstractTextFilesFirehoseFactory
@@ -208,14 +214,12 @@ public class FirehoseSampler
         String raw = null;
         try {
           final InputRowPlusRaw row = firehose.nextRowWithRaw();
-
           if (row == null || row.isEmpty()) {
             continue;
           }
 
           if (row.getRaw() != null) {
             raw = StringUtils.fromUtf8(row.getRaw());
-
             if (!usingCachedData) {
               dataToCache.add(row.getRaw());
             }
@@ -248,7 +252,6 @@ public class FirehoseSampler
           counter++;
         }
       }
-
       final List<String> columnNames = index.getColumnNames();
       columnNames.remove(SamplerInputRow.SAMPLER_ORDERING_COLUMN);
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -1029,6 +1029,7 @@ public class IndexTaskTest extends IngestionTestBase
                 new ArrayList<>()
             ),
             null,
+            null,
             null
         ),
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -235,6 +235,7 @@ public class IngestSegmentFirehoseFactoryTest
                     ImmutableList.of()
                 ),
                 null,
+                null,
                 null
             )
         )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -96,6 +96,7 @@ public class IngestSegmentFirehoseFactoryTimelineTest
                   null
               ),
               null,
+              null,
               null
           )
       )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/FirehoseSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/FirehoseSamplerTest.java
@@ -808,7 +808,7 @@ public class FirehoseSamplerTest
         ImmutableList.of("t", "dim1", "dim2", "met1"),
         false,
         0
-    ) : new JSONParseSpec(timestampSpec, dimensionsSpec, null, null);
+    ) : new JSONParseSpec(timestampSpec, dimensionsSpec, null, null, null);
   }
 
   private String getUnparseableTimestampString()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -116,7 +116,8 @@ public class SeekableStreamIndexTaskTestBase extends EasyMockSupport
                       null
                   ),
                   new JSONPathSpec(true, ImmutableList.of()),
-                  ImmutableMap.of()
+                  null,
+                  null
               ),
               StandardCharsets.UTF_8.name()
           ),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -571,6 +571,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
                         null
                     ),
                     new JSONPathSpec(true, ImmutableList.of()),
+                    null,
                     ImmutableMap.of()
                 ),
                 StandardCharsets.UTF_8.name()

--- a/processing/src/main/java/org/apache/druid/segment/transform/TransformingStringInputRowParser.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/TransformingStringInputRowParser.java
@@ -50,6 +50,12 @@ public class TransformingStringInputRowParser extends StringInputRowParser
     return super.parseBatch(input).stream().map(transformer::transform).collect(Collectors.toList());
   }
 
+  @Override
+  public List<InputRow> parseBatch(final String input)
+  {
+    return super.parseBatch(input).stream().map(transformer::transform).collect(Collectors.toList());
+  }
+
   @Nullable
   @Override
   public InputRow parse(@Nullable final String input)

--- a/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
@@ -127,6 +127,7 @@ public class DoubleStorageTest
               ImmutableList.of()
           ),
           null,
+          null,
           null
       )
   );

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -148,7 +148,6 @@ public class DataSchema
       dimensionExclusions.addAll(aggregator.requiredFields());
       dimensionExclusions.add(aggregator.getName());
     }
-
     if (inputRowParser.getParseSpec() != null) {
       final DimensionsSpec dimensionsSpec = inputRowParser.getParseSpec().getDimensionsSpec();
       final TimestampSpec timestampSpec = inputRowParser.getParseSpec().getTimestampSpec();

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
@@ -35,6 +35,8 @@ import org.joda.time.DateTime;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -77,6 +79,7 @@ public class TimedShutoffFirehoseFactory implements FirehoseFactory<InputRowPars
   {
     private final Firehose firehose;
     private final ScheduledExecutorService shutdownExec;
+    private Iterator<InputRow> parsedInputRows = new ArrayList<InputRow>().iterator();
     @GuardedBy("this")
     private boolean closed = false;
 
@@ -85,7 +88,6 @@ public class TimedShutoffFirehoseFactory implements FirehoseFactory<InputRowPars
       firehose = sampling
                  ? delegateFactory.connectForSampler(parser, temporaryDirectory)
                  : delegateFactory.connect(parser, temporaryDirectory);
-
       shutdownExec = Execs.scheduledSingleThreaded("timed-shutoff-firehose-%d");
 
       shutdownExec.schedule(

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -72,6 +72,7 @@ public class DataSchemaTest
                 new TimestampSpec("time", "auto", null),
                 new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dimB", "dimA")), null, null),
                 null,
+                null,
                 null
             ),
             null
@@ -109,6 +110,7 @@ public class DataSchemaTest
                     null
                 ),
                 null,
+                null,
                 null
             ),
             null
@@ -145,6 +147,7 @@ public class DataSchemaTest
                     ImmutableList.of(),
                     null
                 ),
+                null,
                 null,
                 null
             ),
@@ -204,6 +207,7 @@ public class DataSchemaTest
                     "metric1"
                 )), ImmutableList.of("dimC"), null),
                 null,
+                null,
                 null
             ),
             null
@@ -236,6 +240,7 @@ public class DataSchemaTest
                     ImmutableList.of("dimC"),
                     null
                 ),
+                null,
                 null,
                 null
             ),
@@ -301,6 +306,7 @@ public class DataSchemaTest
                     ImmutableList.of("dimC"),
                     null
                 ),
+                null,
                 null,
                 null
             ),
@@ -397,6 +403,7 @@ public class DataSchemaTest
             new TimestampSpec("xXx", null, null),
             new DimensionsSpec(null, Arrays.asList("metric1", "xXx", "col1"), null),
             null,
+            null,
             null
         )
     );
@@ -423,6 +430,7 @@ public class DataSchemaTest
             new JSONParseSpec(
                 new TimestampSpec("time", "auto", null),
                 new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dimB", "dimA")), null, null),
+                null,
                 null,
                 null
             ),
@@ -462,6 +470,7 @@ public class DataSchemaTest
             new JSONParseSpec(
                 new TimestampSpec("time", "auto", null),
                 new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dimB", "dimA")), null, null),
+                null,
                 null,
                 null
             ),

--- a/server/src/test/java/org/apache/druid/segment/realtime/FireDepartmentTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/FireDepartmentTest.java
@@ -89,6 +89,7 @@ public class FireDepartmentTest
                             null
                         ),
                         null,
+                        null,
                         null
                     ),
                     null

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -130,6 +130,7 @@ public class AppenderatorTester implements AutoCloseable
                 new TimestampSpec("ts", "auto", null),
                 new DimensionsSpec(null, null, null),
                 null,
+                null,
                 null
             )
         ),

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
@@ -115,6 +115,7 @@ public class DefaultOfflineAppenderatorFactoryTest
                 new TimestampSpec("ts", "auto", null),
                 new DimensionsSpec(null, null, null),
                 null,
+                null,
                 null
             )
         ),

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseIdleTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseIdleTest.java
@@ -77,6 +77,7 @@ public class EventReceiverFirehoseIdleTest
                     null
                 ), new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("d1")), null, null),
                 null,
+                null,
                 null
             )
         ),

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseTest.java
@@ -93,6 +93,7 @@ public class EventReceiverFirehoseTest
                     null
                 ), new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("d1")), null, null),
                 null,
+                null,
                 null
             )
         ),
@@ -239,6 +240,7 @@ public class EventReceiverFirehoseTest
                             "auto",
                             null
                         ), new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("d1")), null, null),
+                        null,
                         null,
                         null
                     )

--- a/server/src/test/java/org/apache/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -141,6 +141,7 @@ public class RealtimePlumberSchoolTest
                     new TimestampSpec("timestamp", "auto", null),
                     new DimensionsSpec(null, null, null),
                     null,
+                    null,
                     null
                 ),
                 null
@@ -160,6 +161,7 @@ public class RealtimePlumberSchoolTest
                 new JSONParseSpec(
                     new TimestampSpec("timestamp", "auto", null),
                     new DimensionsSpec(null, null, null),
+                    null,
                     null,
                     null
                 ),


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Add explodeSpec feature, to give user ability to explode array objects without writing their own pre-processing scripts.



<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


#### trying to add a forbidden-apis 

in `FileIteratingFirehose`, the field ```private final ArrayList<InputRow> parsedInputRows;``` should be better declared as  `LinkedList`, as consequential operation involves lots of `push` and `pop`, so better to use a queue. `ArrayDeque` doesn't work here because we need to insert `null`

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `JSONExplodeSpec`
 * `JSONExploderMaker`
 * `ObjectExploder`
 * `ObjectExploders`
