### PR TITLE
Add docs for docker; fix compose with latest

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ZOO_MY_ID=1
 
   coordinator:
-    image: apache/incubator-druid
+    image: apache/incubator-druid:0.16.0-incubating
     container_name: coordinator
     volumes:
       - coordinator_var:/opt/druid/var
@@ -61,7 +61,7 @@ services:
       - environment
 
   broker:
-    image: apache/incubator-druid
+    image: apache/incubator-druid:0.16.0-incubating
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
@@ -77,7 +77,7 @@ services:
       - environment
 
   historical:
-    image: apache/incubator-druid
+    image: apache/incubator-druid:0.16.0-incubating
     container_name: historical
     volumes:
       - historical_var:/opt/druid/var
@@ -93,7 +93,7 @@ services:
       - environment
 
   overlord:
-    image: apache/incubator-druid
+    image: apache/incubator-druid:0.16.0-incubating
     container_name: overlord
     volumes:
       - overlord_var:/opt/druid/var
@@ -108,7 +108,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/incubator-druid
+    image: apache/incubator-druid:0.16.0-incubating
     container_name: middlemanager
     volumes:
       - middle_var:/opt/druid/var
@@ -124,7 +124,7 @@ services:
       - environment
 
   router:
-    image: apache/incubator-druid
+    image: apache/incubator-druid:0.16.0-incubating
     container_name: router
     volumes:
       - router_var:/opt/druid/var

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -123,6 +123,22 @@ The [Druid router process](../design/router.md), which serves the [Druid console
 
 It takes a few seconds for all the Druid processes to fully start up. If you open the console immediately after starting the services, you may see some errors that you can safely ignore.
 
+## Alternative: Running with Docker
+
+To get the full composition:
+```bash
+$ wget https://raw.githubusercontent.com/apache/incubator-druid/master/distribution/docker/docker-compose.yml
+```
+
+To start `druid`:
+```
+$ docker-compose up
+```
+
+Once the composition has started, you can navigate to [http://localhost:3001](http://localhost:3001) and the *Druid Console* is now available:
+
+![Druid console](../assets/tutorial-quickstart-01.png "Druid console")
+
 
 ## Loading data
 


### PR DESCRIPTION
Fixes #8702.

### Description

Adds info how to get start with Druid when using Docker.

Adds the latest docker tag in compose to be able to work out-of-the-box without having to re-tag the images locally. 