### PR TITLE
OpenJDK historical segment hand-off fails with Illegal Field Name error

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -530,7 +530,7 @@ public class DruidCoordinator
       final List<Pair<? extends CoordinatorRunnable, Duration>> coordinatorRunnables = new ArrayList<>();
       coordinatorRunnables.add(
           Pair.of(
-              new CoordinatorHistoricalManagerRunnable(startingLeaderCounter),
+              new CoordinatorHistoricalManagerRunnable(this, startingLeaderCounter),
               config.getCoordinatorPeriod()
           )
       );
@@ -689,11 +689,11 @@ public class DruidCoordinator
 
   private class CoordinatorHistoricalManagerRunnable extends CoordinatorRunnable
   {
-    public CoordinatorHistoricalManagerRunnable(final int startingLeaderCounter)
+    public CoordinatorHistoricalManagerRunnable(final DruidCoordinator druidCoordinator, final int startingLeaderCounter)
     {
       super(
           ImmutableList.of(
-              new DruidCoordinatorSegmentInfoLoader(DruidCoordinator.this),
+              new DruidCoordinatorSegmentInfoLoader(druidCoordinator),
               params -> {
                 List<ImmutableDruidServer> servers = serverInventoryView
                     .getInventory()
@@ -756,11 +756,11 @@ public class DruidCoordinator
                              .withBalancerReferenceTimestamp(DateTimes.nowUtc())
                              .build();
               },
-              new DruidCoordinatorRuleRunner(DruidCoordinator.this),
+              new DruidCoordinatorRuleRunner(druidCoordinator),
               new DruidCoordinatorCleanupUnneeded(),
-              new DruidCoordinatorCleanupOvershadowed(DruidCoordinator.this),
-              new DruidCoordinatorBalancer(DruidCoordinator.this),
-              new DruidCoordinatorLogger(DruidCoordinator.this)
+              new DruidCoordinatorCleanupOvershadowed(druidCoordinator),
+              new DruidCoordinatorBalancer(druidCoordinator),
+              new DruidCoordinatorLogger(druidCoordinator)
           ),
           startingLeaderCounter
       );


### PR DESCRIPTION
### Description
While trying to use Druid (apache incubating) on OpenJDK (I have tried to run it with the latest 8 and 11 versions of OpenJDK), everything seems to work well, but when the segments go to be handed off to the "historical" segment manager (I'm not sure of the details of this), the app fails.  All my segments then become "unavailable".  coordinator-overlord.log shows this error:
2019-10-31T16:23:02,953 ERROR
[LeaderSelector[/druid/coordinator/_COORDINATOR]]
org.apache.curator.framework.listen.ListenerContainer - Listener
(org.apache.druid.curator.discovery.CuratorDruidLeaderSelector$1@1e7d3d87
)
threw an exception
java.lang.ClassFormatError: Illegal field name
"org.apache.druid.server.coordinator.DruidCoordinator$this" in class


<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
a code change to:  DruidCoordinator.java @line 690.  the instance inner
class CoordinatorHistoricalManagerRunnable has a constructor that is
referencing DruidCoordinator.this prior to the super(...) constructor
call completing.  This causes a failure.  A work-around is to pass the
coordinator
instance to the constructor:
CoordinatorHistoricalManagerRunnable(final DruidCoordinator druidCoordinator, final int
startingLeaderCounter)
and then, reference druidCoordinator instead of DruidCoordinator.this throughout that
constructor.  


<hr>

##### Key changed/added classes in this PR
 * `DruidCoordinator.CoordinatorHistoricalManagerRunnable`

