### PR TITLE
SQL Server Metadata store fix

### DIFF
--- a/extensions-contrib/sqlserver-metadata-storage/src/main/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnector.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/main/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnector.java
@@ -236,11 +236,11 @@ public class SQLServerConnector extends SQLMetadataConnector
             handle.createStatement(StringUtils.format(
                 "MERGE INTO %1$s WITH (UPDLOCK, HOLDLOCK) as target"
                     + " USING "
-                    + " (:key, :value) as source (%2$s, %3$s)"
+                    + " (SELECT :key, :value) as source (%2$s, %3$s)"
                     + " ON"
                     + " (target.%2$s = source.%2$s)"
                     + " WHEN MATCHED THEN UPDATE SET %3$s = :value"
-                    + " WHEN NOT MATCHED THEN INSERT (%2$s, %3$s) VALUES (:key, :value)",
+                    + " WHEN NOT MATCHED THEN INSERT (%2$s, %3$s) VALUES (:key, :value);",
                 tableName,
                 keyColumn,
                 valueColumn))


### PR DESCRIPTION
### Description
The SQL Server Metadata store throws the following exception when creating a new compaction rule in the coordinator. This PR fixes the cause of this exception.

java.util.concurrent.ExecutionException: org.skife.jdbi.v2.exceptions.CallbackFailedException: org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException: com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near ','. [statement:"MERGE INTO druid_config WITH (UPDLOCK, HOLDLOCK) as target USING  (:key, :value) as source (name, payload) ON (target.name = source.name) WHEN MATCHED THEN UPDATE SET payload = :value WHEN NOT MATCHED THEN INSERT (name, payload) VALUES (:key, :value)", located:"MERGE INTO druid_config WITH (UPDLOCK, HOLDLOCK) as target USING  (:key, :value) as source (name, payload) ON (target.name = source.name) WHEN MATCHED THEN UPDATE SET payload = :value WHEN NOT MATCHED THEN INSERT (name, payload) VALUES (:key, :value)", rewritten:"MERGE INTO druid_config WITH (UPDLOCK, HOLDLOCK) as target USING  (?, ?) as source (name, payload) ON (target.name = source.name) WHEN MATCHED THEN UPDATE SET payload = ? WHEN NOT MATCHED THEN INSERT (name, payload) VALUES (?, ?)", arguments:{ positional:{}, named:{value:[123, 34, 99, 111, 109, 112, 97, 99, 116, 105, 111, 110, 67, 111, 110, 102, 105, 103, 115, 34, 58, 91, 123, 34, 100, 97, 116, 97, 83, 111, 117, 114, 99, 101, 34, 58, 34, 101, 101, 95, 117, 107, 95, 97, 112, 116, 117, 115, 95, 49, 34, 44, 34, 116, 97, 115, 107, 80, 114, 105, 111, 114, 105, 116, 121, 34, 58, 50, 53, 44, 34, 105, 110, 112, 117, 116, 83, 101, 103, 109, 101, 110, 116, 83, 105, 122, 101, 66, 121, 116, 101, 115, 34, 58, 52, 49, 57, 52, 51, 48, 52, 48, 48, 44, 34, 116, 97, 114, 103, 101, 116, 67, 111, 109, 112, 97, 99, 116, 105, 111, 110, 83, 105, 122, 101, 66, 121, 116, 101, 115, 34, 58, 52, 49, 57, 52, 51, 48, 52, 48, 48, 44, 34, 109, 97, 120, 82, 111, 119, 115, 80, 101, 114, 83, 101, 103, 109, 101, 110, 116, 34, 58, 110, 117, 108, 108, 44, 34, 109, 97, 120, 78, 117, 109, 83, 101, 103, 109, 101, 110, 116, 115, 84, 111, 67, 111, 109, 112, 97, 99, 116, 34, 58, 49, 53, 48, 44, 34, 115, 107, 105, 112, 79, 102, 102, 115, 101, 116, 70, 114, 111, 109, 76, 97, 116, 101, 115, 116, 34, 58, 34, 80, 49, 68, 34, 44, 34, 116, 117, 110, 105, 110, 103, 67, 111, 110, 102, 105, 103, 34, 58, 110, 117, 108, 108, 44, 34, 116, 97, 115, 107, 67, 111, 110, 116, 101, 120, 116, 34, 58, 110, 117, 108, 108, 125, 93, 44, 34, 99, 111, 109, 112, 97, 99, 116, 105, 111, 110, 84, 97, 115, 107, 83, 108, 111, 116, 82, 97, 116, 105, 111, 34, 58, 48, 46, 49, 44, 34, 109, 97, 120, 67, 111, 109, 112, 97, 99, 116, 105, 111, 110, 84, 97, 115, 107, 83, 108, 111, 116, 115, 34, 58, 50, 49, 52, 55, 52, 56, 51, 54, 52, 55, 125],key:'coordinator.compaction.config'}, finder:[]}]

The patch fixes the SQL MERGE query that was wrongly written.

<hr>

This PR has:
- [x ] been self-reviewed.
- [ n/a] added documentation for new or modified features or behaviors.
- [n/a] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ n/a] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [n/a] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [n/a] added unit tests or modified existing tests to cover new code paths.
- [n/a] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
org.apache.druid.metadata.storage.sqlserver.SQLServerConnector
