### PR TITLE
ensure valid HDFS names

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -203,8 +203,8 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
             segment.getInterval().getStart().toString(ISODateTimeFormat.basicDateTime()),
             segment.getInterval().getEnd().toString(ISODateTimeFormat.basicDateTime())
         ),
-        segment.getVersion().replace(':', '_')
-    );
+        segment.getVersion()
+    ).replace(':', '_');
   }
 
   @Override


### PR DESCRIPTION
Fixes #8840 .

### Description

Looks like the replace() just got moved to the wrong spot, as the ISO times do include them for sure.

<hr>

This PR has:
- [X] been self-reviewed.
- [X] been tested in a production Druid cluster.
