### PR TITLE
Replace PyYAML deprecated load_all interface

### DIFF
--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -317,7 +317,7 @@ def check_licenses(license_yaml, dependency_reports_root):
     registered_dep_to_licenses = {}
     skipping_licenses = {}
     with open(license_yaml) as registry_file:
-        licenses_list = list(yaml.load_all(registry_file))
+        licenses_list = list(yaml.full_load(registry_file))
     for license in licenses_list:
         if 'libraries' in license:
             for library in license['libraries']:

--- a/distribution/bin/generate-binary-license.py
+++ b/distribution/bin/generate-binary-license.py
@@ -137,7 +137,7 @@ def generate_license(apache_license_v2, license_yaml):
     # Print Apache license first.
     print_outfile(apache_license_v2)
     with open(license_yaml, encoding='utf-8') as registry_file:
-        licenses_list = list(yaml.load_all(registry_file))
+        licenses_list = list(yaml.full_load(registry_file))
 
     # Group licenses by license_name, license_category, and then module.
     licenses_map = {}

--- a/distribution/bin/generate-binary-notice.py
+++ b/distribution/bin/generate-binary-notice.py
@@ -57,7 +57,7 @@ def generate_notice(source_notice, dependences_yaml):
     # Print Apache license first.
     print_outfile(source_notice)
     with open(dependences_yaml, encoding='utf-8') as registry_file:
-        dependencies = list(yaml.load_all(registry_file))
+        dependencies = list(yaml.full_load(registry_file))
 
     # Group dependencies by module
     modules_map = defaultdict(list)


### PR DESCRIPTION
Reference

- [PyYAML yaml.load(input) Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)