### PR TITLE
concurrent access to charsetfix method throws IllegalStateException bugfix#8967

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
@@ -53,7 +53,6 @@ public class JSONFlattenerMaker implements ObjectFlatteners.FlattenerMaker<JsonN
                    .options(EnumSet.of(Option.SUPPRESS_EXCEPTIONS))
                    .build();
 
-  private final CharsetEncoder enc = StandardCharsets.UTF_8.newEncoder();
 
   @Override
   public Iterable<String> discoverRootFields(final JsonNode obj)
@@ -150,6 +149,7 @@ public class JSONFlattenerMaker implements ObjectFlatteners.FlattenerMaker<JsonN
   @Nullable
   private String charsetFix(String s)
   {
+    CharsetEncoder enc = StandardCharsets.UTF_8.newEncoder();
     if (s != null && !enc.canEncode(s)) {
       // Some whacky characters are in this string (e.g. \uD900). These are problematic because they are decodeable
       // by new String(...) but will not encode into the same character. This dance here will replace these


### PR DESCRIPTION
issue #8967  
### Description:
java.nio.charset.CharsetEncoder.canEncode throws IllegalStateException if an encoding 

operation is already in progress.And 

org.apache.druid.java.util.common.parsers.JSONFlattenerMaker has a private final 

CharsetEncoder enc = StandardCharsets.UTF_8.newEncoder() as its member variable and the 

charsetFix() executes  "if (s != null && !enc.canEncode(s))" which makes charsetFix() 

cannot be accessed concurrently either.

### Fixed the bug: 
access  JSONFlattenerMaker charsetFix() concurrently  throws IllegalStateException

---------------------------------------------------------------------------------------------------
### Stack Trace:

java.lang.IllegalStateException: Current state = CODING_END, new state = CODING
	at java.nio.charset.CharsetEncoder.throwIllegalStateException(CharsetEncoder.java:992)
	at java.nio.charset.CharsetEncoder.canEncode(CharsetEncoder.java:904)
	at java.nio.charset.CharsetEncoder.canEncode(CharsetEncoder.java:985)
	at org.apache.druid.java.util.common.parsers.JSONFlattenerMaker.charsetFix(JSONFlattenerMaker.java:144)
	at org.apache.druid.java.util.common.parsers.JSONFlattenerMaker.valueConversionFunction(JSONFlattenerMaker.java:116)
	at org.apache.druid.java.util.common.parsers.JSONFlattenerMaker.getRootField(JSONFlattenerMaker.java:71)
	at org.apache.druid.java.util.common.parsers.JSONFlattenerMaker.getRootField(JSONFlattenerMaker.java:44)
	at org.apache.druid.java.util.common.parsers.ObjectFlatteners.lambda$create$0(ObjectFlatteners.java:54)
	at org.apache.druid.java.util.common.parsers.ObjectFlatteners$1$1.get(ObjectFlatteners.java:112)
	at org.apache.druid.data.input.MapBasedRow.getRaw(MapBasedRow.java:85)
	at org.apache.druid.segment.incremental.IncrementalIndex.toIncrementalIndexRow(IncrementalIndex.java:675)
	at org.apache.druid.segment.incremental.IncrementalIndex.add(IncrementalIndex.java:609)
	at org.apache.druid.segment.realtime.plumber.Sink.add(Sink.java:179)
	at org.apache.druid.segment.realtime.appenderator.AppenderatorImpl.add(AppenderatorImpl.java:253)
	at org.apache.druid.segment.realtime.appenderator.BaseAppenderatorDriver.append(BaseAppenderatorDriver.java:403)
	at org.apache.druid.segment.realtime.appenderator.StreamAppenderatorDriver.add(StreamAppenderatorDriver.java:180)
	at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.runInternal(SeekableStreamIndexTaskRunner.java:602)
	at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.run(SeekableStreamIndexTaskRunner.java:251)
	at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask.run(SeekableStreamIndexTask.java:146)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:419)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:391)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

-------------------------------------------------------------------------------------------------

### Key changed/added classes in this PR
 JSONFlattenerMaker
