### PR TITLE
Use InputRowContextExecutor instead of IncrementalIndex instance ThreadLocal

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/incremental/InputRowContextExecutor.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/InputRowContextExecutor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.incremental;
+
+import com.google.common.base.Supplier;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.java.util.common.ISE;
+
+public class InputRowContextExecutor
+{
+  //CHECKSTYLE.OFF: Regexp
+  private static final ThreadLocal<InputRow> in = new ThreadLocal<>();
+  //CHECKSTYLE.ON: Regexp
+  private final InputRow row;
+  private final Runnable runnable;
+
+  public InputRowContextExecutor(InputRow row, Runnable runnable)
+  {
+    this.row = row;
+    this.runnable = runnable;
+  }
+
+  public void execute()
+  {
+    if (in.get() != null) {
+      throw new ISE("Nesteed " + InputRow.class.getSimpleName() + " context not allowed.");
+    }
+    in.set(row);
+    try {
+      runnable.run();
+    } 
+    finally {
+      in.remove();
+    }
+
+  }
+
+  public static final Supplier<InputRow> getRowSupplier()
+  {
+    return in::get;
+  }
+
+}

--- a/processing/src/main/java/org/apache/druid/segment/incremental/InputRowContextExecutor.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/InputRowContextExecutor.java
@@ -25,9 +25,9 @@ import org.apache.druid.java.util.common.ISE;
 
 public class InputRowContextExecutor
 {
-  //CHECKSTYLE.OFF: Regexp
+  //CHECKSTYLE.OFF: ConstantName
   private static final ThreadLocal<InputRow> in = new ThreadLocal<>();
-  //CHECKSTYLE.ON: Regexp
+  //CHECKSTYLE.ON: ConstantName
   private final InputRow row;
   private final Runnable runnable;
 


### PR DESCRIPTION
Fixes #8886 .

### Description

The `IncrementalIndex.in` replaced with static `ThreadLocal` within `InputRowContextExecutor`. 

<hr>

##### Key changed/added classes in this PR
 * `InputRowContextExecutor`
 * `IncrementalIndex`
 * `OffheapIncrementalIndex`
 * `OnheapIncrementalIndex`

