### PR TITLE
Overlord can support many autoscalers of different categories

### DIFF
--- a/extensions-core/ec2-extensions/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
+++ b/extensions-core/ec2-extensions/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScaler;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScalingData;
 import org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningConfig;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 
 import java.util.ArrayList;
@@ -55,6 +56,7 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
 
   private final int minNumWorkers;
   private final int maxNumWorkers;
+  private final String category;
   private final EC2EnvironmentConfig envConfig;
   private final AmazonEC2 amazonEC2Client;
   private final SimpleWorkerProvisioningConfig config;
@@ -65,11 +67,13 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
       @JsonProperty("maxNumWorkers") int maxNumWorkers,
       @JsonProperty("envConfig") EC2EnvironmentConfig envConfig,
       @JacksonInject AmazonEC2 amazonEC2Client,
-      @JacksonInject SimpleWorkerProvisioningConfig config
+      @JacksonInject SimpleWorkerProvisioningConfig config,
+      @JsonProperty(value = "category", defaultValue = CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY) String category
   )
   {
     this.minNumWorkers = minNumWorkers;
     this.maxNumWorkers = maxNumWorkers;
+    this.category = category;
     this.envConfig = envConfig;
     this.amazonEC2Client = amazonEC2Client;
     this.config = config;
@@ -87,6 +91,12 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
   public int getMaxNumWorkers()
   {
     return maxNumWorkers;
+  }
+
+  @Override
+  public String getCategory()
+  {
+    return category;
   }
 
   @Override

--- a/extensions-core/ec2-extensions/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
+++ b/extensions-core/ec2-extensions/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
@@ -40,11 +40,11 @@ import com.google.common.collect.Lists;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScaler;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScalingData;
 import org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningConfig;
-import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  */
@@ -68,7 +68,7 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
       @JsonProperty("envConfig") EC2EnvironmentConfig envConfig,
       @JacksonInject AmazonEC2 amazonEC2Client,
       @JacksonInject SimpleWorkerProvisioningConfig config,
-      @JsonProperty(value = "category", defaultValue = CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY) String category
+      @JsonProperty("category") String category
   )
   {
     this.minNumWorkers = minNumWorkers;
@@ -94,6 +94,7 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
   }
 
   @Override
+  @JsonProperty
   public String getCategory()
   {
     return category;
@@ -341,6 +342,7 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
            "envConfig=" + envConfig +
            ", maxNumWorkers=" + maxNumWorkers +
            ", minNumWorkers=" + minNumWorkers +
+           ", category=" + category +
            '}';
   }
 
@@ -353,28 +355,16 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     EC2AutoScaler that = (EC2AutoScaler) o;
-
-    if (maxNumWorkers != that.maxNumWorkers) {
-      return false;
-    }
-    if (minNumWorkers != that.minNumWorkers) {
-      return false;
-    }
-    if (envConfig != null ? !envConfig.equals(that.envConfig) : that.envConfig != null) {
-      return false;
-    }
-
-    return true;
+    return minNumWorkers == that.minNumWorkers &&
+           maxNumWorkers == that.maxNumWorkers &&
+           Objects.equals(category, that.category) &&
+           Objects.equals(envConfig, that.envConfig);
   }
 
   @Override
   public int hashCode()
   {
-    int result = minNumWorkers;
-    result = 31 * result + maxNumWorkers;
-    result = 31 * result + (envConfig != null ? envConfig.hashCode() : 0);
-    return result;
+    return Objects.hash(minNumWorkers, maxNumWorkers, category, envConfig);
   }
 }

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScalingData;
 import org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningConfig;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -101,7 +102,8 @@ public class EC2AutoScalerTest
         1,
         ENV_CONFIG,
         amazonEC2Client,
-        managementConfig
+        managementConfig,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
     );
 
     EasyMock.expect(amazonEC2Client.runInstances(EasyMock.anyObject(RunInstancesRequest.class))).andReturn(
@@ -145,7 +147,8 @@ public class EC2AutoScalerTest
         1,
         ENV_CONFIG,
         amazonEC2Client,
-        managementConfig
+        managementConfig,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
     );
 
     final int n = 150;
@@ -198,7 +201,8 @@ public class EC2AutoScalerTest
         1,
         ENV_CONFIG,
         amazonEC2Client,
-        managementConfig
+        managementConfig,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
     );
 
     final int n = 150;

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
@@ -70,7 +70,8 @@ public class WorkerBehaviorConfigTest
                 )
             ),
             null,
-            null
+            null,
+            CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
         )
     );
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/AutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/AutoScaler.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.overlord.autoscaling;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.guice.annotations.ExtensionPoint;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -36,7 +37,10 @@ public interface AutoScaler<T>
 
   int getMaxNumWorkers();
 
-  String getCategory();
+  default String getCategory()
+  {
+    return CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY;
+  }
 
   /**
    * This method is unused, but AutoScaler is an {@link ExtensionPoint}, so we cannot remove it.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/AutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/AutoScaler.java
@@ -36,6 +36,8 @@ public interface AutoScaler<T>
 
   int getMaxNumWorkers();
 
+  String getCategory();
+
   /**
    * This method is unused, but AutoScaler is an {@link ExtensionPoint}, so we cannot remove it.
    */

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.autoscaling;
+
+import org.joda.time.Period;
+
+public class CategoriedProvisioningConfig extends PendingTaskBasedWorkerProvisioningConfig
+{
+  @Override
+  public CategoriedProvisioningConfig setMaxScalingStep(int maxScalingStep)
+  {
+    super.setMaxScalingStep(maxScalingStep);
+    return this;
+  }
+
+  @Override
+  public CategoriedProvisioningConfig setWorkerIdleTimeout(Period workerIdleTimeout)
+  {
+    super.setWorkerIdleTimeout(workerIdleTimeout);
+    return this;
+  }
+
+  @Override
+  public CategoriedProvisioningConfig setMaxScalingDuration(Period maxScalingDuration)
+  {
+    super.setMaxScalingDuration(maxScalingDuration);
+    return this;
+  }
+
+  @Override
+  public CategoriedProvisioningConfig setNumEventsToTrack(int numEventsToTrack)
+  {
+    super.setNumEventsToTrack(numEventsToTrack);
+    return this;
+  }
+
+  @Override
+  public CategoriedProvisioningConfig setWorkerVersion(String workerVersion)
+  {
+    super.setWorkerVersion(workerVersion);
+    return this;
+  }
+
+  @Override
+  public CategoriedProvisioningConfig setPendingTaskTimeout(Period pendingTaskTimeout)
+  {
+    super.setPendingTaskTimeout(pendingTaskTimeout);
+    return this;
+  }
+
+  @Override
+  public CategoriedProvisioningConfig setWorkerPort(int workerPort)
+  {
+    super.setWorkerPort(workerPort);
+    return this;
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -1,0 +1,628 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.autoscaling;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
+import org.apache.druid.indexing.overlord.WorkerTaskRunner;
+import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.EqualDistributionWithCategorySpecWorkerSelectStrategy;
+import org.apache.druid.indexing.overlord.setup.FillCapacityWithCategorySpecWorkerSelectStrategy;
+import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerSelectStrategy;
+import org.apache.druid.indexing.worker.Worker;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+@JsonTypeName("categoriedTaskBased")
+public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningStrategy
+{
+  private static final String SCHEME = "http";
+  private static final EmittingLogger log = new EmittingLogger(CategoriedProvisioningStrategy.class);
+
+  private final CategoriedProvisioningConfig config;
+  private final Supplier<WorkerBehaviorConfig> workerConfigRef;
+
+  @Nullable
+  private static CategoriedWorkerBehaviorConfig getCategoriedWorkerBehaviorConfig(
+      Supplier<WorkerBehaviorConfig> workerConfigRef,
+      String action,
+      EmittingLogger log
+  )
+  {
+    final WorkerBehaviorConfig workerBehaviorConfig = workerConfigRef.get();
+    if (workerBehaviorConfig == null) {
+      log.error("No workerConfig available, cannot %s workers.", action);
+      return null;
+    }
+    if (!(workerBehaviorConfig instanceof CategoriedWorkerBehaviorConfig)) {
+      log.error(
+          "Only DefaultWorkerBehaviorConfig is supported as WorkerBehaviorConfig, [%s] given, cannot %s workers",
+          workerBehaviorConfig,
+          action
+      );
+      return null;
+    }
+    final CategoriedWorkerBehaviorConfig workerConfig = (CategoriedWorkerBehaviorConfig) workerBehaviorConfig;
+    if (workerConfig.getDefaultAutoScaler() == null) {
+      log.error("No default autoScaler available, cannot %s workers", action);
+      return null;
+    }
+    if (!((workerConfig.getSelectStrategy() instanceof FillCapacityWithCategorySpecWorkerSelectStrategy)
+          || (workerConfig.getSelectStrategy() instanceof EqualDistributionWithCategorySpecWorkerSelectStrategy))) {
+      log.error("Select strategy %s is not supported", workerConfig.getSelectStrategy());
+      return null;
+    }
+    return workerConfig;
+  }
+
+  @Inject
+  public CategoriedProvisioningStrategy(
+      CategoriedProvisioningConfig config,
+      Supplier<WorkerBehaviorConfig> workerConfigRef,
+      ProvisioningSchedulerConfig provisioningSchedulerConfig
+  )
+  {
+    this(
+        config,
+        workerConfigRef,
+        provisioningSchedulerConfig,
+        () -> ScheduledExecutors.fixed(1, "CategoriedProvisioning-manager--%d")
+    );
+  }
+
+  public CategoriedProvisioningStrategy(
+      CategoriedProvisioningConfig config,
+      Supplier<WorkerBehaviorConfig> workerConfigRef,
+      ProvisioningSchedulerConfig provisioningSchedulerConfig,
+      Supplier<ScheduledExecutorService> execFactory
+  )
+  {
+    super(provisioningSchedulerConfig, execFactory);
+    this.config = config;
+    this.workerConfigRef = workerConfigRef;
+  }
+
+  @Override
+  protected Provisioner makeProvisioner(WorkerTaskRunner runner)
+  {
+    return new CategoriedProvisioner(runner);
+  }
+
+  private class CategoriedProvisioner implements Provisioner
+  {
+    private final WorkerTaskRunner runner;
+    private final ScalingStats scalingStats = new ScalingStats(config.getNumEventsToTrack());
+
+    private final Map<String, Set<String>> currentlyProvisioning = new HashMap<>();
+    private final Map<String, Set<String>> currentlyTerminating = new HashMap<>();
+
+    private DateTime lastProvisionTime = DateTimes.nowUtc();
+    private DateTime lastTerminateTime = DateTimes.nowUtc();
+
+    private CategoriedProvisioner(WorkerTaskRunner runner)
+    {
+      this.runner = runner;
+    }
+
+    @Override
+    public boolean doTerminate()
+    {
+      Collection<ImmutableWorkerInfo> zkWorkers = runner.getWorkers();
+      log.debug("Workers: %d [%s]", zkWorkers.size(), zkWorkers);
+      final CategoriedWorkerBehaviorConfig workerConfig = getCategoriedWorkerBehaviorConfig(
+          workerConfigRef,
+          "terminate",
+          log
+      );
+      if (workerConfig == null) {
+        return false;
+      }
+
+      boolean didTerminate = false;
+
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = zkWorkers.stream().collect(Collectors.groupingBy(
+          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
+      );
+
+      Set<String> allCategories = workersByCategories.keySet();
+      log.debug(
+          "Workers of %d categories: %s",
+          workersByCategories.size(),
+          allCategories
+      );
+
+      for (String category : allCategories) {
+        Set<String> currentlyProvisioning = this.currentlyProvisioning.getOrDefault(category, Collections.emptySet());
+        log.info(
+            "Currently provisioning of category %s: %d %s",
+            category,
+            currentlyProvisioning.size(),
+            currentlyProvisioning
+        );
+        if (!currentlyProvisioning.isEmpty()) {
+          log.debug("Already provisioning nodes of category %s, Not Terminating any nodes.", category);
+          return false;
+        }
+
+        List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
+        currentlyTerminating.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
+        AutoScaler groupAutoscaler = getCategoryAutoscaler(category, workerConfig);
+
+        didTerminate = doTerminate(
+            category,
+            categoryWorkers,
+            currentlyTerminating,
+            groupAutoscaler
+        ) || didTerminate;
+      }
+
+      return didTerminate;
+    }
+
+    private boolean doTerminate(
+        String category,
+        Collection<ImmutableWorkerInfo> zkWorkers,
+        Set<String> currentlyTerminating,
+        AutoScaler autoScaler
+    )
+    {
+      boolean didTerminate = false;
+      final Collection<String> workerNodeIds = getWorkerNodeIDs(runner.getLazyWorkers(), autoScaler);
+      log.debug(
+          "Currently terminating of category %s: %d %s",
+          category,
+          currentlyTerminating.size(),
+          currentlyTerminating
+      );
+      currentlyTerminating.retainAll(workerNodeIds);
+      log.debug(
+          "Currently terminating of category %s among WorkerNodeIds: %d %s",
+          category,
+          currentlyTerminating.size(),
+          currentlyTerminating
+      );
+
+      if (currentlyTerminating.isEmpty()) {
+        final int maxWorkersToTerminate = maxWorkersToTerminate(zkWorkers, autoScaler);
+        log.info("Max workers to terminate of category %s: %d", category, maxWorkersToTerminate);
+        final Predicate<ImmutableWorkerInfo> isLazyWorker = ProvisioningUtil.createLazyWorkerPredicate(config);
+        final Collection<String> laziestWorkerIps =
+            Collections2.transform(
+                runner.markWorkersLazy(isLazyWorker, maxWorkersToTerminate),
+                Worker::getIp
+            );
+        log.info("Laziest worker ips of category %s: %d %s", category, laziestWorkerIps.size(), laziestWorkerIps);
+        if (laziestWorkerIps.isEmpty()) {
+          log.debug("Found no lazy workers for category %s", category);
+        } else {
+          log.info(
+              "Terminating %,d lazy workers of category %s: %s",
+              laziestWorkerIps.size(),
+              category,
+              Joiner.on(", ").join(laziestWorkerIps)
+          );
+
+          final AutoScalingData terminated = autoScaler.terminate(ImmutableList.copyOf(laziestWorkerIps));
+          if (terminated != null) {
+            log.info(
+                "Terminated of category %s: %d %s",
+                category,
+                terminated.getNodeIds().size(),
+                terminated.getNodeIds()
+            );
+            currentlyTerminating.addAll(terminated.getNodeIds());
+            lastTerminateTime = DateTimes.nowUtc();
+            scalingStats.addTerminateEvent(terminated);
+            didTerminate = true;
+          }
+        }
+      } else {
+        Duration durSinceLastTerminate = new Duration(lastTerminateTime, DateTimes.nowUtc());
+
+        log.info(
+            "%s terminating of category %s. Current wait time: %s",
+            currentlyTerminating,
+            category,
+            durSinceLastTerminate
+        );
+
+        if (durSinceLastTerminate.isLongerThan(config.getMaxScalingDuration().toStandardDuration())) {
+          log.makeAlert("Worker node termination taking too long!")
+             .addData("millisSinceLastTerminate", durSinceLastTerminate.getMillis())
+             .addData("terminatingCount", currentlyTerminating.size())
+             .emit();
+
+          currentlyTerminating.clear();
+        }
+      }
+
+      return didTerminate;
+    }
+
+    @Override
+    public boolean doProvision()
+    {
+      Collection<Task> pendingTasks = runner.getPendingTaskPayloads();
+      log.debug("Pending tasks: %d %s", pendingTasks.size(), pendingTasks);
+      Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
+      log.debug("Workers: %d %s", workers.size(), workers);
+      boolean didProvision = false;
+      final CategoriedWorkerBehaviorConfig workerConfig = getCategoriedWorkerBehaviorConfig(
+          workerConfigRef,
+          "provision",
+          log
+      );
+      if (workerConfig == null) {
+        return false;
+      }
+
+      // Group tasks by categories
+      Map<String, List<Task>> tasksByCategories = pendingTasks.stream().collect(Collectors.groupingBy(Task::getType));
+
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = workers.stream().collect(Collectors.groupingBy(
+          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
+      );
+
+      // Merge categories of tasks and workers
+      Set<String> allCategories = new HashSet<>(tasksByCategories.keySet());
+      allCategories.addAll(workersByCategories.keySet());
+
+      log.debug(
+          "Pending Tasks of %d categories, Workers of %d categories (%d common categories: %s)",
+          tasksByCategories.size(),
+          workersByCategories.size(),
+          allCategories.size(),
+          allCategories
+      );
+
+      if (allCategories.isEmpty()) {
+        // Likely empty categories means initialization. Just spinup required amount of workers
+        currentlyProvisioning.putIfAbsent(WorkerConfig.DEFAULT_CATEGORY, new HashSet<>());
+        Set<String> currentlyProvisioning = this.currentlyProvisioning.get(WorkerConfig.DEFAULT_CATEGORY);
+        didProvision = doProvision(
+            WorkerConfig.DEFAULT_CATEGORY,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            workerConfig,
+            currentlyProvisioning,
+            workerConfig.getDefaultAutoScaler()
+        );
+        return didProvision;
+      }
+
+      for (String category : allCategories) {
+        List<Task> categoryTasks = tasksByCategories.getOrDefault(category, Collections.emptyList());
+        List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
+        currentlyProvisioning.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
+        AutoScaler groupAutoscaler = getCategoryAutoscaler(category, workerConfig);
+
+        didProvision = doProvision(
+            category,
+            categoryWorkers,
+            categoryTasks,
+            workerConfig,
+            currentlyProvisioning,
+            groupAutoscaler
+        ) || didProvision;
+      }
+
+      return didProvision;
+    }
+
+    private boolean doProvision(
+        String category,
+        Collection<ImmutableWorkerInfo> workers,
+        Collection<Task> pendingTasks,
+        CategoriedWorkerBehaviorConfig workerConfig,
+        Set<String> currentlyProvisioning,
+        AutoScaler autoScaler
+    )
+    {
+      boolean didProvision = false;
+
+      if (autoScaler == null) {
+        log.error("No autoScaler available, cannot execute doProvision for workers of category %s", category);
+        return false;
+      }
+
+      final Collection<String> workerNodeIds = getWorkerNodeIDs(
+          Collections2.transform(
+              workers,
+              ImmutableWorkerInfo::getWorker
+          ),
+          autoScaler
+      );
+      log.info("Currently provisioning: %d %s", currentlyProvisioning.size(), currentlyProvisioning);
+      currentlyProvisioning.removeAll(workerNodeIds);
+      log.debug(
+          "Currently provisioning without WorkerNodeIds: %d %s",
+          currentlyProvisioning.size(),
+          currentlyProvisioning
+      );
+
+      if (currentlyProvisioning.isEmpty()) {
+        int workersToProvision = getScaleUpNodeCount(
+            runner.getConfig(),
+            workerConfig,
+            pendingTasks,
+            workers,
+            autoScaler
+        );
+        log.info("Workers to provision: %d", workersToProvision);
+        while (workersToProvision > 0) {
+          final AutoScalingData provisioned = autoScaler.provision();
+          final List<String> newNodes;
+          if (provisioned == null || (newNodes = provisioned.getNodeIds()).isEmpty()) {
+            log.warn("NewNodes is empty, returning from provision loop");
+            break;
+          } else {
+            log.info("Provisioned: %d [%s]", provisioned.getNodeIds().size(), provisioned.getNodeIds());
+            currentlyProvisioning.addAll(newNodes);
+            lastProvisionTime = DateTimes.nowUtc();
+            scalingStats.addProvisionEvent(provisioned);
+            workersToProvision -= provisioned.getNodeIds().size();
+            didProvision = true;
+          }
+        }
+      } else {
+        Duration durSinceLastProvision = new Duration(lastProvisionTime, DateTimes.nowUtc());
+        log.info("%s provisioning. Current wait time: %s", currentlyProvisioning, durSinceLastProvision);
+        if (durSinceLastProvision.isLongerThan(config.getMaxScalingDuration().toStandardDuration())) {
+          log.makeAlert("Worker node provisioning taking too long!")
+             .addData("millisSinceLastProvision", durSinceLastProvision.getMillis())
+             .addData("provisioningCount", currentlyProvisioning.size())
+             .emit();
+
+          autoScaler.terminateWithIds(Lists.newArrayList(currentlyProvisioning));
+          currentlyProvisioning.clear();
+        }
+      }
+
+      return didProvision;
+    }
+
+    @Override
+    public ScalingStats getStats()
+    {
+      return scalingStats;
+    }
+
+    private Collection<String> getWorkerNodeIDs(Collection<Worker> workers, AutoScaler<?> autoScaler)
+    {
+      List<String> ips = new ArrayList<>(workers.size());
+      for (Worker worker : workers) {
+        ips.add(worker.getIp());
+      }
+      List<String> workerNodeIds = autoScaler.ipToIdLookup(ips);
+      log.info("WorkerNodeIds: %d %s", workerNodeIds.size(), workerNodeIds);
+      return workerNodeIds;
+    }
+
+    private int getScaleUpNodeCount(
+        final WorkerTaskRunnerConfig remoteTaskRunnerConfig,
+        final CategoriedWorkerBehaviorConfig workerConfig,
+        final Collection<Task> pendingTasks,
+        final Collection<ImmutableWorkerInfo> workers,
+        AutoScaler autoScaler
+    )
+    {
+      final int minWorkerCount = autoScaler.getMinNumWorkers();
+      final int maxWorkerCount = autoScaler.getMaxNumWorkers();
+      log.info("Min/max workers: %d/%d", minWorkerCount, maxWorkerCount);
+      final int currValidWorkers = getCurrValidWorkers(workers);
+
+      // If there are no worker, spin up minWorkerCount, we cannot determine the exact capacity here to fulfill the need
+      // since we are not aware of the expectedWorkerCapacity.
+      int moreWorkersNeeded = currValidWorkers == 0 ? minWorkerCount : getWorkersNeededToAssignTasks(
+          remoteTaskRunnerConfig,
+          workerConfig,
+          pendingTasks,
+          workers
+      );
+      log.debug("More workers needed: %d", moreWorkersNeeded);
+
+      int want = Math.max(
+          minWorkerCount - currValidWorkers,
+          // Additional workers needed to reach minWorkerCount
+          Math.min(config.getMaxScalingStep(), moreWorkersNeeded)
+          // Additional workers needed to run current pending tasks
+      );
+      log.info("Want workers: %d", want);
+
+      if (want > 0 && currValidWorkers >= maxWorkerCount) {
+        log.warn(
+            "Unable to provision more workers. Current workerCount[%d] maximum workerCount[%d].",
+            currValidWorkers,
+            maxWorkerCount
+        );
+        return 0;
+      }
+      want = Math.min(want, maxWorkerCount - currValidWorkers);
+      return want;
+    }
+
+    private int getWorkersNeededToAssignTasks(
+        final WorkerTaskRunnerConfig workerTaskRunnerConfig,
+        final CategoriedWorkerBehaviorConfig workerConfig,
+        final Collection<Task> pendingTasks,
+        final Collection<ImmutableWorkerInfo> workers
+    )
+    {
+      final Collection<ImmutableWorkerInfo> validWorkers = Collections2.filter(
+          workers,
+          ProvisioningUtil.createValidWorkerPredicate(config)
+      );
+      log.debug("Valid workers: %d %s", validWorkers.size(), validWorkers);
+
+      Map<String, ImmutableWorkerInfo> workersMap = new HashMap<>();
+      for (ImmutableWorkerInfo worker : validWorkers) {
+        workersMap.put(worker.getWorker().getHost(), worker);
+      }
+      WorkerSelectStrategy workerSelectStrategy = workerConfig.getSelectStrategy();
+      int need = 0;
+      int capacity = getExpectedWorkerCapacity(workers);
+      log.info("Expected worker capacity: %d", capacity);
+
+      // Simulate assigning tasks to dummy workers using configured workerSelectStrategy
+      // the number of additional workers needed to assign all the pending tasks is noted
+      for (Task task : pendingTasks) {
+        final ImmutableWorkerInfo selectedWorker = workerSelectStrategy.findWorkerForTask(
+            workerTaskRunnerConfig,
+            ImmutableMap.copyOf(workersMap),
+            task
+        );
+        final ImmutableWorkerInfo workerRunningTask;
+        if (selectedWorker != null) {
+          workerRunningTask = selectedWorker;
+          log.debug("Worker[%s] able to take the task[%s]", task, workerRunningTask);
+        } else {
+          // None of the existing worker can run this task, we need to provision one worker for it.
+          // create a dummy worker and try to simulate assigning task to it.
+          workerRunningTask = createDummyWorker(
+              SCHEME,
+              "dummy" + need,
+              capacity,
+              workerTaskRunnerConfig.getMinWorkerVersion()
+          );
+          log.debug("Need more workers, creating a dummy worker[%s]", workerRunningTask);
+          need++;
+        }
+        // Update map with worker running task
+        workersMap.put(workerRunningTask.getWorker().getHost(), workerWithTask(workerRunningTask, task));
+      }
+      return need;
+    }
+
+    private int getCurrValidWorkers(Collection<ImmutableWorkerInfo> workers)
+    {
+      final Predicate<ImmutableWorkerInfo> isValidWorker = ProvisioningUtil.createValidWorkerPredicate(config);
+      final int currValidWorkers = Collections2.filter(workers, isValidWorker).size();
+      log.debug("Current valid workers: %d", currValidWorkers);
+      return currValidWorkers;
+    }
+
+    private int getExpectedWorkerCapacity(final Collection<ImmutableWorkerInfo> workers)
+    {
+      int size = workers.size();
+      if (size == 0) {
+        // No existing workers assume capacity per worker as 1
+        return 1;
+      } else {
+        // Assume all workers have same capacity
+        return workers.iterator().next().getWorker().getCapacity();
+      }
+    }
+
+    private ImmutableWorkerInfo createDummyWorker(String scheme, String host, int capacity, String version)
+    {
+      return new ImmutableWorkerInfo(
+          new Worker(scheme, host, "-2", capacity, version, WorkerConfig.DEFAULT_CATEGORY),
+          0,
+          new HashSet<>(),
+          new HashSet<>(),
+          DateTimes.nowUtc()
+      );
+    }
+
+    private ImmutableWorkerInfo workerWithTask(ImmutableWorkerInfo immutableWorker, Task task)
+    {
+      return new ImmutableWorkerInfo(
+          immutableWorker.getWorker(),
+          immutableWorker.getCurrCapacityUsed() + 1,
+          Sets.union(
+              immutableWorker.getAvailabilityGroups(),
+              Sets.newHashSet(
+                  task.getTaskResource()
+                      .getAvailabilityGroup()
+              )
+          ),
+          Sets.union(
+              immutableWorker.getRunningTasks(),
+              Sets.newHashSet(
+                  task.getId()
+              )
+          ),
+          DateTimes.nowUtc()
+      );
+    }
+
+    private int maxWorkersToTerminate(Collection<ImmutableWorkerInfo> zkWorkers, AutoScaler autoScaler)
+    {
+      final int currValidWorkers = getCurrValidWorkers(zkWorkers);
+      final int invalidWorkers = zkWorkers.size() - currValidWorkers;
+      final int minWorkers = autoScaler.getMinNumWorkers();
+      log.info("Min workers: %d", minWorkers);
+
+      // Max workers that can be terminated
+      // All invalid workers + any lazy workers above minCapacity
+      return invalidWorkers + Math.max(
+          0,
+          Math.min(
+              config.getMaxScalingStep(),
+              currValidWorkers - minWorkers
+          )
+      );
+    }
+
+    @Nullable
+    private AutoScaler getCategoryAutoscaler(String category, CategoriedWorkerBehaviorConfig workerConfig)
+    {
+      AutoScaler autoScaler = workerConfig.getCategoryAutoScalers().get(category);
+      if (autoScaler == null && workerConfig.isStrong()) {
+        log.warn(
+            "No autoscaler found for category %s. Tasks of this category will not be assigned to default autoscaler because of strong affinity.",
+            category
+        );
+        return null;
+      }
+      return autoScaler == null ? workerConfig.getDefaultAutoScaler() : autoScaler;
+    }
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -180,9 +180,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
           )
       ));
 
-      Map<String, List<ImmutableWorkerInfo>> workersByCategories = workers.stream().collect(Collectors.groupingBy(
-          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
-      );
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = ProvisioningUtil.getWorkersByCategories(workers);
 
       // Merge categories of tasks and workers
       Set<String> allCategories = new HashSet<>(tasksByCategories.keySet());
@@ -423,9 +421,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
 
       boolean didTerminate = false;
 
-      Map<String, List<ImmutableWorkerInfo>> workersByCategories = zkWorkers.stream().collect(Collectors.groupingBy(
-          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
-      );
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = ProvisioningUtil.getWorkersByCategories(zkWorkers);
 
       Set<String> allCategories = workersByCategories.keySet();
       log.debug(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -325,7 +325,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
 
       // If there are no worker, spin up minWorkerCount (or 1 if minWorkerCount is 0), we cannot determine the exact capacity here to fulfill the need
       // since we are not aware of the expectedWorkerCapacity.
-      int moreWorkersNeeded = currValidWorkers == 0 ? Math.max(minWorkerCount, 1) : getWorkersNeededToAssignTasks(
+      int moreWorkersNeeded = currValidWorkers == 0 ? Math.max(minWorkerCount, pendingTasks.isEmpty() ? 0 : 1) : getWorkersNeededToAssignTasks(
           remoteTaskRunnerConfig,
           workerConfig,
           pendingTasks,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -205,7 +205,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
         return didProvision;
       }
 
-      Map<String, AutoScaler> autoscalersByCategory = mapAutoscalerByCategory(workerConfig.getAutoScalers());
+      Map<String, AutoScaler> autoscalersByCategory = ProvisioningUtil.mapAutoscalerByCategory(workerConfig.getAutoScalers());
 
       for (String category : allCategories) {
         List<Task> categoryTasks = tasksByCategories.getOrDefault(category, Collections.emptyList());
@@ -430,7 +430,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
           allCategories
       );
 
-      Map<String, AutoScaler> autoscalersByCategory = mapAutoscalerByCategory(workerConfig.getAutoScalers());
+      Map<String, AutoScaler> autoscalersByCategory = ProvisioningUtil.mapAutoscalerByCategory(workerConfig.getAutoScalers());
 
       for (String category : allCategories) {
         Set<String> currentlyProvisioning = this.currentlyProvisioning.getOrDefault(category, Collections.emptySet());
@@ -656,23 +656,6 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
       return autoScaler == null
              ? autoscalersByCategory.get(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY)
              : autoScaler;
-    }
-
-    private Map<String, AutoScaler> mapAutoscalerByCategory(List<AutoScaler> autoScalers)
-    {
-      Map<String, AutoScaler> result = autoScalers.stream().collect(Collectors.groupingBy(
-          autoScaler -> autoScaler.getCategory() == null
-                        ? CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
-                        : autoScaler.getCategory(),
-          Collectors.collectingAndThen(Collectors.toList(), values -> values.get(0))
-      ));
-
-      if (result.size() != autoScalers.size()) {
-        log.warn(
-            "Probably autoscalers with duplicated categories were defined. The first instance of each duplicate category will be used.");
-      }
-
-      return result;
     }
 
     @Nullable

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -60,8 +60,6 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
-import static org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY;
-
 @JsonTypeName("categoriedTaskBased")
 public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningStrategy
 {
@@ -319,7 +317,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
           task -> WorkerSelectUtils.getTaskCategory(
               task,
               workerCategorySpec,
-              DEFAULT_AUTOSCALER_CATEGORY
+              CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
           )
       ));
 
@@ -648,7 +646,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
     private AutoScaler getCategoryAutoscaler(String category, Map<String, AutoScaler> autoscalersByCategory)
     {
       AutoScaler autoScaler = autoscalersByCategory.get(category);
-      boolean isStrongAssignment = !autoscalersByCategory.containsKey(DEFAULT_AUTOSCALER_CATEGORY);
+      boolean isStrongAssignment = !autoscalersByCategory.containsKey(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY);
 
       if (autoScaler == null && isStrongAssignment) {
         log.warn(
@@ -657,7 +655,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
         );
         return null;
       }
-      return autoScaler == null ? autoscalersByCategory.get(DEFAULT_AUTOSCALER_CATEGORY) : autoScaler;
+      return autoScaler == null ? autoscalersByCategory.get(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY) : autoScaler;
     }
 
     private Map<String, AutoScaler> mapAutoscalerByCategory(List<AutoScaler> autoScalers)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -212,7 +212,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
         List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
         currentlyProvisioning.putIfAbsent(category, new HashSet<>());
         Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
-        AutoScaler groupAutoscaler = getCategoryAutoscaler(category, autoscalersByCategory);
+        AutoScaler groupAutoscaler = ProvisioningUtil.getAutoscalerByCategory(category, autoscalersByCategory);
 
         didProvision = doProvision(
             category,
@@ -448,7 +448,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
         List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
         currentlyTerminating.putIfAbsent(category, new HashSet<>());
         Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
-        AutoScaler groupAutoscaler = getCategoryAutoscaler(category, autoscalersByCategory);
+        AutoScaler groupAutoscaler = ProvisioningUtil.getAutoscalerByCategory(category, autoscalersByCategory);
 
         didTerminate = doTerminate(
             category,
@@ -638,24 +638,6 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
           currentlyProvisioning,
           autoScaler
       );
-    }
-
-    @Nullable
-    private AutoScaler getCategoryAutoscaler(String category, Map<String, AutoScaler> autoscalersByCategory)
-    {
-      AutoScaler autoScaler = autoscalersByCategory.get(category);
-      boolean isStrongAssignment = !autoscalersByCategory.containsKey(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY);
-
-      if (autoScaler == null && isStrongAssignment) {
-        log.warn(
-            "No autoscaler found for category %s. Tasks of this category will not be assigned to default autoscaler because of strong affinity.",
-            category
-        );
-        return null;
-      }
-      return autoScaler == null
-             ? autoscalersByCategory.get(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY)
-             : autoScaler;
     }
 
     @Nullable

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -324,9 +324,11 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
       allCategories.addAll(workersByCategories.keySet());
 
       log.debug(
-          "Pending Tasks of %d categories, Workers of %d categories (%d common categories: %s)",
+          "Pending Tasks of %d categories (%s), Workers of %d categories (%s). %d common categories: %s",
           tasksByCategories.size(),
+          tasksByCategories.keySet(),
           workersByCategories.size(),
+          workersByCategories.keySet(),
           allCategories.size(),
           allCategories
       );
@@ -334,7 +336,11 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
       if (allCategories.isEmpty()) {
         // Likely empty categories means initialization. Just try to spinup required amount of workers of each non empty autoscalers
         if (workerConfig.getDefaultAutoScaler() != null) {
-          didProvision = initAutoscaler(workerConfig.getDefaultAutoScaler(), CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, workerConfig);
+          didProvision = initAutoscaler(
+              workerConfig.getDefaultAutoScaler(),
+              CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+              workerConfig
+          );
         }
         for (Map.Entry<String, AutoScaler> autoscalerInfo : workerConfig.getAutoScalers().entrySet()) {
           String category = autoscalerInfo.getKey();
@@ -639,6 +645,9 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
     @Nullable
     private AutoScaler getCategoryAutoscaler(String category, CategoriedWorkerBehaviorConfig workerConfig)
     {
+      if (CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY.equals(category)) {
+        return workerConfig.getDefaultAutoScaler();
+      }
       AutoScaler autoScaler = workerConfig.getAutoScalers().get(category);
       if (autoScaler == null && workerConfig.isStrong()) {
         log.warn(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategy.java
@@ -34,8 +34,7 @@ import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.WorkerTaskRunner;
 import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
-import org.apache.druid.indexing.overlord.setup.EqualDistributionWithCategorySpecWorkerSelectStrategy;
-import org.apache.druid.indexing.overlord.setup.FillCapacityWithCategorySpecWorkerSelectStrategy;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerSelectStrategy;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
 import org.apache.druid.indexing.overlord.setup.WorkerSelectStrategy;
@@ -90,9 +89,7 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
       return null;
     }
     final CategoriedWorkerBehaviorConfig workerConfig = (CategoriedWorkerBehaviorConfig) workerBehaviorConfig;
-    // TODO Create a superclass
-    if (!((workerConfig.getSelectStrategy() instanceof FillCapacityWithCategorySpecWorkerSelectStrategy)
-          || (workerConfig.getSelectStrategy() instanceof EqualDistributionWithCategorySpecWorkerSelectStrategy))) {
+    if (!(workerConfig.getSelectStrategy() instanceof CategoriedWorkerSelectStrategy)) {
       log.error("Select strategy %s is not supported", workerConfig.getSelectStrategy());
       return null;
     }
@@ -687,11 +684,8 @@ public class CategoriedProvisioningStrategy extends AbstractWorkerProvisioningSt
     {
       if (workerConfig != null && workerConfig.getSelectStrategy() != null) {
         WorkerSelectStrategy selectStrategy = workerConfig.getSelectStrategy();
-        // TODO Replace by superclass
-        if (selectStrategy instanceof FillCapacityWithCategorySpecWorkerSelectStrategy) {
-          return ((FillCapacityWithCategorySpecWorkerSelectStrategy) selectStrategy).getWorkerCategorySpec();
-        } else if (selectStrategy instanceof EqualDistributionWithCategorySpecWorkerSelectStrategy) {
-          return ((EqualDistributionWithCategorySpecWorkerSelectStrategy) selectStrategy).getWorkerCategorySpec();
+        if (selectStrategy instanceof CategoriedWorkerSelectStrategy) {
+          return ((CategoriedWorkerSelectStrategy) selectStrategy).getWorkerCategorySpec();
         }
       }
       return null;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/NoopAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/NoopAutoScaler.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.indexing.overlord.autoscaling;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 
@@ -34,8 +34,9 @@ public class NoopAutoScaler<Void> implements AutoScaler<Void>
   private static final EmittingLogger log = new EmittingLogger(NoopAutoScaler.class);
   private final String category;
 
+  @JsonCreator
   public NoopAutoScaler(
-      @JsonProperty(value = "category", defaultValue = CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY) String category
+      @JsonProperty("category") String category
   )
   {
     this.category = category;
@@ -54,6 +55,7 @@ public class NoopAutoScaler<Void> implements AutoScaler<Void>
   }
 
   @Override
+  @JsonProperty
   public String getCategory()
   {
     return category;
@@ -68,35 +70,43 @@ public class NoopAutoScaler<Void> implements AutoScaler<Void>
   @Override
   public AutoScalingData provision()
   {
-    log.info("If I were a real strategy I'd create something now in category %s", category);
+    log.info("If I were a real strategy I'd create something now [category: %s]", category);
     return null;
   }
 
   @Override
   public AutoScalingData terminate(List<String> ips)
   {
-    log.info("If I were a real strategy I'd terminate %s now in category %s", ips, category);
+    log.info("If I were a real strategy I'd terminate %s now [category: %s]", ips, category);
     return null;
   }
 
   @Override
   public AutoScalingData terminateWithIds(List<String> ids)
   {
-    log.info("If I were a real strategy I'd terminate %s now", ids);
+    log.info("If I were a real strategy I'd terminate %s now [category: %s]", ids, category);
     return null;
   }
 
   @Override
   public List<String> ipToIdLookup(List<String> ips)
   {
-    log.info("I'm not a real strategy so I'm returning what I got %s", ips);
+    log.info("I'm not a real strategy so I'm returning what I got %s [category: %s]", ips, category);
     return ips;
   }
 
   @Override
   public List<String> idToIpLookup(List<String> nodeIds)
   {
-    log.info("I'm not a real strategy so I'm returning what I got %s", nodeIds);
+    log.info("I'm not a real strategy so I'm returning what I got %s [category: %s]", nodeIds, category);
     return nodeIds;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "NoopAutoScaler{" +
+           "category='" + category + '\'' +
+           '}';
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/NoopAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/NoopAutoScaler.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.indexing.overlord.autoscaling;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 
@@ -30,6 +32,14 @@ import java.util.List;
 public class NoopAutoScaler<Void> implements AutoScaler<Void>
 {
   private static final EmittingLogger log = new EmittingLogger(NoopAutoScaler.class);
+  private final String category;
+
+  public NoopAutoScaler(
+      @JsonProperty(value = "category", defaultValue = CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY) String category
+  )
+  {
+    this.category = category;
+  }
 
   @Override
   public int getMinNumWorkers()
@@ -44,6 +54,12 @@ public class NoopAutoScaler<Void> implements AutoScaler<Void>
   }
 
   @Override
+  public String getCategory()
+  {
+    return category;
+  }
+
+  @Override
   public Void getEnvConfig()
   {
     throw new UOE("No config for Noop!");
@@ -52,14 +68,14 @@ public class NoopAutoScaler<Void> implements AutoScaler<Void>
   @Override
   public AutoScalingData provision()
   {
-    log.info("If I were a real strategy I'd create something now");
+    log.info("If I were a real strategy I'd create something now in category %s", category);
     return null;
   }
 
   @Override
   public AutoScalingData terminate(List<String> ips)
   {
-    log.info("If I were a real strategy I'd terminate %s now", ips);
+    log.info("If I were a real strategy I'd terminate %s now in category %s", ips, category);
     return null;
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -246,9 +246,9 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       log.info("Min/max workers: %d/%d", minWorkerCount, maxWorkerCount);
       final int currValidWorkers = getCurrValidWorkers(workers);
 
-      // If there are no worker, spin up minWorkerCount, we cannot determine the exact capacity here to fulfill the need
+      // If there are no worker, spin up minWorkerCount (or 1 if minWorkerCount is 0), we cannot determine the exact capacity here to fulfill the need
       // since we are not aware of the expectedWorkerCapacity.
-      int moreWorkersNeeded = currValidWorkers == 0 ? minWorkerCount : getWorkersNeededToAssignTasks(
+      int moreWorkersNeeded = currValidWorkers == 0 ? Math.max(minWorkerCount, 1) : getWorkersNeededToAssignTasks(
           remoteTaskRunnerConfig,
           workerConfig,
           pendingTasks,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -109,8 +109,8 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
     private final Map<String, Set<String>> currentlyProvisioningMap = new HashMap<>();
     private final Map<String, Set<String>> currentlyTerminatingMap = new HashMap<>();
 
-    private final Map<String, DateTime> lastProvisionTimeMap = new HashMap<>();//DateTimes.nowUtc();
-    private final Map<String, DateTime> lastTerminateTimeMap = new HashMap<>();//lastProvisionTime;
+    private final Map<String, DateTime> lastProvisionTimeMap = new HashMap<>();
+    private final Map<String, DateTime> lastTerminateTimeMap = new HashMap<>();
 
     private PendingProvisioner(WorkerTaskRunner runner)
     {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -145,9 +145,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
           )
       ));
 
-      Map<String, List<ImmutableWorkerInfo>> workersByCategories = workers.stream().collect(Collectors.groupingBy(
-          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
-      );
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = ProvisioningUtil.getWorkersByCategories(workers);
 
       // Merge categories of tasks and workers
       Set<String> allCategories = new HashSet<>(tasksByCategories.keySet());
@@ -390,9 +388,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
 
       boolean didTerminate = false;
 
-      Map<String, List<ImmutableWorkerInfo>> workersByCategories = zkWorkers.stream().collect(Collectors.groupingBy(
-          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
-      );
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = ProvisioningUtil.getWorkersByCategories(zkWorkers);
 
       Set<String> allCategories = workersByCategories.keySet();
       log.debug(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
@@ -20,11 +20,29 @@
 package org.apache.druid.indexing.overlord.autoscaling;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerSelectStrategy;
+import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
+import org.apache.druid.indexing.overlord.setup.WorkerSelectStrategy;
+import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ProvisioningUtil
 {
+  private static final EmittingLogger log = new EmittingLogger(ProvisioningUtil.class);
+
   public static Predicate<ImmutableWorkerInfo> createValidWorkerPredicate(
       final SimpleWorkerProvisioningConfig config
   )
@@ -61,4 +79,96 @@ public class ProvisioningUtil
     };
   }
 
+  @Nullable
+  public static CategoriedWorkerBehaviorConfig getCategoriedWorkerBehaviorConfig(
+      Supplier<WorkerBehaviorConfig> workerConfigRef,
+      String action
+  )
+  {
+    final WorkerBehaviorConfig workerBehaviorConfig = workerConfigRef.get();
+    if (workerBehaviorConfig == null) {
+      log.error("No workerConfig available, cannot %s workers.", action);
+      return null;
+    }
+
+    CategoriedWorkerBehaviorConfig workerConfig;
+    if (workerBehaviorConfig instanceof DefaultWorkerBehaviorConfig) {
+      AutoScaler autoscaler = ((DefaultWorkerBehaviorConfig) workerBehaviorConfig).getAutoScaler();
+      WorkerSelectStrategy workerSelectStrategy = workerBehaviorConfig.getSelectStrategy();
+      List<AutoScaler> autoscalers = autoscaler == null
+                                     ? Collections.emptyList()
+                                     : Collections.singletonList(autoscaler);
+      workerConfig = new CategoriedWorkerBehaviorConfig(workerSelectStrategy, autoscalers);
+    } else if (workerBehaviorConfig instanceof CategoriedWorkerBehaviorConfig) {
+      workerConfig = (CategoriedWorkerBehaviorConfig) workerBehaviorConfig;
+    } else {
+      log.error(
+          "Only DefaultWorkerBehaviorConfig or CategoriedWorkerBehaviorConfig are supported as WorkerBehaviorConfig, [%s] given, cannot %s workers",
+          workerBehaviorConfig,
+          action
+      );
+      return null;
+    }
+    if (workerConfig.getAutoScalers() == null || workerConfig.getAutoScalers().isEmpty()) {
+      log.error("No autoScaler available, cannot %s workers", action);
+      return null;
+    }
+
+    return workerConfig;
+  }
+
+  @Nullable
+  public static WorkerCategorySpec getWorkerCategorySpec(CategoriedWorkerBehaviorConfig workerConfig)
+  {
+    if (workerConfig != null && workerConfig.getSelectStrategy() != null) {
+      WorkerSelectStrategy selectStrategy = workerConfig.getSelectStrategy();
+      if (selectStrategy instanceof CategoriedWorkerSelectStrategy) {
+        return ((CategoriedWorkerSelectStrategy) selectStrategy).getWorkerCategorySpec();
+      }
+    }
+    return null;
+  }
+
+  public static Map<String, AutoScaler> mapAutoscalerByCategory(List<AutoScaler> autoScalers)
+  {
+    Map<String, AutoScaler> result = autoScalers.stream().collect(Collectors.groupingBy(
+        ProvisioningUtil::getAutoscalerCategory,
+        Collectors.collectingAndThen(Collectors.toList(), values -> values.get(0))
+    ));
+
+    if (result.size() != autoScalers.size()) {
+      log.warn(
+          "Probably autoscalers with duplicated categories were defined. The first instance of each duplicate category will be used.");
+    }
+
+    return result;
+  }
+
+  @Nullable
+  public static AutoScaler getAutoscalerByCategory(String category, Map<String, AutoScaler> autoscalersByCategory)
+  {
+    AutoScaler autoScaler = autoscalersByCategory.get(category);
+    boolean isStrongAssignment = !autoscalersByCategory.containsKey(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY);
+
+    if (autoScaler == null && isStrongAssignment) {
+      log.warn(
+          "No autoscaler found for category %s. Tasks of this category will not be assigned to default autoscaler because of strong affinity.",
+          category
+      );
+      return null;
+    }
+    return autoScaler == null
+           ? autoscalersByCategory.get(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY)
+           : autoScaler;
+  }
+
+  public static Collection<Worker> getWorkersOfCategory(Collection<Worker> workers, String category) {
+    return workers.stream().filter(worker -> category.equals(worker.getCategory())).collect(Collectors.toList());
+  }
+
+  public static String getAutoscalerCategory(AutoScaler autoScaler) {
+    return autoScaler.getCategory() == null
+           ? CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
+           : autoScaler.getCategory();
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
@@ -29,6 +29,7 @@ import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
 import org.apache.druid.indexing.overlord.setup.WorkerSelectStrategy;
 import org.apache.druid.indexing.worker.Worker;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 
@@ -172,5 +173,14 @@ public class ProvisioningUtil
     return autoScaler.getCategory() == null
            ? CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
            : autoScaler.getCategory();
+  }
+
+  public static Map<String, List<ImmutableWorkerInfo>> getWorkersByCategories(Collection<ImmutableWorkerInfo> workers)
+  {
+    return workers.stream().collect(Collectors.groupingBy(
+        immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory() == null
+                               ? WorkerConfig.DEFAULT_CATEGORY
+                               : immutableWorkerInfo.getWorker().getCategory())
+    );
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
@@ -162,11 +162,13 @@ public class ProvisioningUtil
            : autoScaler;
   }
 
-  public static Collection<Worker> getWorkersOfCategory(Collection<Worker> workers, String category) {
+  public static Collection<Worker> getWorkersOfCategory(Collection<Worker> workers, String category)
+  {
     return workers.stream().filter(worker -> category.equals(worker.getCategory())).collect(Collectors.toList());
   }
 
-  public static String getAutoscalerCategory(AutoScaler autoScaler) {
+  public static String getAutoscalerCategory(AutoScaler autoScaler)
+  {
     return autoScaler.getCategory() == null
            ? CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
            : autoScaler.getCategory();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/ProvisioningUtil.java
@@ -150,7 +150,7 @@ public class ProvisioningUtil
   {
     AutoScaler autoScaler = autoscalersByCategory.get(category);
     boolean isStrongAssignment = !autoscalersByCategory.containsKey(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY);
-
+    log.debug("Found autoscaler %s for category %s in available categories %s. Is strong assignment=%b. ", autoScaler, category, autoscalersByCategory, isStrongAssignment);
     if (autoScaler == null && isStrongAssignment) {
       log.warn(
           "No autoscaler found for category %s. Tasks of this category will not be assigned to default autoscaler because of strong affinity.",

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
@@ -149,6 +149,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
       updateTargetWorkerCount(workerConfig, pendingTasks, workers);
 
       int want = targetWorkerCount - (currValidWorkers + currentlyProvisioning.size());
+      log.info("Want workers: %d", want);
       while (want > 0) {
         final AutoScalingData provisioned = workerConfig.getAutoScaler().provision();
         final List<String> newNodes;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
@@ -164,9 +164,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
           workerCategorySpec
       );
 
-      Map<String, List<ImmutableWorkerInfo>> workersByCategories = workers.stream().collect(Collectors.groupingBy(
-          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
-      );
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = ProvisioningUtil.getWorkersByCategories(workers);
 
       // Merge categories of tasks and workers
       Set<String> allCategories = new HashSet<>(tasksByCategories.keySet());
@@ -310,9 +308,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
           workerCategorySpec
       );
 
-      Map<String, List<ImmutableWorkerInfo>> workersByCategories = workers.stream().collect(Collectors.groupingBy(
-          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
-      );
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = ProvisioningUtil.getWorkersByCategories(workers);
 
       Set<String> allCategories = workersByCategories.keySet();
       log.debug(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
@@ -142,7 +142,9 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
     public synchronized boolean doProvision()
     {
       Collection<? extends TaskRunnerWorkItem> pendingTasks = runner.getPendingTasks();
+      log.debug("Pending tasks: %d %s", pendingTasks.size(), pendingTasks);
       Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
+      log.debug("Workers: %d %s", workers.size(), workers);
       boolean didProvision = false;
       final CategoriedWorkerBehaviorConfig workerConfig = ProvisioningUtil.getCategoriedWorkerBehaviorConfig(
           workerConfigRef,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
@@ -103,8 +103,8 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
     private final WorkerTaskRunner runner;
     private final ScalingStats scalingStats = new ScalingStats(config.getNumEventsToTrack());
 
-    private final Map<String, Set<String>> currentlyProvisioning = new HashMap<>();
-    private final Map<String, Set<String>> currentlyTerminating = new HashMap<>();
+    private final Map<String, Set<String>> currentlyProvisioningMap = new HashMap<>();
+    private final Map<String, Set<String>> currentlyTerminatingMap = new HashMap<>();
 
     private final Map<String, Integer> targetWorkerCountMap = new HashMap<>();
     private final Map<String, DateTime> lastProvisionTimeMap = new HashMap<>();
@@ -203,10 +203,10 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
         category = ProvisioningUtil.getAutoscalerCategory(categoryAutoscaler);
 
         List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
-        currentlyProvisioning.putIfAbsent(category, new HashSet<>());
-        Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
-        currentlyTerminating.putIfAbsent(category, new HashSet<>());
-        Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
+        currentlyProvisioningMap.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyProvisioning = this.currentlyProvisioningMap.get(category);
+        currentlyTerminatingMap.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyTerminating = this.currentlyTerminatingMap.get(category);
 
         didProvision = doProvision(
             category,
@@ -332,10 +332,10 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
         // Correct category name by selected autoscaler
         category = ProvisioningUtil.getAutoscalerCategory(categoryAutoscaler);
         List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
-        currentlyProvisioning.putIfAbsent(category, new HashSet<>());
-        Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
-        currentlyTerminating.putIfAbsent(category, new HashSet<>());
-        Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
+        currentlyProvisioningMap.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyProvisioning = this.currentlyProvisioningMap.get(category);
+        currentlyTerminatingMap.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyTerminating = this.currentlyTerminatingMap.get(category);
         List<? extends TaskRunnerWorkItem> categoryPendingTasks = pendingTasksByCategories.getOrDefault(
             category,
             Collections.emptyList()
@@ -553,10 +553,10 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
 
     private boolean initAutoscaler(AutoScaler autoScaler, String category)
     {
-      currentlyProvisioning.putIfAbsent(category, new HashSet<>());
-      Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
-      currentlyTerminating.putIfAbsent(category, new HashSet<>());
-      Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
+      currentlyProvisioningMap.putIfAbsent(category, new HashSet<>());
+      Set<String> currentlyProvisioning = this.currentlyProvisioningMap.get(category);
+      currentlyTerminatingMap.putIfAbsent(category, new HashSet<>());
+      Set<String> currentlyTerminating = this.currentlyTerminatingMap.get(category);
       return doProvision(
           category,
           Collections.emptyList(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
@@ -29,11 +29,14 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
 import org.apache.druid.indexing.overlord.WorkerTaskRunner;
-import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
+import org.apache.druid.indexing.overlord.setup.WorkerSelectUtils;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
@@ -42,16 +45,21 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 /**
+ *
  */
-
 public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioningStrategy
 {
+  public static final Integer TARGET_WORKER_DEFAULT = -1;
   private static final EmittingLogger log = new EmittingLogger(SimpleWorkerProvisioningStrategy.class);
 
   private final SimpleWorkerProvisioningConfig config;
@@ -68,14 +76,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
         config,
         workerConfigRef,
         provisioningSchedulerConfig,
-        new Supplier<ScheduledExecutorService>()
-        {
-          @Override
-          public ScheduledExecutorService get()
-          {
-            return ScheduledExecutors.fixed(1, "SimpleResourceManagement-manager--%d");
-          }
-        }
+        () -> ScheduledExecutors.fixed(1, "SimpleResourceManagement-manager--%d")
     );
   }
 
@@ -102,16 +103,39 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
     private final WorkerTaskRunner runner;
     private final ScalingStats scalingStats = new ScalingStats(config.getNumEventsToTrack());
 
-    private final Set<String> currentlyProvisioning = new HashSet<>();
-    private final Set<String> currentlyTerminating = new HashSet<>();
+    private final Map<String, Set<String>> currentlyProvisioning = new HashMap<>();
+    private final Map<String, Set<String>> currentlyTerminating = new HashMap<>();
 
-    private int targetWorkerCount = -1;
-    private DateTime lastProvisionTime = DateTimes.nowUtc();
-    private DateTime lastTerminateTime = lastProvisionTime;
+    private final Map<String, Integer> targetWorkerCountMap = new HashMap<>();
+    private final Map<String, DateTime> lastProvisionTimeMap = new HashMap<>();
+    private final Map<String, DateTime> lastTerminateTimeMap = new HashMap<>();
 
     SimpleProvisioner(WorkerTaskRunner runner)
     {
       this.runner = runner;
+    }
+
+    private Map<String, List<TaskRunnerWorkItem>> groupTasksByCategories(
+        Collection<? extends TaskRunnerWorkItem> pendingTasks,
+        WorkerTaskRunner runner,
+        WorkerCategorySpec workerCategorySpec
+    )
+    {
+      Collection<Task> pendingTasksPayload = runner.getPendingTaskPayloads();
+      Map<String, List<Task>> taskPayloadsById = pendingTasksPayload.stream()
+                                                                    .collect(Collectors.groupingBy(Task::getId));
+
+      return pendingTasks.stream().collect(Collectors.groupingBy(task -> {
+        List<Task> taskPayloads = taskPayloadsById.get(task.getTaskId());
+        if (taskPayloads == null || taskPayloads.isEmpty()) {
+          return CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY;
+        }
+        return WorkerSelectUtils.getTaskCategory(
+            taskPayloads.get(0),
+            workerCategorySpec,
+            CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY
+        );
+      }));
     }
 
     @Override
@@ -120,45 +144,121 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
       Collection<? extends TaskRunnerWorkItem> pendingTasks = runner.getPendingTasks();
       Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
       boolean didProvision = false;
-      final DefaultWorkerBehaviorConfig workerConfig =
-          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, "provision", log);
+      final CategoriedWorkerBehaviorConfig workerConfig = ProvisioningUtil.getCategoriedWorkerBehaviorConfig(
+          workerConfigRef,
+          "provision"
+      );
       if (workerConfig == null) {
+        log.info("No worker config found. Skip provisioning.");
         return false;
       }
+
+      WorkerCategorySpec workerCategorySpec = ProvisioningUtil.getWorkerCategorySpec(workerConfig);
+
+      // Group tasks by categories
+      Map<String, List<TaskRunnerWorkItem>> tasksByCategories = groupTasksByCategories(
+          pendingTasks,
+          runner,
+          workerCategorySpec
+      );
+
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = workers.stream().collect(Collectors.groupingBy(
+          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
+      );
+
+      // Merge categories of tasks and workers
+      Set<String> allCategories = new HashSet<>(tasksByCategories.keySet());
+      allCategories.addAll(workersByCategories.keySet());
+
+      log.debug(
+          "Pending Tasks of %d categories (%s), Workers of %d categories (%s). %d common categories: %s",
+          tasksByCategories.size(),
+          tasksByCategories.keySet(),
+          workersByCategories.size(),
+          workersByCategories.keySet(),
+          allCategories.size(),
+          allCategories
+      );
+
+      if (allCategories.isEmpty()) {
+        // Likely empty categories means initialization.
+        // Just try to spinup required amount of workers of each non empty autoscalers
+        return initAutoscalers(workerConfig);
+      }
+
+      Map<String, AutoScaler> autoscalersByCategory = ProvisioningUtil.mapAutoscalerByCategory(workerConfig.getAutoScalers());
+
+      for (String category : allCategories) {
+        List<? extends TaskRunnerWorkItem> categoryTasks = tasksByCategories.getOrDefault(
+            category,
+            Collections.emptyList()
+        );
+        AutoScaler categoryAutoscaler = ProvisioningUtil.getAutoscalerByCategory(category, autoscalersByCategory);
+
+        if (categoryAutoscaler == null) {
+          log.error("No autoScaler available, cannot execute doProvision for workers of category %s", category);
+          continue;
+        }
+        // Correct category name by selected autoscaler
+        category = ProvisioningUtil.getAutoscalerCategory(categoryAutoscaler);
+
+        List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
+        currentlyProvisioning.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
+        currentlyTerminating.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
+
+        didProvision = doProvision(
+            category,
+            categoryWorkers,
+            categoryTasks,
+            currentlyProvisioning,
+            currentlyTerminating,
+            categoryAutoscaler
+        ) || didProvision;
+      }
+
+      return didProvision;
+    }
+
+    private boolean doProvision(
+        String category,
+        Collection<ImmutableWorkerInfo> workers,
+        Collection<? extends TaskRunnerWorkItem> pendingTasks,
+        Set<String> currentlyProvisioning,
+        Set<String> currentlyTerminating,
+        AutoScaler<?> autoScaler
+    )
+    {
+      boolean didProvision = false;
 
       final Predicate<ImmutableWorkerInfo> isValidWorker = ProvisioningUtil.createValidWorkerPredicate(config);
       final int currValidWorkers = Collections2.filter(workers, isValidWorker).size();
 
-      final List<String> workerNodeIds = workerConfig.getAutoScaler().ipToIdLookup(
+      final List<String> workerNodeIds = autoScaler.ipToIdLookup(
           Lists.newArrayList(
               Iterables.transform(
                   workers,
-                  new Function<ImmutableWorkerInfo, String>()
-                  {
-                    @Override
-                    public String apply(ImmutableWorkerInfo input)
-                    {
-                      return input.getWorker().getIp();
-                    }
-                  }
+                  input -> input.getWorker().getIp()
               )
           )
       );
       currentlyProvisioning.removeAll(workerNodeIds);
 
-      updateTargetWorkerCount(workerConfig, pendingTasks, workers);
+      updateTargetWorkerCount(autoScaler, pendingTasks, workers, category, currentlyProvisioning, currentlyTerminating);
+      int targetWorkerCount = targetWorkerCountMap.getOrDefault(category, TARGET_WORKER_DEFAULT);
 
       int want = targetWorkerCount - (currValidWorkers + currentlyProvisioning.size());
       log.info("Want workers: %d", want);
       while (want > 0) {
-        final AutoScalingData provisioned = workerConfig.getAutoScaler().provision();
+        final AutoScalingData provisioned = autoScaler.provision();
         final List<String> newNodes;
         if (provisioned == null || (newNodes = provisioned.getNodeIds()).isEmpty()) {
           log.warn("NewNodes is empty, returning from provision loop");
           break;
         } else {
           currentlyProvisioning.addAll(newNodes);
-          lastProvisionTime = DateTimes.nowUtc();
+          lastProvisionTimeMap.put(category, DateTimes.nowUtc());
           scalingStats.addProvisionEvent(provisioned);
           want -= provisioned.getNodeIds().size();
           didProvision = true;
@@ -166,6 +266,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
       }
 
       if (!currentlyProvisioning.isEmpty()) {
+        DateTime lastProvisionTime = lastProvisionTimeMap.getOrDefault(category, DateTimes.nowUtc());
         Duration durSinceLastProvision = new Duration(lastProvisionTime, DateTimes.nowUtc());
         log.info("%s provisioning. Current wait time: %s", currentlyProvisioning, durSinceLastProvision);
         if (durSinceLastProvision.isLongerThan(config.getMaxScalingDuration().toStandardDuration())) {
@@ -174,7 +275,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
              .addData("provisioningCount", currentlyProvisioning.size())
              .emit();
 
-          workerConfig.getAutoScaler().terminateWithIds(Lists.newArrayList(currentlyProvisioning));
+          autoScaler.terminateWithIds(Lists.newArrayList(currentlyProvisioning));
           currentlyProvisioning.clear();
         }
       }
@@ -185,27 +286,92 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
     @Override
     public synchronized boolean doTerminate()
     {
+      Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
       Collection<? extends TaskRunnerWorkItem> pendingTasks = runner.getPendingTasks();
-      final DefaultWorkerBehaviorConfig workerConfig =
-          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, "terminate", log);
+      final CategoriedWorkerBehaviorConfig workerConfig = ProvisioningUtil.getCategoriedWorkerBehaviorConfig(
+          workerConfigRef,
+          "terminate"
+      );
       if (workerConfig == null) {
+        log.info("No worker config found. Skip terminating.");
         return false;
       }
 
       boolean didTerminate = false;
+
+      WorkerCategorySpec workerCategorySpec = ProvisioningUtil.getWorkerCategorySpec(workerConfig);
+
+      // Group tasks by categories
+      Map<String, List<TaskRunnerWorkItem>> pendingTasksByCategories = groupTasksByCategories(
+          pendingTasks,
+          runner,
+          workerCategorySpec
+      );
+
+      Map<String, List<ImmutableWorkerInfo>> workersByCategories = workers.stream().collect(Collectors.groupingBy(
+          immutableWorkerInfo -> immutableWorkerInfo.getWorker().getCategory())
+      );
+
+      Set<String> allCategories = workersByCategories.keySet();
+      log.debug(
+          "Workers of %d categories: %s",
+          workersByCategories.size(),
+          allCategories
+      );
+
+      Map<String, AutoScaler> autoscalersByCategory = ProvisioningUtil.mapAutoscalerByCategory(workerConfig.getAutoScalers());
+
+      for (String category : allCategories) {
+        AutoScaler categoryAutoscaler = ProvisioningUtil.getAutoscalerByCategory(category, autoscalersByCategory);
+
+        if (categoryAutoscaler == null) {
+          log.error("No autoScaler available, cannot execute doTerminate for workers of category %s", category);
+          continue;
+        }
+
+        // Correct category name by selected autoscaler
+        category = ProvisioningUtil.getAutoscalerCategory(categoryAutoscaler);
+        List<ImmutableWorkerInfo> categoryWorkers = workersByCategories.getOrDefault(category, Collections.emptyList());
+        currentlyProvisioning.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
+        currentlyTerminating.putIfAbsent(category, new HashSet<>());
+        Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
+        List<? extends TaskRunnerWorkItem> categoryPendingTasks = pendingTasksByCategories.getOrDefault(
+            category,
+            Collections.emptyList()
+        );
+
+        didTerminate = doTerminate(
+            category,
+            categoryWorkers,
+            currentlyProvisioning,
+            currentlyTerminating,
+            categoryAutoscaler,
+            categoryPendingTasks
+        ) || didTerminate;
+      }
+
+      return didTerminate;
+    }
+
+    private boolean doTerminate(
+        String category,
+        Collection<ImmutableWorkerInfo> workers,
+        Set<String> currentlyProvisioning,
+        Set<String> currentlyTerminating,
+        AutoScaler<?> autoScaler,
+        List<? extends TaskRunnerWorkItem> pendingTasks
+    )
+    {
+      boolean didTerminate = false;
+
+      Collection<Worker> lazyWorkers = ProvisioningUtil.getWorkersOfCategory(runner.getLazyWorkers(), category);
       final Set<String> workerNodeIds = Sets.newHashSet(
-          workerConfig.getAutoScaler().ipToIdLookup(
+          autoScaler.ipToIdLookup(
               Lists.newArrayList(
                   Iterables.transform(
-                      runner.getLazyWorkers(),
-                      new Function<Worker, String>()
-                      {
-                        @Override
-                        public String apply(Worker input)
-                        {
-                          return input.getIp();
-                        }
-                      }
+                      lazyWorkers,
+                      Worker::getIp
                   )
               )
           )
@@ -213,8 +379,8 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
 
       currentlyTerminating.retainAll(workerNodeIds);
 
-      Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
-      updateTargetWorkerCount(workerConfig, pendingTasks, workers);
+      updateTargetWorkerCount(autoScaler, pendingTasks, workers, category, currentlyProvisioning, currentlyTerminating);
+      int targetWorkerCount = targetWorkerCountMap.getOrDefault(category, TARGET_WORKER_DEFAULT);
 
       if (currentlyTerminating.isEmpty()) {
 
@@ -243,17 +409,17 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
                 Joiner.on(", ").join(laziestWorkerIps)
             );
 
-            final AutoScalingData terminated = workerConfig.getAutoScaler()
-                                                           .terminate(ImmutableList.copyOf(laziestWorkerIps));
+            final AutoScalingData terminated = autoScaler.terminate(ImmutableList.copyOf(laziestWorkerIps));
             if (terminated != null) {
               currentlyTerminating.addAll(terminated.getNodeIds());
-              lastTerminateTime = DateTimes.nowUtc();
+              lastTerminateTimeMap.put(category, DateTimes.nowUtc());
               scalingStats.addTerminateEvent(terminated);
               didTerminate = true;
             }
           }
         }
       } else {
+        DateTime lastTerminateTime = lastTerminateTimeMap.getOrDefault(category, DateTimes.nowUtc());
         Duration durSinceLastTerminate = new Duration(lastTerminateTime, DateTimes.nowUtc());
 
         log.info("%s terminating. Current wait time: %s", currentlyTerminating, durSinceLastTerminate);
@@ -273,9 +439,12 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
 
 
     private void updateTargetWorkerCount(
-        final DefaultWorkerBehaviorConfig workerConfig,
+        final AutoScaler autoScaler,
         final Collection<? extends TaskRunnerWorkItem> pendingTasks,
-        final Collection<ImmutableWorkerInfo> zkWorkers
+        final Collection<ImmutableWorkerInfo> zkWorkers,
+        String category,
+        Set<String> currentlyProvisioning,
+        Set<String> currentlyTerminating
     )
     {
       final Collection<ImmutableWorkerInfo> validWorkers = Collections2.filter(
@@ -283,13 +452,15 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
           ProvisioningUtil.createValidWorkerPredicate(config)
       );
       final Predicate<ImmutableWorkerInfo> isLazyWorker = ProvisioningUtil.createLazyWorkerPredicate(config);
-      final int minWorkerCount = workerConfig.getAutoScaler().getMinNumWorkers();
-      final int maxWorkerCount = workerConfig.getAutoScaler().getMaxNumWorkers();
+      final int minWorkerCount = autoScaler.getMinNumWorkers();
+      final int maxWorkerCount = autoScaler.getMaxNumWorkers();
 
       if (minWorkerCount > maxWorkerCount) {
         log.error("Huh? minWorkerCount[%d] > maxWorkerCount[%d]. I give up!", minWorkerCount, maxWorkerCount);
         return;
       }
+
+      int targetWorkerCount = targetWorkerCountMap.getOrDefault(category, TARGET_WORKER_DEFAULT);
 
       if (targetWorkerCount < 0) {
         // Initialize to size of current worker pool, subject to pool size limits
@@ -347,6 +518,8 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
             maxWorkerCount
         );
       }
+
+      targetWorkerCountMap.put(category, targetWorkerCount);
     }
 
     private boolean hasTaskPendingBeyondThreshold(Collection<? extends TaskRunnerWorkItem> pendingTasks)
@@ -367,6 +540,31 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
     {
       return scalingStats;
     }
-  }
 
+    private boolean initAutoscalers(CategoriedWorkerBehaviorConfig workerConfig)
+    {
+      boolean didProvision = false;
+      for (AutoScaler autoScaler : workerConfig.getAutoScalers()) {
+        String category = ProvisioningUtil.getAutoscalerCategory(autoScaler);
+        didProvision = initAutoscaler(autoScaler, category) || didProvision;
+      }
+      return didProvision;
+    }
+
+    private boolean initAutoscaler(AutoScaler autoScaler, String category)
+    {
+      currentlyProvisioning.putIfAbsent(category, new HashSet<>());
+      Set<String> currentlyProvisioning = this.currentlyProvisioning.get(category);
+      currentlyTerminating.putIfAbsent(category, new HashSet<>());
+      Set<String> currentlyTerminating = this.currentlyTerminating.get(category);
+      return doProvision(
+          category,
+          Collections.emptyList(),
+          Collections.emptyList(),
+          currentlyProvisioning,
+          currentlyTerminating,
+          autoScaler
+      );
+    }
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScaler;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 
 public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
@@ -33,19 +33,16 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
   public static final String DEFAULT_AUTOSCALER_CATEGORY = WorkerConfig.DEFAULT_CATEGORY;
 
   private final WorkerSelectStrategy selectStrategy;
-  private final AutoScaler defaultAutoScaler;
-  private final Map<String, AutoScaler> categoryAutoScalers;
+  private final List<AutoScaler> autoScalers;
 
   @JsonCreator
   public CategoriedWorkerBehaviorConfig(
       @JsonProperty("selectStrategy") WorkerSelectStrategy selectStrategy,
-      @JsonProperty("defaultAutoScaler") AutoScaler defaultAutoScaler,
-      @JsonProperty("categoryAutoScalers") Map<String, AutoScaler> categoryAutoScalers
+      @JsonProperty("autoScalers") List<AutoScaler> autoScalers
   )
   {
     this.selectStrategy = selectStrategy;
-    this.defaultAutoScaler = defaultAutoScaler;
-    this.categoryAutoScalers = categoryAutoScalers;
+    this.autoScalers = autoScalers;
   }
 
   @Override
@@ -56,20 +53,9 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
   }
 
   @JsonProperty
-  public AutoScaler getDefaultAutoScaler()
+  public List<AutoScaler> getAutoScalers()
   {
-    return defaultAutoScaler;
-  }
-
-  @JsonProperty
-  public Map<String, AutoScaler> getAutoScalers()
-  {
-    return categoryAutoScalers;
-  }
-
-  public boolean isStrong()
-  {
-    return defaultAutoScaler == null;
+    return autoScalers;
   }
 
   @Override
@@ -83,14 +69,13 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
     }
     CategoriedWorkerBehaviorConfig that = (CategoriedWorkerBehaviorConfig) o;
     return Objects.equals(selectStrategy, that.selectStrategy) &&
-           Objects.equals(defaultAutoScaler, that.defaultAutoScaler) &&
-           Objects.equals(categoryAutoScalers, that.categoryAutoScalers);
+           Objects.equals(autoScalers, that.autoScalers);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(selectStrategy, defaultAutoScaler, categoryAutoScalers);
+    return Objects.hash(selectStrategy, autoScalers);
   }
 
   @Override
@@ -98,8 +83,7 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
   {
     return "WorkerConfiguration{" +
            "selectStrategy=" + selectStrategy +
-           ", defaultAutoScaler=" + defaultAutoScaler +
-           ", categoryAutoScalers=" + categoryAutoScalers +
+           ", autoScalers=" + autoScalers +
            '}';
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
@@ -22,13 +22,15 @@ package org.apache.druid.indexing.overlord.setup;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScaler;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
 
 import java.util.Map;
 import java.util.Objects;
 
 public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
 {
-  public static final String DEFAULT_AUTOSCALER_CATEGORY = "_default_autoscaler_category";
+  // Use the same category constant as for worker category to match default workers and autoscalers
+  public static final String DEFAULT_AUTOSCALER_CATEGORY = WorkerConfig.DEFAULT_CATEGORY;
 
   private final WorkerSelectStrategy selectStrategy;
   private final AutoScaler defaultAutoScaler;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
@@ -28,23 +28,22 @@ import java.util.Objects;
 
 public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
 {
+  public static final String DEFAULT_AUTOSCALER_CATEGORY = "_default_autoscaler_category";
+
   private final WorkerSelectStrategy selectStrategy;
   private final AutoScaler defaultAutoScaler;
   private final Map<String, AutoScaler> categoryAutoScalers;
-  private final boolean strong;
 
   @JsonCreator
   public CategoriedWorkerBehaviorConfig(
       @JsonProperty("selectStrategy") WorkerSelectStrategy selectStrategy,
       @JsonProperty("defaultAutoScaler") AutoScaler defaultAutoScaler,
-      @JsonProperty("categoryAutoScalers") Map<String, AutoScaler> categoryAutoScalers,
-      @JsonProperty("strong") boolean strong
+      @JsonProperty("categoryAutoScalers") Map<String, AutoScaler> categoryAutoScalers
   )
   {
     this.selectStrategy = selectStrategy;
     this.defaultAutoScaler = defaultAutoScaler;
     this.categoryAutoScalers = categoryAutoScalers;
-    this.strong = strong;
   }
 
   @Override
@@ -61,15 +60,14 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
   }
 
   @JsonProperty
-  public Map<String, AutoScaler> getCategoryAutoScalers()
+  public Map<String, AutoScaler> getAutoScalers()
   {
     return categoryAutoScalers;
   }
 
-  @JsonProperty
   public boolean isStrong()
   {
-    return strong;
+    return defaultAutoScaler == null;
   }
 
   @Override
@@ -82,8 +80,7 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
       return false;
     }
     CategoriedWorkerBehaviorConfig that = (CategoriedWorkerBehaviorConfig) o;
-    return strong == that.strong &&
-           Objects.equals(selectStrategy, that.selectStrategy) &&
+    return Objects.equals(selectStrategy, that.selectStrategy) &&
            Objects.equals(defaultAutoScaler, that.defaultAutoScaler) &&
            Objects.equals(categoryAutoScalers, that.categoryAutoScalers);
   }
@@ -91,7 +88,7 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
   @Override
   public int hashCode()
   {
-    return Objects.hash(selectStrategy, defaultAutoScaler, categoryAutoScalers, strong);
+    return Objects.hash(selectStrategy, defaultAutoScaler, categoryAutoScalers);
   }
 
   @Override
@@ -101,7 +98,6 @@ public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
            "selectStrategy=" + selectStrategy +
            ", defaultAutoScaler=" + defaultAutoScaler +
            ", categoryAutoScalers=" + categoryAutoScalers +
-           ", strong=" + strong +
            '}';
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerBehaviorConfig.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.setup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexing.overlord.autoscaling.AutoScaler;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class CategoriedWorkerBehaviorConfig implements WorkerBehaviorConfig
+{
+  private final WorkerSelectStrategy selectStrategy;
+  private final AutoScaler defaultAutoScaler;
+  private final Map<String, AutoScaler> categoryAutoScalers;
+  private final boolean strong;
+
+  @JsonCreator
+  public CategoriedWorkerBehaviorConfig(
+      @JsonProperty("selectStrategy") WorkerSelectStrategy selectStrategy,
+      @JsonProperty("defaultAutoScaler") AutoScaler defaultAutoScaler,
+      @JsonProperty("categoryAutoScalers") Map<String, AutoScaler> categoryAutoScalers,
+      @JsonProperty("strong") boolean strong
+  )
+  {
+    this.selectStrategy = selectStrategy;
+    this.defaultAutoScaler = defaultAutoScaler;
+    this.categoryAutoScalers = categoryAutoScalers;
+    this.strong = strong;
+  }
+
+  @Override
+  @JsonProperty
+  public WorkerSelectStrategy getSelectStrategy()
+  {
+    return selectStrategy;
+  }
+
+  @JsonProperty
+  public AutoScaler getDefaultAutoScaler()
+  {
+    return defaultAutoScaler;
+  }
+
+  @JsonProperty
+  public Map<String, AutoScaler> getCategoryAutoScalers()
+  {
+    return categoryAutoScalers;
+  }
+
+  @JsonProperty
+  public boolean isStrong()
+  {
+    return strong;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CategoriedWorkerBehaviorConfig that = (CategoriedWorkerBehaviorConfig) o;
+    return strong == that.strong &&
+           Objects.equals(selectStrategy, that.selectStrategy) &&
+           Objects.equals(defaultAutoScaler, that.defaultAutoScaler) &&
+           Objects.equals(categoryAutoScalers, that.categoryAutoScalers);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(selectStrategy, defaultAutoScaler, categoryAutoScalers, strong);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "WorkerConfiguration{" +
+           "selectStrategy=" + selectStrategy +
+           ", defaultAutoScaler=" + defaultAutoScaler +
+           ", categoryAutoScalers=" + categoryAutoScalers +
+           ", strong=" + strong +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerSelectStrategy.java
@@ -1,0 +1,6 @@
+package org.apache.druid.indexing.overlord.setup;
+
+public interface CategoriedWorkerSelectStrategy extends WorkerSelectStrategy
+{
+  WorkerCategorySpec getWorkerCategorySpec();
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/CategoriedWorkerSelectStrategy.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.indexing.overlord.setup;
 
 public interface CategoriedWorkerSelectStrategy extends WorkerSelectStrategy

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/DefaultWorkerBehaviorConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/DefaultWorkerBehaviorConfig.java
@@ -28,7 +28,7 @@ import org.apache.druid.indexing.overlord.autoscaling.NoopAutoScaler;
  */
 public class DefaultWorkerBehaviorConfig implements WorkerBehaviorConfig
 {
-  private static final AutoScaler DEFAULT_AUTOSCALER = new NoopAutoScaler();
+  private static final AutoScaler DEFAULT_AUTOSCALER = new NoopAutoScaler(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY);
 
   public static DefaultWorkerBehaviorConfig defaultConfig()
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategy.java
@@ -29,7 +29,7 @@ import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class EqualDistributionWithCategorySpecWorkerSelectStrategy implements WorkerSelectStrategy
+public class EqualDistributionWithCategorySpecWorkerSelectStrategy implements CategoriedWorkerSelectStrategy
 {
   private final WorkerCategorySpec workerCategorySpec;
 
@@ -42,6 +42,7 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategy implements Wo
   }
 
   @JsonProperty
+  @Override
   public WorkerCategorySpec getWorkerCategorySpec()
   {
     return workerCategorySpec;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategy.java
@@ -29,7 +29,7 @@ import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class FillCapacityWithCategorySpecWorkerSelectStrategy implements WorkerSelectStrategy
+public class FillCapacityWithCategorySpecWorkerSelectStrategy implements CategoriedWorkerSelectStrategy
 {
   private final WorkerCategorySpec workerCategorySpec;
 
@@ -42,6 +42,7 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategy implements WorkerS
   }
 
   @JsonProperty
+  @Override
   public WorkerCategorySpec getWorkerCategorySpec()
   {
     return workerCategorySpec;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerBehaviorConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerBehaviorConfig.java
@@ -34,7 +34,8 @@ import org.apache.druid.guice.annotations.ExtensionPoint;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = DefaultWorkerBehaviorConfig.class)
 @JsonSubTypes(value = {
-    @JsonSubTypes.Type(name = "default", value = DefaultWorkerBehaviorConfig.class)
+    @JsonSubTypes.Type(name = "default", value = DefaultWorkerBehaviorConfig.class),
+    @JsonSubTypes.Type(name = "categoried", value = CategoriedWorkerBehaviorConfig.class)
 })
 @ExtensionPoint
 public interface WorkerBehaviorConfig

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Maps;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
-import org.apache.druid.java.util.emitter.EmittingLogger;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -34,8 +33,6 @@ import java.util.stream.Collectors;
 
 public class WorkerSelectUtils
 {
-  private static final EmittingLogger log = new EmittingLogger(WorkerSelectUtils.class);
-
   private WorkerSelectUtils()
   {
     // No instantiation.
@@ -132,7 +129,7 @@ public class WorkerSelectUtils
             runnableWorkers
         );
         final ImmutableWorkerInfo selected = workerSelector.apply(categoryWorkers);
-        log.debug("Selected worker %s for category %s. Spec strong assignment is %b", selected, preferredCategory, workerCategorySpec.isStrong());
+
         if (selected != null) {
           return selected;
         } else if (workerCategorySpec.isStrong()) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Maps;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+import org.apache.druid.java.util.emitter.EmittingLogger;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -33,6 +34,8 @@ import java.util.stream.Collectors;
 
 public class WorkerSelectUtils
 {
+  private static final EmittingLogger log = new EmittingLogger(WorkerSelectUtils.class);
+
   private WorkerSelectUtils()
   {
     // No instantiation.
@@ -129,7 +132,7 @@ public class WorkerSelectUtils
             runnableWorkers
         );
         final ImmutableWorkerInfo selected = workerSelector.apply(categoryWorkers);
-
+        log.debug("Selected worker %s for category %s. Spec strong assignment is %b", selected, preferredCategory, workerCategorySpec.isStrong());
         if (selected != null) {
           return selected;
         } else if (workerCategorySpec.isStrong()) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
@@ -190,7 +190,7 @@ public class WorkerSelectUtils
   )
   {
     return ImmutableMap.copyOf(
-        Maps.filterValues(workerMap, workerInfo -> workerInfo.getWorker().getCategory().equals(category))
+        Maps.filterValues(workerMap, workerInfo -> category.equals(workerInfo.getWorker().getCategory()))
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
@@ -57,7 +57,11 @@ public class WorkerSelectUtils
       final Function<ImmutableMap<String, ImmutableWorkerInfo>, ImmutableWorkerInfo> workerSelector
   )
   {
-    final Map<String, ImmutableWorkerInfo> runnableWorkers = getRunnableWorkers(task, allWorkers, workerTaskRunnerConfig);
+    final Map<String, ImmutableWorkerInfo> runnableWorkers = getRunnableWorkers(
+        task,
+        allWorkers,
+        workerTaskRunnerConfig
+    );
 
     if (affinityConfig == null) {
       // All runnable workers are valid.
@@ -92,10 +96,10 @@ public class WorkerSelectUtils
   /**
    * Helper for {@link WorkerSelectStrategy} implementations.
    *
-   * @param allWorkers     map of all workers, in the style provided to {@link WorkerSelectStrategy}
+   * @param allWorkers         map of all workers, in the style provided to {@link WorkerSelectStrategy}
    * @param workerCategorySpec worker category spec, or null
-   * @param workerSelector function that receives a list of eligible workers: version is high enough, worker can run
-   *                       the task, and worker satisfies the worker category spec. may return null.
+   * @param workerSelector     function that receives a list of eligible workers: version is high enough, worker can run
+   *                           the task, and worker satisfies the worker category spec. may return null.
    *
    * @return selected worker from "allWorkers", or null.
    */
@@ -108,7 +112,11 @@ public class WorkerSelectUtils
       final Function<ImmutableMap<String, ImmutableWorkerInfo>, ImmutableWorkerInfo> workerSelector
   )
   {
-    final Map<String, ImmutableWorkerInfo> runnableWorkers = getRunnableWorkers(task, allWorkers, workerTaskRunnerConfig);
+    final Map<String, ImmutableWorkerInfo> runnableWorkers = getRunnableWorkers(
+        task,
+        allWorkers,
+        workerTaskRunnerConfig
+    );
 
     // select worker according to worker category spec
     if (workerCategorySpec != null) {
@@ -116,7 +124,10 @@ public class WorkerSelectUtils
 
       if (preferredCategory != null) {
         // select worker from preferred category
-        final ImmutableMap<String, ImmutableWorkerInfo> categoryWorkers = getCategoryWorkers(preferredCategory, runnableWorkers);
+        final ImmutableMap<String, ImmutableWorkerInfo> categoryWorkers = getCategoryWorkers(
+            preferredCategory,
+            runnableWorkers
+        );
         final ImmutableWorkerInfo selected = workerSelector.apply(categoryWorkers);
 
         if (selected != null) {
@@ -132,7 +143,8 @@ public class WorkerSelectUtils
   }
 
   @Nullable
-  public static String getTaskCategory(Task task, WorkerCategorySpec workerCategorySpec, String defaultValue) {
+  public static String getTaskCategory(Task task, WorkerCategorySpec workerCategorySpec, String defaultValue)
+  {
     // select worker according to worker category spec
     if (workerCategorySpec != null) {
       final WorkerCategorySpec.CategoryConfig categoryConfig = workerCategorySpec.getCategoryMap().get(task.getType());
@@ -167,8 +179,8 @@ public class WorkerSelectUtils
   /**
    * Return workers belong to this category.
    *
-   * @param category worker category name
-   * @param workerMap  map of worker hostname to worker info
+   * @param category  worker category name
+   * @param workerMap map of worker hostname to worker info
    *
    * @return map of worker hostname to worker info
    */

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.autoscaling;
+
+import org.apache.druid.common.guava.DSuppliers;
+import org.apache.druid.indexing.common.TestTasks;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.RemoteTaskRunner;
+import org.apache.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.FillCapacityWithCategorySpecWorkerSelectStrategy;
+import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.easymock.EasyMock;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CategoriedProvisioningStrategyTest
+{
+  private AutoScaler autoScalerDefault;
+  private AutoScaler autoScalerCategory1;
+  private AutoScaler autoScalerCategory2;
+  private final Map<String, AutoScaler> categoryAutoScaler = new HashMap<>();
+  private Task testTask;
+  private CategoriedProvisioningConfig config;
+  private final ScheduledExecutorService executorService = Execs.scheduledSingleThreaded("test service");
+  private static final String MIN_VERSION = "2014-01-00T00:01:00Z";
+  private static final String INVALID_VERSION = "0";
+
+  @Before
+  public void setup()
+  {
+    autoScalerDefault = EasyMock.createMock(AutoScaler.class);
+
+    autoScalerCategory1 = EasyMock.createMock(AutoScaler.class);
+    autoScalerCategory2 = EasyMock.createMock(AutoScaler.class);
+
+    categoryAutoScaler.clear();
+    categoryAutoScaler.put("category1", autoScalerCategory1);
+    categoryAutoScaler.put("category2", autoScalerCategory2);
+
+    testTask = TestTasks.immediateSuccess("task1");
+
+    config = new CategoriedProvisioningConfig()
+        .setMaxScalingDuration(new Period(1000))
+        .setNumEventsToTrack(10)
+        .setPendingTaskTimeout(new Period(0))
+        .setWorkerVersion(MIN_VERSION)
+        .setMaxScalingStep(2);
+  }
+
+  @Test
+  public void testDefaultAutoscalerSuccessfullInitialMinWorkers()
+  {
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
+
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
+    setupAutoscaler(autoScalerDefault, 3, 5, Collections.emptyList());
+    setupAutoscaler(autoScalerCategory1, 2, 4, Collections.emptyList());
+    setupAutoscaler(autoScalerCategory2, 4, 6, Collections.emptyList());
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // No pending tasks
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getWorkers()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getConfig()).andReturn(new RemoteTaskRunnerConfig());
+
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    ).times(3);
+
+    EasyMock.replay(runner, autoScalerDefault);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    Assert.assertEquals(3, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+  }
+
+  @Test
+  public void testStrongAssigmentDoesntInitialMinWorkers()
+  {
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
+
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(3);
+    EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.emptyList());
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // No pending tasks
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.emptyList()
+    );
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Collections.emptyList()
+    );
+    EasyMock.expect(runner.getConfig()).andReturn(new RemoteTaskRunnerConfig());
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    ).times(3);
+    EasyMock.replay(runner, autoScalerDefault);
+
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    Assert.assertTrue(provisioner.getStats().toList().size() == 3);
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertTrue(
+          event.getEvent() == ScalingStats.EVENT.PROVISION
+      );
+    }
+  }
+
+
+  private void setupAutoscaler(AutoScaler autoScaler, int minWorkers, int maxWorkers, List<String> pendingTasks) {
+    EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(minWorkers);
+    EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(maxWorkers);
+    EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(pendingTasks);
+  }
+
+  private AtomicReference<WorkerBehaviorConfig> createWorkerConfigRef(boolean isStrong)
+  {
+    return new AtomicReference<>(
+        new CategoriedWorkerBehaviorConfig(
+            new FillCapacityWithCategorySpecWorkerSelectStrategy(null),
+            autoScalerDefault,
+            categoryAutoScaler,
+            isStrong
+        )
+    );
+  }
+
+  private CategoriedProvisioningStrategy createStrategy(AtomicReference<WorkerBehaviorConfig> workerConfigRef)
+  {
+    return new CategoriedProvisioningStrategy(
+        config,
+        DSuppliers.of(workerConfigRef),
+        new ProvisioningSchedulerConfig(),
+        () -> executorService
+    );
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
@@ -108,9 +108,15 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
+    setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        3,
+        5,
+        Collections.emptyList()
+    );
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 2, 4, Collections.emptyList());
-    setupAutoscaler(autoScalerCategory2, CATEGORY_2,4, 6, Collections.emptyList());
+    setupAutoscaler(autoScalerCategory2, CATEGORY_2, 4, 6, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -203,7 +209,13 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
+    setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        3,
+        5,
+        Collections.emptyList()
+    );
     autoScalers.add(autoScalerDefault);
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -281,7 +293,7 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerCategory1, CATEGORY_1,5, 7, Collections.emptyList());
+    setupAutoscaler(autoScalerCategory1, CATEGORY_1, 5, 7, Collections.emptyList());
     autoScalers.add(autoScalerCategory1);
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -515,7 +527,13 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
+    setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        3,
+        5,
+        Collections.emptyList()
+    );
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 3, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 3, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
@@ -606,7 +624,9 @@ public class CategoriedProvisioningStrategyTest
 
     EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
-    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY).times(2);
+    EasyMock.expect(autoScalerDefault.getCategory())
+            .andReturn(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY)
+            .times(2);
     EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.emptyList()).times(2);
     EasyMock.expect(autoScalerDefault.terminateWithIds(EasyMock.anyObject()))
@@ -728,7 +748,13 @@ public class CategoriedProvisioningStrategyTest
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
-    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 1, 3, Collections.emptyList());
+    setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        1,
+        3,
+        Collections.emptyList()
+    );
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 2, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 4, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
@@ -822,7 +848,12 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
-    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 1, Collections.emptyList());
+    setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        1,
+        Collections.emptyList()
+    );
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
@@ -886,7 +917,9 @@ public class CategoriedProvisioningStrategyTest
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(1);
-    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY).times(2);
+    EasyMock.expect(autoScalerDefault.getCategory())
+            .andReturn(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY)
+            .times(2);
     EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip")).times(2);
     EasyMock.expect(autoScalerDefault.terminate(EasyMock.anyObject())).andReturn(
@@ -962,7 +995,13 @@ public class CategoriedProvisioningStrategyTest
   }
 
 
-  private void setupAutoscaler(AutoScaler autoScaler, String category, int minWorkers, int maxWorkers, List<String> pendingTasks)
+  private void setupAutoscaler(
+      AutoScaler autoScaler,
+      String category,
+      int minWorkers,
+      int maxWorkers,
+      List<String> pendingTasks
+  )
   {
     setupAutoscaler(autoScaler, category, minWorkers, pendingTasks);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(maxWorkers);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
@@ -103,10 +103,10 @@ public class CategoriedProvisioningStrategyTest
   public void testDefaultAutoscalerSuccessfulInitialMinWorkers()
   {
     // Not strong affinity autoscaling mode will use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(false);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerDefault, 3, 5, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, 2, 4, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, 4, 6, Collections.emptyList());
@@ -151,11 +151,11 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testDefaultAutoscalerDidntSpawnInitialMinWorkers()
   {
-    // Strong affinity autoscaling mode will not use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(false);
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerCategory1, 2, 4, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, 4, 6, Collections.emptyList());
 
@@ -195,11 +195,11 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testDefaultAutoscalerSuccessfulMinWorkers()
   {
-    // Not strong affinity autoscaling mode will use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(false);
+    // Not strong affinity autoscaling mode will use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerDefault, 3, 5, Collections.emptyList());
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -236,11 +236,11 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testAnyAutoscalerDontSpawnMinWorkers()
   {
-    // Strong affinity autoscaling mode will not use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(false);
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     // No pending tasks
@@ -266,8 +266,6 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testCategoriedAutoscalerSpawnedMinWorkers()
   {
-    // Strong affinity autoscaling mode will not use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(
         false,
         TASK_TYPE_1,
@@ -275,8 +273,10 @@ public class CategoriedProvisioningStrategyTest
         DATA_SOURCE_1,
         CATEGORY_2
     );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerCategory1, 5, 7, Collections.emptyList());
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -310,8 +310,6 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testCategoriedAutoscalerSpawnedAdditionalWorker()
   {
-    // Strong affinity autoscaling mode will not use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(
         false,
         TASK_TYPE_1,
@@ -319,8 +317,10 @@ public class CategoriedProvisioningStrategyTest
         DATA_SOURCE_1,
         CATEGORY_2
     );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerCategory1, 2, 3, Collections.emptyList());
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -356,8 +356,6 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testCategoriedAutoscalerSpawnedUpToMaxWorkers()
   {
-    // Strong affinity autoscaling mode will not use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(
         false,
         TASK_TYPE_1,
@@ -365,8 +363,10 @@ public class CategoriedProvisioningStrategyTest
         DATA_SOURCE_1,
         CATEGORY_2
     );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerCategory1, 2, 3, Collections.emptyList());
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -405,8 +405,6 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testAllCategoriedAutoscalersStrongly()
   {
-    // Strong affinity autoscaling mode will not use default autoscaler
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(
         false,
         TASK_TYPE_1,
@@ -430,8 +428,10 @@ public class CategoriedProvisioningStrategyTest
             )
         )
     );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerCategory1, 1, 3, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, 1, 3, Collections.emptyList());
 
@@ -481,7 +481,6 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testAllCategoriedAutoscalersNotStrongMode()
   {
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(
         false,
         TASK_TYPE_1,
@@ -505,8 +504,9 @@ public class CategoriedProvisioningStrategyTest
             )
         )
     );
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
     setupAutoscaler(autoScalerDefault, 3, 5, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, 1, 3, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, 1, 3, Collections.emptyList());
@@ -568,7 +568,6 @@ public class CategoriedProvisioningStrategyTest
     EasyMock.expectLastCall().times(3);
     EasyMock.replay(emitter);
 
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(
         false,
         TASK_TYPE_1,
@@ -592,8 +591,9 @@ public class CategoriedProvisioningStrategyTest
             )
         )
     );
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
@@ -680,15 +680,8 @@ public class CategoriedProvisioningStrategyTest
   public void testNullWorkerConfig()
   {
     AtomicReference<WorkerBehaviorConfig> workerConfig = new AtomicReference<>(null);
-    WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(
-        false,
-        TASK_TYPE_1,
-        CATEGORY_1,
-        DATA_SOURCE_1,
-        CATEGORY_2
-    );
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     // One pending task
@@ -716,10 +709,10 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testNullWorkerCategorySpecNotStrong()
   {
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
     WorkerCategorySpec workerCategorySpec = null;
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     setupAutoscaler(autoScalerDefault, 1, 3, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, 1, 2, Collections.emptyList());
@@ -766,10 +759,10 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testNullWorkerCategorySpecStrong()
   {
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true);
     WorkerCategorySpec workerCategorySpec = null;
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(true, workerCategorySpec);
 
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     setupAutoscaler(autoScalerCategory1, 1, 2, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, 1, 4, Collections.emptyList());
@@ -809,9 +802,9 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testDoSuccessfulTerminateForAllCategories()
   {
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(false);
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     setupAutoscaler(autoScalerDefault, 1, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, 1, Collections.emptyList());
@@ -871,9 +864,9 @@ public class CategoriedProvisioningStrategyTest
   @Test
   public void testSomethingTerminating()
   {
-    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false);
     WorkerCategorySpec workerCategorySpec = createWorkerCategorySpec(false);
-    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig, workerCategorySpec);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(false, workerCategorySpec);
+    CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(1);
     EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
@@ -999,11 +992,11 @@ public class CategoriedProvisioningStrategyTest
     return new WorkerCategorySpec(categoryMap, isStrong);
   }
 
-  private AtomicReference<WorkerBehaviorConfig> createWorkerConfigRef(boolean isStrong)
+  private AtomicReference<WorkerBehaviorConfig> createWorkerConfigRef(boolean isStrong, WorkerCategorySpec workerCategorySpec)
   {
     return new AtomicReference<>(
         new CategoriedWorkerBehaviorConfig(
-            new FillCapacityWithCategorySpecWorkerSelectStrategy(null),
+            new FillCapacityWithCategorySpecWorkerSelectStrategy(workerCategorySpec),
             isStrong ? null : autoScalerDefault,
             categoryAutoScaler
         )
@@ -1011,14 +1004,12 @@ public class CategoriedProvisioningStrategyTest
   }
 
   private CategoriedProvisioningStrategy createStrategy(
-      AtomicReference<WorkerBehaviorConfig> workerConfigRef,
-      WorkerCategorySpec workerCategorySpec
+      AtomicReference<WorkerBehaviorConfig> workerConfigRef
   )
   {
     return new CategoriedProvisioningStrategy(
         config,
         DSuppliers.of(workerConfigRef),
-        workerCategorySpec,
         new ProvisioningSchedulerConfig(),
         () -> executorService
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
@@ -108,8 +108,8 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     PendingTaskBasedWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerCategory1, CATEGORY_1, 2, 4, Collections.emptyList(), 1, 1, 1, 1);
-    setupAutoscaler(autoScalerCategory2, CATEGORY_2, 4, 6, Collections.emptyList(), 1, 1, 1, 1);
+    setupAutoscaler(autoScalerCategory1, CATEGORY_1, 2, 4, Collections.emptyList(), 2, 1, 1, 1);
+    setupAutoscaler(autoScalerCategory2, CATEGORY_2, 4, 6, Collections.emptyList(), 2, 1, 1, 1);
     autoScalers.addAll(Arrays.asList(autoScalerCategory1, autoScalerCategory2));
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -578,7 +578,7 @@ public class CategoriedProvisioningStrategyTest
 
     EasyMock.expect(autoScalerCategory1.getMinNumWorkers()).andReturn(1);
     EasyMock.expect(autoScalerCategory1.getMaxNumWorkers()).andReturn(3);
-    EasyMock.expect(autoScalerCategory1.getCategory()).andReturn(CATEGORY_1).times(4);
+    EasyMock.expect(autoScalerCategory1.getCategory()).andReturn(CATEGORY_1).times(8);
     EasyMock.expect(autoScalerCategory1.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.emptyList()).times(2);
     EasyMock.expect(autoScalerCategory1.terminateWithIds(EasyMock.anyObject()))
@@ -586,7 +586,7 @@ public class CategoriedProvisioningStrategyTest
 
     EasyMock.expect(autoScalerCategory2.getMinNumWorkers()).andReturn(1);
     EasyMock.expect(autoScalerCategory2.getMaxNumWorkers()).andReturn(3);
-    EasyMock.expect(autoScalerCategory2.getCategory()).andReturn(CATEGORY_2).times(4);
+    EasyMock.expect(autoScalerCategory2.getCategory()).andReturn(CATEGORY_2).times(8);
     EasyMock.expect(autoScalerCategory2.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.emptyList()).times(2);
     EasyMock.expect(autoScalerCategory2.terminateWithIds(EasyMock.anyObject()))
@@ -930,7 +930,7 @@ public class CategoriedProvisioningStrategyTest
     );
 
     EasyMock.expect(autoScalerCategory1.getMinNumWorkers()).andReturn(1);
-    EasyMock.expect(autoScalerCategory1.getCategory()).andReturn(CATEGORY_1).times(4);
+    EasyMock.expect(autoScalerCategory1.getCategory()).andReturn(CATEGORY_1).times(8);
     EasyMock.expect(autoScalerCategory1.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip")).times(2);
     EasyMock.expect(autoScalerCategory1.terminate(EasyMock.anyObject())).andReturn(
@@ -938,7 +938,7 @@ public class CategoriedProvisioningStrategyTest
     );
 
     EasyMock.expect(autoScalerCategory2.getMinNumWorkers()).andReturn(1);
-    EasyMock.expect(autoScalerCategory2.getCategory()).andReturn(CATEGORY_2).times(4);
+    EasyMock.expect(autoScalerCategory2.getCategory()).andReturn(CATEGORY_2).times(8);
     EasyMock.expect(autoScalerCategory2.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip")).times(2);
     EasyMock.expect(autoScalerCategory2.terminate(EasyMock.anyObject())).andReturn(
@@ -1048,19 +1048,16 @@ public class CategoriedProvisioningStrategyTest
     EasyMock.verify(autoScalerDefault);
 
     EasyMock.reset(autoScalerDefault);
-    // Increase minNumWorkers
+    // Increase minNumWorkers and expect provisioning
     EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
     EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip"));
-    EasyMock.expect(autoScalerDefault.provision()).andReturn(
-        new AutoScalingData(Collections.singletonList("h3"))
-    );
     // Should provision two new workers
     EasyMock.expect(autoScalerDefault.provision()).andReturn(
-        new AutoScalingData(Collections.singletonList("h4"))
-    );
-    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null);
+        new AutoScalingData(Collections.singletonList("h3"))
+    ).times(3);
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null).times(2);
     EasyMock.replay(autoScalerDefault);
     provisionedSomething = provisioner.doProvision();
     Assert.assertTrue(provisionedSomething);
@@ -1083,7 +1080,7 @@ public class CategoriedProvisioningStrategyTest
     EasyMock.expect(autoScalerDefault.provision()).andReturn(
         new AutoScalingData(Collections.singletonList("aNode"))
     );
-    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null);
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null).times(2);
 
     EasyMock.replay(autoScalerDefault);
     autoScalers.add(autoScalerDefault);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
@@ -49,7 +49,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/CategoriedProvisioningStrategyTest.java
@@ -58,7 +58,6 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY;
 
 public class CategoriedProvisioningStrategyTest
 {
@@ -109,7 +108,7 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerDefault, DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
+    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 2, 4, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, CATEGORY_2,4, 6, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
@@ -204,7 +203,7 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerDefault, DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
+    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
     autoScalers.add(autoScalerDefault);
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
@@ -516,7 +515,7 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
-    setupAutoscaler(autoScalerDefault, DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
+    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 3, 5, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 3, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 3, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
@@ -607,7 +606,7 @@ public class CategoriedProvisioningStrategyTest
 
     EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
-    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(DEFAULT_AUTOSCALER_CATEGORY).times(2);
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY).times(2);
     EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.emptyList()).times(2);
     EasyMock.expect(autoScalerDefault.terminateWithIds(EasyMock.anyObject()))
@@ -729,7 +728,7 @@ public class CategoriedProvisioningStrategyTest
 
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
-    setupAutoscaler(autoScalerDefault, DEFAULT_AUTOSCALER_CATEGORY, 1, 3, Collections.emptyList());
+    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 1, 3, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 2, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 4, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
@@ -823,7 +822,7 @@ public class CategoriedProvisioningStrategyTest
     AtomicReference<WorkerBehaviorConfig> workerConfig = createWorkerConfigRef(workerCategorySpec);
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
-    setupAutoscaler(autoScalerDefault, DEFAULT_AUTOSCALER_CATEGORY, 1, Collections.emptyList());
+    setupAutoscaler(autoScalerDefault, CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY, 1, Collections.emptyList());
     setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, Collections.emptyList());
     setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, Collections.emptyList());
     autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
@@ -887,7 +886,7 @@ public class CategoriedProvisioningStrategyTest
     CategoriedProvisioningStrategy strategy = createStrategy(workerConfig);
 
     EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(1);
-    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(DEFAULT_AUTOSCALER_CATEGORY).times(2);
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY).times(2);
     EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip")).times(2);
     EasyMock.expect(autoScalerDefault.terminate(EasyMock.anyObject())).andReturn(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
@@ -35,7 +35,6 @@ import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.FillCapacityWorkerSelectStrategy;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
-import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
 import org.apache.druid.indexing.worker.TaskAnnouncement;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
@@ -56,12 +55,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ *
  */
 public class PendingTaskBasedProvisioningStrategyTest
 {
@@ -624,7 +623,11 @@ public class PendingTaskBasedProvisioningStrategyTest
         int capacity
     )
     {
-      super(new Worker(scheme, host, ip, capacity, version, WorkerConfig.DEFAULT_CATEGORY), null, new DefaultObjectMapper());
+      super(
+          new Worker(scheme, host, ip, capacity, version, WorkerConfig.DEFAULT_CATEGORY),
+          null,
+          new DefaultObjectMapper()
+      );
 
       this.testTask = testTask;
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
@@ -31,9 +31,11 @@ import org.apache.druid.indexing.overlord.RemoteTaskRunner;
 import org.apache.druid.indexing.overlord.RemoteTaskRunnerWorkItem;
 import org.apache.druid.indexing.overlord.ZkWorker;
 import org.apache.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.FillCapacityWorkerSelectStrategy;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
 import org.apache.druid.indexing.worker.TaskAnnouncement;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
@@ -54,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -62,6 +65,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class PendingTaskBasedProvisioningStrategyTest
 {
+  public static final String DEFAULT_CATEGORY = CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY;
   private AutoScaler autoScaler;
   private Task testTask;
   private PendingTaskBasedWorkerProvisioningStrategy strategy;
@@ -109,6 +113,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   @Test
   public void testSuccessfulInitialMinWorkersProvision()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -140,6 +145,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   @Test
   public void testSuccessfulMinWorkersProvision()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -174,6 +180,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   @Test
   public void testSuccessfulMinWorkersProvisionWithOldVersionNodeRunning()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -209,6 +216,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   @Test
   public void testSomethingProvisioning()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(8);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0).times(1);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2).times(1);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -266,6 +274,7 @@ public class PendingTaskBasedProvisioningStrategyTest
     EasyMock.expectLastCall();
     EasyMock.replay(emitter);
 
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(8);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0).times(1);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2).times(1);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -323,6 +332,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   @Test
   public void testDoSuccessfulTerminate()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(new ArrayList<String>());
@@ -367,6 +377,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   @Test
   public void testSomethingTerminating()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(8);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0).times(1);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip")).times(2);
@@ -411,6 +422,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   public void testNoActionNeeded()
   {
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip"));
@@ -442,6 +454,7 @@ public class PendingTaskBasedProvisioningStrategyTest
     EasyMock.verify(autoScaler);
 
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -460,6 +473,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   {
     // Don't terminate anything
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
             .andReturn(Collections.singletonList("ip"));
@@ -487,6 +501,7 @@ public class PendingTaskBasedProvisioningStrategyTest
 
     // Don't provision anything
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -497,6 +512,7 @@ public class PendingTaskBasedProvisioningStrategyTest
     EasyMock.verify(autoScaler);
 
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     // Increase minNumWorkers
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);
@@ -520,6 +536,7 @@ public class PendingTaskBasedProvisioningStrategyTest
   public void testMinCountIncreaseNoWorkers()
   {
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     // Expect min number to be zero, but autoscaling should work for that case as well even there is no workers running
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
@@ -517,6 +517,35 @@ public class PendingTaskBasedProvisioningStrategyTest
   }
 
   @Test
+  public void testMinCountIncreaseNoWorkers()
+  {
+    EasyMock.reset(autoScaler);
+    // Expect min number to be zero, but autoscaling should work for that case as well even there is no workers running
+    EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
+    EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip"));
+    EasyMock.expect(autoScaler.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    );
+    EasyMock.replay(autoScaler);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.singletonList(NoopTask.create()));
+    EasyMock.expect(runner.getWorkers()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getConfig()).andReturn(new RemoteTaskRunnerConfig());
+
+    EasyMock.replay(runner);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    Assert.assertEquals(1, provisioner.getStats().toList().size());
+    Assert.assertSame(provisioner.getStats().toList().get(0).getEvent(), ScalingStats.EVENT.PROVISION);
+    EasyMock.verify(autoScaler, runner);
+  }
+
+  @Test
   public void testNullWorkerConfig()
   {
     workerConfig.set(null);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.RemoteTaskRunner;
 import org.apache.druid.indexing.overlord.RemoteTaskRunnerWorkItem;
 import org.apache.druid.indexing.overlord.ZkWorker;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
 import org.apache.druid.indexing.worker.TaskAnnouncement;
@@ -61,6 +62,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class SimpleProvisioningStrategyTest
 {
+  public static final String DEFAULT_CATEGORY = CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY;
   private AutoScaler autoScaler;
   private Task testTask;
   private SimpleWorkerProvisioningStrategy strategy;
@@ -113,6 +115,7 @@ public class SimpleProvisioningStrategyTest
   @Test
   public void testSuccessfulProvision()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -125,6 +128,11 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
+        )
+    );
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
         )
     );
     EasyMock.expect(runner.getWorkers()).andReturn(
@@ -151,6 +159,7 @@ public class SimpleProvisioningStrategyTest
   @Test
   public void testSomethingProvisioning()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(8);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0).times(2);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2).times(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -163,6 +172,11 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
+        )
+    ).times(2);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
         )
     ).times(2);
     EasyMock.expect(runner.getWorkers()).andReturn(
@@ -207,6 +221,7 @@ public class SimpleProvisioningStrategyTest
     EasyMock.expectLastCall().atLeastOnce();
     EasyMock.replay(emitter);
 
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(8);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0).times(2);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2).times(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -222,6 +237,11 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
+        )
+    ).times(2);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
         )
     ).times(2);
     EasyMock.expect(runner.getWorkers()).andReturn(
@@ -262,6 +282,7 @@ public class SimpleProvisioningStrategyTest
   @Test
   public void testDoSuccessfulTerminate()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(1);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -275,6 +296,11 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
+        )
+    ).times(2);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
         )
     ).times(2);
     EasyMock.expect(runner.getWorkers()).andReturn(
@@ -302,6 +328,7 @@ public class SimpleProvisioningStrategyTest
   @Test
   public void testSomethingTerminating()
   {
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(8);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0).times(2);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(1).times(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -316,6 +343,11 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
+        )
+    ).times(2);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
         )
     ).times(2);
     EasyMock.expect(runner.getWorkers()).andReturn(
@@ -353,6 +385,7 @@ public class SimpleProvisioningStrategyTest
   public void testNoActionNeeded()
   {
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -364,6 +397,11 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
+        )
+    ).times(2);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
         )
     ).times(2);
     EasyMock.expect(runner.getWorkers()).andReturn(
@@ -384,6 +422,7 @@ public class SimpleProvisioningStrategyTest
     EasyMock.verify(autoScaler);
 
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -402,6 +441,7 @@ public class SimpleProvisioningStrategyTest
   {
     // Don't terminate anything
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -410,6 +450,11 @@ public class SimpleProvisioningStrategyTest
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getPendingTasks()).andReturn(
         Collections.emptyList()
+    ).times(3);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
+        )
     ).times(3);
     EasyMock.expect(runner.getWorkers()).andReturn(
         Collections.singletonList(
@@ -428,6 +473,7 @@ public class SimpleProvisioningStrategyTest
 
     // Don't provision anything
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(2);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -439,6 +485,7 @@ public class SimpleProvisioningStrategyTest
 
     EasyMock.reset(autoScaler);
     // Increase minNumWorkers
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(3);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);
     EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
@@ -461,6 +508,7 @@ public class SimpleProvisioningStrategyTest
   public void testMinCountIncreaseNoWorkers()
   {
     EasyMock.reset(autoScaler);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(DEFAULT_CATEGORY).times(4);
     // Expect min number to be zero, but autoscaling should work for that case as well even there is no workers running
     EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
     EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(5);
@@ -476,6 +524,11 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new RemoteTaskRunnerWorkItem(testTask.getId(), testTask.getType(), null, null, testTask.getDataSource())
                 .withQueueInsertionTime(DateTimes.nowUtc())
+        )
+    );
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(
+        Collections.singletonList(
+            testTask
         )
     );
     EasyMock.expect(runner.getWorkers()).andReturn(Collections.emptyList());
@@ -507,7 +560,7 @@ public class SimpleProvisioningStrategyTest
         Collections.singletonList(
             new TestZkWorker(null).toImmutable()
         )
-    ).times(1);
+    ).times(2);
     EasyMock.replay(runner);
 
     Provisioner provisioner = strategy.makeProvisioner(runner);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ *
  */
 public class SimpleProvisioningStrategyTest
 {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTestExtended.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/SimpleProvisioningStrategyTestExtended.java
@@ -1,0 +1,1220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.autoscaling;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.guava.DSuppliers;
+import org.apache.druid.indexing.common.TestTasks;
+import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.RemoteTaskRunner;
+import org.apache.druid.indexing.overlord.RemoteTaskRunnerWorkItem;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
+import org.easymock.EasyMock;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ *
+ */
+public class SimpleProvisioningStrategyTestExtended
+{
+  public static final String DEFAULT_CATEGORY = CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY;
+  private static final String DEFAULT_CATEGORY_1 = "default_category1";
+  private static final String DEFAULT_CATEGORY_2 = "default_category2";
+  private static final String CATEGORY_1 = "category1";
+  private static final String CATEGORY_2 = "category2";
+  private static final String TASK_TYPE_1 = "taskType1";
+  private static final String TASK_TYPE_2 = "taskType2";
+  private static final String TASK_TYPE_3 = "taskType3";
+  private static final String DATA_SOURCE_1 = "ds1";
+  private static final String DATA_SOURCE_2 = "ds2";
+  private AutoScaler autoScalerDefault;
+  private AutoScaler autoScalerCategory1;
+  private AutoScaler autoScalerCategory2;
+  private final List<AutoScaler> autoScalers = new ArrayList<>();
+  private Task testTask;
+  private final ScheduledExecutorService executorService = Execs.scheduledSingleThreaded("test service");
+  private SimpleWorkerProvisioningConfig config;
+
+  @Before
+  public void setUp()
+  {
+    autoScalerDefault = EasyMock.createMock(AutoScaler.class);
+
+    autoScalerCategory1 = EasyMock.createMock(AutoScaler.class);
+    autoScalerCategory2 = EasyMock.createMock(AutoScaler.class);
+
+    autoScalers.clear();
+
+    testTask = TestTasks.immediateSuccess("task1");
+
+    config = new SimpleWorkerProvisioningConfig()
+        .setWorkerIdleTimeout(new Period(0))
+        .setMaxScalingDuration(new Period(1000))
+        .setNumEventsToTrack(10)
+        .setPendingTaskTimeout(new Period(0))
+        .setWorkerVersion("");
+  }
+
+  @After
+  public void tearDown()
+  {
+    executorService.shutdownNow();
+  }
+
+  @Test
+  public void testDefaultAutoscalerDidntSpawnInitialMinWorkers()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 2, 4, Collections.emptyList(), 2, 1, 1, 1);
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory2, CATEGORY_2, 4, 6, Collections.emptyList(), 2, 1, 1, 1);
+    autoScalers.addAll(Arrays.asList(autoScalerCategory1, autoScalerCategory2));
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // No pending tasks
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getPendingTasks()).andReturn(Collections.emptyList());
+    // No workers
+    EasyMock.expect(runner.getWorkers()).andReturn(Collections.emptyList());
+
+    // Expect to create 2 workers
+    EasyMock.expect(autoScalerCategory1.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category1Node"))
+    ).times(2);
+
+    // Expect to create 4 workers
+    EasyMock.expect(autoScalerCategory2.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category2Node"))
+    ).times(4);
+
+    EasyMock.replay(runner, autoScalerCategory1, autoScalerCategory2);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+
+    // In total expect provisioning of 2 + 4 = 6 workers
+    Assert.assertEquals(6, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+
+    EasyMock.verify(runner, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testDefaultAutoscalerSuccessfulMinWorkers()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    // Not strong affinity autoscaling mode will use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+    StrategyTestUtils.setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        3,
+        5,
+        Collections.emptyList()
+    );
+    autoScalers.add(autoScalerDefault);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // No pending tasks
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getPendingTasks()).andReturn(Collections.emptyList());
+    // 1 node already running, only provision 2 more.
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Collections.singletonList(
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable()
+        )
+    );
+
+    // Expect to create 2 workers
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    ).times(2);
+
+    EasyMock.replay(runner, autoScalerDefault);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    // Two workers should be provisioned
+    Assert.assertEquals(2, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+
+    EasyMock.verify(runner, autoScalerDefault);
+  }
+
+  @Test
+  public void testAnyAutoscalerDontSpawnMinWorkers()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // No pending tasks
+    EasyMock.expect(runner.getPendingTasks()).andReturn(Collections.emptyList());
+
+    // 1 worker already running. That means no initialization is required.
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Collections.singletonList(
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable()
+        )
+    );
+
+    EasyMock.replay(runner);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertFalse(provisionedSomething);
+    Assert.assertTrue(provisioner.getStats().toList().isEmpty());
+
+    EasyMock.verify(runner);
+  }
+
+  @Test
+  public void testCategoriedAutoscalerSpawnedMinWorkers()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(
+        false,
+        TASK_TYPE_1,
+        CATEGORY_1,
+        DATA_SOURCE_1,
+        CATEGORY_2
+    );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 5, 7, Collections.emptyList());
+    autoScalers.add(autoScalerCategory1);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // One pending task
+    String taskId = "taskId";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Collections.singletonList(StrategyTestUtils.TestTask.create(
+                taskId,
+                TASK_TYPE_1,
+                DATA_SOURCE_2
+            )));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Collections.singletonList(new RemoteTaskRunnerWorkItem(
+                taskId,
+                TASK_TYPE_1,
+                null,
+                null,
+                DATA_SOURCE_2
+            )));
+    // No workers
+    EasyMock.expect(runner.getWorkers()).andReturn(Collections.emptyList());
+
+    // Expect to create 5 workers
+    EasyMock.expect(autoScalerCategory1.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category1Node"))
+    ).times(5);
+
+    EasyMock.replay(runner, autoScalerCategory1);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    // Five workers should be created
+    Assert.assertEquals(5, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+
+    EasyMock.verify(runner, autoScalerCategory1);
+  }
+
+  @Test
+  public void testCategoriedAutoscalerSpawnedAdditionalWorker()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(
+        false,
+        TASK_TYPE_1,
+        CATEGORY_1,
+        DATA_SOURCE_1,
+        CATEGORY_2
+    );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 2, 3, Collections.emptyList());
+    autoScalers.add(autoScalerCategory1);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // One pending task
+    String taskId = "taskId";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Collections.singletonList(StrategyTestUtils.TestTask.create(
+                taskId,
+                TASK_TYPE_1,
+                DATA_SOURCE_2
+            )));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Collections.singletonList(new RemoteTaskRunnerWorkItem(
+                taskId,
+                TASK_TYPE_1,
+                null,
+                null,
+                DATA_SOURCE_2
+            )));
+    // Min workers are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable()
+        )
+    );
+
+    EasyMock.expect(autoScalerCategory1.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category1Node"))
+    );
+
+    EasyMock.replay(runner, autoScalerCategory1);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    // Expecting provisioning of one node for the pending task
+    Assert.assertEquals(1, provisioner.getStats().toList().size());
+    Assert.assertSame(provisioner.getStats().toList().get(0).getEvent(), ScalingStats.EVENT.PROVISION);
+
+    EasyMock.verify(runner, autoScalerCategory1);
+  }
+
+  @Test
+  public void testCategoriedAutoscalerSpawnedUpToMaxWorkers()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(
+        false,
+        TASK_TYPE_1,
+        CATEGORY_1,
+        DATA_SOURCE_1,
+        CATEGORY_2
+    );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 2, 3, Collections.emptyList());
+    autoScalers.add(autoScalerCategory1);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // Two pending tasks
+    String task1Id = "task1Id";
+    String task2Id = "task2Id";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Arrays.asList(
+                StrategyTestUtils.TestTask.create(task1Id, TASK_TYPE_1, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task2Id, TASK_TYPE_1, DATA_SOURCE_2)
+            ));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Arrays.asList(
+                new RemoteTaskRunnerWorkItem(task1Id, TASK_TYPE_1, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task2Id, TASK_TYPE_1, null, null, DATA_SOURCE_2)
+            ));
+    // Min workers are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable()
+        )
+    );
+
+    EasyMock.expect(autoScalerCategory1.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category1Node"))
+    );
+
+    EasyMock.replay(runner, autoScalerCategory1);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    // Can only spawn one worker because of maximum limit
+    Assert.assertEquals(1, provisioner.getStats().toList().size());
+    Assert.assertSame(provisioner.getStats().toList().get(0).getEvent(), ScalingStats.EVENT.PROVISION);
+
+    EasyMock.verify(runner, autoScalerCategory1);
+  }
+
+  @Test
+  public void testAllCategoriedAutoscalersStrongly()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(
+        false,
+        TASK_TYPE_1,
+        new WorkerCategorySpec.CategoryConfig(
+            DEFAULT_CATEGORY_1,
+            ImmutableMap.of(
+                DATA_SOURCE_1,
+                CATEGORY_1,
+                DATA_SOURCE_2,
+                CATEGORY_2
+            )
+        ),
+        TASK_TYPE_2,
+        new WorkerCategorySpec.CategoryConfig(
+            DEFAULT_CATEGORY_2,
+            ImmutableMap.of(
+                DATA_SOURCE_1,
+                CATEGORY_1,
+                DATA_SOURCE_2,
+                CATEGORY_2
+            )
+        )
+    );
+    // Strong affinity autoscaling mode will not use default autoscaler
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 3, Collections.emptyList());
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 3, Collections.emptyList());
+    autoScalers.addAll(Arrays.asList(autoScalerCategory1, autoScalerCategory2));
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // Four pending tasks: three have their categorized autoscalers and one for default autoscaler
+    String task1Id = "task1Id";
+    String task2Id = "task2Id";
+    String task3Id = "task3Id";
+    String task4Id = "task4Id";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Arrays.asList(
+                StrategyTestUtils.TestTask.create(task1Id, TASK_TYPE_1, DATA_SOURCE_1),
+                StrategyTestUtils.TestTask.create(task2Id, TASK_TYPE_2, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task3Id, TASK_TYPE_1, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task4Id, TASK_TYPE_3, DATA_SOURCE_2)
+            ));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Arrays.asList(
+                new RemoteTaskRunnerWorkItem(task1Id, TASK_TYPE_1, null, null, DATA_SOURCE_1),
+                new RemoteTaskRunnerWorkItem(task2Id, TASK_TYPE_2, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task3Id, TASK_TYPE_1, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task4Id, TASK_TYPE_3, null, null, DATA_SOURCE_2)
+            ));
+    // Min workers number of the each category are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    // Expect to create 1 worker
+    EasyMock.expect(autoScalerCategory1.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category1Node"))
+    );
+
+    // Expect to create 2 workers
+    EasyMock.expect(autoScalerCategory2.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category2Node"))
+    );
+
+    EasyMock.replay(runner, autoScalerCategory1, autoScalerCategory2);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    // In total expect provisioning of 1 + (2 - 1) = 2 workers
+    Assert.assertEquals(2, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+
+    EasyMock.verify(runner, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testAllCategoriedAutoscalersNotStrongMode()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(
+        false,
+        TASK_TYPE_1,
+        new WorkerCategorySpec.CategoryConfig(
+            DEFAULT_CATEGORY_1,
+            ImmutableMap.of(
+                DATA_SOURCE_1,
+                CATEGORY_1,
+                DATA_SOURCE_2,
+                CATEGORY_2
+            )
+        ),
+        TASK_TYPE_2,
+        new WorkerCategorySpec.CategoryConfig(
+            DEFAULT_CATEGORY_2,
+            ImmutableMap.of(
+                DATA_SOURCE_1,
+                CATEGORY_1,
+                DATA_SOURCE_2,
+                CATEGORY_2
+            )
+        )
+    );
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+    StrategyTestUtils.setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        3,
+        5,
+        Collections.emptyList()
+    );
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 3, Collections.emptyList());
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 3, Collections.emptyList());
+    autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // Four pending tasks: three have their categorized autoscalers and one for default autoscaler
+    String task1Id = "task1Id";
+    String task2Id = "task2Id";
+    String task3Id = "task3Id";
+    String task4Id = "task4Id";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Arrays.asList(
+                StrategyTestUtils.TestTask.create(task1Id, TASK_TYPE_1, DATA_SOURCE_1),
+                StrategyTestUtils.TestTask.create(task2Id, TASK_TYPE_2, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task3Id, TASK_TYPE_1, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task4Id, TASK_TYPE_3, DATA_SOURCE_2)
+            ));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Arrays.asList(
+                new RemoteTaskRunnerWorkItem(task1Id, TASK_TYPE_1, null, null, DATA_SOURCE_1),
+                new RemoteTaskRunnerWorkItem(task2Id, TASK_TYPE_2, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task3Id, TASK_TYPE_1, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task4Id, TASK_TYPE_3, null, null, DATA_SOURCE_2)
+            ));
+    // Min workers of two categoriez are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    // Expect to create 3 workers
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    ).times(3);
+
+    // Expect to create 1 worker
+    EasyMock.expect(autoScalerCategory1.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category1Node"))
+    );
+
+    // Expect to create 1 worker
+    EasyMock.expect(autoScalerCategory2.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category2Node"))
+    );
+
+    EasyMock.replay(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    // In total expect provisioning of 3 + 1 + 1 = 5 workers
+    Assert.assertEquals(5, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+
+    EasyMock.verify(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testAllCategoriedAutoscalersAlert() throws InterruptedException
+  {
+    ServiceEmitter emitter = EasyMock.createMock(ServiceEmitter.class);
+    EmittingLogger.registerEmitter(emitter);
+    emitter.emit(EasyMock.<ServiceEventBuilder>anyObject());
+    EasyMock.expectLastCall().times(2);
+    EasyMock.replay(emitter);
+
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(
+        false,
+        TASK_TYPE_1,
+        new WorkerCategorySpec.CategoryConfig(
+            DEFAULT_CATEGORY_1,
+            ImmutableMap.of(
+                DATA_SOURCE_1,
+                CATEGORY_1,
+                DATA_SOURCE_2,
+                CATEGORY_2
+            )
+        ),
+        TASK_TYPE_2,
+        new WorkerCategorySpec.CategoryConfig(
+            DEFAULT_CATEGORY_2,
+            ImmutableMap.of(
+                DATA_SOURCE_1,
+                CATEGORY_1,
+                DATA_SOURCE_2,
+                CATEGORY_2
+            )
+        )
+    );
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(3).times(2);
+    EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5).times(2);
+    EasyMock.expect(autoScalerDefault.getCategory())
+            .andReturn(null)
+            .times(4);
+    EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.emptyList()).times(2);
+
+    EasyMock.expect(autoScalerCategory1.getMinNumWorkers()).andReturn(1).times(2);
+    EasyMock.expect(autoScalerCategory1.getMaxNumWorkers()).andReturn(3).times(2);
+    EasyMock.expect(autoScalerCategory1.getCategory()).andReturn(CATEGORY_1).times(8);
+    EasyMock.expect(autoScalerCategory1.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.emptyList()).times(2);
+    EasyMock.expect(autoScalerCategory1.terminateWithIds(EasyMock.anyObject()))
+            .andReturn(null);
+
+    EasyMock.expect(autoScalerCategory2.getMinNumWorkers()).andReturn(1).times(2);
+    EasyMock.expect(autoScalerCategory2.getMaxNumWorkers()).andReturn(3).times(2);
+    EasyMock.expect(autoScalerCategory2.getCategory()).andReturn(CATEGORY_2).times(8);
+    EasyMock.expect(autoScalerCategory2.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.emptyList()).times(2);
+    EasyMock.expect(autoScalerCategory2.terminateWithIds(EasyMock.anyObject()))
+            .andReturn(null);
+
+    autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // Four pending tasks: three have their categorized autoscalers and one for default autoscaler
+    String task1Id = "task1Id";
+    String task2Id = "task2Id";
+    String task3Id = "task3Id";
+    String task4Id = "task4Id";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Arrays.asList(
+                StrategyTestUtils.TestTask.create(task1Id, TASK_TYPE_1, DATA_SOURCE_1),
+                StrategyTestUtils.TestTask.create(task2Id, TASK_TYPE_2, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task3Id, TASK_TYPE_1, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task4Id, TASK_TYPE_3, DATA_SOURCE_2)
+            )).times(2);
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Arrays.asList(
+                new RemoteTaskRunnerWorkItem(task1Id, TASK_TYPE_1, null, null, DATA_SOURCE_1),
+                new RemoteTaskRunnerWorkItem(task2Id, TASK_TYPE_2, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task3Id, TASK_TYPE_1, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task4Id, TASK_TYPE_3, null, null, DATA_SOURCE_2)
+            )).times(2);
+    // Min workers of two categoriez are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    ).times(2);
+
+    // Expect to create 5 workers
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    ).times(5);
+
+    // Expect to create 1 worker
+    EasyMock.expect(autoScalerCategory1.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category1Node"))
+    );
+
+    // Expect to create 1 worker
+    EasyMock.expect(autoScalerCategory2.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("category2Node"))
+    );
+
+    EasyMock.replay(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    Assert.assertEquals(5, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+    DateTime createdTime = provisioner.getStats().toList().get(0).getTimestamp();
+
+    Thread.sleep(2000);
+
+    provisionedSomething = provisioner.doProvision();
+
+    Assert.assertTrue(provisionedSomething);
+    Assert.assertEquals(7, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+
+    EasyMock.verify(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2, emitter);
+  }
+
+  @Test
+  public void testNullWorkerConfig()
+  {
+    AtomicReference<WorkerBehaviorConfig> workerConfig = new AtomicReference<>(null);
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // One pending task
+    String taskId = "taskId";
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Collections.singletonList(
+                new RemoteTaskRunnerWorkItem(taskId, TASK_TYPE_1, null, null, DATA_SOURCE_1)
+            ));
+    // Min workers of two categoriez are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    EasyMock.replay(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertFalse(provisionedSomething);
+    // No workers should be created
+    Assert.assertTrue(provisioner.getStats().toList().isEmpty());
+
+    EasyMock.verify(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testNullWorkerCategorySpecNotStrong()
+  {
+    WorkerCategorySpec workerCategorySpec = null;
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    StrategyTestUtils.setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        1,
+        3,
+        Collections.emptyList()
+    );
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 2, Collections.emptyList());
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 4, Collections.emptyList());
+    autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
+
+    // Expect to create 1 worker for 3 tasks because of maxLimit
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    );
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    // Three pending tasks
+    String task1Id = "task1Id";
+    String task2Id = "task2Id";
+    String task3Id = "task3Id";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Arrays.asList(
+                StrategyTestUtils.TestTask.create(task1Id, TASK_TYPE_1, DATA_SOURCE_1),
+                StrategyTestUtils.TestTask.create(task2Id, TASK_TYPE_2, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task3Id, TASK_TYPE_1, DATA_SOURCE_2)
+            ));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Arrays.asList(
+                new RemoteTaskRunnerWorkItem(task1Id, TASK_TYPE_1, null, null, DATA_SOURCE_1),
+                new RemoteTaskRunnerWorkItem(task2Id, TASK_TYPE_2, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task3Id, TASK_TYPE_1, null, null, DATA_SOURCE_2)
+            ));
+    // Min workers of two categories and one default are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    EasyMock.replay(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    // Two workers for default autoscaler should be created
+    Assert.assertEquals(1, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.PROVISION);
+    }
+
+    EasyMock.verify(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testNullWorkerCategorySpecStrong()
+  {
+    WorkerCategorySpec workerCategorySpec = null;
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 2, Collections.emptyList());
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 4, Collections.emptyList());
+    autoScalers.addAll(Arrays.asList(autoScalerCategory1, autoScalerCategory2));
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+
+    // Three pending tasks
+    String task1Id = "task1Id";
+    String task2Id = "task2Id";
+    String task3Id = "task3Id";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Arrays.asList(
+                StrategyTestUtils.TestTask.create(task1Id, TASK_TYPE_1, DATA_SOURCE_1),
+                StrategyTestUtils.TestTask.create(task2Id, TASK_TYPE_2, DATA_SOURCE_2),
+                StrategyTestUtils.TestTask.create(task3Id, TASK_TYPE_1, DATA_SOURCE_2)
+            ));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Arrays.asList(
+                new RemoteTaskRunnerWorkItem(task1Id, TASK_TYPE_1, null, null, DATA_SOURCE_1),
+                new RemoteTaskRunnerWorkItem(task2Id, TASK_TYPE_2, null, null, DATA_SOURCE_2),
+                new RemoteTaskRunnerWorkItem(task3Id, TASK_TYPE_1, null, null, DATA_SOURCE_2)
+            ));
+
+    // Min workers of two categories and one default are running
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    EasyMock.replay(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertFalse(provisionedSomething);
+    // No workers should be created because of strong affinity
+    Assert.assertTrue(provisioner.getStats().toList().isEmpty());
+
+    EasyMock.verify(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testDoSuccessfulTerminateForAllCategories()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    StrategyTestUtils.setupAutoscaler(
+        autoScalerDefault,
+        CategoriedWorkerBehaviorConfig.DEFAULT_AUTOSCALER_CATEGORY,
+        1,
+        1,
+        Collections.emptyList()
+    );
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 1, Collections.emptyList());
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 1, Collections.emptyList());
+    autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
+
+    EasyMock.expect(autoScalerDefault.terminate(EasyMock.anyObject())).andReturn(
+        new AutoScalingData(Collections.emptyList())
+    );
+    EasyMock.expect(autoScalerCategory1.terminate(EasyMock.anyObject())).andReturn(
+        new AutoScalingData(Collections.emptyList())
+    );
+    EasyMock.expect(autoScalerCategory2.terminate(EasyMock.anyObject())).andReturn(
+        new AutoScalingData(Collections.emptyList())
+    );
+    EasyMock.replay(autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getPendingTasks()).andReturn(Collections.emptyList());
+
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    EasyMock.expect(runner.markWorkersLazy(EasyMock.anyObject(), EasyMock.anyInt()))
+            .andReturn(
+                Arrays.asList(
+                    new StrategyTestUtils.TestZkWorker(testTask).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).getWorker()
+                )
+            ).times(3);
+
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(Collections.emptyList()).times(3);
+    EasyMock.replay(runner);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean terminatedSomething = provisioner.doTerminate();
+
+    Assert.assertTrue(terminatedSomething);
+    Assert.assertEquals(3, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.TERMINATE);
+    }
+
+    EasyMock.verify(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testDoSuccessfulTerminateWithoutDefaultAutoscaler()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory1, CATEGORY_1, 1, 1, Collections.emptyList());
+    StrategyTestUtils.setupAutoscaler(autoScalerCategory2, CATEGORY_2, 1, 1, Collections.emptyList());
+    autoScalers.addAll(Arrays.asList(autoScalerCategory1, autoScalerCategory2));
+
+    EasyMock.expect(autoScalerCategory1.terminate(EasyMock.anyObject())).andReturn(
+        new AutoScalingData(Collections.emptyList())
+    );
+    EasyMock.expect(autoScalerCategory2.terminate(EasyMock.anyObject())).andReturn(
+        new AutoScalingData(Collections.emptyList())
+    );
+    EasyMock.replay(autoScalerCategory1, autoScalerCategory2);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getPendingTasks()).andReturn(Collections.emptyList());
+
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    EasyMock.expect(runner.markWorkersLazy(EasyMock.anyObject(), EasyMock.anyInt()))
+            .andReturn(
+                Arrays.asList(
+                    new StrategyTestUtils.TestZkWorker(testTask).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).getWorker(),
+                    new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).getWorker()
+                )
+            ).times(2);
+
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(Collections.emptyList()).times(2);
+    EasyMock.replay(runner);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean terminatedSomething = provisioner.doTerminate();
+
+    Assert.assertTrue(terminatedSomething);
+    Assert.assertEquals(2, provisioner.getStats().toList().size());
+    for (ScalingStats.ScalingEvent event : provisioner.getStats().toList()) {
+      Assert.assertSame(event.getEvent(), ScalingStats.EVENT.TERMINATE);
+    }
+
+    EasyMock.verify(runner, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testSomethingTerminating()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(2);
+    EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScalerDefault.getCategory())
+            .andReturn(null)
+            .times(2);
+    EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip")).times(1);
+
+    EasyMock.expect(autoScalerCategory1.getMinNumWorkers()).andReturn(2);
+    EasyMock.expect(autoScalerCategory1.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScalerCategory1.getCategory()).andReturn(CATEGORY_1).times(4);
+    EasyMock.expect(autoScalerCategory1.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip")).times(1);
+
+    EasyMock.expect(autoScalerCategory2.getMinNumWorkers()).andReturn(2);
+    EasyMock.expect(autoScalerCategory2.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScalerCategory2.getCategory()).andReturn(CATEGORY_2).times(4);
+    EasyMock.expect(autoScalerCategory2.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip")).times(1);
+
+    autoScalers.addAll(Arrays.asList(autoScalerDefault, autoScalerCategory1, autoScalerCategory2));
+
+    EasyMock.replay(autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.emptyList());
+    EasyMock.expect(runner.getPendingTasks()).andReturn(Collections.emptyList());
+
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Arrays.asList(
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_1).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable(),
+            new StrategyTestUtils.TestZkWorker(testTask, CATEGORY_2).toImmutable()
+        )
+    );
+
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(Collections.emptyList()).times(3);
+    EasyMock.replay(runner);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean terminatedSomething = provisioner.doTerminate();
+
+    Assert.assertFalse(terminatedSomething);
+    Assert.assertTrue(provisioner.getStats().toList().isEmpty());
+
+    EasyMock.verify(runner, autoScalerDefault, autoScalerCategory1, autoScalerCategory2);
+  }
+
+  @Test
+  public void testMinCountIncrease()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    // Don't terminate anything
+    EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(0);
+    EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip"));
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null).times(2);
+    EasyMock.replay(autoScalerDefault);
+    autoScalers.add(autoScalerDefault);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    EasyMock.expect(runner.getPendingTaskPayloads()).andReturn(Collections.emptyList()).times(3);
+    EasyMock.expect(runner.getPendingTasks()).andReturn(Collections.emptyList()).times(3);
+    EasyMock.expect(runner.getWorkers()).andReturn(
+        Collections.singletonList(
+            new StrategyTestUtils.TestZkWorker(
+                NoopTask.create(),
+                "http",
+                "h1",
+                "i1",
+                StrategyTestUtils.MIN_VERSION,
+                1,
+                DEFAULT_CATEGORY_1
+            ).toImmutable()
+        )
+    ).times(3);
+
+    EasyMock.expect(runner.getLazyWorkers()).andReturn(new ArrayList<>());
+    EasyMock.replay(runner);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean terminatedSomething = provisioner.doTerminate();
+    Assert.assertFalse(terminatedSomething);
+    EasyMock.verify(autoScalerDefault);
+
+    // Don't provision anything
+    EasyMock.reset(autoScalerDefault);
+    EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(0);
+    EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(2);
+    EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip"));
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null).times(2);
+    EasyMock.replay(autoScalerDefault);
+
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertFalse(provisionedSomething);
+    Assert.assertTrue(provisioner.getStats().toList().isEmpty());
+    EasyMock.verify(autoScalerDefault);
+
+    EasyMock.reset(autoScalerDefault);
+    // Increase minNumWorkers and expect provisioning
+    EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(3);
+    EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip"));
+    // Should provision two new workers
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("h3"))
+    ).times(3);
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null).times(2);
+    EasyMock.replay(autoScalerDefault);
+    provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    EasyMock.verify(autoScalerDefault);
+    EasyMock.verify(runner);
+  }
+
+  @Test
+  public void testMinCountIncreaseNoWorkers()
+  {
+    WorkerCategorySpec workerCategorySpec = StrategyTestUtils.createWorkerCategorySpec(false);
+    AtomicReference<WorkerBehaviorConfig> workerConfig = StrategyTestUtils.createWorkerConfigRef(
+        workerCategorySpec,
+        autoScalers
+    );
+    SimpleWorkerProvisioningStrategy strategy = createStrategy(workerConfig);
+
+    // Expect min number to be zero, but autoscaling should work for that case as well even there is no workers running
+    EasyMock.expect(autoScalerDefault.getMinNumWorkers()).andReturn(0);
+    EasyMock.expect(autoScalerDefault.getMaxNumWorkers()).andReturn(5);
+    EasyMock.expect(autoScalerDefault.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(Collections.singletonList("ip"));
+    EasyMock.expect(autoScalerDefault.provision()).andReturn(
+        new AutoScalingData(Collections.singletonList("aNode"))
+    );
+    EasyMock.expect(autoScalerDefault.getCategory()).andReturn(null).times(2);
+
+    EasyMock.replay(autoScalerDefault);
+    autoScalers.add(autoScalerDefault);
+
+    RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
+    String taskId = "taskId";
+    EasyMock.expect(runner.getPendingTaskPayloads())
+            .andReturn(Collections.singletonList(StrategyTestUtils.TestTask.create(
+                taskId,
+                TASK_TYPE_1,
+                DATA_SOURCE_2
+            )));
+    EasyMock.expect(runner.getPendingTasks())
+            .andReturn(Collections.singletonList(
+                new RemoteTaskRunnerWorkItem(taskId, TASK_TYPE_1, null, null, DATA_SOURCE_2)
+            ));
+    EasyMock.expect(runner.getWorkers()).andReturn(Collections.emptyList());
+
+    EasyMock.replay(runner);
+
+    Provisioner provisioner = strategy.makeProvisioner(runner);
+    boolean provisionedSomething = provisioner.doProvision();
+    Assert.assertTrue(provisionedSomething);
+    Assert.assertEquals(1, provisioner.getStats().toList().size());
+    Assert.assertSame(provisioner.getStats().toList().get(0).getEvent(), ScalingStats.EVENT.PROVISION);
+
+    EasyMock.verify(autoScalerDefault, runner);
+  }
+
+  //********************************************************
+  private SimpleWorkerProvisioningStrategy createStrategy(
+      AtomicReference<WorkerBehaviorConfig> workerConfigRef
+  )
+  {
+    return new SimpleWorkerProvisioningStrategy(
+        config,
+        DSuppliers.of(workerConfigRef),
+        new ProvisioningSchedulerConfig(),
+        () -> executorService
+    );
+  }
+
+
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/StrategyTestUtils.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/StrategyTestUtils.java
@@ -1,7 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.indexing.overlord.autoscaling;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.common.guava.DSuppliers;
 import org.apache.druid.data.input.FirehoseFactory;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
@@ -115,7 +133,10 @@ public class StrategyTestUtils
     return new WorkerCategorySpec(categoryMap, isStrong);
   }
 
-  public static AtomicReference<WorkerBehaviorConfig> createWorkerConfigRef(WorkerCategorySpec workerCategorySpec, List<AutoScaler> autoScalers)
+  public static AtomicReference<WorkerBehaviorConfig> createWorkerConfigRef(
+      WorkerCategorySpec workerCategorySpec,
+      List<AutoScaler> autoScalers
+  )
   {
     return new AtomicReference<>(
         new CategoriedWorkerBehaviorConfig(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/StrategyTestUtils.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/StrategyTestUtils.java
@@ -1,0 +1,215 @@
+package org.apache.druid.indexing.overlord.autoscaling;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.guava.DSuppliers;
+import org.apache.druid.data.input.FirehoseFactory;
+import org.apache.druid.indexer.TaskLocation;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.ZkWorker;
+import org.apache.druid.indexing.overlord.setup.CategoriedWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.FillCapacityWithCategorySpecWorkerSelectStrategy;
+import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.WorkerCategorySpec;
+import org.apache.druid.indexing.worker.TaskAnnouncement;
+import org.apache.druid.indexing.worker.Worker;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.easymock.EasyMock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class StrategyTestUtils
+{
+  public static final String MIN_VERSION = "2014-01-00T00:01:00Z";
+
+  public static void setupAutoscaler(
+      AutoScaler autoScaler,
+      String category,
+      int minWorkers,
+      int maxWorkers,
+      List<String> pendingTasks
+  )
+  {
+    setupAutoscaler(autoScaler, category, minWorkers, pendingTasks);
+    EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(maxWorkers);
+  }
+
+  public static void setupAutoscaler(
+      AutoScaler autoScaler,
+      String category,
+      int minWorkers,
+      int maxWorkers,
+      List<String> pendingTasks,
+      int categoryTimes,
+      int minWorkersTimes,
+      int maxWorkersTimes,
+      int pendingTasksTimes
+  )
+  {
+    setupAutoscaler(autoScaler, category, minWorkers, pendingTasks, categoryTimes, minWorkersTimes, pendingTasksTimes);
+    EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(maxWorkers).times(maxWorkersTimes);
+  }
+
+  public static void setupAutoscaler(AutoScaler autoScaler, String category, int minWorkers, List<String> pendingTasks)
+  {
+    setupAutoscaler(autoScaler, category, minWorkers, pendingTasks, 4, 1, 1);
+  }
+
+  public static void setupAutoscaler(
+      AutoScaler autoScaler,
+      String category,
+      int minWorkers,
+      List<String> pendingTasks,
+      int categoryTimes,
+      int minWorkersTimes,
+      int pendingTasksTimes
+  )
+  {
+    EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(minWorkers).times(minWorkersTimes);
+    EasyMock.expect(autoScaler.getCategory()).andReturn(category).times(categoryTimes);
+    EasyMock.expect(autoScaler.ipToIdLookup(EasyMock.anyObject()))
+            .andReturn(pendingTasks).times(pendingTasksTimes);
+  }
+
+  public static WorkerCategorySpec createWorkerCategorySpec(boolean isStrong)
+  {
+    Map<String, WorkerCategorySpec.CategoryConfig> categoryMap = new HashMap<>();
+    return new WorkerCategorySpec(categoryMap, isStrong);
+  }
+
+  public static WorkerCategorySpec createWorkerCategorySpec(
+      boolean isStrong,
+      String taskType,
+      String defaultCategory,
+      String datasource,
+      String category
+  )
+  {
+    Map<String, String> categoryAffinity = new HashMap<>();
+    categoryAffinity.put(datasource, category);
+    WorkerCategorySpec.CategoryConfig categoryConfig = new WorkerCategorySpec.CategoryConfig(
+        defaultCategory,
+        categoryAffinity
+    );
+    Map<String, WorkerCategorySpec.CategoryConfig> categoryMap = new HashMap<>();
+    categoryMap.put(taskType, categoryConfig);
+    return new WorkerCategorySpec(categoryMap, isStrong);
+  }
+
+  public static WorkerCategorySpec createWorkerCategorySpec(
+      boolean isStrong,
+      String taskType1,
+      WorkerCategorySpec.CategoryConfig categoryConfig1,
+      String taskType2,
+      WorkerCategorySpec.CategoryConfig categoryConfig2
+  )
+  {
+    Map<String, WorkerCategorySpec.CategoryConfig> categoryMap = new HashMap<>();
+    categoryMap.put(taskType1, categoryConfig1);
+    categoryMap.put(taskType2, categoryConfig2);
+    return new WorkerCategorySpec(categoryMap, isStrong);
+  }
+
+  public static AtomicReference<WorkerBehaviorConfig> createWorkerConfigRef(WorkerCategorySpec workerCategorySpec, List<AutoScaler> autoScalers)
+  {
+    return new AtomicReference<>(
+        new CategoriedWorkerBehaviorConfig(
+            new FillCapacityWithCategorySpecWorkerSelectStrategy(workerCategorySpec),
+            autoScalers
+        )
+    );
+  }
+
+  public static class TestZkWorker extends ZkWorker
+  {
+    private final Task testTask;
+
+    public TestZkWorker(
+        Task testTask
+    )
+    {
+      this(testTask, "http", "host", "ip", MIN_VERSION, 1, WorkerConfig.DEFAULT_CATEGORY);
+    }
+
+    public TestZkWorker(
+        Task testTask,
+        String category
+    )
+    {
+      this(testTask, "http", "host", "ip", MIN_VERSION, 1, category);
+    }
+
+    public TestZkWorker(
+        Task testTask,
+        String scheme,
+        String host,
+        String ip,
+        String version,
+        int capacity,
+        String category
+    )
+    {
+      super(new Worker(scheme, host, ip, capacity, version, category), null, new DefaultObjectMapper());
+
+      this.testTask = testTask;
+    }
+
+    @Override
+    public Map<String, TaskAnnouncement> getRunningTasks()
+    {
+      if (testTask == null) {
+        return new HashMap<>();
+      }
+      return ImmutableMap.of(
+          testTask.getId(),
+          TaskAnnouncement.create(
+              testTask,
+              TaskStatus.running(testTask.getId()),
+              TaskLocation.unknown()
+          )
+      );
+    }
+  }
+
+  public static class TestTask extends NoopTask
+  {
+    private final String type;
+
+    public TestTask(
+        String id,
+        String groupId,
+        String dataSource,
+        long runTime,
+        long isReadyTime,
+        String isReadyResult,
+        FirehoseFactory firehoseFactory,
+        Map<String, Object> context,
+        String type
+    )
+    {
+      super(id, groupId, dataSource, runTime, isReadyTime, isReadyResult, firehoseFactory, context);
+      this.type = type;
+    }
+
+    public static TestTask create(String taskType, String dataSource)
+    {
+      return new TestTask(null, null, dataSource, 0, 0, null, null, null, taskType);
+    }
+
+    public static TestTask create(String id, String taskType, String dataSource)
+    {
+      return new TestTask(id, null, dataSource, 0, 0, null, null, null, taskType);
+    }
+
+    @Override
+    public String getType()
+    {
+      return type;
+    }
+  }
+}

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -73,6 +73,7 @@ import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskRunnerFactory;
 import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.TaskStorageQueryAdapter;
+import org.apache.druid.indexing.overlord.autoscaling.CategoriedProvisioningConfig;
 import org.apache.druid.indexing.overlord.autoscaling.CategoriedProvisioningStrategy;
 import org.apache.druid.indexing.overlord.autoscaling.PendingTaskBasedWorkerProvisioningConfig;
 import org.apache.druid.indexing.overlord.autoscaling.PendingTaskBasedWorkerProvisioningStrategy;
@@ -315,6 +316,7 @@ public class CliOverlord extends ServerRunnable
                 PendingTaskBasedWorkerProvisioningConfig.class
             );
             JsonConfigProvider.bind(binder, "druid.indexer.autoscale", SimpleWorkerProvisioningConfig.class);
+            JsonConfigProvider.bind(binder, "druid.indexer.autoscale", CategoriedProvisioningConfig.class);
 
             PolyBind.createChoice(
                 binder,

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -73,6 +73,7 @@ import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskRunnerFactory;
 import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.TaskStorageQueryAdapter;
+import org.apache.druid.indexing.overlord.autoscaling.CategoriedProvisioningStrategy;
 import org.apache.druid.indexing.overlord.autoscaling.PendingTaskBasedWorkerProvisioningConfig;
 import org.apache.druid.indexing.overlord.autoscaling.PendingTaskBasedWorkerProvisioningStrategy;
 import org.apache.druid.indexing.overlord.autoscaling.ProvisioningSchedulerConfig;
@@ -124,6 +125,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import java.util.List;
 
 /**
+ *
  */
 @Command(
     name = "overlord",
@@ -326,6 +328,7 @@ public class CliOverlord extends ServerRunnable
             );
             biddy.addBinding("simple").to(SimpleWorkerProvisioningStrategy.class);
             biddy.addBinding("pendingTaskBased").to(PendingTaskBasedWorkerProvisioningStrategy.class);
+            biddy.addBinding("categoriedTaskBased").to(CategoriedProvisioningStrategy.class);
           }
 
           private void configureOverlordHelpers(Binder binder)
@@ -345,6 +348,7 @@ public class CliOverlord extends ServerRunnable
   }
 
   /**
+   *
    */
   private static class OverlordJettyServerInitializer implements JettyServerInitializer
   {


### PR DESCRIPTION
Fixes #8695.

### Description
Added support of many autoscalers of different categories to serve tasks of according category.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `CategoriedWorkerBehaviorConfig`
 * `PendingTaskBasedWorkerProvisioningStrategy`
 * `SimpleWorkerProvisioningStrategy`
