### PR TITLE
Kafka lookup custom Json and Jq extractor

### DIFF
--- a/docs/development/extensions-core/kafka-extraction-namespace.md
+++ b/docs/development/extensions-core/kafka-extraction-namespace.md
@@ -44,7 +44,7 @@ If you need updates to populate as promptly as possible, it is possible to plug 
 |Parameter|Description|Required|Default|
 |---------|-----------|--------|-------|
 |`kafkaTopic`|The Kafka topic to read the data from|Yes||
-|`kafkaProperties`|Kafka consumer properties. At least"bootstrap.servers" must be specified. |Yes||
+|`kafkaProperties`|Kafka consumer properties. At least `bootstrap.servers` must be specified. |Yes||
 |`connectTimeout`|How long to wait for an initial connection|No|`0` (do not wait)|
 |`isOneToOne`|The map is a one-to-one (see [Lookup DimensionSpecs](../../querying/dimensionspecs.md))|No|`false`|
 |`namespaceParseSpec`|How to extract key and value pairs from Kafka message|No|null|
@@ -55,12 +55,12 @@ The consumer properties `group.id` and `auto.offset.reset` CANNOT be set in `kaf
 
 See [lookups](../../querying/lookups.md) for how to configure and use lookups.
 
-# Json Extrators
+# JSON Extractors
 
-Besides simple kafka key and message mapping, extraction allows to extract values from Kafka JSON messages.
+Besides simple Kafka key and message mapping, extraction allows to extract values from Kafka JSON messages.
 
-## Custom Json Extractor
-Allows to extract key and value from Kafka json message as per the following example:
+## Custom JSON Extractors
+Allows to extract key and value from Kafka JSON message as per the following example:
 
 ```json
 {
@@ -77,9 +77,9 @@ Allows to extract key and value from Kafka json message as per the following exa
 }
 ```
 
-## Jq Json Extractor
+## Jq JSON Extractors
 
-Allows to extract key and value from Kafka json message using [JQ expressions](https://github.com/stedolan/jq/wiki/Cookbook). In the following example, Json array of categories parsed into a string where each categorie id get maps to the coresponding categorie name.
+Allows to extract key and value from Kafka JSON message using [JQ expressions](https://github.com/stedolan/jq/wiki/Cookbook). In the following example, JSON array of categories parsed into a string where each category id get maps to category name.
 
 ```json
 {

--- a/extensions-core/kafka-extraction-namespace/pom.xml
+++ b/extensions-core/kafka-extraction-namespace/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.apache.druid.extensions</groupId>
   <artifactId>druid-kafka-extraction-namespace</artifactId>
   <name>druid-kafka-extraction-namespace</name>
-  <description>Extension to rename Druid dimension values using Kafka8</description>
+  <description>Extension to rename Druid dimension values using Apache Kafka</description>
 
   <parent>
     <groupId>org.apache.druid</groupId>

--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaDelegateParser.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaDelegateParser.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.lookup.kafka;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.parsers.Parser;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaDelegateParser implements Parser<String, String>
+{
+  private final Parser<String, Object> delegate;
+  private final String key;
+  private final String value;
+
+  public KafkaDelegateParser(
+      Parser<String, Object> delegate,
+      @NotNull String key,
+      @NotNull String value
+  )
+  {
+    this.delegate = delegate;
+    this.key = key;
+    this.value = value;
+  }
+
+  @Override
+  public Map<String, String> parseToMap(String input)
+  {
+    final Map<String, Object> parseToMap = delegate.parseToMap(input);
+    final String parsedKey = Preconditions.checkNotNull(
+        parseToMap.get(this.key),
+        "Key column [%s] missing data in line [%s]",
+        this.key,
+        input
+    ).toString(); // Just in case is long
+    final Object parsedValue = parseToMap.get(value);
+    if (parsedValue == null) {
+      // Skip null or missing values, treat them as if there were no row at all.
+      return ImmutableMap.of();
+    }
+    return ImmutableMap.of(parsedKey, parsedValue.toString());
+  }
+
+  @Override
+  public void setFieldNames(Iterable<String> fieldNames)
+  {
+    delegate.setFieldNames(fieldNames);
+  }
+
+  @Override
+  public List<String> getFieldNames()
+  {
+    return delegate.getFieldNames();
+  }
+}

--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaJqJsonDataParser.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaJqJsonDataParser.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.lookup.kafka;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathParser;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.common.parsers.Parser;
+
+import java.util.Objects;
+
+@JsonTypeName("jqJson")
+public class KafkaJqJsonDataParser implements KafkaLookupDataParser
+{
+  private final Parser<String, String> parser;
+  private final String keyFieldName;
+  private final JSONPathFieldSpec valueJsonSpec;
+
+  @JsonCreator
+  public KafkaJqJsonDataParser(
+      @JacksonInject @Json ObjectMapper jsonMapper,
+      @JsonProperty("keyFieldName") final String keyFieldName,
+      @JsonProperty("valueSpec") final JSONPathFieldSpec valueJsonSpec
+  )
+  {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(keyFieldName), "[keyFieldName] cannot be empty");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(valueJsonSpec.getName()), "[valueJsonSpec] cannot be empty");
+    this.keyFieldName = keyFieldName;
+    this.valueJsonSpec = valueJsonSpec;
+
+    // Copy jsonMapper; don't want to share canonicalization tables, etc., with the global ObjectMapper.
+    JSONPathSpec flattenSpec = new JSONPathSpec(
+        false,
+        ImmutableList.of(
+            new JSONPathFieldSpec(JSONPathFieldType.ROOT, keyFieldName, keyFieldName),
+            valueJsonSpec
+        )
+    );
+    this.parser = new KafkaDelegateParser(
+        new JSONPathParser(flattenSpec, jsonMapper.copy()),
+        keyFieldName,
+        valueJsonSpec.getName()
+    );
+  }
+
+  @JsonProperty
+  public String getKeyFieldName()
+  {
+    return this.keyFieldName;
+  }
+
+  @JsonProperty
+  public JSONPathFieldSpec getValueJsonSpec()
+  {
+    return this.valueJsonSpec;
+  }
+
+  @Override
+  public Parser<String, String> getParser()
+  {
+    return this.parser;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof KafkaJqJsonDataParser)) {
+      return false;
+    }
+    KafkaJqJsonDataParser that = (KafkaJqJsonDataParser) o;
+    return Objects.equals(getKeyFieldName(), that.getKeyFieldName()) &&
+        Objects.equals(getValueJsonSpec(), that.getValueJsonSpec());
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(getKeyFieldName(), getValueJsonSpec());
+  }
+
+  @Override
+  public String toString()
+  {
+    return "JSONKafkaFlatDataParser{" +
+      "keyFieldName='" + keyFieldName + '\'' +
+      ", valueJsonSpec='" + valueJsonSpec + '\'' +
+      '}';
+  }
+}

--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaJsonFlatDataParser.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaJsonFlatDataParser.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.lookup.kafka;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathParser;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.common.parsers.Parser;
+
+import java.util.Objects;
+
+@JsonTypeName("customJson")
+public class KafkaJsonFlatDataParser implements KafkaLookupDataParser
+{
+  private final Parser<String, String> parser;
+  private final String keyFieldName;
+  private final String valueFieldName;
+
+  @JsonCreator
+  public KafkaJsonFlatDataParser(
+      @JacksonInject @Json ObjectMapper jsonMapper,
+      @JsonProperty("keyFieldName") final String keyFieldName,
+      @JsonProperty("valueFieldName") final String valueFieldName
+  )
+  {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(keyFieldName), "[keyFieldName] cannot be empty");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(valueFieldName), "[valueFieldName] cannot be empty");
+    this.keyFieldName = keyFieldName;
+    this.valueFieldName = valueFieldName;
+
+    // Copy jsonMapper; don't want to share canonicalization tables, etc., with the global ObjectMapper.
+    this.parser = new KafkaDelegateParser(
+        new JSONPathParser(
+            new JSONPathSpec(
+                false,
+                ImmutableList.of(
+                    new JSONPathFieldSpec(JSONPathFieldType.ROOT, keyFieldName, keyFieldName),
+                    new JSONPathFieldSpec(JSONPathFieldType.ROOT, valueFieldName, valueFieldName)
+                )
+            ),
+            jsonMapper.copy()
+        ),
+        keyFieldName,
+        valueFieldName
+    );
+  }
+
+  @JsonProperty
+  public String getKeyFieldName()
+  {
+    return this.keyFieldName;
+  }
+
+  @JsonProperty
+  public String getValueFieldName()
+  {
+    return this.valueFieldName;
+  }
+
+  @Override
+  public Parser<String, String> getParser()
+  {
+    return this.parser;
+  }
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KafkaJsonFlatDataParser that = (KafkaJsonFlatDataParser) o;
+    return Objects.equals(keyFieldName, that.keyFieldName) &&
+        Objects.equals(valueFieldName, that.valueFieldName);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "KafkaJsonFlatDataParser{" +
+        "keyFieldName='" + keyFieldName + '\'' +
+        ", valueFieldName='" + valueFieldName + '\'' +
+        '}';
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(keyFieldName, valueFieldName);
+  }
+}

--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaLookupDataParser.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/kafka/KafkaLookupDataParser.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.lookup.kafka;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.java.util.common.parsers.Parser;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "format")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "customJson", value = KafkaJsonFlatDataParser.class),
+    @JsonSubTypes.Type(name = "jqJson", value = KafkaJqJsonDataParser.class)
+})
+public interface KafkaLookupDataParser
+{
+  Parser<String, String> getParser();
+}

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -25,14 +25,20 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Bytes;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.query.lookup.kafka.KafkaJqJsonDataParser;
+import org.apache.druid.query.lookup.kafka.KafkaJsonFlatDataParser;
 import org.apache.druid.server.lookup.namespace.cache.CacheHandler;
 import org.apache.druid.server.lookup.namespace.cache.NamespaceExtractionCacheManager;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
 import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,6 +51,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +76,10 @@ import java.util.concurrent.atomic.AtomicLong;
 })
 public class KafkaLookupExtractorFactoryTest
 {
+  static {
+    NullHandling.initializeForTests();
+  }
+
   private static final String TOPIC = "some_topic";
   private static final Map<String, String> DEFAULT_PROPERTIES = ImmutableMap.of(
       "some.property", "some.value"
@@ -76,6 +88,10 @@ public class KafkaLookupExtractorFactoryTest
   private final NamespaceExtractionCacheManager cacheManager = PowerMock.createStrictMock(
       NamespaceExtractionCacheManager.class);
   private final CacheHandler cacheHandler = PowerMock.createStrictMock(CacheHandler.class);
+  private static final ObjectMapper MAPPER = new DefaultObjectMapper();
+  private static final String JSON1 = "{\"id\":\"key0\",\"name\":\"User0\",\"email\":\"user0@gmail.com\",\"status\":\"active\"}";
+  private static final String JSON2 = "{\"id\":\"key1\",\"name\":\"User1\",\"email\":\"user1@gmail.com\",\"status\":\"active\"}";
+  private static final String JSON3 = "{\"id\":\"key2\",\"name\":\"User2\",\"email\":\"user2@gmail.com\",\"status\":\"active\"}";
 
 
   @Rule
@@ -247,7 +263,8 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         DEFAULT_PROPERTIES,
         1,
-        false
+        false,
+        null
     )));
 
     Assert.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
@@ -255,7 +272,8 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         DEFAULT_PROPERTIES,
         0,
-        true
+        true,
+        null
     )));
   }
 
@@ -288,7 +306,8 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         ImmutableMap.of("bootstrap.servers", "localhost"),
         10_000L,
-        false
+        false,
+        null
     )
     {
       @Override
@@ -320,7 +339,8 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         ImmutableMap.of("bootstrap.servers", "localhost"),
         1,
-        false
+        false,
+        null
     )
     {
       @Override
@@ -387,7 +407,8 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         ImmutableMap.of("bootstrap.servers", "localhost"),
         10_000L,
-        false
+        false,
+        null
     )
     {
       @Override
@@ -490,7 +511,8 @@ public class KafkaLookupExtractorFactoryTest
         kafkaTopic,
         kafkaProperties,
         connectTimeout,
-        injective
+        injective,
+        null
     );
     final KafkaLookupExtractorFactory otherFactory = mapper.readValue(
         mapper.writeValueAsString(factory),
@@ -502,13 +524,164 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertEquals(injective, otherFactory.isInjective());
   }
 
-  private IAnswer<Boolean> getBlockingAnswer()
+  @Test
+  public void testSimpleKVExtractor()
   {
-    return () -> {
-      Thread.sleep(60000);
-      Assert.fail("Test failed to complete within 60000ms");
+    MockConsumer kafkaConsumer = getMockConsumer();
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0L, "key0", "value0"));
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1L, "key1", "value1"));
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2L, "key2", "value2"));
 
-      return false;
+    EasyMock.expect(cacheManager.createCache())
+        .andReturn(cacheHandler)
+        .once();
+    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
+    cacheHandler.close();
+    EasyMock.expectLastCall().once();
+    PowerMock.replay(cacheManager, cacheHandler);
+
+    final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
+        cacheManager,
+        TOPIC,
+        ImmutableMap.of("bootstrap.servers", "localhost"),
+        10_000L,
+        false,
+        null
+    )
+    {
+      @Override
+      Consumer<String, String> getConsumer()
+      {
+        return kafkaConsumer;
+      }
     };
+    Assert.assertTrue(factory.start());
+    waitForEvents(factory, 3);
+    Assert.assertEquals("value0", factory.get().apply("key0"));
+    Assert.assertEquals("value1", factory.get().apply("key1"));
+    Assert.assertEquals("value2", factory.get().apply("key2"));
+  }
+
+  @Test
+  public void testCustomJsonExtractor()
+  {
+    MockConsumer kafkaConsumer = getMockConsumer();
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0L, "key0", JSON1));
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1L, "key1", JSON2));
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2L, "key2", JSON3));
+
+    EasyMock.expect(cacheManager.createCache())
+        .andReturn(cacheHandler)
+        .once();
+    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
+    cacheHandler.close();
+    EasyMock.expectLastCall().once();
+    PowerMock.replay(cacheManager, cacheHandler);
+
+    final KafkaJsonFlatDataParser parser = new KafkaJsonFlatDataParser(
+        MAPPER,
+        "id",
+        "name"
+    );
+
+    final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
+        cacheManager,
+        TOPIC,
+        ImmutableMap.of("bootstrap.servers", "localhost"),
+        10_000L,
+        false,
+        parser
+    )
+    {
+      @Override
+      Consumer<String, String> getConsumer()
+      {
+        return kafkaConsumer;
+      }
+    };
+    Assert.assertTrue(factory.start());
+    waitForEvents(factory, 3);
+
+    Assert.assertEquals("User0", factory.get().apply("key0"));
+    Assert.assertEquals("User1", factory.get().apply("key1"));
+    Assert.assertEquals("User2", factory.get().apply("key2"));
+  }
+
+  @Test
+  public void testJqJsonExtractor()
+  {
+    MockConsumer kafkaConsumer = getMockConsumer();
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0L, "key0", JSON1));
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1L, "key1", JSON2));
+    kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2L, "key2", JSON3));
+
+    EasyMock.expect(cacheManager.createCache())
+        .andReturn(cacheHandler)
+        .once();
+    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
+    cacheHandler.close();
+    EasyMock.expectLastCall().once();
+    PowerMock.replay(cacheManager, cacheHandler);
+
+    JSONPathFieldSpec jqField = JSONPathFieldSpec.createJqField("name", ".email + \"_\" + .status");
+
+    final KafkaJqJsonDataParser parser = new KafkaJqJsonDataParser(
+        MAPPER,
+        "id",
+        jqField
+    );
+
+    final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
+        cacheManager,
+        TOPIC,
+        ImmutableMap.of("bootstrap.servers", "localhost"),
+        10_000L,
+        false,
+        parser
+    )
+    {
+      @Override
+      Consumer<String, String> getConsumer()
+      {
+        return kafkaConsumer;
+      }
+    };
+    Assert.assertTrue(factory.start());
+    waitForEvents(factory, 3);
+
+    Assert.assertEquals("user0@gmail.com_active", factory.get().apply("key0"));
+    Assert.assertEquals("user1@gmail.com_active", factory.get().apply("key1"));
+    Assert.assertEquals("user2@gmail.com_active", factory.get().apply("key2"));
+  }
+
+  private void waitForEvents(KafkaLookupExtractorFactory factory, int eventCount)
+  {
+    long start = System.currentTimeMillis();
+    int timeOutMs = 10_000;
+    while (factory.getCompletedEventCount() != eventCount) {
+      try {
+        Thread.sleep(100);
+      }
+      catch (InterruptedException ingnore) {
+      }
+      if (System.currentTimeMillis() > start + timeOutMs) {
+        throw new ISE("Took too long to update event");
+      }
+    }
+  }
+
+  private MockConsumer<String, String> getMockConsumer()
+  {
+    MockConsumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    kafkaConsumer.subscribe(Collections.singletonList(TOPIC));
+    TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+    kafkaConsumer.rebalance(Collections.singletonList(topicPartition));
+    kafkaConsumer.updateBeginningOffsets(new HashMap<TopicPartition, Long>()
+      {
+        {
+          put(topicPartition, 0L);
+        }
+      });
+    return kafkaConsumer;
   }
 }


### PR DESCRIPTION
Fixes #8097.

### Description

PR adds custom Json and Jq extractors for Kafka lookup module. The extractors were adopted from `lookup-cached-global` module.

This PR has:
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests for custom Json extractors 
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) 
- [x] has been tested in production :smiley: 


