### PR TITLE
[Backport] fix vectorized query engine numeric filter matchers against null values

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/vector/DoubleVectorValueMatcher.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/vector/DoubleVectorValueMatcher.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.filter.vector;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.filter.DruidDoublePredicate;
 import org.apache.druid.query.filter.DruidPredicateFactory;
 import org.apache.druid.segment.DimensionHandlerUtils;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 public class DoubleVectorValueMatcher implements VectorValueMatcherFactory
 {
   private final VectorValueSelector selector;
+  private final boolean canHaveNulls = !NullHandling.replaceWithDefault();
 
   public DoubleVectorValueMatcher(final VectorValueSelector selector)
   {
@@ -38,6 +40,10 @@ public class DoubleVectorValueMatcher implements VectorValueMatcherFactory
   @Override
   public VectorValueMatcher makeMatcher(@Nullable final String value)
   {
+    if (value == null && canHaveNulls) {
+      return makeNullValueMatcher(selector);
+    }
+
     final Double matchVal = DimensionHandlerUtils.convertObjectToDouble(value);
 
     if (matchVal == null) {

--- a/processing/src/main/java/org/apache/druid/query/filter/vector/FloatVectorValueMatcher.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/vector/FloatVectorValueMatcher.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.filter.vector;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.filter.DruidFloatPredicate;
 import org.apache.druid.query.filter.DruidPredicateFactory;
 import org.apache.druid.segment.DimensionHandlerUtils;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 public class FloatVectorValueMatcher implements VectorValueMatcherFactory
 {
   private final VectorValueSelector selector;
+  private final boolean canHaveNulls = !NullHandling.replaceWithDefault();
 
   public FloatVectorValueMatcher(final VectorValueSelector selector)
   {
@@ -38,6 +40,10 @@ public class FloatVectorValueMatcher implements VectorValueMatcherFactory
   @Override
   public VectorValueMatcher makeMatcher(@Nullable final String value)
   {
+    if (value == null && canHaveNulls) {
+      return makeNullValueMatcher(selector);
+    }
+
     final Float matchVal = DimensionHandlerUtils.convertObjectToFloat(value);
 
     if (matchVal == null) {

--- a/processing/src/main/java/org/apache/druid/query/filter/vector/LongVectorValueMatcher.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/vector/LongVectorValueMatcher.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.filter.vector;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.filter.DruidLongPredicate;
 import org.apache.druid.query.filter.DruidPredicateFactory;
 import org.apache.druid.segment.DimensionHandlerUtils;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 public class LongVectorValueMatcher implements VectorValueMatcherFactory
 {
   private final VectorValueSelector selector;
+  private final boolean canHaveNulls = !NullHandling.replaceWithDefault();
 
   public LongVectorValueMatcher(final VectorValueSelector selector)
   {
@@ -38,6 +40,10 @@ public class LongVectorValueMatcher implements VectorValueMatcherFactory
   @Override
   public VectorValueMatcher makeMatcher(@Nullable final String value)
   {
+    if (value == null && canHaveNulls) {
+      return makeNullValueMatcher(selector);
+    }
+
     final Long matchVal = DimensionHandlerUtils.convertObjectToLong(value);
 
     if (matchVal == null) {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -2277,8 +2277,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Test
   public void testNullLongFilter() throws Exception
   {
-    // bug https://github.com/apache/incubator-druid/issues/9062 prevents this test from passing
-    skipVectorize();
     testQuery(
         "SELECT COUNT(*)\n"
         + "FROM druid.numfoo\n"
@@ -2302,8 +2300,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Test
   public void testNullDoubleFilter() throws Exception
   {
-    // bug https://github.com/apache/incubator-druid/issues/9062 prevents this test from passing
-    skipVectorize();
     testQuery(
         "SELECT COUNT(*)\n"
         + "FROM druid.numfoo\n"
@@ -2328,8 +2324,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Test
   public void testNullFloatFilter() throws Exception
   {
-    // bug https://github.com/apache/incubator-druid/issues/9062 prevents this test from passing
-    skipVectorize();
     testQuery(
         "SELECT COUNT(*)\n"
         + "FROM druid.numfoo\n"


### PR DESCRIPTION
Backport of #9063 to 0.17.0-incubating.