### PR TITLE
Web console: make supervisor statistics dialog more robust

### DIFF
--- a/web-console/src/components/supervisor-statistics-table/supervisor-statistics-table.tsx
+++ b/web-console/src/components/supervisor-statistics-table/supervisor-statistics-table.tsx
@@ -123,9 +123,13 @@ export class SupervisorStatisticsTable extends React.PureComponent<
       },
     ];
 
-    if (data && data.length) {
+    const movingAveragesBuildSegments = deepGet(
+      data as any,
+      '0.summary.movingAverages.buildSegments',
+    );
+    if (movingAveragesBuildSegments) {
       columns = columns.concat(
-        Object.keys(deepGet(data[0], 'summary.movingAverages.buildSegments'))
+        Object.keys(movingAveragesBuildSegments)
           .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
           .map(
             (interval: string): Column<TableRow> => {


### PR DESCRIPTION
If `'summary.movingAverages.buildSegments'` does not exist on `data[0]` which I guess could happen the current code throws an NPE