### PR TITLE
Fix deserialization of maxBytesInMemory

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/index/RealtimeAppenderatorTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/index/RealtimeAppenderatorTuningConfig.java
@@ -143,6 +143,7 @@ public class RealtimeAppenderatorTuningConfig implements TuningConfig, Appendera
   }
 
   @Override
+  @JsonProperty
   public long getMaxBytesInMemory()
   {
     return maxBytesInMemory;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -394,7 +394,7 @@ public class TaskSerdeTest
 
             new RealtimeTuningConfig(
                 1,
-                null,
+                10L,
                 new Period("PT10M"),
                 null,
                 null,
@@ -444,6 +444,10 @@ public class TaskSerdeTest
     Assert.assertEquals(
         task.getRealtimeIngestionSchema().getTuningConfig().getWindowPeriod(),
         task2.getRealtimeIngestionSchema().getTuningConfig().getWindowPeriod()
+    );
+    Assert.assertEquals(
+        task.getRealtimeIngestionSchema().getTuningConfig().getMaxBytesInMemory(),
+        task2.getRealtimeIngestionSchema().getTuningConfig().getMaxBytesInMemory()
     );
     Assert.assertEquals(
         task.getRealtimeIngestionSchema().getDataSchema().getGranularitySpec().getSegmentGranularity(),

--- a/server/src/main/java/org/apache/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/RealtimeTuningConfig.java
@@ -174,6 +174,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   }
 
   @Override
+  @JsonProperty
   public long getMaxBytesInMemory()
   {
     return maxBytesInMemory;


### PR DESCRIPTION
The `maxBytesInMemory` property within realtime tuning config isn't presently deserializable and as a result, realtime ingestion task logs do not display this property within the ingestion spec. This PR fixes the issue. 


This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
