### PR TITLE
confluent schema registry client to accept config and headers

### DIFF
--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -169,14 +169,42 @@ Details can be found in Schema Registry [documentation](http://docs.confluent.io
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
 | type | String | This should say `schema_registry`. | no |
-| url | String | Specifies the url endpoint of the Schema Registry. | yes |
-| capacity | Integer | Specifies the max size of the cache (default == Integer.MAX_VALUE). | no |
+| url  | String | Specifies the url endpoint of the Schema Registry. | yes |
+| capacity | Integer | Specifies the max size of the cache (default == Integer.MAX_VALUE). | no 
+| urls | Array<String> | Specifies the url endpoints of the multiple Schema Registry instances. | yes(if `url` is not provided) |
+| config | Json | To send additional configurations, configured for Schema Registry   | no |
+| headers | Json | To send headers to the Schema Registry    | no |
 
+
+For a single schema registry instance, use Field `url` or `urls` for multi instances.
+
+Single Instance:
 ```json
 ...
 "avroBytesDecoder" : {
    "type" : "schema_registry",
    "url" : <schema-registry-url>
+}
+...
+```
+
+Multiple Instances:
+```json
+...
+"avroBytesDecoder" : {
+   "type"   : "schema_registry",
+   "urls"   : [<schema-registry-url-1>, <schema-registry-url-2>, ...],
+   "config" : {
+               "schema.registry.basic.auth.credentials.source" : "USER_INFO",
+               "schema.registry.basic.auth.user.info"          : "fred:letmein",
+               ... 
+              },
+   "headers": {
+               "traceID"   : "b29c5de2-0db4-490b-b421",
+               "timeStamp" : "1577191871865",
+               ...
+               
+             }
 }
 ...
 ```

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -36,7 +36,7 @@
 
   <properties>
     <schemarepo.version>0.1.3</schemarepo.version>
-    <confluent.version>3.0.1</confluent.version>
+    <confluent.version>5.2.0</confluent.version>
   </properties>
 
   <repositories>

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -31,7 +31,10 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
@@ -41,11 +44,18 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
   @JsonCreator
   public SchemaRegistryBasedAvroBytesDecoder(
       @JsonProperty("url") String url,
-      @JsonProperty("capacity") Integer capacity
+      @JsonProperty("capacity") Integer capacity,
+      @JsonProperty("urls") List<String> urls,
+      @JsonProperty("config") @Nullable Map<String, ?> config,
+      @JsonProperty("headers") @Nullable Map<String, String> headers
   )
   {
     int identityMapCapacity = capacity == null ? Integer.MAX_VALUE : capacity;
-    this.registry = new CachedSchemaRegistryClient(url, identityMapCapacity);
+    if (!url.isEmpty()) {
+      this.registry = new CachedSchemaRegistryClient(url, identityMapCapacity, config, headers);
+    } else {
+      this.registry = new CachedSchemaRegistryClient(urls, identityMapCapacity, config, headers);
+    }
   }
 
   //For UT only

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -45,7 +45,7 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
   public SchemaRegistryBasedAvroBytesDecoder(
       @JsonProperty("url") String url,
       @JsonProperty("capacity") Integer capacity,
-      @JsonProperty("urls") List<String> urls,
+      @JsonProperty("urls") @Nullable List<String> urls,
       @JsonProperty("config") @Nullable Map<String, ?> config,
       @JsonProperty("headers") @Nullable Map<String, String> headers
   )

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -73,7 +73,7 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
       int id = bytes.getInt(); // extract schema registry id
       int length = bytes.limit() - 1 - 4;
       int offset = bytes.position() + bytes.arrayOffset();
-      Schema schema = registry.getByID(id);
+      Schema schema = registry.getById(id);
       DatumReader<GenericRecord> reader = new GenericDatumReader<>(schema);
       return reader.read(null, DecoderFactory.get().binaryDecoder(bytes.array(), offset, length, null));
     }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -52,7 +52,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testParse() throws Exception
   {
     // Given
-    Mockito.when(registry.getByID(ArgumentMatchers.eq(1234))).thenReturn(SomeAvroDatum.getClassSchema());
+    Mockito.when(registry.getById(ArgumentMatchers.eq(1234))).thenReturn(SomeAvroDatum.getClassSchema());
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     Schema schema = SomeAvroDatum.getClassSchema();
     byte[] bytes = getAvroDatum(schema, someAvroDatum);
@@ -68,7 +68,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testParseCorrupted() throws Exception
   {
     // Given
-    Mockito.when(registry.getByID(ArgumentMatchers.eq(1234))).thenReturn(SomeAvroDatum.getClassSchema());
+    Mockito.when(registry.getById(ArgumentMatchers.eq(1234))).thenReturn(SomeAvroDatum.getClassSchema());
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     Schema schema = SomeAvroDatum.getClassSchema();
     byte[] bytes = getAvroDatum(schema, someAvroDatum);
@@ -81,7 +81,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testParseWrongId() throws Exception
   {
     // Given
-    Mockito.when(registry.getByID(ArgumentMatchers.anyInt())).thenThrow(new IOException("no pasaran"));
+    Mockito.when(registry.getById(ArgumentMatchers.anyInt())).thenThrow(new IOException("no pasaran"));
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     Schema schema = SomeAvroDatum.getClassSchema();
     byte[] bytes = getAvroDatum(schema, someAvroDatum);


### PR DESCRIPTION
Fixes #8806 .


### Description

Enhancing  schema registry client i.e. `SchemaRegistryBasedAvroBytesDecoder`  to accept additional config's, header's and able to query schema's from multi schema instances.


1. Changed `SchemaRegistryBasedAvroBytesDecoder` to accept `config` and `header's` as Json properties. 
2. Added support to give multi url's for multi schema instances by sending as array: `urls`
3. Upgraded confluent version to `5.2.0`, which is compatible with existing kafka version: `2.2.1`
4. Changed depreciated method `getByID` to `getById`. 


This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] been tested in a test Druid cluster.


##### Key changed/added classes in this PR
 * `SchemaRegistryBasedAvroBytesDecoder`

