### PR TITLE
Nuke segment only after it is successfully deleted

### DIFF
--- a/core/src/test/java/org/apache/druid/segment/loading/FailingDataSegmentKiller.java
+++ b/core/src/test/java/org/apache/druid/segment/loading/FailingDataSegmentKiller.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import org.apache.druid.timeline.DataSegment;
+
+import java.io.IOException;
+
+/**
+ * A {@link DataSegmentKiller} that does nothing, but will throw a {@link LoadingSegment}
+ */
+public class FailingDataSegmentKiller implements DataSegmentKiller
+{
+  private final DataSegment failingSegment;
+
+  public FailingDataSegmentKiller(DataSegment failingSegment)
+  {
+    this.failingSegment = failingSegment;
+  }
+
+  @Override
+  public void kill(DataSegment segment) throws SegmentLoadingException
+  {
+    if (failingSegment.equals(segment)) {
+      throw new SegmentLoadingException("Thrown from FailingDataSegmentKiller#kill %s", failingSegment);
+    }
+  }
+
+  @Override
+  public void killAll() throws IOException
+  {
+    throw new IOException("Thrown from test - FailingDataSegmentKiller#killAll");
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillTask.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.common.task;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.client.indexing.ClientKillQuery;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskLock;
@@ -36,7 +37,6 @@ import org.joda.time.Interval;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -91,9 +91,9 @@ public class KillTask extends AbstractFixedIntervalTask
     }
 
     // Kill segments
-    toolbox.getTaskActionClient().submit(new SegmentNukeAction(new HashSet<>(unusedSegments)));
     for (DataSegment segment : unusedSegments) {
       toolbox.getDataSegmentKiller().kill(segment);
+      toolbox.getTaskActionClient().submit(new SegmentNukeAction(ImmutableSet.of(segment)));
     }
 
     return TaskStatus.success(getId());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -56,6 +56,7 @@ import org.apache.druid.metadata.SQLMetadataSegmentManager;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexMergerV9;
+import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
 import org.apache.druid.segment.loading.NoopDataSegmentKiller;
@@ -94,6 +95,8 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
   private IndexerSQLMetadataStorageCoordinator storageCoordinator;
   private MetadataSegmentManager segmentManager;
   private TaskLockbox lockbox;
+  // protected so tests can override the default behavior
+  protected DataSegmentKiller dataSegmentKiller;
 
   @Before
   public void setUp() throws IOException
@@ -103,6 +106,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
     final SQLMetadataConnector connector = derbyConnectorRule.getConnector();
     connector.createTaskTables();
     connector.createSegmentTable();
+    dataSegmentKiller = new NoopDataSegmentKiller();
     taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
     storageCoordinator = new IndexerSQLMetadataStorageCoordinator(
         objectMapper,
@@ -298,7 +302,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
             taskActionClient,
             null,
             new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig()),
-            new NoopDataSegmentKiller(),
+            dataSegmentKiller,
             null,
             null,
             null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillTaskTest.java
@@ -26,18 +26,23 @@ import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.segment.loading.FailingDataSegmentKiller;
+import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 public class KillTaskTest extends IngestionTestBase
 {
   private static final String DATA_SOURCE = "dataSource";
+  private static final String VERSION = DateTimes.nowUtc().toString();
 
   private TaskRunner taskRunner;
 
@@ -50,25 +55,17 @@ public class KillTaskTest extends IngestionTestBase
   @Test
   public void testKill() throws Exception
   {
-    final String version = DateTimes.nowUtc().toString();
-    final Set<DataSegment> segments = ImmutableSet.of(
-        newSegment(Intervals.of("2019-01-01/2019-02-01"), version),
-        newSegment(Intervals.of("2019-02-01/2019-03-01"), version),
-        newSegment(Intervals.of("2019-03-01/2019-04-01"), version),
-        newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
-    );
-    final Set<DataSegment> announced = getMetadataStorageCoordinator().announceHistoricalSegments(segments);
-
-    Assert.assertEquals(segments, announced);
+    announceSegmentsWithIntervals(VERSION,
+            "2019-01-01/2019-02-01", "2019-02-01/2019-03-01", "2019-03-01/2019-04-01", "2019-04-01/2019-05-01");
 
     Assert.assertTrue(
         getMetadataSegmentManager().markSegmentAsUnused(
-            newSegment(Intervals.of("2019-02-01/2019-03-01"), version).getId().toString()
+            newSegment(Intervals.of("2019-02-01/2019-03-01"), VERSION).getId().toString()
         )
     );
     Assert.assertTrue(
         getMetadataSegmentManager().markSegmentAsUnused(
-            newSegment(Intervals.of("2019-03-01/2019-04-01"), version).getId().toString()
+            newSegment(Intervals.of("2019-03-01/2019-04-01"), VERSION).getId().toString()
         )
     );
 
@@ -79,17 +76,67 @@ public class KillTaskTest extends IngestionTestBase
     final List<DataSegment> unusedSegments =
         getMetadataStorageCoordinator().getUnusedSegmentsForInterval(DATA_SOURCE, Intervals.of("2019/2020"));
 
-    Assert.assertEquals(ImmutableList.of(newSegment(Intervals.of("2019-02-01/2019-03-01"), version)), unusedSegments);
+    Assert.assertEquals(ImmutableList.of(newSegment(Intervals.of("2019-02-01/2019-03-01"), VERSION)), unusedSegments);
     Assert.assertEquals(
         ImmutableSet.of(
-            newSegment(Intervals.of("2019-01-01/2019-02-01"), version),
-            newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
+            newSegment(Intervals.of("2019-01-01/2019-02-01"), VERSION),
+            newSegment(Intervals.of("2019-04-01/2019-05-01"), VERSION)
         ),
         ImmutableSet.copyOf(
             getMetadataStorageCoordinator()
                 .getUsedSegmentsForInterval(DATA_SOURCE, Intervals.of("2019/2020"), Segments.ONLY_VISIBLE)
         )
     );
+  }
+
+  @Test(expected = SegmentLoadingException.class)
+  public void testKillWithSegmentLoadingExceptionShouldNotNukeSegment() throws Exception
+  {
+    announceSegmentsWithIntervals(VERSION,
+            "2019-01-01/2019-02-01", "2019-02-01/2019-03-01", "2019-03-01/2019-04-01", "2019-04-01/2019-05-01");
+    DataSegment febSegment = newSegment(Intervals.of("2019-02-01/2019-03-01"), VERSION);
+    DataSegment marchSegment = newSegment(Intervals.of("2019-03-01/2019-04-01"), VERSION);
+    Assert.assertTrue(
+            getMetadataSegmentManager().markSegmentAsUnused(febSegment.getId().toString())
+    );
+    Assert.assertTrue(
+            getMetadataSegmentManager().markSegmentAsUnused(marchSegment.getId().toString())
+    );
+    dataSegmentKiller = new FailingDataSegmentKiller(marchSegment);
+
+    final KillTask task = new KillTask(null, DATA_SOURCE, Intervals.of("2019-02-01/2019-04-01"), null);
+
+    try {
+      taskRunner.run(task).get();
+    }
+    catch (RuntimeException e) {
+      assert e.getCause() instanceof SegmentLoadingException;
+      final List<DataSegment> unusedSegments =
+              getMetadataStorageCoordinator().getUnusedSegmentsForInterval(DATA_SOURCE, Intervals.of("2019/2020"));
+
+      Assert.assertEquals(ImmutableList.of(marchSegment), unusedSegments);
+      Assert.assertEquals(
+              ImmutableSet.of(
+                      newSegment(Intervals.of("2019-01-01/2019-02-01"), VERSION),
+                      newSegment(Intervals.of("2019-04-01/2019-05-01"), VERSION)
+              ),
+              ImmutableSet.copyOf(
+                      getMetadataStorageCoordinator()
+                              .getUsedSegmentsForInterval(DATA_SOURCE, Intervals.of("2019/2020"), Segments.ONLY_VISIBLE)
+              )
+      );
+      throw (SegmentLoadingException) e.getCause();
+    }
+  }
+
+  private void announceSegmentsWithIntervals(String version, String... intervals) throws IOException
+  {
+    ImmutableSet.Builder<DataSegment> segmentsBuilder = ImmutableSet.builder();
+    Arrays.asList(intervals).forEach(interval -> segmentsBuilder.add(newSegment(Intervals.of(interval), version)));
+    ImmutableSet<DataSegment> segments = segmentsBuilder.build();
+    final Set<DataSegment> announced = getMetadataStorageCoordinator().announceHistoricalSegments(segments);
+
+    Assert.assertEquals(segments, announced);
   }
 
   private static DataSegment newSegment(Interval interval, String version)


### PR DESCRIPTION
When a kill task was issued, segments would be nuked from the metadata store
if the task could acquire a lock that covered all segments. Then it would attempt
to kill the segments one by one.

Killing a segment is not guaranteed to succeed so it is possible to leave segments
hanging around on disk with no easy way to clean them up.

This PR has:
- [ ] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] been tested in a test Druid cluster.