### PR TITLE
Upgrade kafka library to 2.2.1

### DIFF
--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -33,10 +33,6 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <properties>
-    <apache.kafka.version>2.2.1</apache.kafka.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.druid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>4.1.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
-        <apache.kafka.version>2.1.1</apache.kafka.version>
+        <apache.kafka.version>2.2.1</apache.kafka.version>
         <avatica.version>1.15.0</avatica.version>
         <avro.version>1.9.1</avro.version>
         <calcite.version>1.21.0</calcite.version>


### PR DESCRIPTION
The kafka indexing service has been using 2.2.1 for a release. It appears
to be stable so the project-level pom is updated to use this version as well.
This makes it easier to update the library versions in case we find a bug or
security vulnerability that requires us to patch the library.

This PR has:
- [x] been self-reviewed.
- [ ] been tested in a test Druid cluster.