### PR TITLE
Add Nullhandling instance to tests

### DIFF
--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.query.topn.DimensionAndMetricValueExtractor;
 import org.apache.druid.query.topn.TopNResultValue;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,7 +57,7 @@ import java.util.List;
  *
  */
 @RunWith(Parameterized.class)
-public class SketchAggregationWithSimpleDataTest
+public class SketchAggregationWithSimpleDataTest extends InitializedNullHandlingTest
 {
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.groupby.epinephelinae.GrouperTestUtil;
 import org.apache.druid.query.groupby.epinephelinae.TestColumnSelectorFactory;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -59,7 +60,7 @@ import java.util.List;
  *
  */
 @RunWith(Parameterized.class)
-public class OldApiSketchAggregationTest
+public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
 {
   private final AggregationTestHelper helper;
 


### PR DESCRIPTION
This PR adds initialization of Nullhandling to tests which are presently failing when run independently.
Related to #8876 

<hr>

This PR has:
- [x] been self-reviewed.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
<hr>
