### PR TITLE
Graduation update for ASF release process guide and download links

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "upstream": "apache/druid",
   "branches": [
-    { "name": "0.16.0-incubating", "checked": true },
-    { "name": "0.17.0-incubating", "checked": true }
+    { "name": "0.16.1-incubating", "checked": true },
+    { "name": "0.17.0", "checked": true }
   ]
 }

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -291,7 +291,7 @@ To make the staged repo publicly accessible, "Close" the staging repo.
 
 ## Release candidates and voting
 
-Release votes on held on the dev mailing list, dev@druid.apache.org. Druid PMC votes are binding.
+Release votes are held on the dev mailing list, dev@druid.apache.org. Druid PMC votes are binding.
 
 You can use the following template for the release vote thread, replacing values as necessary.
 

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -28,21 +28,21 @@ First up in performing an official release of Apache Druid is to announce in the
 Next up is creating the release branch off of master (or the previous release branch for a bug fix release). Be sure to do this from the apache git repo, _not your fork_. Name the branch for the release version that is being created, omitting the `druid` prefix that will appear on the release candidate and release tags:
 
 ```bash
-$ git checkout origin/0.15.0-incubating
+$ git checkout origin/0.17.0
 ...
-$ git checkout -b 0.15.1-incubating
+$ git checkout -b 0.17.1
 ```
 
 ```bash
 $ git checkout origin/master
 ...
-$ git checkout -b 0.16.0-incubating
+$ git checkout -b 0.17.0
 ```
 
 Then push the branch to `origin`. If doing a quarterly release, it will also be necessary to bump the version in master to the next release snapshot:
 
 ```bash
-$ mvn versions:set -DnewVersion=0.17.0-incubating-SNAPSHOT
+$ mvn versions:set -DnewVersion=0.18.0-SNAPSHOT
 ```
 
 and open a PR to the master branch. Bug fix releases should already have the correct snapshot version from the previous releases on the branch, so this step is not necessary.
@@ -82,10 +82,10 @@ sub   rsa4096 2019-02-28 [E]
 
 If all goes well, your Apache account will be associated with that key, which you can check at https://people.apache.org/committer-index.html
 
-You will also need to add your key to our project KEYS file: https://dist.apache.org/repos/dist/release/incubator/druid/KEYS, this repo can be pulled with:
+You will also need to add your key to our project KEYS file: https://dist.apache.org/repos/dist/release/druid/KEYS, this repo can be pulled with:
 
 ```bash
-$ svn co https://dist.apache.org/repos/dist/release/incubator/druid
+$ svn co https://dist.apache.org/repos/dist/release/druid
 ```
 
 Add your entry to the file and commit:
@@ -128,7 +128,7 @@ http://www.apache.org/legal/src-headers.html
 http://www.apache.org/legal/resolved.html
 
 
-There are in effect 2 versions of the `LICENSE` and `NOTICE` file needed to perform a release, one set for the official ASF source release which are the actual `LICENSE` and `NOTICE` file in the root directory, and second for the convenience binary release which includes all of Druid's dependencies which we synthesize using some tools we have developed over the initial set of 'incubating' releases.
+There are in effect 2 versions of the `LICENSE` and `NOTICE` file needed to perform a release, one set for the official ASF source release which are the actual `LICENSE` and `NOTICE` file in the root directory, and second for the convenience binary release which includes all of Druid's dependencies which we synthesize using some tools we have developed over the initial set of releases.
 
 ### licenses.yaml
 
@@ -181,7 +181,7 @@ It is also the release managers responsibility for correctly assigning all PRs m
 | [find-missing-backports](bin/find-missing-backports.py) | Find PRs which have been back-ported to one release branch but not another. Useful if a bug fix release based on the previous release is required during a release cycle. |
 
 
-Next create an issue in the Druid github to contain the release notes and allow the community to provide feedback prior to the release. Make sure to attach it to the release milestone in github. It is highly recommended to review [previous release notes for reference](https://github.com/apache/druid/issues?utf8=%E2%9C%93&q=is%3Aissue+%22incubating+release+notes%22+label%3A%22Release+Notes%22+is%3Aclosed+) of how to best structure them. Be sure to call out any exciting new features, important bug fixes, and any compatibility concerns for users or operators to consider when upgrading to this release.
+Next create an issue in the Druid github to contain the release notes and allow the community to provide feedback prior to the release. Make sure to attach it to the release milestone in github. It is highly recommended to review [previous release notes for reference](https://github.com/apache/druid/releases) of how to best structure them. Be sure to call out any exciting new features, important bug fixes, and any compatibility concerns for users or operators to consider when upgrading to this release.
 
 
 ## Building a release candidate
@@ -191,10 +191,10 @@ Next create an issue in the Druid github to contain the release notes and allow 
 Once the release branch is good for an RC, you can build a new tag with:
 
 ```bash
-$ mvn -DreleaseVersion=0.16.0-incubating -DdevelopmentVersion=0.16.1-incubating-SNAPSHOT -Dtag=druid-0.16.0-incubating-rc3 -DpushChanges=false clean release:clean release:prepare
+$ mvn -DreleaseVersion=0.17.0 -DdevelopmentVersion=0.18.0-SNAPSHOT -Dtag=druid-0.17.0-rc3 -DpushChanges=false clean release:clean release:prepare
 ```
 
-In this example it will create a tag, `druid-0.16.0-incubating-rc3`. If this release passes vote then we can add the final `druid-0.16.0-incubating` release tag later.
+In this example it will create a tag, `druid-0.17.0-rc3`. If this release passes vote then we can add the final `druid-0.17.0` release tag later.
 
 **Retain the release.properties file! You will need it when uploading the Maven artifacts for the final release.**
 
@@ -207,7 +207,7 @@ $ git clone git@github.com:apache/druid.git druid-release
 ### Switch to tag
 
 ```bash
-$ git checkout druid-0.16.0-incubating-rc3
+$ git checkout druid-0.17.0-rc3
 ```
 
 ### Build Artifacts
@@ -219,30 +219,30 @@ $ mvn clean install -Papache-release,dist,rat -DskipTests -Dgpg.keyname=<your GP
 This should produce the following artifacts:
 
 ```plaintext
-apache-druid-0.16.0-incubating-bin.tar.gz
-apache-druid-0.16.0-incubating-bin.tar.gz.asc
-apache-druid-0.16.0-incubating-bin.tar.gz.sha512
-apache-druid-0.16.0-incubating-src.tar.gz
-apache-druid-0.16.0-incubating-src.tar.gz.asc
-apache-druid-0.16.0-incubating-src.tar.gz.sha512
+apache-druid-0.17.0-bin.tar.gz
+apache-druid-0.17.0-bin.tar.gz.asc
+apache-druid-0.17.0-bin.tar.gz.sha512
+apache-druid-0.17.0-src.tar.gz
+apache-druid-0.17.0-src.tar.gz.asc
+apache-druid-0.17.0-src.tar.gz.sha512
 ```
 
-Ensure that the GPG key fingerprint used in the `mvn install` command matches your release signing key in https://dist.apache.org/repos/dist/release/incubator/druid/KEYS.                                                                                               
+Ensure that the GPG key fingerprint used in the `mvn install` command matches your release signing key in https://dist.apache.org/repos/dist/release/druid/KEYS.                                                                                               
  
 ### Verify checksums
 
 ```bash
-$ diff <(shasum -a512 apache-druid-0.16.0-incubating-bin.tar.gz | cut -d ' ' -f1) <(cat apache-druid-0.16.0-incubating-bin.tar.gz.sha512 ; echo)
+$ diff <(shasum -a512 apache-druid-0.17.0-bin.tar.gz | cut -d ' ' -f1) <(cat apache-druid-0.17.0-bin.tar.gz.sha512 ; echo)
 ...
-$ diff <(shasum -a512 apache-druid-0.16.0-incubating-src.tar.gz | cut -d ' ' -f1) <(cat apache-druid-0.16.0-incubating-src.tar.gz.sha512 ; echo)
+$ diff <(shasum -a512 apache-druid-0.17.0-src.tar.gz | cut -d ' ' -f1) <(cat apache-druid-0.17.0-src.tar.gz.sha512 ; echo)
 ```
 
 ### Verify GPG signatures
 
 ```bash
-$ gpg --verify apache-druid-0.16.0-incubating-bin.tar.gz.asc apache-druid-0.16.0-incubating-bin.tar.gz
+$ gpg --verify apache-druid-0.17.0-bin.tar.gz.asc apache-druid-0.17.0-bin.tar.gz
 ...
-$ gpg --verify apache-druid-0.16.0-incubating-src.tar.gz.asc apache-druid-0.16.0-incubating-src.tar.gz
+$ gpg --verify apache-druid-0.17.0-src.tar.gz.asc apache-druid-0.17.0-src.tar.gz
 ```
 
 ### Commit artifacts to SVN repo
@@ -250,15 +250,15 @@ $ gpg --verify apache-druid-0.16.0-incubating-src.tar.gz.asc apache-druid-0.16.0
 Checkout the dist/dev repo and add a directory for the new release candidate. The KEYS file in this repo is obsoleted and should not be used.
 
 ```bash
-$ svn checkout https://dist.apache.org/repos/dist/dev/incubator/druid
+$ svn checkout https://dist.apache.org/repos/dist/dev/druid
 ```
 
 Copy the `src` and `bin` artifacts to a folder for the release version and add it to SVN and publish the artifacts:
 
 ```bash
-$ svn add 0.16.0-incubating-rc3
+$ svn add 0.17.0-rc3
 ...
-$ svn commit -m 'add 0.16.0-incubating-rc3 artifacts'
+$ svn commit -m 'add 0.17.0-rc3 artifacts'
 ```
 
 ### Update druid.staged.apache.org
@@ -267,7 +267,7 @@ $ svn commit -m 'add 0.16.0-incubating-rc3 artifacts'
 
 2. From druid-website, checkout branch `asf-staging`.
 
-3. From druid-website-src, run `./release.sh 0.16.0-incubating 0.16.0-incubating`, replacing `0.16.0-incubating` where the first argument is the release version and 2nd argument is commit-ish. This script will:
+3. From druid-website-src, run `./release.sh 0.17.0 0.17.0`, replacing `0.17.0` where the first argument is the release version and 2nd argument is commit-ish. This script will:
 
 * checkout the tag of the Druid release version
 * build the docs for that version into druid-website-src
@@ -276,21 +276,29 @@ $ svn commit -m 'add 0.16.0-incubating-rc3 artifacts'
 
 4. Make a PR to the src repo (https://github.com/apache/druid-website-src) for the release branch. Once the website PR is pushed to `asf-site`, https://druid.staged.apache.org/ will be updated near immediately with the new docs.
 
+### Create staged Maven repo
+
+Before opening the release vote thread, we create a staged maven repository containing the RC artifacts.	
+
+You can generate a staged maven repo for the RC with the following steps:	
+
+- Copy the `release.properties` that was generated when the RC tag was created back to your repo root (You'll need to change scm.tag in that file to match the specific rc tag you created if you did not specify `-Dtag` when creating the release). If you still have the working copy that build the `tag` available, you may use that.	
+- Run `mvn release:perform`	
+
+This will create a staged Maven repo here (login with Apache credentials): https://repository.apache.org/#stagingRepositories	
+
+To make the staged repo publicly accessible, "Close" the staging repo.
+
 ## Release candidates and voting
 
-Until we graduate from incubation, releases have two stages of voting:
+Release votes on held on the dev mailing list, dev@druid.apache.org. Druid PMC votes are binding.
 
-- Druid community vote (dev@druid.apache.org, Druid PPMC votes are binding)
-- Incubator vote (general@incubator.apache.org, Incubator PMC votes are binding)
-
-### Druid PPMC Vote
-
-For the Druid community vote, send an email to dev@druid.apache.org, using something like the following as a template, replacing values as necessary.
+You can use the following template for the release vote thread, replacing values as necessary.
 
 ##### Subject
 
 ```plaintext
-[VOTE] Release Apache Druid 0.16.0 [RC3]
+[VOTE] Release Apache Druid 0.17.0 [RC3]
 ```
 
 ##### Body
@@ -298,27 +306,27 @@ For the Druid community vote, send an email to dev@druid.apache.org, using somet
 ```plaintext
 Hi all,
 
-I have created a build for Apache Druid 0.16.0, release
+I have created a build for Apache Druid 0.17.0, release
 candidate 3.
 
 Thanks for everyone who has helped contribute to the release! You can read
 the proposed release notes here:
-https://github.com/apache/druid/issues/8369
+https://github.com/apache/druid/issues/9066
 
 The release candidate has been tagged in GitHub as
-druid-0.16.0-incubating-rc3 (54d29e438a4df34d75e2385af6cefd1092c4ebb3),
+druid-0.17.0-rc3 (54d29e438a4df34d75e2385af6cefd1092c4ebb3),
 available here:
-https://github.com/apache/druid/releases/tag/druid-0.16.0-incubating-rc3
+https://github.com/apache/druid/releases/tag/druid-0.17.0-rc3
 
 The artifacts to be voted on are located here:
-https://dist.apache.org/repos/dist/dev/incubator/druid/0.16.0-incubating-rc3/
+https://dist.apache.org/repos/dist/dev/druid/0.17.0-rc3/
 
 Staged druid.apache.org website documentation is available here:
-https://druid.staged.apache.org/docs/0.16.0-incubating/design/index.html
+https://druid.staged.apache.org/docs/0.17.0/design/index.html
 
 A Docker image containing the binary of the release candidate can be
 retrieved via:
-docker pull apache/druid:0.16.0-incubating-rc3
+docker pull apache/druid:0.17.0-rc3
 
 artifact checksums
 src:
@@ -332,27 +340,27 @@ https://people.apache.org/keys/committer/cwylie.asc
 
 This key and the key of other committers can also be found in the project's
 KEYS file here:
-https://dist.apache.org/repos/dist/release/incubator/druid/KEYS
+https://dist.apache.org/repos/dist/release/druid/KEYS
 
 (If you are a committer, please feel free to add your own key to that file
 by following the instructions in the file's header.)
 
 
 Verify checksums:
-diff <(shasum -a512 apache-druid-0.16.0-incubating-src.tar.gz | \
+diff <(shasum -a512 apache-druid-0.17.0-src.tar.gz | \
 cut -d ' ' -f1) \
-<(cat apache-druid-0.16.0-incubating-src.tar.gz.sha512 ; echo)
+<(cat apache-druid-0.17.0-src.tar.gz.sha512 ; echo)
 
-diff <(shasum -a512 apache-druid-0.16.0-incubating-bin.tar.gz | \
+diff <(shasum -a512 apache-druid-0.17.0-bin.tar.gz | \
 cut -d ' ' -f1) \
-<(cat apache-druid-0.16.0-incubating-bin.tar.gz.sha512 ; echo)
+<(cat apache-druid-0.17.0-bin.tar.gz.sha512 ; echo)
 
 Verify signatures:
-gpg --verify apache-druid-0.16.0-incubating-src.tar.gz.asc \
-apache-druid-0.16.0-incubating-src.tar.gz
+gpg --verify apache-druid-0.17.0-src.tar.gz.asc \
+apache-druid-0.17.0-src.tar.gz
 
-gpg --verify apache-druid-0.16.0-incubating-bin.tar.gz.asc \
-apache-druid-0.16.0-incubating-bin.tar.gz
+gpg --verify apache-druid-0.17.0-bin.tar.gz.asc \
+apache-druid-0.17.0-bin.tar.gz
 
 Please review the proposed artifacts and vote. Note that Apache has
 specific requirements that must be met before +1 binding votes can be cast
@@ -369,26 +377,14 @@ mvn apache-rat:check -Prat
 This vote will be open for at least 72 hours. The vote will pass if a
 majority of at least three +1 PMC votes are cast.
 
-Once the vote has passed, the second stage vote will be called on the
-Apache Incubator mailing list to get approval from the Incubator PMC.
-
-[ ] +1 Release this package as Apache Druid 0.16.0
+[ ] +1 Release this package as Apache Druid 0.17.0
 [ ] 0 I don't feel strongly about it, but I'm okay with the release
 [ ] -1 Do not release this package because...
 
 Thanks!
-
-Apache Druid is an effort undergoing incubation at The Apache
-Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is
-required of all newly accepted projects until a further review indicates
-that the infrastructure, communications, and decision making process have
-stabilized in a manner consistent with other successful ASF projects. While
-incubation status is not necessarily a reflection of the completeness or
-stability of the code, it does indicate that the project has yet to be
-fully endorsed by the ASF.
 ```
 
-Anyone can vote on a release. When voting, you should list out what exactly you checked and note whether or not your vote is binding. (It is binding if you are on the Druid PPMC, otherwise it is non-binding.) A sample vote would look like:
+Anyone can vote on a release. When voting, you should list out what exactly you checked and note whether or not your vote is binding. (It is binding if you are on the Druid PMC, otherwise it is non-binding.) A sample vote would look like:
 
 ```plaintext
 +1 (binding)
@@ -416,14 +412,14 @@ According to Apache release policy,
 - Releases may not be vetoed.
 - Before casting +1 binding votes, individuals are required to download all signed source code packages onto their own hardware, verify that they meet all requirements of ASF policy, validate all cryptographic signatures, compile as provided, and test the result on their own platform.
 
-### Druid PPMC vote result
+### Druid PMC vote result
 
 Once the Druid community vote passes (or fails), close the vote with a thread like the following:
 
 ##### Subject
 
 ```plaintext
-[RESULT][VOTE] Release Apache Druid 0.16.0 [RC3]
+[RESULT][VOTE] Release Apache Druid 0.17.0 [RC3]
 ```
 
 ##### Body
@@ -441,187 +437,33 @@ Surekha Saharan: +1 (non-binding)
 ...
 ```
 
-### IPMC vote
-
-The next step is to raise a vote thread on the incubator PMC mailing list.
-
-Before doing so, we create a staged maven repository containing the RC artifacts.
-
-You can generate a staged maven repo for the RC with the following steps:
-
-- Copy the `release.properties` that was generated when the RC tag was created back to your repo root (You'll need to change scm.tag in that file to match the specific rc tag you created if you did not specify `-Dtag` when creating the release). If you still have the working copy that build the `tag` available, you may use that.
-- Run `mvn release:perform`
-
-This will create a staged Maven repo here (login with Apache credentials): https://repository.apache.org/#stagingRepositories
-
-To make the staged repo publicly accessible, "Close" the staging repo.
-
-Here is the IPMC vote template. Please note that "6190EEFC" in the template is your key id which is the last 16 (or 8) hex digits your key.
-
-##### Subject
-
-```plaintext
-[VOTE] Release Apache Druid 0.16.0 [RC3]
-```
-
-##### Body
-
-```plaintext
-Hi IPMC,
-
-The Apache Druid community has voted on and approved a proposal to release
-Apache Druid 0.16.0 (rc3).
-
-We now kindly request the Incubator PMC members review and vote on this
-incubator release.
-
-Apache Druid is a high performance analytics data store for
-event-driven data.
-
-The community voting thread can be found here:
-https://lists.apache.org/thread.html/ea2f70b0533f403215288ae35294adc59f9ab33accabd9048eeb082f@%3Cdev.druid.apache.org%3E
-
-We have already received 2 +1 votes from IPMC members (Julian Hyde and
-Furkan KAMACI) during our community vote which I believe can be carried
-over to this vote as +1 (binding).
-
-During our previous IPMC release vote, a concern was raised about
-licensing/distribution of a file containing example data, and we have
-raised https://issues.apache.org/jira/browse/LEGAL-480 to get to the bottom
-of this. The discussion is currently ongoing there, but at this point it
-seems possible that including this file might end up being acceptable, so I
-have decided to proceed with this vote now. If it turns out that we cannot
-distribute this file then we intend to switch to a different example data
-file in a future release.
-
-The release notes are available here:
-https://github.com/apache/druid/issues/8369
-
-The release candidate has been tagged in GitHub as
-druid-0.16.0-incubating-rc3 (54d29e438a4df34d75e2385af6cefd1092c4ebb3),
-available here:
-https://github.com/apache/druid/releases/tag/druid-0.16.0-incubating-rc3
-
-The artifacts to be voted on are located here:
-https://dist.apache.org/repos/dist/dev/incubator/druid/0.16.0-incubating-rc3/
-
-A staged Maven repository is available for review at:
-https://repository.apache.org/content/repositories/orgapachedruid-1009/
-
-A Docker image containing the binary of the release candidate can be
-retrieved via:
-docker pull apache/druid:0.16.0-incubating-rc3
-
-artifact checksums
-src:
-1f25c55e83069cf7071a97c1e0d56732437dbac4ef373ed1ed72b5b618021b74c107269642226e80081354c8da2e92dc26f1541b01072a4720fd6cfe8dc161a8
-bin:
-0c4b71f077e28d2f4d3bc3f072543374570b98ec6a1918a5e1828e1da7e3871b5efb04070a8bcdbc172a817e43254640ce28a99757984be7d8dd3d607f1d870e
-docker: df9b900d3726ce123a5c054768da1ea08eba6efe635ced5abc3ad72d6c835e2c
-
-Release artifacts are signed with the key (6190EEFC):
-https://people.apache.org/keys/committer/cwylie.asc
-
-This key and the key of other committers can be found in the project's KEYS
-file here:
-https://www.apache.org/dist/incubator/druid/KEYS
-
-Staged druid.apache.org website documentation is available here:
-https://druid.staged.apache.org/docs/0.16.0-incubating/design/index.html
-
-As part of the validation process, the release artifacts can be generated
-from source by running:
-mvn clean install -Papache-release,dist
-
-The RAT license check can be run from source by:
-mvn apache-rat:check -Prat
-
-This vote will be open for at least 72 hours. The vote will pass if a
-majority of at least three +1 IPMC votes are cast.
-
-[ ] +1 Release this package as Apache Druid 0.16.0
-[ ]  0 I don't feel strongly about it, but I'm okay with the release
-[ ] -1 Do not release this package because...
-
-Thank you IPMC! We appreciate your efforts in helping the Apache Druid
-community to validate this release.
-
-On behalf of the Apache Druid Community,
-Clint
-
-Apache Druid is an effort undergoing incubation at The Apache
-Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is
-required of all newly accepted projects until a further review indicates
-that the infrastructure, communications, and decision making process have
-stabilized in a manner consistent with other successful ASF projects. While
-incubation status is not necessarily a reflection of the completeness or
-stability of the code, it does indicate that the project has yet to be
-fully endorsed by the ASF.
-```
-
 ### Cancelling a vote
 
-If for any reason during the Druid PPMC or IPMC vote a blocking issue becomes apparent, a vote should be officially cancelled by sending an email with the following subject line: `[CANCEL][VOTE] Release Apache Druid 0.15.1 [RC1]` and the reasons for the cancellation in the body.
+If for any reason during the Druid PMC vote a blocking issue becomes apparent, a vote should be officially cancelled by sending an email with the following subject line: `[CANCEL][VOTE] Release Apache Druid 0.17.0 [RC3]` and the reasons for the cancellation in the body.
 
 ### Previous vote threads for additional examples
 
-- [Druid PPMC](https://lists.apache.org/list.html?dev@druid.apache.org:lte=1y:%22%5BVOTE%5D%20Release%20Apache%20Druid%20(incubating)%22)
-- [IPMC](https://lists.apache.org/list.html?general@incubator.apache.org:lte=1y:%22%5BVOTE%5D%20Release%20Apache%20Druid%20(incubating)%22)
-
+- [Druid PMC](https://lists.apache.org/list.html?dev@druid.apache.org:lte=1y:%22%5BVOTE%5D%20Release%20Apache%20Druid%22)
 
 ## Final Release
 
-Once a release candidate has passed the incubator PMC vote, you'll need to do the following:
+Once a release candidate has passed the Druid PMC vote, you'll need to do the following:
 
-- Close the IPMC vote thread
+- Close the Druid PMC vote thread as described above
 - Publish release artifacts to the release SVN repo
 - Publish the staged Maven repo
-- Wait 24 hours to allow the artifacts to propagate across mirror
+- Wait 24 hours to allow the artifacts to propagate across mirrors
 - Update the druid.apache.org website
 - Announce the release
 
-### Close the IPMC vote thread
-
-##### Subject
-
-```plaintext
-[RESULT] [VOTE] Release Apache Druid 0.16.0 [RC3]
-```
-
-##### Body
-
-```plaintext
-Hi all,
-
-The vote to release Apache Druid 0.16.0 has passed with 3 +1
-binding votes:
-
-Julian Hyde
-Furkan KAMACI
-Gian Merlino
-
-
-Vote thread:
-https://lists.apache.org/thread.html/a2eff0f2ef609a8960265d1f32c27748c5ea69bd00f511eca2022e0f@%3Cgeneral.incubator.apache.org%3E
-
-
-Thank you to the above IPMC members for taking the time to review and
-provide guidance on our release!
-
-We will proceed with publishing the approved artifacts and sending out the
-appropriate announcements in the coming days.
-
-On behalf of the Apache Druid Community,
-Clint
-```
 ### Create git tag
 
 Tag the rc that passed vote as the release tag and push to github.
 
 ```bash
-$ git checkout druid-0.16.0-incubating-rc3
-$ git tag druid-0.16.0-incubating
-$ git push origin/druid-0.16.0-incubating
+$ git checkout druid-0.17.0-rc3
+$ git tag druid-0.17.0
+$ git push origin/druid-0.17.0
 ```
 
 ### Publish release artifacts to SVN
@@ -629,19 +471,19 @@ $ git push origin/druid-0.16.0-incubating
 The final release artifacts are kept in the following repo (same as KEYS):
 
 ```bash
-$ svn checkout https://dist.apache.org/repos/dist/release/incubator/druid
+$ svn checkout https://dist.apache.org/repos/dist/release/druid
 ```
 
 Create a new directory for the release and put the artifacts there.
 
 ```bash
-$ svn add 0.16.0-incubating
+$ svn add 0.17.0
 ...
-$ svn commit -m 'add 0.16.0-incubating artifacts'
+$ svn commit -m 'add 0.17.0 artifacts'
 ```
 
 ### Publish the staged Maven repo
-Returning to the staged repo you created for the IPMC vote ( https://repository.apache.org/#stagingRepositories), "Release" the repo to publish the Maven artifacts.
+Returning to the staged repo you created for the Druid PMC vote ( https://repository.apache.org/#stagingRepositories), "Release" the repo to publish the Maven artifacts.
 
 https://central.sonatype.org/pages/releasing-the-deployment.html#close-and-drop-or-release-your-staging-repository
 
@@ -671,7 +513,7 @@ druid_versions:
         date: 2019-08-15
 ```
 
-3. From druid-website-src, run `./release.sh 0.16.0-incubating 0.16.0-incubating`, replacing `0.16.0-incubating` where the first argument is the release version and 2nd argument is commit-ish. This script will:
+3. From druid-website-src, run `./release.sh 0.17.0 0.17.0`, replacing `0.17.0` where the first argument is the release version and 2nd argument is commit-ish. This script will:
 
 * checkout the tag of the Druid release version
 * build the docs for that version into druid-website-src
@@ -684,29 +526,25 @@ druid_versions:
 
 Copy the release notes and create the release from the tag.
 
-
 ### Announce the release
 
-Announce the release to all the lists, announce@apache.org, general@incubator.apache.org, dev@druid.apache.org, druid-user@googlegroups.com (general announcement list, incubator general list, druid dev list, druid user group).
+Announce the release to all the lists, announce@apache.org, dev@druid.apache.org, druid-user@googlegroups.com (general announcement list, druid dev list, druid user group).
 
 Additionally, announce it to the Druid official ASF Slack channel, https://druid.apache.org/community/join-slack.
-
-**Be sure to include the Apache incubation disclaimer.**
 
 ##### subject
 
 ```plaintext
-[ANNOUNCE] Apache Druid 0.16.0 release
+[ANNOUNCE] Apache Druid 0.17.0 release
 ```
 
 ##### body
 
 ```plaintext
-The Apache Druid team is proud to announce the release of Apache Druid
-(incubating) 0.16.0. Druid is a high performance analytics data store for
-event-driven data.
+The Apache Druid team is proud to announce the release of Apache Druid 0.17.0. 
+Druid is a high performance analytics data store for event-driven data.
 
-Apache Druid 0.16.0-incubating contains over 350 new features, performance
+Apache Druid 0.17.0 contains over 350 new features, performance
 enhancements, bug fixes, and major documentation improvements from 50
 contributors. Major new features and improvements include:
 
@@ -722,23 +560,12 @@ Source and binary distributions can be downloaded from:
 https://druid.apache.org/downloads.html
 
 Release notes are at:
-https://github.com/apache/druid/releases/tag/druid-0.16.0-incubating
+https://github.com/apache/druid/releases/tag/druid-0.17.0
 
 A big thank you to all the contributors in this milestone release!
-
-----
-
-Disclaimer: Apache Druid is an effort undergoing incubation at The Apache
-Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is
-required of all newly accepted projects until a further review indicates
-that the infrastructure, communications, and decision making process have
-stabilized in a manner consistent with other successful ASF projects. While
-incubation status is not necessarily a reflection of the completeness or
-stability of the code, it does indicate that the project has yet to be
-fully endorsed by the ASF.
 ```
 
-[Previous release announcements](https://lists.apache.org/list.html?general@incubator.apache.org:lte=1y:%22%5BANNOUNCE%5D%20Apache%20Druid%20(incubating%22))
+[Previous release announcements](https://lists.apache.org/list.html?dev@druid.apache.org:lte=1y:%22%5BANNOUNCE%5D%20Apache%20Druid%22)
 
 Sticky the announcement on the ['druid-user' group](https://groups.google.com/forum/?pli=1#!forum/druid-user).
 
@@ -748,8 +575,8 @@ Update the release version and date on the [Apache Druid Wikipedia article](http
 
 ### Remove old releases which are not 'active'
 
-Removing old releases from the ['release' SVN repository](https://dist.apache.org/repos/dist/release/incubator/druid) which are not actively being developed is an Apache policy. The contents of this directory controls which artifacts are available on the Apache download mirror network. All other releases are available from the Apache archives, so removal from here is not a permanent deletion.
+Removing old releases from the ['release' SVN repository](https://dist.apache.org/repos/dist/release/druid) which are not actively being developed is an Apache policy. The contents of this directory controls which artifacts are available on the Apache download mirror network. All other releases are available from the Apache archives, so removal from here is not a permanent deletion.
 
 We consider the 'active' releases to be the latest versions of the current and previous quarterly releases. If you are adding a new quarterly release, remove the oldest quarterly release. If you are adding a bug fix release, remove the current quarterly release. 
 
-For example, if the new release is a bug fix, `0.15.1-incubating`, and the current versions are `0.15.0-incubating`, and `0.14.2-incubating`, then you would delete `0.15.0-incubating`, leaving `0.14.2-incubating` and `0.15.1-incubating` on the mirrors. If instead we were adding `0.16.0-incubating`, the resulting set of 'active' releases would be `0.15.0-incubating` and `0.16.0-incubating`.
+For example, if the new release is a bug fix, `0.18.1`, and the current versions are `0.18.0`, and `0.17.1`, then you would delete `0.18.0`, leaving `0.18.1` and `0.17.1` on the mirrors. If instead we were adding `0.19.0`, the resulting set of 'active' releases would be `0.19.0` and `0.18.0`.

--- a/distribution/bin/find-missing-backports.py
+++ b/distribution/bin/find-missing-backports.py
@@ -69,7 +69,7 @@ def find_next_url(links):
 
 if len(sys.argv) != 5:
   sys.stderr.write('usage: program <github-username> <previous-release-branch> <current-release-branch> <milestone-number>\n')
-  sys.stderr.write("  e.g., program myusername 0.14.0-incubating 0.15.0-incubating 30")
+  sys.stderr.write("  e.g., program myusername 0.17.0 0.18.0 30")
   sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.")
   sys.exit(1)
 

--- a/distribution/bin/get-milestone-prs.py
+++ b/distribution/bin/get-milestone-prs.py
@@ -24,7 +24,7 @@ import time
 
 if len(sys.argv) != 5:
   sys.stderr.write('usage: program <github-username> <upstream-remote> <previous-release-branch> <current-release-branch>\n')
-  sys.stderr.write("  e.g., program myusername upstream 0.13.0-incubating 0.14.0-incubating")
+  sys.stderr.write("  e.g., program myusername upstream 0.17.0 0.18.0")
   sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.")
   sys.exit(1)
 

--- a/docs/tutorials/cluster.md
+++ b/docs/tutorials/cluster.md
@@ -148,7 +148,7 @@ First, download and unpack the release archive. It's best to do this on a single
 since you will be editing the configurations and then copying the modified distribution out to all
 of your servers.
 
-[Download](https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/{{DRUIDVERSION}}/apache-druid-{{DRUIDVERSION}}-bin.tar.gz)
+[Download](https://www.apache.org/dyn/closer.cgi?path=/druid/{{DRUIDVERSION}}/apache-druid-{{DRUIDVERSION}}-bin.tar.gz)
 the {{DRUIDVERSION}} release.
 
 Extract Druid by running the following commands in your terminal:

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -55,7 +55,7 @@ configuration than `micro-quickstart`.
 
 ## Getting started
 
-[Download](https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/{{DRUIDVERSION}}/apache-druid-{{DRUIDVERSION}}-bin.tar.gz)
+[Download](https://www.apache.org/dyn/closer.cgi?path=/druid/{{DRUIDVERSION}}/apache-druid-{{DRUIDVERSION}}-bin.tar.gz)
 the {{DRUIDVERSION}} release.
 
 Extract Druid by running the following commands in your terminal:

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <connection>scm:git:ssh://git@github.com/apache/druid.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/apache/druid.git</developerConnection>
         <url>https://github.com/apache/druid.git</url>
-        <tag>0.18.0-incubating-SNAPSHOT</tag>
+        <tag>0.18.0-SNAPSHOT</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <connection>scm:git:ssh://git@github.com/apache/druid.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/apache/druid.git</developerConnection>
         <url>https://github.com/apache/druid.git</url>
-        <tag>0.13.0-incubating-SNAPSHOT</tag>
+        <tag>0.18.0-incubating-SNAPSHOT</tag>
     </scm>
 
     <properties>
@@ -1490,7 +1490,6 @@
                             </properties>
                             <resourceBundles>
                                 <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
-                                <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT</resourceBundle>
                             </resourceBundles>
                         </configuration>
                     </execution>

--- a/website/script/fix-path.js
+++ b/website/script/fix-path.js
@@ -19,7 +19,7 @@
 const replace = require('replace-in-file');
 
 if (process.argv.length !== 4) {
-  console.log('Usage: node fix-path.js latest 0.16.0-incubating');
+  console.log('Usage: node fix-path.js latest 0.17.0');
   process.exit(1);
 }
 


### PR DESCRIPTION
This PR is a follow on to #9108:
 - updates the ASF release process guide, removing incubation-specific steps and updating the example `*-incubating` versions to hypothetical/future non-incubating versions
 - updates download links referenced in the docs to point to the new repo (I've copied the KEYS, 0.15.1-incubating artifacts, and 0.16.1-incubating artifacts already to our new repo).
- Adjusts some misc. areas where `*-incubating` versions were used as examples

This PR does not adjust remaining references to our incubation Dockerhub repo, as we need https://issues.apache.org/jira/browse/INFRA-19648 to be resolved first.