### PR TITLE
fix web console data loader dimension types

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -510,7 +510,7 @@ const DIMENSION_SPEC_FORM_FIELDS: Field<DimensionSpec>[] = [
   {
     name: 'type',
     type: 'string',
-    suggestions: ['string', 'long', 'float'],
+    suggestions: ['string', 'long', 'float', 'double'],
   },
   {
     name: 'createBitmapIndex',

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2182,7 +2182,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         <div className="control">
           <Callout className="intro">
             <p>
-              Each column in Druid must have an assigned type (string, long, float, complex, etc).
+              Each column in Druid must have an assigned type (string, long, float, double, complex,
+              etc).
             </p>
             {dimensionMode === 'specific' && (
               <p>
@@ -2570,13 +2571,14 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       const convertToDimensionMenu = (
         <Menu>
           <MenuItem
-            text="Convert to STRING dimension"
-            onClick={() => convertToDimension('STRING')}
+            text="Convert to string dimension"
+            onClick={() => convertToDimension('string')}
           />
-          <MenuItem text="Convert to LONG dimension" onClick={() => convertToDimension('LONG')} />
+          <MenuItem text="Convert to long dimension" onClick={() => convertToDimension('long')} />
+          <MenuItem text="Convert to float dimension" onClick={() => convertToDimension('float')} />
           <MenuItem
-            text="Convert to DOUBLE dimension"
-            onClick={() => convertToDimension('DOUBLE')}
+            text="Convert to double dimension"
+            onClick={() => convertToDimension('double')}
           />
         </Menu>
       );


### PR DESCRIPTION
### Description
This PR fixes an issue with the web console data loader wizard, which is using all-caps types 'STRING', 'LONG', 'DOUBLE' when converting something it thinks is a metric into a dimension, which don't get correctly recognized by the dimension schema json deserialization, resulting in the column types defaulting to 'string'.

Additionally, the types presented in the type dropdown once converted to a dimension differ from the types available to convert a metric to ('string', 'long', 'float' vs 'STRING', 'LONG', 'DOUBLE').

These have been standardized to use 'string', 'long', 'float', 'double' in all the places.


<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
