### PR TITLE
fix InputFormat serde issue with SeekableStream based supervisors

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpecTest.java
@@ -138,6 +138,93 @@ public class KafkaSupervisorSpecTest
     Assert.assertTrue(serialized.contains("\"tuningConfig\":{"));
     Assert.assertTrue(serialized.contains("\"indexSpec\":{"));
     Assert.assertTrue(serialized.contains("\"suspended\":false"));
+    Assert.assertTrue(serialized.contains("\"parser\":{"));
+
+    KafkaSupervisorSpec spec2 = mapper.readValue(serialized, KafkaSupervisorSpec.class);
+
+    String stable = mapper.writeValueAsString(spec2);
+
+    Assert.assertEquals(serialized, stable);
+  }
+
+  @Test
+  public void testSerdeWithInputFormat() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"type\": \"kafka\",\n"
+                  + "  \"dataSchema\": {\n"
+                  + "    \"dataSource\": \"metrics-kafka\",\n"
+                  + "    \"timestampSpec\": {\n"
+                  + "      \"column\": \"timestamp\",\n"
+                  + "      \"format\": \"auto\"\n"
+                  + "     },\n"
+                  + "    \"dimensionsSpec\": {\n"
+                  + "      \"dimensions\": [],\n"
+                  + "      \"dimensionExclusions\": [\n"
+                  + "        \"timestamp\",\n"
+                  + "        \"value\"\n"
+                  + "       ]\n"
+                  + "    },\n"
+                  + "    \"metricsSpec\": [\n"
+                  + "      {\n"
+                  + "        \"name\": \"count\",\n"
+                  + "        \"type\": \"count\"\n"
+                  + "      },\n"
+                  + "      {\n"
+                  + "        \"name\": \"value_sum\",\n"
+                  + "        \"fieldName\": \"value\",\n"
+                  + "        \"type\": \"doubleSum\"\n"
+                  + "      },\n"
+                  + "      {\n"
+                  + "        \"name\": \"value_min\",\n"
+                  + "        \"fieldName\": \"value\",\n"
+                  + "        \"type\": \"doubleMin\"\n"
+                  + "      },\n"
+                  + "      {\n"
+                  + "        \"name\": \"value_max\",\n"
+                  + "        \"fieldName\": \"value\",\n"
+                  + "        \"type\": \"doubleMax\"\n"
+                  + "      }\n"
+                  + "    ],\n"
+                  + "    \"granularitySpec\": {\n"
+                  + "      \"type\": \"uniform\",\n"
+                  + "      \"segmentGranularity\": \"HOUR\",\n"
+                  + "      \"queryGranularity\": \"NONE\"\n"
+                  + "    }\n"
+                  + "  },\n"
+                  + "  \"ioConfig\": {\n"
+                  + "    \"topic\": \"metrics\",\n"
+                  + "    \"inputFormat\": {\n"
+                  + "      \"type\": \"json\",\n"
+                  + "      \"flattenSpec\": {\n"
+                  + "        \"useFieldDiscovery\": true,\n"
+                  + "        \"fields\": []\n"
+                  + "      },\n"
+                  + "      \"featureSpec\": {}\n"
+                  + "    },"
+                  + "    \"consumerProperties\": {\n"
+                  + "      \"bootstrap.servers\": \"localhost:9092\"\n"
+                  + "    },\n"
+                  + "    \"taskCount\": 1\n"
+                  + "  }\n"
+                  + "}";
+    KafkaSupervisorSpec spec = mapper.readValue(json, KafkaSupervisorSpec.class);
+
+    Assert.assertNotNull(spec);
+    Assert.assertNotNull(spec.getDataSchema());
+    Assert.assertEquals(4, spec.getDataSchema().getAggregators().length);
+    Assert.assertNotNull(spec.getIoConfig());
+    Assert.assertEquals("metrics", spec.getIoConfig().getTopic());
+    Assert.assertNotNull(spec.getTuningConfig());
+    Assert.assertNull(spec.getContext());
+    Assert.assertFalse(spec.isSuspended());
+    String serialized = mapper.writeValueAsString(spec);
+
+    // expect default values populated in reserialized string
+    Assert.assertTrue(serialized.contains("\"tuningConfig\":{"));
+    Assert.assertTrue(serialized.contains("\"indexSpec\":{"));
+    Assert.assertTrue(serialized.contains("\"suspended\":false"));
+    Assert.assertTrue(serialized.contains("\"inputFormat\":{"));
 
     KafkaSupervisorSpec spec2 = mapper.readValue(serialized, KafkaSupervisorSpec.class);
 
@@ -223,6 +310,95 @@ public class KafkaSupervisorSpecTest
     Assert.assertTrue(serialized.contains("\"tuningConfig\":{"));
     Assert.assertTrue(serialized.contains("\"indexSpec\":{"));
     Assert.assertTrue(serialized.contains("\"suspended\":false"));
+    Assert.assertTrue(serialized.contains("\"parser\":{"));
+
+    KafkaSupervisorSpec spec2 = mapper.readValue(serialized, KafkaSupervisorSpec.class);
+
+    String stable = mapper.writeValueAsString(spec2);
+
+    Assert.assertEquals(serialized, stable);
+  }
+
+  @Test
+  public void testSerdeWithSpecAndInputFormat() throws IOException
+  {
+    String json = "{\n"
+                  + "  \"type\": \"kafka\",\n"
+                  + "  \"spec\": {\n"
+                  + "  \"dataSchema\": {\n"
+                  + "    \"dataSource\": \"metrics-kafka\",\n"
+                  + "    \"timestampSpec\": {\n"
+                  + "      \"column\": \"timestamp\",\n"
+                  + "      \"format\": \"auto\"\n"
+                  + "    },\n"
+                  + "    \"dimensionsSpec\": {\n"
+                  + "      \"dimensions\": [],\n"
+                  + "      \"dimensionExclusions\": [\n"
+                  + "        \"timestamp\",\n"
+                  + "        \"value\"\n"
+                  + "      ]\n"
+                  + "    },\n"
+                  + "    \"metricsSpec\": [\n"
+                  + "      {\n"
+                  + "        \"name\": \"count\",\n"
+                  + "        \"type\": \"count\"\n"
+                  + "      },\n"
+                  + "      {\n"
+                  + "        \"name\": \"value_sum\",\n"
+                  + "        \"fieldName\": \"value\",\n"
+                  + "        \"type\": \"doubleSum\"\n"
+                  + "      },\n"
+                  + "      {\n"
+                  + "        \"name\": \"value_min\",\n"
+                  + "        \"fieldName\": \"value\",\n"
+                  + "        \"type\": \"doubleMin\"\n"
+                  + "      },\n"
+                  + "      {\n"
+                  + "        \"name\": \"value_max\",\n"
+                  + "        \"fieldName\": \"value\",\n"
+                  + "        \"type\": \"doubleMax\"\n"
+                  + "      }\n"
+                  + "    ],\n"
+                  + "    \"granularitySpec\": {\n"
+                  + "      \"type\": \"uniform\",\n"
+                  + "      \"segmentGranularity\": \"HOUR\",\n"
+                  + "      \"queryGranularity\": \"NONE\"\n"
+                  + "    }\n"
+                  + "  },\n"
+                  + "  \"ioConfig\": {\n"
+                  + "    \"topic\": \"metrics\",\n"
+                  + "    \"inputFormat\": {\n"
+                  + "      \"type\": \"json\",\n"
+                  + "      \"flattenSpec\": {\n"
+                  + "        \"useFieldDiscovery\": true,\n"
+                  + "        \"fields\": []\n"
+                  + "      },\n"
+                  + "      \"featureSpec\": {}\n"
+                  + "    },"
+                  + "    \"consumerProperties\": {\n"
+                  + "      \"bootstrap.servers\": \"localhost:9092\"\n"
+                  + "    },\n"
+                  + "    \"taskCount\": 1\n"
+                  + "  }\n"
+                  + "  }\n"
+                  + "}";
+    KafkaSupervisorSpec spec = mapper.readValue(json, KafkaSupervisorSpec.class);
+
+    Assert.assertNotNull(spec);
+    Assert.assertNotNull(spec.getDataSchema());
+    Assert.assertEquals(4, spec.getDataSchema().getAggregators().length);
+    Assert.assertNotNull(spec.getIoConfig());
+    Assert.assertEquals("metrics", spec.getIoConfig().getTopic());
+    Assert.assertNotNull(spec.getTuningConfig());
+    Assert.assertNull(spec.getContext());
+    Assert.assertFalse(spec.isSuspended());
+    String serialized = mapper.writeValueAsString(spec);
+
+    // expect default values populated in reserialized string
+    Assert.assertTrue(serialized.contains("\"tuningConfig\":{"));
+    Assert.assertTrue(serialized.contains("\"indexSpec\":{"));
+    Assert.assertTrue(serialized.contains("\"suspended\":false"));
+    Assert.assertTrue(serialized.contains("\"inputFormat\":{"));
 
     KafkaSupervisorSpec spec2 = mapper.readValue(serialized, KafkaSupervisorSpec.class);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
@@ -102,7 +102,7 @@ public abstract class SeekableStreamSupervisorIOConfig
   }
 
   @Nullable
-  @JsonProperty
+  @JsonProperty("inputFormat")
   private InputFormat getGivenInputFormat()
   {
     return inputFormat;


### PR DESCRIPTION
### Description
This PR fixes an issue with `SeekableStream` based supervisors such as kafka and kinesis indexing, where the `InputFormat`, if used instead of defining a `Parser`, was not being serialized to the correct property, causing it to be lost upon updates.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] been tested in a test Druid cluster.
