### PR TITLE
data loader style fix for double typed columns

### DIFF
--- a/web-console/src/views/load-data-view/schema-table/schema-table.scss
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.scss
@@ -25,7 +25,10 @@
         background: rgba(19, 129, 201, 0.5);
       }
       &.float {
-        background: rgba(25, 145, 201, 0.5);
+        background: rgba(22, 129, 201, 0.5);
+      }
+      &.double {
+        background: rgba(25, 129, 201, 0.5);
       }
     }
 
@@ -42,7 +45,10 @@
         background: rgba(19, 129, 201, 0.1);
       }
       &.float {
-        background: rgba(25, 145, 201, 0.1);
+        background: rgba(22, 129, 201, 0.1);
+      }
+      &.double {
+        background: rgba(25, 129, 201, 0.1);
       }
     }
 


### PR DESCRIPTION
### Description

Forgot to update style for 'double' typed columns in #9135, so this adds it.

before:

<img width="613" alt="Screen Shot 2020-01-06 at 11 28 00 PM" src="https://user-images.githubusercontent.com/1577461/71876687-377b7e80-30dc-11ea-94b6-2f707202c585.png">

after:

<img width="623" alt="after" src="https://user-images.githubusercontent.com/1577461/71876515-bb813680-30db-11ea-9a33-313640057642.png">

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.

