### PR TITLE
[Backport] data loader style fix for double typed columns

### DIFF
--- a/web-console/src/views/load-data-view/schema-table/schema-table.scss
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.scss
@@ -25,7 +25,10 @@
         background: rgba(19, 129, 201, 0.5);
       }
       &.float {
-        background: rgba(25, 145, 201, 0.5);
+        background: rgba(22, 129, 201, 0.5);
+      }
+      &.double {
+        background: rgba(25, 129, 201, 0.5);
       }
     }
 
@@ -42,7 +45,10 @@
         background: rgba(19, 129, 201, 0.1);
       }
       &.float {
-        background: rgba(25, 145, 201, 0.1);
+        background: rgba(22, 129, 201, 0.1);
+      }
+      &.double {
+        background: rgba(25, 129, 201, 0.1);
       }
     }
 


### PR DESCRIPTION
Backport of #9137 to 0.17.0.