### PR TITLE
add middle manager and indexer worker category to tier column of services view

### DIFF
--- a/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
+++ b/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
@@ -138,7 +138,8 @@ exports[`services view action services view 1`] = `
         Object {
           "Cell": [Function],
           "Header": "Tier",
-          "accessor": "tier",
+          "accessor": [Function],
+          "id": "tier",
           "show": true,
         },
         Object {

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -348,7 +348,10 @@ ORDER BY "rank" DESC, "service" DESC`;
           },
           {
             Header: 'Tier',
-            accessor: 'tier',
+            id: 'tier',
+            accessor: row => {
+              return row.tier ? row.tier : row.worker ? row.worker.category : null;
+            },
             Cell: row => {
               const value = row.value;
               return (


### PR DESCRIPTION
### Description
#7066 added worker 'categories' to middle managers/indexers, this PR extends the 'services' view of the web console to display the worker category in the 'tier' column.

![Screen Shot 2020-01-08 at 5 53 57 PM](https://user-images.githubusercontent.com/1577461/72032454-4c732180-3244-11ea-827c-ac90f75422b2.png)

If this is too confusing with historical tiers, we could put this information somewhere else, but it does seem useful to display somewhere.


<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
