### PR TITLE
fix Hadoop ingestion fails due to error 'JavaScript is disabled' on certain config

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
@@ -96,7 +96,7 @@ public class DetermineHashedPartitionsJob implements Jobby
           StringUtils.format("%s-determine_partitions_hashed-%s", config.getDataSource(), config.getIntervals())
       );
 
-      JobHelper.injectSystemProperties(groupByJob);
+      JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config.getAllowedHadoopPrefix());
       config.addJobProperties(groupByJob);
       groupByJob.setMapperClass(DetermineCardinalityMapper.class);
       groupByJob.setMapOutputKeyClass(LongWritable.class);

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
@@ -135,7 +135,7 @@ public class DeterminePartitionsJob implements Jobby
             StringUtils.format("%s-determine_partitions_groupby-%s", config.getDataSource(), config.getIntervals())
         );
 
-        JobHelper.injectSystemProperties(groupByJob);
+        JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config.getAllowedHadoopPrefix());
         config.addJobProperties(groupByJob);
 
         groupByJob.setMapperClass(DeterminePartitionsGroupByMapper.class);
@@ -191,7 +191,7 @@ public class DeterminePartitionsJob implements Jobby
 
       dimSelectionJob.getConfiguration().set("io.sort.record.percent", "0.19");
 
-      JobHelper.injectSystemProperties(dimSelectionJob);
+      JobHelper.injectSystemProperties(dimSelectionJob.getConfiguration(), config.getAllowedHadoopPrefix());
       config.addJobProperties(dimSelectionJob);
 
       if (!partitionsSpec.isAssumeGrouped()) {

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -105,7 +105,7 @@ public class IndexGeneratorJob implements Jobby
 
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
-    final Configuration conf = JobHelper.injectSystemProperties(new Configuration());
+    final Configuration conf = JobHelper.injectSystemProperties(new Configuration(), config.getAllowedHadoopPrefix());
     config.addJobProperties(conf);
 
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
@@ -167,7 +167,7 @@ public class IndexGeneratorJob implements Jobby
 
       job.getConfiguration().set("io.sort.record.percent", "0.23");
 
-      JobHelper.injectSystemProperties(job);
+      JobHelper.injectSystemProperties(job.getConfiguration(), config.getAllowedHadoopPrefix());
       config.addJobProperties(job);
       // inject druid properties like deep storage bindings
       JobHelper.injectDruidProperties(job.getConfiguration(), config.getAllowedHadoopPrefix());


### PR DESCRIPTION
Fixes Hadoop ingestion fails due to error "JavaScript is disabled", if determine partition map reduce job is run and "mapreduce.reduce.java.opts" + "mapreduce.map.java.opts" is not set with druid.javascript.enabled=true

### Description

The root cause of the failure is depending on if the determine_partitions map reduce job needs to be run or not. If the determine_partitions map reduce job needs to be run, then it will fail with the "JavaScript is disabled" error if "mapreduce.reduce.java.opts" + "mapreduce.map.java.opts" is not set with druid.javascript.enabled=true. This is due to peon not sending the druid.javascript.enabled value (that is set in the _common/common.runtime.properties) to hadoop when running the determine_partitions map reduce job

The determine_partitions is run for many configuration settings. For example, if "maxRowsPerSegment" is null but numShard is also null, then maxRowsPerSegment is internally set to default value of 5000000 and the determine_partitions job is run.

The fix is simply to include the druid.javascript.enabled prop when running the determine_partitions map reduce job (similar to how we do when we send the index-generator map reduce job. (Note that the druid.javascript.enabled is inject correctly for index-generator job).

Current workaround is to pass the druid.javascript.enabled=true in "mapreduce.map.java.opts" and "mapreduce.reduce.java.opts" in addition to setting druid.javascript.enabled=true in _common/common.runtime.properties

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

