### PR TITLE
Add jackson-mapper-asl for hdfs-storage extension

### DIFF
--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -255,11 +255,6 @@
               <groupId>commons-beanutils</groupId>
               <artifactId>commons-beanutils-core</artifactId>
             </exclusion>
-            <exclusion>
-              <!-- excluded to remove security vulnerabilities; jackson-mapper-asl is renamed to jackson-databind -->
-              <groupId>org.codehaus.jackson</groupId>
-              <artifactId>jackson-mapper-asl</artifactId>
-            </exclusion>
           </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #9176.

### Description

Previously jackson-mapper-asl was excluded to remove a security vulnerability; however, it is required for functionality (e.g., org.apache.hadoop.security.token.delegation.web.DelegationTokenAuthenticator).

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.