### PR TITLE
Suppress CVE-2019-20330 for htrace-core-4.0.1

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -194,5 +194,6 @@
     <cve>CVE-2019-16943</cve>
     <cve>CVE-2019-17267</cve>
     <cve>CVE-2019-17531</cve>
+    <cve>CVE-2019-20330</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Description

CVE-2019-20330 was updated on 14 Jan 2020, which now gets flagged by the security vulnerability scan. Since the CVE is for jackson-databind, via htrace-core-4.0.1, it can be added to the existing list of security vulnerability suppressions for that dependency.

<hr>

This PR has:
- [x] been self-reviewed.
