### PR TITLE
Docs: move search to the left

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -31,6 +31,7 @@ const siteConfig = {
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
+    { search: true },
     {href: '/technology', label: 'Technology'},
     {href: '/use-cases', label: 'Use Cases'},
     {href: '/druid-powered', label: 'Powered By'},


### PR DESCRIPTION
Put the doc search on the left of all the links

![image](https://user-images.githubusercontent.com/177816/72405658-83e34180-370e-11ea-8aa3-f9f92712114c.png)

