### PR TITLE
Add ReplaceMissingValueExtractionFn

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/extraction/ExtractionCacheHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/ExtractionCacheHelper.java
@@ -39,4 +39,5 @@ public class ExtractionCacheHelper
   public static final byte CACHE_TYPE_ID_LOWER = 0xC;
   public static final byte CACHE_TYPE_ID_BUCKET = 0xD;
   public static final byte CACHE_TYPE_ID_STRLEN = 0xE;
+  public static final byte CACHE_TYPE_ID_MISSINGVALUE = 0xF;
 }

--- a/processing/src/main/java/org/apache/druid/query/extraction/ExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/ExtractionFn.java
@@ -52,7 +52,8 @@ import javax.annotation.Nullable;
     @JsonSubTypes.Type(name = "upper", value = UpperExtractionFn.class),
     @JsonSubTypes.Type(name = "lower", value = LowerExtractionFn.class),
     @JsonSubTypes.Type(name = "bucket", value = BucketExtractionFn.class),
-    @JsonSubTypes.Type(name = "strlen", value = StrlenExtractionFn.class)
+    @JsonSubTypes.Type(name = "strlen", value = StrlenExtractionFn.class),
+    @JsonSubTypes.Type(name = "replaceMissing", value = ReplaceMissingValueExtractionFn.class)
 })
 public interface ExtractionFn extends Cacheable
 {

--- a/processing/src/main/java/org/apache/druid/query/extraction/ReplaceMissingValueExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/ReplaceMissingValueExtractionFn.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.extraction;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Functions;
+import org.apache.druid.java.util.common.StringUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class ReplaceMissingValueExtractionFn extends FunctionalExtraction
+{
+
+  /**
+   * ReplaceMissingValueExtractionFn is a coalesce-like extraction function: nulls will be replaced with the given value.
+   *
+   * @param replaceMissingValueWith String value to replace missing values with (instead of `null`)
+   */
+  @JsonCreator
+  public ReplaceMissingValueExtractionFn(
+          @JsonProperty("replaceMissingValueWith") final String replaceMissingValueWith
+  )
+  {
+    super(Functions.identity(), false, replaceMissingValueWith, false);
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    try {
+      final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      outputStream.write(ExtractionCacheHelper.CACHE_TYPE_ID_MISSINGVALUE);
+      if (getReplaceMissingValueWith() != null) {
+        outputStream.write(StringUtils.toUtf8(getReplaceMissingValueWith()));
+      }
+
+      return outputStream.toByteArray();
+    }
+    catch (IOException ex) {
+      // If ByteArrayOutputStream.write has problems, that is a very bad thing
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/extraction/ReplaceMissingValueExtractionFnTest.java
+++ b/processing/src/test/java/org/apache/druid/query/extraction/ReplaceMissingValueExtractionFnTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.extraction;
+
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class ReplaceMissingValueExtractionFnTest extends InitializedNullHandlingTest
+{
+
+  @Test
+  public void testApply()
+  {
+    ExtractionFn extractionFn = new ReplaceMissingValueExtractionFn("MISSING");
+
+    Assert.assertEquals("123", extractionFn.apply("123"));
+    Assert.assertEquals("MISSING", extractionFn.apply(null));
+    Assert.assertEquals("MISSING", extractionFn.apply(""));
+  }
+
+  @Test
+  public void testNull()
+  {
+    ExtractionFn extractionFn = new ReplaceMissingValueExtractionFn(null);
+    Assert.assertEquals("123", extractionFn.apply("123"));
+    Assert.assertEquals(null, extractionFn.apply(""));
+    Assert.assertEquals(null, extractionFn.apply(null));
+  }
+
+  @Test
+  public void testGetCacheKey()
+  {
+    ExtractionFn extractionFn = new ReplaceMissingValueExtractionFn("MISSING");
+    ExtractionFn other = new ReplaceMissingValueExtractionFn("MISSING");
+    Assert.assertArrayEquals(extractionFn.getCacheKey(), other.getCacheKey());
+
+    other = new ReplaceMissingValueExtractionFn("MISSING2");
+    Assert.assertFalse(Arrays.equals(extractionFn.getCacheKey(), other.getCacheKey()));
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/extraction/ReplaceMissingValueExtractionFnTest.java
+++ b/processing/src/test/java/org/apache/druid/query/extraction/ReplaceMissingValueExtractionFnTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.extraction;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,7 +36,11 @@ public class ReplaceMissingValueExtractionFnTest extends InitializedNullHandling
 
     Assert.assertEquals("123", extractionFn.apply("123"));
     Assert.assertEquals("MISSING", extractionFn.apply(null));
-    Assert.assertEquals("MISSING", extractionFn.apply(""));
+    if (NullHandling.sqlCompatible()) {
+      Assert.assertEquals("", extractionFn.apply(""));
+    } else {
+      Assert.assertEquals("MISSING", extractionFn.apply(""));
+    }
   }
 
   @Test
@@ -43,8 +48,13 @@ public class ReplaceMissingValueExtractionFnTest extends InitializedNullHandling
   {
     ExtractionFn extractionFn = new ReplaceMissingValueExtractionFn(null);
     Assert.assertEquals("123", extractionFn.apply("123"));
-    Assert.assertEquals(null, extractionFn.apply(""));
     Assert.assertEquals(null, extractionFn.apply(null));
+
+    if (NullHandling.sqlCompatible()) {
+      Assert.assertEquals("", extractionFn.apply(""));
+    } else {
+      Assert.assertEquals(null, extractionFn.apply(""));
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description

This adds a new built-in extraction function to coalesce missing values to a provided value. I'd be happy to find out that there's an existing good way to do this; I ended up with a query like this: 
```
...
  "dimensions": [
    {
      "type": "extraction",
      "dimension": "field_name",
      "outputName": "output_field_name",
      "extractionFn": {
        "type": "regex",
        "expr": "(.+)",
        "replaceMissingValue": true,
        "replaceMissingValueWith": "0"
      }
    },
...
```

This is obviously a roundabout way of achieving what I want to accomplish, but I couldn't find any other way to do this using the existing built-in extraction functions. (It also can't quite be done with the map-based `lookup` extractor). I'd be happy to learn if there's a better approach (?). 

This PR provides an extraction function that allows you to directly execute this 'coalesce null values' operation. You'd configure it like this:

```
...
  "dimensions": [
    {
      "type": "extraction",
      "dimension": "field_name",
      "outputName": "output_field_name",
      "extractionFn": {
        "type": "replaceMissing",
        "replaceMissingValueWith": "0"
      }
    },
...
```

It does this by extending `FunctionalExtraction` (passing in the identity function) and configuring the null replacement options in that class. Nothing too complicated.

If this seems useful, I'm happy to update documentation/tests/etc as needed in this PR, but didn't want to go through that effort if already a better way to do this that I just didn't find. :) 

Thanks!

<hr>

This PR has:
- [x] been self-reviewed, *although I'm only passingly familiar with the Druid codebase*.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.


<hr>

##### Key changed/added classes in this PR
 * `ReplaceMissingValueExtractionFn`
