### PR TITLE
Fix comment in distribution/docker/druid.sh

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -35,7 +35,7 @@
 # - DRUID_NEWSIZE -- set Java new size
 # - DRUID_MAXDIRECTMEMORYSIZE -- set Java max direct memory size
 #
-# - DRUID_CONFIG -- full path to a file for druid 'common' properties
+# - DRUID_CONFIG_COMMON -- full path to a file for druid 'common' properties
 # - DRUID_CONFIG_${service} -- full path to a file for druid 'service' properties
 
 set -e


### PR DESCRIPTION
### Description

Fix `DRUID_CONFIG` in `distribution/docker/druid.sh` comment to `DRUID_CONFIG_COMMON`.

In fact, this script references `DRUID_CONFIG_COMMON`.
https://github.com/apache/druid/blob/b2877119d07a973b19aa48cb1e278779bf88e874/distribution/docker/druid.sh#L116-L121