### PR TITLE
Web console: fix bug where arrays can not be emptied out in the coordinator dialog

### DIFF
--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -45,6 +45,7 @@ export interface Field<M> {
     | 'json'
     | 'interval';
   defaultValue?: any;
+  emptyValue?: any;
   suggestions?: Functor<M, Suggestion[]>;
   placeholder?: string;
   min?: number;
@@ -99,10 +100,16 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
     const { model } = this.props;
     if (!model) return;
 
-    const newModel =
-      typeof newValue === 'undefined'
-        ? deepDelete(model, field.name)
-        : deepSet(model, field.name, newValue);
+    let newModel: T;
+    if (typeof newValue === 'undefined') {
+      if (typeof field.emptyValue === 'undefined') {
+        newModel = deepDelete(model, field.name);
+      } else {
+        newModel = deepSet(model, field.name, field.emptyValue);
+      }
+    } else {
+      newModel = deepSet(model, field.name, newValue);
+    }
 
     this.modelChange(newModel);
   };

--- a/web-console/src/dialogs/coordinator-dynamic-config-dialog/coordinator-dynamic-config-dialog.tsx
+++ b/web-console/src/dialogs/coordinator-dynamic-config-dialog/coordinator-dynamic-config-dialog.tsx
@@ -180,6 +180,7 @@ export class CoordinatorDynamicConfigDialog extends React.PureComponent<
             {
               name: 'killDataSourceWhitelist',
               type: 'string-array',
+              emptyValue: [],
               info: (
                 <>
                   List of dataSources for which kill tasks are sent if property{' '}
@@ -191,6 +192,7 @@ export class CoordinatorDynamicConfigDialog extends React.PureComponent<
             {
               name: 'killPendingSegmentsSkipList',
               type: 'string-array',
+              emptyValue: [],
               info: (
                 <>
                   List of dataSources for which pendingSegments are NOT cleaned up if property{' '}
@@ -259,6 +261,7 @@ export class CoordinatorDynamicConfigDialog extends React.PureComponent<
             {
               name: 'decommissioningNodes',
               type: 'string-array',
+              emptyValue: [],
               info: (
                 <>
                   List of historical services to 'decommission'. Coordinator will not assign new


### PR DESCRIPTION
Allow the defining of specific empty values in the AutoForm