### PR TITLE
[0.17.0] Link javaOpts to middlemanager runtime.properties docs (#9101)

### DIFF
--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -38,7 +38,7 @@ The AWS SDK requires that the target region be specified. Two ways of doing this
 As an example, to set the region to 'us-east-1' through system properties:
 
 - Add `-Daws.region=us-east-1` to the jvm.config file for all Druid services.
-- Add `-Daws.region=us-east-1` to `druid.indexer.runner.javaOpts` in middleManager/runtime.properties so that the property will be passed to Peon (worker) processes.
+- Add `-Daws.region=us-east-1` to `druid.indexer.runner.javaOpts` in [Middle Manager configuration](../../configuration/index.md#middlemanager-configuration) so that the property will be passed to Peon (worker) processes.
 
 |Property|Description|Default|
 |--------|-----------|-------|

--- a/docs/operations/other-hadoop.md
+++ b/docs/operations/other-hadoop.md
@@ -55,7 +55,7 @@ Generally, you should only set one of these parameters, not both.
 These properties can be set in either one of the following ways:
 
 - Using the task definition, e.g. add `"mapreduce.job.classloader": "true"` to the `jobProperties` of the `tuningConfig` of your indexing task (see the [Hadoop batch ingestion documentation](../ingestion/hadoop.md)).
-- Using system properties, e.g. on the MiddleManager set `druid.indexer.runner.javaOpts=... -Dhadoop.mapreduce.job.classloader=true`.
+- Using system properties, e.g. on the MiddleManager set `druid.indexer.runner.javaOpts=... -Dhadoop.mapreduce.job.classloader=true` in [Middle Manager configuration](../configuration/index.md#middlemanager-configuration).
 
 ### Overriding specific classes
 


### PR DESCRIPTION
Backports the following commits to 0.17.0:
 - Link javaOpts to middlemanager runtime.properties docs (#9101)