### PR TITLE
Fix DOCKER_HOST_IP handling for multihomed machines.

### DIFF
--- a/integration-tests/docker/tls/set-docker-host-ip.sh
+++ b/integration-tests/docker/tls/set-docker-host-ip.sh
@@ -18,7 +18,7 @@
 DOCKER_HOST_IP="$(host "$(hostname)" | perl -nle '/has address (.*)/ && print $1')"
 if [ -z "$DOCKER_HOST_IP" ]; then
     # Mac specific way to get host ip
-    DOCKER_HOST_IP="$(dscacheutil -q host -a name "$(HOSTNAME)" | perl -nle '/ip_address: (.*)/ && print $1')"
+    DOCKER_HOST_IP="$(dscacheutil -q host -a name "$(HOSTNAME)" | perl -nle '/ip_address: (.*)/ && print $1' | tail -n1)"
 fi
 
 if [ -z "$DOCKER_HOST_IP" ]; then


### PR DESCRIPTION
By picking one. Otherwise, when a machine has multiple IP addresses, DOCKER_HOST_IP
would have a newline in the middle, causing havoc in configuration files.