### PR TITLE
enable running indexer in docker container

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -54,6 +54,7 @@ getConfPath() {
     _common) echo $cluster_conf_base/_common ;;
     historical) echo $cluster_conf_base/data/historical ;;
     middleManager) echo $cluster_conf_base/data/middleManager ;;
+    indexer) echo $cluster_conf_base/data/middleManager ;;
     coordinator | overlord) echo $cluster_conf_base/master/coordinator-overlord ;;
     broker) echo $cluster_conf_base/query/broker ;;
     router) echo $cluster_conf_base/query/router ;;


### PR DESCRIPTION
### Description

#### Added Indexer as a valid service which uses middleManager's config file

In order to reduce ram usage we would like to use indexer instead of middleManager/Peon. The current list of possible config locations does not include an entry for indexer. This PR adds one so that indexer can function using this container.

This PR has:
- [x] been self-reviewed.
