### PR TITLE
Address CVE-2019-12399

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -205,7 +205,7 @@ public class TestKafkaExtractionCluster
 
   private void checkServer()
   {
-    if (!kafkaServer.apis().controller().isActive()) {
+    if (!kafkaServer.kafkaController().isActive()) {
       throw new ISE("server is not active!");
     }
   }

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -33,10 +33,6 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <properties>
-    <apache.kafka.version>2.2.1</apache.kafka.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.druid</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3093,7 +3093,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 2.2.1
+version: 2.2.2
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -3967,7 +3967,7 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 2.1.1
+version: 2.2.2
 libraries:
   - org.apache.kafka: kafka_2.12
   - org.apache.kafka: kafka-clients

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>4.1.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
-        <apache.kafka.version>2.1.1</apache.kafka.version>
+        <apache.kafka.version>2.2.2</apache.kafka.version>
         <avatica.version>1.15.0</avatica.version>
         <avro.version>1.9.1</avro.version>
         <calcite.version>1.21.0</calcite.version>


### PR DESCRIPTION
### Description

Update kafka version to 2.2.2 to address CVE-2019-12399. Kafka versions
2.1.x and 2.2.x were being used by different modules, so unify the
version and specify in the root POM as well.
<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)