### PR TITLE
Add a dedicated thread to execute callbacks attached by TaskQueue

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -97,6 +97,11 @@ public class TaskQueue
           .setDaemon(false)
           .setNameFormat("TaskQueue-Manager").build()
   );
+  private final ExecutorService taskStatusHandlerExec = Executors.newSingleThreadExecutor(
+      new ThreadFactoryBuilder()
+          .setDaemon(false)
+          .setNameFormat("TaskQueue-TaskStatusHandler").build()
+  );
   private final ScheduledExecutorService storageSyncExec = Executors.newSingleThreadScheduledExecutor(
       new ThreadFactoryBuilder()
           .setDaemon(false)
@@ -217,6 +222,7 @@ public class TaskQueue
       taskFutures.clear();
       active = false;
       managerExec.shutdownNow();
+      taskStatusHandlerExec.shutdownNow();
       storageSyncExec.shutdownNow();
       managementMayBeNecessary.signalAll();
     }
@@ -583,7 +589,8 @@ public class TaskQueue
                  .emit();
             }
           }
-        }
+        },
+        taskStatusHandlerExec
     );
     return statusFuture;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -40,6 +40,7 @@ import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
@@ -97,11 +98,7 @@ public class TaskQueue
           .setDaemon(false)
           .setNameFormat("TaskQueue-Manager").build()
   );
-  private final ExecutorService taskStatusHandlerExec = Executors.newSingleThreadExecutor(
-      new ThreadFactoryBuilder()
-          .setDaemon(false)
-          .setNameFormat("TaskQueue-TaskStatusHandler").build()
-  );
+  private final ExecutorService taskStatusHandlerExec = Execs.singleThreaded("TaskQueue-TaskStatusHandler");
   private final ScheduledExecutorService storageSyncExec = Executors.newSingleThreadScheduledExecutor(
       new ThreadFactoryBuilder()
           .setDaemon(false)


### PR DESCRIPTION

This PR adds a dedicated thread to execute callbacks of task status updates attached by `TaskQueue ` and then the specific thread which notifies the change of task status can return as soon as possible.

### Description
Found that tasks sometimes are failed to assign within the default timeout(5 minutes) but the tasks were actually already running on middleManager according to the logs.
Also found that the thread of pendingTasksExec, which supposed to be notified with the task status changing within the timeout, fails to be waked up. 

After diving into this issue, I think I have found the root cause. The Guava concurrent framework will schedule the callback to be run by this syncer thread and the task syncer thread possibly get stuck if it waits in the giant lock. 
Both the `remote` and `httpRemote` task runner have this issue.

Since the callback handler attached by TaskQueue seem a bit heavyweight, it will be better to provide a dedicated thread to execute these callbacks. 
This issue can be fixed by adding a single thread executor to handle callbacks attached by `TaskQueue`.


<hr>

This PR has:
- [X] been self-reviewed.
- [X] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed classes in this PR
 * `TaskQueue`
