### PR TITLE
Add an IndexedTableLoader Extension

### DIFF
--- a/core/src/main/java/org/apache/druid/concurrent/LifecycleLock.java
+++ b/core/src/main/java/org/apache/druid/concurrent/LifecycleLock.java
@@ -66,7 +66,7 @@ import java.util.concurrent.locks.AbstractQueuedSynchronizer;
  *   }
  * }
  */
-public final class LifecycleLock
+public class LifecycleLock
 {
   private static class Sync extends AbstractQueuedSynchronizer
   {

--- a/extensions-contrib/indexed-table-loader/pom.xml
+++ b/extensions-contrib/indexed-table-loader/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.druid.extensions.contrib</groupId>
+    <artifactId>indexed-table-loader</artifactId>
+    <name>indexed-table-loader</name>
+    <description>indexed-table-loader</description>
+
+    <parent>
+        <groupId>org.apache.druid</groupId>
+        <artifactId>druid</artifactId>
+        <version>0.18.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.druid</groupId>
+            <artifactId>druid-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.druid</groupId>
+            <artifactId>druid-indexing-service</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.2.10</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableLoaderDruidModule.java
+++ b/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableLoaderDruidModule.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.fasterxml.jackson.databind.Module;
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import org.apache.druid.guice.JsonConfigProvider;
+import org.apache.druid.guice.LifecycleModule;
+import org.apache.druid.indextable.loader.config.IndexedTableConfig;
+import org.apache.druid.indextable.loader.config.IndexedTableLoaderConfig;
+import org.apache.druid.initialization.DruidModule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Druid Module responsible for loading an IndexTable from an IngestionSpec.
+ */
+public class IndexedTableLoaderDruidModule implements DruidModule
+{
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    binder.bind(Key.get(new TypeLiteral<Map<String, IndexedTableConfig>>() {}))
+          .toProvider(IndexedTableLoaderProvider.class)
+          .in(Scopes.SINGLETON);
+    JsonConfigProvider.bind(binder, "druid.indexedTable.loader", IndexedTableLoaderConfig.class);
+    LifecycleModule.register(binder, IndexedTableManager.class);
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableLoaderProvider.java
+++ b/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableLoaderProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.indextable.loader.config.IndexedTableConfig;
+import org.apache.druid.indextable.loader.config.IndexedTableLoaderConfig;
+import org.apache.druid.java.util.common.ISE;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+class IndexedTableLoaderProvider implements Provider<Map<String, IndexedTableConfig>>
+{
+  private final String configPath;
+  private final ObjectMapper mapper;
+
+  @Inject
+  IndexedTableLoaderProvider(IndexedTableLoaderConfig config, @Json ObjectMapper mapper)
+  {
+    configPath = config.getConfigFilePath();
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Map<String, IndexedTableConfig> get()
+  {
+    try {
+      File configFile = getFile(configPath);
+      Map<String, IndexedTableConfig> loadMap =
+          mapper.readerFor(new TypeReference<Map<String, IndexedTableConfig>>() {})
+                .readValue(configFile);
+      return loadMap;
+    }
+    catch (IOException e) {
+      throw new ISE(e, "Could not parse file [%s]", configPath);
+    }
+  }
+
+  @VisibleForTesting
+  File getFile(String path)
+  {
+    return new File(configPath);
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableManager.java
+++ b/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableManager.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import org.apache.druid.concurrent.LifecycleLock;
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.indextable.loader.config.IndexedTableConfig;
+import org.apache.druid.indextable.loader.config.IndexedTableLoaderConfig;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.segment.join.table.IndexedTable;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This class manages all indexed tables.
+ *
+ * Take inspiration from {@link org.apache.druid.query.lookup.LookupReferencesManager}
+ */
+@ManageLifecycle
+public class IndexedTableManager
+{
+  private static final String INDEXED_TABLE_LOADER_THREAD_FORMAT = "IndexedTableManager-loader[%d]";
+  private static final EmittingLogger LOG = new EmittingLogger(IndexedTableManager.class);
+
+  private final Map<String, IndexedTableConfig> indexedTableLoaders;
+  private final ExecutorService loaderExecutorService;
+  private final LifecycleLock lifecycleLock;
+  private final ConcurrentMap<String, IndexedTable> indexedTables;
+
+  @Inject
+  IndexedTableManager(
+      IndexedTableLoaderConfig config,
+      Map<String, IndexedTableConfig> indexedTableLoaders
+  )
+  {
+    this (
+        indexedTableLoaders,
+        Execs.multiThreaded(
+            config.getNumThreads(),
+            INDEXED_TABLE_LOADER_THREAD_FORMAT),
+        new LifecycleLock(),
+        new ConcurrentHashMap<>()
+    );
+  }
+
+  @VisibleForTesting
+  IndexedTableManager(
+      Map<String, IndexedTableConfig> indexedTableLoaders,
+      ExecutorService loaderExecutorService,
+      LifecycleLock lifecycleLock,
+      ConcurrentMap<String, IndexedTable> indexedTables
+  )
+  {
+    this.indexedTableLoaders = indexedTableLoaders;
+    this.loaderExecutorService = loaderExecutorService;
+    this.lifecycleLock = lifecycleLock;
+    this.indexedTables = indexedTables;
+  }
+
+  @LifecycleStart
+  public void start()
+  {
+    if (!lifecycleLock.canStart()) {
+      throw new ISE("IndexedTableManager can not start.");
+    }
+    try {
+      indexedTableLoaders.forEach(
+          (name, loader) -> loaderExecutorService.submit(
+              () -> {
+                // TODO: guicify this
+                LOG.info("loading index table - %s", name);
+                IndexedTableSupplier supplier = new IndexedTableSupplier(
+                    loader.getKeys(), loader.getIngestionSpec(), FileUtils::createTempDir
+                );
+                indexedTables.put(name, supplier.get());
+              }
+          ));
+    }
+    finally {
+      lifecycleLock.exitStart();
+    }
+  }
+
+  /**
+   * Interrupts the loader thread if it is still running
+   */
+  @LifecycleStop
+  public void stop()
+  {
+    if (!lifecycleLock.canStop()) {
+      throw new ISE("can't stop.");
+    }
+    // TODO: better clean up of tasks
+    try {
+      loaderExecutorService.shutdownNow();
+    }
+    finally {
+      lifecycleLock.exitStop();
+    }
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableSupplier.java
+++ b/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/IndexedTableSupplier.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.io.FileUtils;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.InputSource;
+import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.InputRowParser;
+import org.apache.druid.indexing.common.task.IndexTask;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.segment.RowAdapter;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.incremental.IncrementalIndex;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.join.table.IndexedTable;
+import org.apache.druid.segment.join.table.RowBasedIndexedTable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
+
+/**
+ * This class loads an indexed table from a {@link InputFormat}
+ */
+class IndexedTableSupplier implements Supplier<IndexedTable>
+{
+  private final List<String> keys;
+  private final IndexTask.IndexIngestionSpec ingestionSpec;
+  private final Supplier<File> tmpDirSupplier;
+
+  IndexedTableSupplier(
+      List<String> keys,
+      IndexTask.IndexIngestionSpec ingestionSpec,
+      Supplier<File> tmpDirSupplier
+  )
+  {
+    this.keys = keys;
+    this.ingestionSpec = ingestionSpec;
+    this.tmpDirSupplier = tmpDirSupplier;
+  }
+
+  /**
+   *
+   * @return An IndexedTable that is built from reading the ingestionSpec
+   */
+  @Override
+  public IndexedTable get()
+  {
+    File tmpDir = tmpDirSupplier.get();
+    try {
+      DataSchema dataSchema = ingestionSpec.getDataSchema();
+      InputSourceReader inputSourceReader = getInputSourceReader(dataSchema, tmpDir);
+
+      List<InputRow> table = new ArrayList<>();
+      CloseableIterator<InputRow> rowIterator = inputSourceReader.read();
+      Map<String, ValueType> rowSignature = new HashMap<>();
+      DimensionsSpec dimensionsSpec = dataSchema.getDimensionsSpec();
+      dimensionsSpec.getDimensions()
+                    .forEach(dimensionSchema -> rowSignature.put(
+                        dimensionSchema.getName(),
+                        IncrementalIndex.TYPE_MAP.get(dimensionSchema.getValueType())
+                    ));
+
+      while (rowIterator.hasNext()) {
+        InputRow row = rowIterator.next();
+        table.add(row);
+      }
+      return new RowBasedIndexedTable<>(
+          table,
+          new RowAdapter<InputRow>()
+          {
+            @Override
+            public ToLongFunction<InputRow> timestampFunction()
+            {
+              return InputRow::getTimestampFromEpoch;
+            }
+
+            @Override
+            public Function<InputRow, Object> columnFunction(String columnName)
+            {
+              return inputRow -> inputRow.getRaw(columnName);
+            }
+          },
+          rowSignature,
+          keys
+      );
+    }
+    catch (IOException e) {
+      throw new RuntimeException("Could not load IndexedTable - " + ingestionSpec.getDataSchema().getDataSource(), e);
+    }
+    finally {
+      FileUtils.deleteQuietly(tmpDir);
+    }
+  }
+
+  @VisibleForTesting
+  /* TODO: de-duplicate with IndexTask - search for 'inputSource.reader(' */
+  InputSourceReader getInputSourceReader(DataSchema dataSchema, File tmpDir)
+  {
+    final List<String> metricsNames = Arrays.stream(dataSchema.getAggregators())
+                                            .map(AggregatorFactory::getName)
+                                            .collect(Collectors.toList());
+    InputSource inputSource = ingestionSpec.getIOConfig().getNonNullInputSource(dataSchema.getParser());
+    InputSourceReader inputSourceReader = dataSchema.getTransformSpec().decorate(
+        inputSource.reader(
+            new InputRowSchema(
+                dataSchema.getTimestampSpec(),
+                dataSchema.getDimensionsSpec(),
+                metricsNames
+            ),
+            inputSource.needsFormat() ? getInputFormat(ingestionSpec) : null,
+            tmpDir
+        )
+    );
+    return inputSourceReader;
+  }
+  private static InputFormat getInputFormat(IndexTask.IndexIngestionSpec ingestionSchema)
+  {
+    final InputRowParser parser = ingestionSchema.getDataSchema().getParser();
+    return ingestionSchema.getIOConfig().getNonNullInputFormat(
+        parser == null ? null : parser.getParseSpec()
+    );
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/config/IndexedTableConfig.java
+++ b/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/config/IndexedTableConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexing.common.task.IndexTask;
+
+import java.util.List;
+
+/**
+ * The config required for an indexed table to be loaded from an ingestion spec.
+ */
+public class IndexedTableConfig
+{
+  /**
+   * The ingestion spec needed to load the indexed table
+   */
+  private final IndexTask.IndexIngestionSpec ingestionSpec;
+
+  /**
+   * The keys on this indexed table.
+   */
+  private final List<String> keys;
+
+  @JsonCreator
+  public IndexedTableConfig(
+      @JsonProperty("ingestionSpec") IndexTask.IndexIngestionSpec ingestionSpec,
+      @JsonProperty("keys") List<String> keys
+  )
+  {
+    this.ingestionSpec = ingestionSpec;
+    this.keys = keys;
+  }
+
+  public IndexTask.IndexIngestionSpec getIngestionSpec()
+  {
+    return ingestionSpec;
+  }
+
+  public List<String> getKeys()
+  {
+    return keys;
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/config/IndexedTableLoaderConfig.java
+++ b/extensions-contrib/indexed-table-loader/src/main/java/org/apache/druid/indextable/loader/config/IndexedTableLoaderConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Config for the extension that describes the configuration needed for all indexed tables that need to be loaded.
+ */
+public class IndexedTableLoaderConfig
+{
+  @Min(1)
+  @JsonProperty
+  private int numThreads = 1;
+
+  @NotNull
+  @JsonProperty
+  private String configFilePath;
+
+  @JsonProperty
+  public int getNumThreads()
+  {
+    return numThreads;
+  }
+
+  @JsonProperty
+  public String getConfigFilePath()
+  {
+    return configFilePath;
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/indexed-table-loader/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.indextable.loader.IndexedTableLoaderDruidModule

--- a/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableLoaderDruidModuleTest.java
+++ b/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableLoaderDruidModuleTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.ProvisionException;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.LifecycleModule;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.indextable.loader.config.IndexedTableConfig;
+import org.apache.druid.indextable.loader.config.IndexedTableLoaderConfig;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IndexedTableLoaderDruidModuleTest
+{
+  private Properties properties;
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private ObjectMapper mapper;
+  @Mock
+  private ObjectReader reader;
+  @Mock
+  private Map<String, IndexedTableConfig> loadMap;
+
+  private IndexedTableLoaderDruidModule target;
+  private Injector injector;
+
+  @Before
+  public void setUp() throws IOException
+  {
+    properties = new Properties();
+    properties.setProperty("druid.indexedTable.loader.numThreads", "5");
+    properties.setProperty("druid.indexedTable.loader.configFilePath", "/path/to/config");
+
+    Mockito.when(mapper.readerFor(ArgumentMatchers.<TypeReference<ImmutableMap<String, IndexedTableConfig>>>any()))
+           .thenReturn(reader);
+    Mockito.when(reader.readValue(ArgumentMatchers.any(File.class))).thenReturn(loadMap);
+
+    target = new IndexedTableLoaderDruidModule();
+    injector = makeInjector();
+  }
+
+  @Test
+  public void testInjectIndexTableLoadMapIsInjectable()
+  {
+    Map<String, IndexedTableConfig> injectedLoadMap = injector.getInstance(Key.get(new TypeLiteral<Map<String, IndexedTableConfig>>() {}));
+    Assert.assertEquals(loadMap, injectedLoadMap);
+  }
+  @Test
+  public void testInjectIndexedTableLoaderConfigWithoutNumThreadsIsInjectable()
+  {
+    properties.remove("druid.indexedTable.loader.numThreads");
+    IndexedTableLoaderConfig config = injector.getInstance(IndexedTableLoaderConfig.class);
+    Assert.assertNotNull(config);
+  }
+
+  @Test
+  public void testInjectMapOfIndexTableConfigsIsInjectableAndSingleton()
+  {
+    Map<String, IndexedTableConfig> tableLoaders =
+        injector.getInstance(Key.get(new TypeLiteral<Map<String, IndexedTableConfig>>() {}));
+    Map<String, IndexedTableConfig> otherTableLoaders =
+        injector.getInstance(Key.get(new TypeLiteral<Map<String, IndexedTableConfig>>() {}));
+    Assert.assertSame(tableLoaders, otherTableLoaders);
+  }
+  @Test(expected = ProvisionException.class)
+  public void testInjectIndexedTableLoaderConfigWithoutPathToConfigShouldThrowProvisionException()
+  {
+    properties.remove("druid.indexedTable.loader.configFilePath");
+    injector.getInstance(IndexedTableLoaderConfig.class);
+  }
+
+  @Test
+  public void testInjectIndexedTableLoaderConfigIsInjectable()
+  {
+    IndexedTableLoaderConfig config = injector.getInstance(IndexedTableLoaderConfig.class);
+    Assert.assertNotNull(config);
+  }
+
+  @Test
+  public void testInjectIndexedTableManagerIsInjectableAndSingleton()
+  {
+    IndexedTableManager first = injector.getInstance(IndexedTableManager.class);
+    IndexedTableManager second = injector.getInstance(IndexedTableManager.class);
+    Assert.assertSame(first, second);
+  }
+
+  private Injector makeInjector()
+  {
+    return Guice.createInjector(target, new LifecycleModule(), new AbstractModule()
+    {
+      @Override
+      protected void configure()
+      {
+        bind(Validator.class).toInstance(Validation.buildDefaultValidatorFactory().getValidator());
+        bind(Properties.class).toInstance(properties);
+        bind(ObjectMapper.class).annotatedWith(Json.class).toInstance(mapper);
+        bindScope(LazySingleton.class, Scopes.SINGLETON);
+      }
+    });
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableLoaderProviderTest.java
+++ b/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableLoaderProviderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.indextable.loader.config.IndexedTableConfig;
+import org.apache.druid.indextable.loader.config.IndexedTableLoaderConfig;
+import org.apache.druid.java.util.common.ISE;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IndexedTableLoaderProviderTest
+{
+  private static final String CONFIG_FILE_PATH = "CONFIG_FILE_PATH";
+
+  @Mock
+  private ObjectMapper mapper;
+  @Mock
+  private ObjectReader reader;
+  @Mock
+  private IndexedTableLoaderConfig config;
+  @Mock
+  private File configFile;
+  @Mock
+  private Map<String, IndexedTableConfig> loadMap;
+
+  private IndexedTableLoaderProvider target;
+
+  @Before
+  public void setUp() throws IOException
+  {
+    Mockito.when(config.getConfigFilePath()).thenReturn(CONFIG_FILE_PATH);
+    Mockito.when(mapper.readerFor(ArgumentMatchers.<TypeReference<ImmutableMap<String, IndexedTableConfig>>>any()))
+           .thenReturn(reader);
+    Mockito.when(reader.readValue(ArgumentMatchers.any(File.class))).thenReturn(loadMap);
+
+    target = Mockito.spy(new IndexedTableLoaderProvider(config, mapper));
+    Mockito.doReturn(configFile).when(target).getFile(CONFIG_FILE_PATH);
+  }
+
+  @Test
+  public void testGetShouldLoadFileSuccessfully()
+  {
+    Map<String, IndexedTableConfig> loadMap = target.get();
+    Assert.assertEquals(this.loadMap, loadMap);
+  }
+
+  @Test(expected = ISE.class)
+  public void testGetCanNotReadFileShouldThrowISE() throws IOException
+  {
+    Mockito.doThrow(IOException.class).when(reader).readValue(configFile);
+    Map<String, IndexedTableConfig> loadMap = target.get();
+    Assert.assertEquals(this.loadMap, loadMap);
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableManagerTest.java
+++ b/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.concurrent.LifecycleLock;
+import org.apache.druid.indextable.loader.config.IndexedTableConfig;
+import org.apache.druid.indextable.loader.config.IndexedTableLoaderConfig;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.segment.join.table.IndexedTable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IndexedTableManagerTest
+{
+  private static final String TABLE_1 = "TABLE_1";
+  private static final String TABLE_2 = "TABLE_2";
+
+  @Mock
+  private IndexedTableConfig tableConfig1;
+  @Mock
+  private IndexedTableConfig tableConfig2;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private IndexedTableLoaderConfig config;
+  private Map<String, IndexedTableConfig> indexedTableLoaders;
+  @Mock
+  private ExecutorService executorService;
+  @Mock
+  private LifecycleLock lifecycleLock;
+  private ConcurrentMap<String, IndexedTable> indexedTables;
+
+  private IndexedTableManager target;
+
+  @Before
+  public void setUp()
+  {
+    indexedTables = new ConcurrentHashMap<>();
+
+    Mockito.when(lifecycleLock.canStart()).thenReturn(true);
+    Mockito.when(lifecycleLock.canStop()).thenReturn(true);
+    indexedTableLoaders = ImmutableMap.of(TABLE_1, tableConfig1, TABLE_2, tableConfig2);
+    target = new IndexedTableManager(indexedTableLoaders, executorService, lifecycleLock, indexedTables);
+  }
+
+  @Test(expected = ISE.class)
+  public void testStartLifecycleCanNotStartShouldThrowISE()
+  {
+    Mockito.doReturn(false).when(lifecycleLock).canStart();
+    target.start();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testStartWithLoadersThatFailToSubmitShouldExitAndRethrowException()
+  {
+    Mockito.doThrow(RuntimeException.class).when(executorService).submit(ArgumentMatchers.any(Runnable.class));
+    try {
+      target.start();
+    }
+    finally {
+      Mockito.verify(lifecycleLock).exitStart();
+    }
+  }
+
+  @Test
+  public void testStartWithLoadersShouldSubmitAndExit()
+  {
+    target.start();
+    Mockito.verify(executorService, Mockito.times(indexedTableLoaders.size()))
+           .submit(ArgumentMatchers.any(Runnable.class));
+    Mockito.verify(lifecycleLock).exitStart();
+  }
+
+  @Test(expected = ISE.class)
+  public void testStopLifecycleCanNotStopShouldThrowISE()
+  {
+    Mockito.doReturn(false).when(lifecycleLock).canStop();
+    target.stop();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testStopWithShutdownThatFailsShouldExitAndRethrowException()
+  {
+    Mockito.doThrow(RuntimeException.class).when(executorService).shutdownNow();
+    try {
+      target.stop();
+    }
+    finally {
+      Mockito.verify(lifecycleLock).exitStop();
+    }
+  }
+
+  @Test
+  public void testStopShouldShutdownAndExit()
+  {
+    target.stop();
+    Mockito.verify(executorService).shutdownNow();
+    Mockito.verify(lifecycleLock).exitStop();
+  }
+}

--- a/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableSupplierTest.java
+++ b/extensions-contrib/indexed-table-loader/src/test/java/org/apache/druid/indextable/loader/IndexedTableSupplierTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indextable.loader;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.impl.DimensionSchema;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.DoubleDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.indexing.common.task.IndexTask;
+import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.join.table.IndexedTable;
+import org.apache.druid.segment.join.table.RowBasedIndexedTable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class IndexedTableSupplierTest
+{
+  private static final List<String> INDEX_KEYS = ImmutableList.of("key1", "key2");
+
+  private static final List<DimensionSchema> COLUMN_SCHEMA = ImmutableList.of();
+
+  private StringDimensionSchema key1DimentsionSchema;
+  private StringDimensionSchema key2DimentsionSchema;
+  private DoubleDimensionSchema metric1DimensionSchema;
+
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private IndexTask.IndexIngestionSpec ingestionSpec;
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private DataSchema dataSchema;
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private DimensionsSpec dimensionsSpec;
+  @Mock
+  private IndexTask.IndexIOConfig indexIOConfig;
+  @Mock
+  private InputSourceReader inputSourceReader;
+  @Mock
+  private File tmpDir;
+  @Mock
+  private InputRow row1;
+  @Mock
+  private InputRow row2;
+  @Mock
+  private Closeable closeable;
+  private CloseableIterator<InputRow> rowIterator;
+
+  private IndexedTableSupplier target;
+
+  @Before
+  public void setUp() throws IOException
+  {
+    key1DimentsionSchema = new StringDimensionSchema("key1");
+    key2DimentsionSchema = new StringDimensionSchema("key2");
+    metric1DimensionSchema = new DoubleDimensionSchema("metric1");
+
+    Mockito.when(ingestionSpec.getDataSchema()).thenReturn(dataSchema);
+    Mockito.when(dataSchema.getDimensionsSpec()).thenReturn(dimensionsSpec);
+    Mockito.when(dimensionsSpec.getDimensions())
+           .thenReturn(ImmutableList.of(key1DimentsionSchema, key2DimentsionSchema, metric1DimensionSchema));
+    rowIterator = CloseableIterators.wrap(ImmutableList.of(row1, row2).iterator(), closeable);
+    Mockito.when(inputSourceReader.read()).thenReturn(rowIterator);
+
+    target = Mockito.spy(new IndexedTableSupplier(INDEX_KEYS, ingestionSpec, () -> tmpDir));
+    Mockito.doReturn(inputSourceReader).when(target).getInputSourceReader(dataSchema, tmpDir);
+  }
+
+  @Test
+  public void testGetShouldReturnARowBasedIndexedTableAndExhaustIterator() throws IOException
+  {
+    IndexedTable table = target.get();
+    Assert.assertEquals(2, table.numRows());
+    Assert.assertEquals(RowBasedIndexedTable.class, table.getClass());
+    Assert.assertFalse(rowIterator.hasNext());
+  }
+
+  @Test(expected = ISE.class)
+  public void testGetWithKeysMissingInIngestionSpecShouldThrowISE()
+  {
+    Mockito.doReturn(ImmutableList.of(key1DimentsionSchema, metric1DimensionSchema))
+           .when(dimensionsSpec).getDimensions();
+    target.get();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
         <module>extensions-contrib/moving-average-query</module>
         <module>extensions-contrib/tdigestsketch</module>
         <module>extensions-contrib/influxdb-emitter</module>
+        <module>extensions-contrib/indexed-table-loader</module>
         <!-- distribution packaging -->
         <module>distribution</module>
     </modules>


### PR DESCRIPTION
Create an extension that can load an IndexedTable from a provided
IndexIngestionSpec

The extension attemps to load the IngestionSpec on startup and reads the rows
into an RowBasedIndexedTable

This change makes the LifecycleLock non final for easier testing

Follow up patches:
- Hook up the RowBasedIndexTable to a DataSource so that it can be queried
- Refactor the RowBasedIndexTable to accept a row so that it can load the
index table in just one pass over the rows
- Introduce an IndexedTableResource so that the tables can be loaded via an
API instead of just through config
- Refactor the IngestionSpec so that any spec can provide an iterator over
the input source. This will allow the extension to read the IndexedTable from
any format.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
