### PR TITLE
Speed up joins on indexed tables with string keys

### DIFF
--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -80,6 +80,10 @@
             <artifactId>fastutil</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.ning</groupId>
             <artifactId>compress-lzf</artifactId>
         </dependency>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -80,10 +80,6 @@
             <artifactId>fastutil</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.ning</groupId>
             <artifactId>compress-lzf</artifactId>
         </dependency>

--- a/processing/src/main/java/org/apache/druid/segment/ConstantDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/ConstantDimensionSelector.java
@@ -35,7 +35,7 @@ public class ConstantDimensionSelector implements SingleValueHistoricalDimension
 {
   private final String value;
 
-  ConstantDimensionSelector(final String value)
+  public ConstantDimensionSelector(final String value)
   {
     if (NullHandling.isNullOrEquivalent(value)) {
       // There's an optimized implementation for nulls that callers should use instead.

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcherTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcherTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.join.table;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.segment.ConstantDimensionSelector;
+import org.apache.druid.segment.DimensionDictionarySelector;
+import org.apache.druid.segment.column.ValueType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+@RunWith(Enclosed.class)
+public class IndexedTableJoinMatcherTest
+{
+  private static final int SIZE = 3;
+
+  @RunWith(Enclosed.class)
+  public static class ConditionMatcherFactoryTest
+  {
+    public static class MakeDimensionProcessorTest
+    {
+      private static final String KEY = "key";
+
+      static {
+        NullHandling.initializeForTests();
+      }
+
+      @Test
+      public void getsCorrectResultWhenSelectorCardinalityUnknown()
+      {
+        Supplier<IntIterator> target = makeDimensionProcessor(DimensionDictionarySelector.CARDINALITY_UNKNOWN);
+        Assert.assertEquals(KEY.length(), target.get().nextInt());
+      }
+
+      @Test
+      public void getsCorrectResultWhenSelectorCardinalityLow()
+      {
+        int lowCardinality = IndexedTableJoinMatcher.ConditionMatcherFactory.CACHE_MAX_SIZE / 10;
+        Supplier<IntIterator> target = makeDimensionProcessor(lowCardinality);
+        Assert.assertEquals(KEY.length(), target.get().nextInt());
+      }
+
+      @Test
+      public void getsCorrectResultWhenSelectorCardinalityHigh()
+      {
+        int highCardinality = IndexedTableJoinMatcher.ConditionMatcherFactory.CACHE_MAX_SIZE / 10;
+        Supplier<IntIterator> target = makeDimensionProcessor(highCardinality);
+        Assert.assertEquals(KEY.length(), target.get().nextInt());
+      }
+
+      private static Supplier<IntIterator> makeDimensionProcessor(int valueCardinality)
+      {
+        IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
+            new IndexedTableJoinMatcher.ConditionMatcherFactory(
+                ValueType.STRING,
+                IndexedTableJoinMatcherTest::createSingletonIntList
+            );
+        return conditionMatcherFactory.makeDimensionProcessor(new TestDimensionSelector(KEY, valueCardinality));
+      }
+
+      private static class TestDimensionSelector extends ConstantDimensionSelector
+      {
+        private final int valueCardinality;
+
+        TestDimensionSelector(String value, int valueCardinality)
+        {
+          super(value);
+          this.valueCardinality = valueCardinality;
+        }
+
+        @Override
+        public int getValueCardinality()
+        {
+          return valueCardinality;
+        }
+      }
+    }
+  }
+
+  public static class LruLoadingHashMapTest
+  {
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")  // updated via computeIfAbsent
+    private IndexedTableJoinMatcher.LruLoadingHashMap<Long, Long> target;
+
+    private AtomicLong counter;
+
+    @Before
+    public void setup()
+    {
+      counter = new AtomicLong(0);
+      Function<Long, Long> loader = key -> {
+        counter.incrementAndGet();
+        return key;
+      };
+
+      target = new IndexedTableJoinMatcher.LruLoadingHashMap<>(SIZE, loader);
+    }
+
+    @Test
+    public void loadsValueIfAbsent()
+    {
+      Long key = 1L;
+      Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(1L, counter.longValue());
+    }
+
+    @Test
+    public void doesNotLoadIfPresent()
+    {
+      Long key = 1L;
+      Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(1L, counter.longValue());
+    }
+
+    @Test
+    public void evictsLeastRecentlyUsed()
+    {
+      Long start = 1L;
+      Long next = start + SIZE;
+
+      for (long i = start; i < next; i++) {
+        Long key = i;
+        Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
+      }
+
+      Assert.assertEquals(next, target.getAndLoadIfAbsent(next));
+      Assert.assertNull(target.get(start));
+
+      Assert.assertEquals(SIZE + 1, counter.longValue());
+    }
+  }
+
+  public static class Int2IntListLookupTableTest
+  {
+    private IndexedTableJoinMatcher.Int2IntListLookupTable target;
+
+    private AtomicLong counter;
+
+    @Before
+    public void setup()
+    {
+      counter = new AtomicLong(0);
+      IntFunction<IntList> loader = key -> {
+        counter.incrementAndGet();
+        return createSingletonIntList(key);
+      };
+
+      target = new IndexedTableJoinMatcher.Int2IntListLookupTable(SIZE, loader);
+    }
+
+    @Test
+    public void loadsValueIfAbsent()
+    {
+      int key = 1;
+      Assert.assertEquals(createSingletonIntList(key), target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(1L, counter.longValue());
+    }
+
+    @Test
+    public void doesNotLoadIfPresent()
+    {
+      int key = 1;
+      Assert.assertEquals(createSingletonIntList(key), target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(createSingletonIntList(key), target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(1L, counter.longValue());
+    }
+  }
+
+  public static class Int2IntListLruCache
+  {
+    private IndexedTableJoinMatcher.Int2IntListLruCache target;
+
+    private AtomicLong counter;
+
+    @Before
+    public void setup()
+    {
+      counter = new AtomicLong(0);
+      IntFunction<IntList> loader = key -> {
+        counter.incrementAndGet();
+        return createSingletonIntList(key);
+      };
+
+      target = new IndexedTableJoinMatcher.Int2IntListLruCache(SIZE, loader);
+    }
+
+    @Test
+    public void loadsValueIfAbsent()
+    {
+      int key = 1;
+      Assert.assertEquals(createSingletonIntList(key), target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(1L, counter.longValue());
+    }
+
+    @Test
+    public void doesNotLoadIfPresent()
+    {
+      int key = 1;
+      Assert.assertEquals(createSingletonIntList(key), target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(createSingletonIntList(key), target.getAndLoadIfAbsent(key));
+      Assert.assertEquals(1L, counter.longValue());
+    }
+
+    @Test
+    public void evictsLeastRecentlyUsed()
+    {
+      int start = 1;
+      int next = start + SIZE;
+
+      for (int key = start; key < next; key++) {
+        Assert.assertEquals(createSingletonIntList(key), target.getAndLoadIfAbsent(key));
+      }
+
+      Assert.assertEquals(createSingletonIntList(next), target.getAndLoadIfAbsent(next));
+      Assert.assertNull(target.get(start));
+
+      Assert.assertEquals(SIZE + 1, counter.longValue());
+    }
+  }
+
+  private static IntList createSingletonIntList(Object value)
+  {
+    return createSingletonIntList(((String) value).length());
+  }
+
+  private static IntList createSingletonIntList(int value)
+  {
+    return new IntArrayList(Collections.singleton(value));
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
@@ -21,12 +21,14 @@ package org.apache.druid.segment.join.table;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.ConstantDimensionSelector;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ValueType;
@@ -39,12 +41,16 @@ public class IndexedTableJoinableTest
 {
   private static final String PREFIX = "j.";
 
+  static {
+    NullHandling.initializeForTests();
+  }
+
   private final ColumnSelectorFactory dummyColumnSelectorFactory = new ColumnSelectorFactory()
   {
     @Override
     public DimensionSelector makeDimensionSelector(DimensionSpec dimensionSpec)
     {
-      return null;
+      return new ConstantDimensionSelector("dummy");
     }
 
     @Override


### PR DESCRIPTION
### Description

When joining on index tables with string keys, caching the computation of row id to row numbers improves performance on the `JoinAndLookupBenchmark.joinIndexTableStringKey`* benchmarks by about 10% if the column cache is enabled an by about 100% if the column cache is disabled. 

#### Before

```
Benchmark                            (columnCacheSizeBytes)   Score   Error  Units
joinIndexedTableStringKey                                 0  41.899 ± 0.688  ms/op
joinIndexedTableStringKey                             16384  22.707 ± 0.309  ms/op
joinIndexedTableStringKeyWithFilter                       0  41.879 ± 0.507  ms/op
joinIndexedTableStringKeyWithFilter                   16384  22.314 ± 0.114  ms/op
```

#### After

```
Benchmark                            (columnCacheSizeBytes)   Score   Error  Units
joinIndexedTableStringKey                                 0  20.527 ± 0.751  ms/op
joinIndexedTableStringKey                             16384  20.804 ± 0.206  ms/op
joinIndexedTableStringKeyWithFilter                       0  21.374 ± 0.299  ms/op
joinIndexedTableStringKeyWithFilter                   16384  19.723 ± 0.390  ms/op
```

(See https://github.com/apache/druid/pull/9267 for the `JoinAndLookupBenchmark` implementation.)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.