### PR TITLE
Fix timestamp_format expr outside UTC timeZone.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFormatExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFormatExprMacro.java
@@ -65,7 +65,7 @@ public class TimestampFormatExprMacro implements ExprMacroTable.ExprMacro
     }
 
     final DateTimeFormatter formatter = formatString == null
-                                        ? ISODateTimeFormat.dateTime()
+                                        ? ISODateTimeFormat.dateTime().withZone(timeZone)
                                         : DateTimeFormat.forPattern(formatString).withZone(timeZone);
 
     class TimestampFormatExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr


### PR DESCRIPTION
When formatString wasn't set, the default string would be in the local timezone, rather than UTC. We should always use UTC unless the user specifies otherwise in their query.

This is actually caught by existing unit tests, but only if your system timezone is _not_ set to UTC. In Travis, our containers use UTC system time, so they don't catch this.