### PR TITLE
Add getRightEquiConditionKeys to JoinConditionAnalysis

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Represents analysis of a join condition.
@@ -55,6 +56,7 @@ public class JoinConditionAnalysis
   private final boolean isAlwaysFalse;
   private final boolean isAlwaysTrue;
   private final boolean canHashJoin;
+  private final List<String> rightKeyColumns;
 
   private JoinConditionAnalysis(
       final String originalExpression,
@@ -76,6 +78,7 @@ public class JoinConditionAnalysis
                                                                 .allMatch(expr -> expr.isLiteral() && expr.eval(
                                                                     ExprUtils.nilBindings()).asBoolean());
     canHashJoin = nonEquiConditions.stream().allMatch(Expr::isLiteral);
+    rightKeyColumns = getEquiConditions().stream().map(Equality::getRightColumn).distinct().collect(Collectors.toList());
   }
 
   /**
@@ -174,6 +177,14 @@ public class JoinConditionAnalysis
   public boolean canHashJoin()
   {
     return canHashJoin;
+  }
+
+  /**
+   * Returns the distinct column keys from the RHS required to evaluate the equi conditions.
+   */
+  public List<String> getRightKeyColumns()
+  {
+    return rightKeyColumns;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.join;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -32,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -182,9 +184,9 @@ public class JoinConditionAnalysis
   /**
    * Returns the distinct column keys from the RHS required to evaluate the equi conditions.
    */
-  public List<String> getRightKeyColumns()
+  public Set<String> getRightEquiConditionKeys()
   {
-    return rightKeyColumns;
+    return ImmutableSet.copyOf(rightKeyColumns);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
@@ -20,7 +20,6 @@
 package org.apache.druid.segment.join;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -58,7 +57,7 @@ public class JoinConditionAnalysis
   private final boolean isAlwaysFalse;
   private final boolean isAlwaysTrue;
   private final boolean canHashJoin;
-  private final List<String> rightKeyColumns;
+  private final Set<String> rightKeyColumns;
 
   private JoinConditionAnalysis(
       final String originalExpression,
@@ -80,7 +79,7 @@ public class JoinConditionAnalysis
                                                                 .allMatch(expr -> expr.isLiteral() && expr.eval(
                                                                     ExprUtils.nilBindings()).asBoolean());
     canHashJoin = nonEquiConditions.stream().allMatch(Expr::isLiteral);
-    rightKeyColumns = getEquiConditions().stream().map(Equality::getRightColumn).distinct().collect(Collectors.toList());
+    rightKeyColumns = getEquiConditions().stream().map(Equality::getRightColumn).distinct().collect(Collectors.toSet());
   }
 
   /**
@@ -186,7 +185,7 @@ public class JoinConditionAnalysis
    */
   public Set<String> getRightEquiConditionKeys()
   {
-    return ImmutableSet.copyOf(rightKeyColumns);
+    return rightKeyColumns;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/lookup/LookupJoinMatcher.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/lookup/LookupJoinMatcher.java
@@ -191,9 +191,9 @@ public class LookupJoinMatcher implements JoinMatcher
       keyExprs = null;
     } else if (!condition.getNonEquiConditions().isEmpty()) {
       throw new IAE("Cannot join lookup with non-equi condition: %s", condition);
-    } else if (!condition.getEquiConditions()
+    } else if (!condition.getRightEquiConditionKeys()
                          .stream()
-                         .allMatch(eq -> eq.getRightColumn().equals(LookupColumnSelectorFactory.KEY_COLUMN))) {
+                         .allMatch(LookupColumnSelectorFactory.KEY_COLUMN::equals)) {
       throw new IAE("Cannot join lookup with condition referring to non-key column: %s", condition);
     } else {
       keyExprs = condition.getEquiConditions().stream().map(Equality::getLeftExpr).collect(Collectors.toList());

--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTable.java
@@ -25,6 +25,7 @@ import org.apache.druid.segment.column.ValueType;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * An interface to a table where some columns (the 'key columns') have indexes that enable fast lookups.
@@ -36,7 +37,7 @@ public interface IndexedTable
   /**
    * Returns the columns of this table that have indexes.
    */
-  List<String> keyColumns();
+  Set<String> keyColumns();
 
   /**
    * Returns all columns of this table, including the key and non-key columns.

--- a/processing/src/main/java/org/apache/druid/segment/join/table/RowBasedIndexedTable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/RowBasedIndexedTable.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -48,13 +49,13 @@ public class RowBasedIndexedTable<RowType> implements IndexedTable
   private final List<String> columns;
   private final List<ValueType> columnTypes;
   private final List<Function<RowType, Object>> columnFunctions;
-  private final List<String> keyColumns;
+  private final Set<String> keyColumns;
 
   public RowBasedIndexedTable(
       final List<RowType> table,
       final RowAdapter<RowType> rowAdapter,
       final Map<String, ValueType> rowSignature,
-      final List<String> keyColumns
+      final Set<String> keyColumns
   )
   {
     this.table = table;
@@ -107,7 +108,7 @@ public class RowBasedIndexedTable<RowType> implements IndexedTable
   }
 
   @Override
-  public List<String> keyColumns()
+  public Set<String> keyColumns()
   {
     return keyColumns;
   }

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -60,6 +61,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y")));
   }
 
   @Test
@@ -80,6 +82,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y")));
   }
 
   @Test
@@ -100,6 +103,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("z")));
   }
 
   @Test
@@ -120,6 +124,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(== (+ j.x j.y) z)"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
   }
 
   @Test
@@ -140,6 +145,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(== (+ x j.y) j.z)"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
   }
 
   @Test
@@ -160,6 +166,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("2"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
   }
 
   @Test
@@ -180,6 +187,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("0"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
   }
 
   @Test
@@ -200,6 +208,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(== x 1)"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
   }
 
   @Test
@@ -220,6 +229,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("x")));
   }
 
   @Test
@@ -240,6 +250,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y", "z", "zz")));
   }
 
   @Test
@@ -260,6 +271,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(|| (== (+ x y) j.z) (== z j.zz))"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
+    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y")));
   }
 
   @Test
@@ -271,7 +283,7 @@ public class JoinConditionAnalysisTest
                           // These fields are tightly coupled with originalExpression
                           "equiConditions", "nonEquiConditions",
                           // These fields are calculated from nonEquiConditions
-                          "isAlwaysTrue", "isAlwaysFalse", "canHashJoin")
+                          "isAlwaysTrue", "isAlwaysFalse", "canHashJoin", "rightKeyColumns")
                   .verify();
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
@@ -20,12 +20,12 @@
 package org.apache.druid.segment.join;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,7 +61,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y")));
+    Assert.assertEquals(analysis.getRightEquiConditionKeys(), ImmutableSet.of("y"));
   }
 
   @Test
@@ -82,7 +82,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y")));
+    Assert.assertEquals(analysis.getRightEquiConditionKeys(), ImmutableSet.of("y"));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("z")));
+    Assert.assertEquals(analysis.getRightEquiConditionKeys(), ImmutableSet.of("z"));
   }
 
   @Test
@@ -124,7 +124,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(== (+ j.x j.y) z)"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
+    Assert.assertTrue(analysis.getRightEquiConditionKeys().isEmpty());
   }
 
   @Test
@@ -145,7 +145,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(== (+ x j.y) j.z)"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
+    Assert.assertTrue(analysis.getRightEquiConditionKeys().isEmpty());
   }
 
   @Test
@@ -166,7 +166,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("2"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
+    Assert.assertTrue(analysis.getRightEquiConditionKeys().isEmpty());
   }
 
   @Test
@@ -187,7 +187,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("0"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
+    Assert.assertTrue(analysis.getRightEquiConditionKeys().isEmpty());
   }
 
   @Test
@@ -208,7 +208,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(== x 1)"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertTrue(analysis.getRightKeyColumns().isEmpty());
+    Assert.assertTrue(analysis.getRightEquiConditionKeys().isEmpty());
   }
 
   @Test
@@ -229,7 +229,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("x")));
+    Assert.assertEquals(analysis.getRightEquiConditionKeys(), ImmutableSet.of("x"));
   }
 
   @Test
@@ -250,7 +250,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of(),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y", "z", "zz")));
+    Assert.assertEquals(analysis.getRightEquiConditionKeys(), ImmutableSet.of("y", "z", "zz"));
   }
 
   @Test
@@ -271,7 +271,7 @@ public class JoinConditionAnalysisTest
         ImmutableList.of("(|| (== (+ x y) j.z) (== z j.zz))"),
         exprsToStrings(analysis.getNonEquiConditions())
     );
-    Assert.assertThat(analysis.getRightKeyColumns(), CoreMatchers.is(ImmutableList.of("y")));
+    Assert.assertEquals(analysis.getRightEquiConditionKeys(), ImmutableSet.of("y"));
   }
 
   @Test
@@ -282,7 +282,7 @@ public class JoinConditionAnalysisTest
                   .withIgnoredFields(
                           // These fields are tightly coupled with originalExpression
                           "equiConditions", "nonEquiConditions",
-                          // These fields are calculated from nonEquiConditions
+                          // These fields are calculated from other other fields in the class
                           "isAlwaysTrue", "isAlwaysFalse", "canHashJoin", "rightKeyColumns")
                   .verify();
   }

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinTestHelper.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.InputRow;
@@ -252,7 +253,7 @@ public class JoinTestHelper
             rows,
             createMapRowAdapter(COUNTRIES_SIGNATURE),
             COUNTRIES_SIGNATURE,
-            ImmutableList.of("countryNumber", "countryIsoCode")
+            ImmutableSet.of("countryNumber", "countryIsoCode")
         )
     );
   }
@@ -265,7 +266,7 @@ public class JoinTestHelper
             rows,
             createMapRowAdapter(REGIONS_SIGNATURE),
             REGIONS_SIGNATURE,
-            ImmutableList.of("regionIsoCode", "countryIsoCode")
+            ImmutableSet.of("regionIsoCode", "countryIsoCode")
         )
     );
   }

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.join.table;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
@@ -72,7 +73,7 @@ public class IndexedTableJoinableTest
       inlineDataSource.getRowsAsList(),
       inlineDataSource.rowAdapter(),
       inlineDataSource.getRowSignature(),
-      ImmutableList.of("str")
+      ImmutableSet.of("str")
   );
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/join/table/RowBasedIndexedTableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/RowBasedIndexedTableTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.join.table;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.join.JoinTestHelper;
@@ -64,7 +65,7 @@ public class RowBasedIndexedTableTest
   @Test
   public void test_keyColumns_countries()
   {
-    Assert.assertEquals(ImmutableList.of("countryNumber", "countryIsoCode"), countriesTable.keyColumns());
+    Assert.assertEquals(ImmutableSet.of("countryNumber", "countryIsoCode"), countriesTable.keyColumns());
   }
 
   @Test

--- a/server/src/main/java/org/apache/druid/segment/join/InlineJoinableFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/join/InlineJoinableFactory.java
@@ -27,7 +27,6 @@ import org.apache.druid.segment.join.table.RowBasedIndexedTable;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * A {@link JoinableFactory} for {@link InlineDataSource}. It works by building an {@link IndexedTable}.
@@ -39,8 +38,7 @@ public class InlineJoinableFactory implements JoinableFactory
   {
     if (condition.canHashJoin() && dataSource instanceof InlineDataSource) {
       final InlineDataSource inlineDataSource = (InlineDataSource) dataSource;
-      final List<String> rightKeyColumns =
-          condition.getEquiConditions().stream().map(Equality::getRightColumn).distinct().collect(Collectors.toList());
+      final List<String> rightKeyColumns = condition.getRightKeyColumns();
 
       return Optional.of(
           new IndexedTableJoinable(

--- a/server/src/main/java/org/apache/druid/segment/join/InlineJoinableFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/join/InlineJoinableFactory.java
@@ -25,8 +25,8 @@ import org.apache.druid.segment.join.table.IndexedTable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.join.table.RowBasedIndexedTable;
 
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A {@link JoinableFactory} for {@link InlineDataSource}. It works by building an {@link IndexedTable}.
@@ -38,7 +38,7 @@ public class InlineJoinableFactory implements JoinableFactory
   {
     if (condition.canHashJoin() && dataSource instanceof InlineDataSource) {
       final InlineDataSource inlineDataSource = (InlineDataSource) dataSource;
-      final List<String> rightKeyColumns = condition.getRightKeyColumns();
+      final Set<String> rightKeyColumns = condition.getRightEquiConditionKeys();
 
       return Optional.of(
           new IndexedTableJoinable(


### PR DESCRIPTION
This change allows other implementations of JoinableFactory to ask the analysis
for the right key columns instead of having to calculate it themselves.

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.