### PR TITLE
Suppress false-alarm inspection.

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/guava/LimitedSequence.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/guava/LimitedSequence.java
@@ -52,6 +52,7 @@ final class LimitedSequence<T> extends YieldingSequenceBase<T>
     return new LimitedYielder<>(subYielder, limitedAccumulator);
   }
 
+  @SuppressWarnings("InnerClassMayBeStatic") // False alarm: flagged by IDEA inspections, but can't actually be static.
   private class LimitedYielder<OutType> implements Yielder<OutType>
   {
     private final Yielder<OutType> subYielder;


### PR DESCRIPTION
I think a mid-air collision between #9260 and #9293 has led to
master being unable to pass insepctions in TeamCity. Hopefully
this fixes it.

By the way, it can't be static because it references a non-static
private inner class, and _that_ one can't be static because it
references a field of the class that contains both of them.