### PR TITLE
Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
+  netty-3.10.6.Final.jar# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -782,7 +782,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.42.Final
+version: 4.1.45.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1,4 +1,4 @@
-  netty-3.10.6.Final.jar# Licensed to the Apache Software Foundation (ASF) under one
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -149,6 +149,22 @@
     <cve>CVE-2019-16869</cve>
   </suppress>
   <suppress>
+    <!-- TODO: Fix by updating org.apache.druid.java.util.http.client.NettyHttpClient to use netty 4 -->
+    <notes><![CDATA[
+   file name: netty-3.10.6.Final.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty@.*$</packageUrl>
+    <cve>CVE-2019-20445</cve>
+  </suppress>
+  <suppress>
+    <!-- TODO: Fix by updating org.apache.druid.java.util.http.client.NettyHttpClient to use netty 4 -->
+    <notes><![CDATA[
+   file name: netty-3.10.6.Final.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty@.*$</packageUrl>
+    <cve>CVE-2019-20444</cve>
+  </suppress>
+  <suppress>
     <!-- TODO: Fix by upgrading hadoop-auth version -->
     <notes><![CDATA[
    file name: nimbus-jose-jwt-4.41.1.jar

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -147,22 +147,8 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.netty/netty@.*$</packageUrl>
     <cve>CVE-2019-16869</cve>
-  </suppress>
-  <suppress>
-    <!-- TODO: Fix by updating org.apache.druid.java.util.http.client.NettyHttpClient to use netty 4 -->
-    <notes><![CDATA[
-   file name: netty-3.10.6.Final.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.netty/netty@.*$</packageUrl>
-    <cve>CVE-2019-20445</cve>
-  </suppress>
-  <suppress>
-    <!-- TODO: Fix by updating org.apache.druid.java.util.http.client.NettyHttpClient to use netty 4 -->
-    <notes><![CDATA[
-   file name: netty-3.10.6.Final.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.netty/netty@.*$</packageUrl>
     <cve>CVE-2019-20444</cve>
+    <cve>CVE-2019-20445</cve>
   </suppress>
   <suppress>
     <!-- TODO: Fix by upgrading hadoop-auth version -->

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <log4j.version>2.8.2</log4j.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <!-- Spark updated in https://github.com/apache/spark/pull/19884 -->
-        <netty4.version>4.1.42.Final</netty4.version>
+        <netty4.version>4.1.45.Final</netty4.version>
         <node.version>v10.14.2</node.version>
         <npm.version>6.5.0</npm.version>
         <protobuf.version>3.11.0</protobuf.version>


### PR DESCRIPTION
### Description

This change fixes the CVEs, CVE-2019-20445 and CVE-2019-20444,  introduced into druid by netty. The vulnerabilities were fixed in a netty version 4 update, so the version of netty 4 has been updated. For Version 3 however, no fix exists, so the vulnerabilities were suppressed for version 3.

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>
