### PR TITLE
Remove EasyMock dependency from CalciteTests.

### DIFF
--- a/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
@@ -22,9 +22,9 @@ package org.apache.druid.discovery;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.client.selector.DiscoverySelector;
 import org.apache.druid.client.selector.Server;
 import org.apache.druid.concurrent.LifecycleLock;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
@@ -73,7 +73,7 @@ public class DruidLeaderClient
   private final String leaderRequestPath;
 
   //Note: This is kept for back compatibility with pre 0.11.0 releases and should be removed in future.
-  private final ServerDiscoverySelector serverDiscoverySelector;
+  private final DiscoverySelector<Server> serverDiscoverySelector;
 
   private LifecycleLock lifecycleLock = new LifecycleLock();
   private DruidNodeDiscovery druidNodeDiscovery;
@@ -84,7 +84,7 @@ public class DruidLeaderClient
       DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
       NodeRole nodeRoleToWatch,
       String leaderRequestPath,
-      ServerDiscoverySelector serverDiscoverySelector
+      DiscoverySelector<Server> serverDiscoverySelector
   )
   {
     this.httpClient = httpClient;

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -167,10 +167,6 @@
       <artifactId>avatica-metrics</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-x-discovery</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
       <version>${checkerframework.version}</version>


### PR DESCRIPTION
Useful because CalciteTests is used by other modules (e.g. druid-benchmarks)
and we don't want them to have to pull in EasyMock.