### PR TITLE
Logging large segment list handling

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/AbstractTextFilesFirehoseFactory.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/AbstractTextFilesFirehoseFactory.java
@@ -78,11 +78,7 @@ public abstract class AbstractTextFilesFirehoseFactory<T>
               return IOUtils.lineIterator(wrapObjectStream(object, openObjectStream(object)), StandardCharsets.UTF_8);
             }
             catch (Exception e) {
-              LOG.error(
-                  e,
-                  "Exception reading object[%s]",
-                  object
-              );
+              LOG.error(e, "Exception reading object[%s]", object);
               throw new RuntimeException(e);
             }
           }

--- a/core/src/main/java/org/apache/druid/java/util/common/logger/Logger.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/logger/Logger.java
@@ -153,12 +153,12 @@ public class Logger
 
   public void wtf(String message, Object... formatArgs)
   {
-    log.error(StringUtils.nonStrictFormat("WTF?!: " + message, formatArgs), new Exception());
+    log.error(message, formatArgs);
   }
 
   public void wtf(Throwable t, String message, Object... formatArgs)
   {
-    log.error(StringUtils.nonStrictFormat("WTF?!: " + message, formatArgs), t);
+    logException(log::error, t, StringUtils.nonStrictFormat(message, formatArgs));
   }
 
   public boolean isTraceEnabled()
@@ -187,5 +187,11 @@ public class Logger
         fn.accept(StringUtils.nonStrictFormat("%s (%s)", message, t.toString()), null);
       }
     }
+  }
+
+  @FunctionalInterface
+  public interface LogFunction
+  {
+    void log(String msg, Object... format);
   }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/logger/Logger.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/logger/Logger.java
@@ -153,12 +153,12 @@ public class Logger
 
   public void wtf(String message, Object... formatArgs)
   {
-    log.error(message, formatArgs);
+    error(message, formatArgs);
   }
 
   public void wtf(Throwable t, String message, Object... formatArgs)
   {
-    logException(log::error, t, StringUtils.nonStrictFormat(message, formatArgs));
+    error(t, message, formatArgs);
   }
 
   public boolean isTraceEnabled()

--- a/core/src/main/java/org/apache/druid/segment/SegmentUtils.java
+++ b/core/src/main/java/org/apache/druid/segment/SegmentUtils.java
@@ -19,8 +19,6 @@
 
 package org.apache.druid.segment;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
@@ -30,9 +28,7 @@ import com.google.common.primitives.Ints;
 import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.SegmentId;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -42,9 +38,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * Utility methods useful for implementing deep storage extensions.
@@ -52,9 +46,6 @@ import java.util.stream.Stream;
 @PublicApi
 public class SegmentUtils
 {
-  @VisibleForTesting
-  static final int SEGMENTS_PER_LOG_MESSAGE = 64;
-
   private static final HashFunction HASH_FUNCTION = Hashing.sha256();
 
   /**
@@ -102,71 +93,8 @@ public class SegmentUtils
     return Collections2.transform(segments, DataSegment::getId);
   }
 
-  /**
-   * Logs all the segment ids you could ever want, {@link #SEGMENTS_PER_LOG_MESSAGE} at a time, as a comma separated
-   * list.
-   */
-  public static void logSegments(
-      Logger.LogFunction logger,
-      @Nullable final Collection<DataSegment> segments,
-      @Nullable String preamble
-  )
-  {
-    if (segments == null || segments.isEmpty()) {
-      return;
-    }
-    logSegmentIds(logger, segments.stream().map(DataSegment::getId), preamble);
-  }
-
-  /**
-   * Logs all the segment ids you could ever want, {@link #SEGMENTS_PER_LOG_MESSAGE} at a time, as a comma separated
-   * list.
-   */
-  public static void logSegmentIds(
-      Logger.LogFunction logger,
-      @Nullable final Stream<SegmentId> stream,
-      @Nullable String preamble
-  )
-  {
-    Preconditions.checkNotNull(preamble);
-    if (stream == null) {
-      return;
-    }
-    final Iterator<SegmentId> iterator = stream.iterator();
-    if (!iterator.hasNext()) {
-      return;
-    }
-    final String logFormat = preamble + ": %s";
-
-    int counter = 0;
-    StringBuilder sb = null;
-    while (iterator.hasNext()) {
-      SegmentId nextId = iterator.next();
-      if (counter == 0) {
-        // use segmentId string length of first as estimate for total size of builder for this batch
-        sb = new StringBuilder(SEGMENTS_PER_LOG_MESSAGE * (2 + nextId.safeUpperLimitOfStringSize())).append("[");
-      }
-      sb.append(nextId);
-      if (++counter < SEGMENTS_PER_LOG_MESSAGE && iterator.hasNext()) {
-        sb.append(", ");
-      }
-      counter = counter % SEGMENTS_PER_LOG_MESSAGE;
-      if (counter == 0) {
-        // flush
-        sb.append("]");
-        logger.log(logFormat, sb.toString());
-      }
-    }
-
-    // check for stragglers
-    if (counter > 0) {
-      sb.append("]");
-      logger.log(logFormat, sb.toString());
-    }
-  }
-
   private SegmentUtils()
   {
-
+    // no instantiation
   }
 }

--- a/core/src/main/java/org/apache/druid/segment/SegmentUtils.java
+++ b/core/src/main/java/org/apache/druid/segment/SegmentUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.segment;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
@@ -28,8 +30,11 @@ import com.google.common.primitives.Ints;
 import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -37,7 +42,9 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Utility methods useful for implementing deep storage extensions.
@@ -45,6 +52,9 @@ import java.util.List;
 @PublicApi
 public class SegmentUtils
 {
+  @VisibleForTesting
+  static final int SEGMENTS_PER_LOG_MESSAGE = 64;
+
   private static final HashFunction HASH_FUNCTION = Hashing.sha256();
 
   /**
@@ -82,13 +92,81 @@ public class SegmentUtils
    * for log messages. Not useful for anything else, because this doesn't take special effort to escape commas that
    * occur in identifiers (not common, but could potentially occur in a datasource name).
    */
-  public static Object commaSeparatedIdentifiers(final Collection<DataSegment> segments)
+  @Nullable
+  public static Object commaSeparatedIdentifiers(@Nullable final Collection<DataSegment> segments)
   {
+    if (segments == null || segments.isEmpty()) {
+      return null;
+    }
     // Lazy, to avoid preliminary string creation if logging level is turned off
     return Collections2.transform(segments, DataSegment::getId);
   }
 
+  /**
+   * Logs all the segment ids you could ever want, {@link #SEGMENTS_PER_LOG_MESSAGE} at a time, as a comma separated
+   * list.
+   */
+  public static void logSegments(
+      Logger.LogFunction logger,
+      @Nullable final Collection<DataSegment> segments,
+      @Nullable String preamble
+  )
+  {
+    if (segments == null || segments.isEmpty()) {
+      return;
+    }
+    logSegmentIds(logger, segments.stream().map(DataSegment::getId), preamble);
+  }
+
+  /**
+   * Logs all the segment ids you could ever want, {@link #SEGMENTS_PER_LOG_MESSAGE} at a time, as a comma separated
+   * list.
+   */
+  public static void logSegmentIds(
+      Logger.LogFunction logger,
+      @Nullable final Stream<SegmentId> stream,
+      @Nullable String preamble
+  )
+  {
+    Preconditions.checkNotNull(preamble);
+    if (stream == null) {
+      return;
+    }
+    final Iterator<SegmentId> iterator = stream.iterator();
+    if (!iterator.hasNext()) {
+      return;
+    }
+    final String logFormat = preamble + ": %s";
+
+    int counter = 0;
+    StringBuilder sb = null;
+    while (iterator.hasNext()) {
+      SegmentId nextId = iterator.next();
+      if (counter == 0) {
+        // use segmentId string length of first as estimate for total size of builder for this batch
+        sb = new StringBuilder(SEGMENTS_PER_LOG_MESSAGE * (2 + nextId.safeUpperLimitOfStringSize())).append("[");
+      }
+      sb.append(nextId);
+      if (++counter < SEGMENTS_PER_LOG_MESSAGE && iterator.hasNext()) {
+        sb.append(", ");
+      }
+      counter = counter % SEGMENTS_PER_LOG_MESSAGE;
+      if (counter == 0) {
+        // flush
+        sb.append("]");
+        logger.log(logFormat, sb.toString());
+      }
+    }
+
+    // check for stragglers
+    if (counter > 0) {
+      sb.append("]");
+      logger.log(logFormat, sb.toString());
+    }
+  }
+
   private SegmentUtils()
   {
+
   }
 }

--- a/core/src/main/java/org/apache/druid/timeline/SegmentId.java
+++ b/core/src/main/java/org/apache/druid/timeline/SegmentId.java
@@ -409,7 +409,7 @@ public final class SegmentId implements Comparable<SegmentId>
     return sb.toString();
   }
 
-  private int safeUpperLimitOfStringSize()
+  public int safeUpperLimitOfStringSize()
   {
     int delimiters = 4;
     int partitionNumSizeUpperLimit = 3; // less than 1000 partitions

--- a/core/src/test/java/org/apache/druid/java/util/common/logger/LoggerTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/logger/LoggerTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.java.util.common.logger;
 import org.apache.commons.lang.mutable.MutableInt;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;

--- a/core/src/test/java/org/apache/druid/java/util/common/logger/LoggerTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/logger/LoggerTest.java
@@ -19,7 +19,23 @@
 
 package org.apache.druid.java.util.common.logger;
 
+import org.apache.commons.lang.mutable.MutableInt;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.SegmentUtils;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class LoggerTest
 {
@@ -49,5 +65,92 @@ public class LoggerTest
     log.noStackTrace().error(new RuntimeException("beep"), "Feel the hatred of %d years", 10000);
     log.noStackTrace().error(new RuntimeException("beep"), "");
     log.error(new RuntimeException("beep"), "An exception");
+  }
+
+  @Test
+  public void testLogNoSegments()
+  {
+    List<String> messages = new ArrayList<>();
+    Logger.LogFunction logger = getLogToListFunction(messages);
+    Logger.logSegments(logger, Collections.emptyList(), "None segments");
+    Logger.logSegmentIds(logger, Stream.empty(), "None segments");
+
+    Assert.assertEquals(0, messages.size());
+  }
+
+  @Test
+  public void testLogSegments()
+  {
+    List<String> messages = new ArrayList<>();
+    List<DataSegment> segments = makeDataSegments(2).collect(Collectors.toList());
+    Logger.LogFunction logger = getLogToListFunction(messages);
+    Logger.logSegments(logger, segments, "Test segments");
+
+    Assert.assertEquals(1, messages.size());
+    final String expected =
+        "Test segments: [someDataSource_2012-01-01T00:00:00.000Z_2012-01-03T00:00:00.000Z_2020-02-02T00:00:00.000Z,"
+        + " someDataSource_2012-01-02T00:00:00.000Z_2012-01-04T00:00:00.000Z_2020-02-02T00:00:00.000Z]";
+    Assert.assertEquals(expected, messages.get(0));
+  }
+
+
+  @Test
+  public void testLogSegmentIds()
+  {
+    List<String> messages = new ArrayList<>();
+    Stream<SegmentId> segments = makeDataSegments(2).map(DataSegment::getId);
+    Logger.LogFunction logger = getLogToListFunction(messages);
+    Logger.logSegmentIds(logger, segments, "Test segments");
+
+    Assert.assertEquals(1, messages.size());
+    final String expected =
+        "Test segments: [someDataSource_2012-01-01T00:00:00.000Z_2012-01-03T00:00:00.000Z_2020-02-02T00:00:00.000Z,"
+        + " someDataSource_2012-01-02T00:00:00.000Z_2012-01-04T00:00:00.000Z_2020-02-02T00:00:00.000Z]";
+    Assert.assertEquals(expected, messages.get(0));
+  }
+
+
+  @Test
+  public void testLogSegmentsMany()
+  {
+    final int numSegments = 100000;
+    final MutableInt msgCount = new MutableInt();
+    final Stream<SegmentId> segments = makeDataSegments(numSegments).map(DataSegment::getId);
+
+    final Logger.LogFunction logger = (msg, format) -> {
+      String message = StringUtils.format(msg, format);
+      Assert.assertTrue(message.startsWith("Many segments: ["));
+      Assert.assertTrue(message.endsWith("]"));
+      msgCount.increment();
+    };
+    Logger.logSegmentIds(logger, segments, "Many segments");
+
+    final int expected = (int) Math.ceil((double) numSegments / Logger.SEGMENTS_PER_LOG_MESSAGE);
+    Assert.assertEquals(expected, msgCount.getValue());
+  }
+
+  private Logger.LogFunction getLogToListFunction(List<String> messages)
+  {
+    return (msg, format) -> messages.add(StringUtils.format(msg, format));
+  }
+
+  private Stream<DataSegment> makeDataSegments(int numSegments)
+  {
+    final DateTime start = DateTimes.of("2012-01-01");
+    final DateTime end = DateTimes.of("2012-01-02");
+    final String version = DateTimes.of("2020-02-02").toString();
+    return IntStream.range(0, numSegments)
+                    .mapToObj(segmentNum -> DataSegment.builder()
+                                                       .dataSource("someDataSource")
+                                                       .interval(
+                                                           new Interval(
+                                                               start.plusDays(segmentNum),
+                                                               end.plusDays(segmentNum + 1)
+                                                           )
+                                                       )
+                                                       .version(version)
+                                                       .size(1)
+                                                       .build());
+
   }
 }

--- a/core/src/test/java/org/apache/druid/segment/SegmentUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/segment/SegmentUtilsTest.java
@@ -21,14 +21,6 @@ package org.apache.druid.segment;
 
 import com.google.common.primitives.Ints;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.mutable.MutableInt;
-import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.SegmentId;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,12 +28,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
  */
@@ -70,92 +56,5 @@ public class SegmentUtilsTest
   public void testException() throws Exception
   {
     SegmentUtils.getVersionFromDir(tempFolder.newFolder());
-  }
-
-  @Test
-  public void testLogNoSegments()
-  {
-    List<String> messages = new ArrayList<>();
-    Logger.LogFunction logger = getLogToListFunction(messages);
-    SegmentUtils.logSegments(logger, Collections.emptyList(), "None segments");
-    SegmentUtils.logSegmentIds(logger, Stream.empty(), "None segments");
-
-    Assert.assertEquals(0, messages.size());
-  }
-
-  @Test
-  public void testLogSegments()
-  {
-    List<String> messages = new ArrayList<>();
-    List<DataSegment> segments = makeDataSegments(2).collect(Collectors.toList());
-    Logger.LogFunction logger = getLogToListFunction(messages);
-    SegmentUtils.logSegments(logger, segments, "Test segments");
-
-    Assert.assertEquals(1, messages.size());
-    final String expected =
-        "Test segments: [someDataSource_2012-01-01T00:00:00.000Z_2012-01-03T00:00:00.000Z_2020-02-02T00:00:00.000Z,"
-        + " someDataSource_2012-01-02T00:00:00.000Z_2012-01-04T00:00:00.000Z_2020-02-02T00:00:00.000Z]";
-    Assert.assertEquals(expected, messages.get(0));
-  }
-
-
-  @Test
-  public void testLogSegmentIds()
-  {
-    List<String> messages = new ArrayList<>();
-    Stream<SegmentId> segments = makeDataSegments(2).map(DataSegment::getId);
-    Logger.LogFunction logger = getLogToListFunction(messages);
-    SegmentUtils.logSegmentIds(logger, segments, "Test segments");
-
-    Assert.assertEquals(1, messages.size());
-    final String expected =
-        "Test segments: [someDataSource_2012-01-01T00:00:00.000Z_2012-01-03T00:00:00.000Z_2020-02-02T00:00:00.000Z,"
-        + " someDataSource_2012-01-02T00:00:00.000Z_2012-01-04T00:00:00.000Z_2020-02-02T00:00:00.000Z]";
-    Assert.assertEquals(expected, messages.get(0));
-  }
-
-
-  @Test
-  public void testLogSegmentsMany()
-  {
-    final int numSegments = 100000;
-    final MutableInt msgCount = new MutableInt();
-    final Stream<SegmentId> segments = makeDataSegments(numSegments).map(DataSegment::getId);
-
-    final Logger.LogFunction logger = (msg, format) -> {
-      String message = StringUtils.format(msg, format);
-      Assert.assertTrue(message.startsWith("Many segments: ["));
-      Assert.assertTrue(message.endsWith("]"));
-      msgCount.increment();
-    };
-    SegmentUtils.logSegmentIds(logger, segments, "Many segments");
-
-    final int expected = (int) Math.ceil((double) numSegments / SegmentUtils.SEGMENTS_PER_LOG_MESSAGE);
-    Assert.assertEquals(expected, msgCount.getValue());
-  }
-
-  private Logger.LogFunction getLogToListFunction(List<String> messages)
-  {
-    return (msg, format) -> messages.add(StringUtils.format(msg, format));
-  }
-
-  private Stream<DataSegment> makeDataSegments(int numSegments)
-  {
-    final DateTime start = DateTimes.of("2012-01-01");
-    final DateTime end = DateTimes.of("2012-01-02");
-    final String version = DateTimes.of("2020-02-02").toString();
-    return IntStream.range(0, numSegments)
-                    .mapToObj(segmentNum -> DataSegment.builder()
-                                                       .dataSource("someDataSource")
-                                                       .interval(
-                                                           new Interval(
-                                                               start.plusDays(segmentNum),
-                                                               end.plusDays(segmentNum + 1)
-                                                           )
-                                                       )
-                                                       .version(version)
-                                                       .size(1)
-                                                       .build());
-
   }
 }

--- a/core/src/test/java/org/apache/druid/segment/SegmentUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/segment/SegmentUtilsTest.java
@@ -21,6 +21,14 @@ package org.apache.druid.segment;
 
 import com.google.common.primitives.Ints;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.mutable.MutableInt;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +36,12 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  */
@@ -56,5 +70,92 @@ public class SegmentUtilsTest
   public void testException() throws Exception
   {
     SegmentUtils.getVersionFromDir(tempFolder.newFolder());
+  }
+
+  @Test
+  public void testLogNoSegments()
+  {
+    List<String> messages = new ArrayList<>();
+    Logger.LogFunction logger = getLogToListFunction(messages);
+    SegmentUtils.logSegments(logger, Collections.emptyList(), "None segments");
+    SegmentUtils.logSegmentIds(logger, Stream.empty(), "None segments");
+
+    Assert.assertEquals(0, messages.size());
+  }
+
+  @Test
+  public void testLogSegments()
+  {
+    List<String> messages = new ArrayList<>();
+    List<DataSegment> segments = makeDataSegments(2).collect(Collectors.toList());
+    Logger.LogFunction logger = getLogToListFunction(messages);
+    SegmentUtils.logSegments(logger, segments, "Test segments");
+
+    Assert.assertEquals(1, messages.size());
+    final String expected =
+        "Test segments: [someDataSource_2012-01-01T00:00:00.000Z_2012-01-03T00:00:00.000Z_2020-02-02T00:00:00.000Z,"
+        + " someDataSource_2012-01-02T00:00:00.000Z_2012-01-04T00:00:00.000Z_2020-02-02T00:00:00.000Z]";
+    Assert.assertEquals(expected, messages.get(0));
+  }
+
+
+  @Test
+  public void testLogSegmentIds()
+  {
+    List<String> messages = new ArrayList<>();
+    Stream<SegmentId> segments = makeDataSegments(2).map(DataSegment::getId);
+    Logger.LogFunction logger = getLogToListFunction(messages);
+    SegmentUtils.logSegmentIds(logger, segments, "Test segments");
+
+    Assert.assertEquals(1, messages.size());
+    final String expected =
+        "Test segments: [someDataSource_2012-01-01T00:00:00.000Z_2012-01-03T00:00:00.000Z_2020-02-02T00:00:00.000Z,"
+        + " someDataSource_2012-01-02T00:00:00.000Z_2012-01-04T00:00:00.000Z_2020-02-02T00:00:00.000Z]";
+    Assert.assertEquals(expected, messages.get(0));
+  }
+
+
+  @Test
+  public void testLogSegmentsMany()
+  {
+    final int numSegments = 100000;
+    final MutableInt msgCount = new MutableInt();
+    final Stream<SegmentId> segments = makeDataSegments(numSegments).map(DataSegment::getId);
+
+    final Logger.LogFunction logger = (msg, format) -> {
+      String message = StringUtils.format(msg, format);
+      Assert.assertTrue(message.startsWith("Many segments: ["));
+      Assert.assertTrue(message.endsWith("]"));
+      msgCount.increment();
+    };
+    SegmentUtils.logSegmentIds(logger, segments, "Many segments");
+
+    final int expected = (int) Math.ceil((double) numSegments / SegmentUtils.SEGMENTS_PER_LOG_MESSAGE);
+    Assert.assertEquals(expected, msgCount.getValue());
+  }
+
+  private Logger.LogFunction getLogToListFunction(List<String> messages)
+  {
+    return (msg, format) -> messages.add(StringUtils.format(msg, format));
+  }
+
+  private Stream<DataSegment> makeDataSegments(int numSegments)
+  {
+    final DateTime start = DateTimes.of("2012-01-01");
+    final DateTime end = DateTimes.of("2012-01-02");
+    final String version = DateTimes.of("2020-02-02").toString();
+    return IntStream.range(0, numSegments)
+                    .mapToObj(segmentNum -> DataSegment.builder()
+                                                       .dataSource("someDataSource")
+                                                       .interval(
+                                                           new Interval(
+                                                               start.plusDays(segmentNum),
+                                                               end.plusDays(segmentNum + 1)
+                                                           )
+                                                       )
+                                                       .version(version)
+                                                       .size(1)
+                                                       .build());
+
   }
 }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthUtils.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthUtils.java
@@ -112,8 +112,8 @@ public class BasicAuthUtils
       return key.getEncoded();
     }
     catch (InvalidKeySpecException ikse) {
-      log.error("WTF? invalid keyspec");
-      throw new RuntimeException("WTF? invalid keyspec", ikse);
+      log.error("Invalid keyspec");
+      throw new RuntimeException("Invalid keyspec", ikse);
     }
     catch (NoSuchAlgorithmException nsae) {
       log.error("%s not supported on this system.", ALGORITHM);

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
@@ -198,7 +198,7 @@ public class CommonCacheNotifier
       );
     }
     catch (MalformedURLException mue) {
-      LOG.error(callerName + ":WTF? Malformed url for DruidNode[%s] and baseUrl[%s]", druidNode, baseUrl);
+      LOG.error(callerName + ": Malformed url for DruidNode[%s] and baseUrl[%s]", druidNode, baseUrl);
 
       throw new RuntimeException(mue);
     }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
@@ -47,7 +47,7 @@ public class GoogleDataSegmentKiller implements DataSegmentKiller
   @Override
   public void kill(DataSegment segment) throws SegmentLoadingException
   {
-    LOG.info("Killing segment [%s]", segment);
+    LOG.info("Killing segment [%s]", segment.getId());
 
     Map<String, Object> loadSpec = segment.getLoadSpec();
     final String bucket = MapUtils.getString(loadSpec, "bucket");

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentMover.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentMover.java
@@ -209,8 +209,10 @@ public class S3DataSegmentMover implements DataSegmentMover
       if (s3Client.doesObjectExist(targetS3Bucket, targetS3Path)) {
         log.info(
             "Not moving file [s3://%s/%s], already present in target location [s3://%s/%s]",
-            s3Bucket, s3Path,
-            targetS3Bucket, targetS3Path
+            s3Bucket,
+            s3Path,
+            targetS3Bucket,
+            targetS3Path
         );
       } else {
         throw new SegmentLoadingException(

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/hadoop/DatasourceIngestionSpec.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/hadoop/DatasourceIngestionSpec.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
@@ -252,7 +253,7 @@ public class DatasourceIngestionSpec
     return "DatasourceIngestionSpec{" +
            "dataSource='" + dataSource + '\'' +
            ", intervals=" + intervals +
-           ", segments=" + segments +
+           ", segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
            ", filter=" + filter +
            ", dimensions=" + dimensions +
            ", metrics=" + metrics +

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/IndexTaskClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/IndexTaskClient.java
@@ -375,7 +375,9 @@ public abstract class IndexTaskClient implements AutoCloseable
           if (headerId != null && !headerId.equals(taskId)) {
             log.warn(
                 "Expected worker to have taskId [%s] but has taskId [%s], will retry in [%d]s",
-                taskId, headerId, TASK_MISMATCH_RETRY_DELAY_SECONDS
+                taskId,
+                headerId,
+                TASK_MISMATCH_RETRY_DELAY_SECONDS
             );
             delay = Duration.standardSeconds(TASK_MISMATCH_RETRY_DELAY_SECONDS);
           } else {
@@ -413,8 +415,11 @@ public abstract class IndexTaskClient implements AutoCloseable
         }
       }
       catch (NoTaskLocationException e) {
-        log.info("No TaskLocation available for task [%s], this task may not have been assigned to a worker yet or "
-                 + "may have already completed", taskId);
+        log.info(
+            "No TaskLocation available for task [%s], this task may not have been assigned to a worker yet "
+            + "or may have already completed",
+            taskId
+        );
         throw e;
       }
       catch (Exception e) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/LocalTaskActionClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/LocalTaskActionClient.java
@@ -57,7 +57,7 @@ public class LocalTaskActionClient implements TaskActionClient
   @Override
   public <RetType> RetType submit(TaskAction<RetType> taskAction)
   {
-    log.info("Performing action for task[%s]: %s", task.getId(), taskAction);
+    log.debug("Performing action for task[%s]: %s", task.getId(), taskAction);
 
     if (auditLogConfig.isEnabled() && taskAction.isAudited()) {
       // Add audit log

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateAction.java
@@ -266,7 +266,11 @@ public class SegmentAllocateAction implements TaskAction<SegmentIdWithShardSpec>
   {
     // Existing segment(s) exist for this row; use the interval of the first one.
     if (!usedSegment.getInterval().contains(rowInterval)) {
-      log.error("The interval of existing segment[%s] doesn't contain rowInterval[%s]", usedSegment, rowInterval);
+      log.error(
+          "The interval of existing segment[%s] doesn't contain rowInterval[%s]",
+          usedSegment.getId(),
+          rowInterval
+      );
       return null;
     } else {
       // If segment allocation failed here, it is highly likely an unrecoverable error. We log here for easier

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -35,6 +35,7 @@ import org.apache.druid.indexing.overlord.SegmentPublishResult;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 
@@ -304,8 +305,8 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
   public String toString()
   {
     return "SegmentTransactionalInsertAction{" +
-           "segmentsToBeOverwritten=" + segmentsToBeOverwritten +
-           ", segments=" + segments +
+           "segmentsToBeOverwritten=" + SegmentUtils.commaSeparatedIdentifiers(segmentsToBeOverwritten) +
+           ", segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
            ", startMetadata=" + startMetadata +
            ", endMetadata=" + endMetadata +
            ", dataSource=" + dataSource +

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -634,7 +634,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
     }
 
     if (spec.getTuningConfig().isLogParseExceptions()) {
-      log.error(pe, "Encountered parse exception: ");
+      log.error(pe, "Encountered parse exception");
     }
 
     if (savedParseExceptions != null) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/ArchiveTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/ArchiveTask.java
@@ -89,7 +89,7 @@ public class ArchiveTask extends AbstractFixedIntervalTask
       if (archivedSegment != null) {
         toolbox.getTaskActionClient().submit(new SegmentMetadataUpdateAction(ImmutableSet.of(archivedSegment)));
       } else {
-        log.info("No action was taken for [%s]", segment);
+        log.info("No action was taken for [%s]", segment.getId());
       }
     }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -285,10 +285,10 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
       if (e instanceof RuntimeException && e.getCause() instanceof InvocationTargetException) {
         InvocationTargetException ite = (InvocationTargetException) e.getCause();
         effectiveException = ite.getCause();
-        log.error(effectiveException, "Got invocation target exception in run(), cause: ");
+        log.error(effectiveException, "Got invocation target exception in run()");
       } else {
         effectiveException = e;
-        log.error(e, "Encountered exception in run():");
+        log.error(e, "Encountered exception in run()");
       }
 
       errorMsg = Throwables.getStackTraceAsString(effectiveException);
@@ -616,7 +616,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
         );
       }
       catch (Exception e) {
-        log.error(e, "Got exception from getTotalMetrics(): ");
+        log.error(e, "Got exception from getTotalMetrics()");
         return null;
       }
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -783,7 +783,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
         }
         catch (ParseException e) {
           if (ingestionSchema.getTuningConfig().isLogParseExceptions()) {
-            log.error(e, "Encountered parse exception: ");
+            log.error(e, "Encountered parse exception");
           }
 
           if (determinePartitionsSavedParseExceptions != null) {
@@ -950,7 +950,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
             buildSegmentsMeters.getUnparseable(),
             buildSegmentsMeters.getThrownAway()
         );
-        log.info("Published segments: %s", SegmentUtils.commaSeparatedIdentifiers(published.getSegments()));
+        log.info("Published [%s] segments", published.getSegments().size());
+        SegmentUtils.logSegments(log::info, published.getSegments(), "Published segments");
 
         toolbox.getTaskReportFileWriter().write(getId(), getTaskCompletionReports());
         return TaskStatus.success(getId());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -950,7 +950,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
             buildSegmentsMeters.getThrownAway()
         );
         log.info("Published [%s] segments", published.getSegments().size());
-        log.infoSegments(published.getSegments(), "Published segments");
+        log.debugSegments(published.getSegments(), "Published segments");
 
         toolbox.getTaskReportFileWriter().write(getId(), getTaskCompletionReports());
         return TaskStatus.success(getId());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -79,7 +79,6 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.IndexSpec;
-import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.indexing.BatchIOConfig;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.IngestionSpec;
@@ -951,7 +950,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
             buildSegmentsMeters.getThrownAway()
         );
         log.info("Published [%s] segments", published.getSegments().size());
-        SegmentUtils.logSegments(log::info, published.getSegments(), "Published segments");
+        log.infoSegments(published.getSegments(), "Published segments");
 
         toolbox.getTaskReportFileWriter().write(getId(), getTaskCompletionReports());
         return TaskStatus.success(getId());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
@@ -191,7 +191,7 @@ public class InputSourceProcessor
     }
 
     if (logParseExceptions) {
-      LOG.error(e, "Encountered parse exception:");
+      LOG.error(e, "Encountered parse exception");
     }
 
     if (buildSegmentsSavedParseExceptions != null) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
@@ -35,7 +35,6 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.aggregation.AggregatorFactory;
-import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.GranularitySpec;
 import org.apache.druid.segment.realtime.appenderator.AppenderatorDriverAddResult;
@@ -156,7 +155,7 @@ public class InputSourceProcessor
                 // If those segments are not pushed here, the remaining available space in appenderator will be kept
                 // small which could lead to smaller segments.
                 final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
-                SegmentUtils.logSegments(LOG::debug, pushed.getSegments(), "Pushed segments");
+                LOG.debugSegments(pushed.getSegments(), "Pushed segments");
               }
             }
           } else {
@@ -175,7 +174,7 @@ public class InputSourceProcessor
       }
 
       final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
-      SegmentUtils.logSegments(LOG::debug, pushed.getSegments(), "Pushed segments");
+      LOG.debugSegments(pushed.getSegments(), "Pushed segments");
 
       return pushed;
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
@@ -156,7 +156,7 @@ public class InputSourceProcessor
                 // If those segments are not pushed here, the remaining available space in appenderator will be kept
                 // small which could lead to smaller segments.
                 final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
-                LOG.debug("Pushed segments: %s", SegmentUtils.commaSeparatedIdentifiers(pushed.getSegments()));
+                SegmentUtils.logSegments(LOG::debug, pushed.getSegments(), "Pushed segments");
               }
             }
           } else {
@@ -175,8 +175,7 @@ public class InputSourceProcessor
       }
 
       final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
-
-      LOG.debug("Pushed segments: %s", SegmentUtils.commaSeparatedIdentifiers(pushed.getSegments()));
+      SegmentUtils.logSegments(LOG::debug, pushed.getSegments(), "Pushed segments");
 
       return pushed;
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/RestoreTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/RestoreTask.java
@@ -92,7 +92,7 @@ public class RestoreTask extends AbstractFixedIntervalTask
       if (restored != null) {
         restoredSegments.add(restored);
       } else {
-        log.info("Segment [%s] did not move, not updating metadata", segment);
+        log.info("Segment [%s] did not move, not updating metadata", segment.getId());
       }
     }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
@@ -287,7 +287,7 @@ public class PartialDimensionDistributionTask extends PerfectRollupWorkerTask
       }
       catch (ParseException e) {
         if (isLogParseExceptions) {
-          LOG.error(e, "Encountered parse exception:");
+          LOG.error(e, "Encountered parse exception");
         }
 
         numParseExceptions++;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -56,7 +56,6 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.aggregation.AggregatorFactory;
-import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.RealtimeIOConfig;
 import org.apache.druid.segment.indexing.granularity.ArbitraryGranularitySpec;
@@ -488,7 +487,7 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
               final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
               pushedSegments.addAll(pushed.getSegments());
               LOG.info("Pushed [%s] segments", pushed.getSegments().size());
-              SegmentUtils.logSegments(LOG::info, pushed.getSegments(), "Pushed segments");
+              LOG.infoSegments(pushed.getSegments(), "Pushed segments");
             }
           } else {
             throw new ISE("Failed to add a row with timestamp[%s]", inputRow.getTimestamp());
@@ -508,7 +507,7 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
       final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
       pushedSegments.addAll(pushed.getSegments());
       LOG.info("Pushed [%s] segments", pushed.getSegments().size());
-      SegmentUtils.logSegments(LOG::info, pushed.getSegments(), "Pushed segments");
+      LOG.infoSegments(pushed.getSegments(), "Pushed segments");
       appenderator.close();
 
       return pushedSegments;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -56,6 +56,7 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.RealtimeIOConfig;
 import org.apache.druid.segment.indexing.granularity.ArbitraryGranularitySpec;
@@ -486,7 +487,8 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
               // which makes the size of segments smaller.
               final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
               pushedSegments.addAll(pushed.getSegments());
-              LOG.info("Pushed segments[%s]", pushed.getSegments());
+              LOG.info("Pushed [%s] segments", pushed.getSegments().size());
+              SegmentUtils.logSegments(LOG::info, pushed.getSegments(), "Pushed segments");
             }
           } else {
             throw new ISE("Failed to add a row with timestamp[%s]", inputRow.getTimestamp());
@@ -505,7 +507,8 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
 
       final SegmentsAndCommitMetadata pushed = driver.pushAllAndClear(pushTimeout);
       pushedSegments.addAll(pushed.getSegments());
-      LOG.info("Pushed segments[%s]", pushed.getSegments());
+      LOG.info("Pushed [%s] segments", pushed.getSegments().size());
+      SegmentUtils.logSegments(LOG::info, pushed.getSegments(), "Pushed segments");
       appenderator.close();
 
       return pushedSegments;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
@@ -184,7 +184,7 @@ public class IngestSegmentFirehoseFactory implements FiniteFirehoseFactory<Input
   @Override
   public Firehose connect(InputRowParser inputRowParser, File temporaryDirectory) throws ParseException
   {
-    log.info(
+    log.debug(
         "Connecting firehose: dataSource[%s], interval[%s], segmentIds[%s]",
         dataSource,
         interval,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -1302,7 +1302,8 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     for (Map.Entry<String, RemoteTaskRunnerWorkItem> entry : runningTasks.entrySet()) {
       if (entry.getValue() == null) {
         log.error(
-            "Huh? null work item for [%s]", entry.getKey()
+            "Huh? null work item for [%s]",
+            entry.getKey()
         );
       } else if (entry.getValue().getWorker() == null) {
         log.error("Huh? no worker for [%s]", entry.getKey());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1023,7 +1023,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
                 sequenceMetadata.getSequenceName(),
                 Preconditions.checkNotNull(publishedSegmentsAndCommitMetadata.getCommitMetadata(), "commitMetadata")
             );
-            SegmentUtils.logSegments(log::info, publishedSegmentsAndCommitMetadata.getSegments(), "Published segments");
+            log.infoSegments(publishedSegmentsAndCommitMetadata.getSegments(), "Published segments");
 
             sequences.remove(sequenceMetadata);
             publishingSequences.remove(sequenceMetadata.getSequenceName());
@@ -1050,8 +1050,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
                           "Failed to hand off %s segments",
                           publishedSegmentsAndCommitMetadata.getSegments().size()
                       );
-                      SegmentUtils.logSegments(
-                          log::warn,
+                      log.warnSegments(
                           publishedSegmentsAndCommitMetadata.getSegments(),
                           "Failed to hand off segments"
                       );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1018,11 +1018,12 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
           public void onSuccess(SegmentsAndCommitMetadata publishedSegmentsAndCommitMetadata)
           {
             log.info(
-                "Published segments %s for sequence [%s] with metadata [%s].",
-                SegmentUtils.commaSeparatedIdentifiers(publishedSegmentsAndCommitMetadata.getSegments()),
+                "Published %s segments for sequence [%s] with metadata [%s].",
+                publishedSegmentsAndCommitMetadata.getSegments().size(),
                 sequenceMetadata.getSequenceName(),
                 Preconditions.checkNotNull(publishedSegmentsAndCommitMetadata.getCommitMetadata(), "commitMetadata")
             );
+            SegmentUtils.logSegments(log::info, publishedSegmentsAndCommitMetadata.getSegments(), "Published segments");
 
             sequences.remove(sequenceMetadata);
             publishingSequences.remove(sequenceMetadata.getSequenceName());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1046,8 +1046,13 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
                   {
                     if (handoffSegmentsAndCommitMetadata == null) {
                       log.warn(
-                          "Failed to hand off segments: %s",
-                          SegmentUtils.commaSeparatedIdentifiers(publishedSegmentsAndCommitMetadata.getSegments())
+                          "Failed to hand off %s segments",
+                          publishedSegmentsAndCommitMetadata.getSegments().size()
+                      );
+                      SegmentUtils.logSegments(
+                          log::warn,
+                          publishedSegmentsAndCommitMetadata.getSegments(),
+                          "Failed to hand off segments"
                       );
                     }
                     handoffFuture.set(handoffSegmentsAndCommitMetadata);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -78,7 +78,6 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.query.aggregation.AggregatorFactory;
-import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.indexing.RealtimeIOConfig;
 import org.apache.druid.segment.realtime.FireDepartment;
 import org.apache.druid.segment.realtime.FireDepartmentMetrics;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -534,7 +534,7 @@ public abstract class WorkerTaskManager
               }
             }
             catch (Exception ex) {
-              log.info(ex, "Exception while getting active tasks from overlord. will retry on next scheduled run.");
+              log.warn(ex, "Exception while getting active tasks from overlord. will retry on next scheduled run.");
 
               if (ex instanceof InterruptedException) {
                 Thread.currentThread().interrupt();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -569,7 +569,7 @@ public abstract class WorkerTaskManager
             }
           }
           catch (Throwable th) {
-            log.error(th, "WTF! Got unknown exception while running the scheduled cleanup.");
+            log.error(th, "Got unknown exception while running the scheduled cleanup.");
           }
         },
         1,

--- a/server/src/main/java/org/apache/druid/client/BrokerServerView.java
+++ b/server/src/main/java/org/apache/druid/client/BrokerServerView.java
@@ -314,7 +314,7 @@ public class BrokerServerView implements TimelineServerView
     synchronized (lock) {
       QueryableDruidServer queryableDruidServer = clients.get(server.getName());
       if (queryableDruidServer == null) {
-        log.error("WTF?! No QueryableDruidServer found for %s", server.getName());
+        log.error("No QueryableDruidServer found for %s", server.getName());
         return null;
       }
       return queryableDruidServer.getQueryRunner();

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -603,7 +603,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
         final QueryRunner serverRunner = serverView.getQueryRunner(server);
 
         if (serverRunner == null) {
-          log.error("Server[%s] doesn't have a query runner", server);
+          log.error("Server[%s] doesn't have a query runner", server.getName());
           return;
         }
 

--- a/server/src/main/java/org/apache/druid/client/DruidServer.java
+++ b/server/src/main/java/org/apache/druid/client/DruidServer.java
@@ -202,7 +202,11 @@ public class DruidServer implements Comparable<DruidServer>
             currSize.addAndGet(segment.getSize());
             totalSegments.incrementAndGet();
           } else {
-            log.warn("Asked to add data segment that already exists!? server[%s], segment[%s]", getName(), segment);
+            log.warn(
+                "Asked to add data segment that already exists!? server[%s], segment[%s]",
+                getName(),
+                segment.getId()
+            );
           }
           return dataSource;
         }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/SegmentPublishResult.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/SegmentPublishResult.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
@@ -116,7 +117,7 @@ public class SegmentPublishResult
   public String toString()
   {
     return "SegmentPublishResult{" +
-           "segments=" + segments +
+           "segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
            ", success=" + success +
            ", errorMsg='" + errorMsg + '\'' +
            '}';

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -161,7 +161,7 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
             () -> {
               try {
                 if (!lifecycleLock.awaitStarted()) {
-                  LOG.error("WTF! lifecycle not started, lookup update notices will not be handled.");
+                  LOG.error("Lifecycle not started, lookup update notices will not be handled.");
                   return;
                 }
 

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -263,7 +263,7 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
         StorageLocation loc = findStorageLocationIfLoaded(segment);
 
         if (loc == null) {
-          log.warn("Asked to cleanup something[%s] that didn't exist.  Skipping.", segment);
+          log.warn("Asked to cleanup something[%s] that didn't exist.  Skipping.", segment.getId());
           return;
         }
 

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
@@ -149,7 +149,10 @@ public class StorageLocation
     if (availableSizeBytes() < segmentSize) {
       log.warn(
           "Segment[%s:%,d] too large for storage[%s:%,d]. Check your druid.segmentCache.locations maxSize param",
-          segmentId, segmentSize, getPath(), availableSizeBytes()
+          segmentId,
+          segmentSize,
+          getPath(),
+          availableSizeBytes()
       );
       return false;
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -1315,7 +1315,8 @@ public class AppenderatorImpl implements Appenderator
       if (indexToPersist.hasSwapped()) {
         log.info(
             "Segment[%s] hydrant[%s] already swapped. Ignoring request to persist.",
-            identifier, indexToPersist
+            identifier,
+            indexToPersist
         );
         return 0;
       }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
@@ -644,13 +644,14 @@ public abstract class BaseAppenderatorDriver implements Closeable
                 segmentsAndCommitMetadata.getSegments().forEach(dataSegmentKiller::killQuietly);
 
                 if (publishResult.getErrorMsg() != null) {
+                  SegmentUtils.logSegments(log::error, ourSegments, "Failed to publish segments");
                   throw new ISE(
-                      "Failed to publish segments because of [%s]: %s",
-                      publishResult.getErrorMsg(),
-                      SegmentUtils.commaSeparatedIdentifiers(ourSegments)
+                      "Failed to publish segments because of [%s]",
+                      publishResult.getErrorMsg()
                   );
                 } else {
-                  throw new ISE("Failed to publish segments: %s", SegmentUtils.commaSeparatedIdentifiers(ourSegments));
+                  SegmentUtils.logSegments(log::error, ourSegments, "Failed to publish segments");
+                  throw new ISE("Failed to publish segments");
                 }
               }
             }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
@@ -657,8 +657,9 @@ public abstract class BaseAppenderatorDriver implements Closeable
           }
           catch (Exception e) {
             // Must not remove segments here, we aren't sure if our transaction succeeded or not.
+            log.noStackTrace().warn(e, "Failed publish");
             SegmentUtils.logSegments(
-                log.noStackTrace()::warn,
+                log::warn,
                 segmentsAndCommitMetadata.getSegments(),
                 "Failed publish, not removing segments"
             );

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
@@ -657,10 +657,10 @@ public abstract class BaseAppenderatorDriver implements Closeable
           }
           catch (Exception e) {
             // Must not remove segments here, we aren't sure if our transaction succeeded or not.
-            log.noStackTrace().warn(
-                e,
-                "Failed publish, not removing segments: %s",
-                SegmentUtils.commaSeparatedIdentifiers(segmentsAndCommitMetadata.getSegments())
+            SegmentUtils.logSegments(
+                log.noStackTrace()::warn,
+                segmentsAndCommitMetadata.getSegments(),
+                "Failed publish, not removing segments"
             );
             Throwables.propagateIfPossible(e);
             throw new RuntimeException(e);

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SegmentsAndCommitMetadata.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SegmentsAndCommitMetadata.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.realtime.appenderator;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
@@ -79,7 +80,7 @@ public class SegmentsAndCommitMetadata
   {
     return getClass().getSimpleName() + "{" +
            "commitMetadata=" + commitMetadata +
-           ", segments=" + segments +
+           ", segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
            '}';
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -686,7 +686,9 @@ public class RealtimePlumber implements Plumber
             if (timestamp > latestCommitTime) {
               log.info(
                   "Found metaData [%s] with latestCommitTime [%s] greater than previous recorded [%s]",
-                  queryableIndex.getMetadata(), timestamp, latestCommitTime
+                  queryableIndex.getMetadata(),
+                  timestamp,
+                  latestCommitTime
               );
               latestCommitTime = timestamp;
               metadata = queryableIndex.getMetadata().get(COMMIT_METADATA_KEY);

--- a/server/src/main/java/org/apache/druid/server/coordinator/CuratorLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CuratorLoadQueuePeon.java
@@ -342,7 +342,9 @@ public class CuratorLoadQueuePeon extends LoadQueuePeon
     if (!ZKPaths.getNodeFromPath(path).equals(segmentHolder.getSegmentIdentifier())) {
       log.warn(
           "Server[%s] entry [%s] was removed even though it's not what is currently loading[%s]",
-          basePath, path, segmentHolder
+          basePath,
+          path,
+          segmentHolder
       );
       return;
     }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/BalanceSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/BalanceSegments.java
@@ -233,7 +233,9 @@ public class BalanceSegments implements CoordinatorDuty
         log.info(
             "Unable to select %d remaining candidate segments out of %d total to balance "
             + "after %d iterations, ending run.",
-            (maxSegmentsToMove - moved - unmoved), maxSegmentsToMove, iter
+            (maxSegmentsToMove - moved - unmoved),
+            maxSegmentsToMove,
+            iter
         );
         break;
       }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -208,10 +208,11 @@ public class CompactSegments implements CoordinatorDuty
             newAutoCompactionContext(config.getTaskContext())
         );
         LOG.info(
-            "Submitted a compactionTask[%s] for segments %s",
+            "Submitted a compactionTask[%s] for %s segments",
             taskId,
-            SegmentUtils.commaSeparatedIdentifiers(segmentsToCompact)
+            segmentsToCompact.size()
         );
+        SegmentUtils.logSegments(LOG::info, segmentsToCompact, "Compacting segments");
         // Count the compaction task itself + its sub tasks
         numSubmittedTasks += findNumMaxConcurrentSubTasks(config.getTuningConfig()) + 1;
       } else {

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -29,7 +29,6 @@ import org.apache.druid.client.indexing.TaskPayloadResponse;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
 import org.apache.druid.server.coordinator.CoordinatorStats;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
@@ -212,7 +211,7 @@ public class CompactSegments implements CoordinatorDuty
             taskId,
             segmentsToCompact.size()
         );
-        SegmentUtils.logSegments(LOG::info, segmentsToCompact, "Compacting segments");
+        LOG.infoSegments(segmentsToCompact, "Compacting segments");
         // Count the compaction task itself + its sub tasks
         numSubmittedTasks += findNumMaxConcurrentSubTasks(config.getTuningConfig()) + 1;
       } else {

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -109,7 +109,9 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String tier, final long count) -> {
           log.info(
               "[%s] : Assigned %s segments among %,d servers",
-              tier, count, cluster.getHistoricalsByTier(tier).size()
+              tier,
+              count,
+              cluster.getHistoricalsByTier(tier).size()
           );
 
           emitTieredStat(emitter, "segment/assigned/count", tier, count);
@@ -121,7 +123,9 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String tier, final long count) -> {
           log.info(
               "[%s] : Dropped %s segments among %,d servers",
-              tier, count, cluster.getHistoricalsByTier(tier).size()
+              tier,
+              count,
+              cluster.getHistoricalsByTier(tier).size()
           );
 
           emitTieredStat(emitter, "segment/dropped/count", tier, count);
@@ -148,7 +152,9 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String tier, final long count) -> {
           log.info(
               "[%s] : Removed %s unneeded segments among %,d servers",
-              tier, count, cluster.getHistoricalsByTier(tier).size()
+              tier,
+              count,
+              cluster.getHistoricalsByTier(tier).size()
           );
           emitTieredStat(emitter, "segment/unneeded/count", tier, count);
         }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
@@ -257,7 +258,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
 
     final CompactionState lastCompactionState = candidates.segments.get(0).getLastCompactionState();
     if (lastCompactionState == null) {
-      log.info("Candidate segment[%s] is not compacted yet. Needs compaction.", candidates.segments.get(0));
+      log.info("Candidate segment[%s] is not compacted yet. Needs compaction.", candidates.segments.get(0).getId());
       return true;
     }
 
@@ -267,7 +268,16 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
         .allMatch(segment -> lastCompactionState.equals(segment.getLastCompactionState()));
 
     if (!allCandidatesHaveSameLastCompactionState) {
-      log.info("Candidates[%s] were compacted with different partitions spec. Needs compaction.", candidates.segments);
+      log.info(
+          "[%s] Candidate segments were compacted with different partitions spec. Needs compaction.",
+          candidates.segments.size()
+      );
+      SegmentUtils.logSegments(
+          log::debug,
+          candidates.segments,
+          "Candidate segments compacted with different partiton spec"
+      );
+
       return true;
     }
 
@@ -275,7 +285,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     if (!(segmentPartitionsSpec instanceof DynamicPartitionsSpec)) {
       log.info(
           "Candidate segment[%s] was compacted with a non dynamic partitions spec. Needs compaction.",
-          candidates.segments.get(0)
+          candidates.segments.get(0).getId()
       );
       return true;
     }
@@ -535,11 +545,6 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
       return segments.isEmpty();
     }
 
-    private int getNumSegments()
-    {
-      return segments.size();
-    }
-
     private long getTotalSize()
     {
       return totalSize;
@@ -549,7 +554,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     public String toString()
     {
       return "SegmentsToCompact{" +
-             "segments=" + segments +
+             "segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
              ", totalSize=" + totalSize +
              '}';
     }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -272,8 +272,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
           "[%s] Candidate segments were compacted with different partitions spec. Needs compaction.",
           candidates.segments.size()
       );
-      SegmentUtils.logSegments(
-          log::debug,
+      log.debugSegments(
           candidates.segments,
           "Candidate segments compacted with different partiton spec"
       );

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
@@ -395,7 +395,7 @@ public abstract class LoadRule implements Rule
       left = dropSegmentFromServers(balancerStrategy, segment, activeServers, left);
     }
     if (left != 0) {
-      log.warn("Wtf, holder was null?  I have no servers serving [%s]?", segment.getId());
+      log.warn("I have no servers serving [%s]?", segment.getId());
     }
     return numToDrop - left;
   }

--- a/server/src/main/java/org/apache/druid/server/router/QueryHostFinder.java
+++ b/server/src/main/java/org/apache/druid/server/router/QueryHostFinder.java
@@ -125,7 +125,7 @@ public class QueryHostFinder
   private Server findServerInner(final Pair<String, Server> selected)
   {
     if (selected == null) {
-      log.error("Danger, Will Robinson! Unable to find any brokers!");
+      log.error("Unable to find any brokers!");
     }
 
     final String serviceName = selected == null ? hostSelector.getDefaultServiceName() : selected.lhs;
@@ -133,7 +133,7 @@ public class QueryHostFinder
 
     if (server == null) {
       log.error(
-          "WTF?! No server found for serviceName[%s]. Using backup",
+          "No server found for serviceName[%s]. Using backup",
           serviceName
       );
 
@@ -141,7 +141,7 @@ public class QueryHostFinder
 
       if (server == null) {
         log.error(
-            "WTF?! No backup found for serviceName[%s]. Using default[%s]",
+            "No backup found for serviceName[%s]. Using default[%s]",
             serviceName,
             hostSelector.getDefaultServiceName()
         );

--- a/server/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
+++ b/server/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
@@ -235,7 +235,7 @@ public class TieredBrokerHostSelector<T>
 
     if (brokerServiceName == null) {
       log.error(
-          "WTF?! No brokerServiceName found for datasource[%s], intervals[%s]. Using default[%s].",
+          "No brokerServiceName found for datasource[%s], intervals[%s]. Using default[%s].",
           query.getDataSource(),
           query.getIntervals(),
           tierConfig.getDefaultBrokerServiceName()
@@ -247,7 +247,7 @@ public class TieredBrokerHostSelector<T>
 
     if (nodesHolder == null) {
       log.error(
-          "WTF?! No nodesHolder found for brokerServiceName[%s]. Using default selector for[%s]",
+          "No nodesHolder found for brokerServiceName[%s]. Using default selector for[%s]",
           brokerServiceName,
           tierConfig.getDefaultBrokerServiceName()
       );

--- a/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -178,7 +178,7 @@ public class PreResponseAuthorizationCheckFilter implements Filter
       outputStream.write(errorJson.getBytes(StandardCharsets.UTF_8));
     }
     catch (IOException ioe) {
-      log.error("WTF? Can't get writer from HTTP response.");
+      log.error("Can't get writer from HTTP response.");
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/security/SecuritySanityCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/SecuritySanityCheckFilter.java
@@ -101,7 +101,7 @@ public class SecuritySanityCheckFilter implements Filter
       outputStream.write(errorJson.getBytes(StandardCharsets.UTF_8));
     }
     catch (IOException ioe) {
-      log.error("WTF? Can't get writer from HTTP response.");
+      log.error("Can't get writer from HTTP response.");
     }
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriverFailTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriverFailTest.java
@@ -239,7 +239,7 @@ public class StreamAppenderatorDriverFailTest extends EasyMockSupport
   {
     expectedException.expect(ExecutionException.class);
     expectedException.expectCause(CoreMatchers.instanceOf(ISE.class));
-    expectedException.expectMessage("Failed to publish segments because of [test]:");
+    expectedException.expectMessage("Failed to publish segments because of [test]");
 
     testFailDuringPublishInternal(false);
   }


### PR DESCRIPTION
### Description
I went through a ton of logs to try and spot places where we could be potentially logging a large number of segments or other unnecessarily large things to try and ensure that logging doesn't ever destroy us, in response to such a thing happening from log containing [`SegmentTransactionalInsertAction.toString`](https://github.com/apache/druid/blob/master/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java#L308) with a very large number of segments (exaggerated by the fact that it was using the whole `DataSegment` rather than the `SegmentId`). To avoid this happening even with `SegmentId`, I added a utility method and set of log methods to `Logger`, dedicated to logging chunks of 64 `SegmentIds` at a time to ensure we will never create a gigantic string to log containing all of the segments no matter how many segments are involved because each message should be sized in the tens of kilobytes.

There remain two areas that exceptions thrown in `SegmentLockHelper`, one in `tryLockSegments` the other in `verifySegmentGranularity` which could I guess create giant strings if you have absurd numbers of segments you are trying to lock, but I was unsure how likely this is to happen and if worth adding a logger here.

I will admit that it is possible this PR is over-correcting, and just ensuring that we always use `commaSeparatedIdentifiers` would be sufficient for all but absurdly large numbers of segments... but I guess does take logs as the culprit out of the equation if we do decide it necessary support such scenarios.

<hr>

This PR has:
- [ ] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.

