### PR TITLE
Make Transform an ExtensionPoint

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/transform/Transform.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/Transform.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.transform;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.guice.annotations.ExtensionPoint;
 
 /**
  * A row transform that is part of a {@link TransformSpec}. Transforms allow adding new fields to input rows. Each
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * they cannot refer to other transforms. And they cannot remove fields, only add them. However, they can shadow a
  * field with another field containing all nulls, which will act similarly to removing the field.
  */
+@ExtensionPoint
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "expression", value = ExpressionTransform.class)


### PR DESCRIPTION
Fixes #9311.

### Description

`Transform` is a useful place for 3rd party developers to add their own extensions. Informally this has been an available extension point since 2017. This PR proposes adding the compatibility guarantees of @ExtensionPoint.

This PR has:
- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.

ToDo:
- [ ] Add documentation changes to https://druid.apache.org/docs/latest/development/modules.html#writing-your-own-extensions

It makes sense to me to add a new item in the list of 15 items under "Writing your own extensions" for completeness sake. I'd be happy to write a dedicated section of these docs, although I think this page seems destined to be split into many pages: one describing the approach for each kind of extension. 