### PR TITLE
fix protobuf extension packaging and docs

### DIFF
--- a/docs/development/extensions-core/protobuf.md
+++ b/docs/development/extensions-core/protobuf.md
@@ -85,7 +85,7 @@ protoc -o /tmp/metrics.desc ./quickstart/protobuf/metrics.proto
 Below is the complete Supervisor spec JSON to be submitted to the Overlord.
 Make sure these keys are properly configured for successful ingestion.
 
-Important superivisor properties
+Important supervisor properties
 - `descriptor` for the descriptor file URL
 - `protoMessageType` from the proto definition
 - `parser` should have `type` set to `protobuf`, but note that the `format` of the `parseSpec` must be `json`
@@ -164,9 +164,9 @@ Important superivisor properties
 }
 ```
 
-## Adding protobuf messages to Kafka
+## Adding Protobuf messages to Kafka
 
-If necessary, from your Kafka installation directory run the following command to create the kafka topic
+If necessary, from your Kafka installation directory run the following command to create the Kafka topic
 
 ```
 ./bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic metrics_pb
@@ -212,7 +212,7 @@ protoc -o metrics.desc metrics.proto
 ```
 
 ### `pb_publisher.py`
-After `metrics_pb2.py` is generated, another script can be constructed to parse JSON data, convert it to protobuf, and produce to a Kafka topic
+After `metrics_pb2.py` is generated, another script can be constructed to parse JSON data, convert it to Protobuf, and produce to a Kafka topic
 
 ```python
 import sys

--- a/docs/development/extensions-core/protobuf.md
+++ b/docs/development/extensions-core/protobuf.md
@@ -74,10 +74,10 @@ message Metrics {
 
 ### Descriptor file
 
-Next, we use the `protoc` Protobuf compiler to generate the descriptor file and save it as `metrics.desc`. The descriptor file must be either in the classpath or reachable by URL.  In this example the descriptor file was saved at `/tmp/metrics.desc`, however this file is also available in the example files.
+Next, we use the `protoc` Protobuf compiler to generate the descriptor file and save it as `metrics.desc`. The descriptor file must be either in the classpath or reachable by URL.  In this example the descriptor file was saved at `/tmp/metrics.desc`, however this file is also available in the example files. From your Druid install directory:
 
 ```
-protoc -o /tmp/metrics.desc metrics.proto
+protoc -o /tmp/metrics.desc ./quickstart/protobuf/metrics.proto
 ```
 
 ## Create Kafka Supervisor
@@ -172,10 +172,10 @@ If necessary, from your Kafka installation directory run the following command t
 ./bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic metrics_pb
 ```
 
-This example script requires `protobuf` and `kafka-python` modules. With the topic in place, messages can be inserted
+This example script requires `protobuf` and `kafka-python` modules. With the topic in place, messages can be inserted running the following command from your Druid installation directory
 
 ```
-../bin/generate-example-metrics | ./pb_publisher.py
+./bin/generate-example-metrics | ./quickstart/protobuf/pb_publisher.py
 ```
 
 You can confirm that data has been inserted to your Kafka topic using the following command from your Kafka installation directory

--- a/docs/development/extensions-core/protobuf.md
+++ b/docs/development/extensions-core/protobuf.md
@@ -215,6 +215,8 @@ protoc -o metrics.desc metrics.proto
 After `metrics_pb2.py` is generated, another script can be constructed to parse JSON data, convert it to Protobuf, and produce to a Kafka topic
 
 ```python
+#!/usr/bin/env python
+
 import sys
 import json
 

--- a/examples/quickstart/protobuf/pb_publisher.py
+++ b/examples/quickstart/protobuf/pb_publisher.py
@@ -32,3 +32,5 @@ for row in iter(sys.stdin):
         setattr(metrics, k, v)
     pb = metrics.SerializeToString()
     producer.send(topic, pb)
+
+producer.flush()

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -109,7 +109,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.1</version>
         <configuration>
-          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
           <relocations>
             <relocation>
               <pattern>com.google.protobuf</pattern>


### PR DESCRIPTION
Fixes #8051.

### Description

This PR fixes `druid-protobuf-extensions` by tweaking how shading is done to not included the jars that are shaded in the packaging.

before:
```
$ ls -1 apache-druid-0.18.0-SNAPSHOT/extensions/druid-protobuf-extensions/
druid-protobuf-extensions-0.18.0-SNAPSHOT.jar
error_prone_annotations-2.3.2.jar
gson-2.8.6.jar
protobuf-dynamic-0.9.3.jar
protobuf-java-3.11.0.jar
protobuf-java-util-3.11.0.jar
```

after:
```
$ ls -1 apache-druid-0.18.0-SNAPSHOT/extensions/druid-protobuf-extensions/
druid-protobuf-extensions-0.18.0-SNAPSHOT.jar
```

I also updated the extension quickstart website docs a bit to make it a bit easier to follow.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] been tested in a test Druid cluster.

