### PR TITLE
Allow overriding default JoinableFactory in SpecificSegmentsQuerySegmentWalker

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -741,7 +741,8 @@ public class CalciteTests
 
     return new SpecificSegmentsQuerySegmentWalker(
         conglomerate,
-        INJECTOR.getInstance(LookupExtractorFactoryContainerProvider.class)
+        INJECTOR.getInstance(LookupExtractorFactoryContainerProvider.class),
+        null
     ).add(
         DataSegment.builder()
                    .dataSource(DATASOURCE1)


### PR DESCRIPTION
This PR adjusts SpecificSegmentsQuerySegmentWalker (used by tests and benchmarks) to allow the caller to provide their own JoinableFactory. 

This is useful for tests/benchmarks where we are not using inline or lookup joins (such as on tables provided through https://github.com/apache/druid/pull/9279)

This PR has:
- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
