### PR TITLE
Optimize TimeExtractionTopNAlgorithm

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/topn/TimeExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TimeExtractionTopNAlgorithm.java
@@ -98,11 +98,10 @@ public class TimeExtractionTopNAlgorithm extends BaseTopNAlgorithm<int[], Map<Co
     while (!cursor.isDone()) {
       final Comparable<?> key = dimensionValueConverter.apply(dimSelector.lookupName(dimSelector.getRow().get(0)));
 
-      Aggregator[] theAggregators = aggregatesStore.get(key);
-      if (theAggregators == null) {
-        theAggregators = makeAggregators(cursor, query.getAggregatorSpecs());
-        aggregatesStore.put(key, theAggregators);
-      }
+      Aggregator[] theAggregators = aggregatesStore.computeIfAbsent(
+          key,
+          k -> makeAggregators(cursor, query.getAggregatorSpecs())
+      );
 
       for (Aggregator aggregator : theAggregators) {
         aggregator.aggregate();


### PR DESCRIPTION
When the time extraction Top N algorithm is looking for aggregators, it makes
2 calls to hashCode on the key. Use Map#computeIfAbsent instead so that the
hashCode is calculated only once