### PR TITLE
Change security vulnerability scan to cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ env:
 # output.  To compensate, use travis_wait to extend the timeout.
 install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
 
+stages:
+  - name: test  # jobs that do not specify a stage get this default value
+    if: type != cron
+  - name: cron
+    if: type = cron
+
 jobs:
   include:
     - name: "animal sniffer checks"
@@ -93,9 +99,8 @@ jobs:
         -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
     - name: "analyze dependencies"
-      script: MAVEN_OPTS='-Xmx3000m' ${MVN} ${MAVEN_SKIP} dependency:analyze -DoutputXML=true -DignoreNonCompile=true -DfailOnWarning=true
-      after_failure: |-
-        echo "FAILURE EXPLANATION:
+      script: |-
+        MAVEN_OPTS='-Xmx3000m' ${MVN} ${MAVEN_SKIP} dependency:analyze -DoutputXML=true -DignoreNonCompile=true -DfailOnWarning=true || { echo "
 
         The dependency analysis has found a dependency that is either:
 
@@ -112,19 +117,8 @@ jobs:
 
         For more information, refer to:
         https://maven.apache.org/plugins/maven-dependency-plugin/analyze-mojo.html
-        "
 
-    - name: "security vulnerabilities"
-      install: skip
-      script: ${MVN} dependency-check:check
-      after_failure: |-
-        echo "FAILURE EXPLANATION:
-
-        The OWASP dependency check has found security vulnerabilities. Please use a newer version
-        of the dependency that does not have vulenerabilities. If the analysis has false positives,
-        they can be suppressed by adding entries to owasp-dependency-check-suppressions.xml (for more
-        information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).
-        "
+        " && false; }
 
     - &package
       name: "(openjdk8) packaging check"
@@ -259,9 +253,8 @@ jobs:
 
     - name: "docs"
       install: (cd website && npm install)
-      script: (cd website && npm run lint && npm run spellcheck)
-      after_failure: |-
-        echo "FAILURE EXPLANATION:
+      script: |-
+        (cd website && npm run lint && npm run spellcheck) || { echo "
 
         If there are spell check errors:
 
@@ -272,7 +265,8 @@ jobs:
         2) Running Spell Check Locally: cd website && npm install && npm run spellcheck
 
         For more information, refer to: https://www.npmjs.com/package/markdown-spellcheck
-        "
+
+        " && false; }
 
     - &integration_batch_index
       name: "batch index integration test"
@@ -324,3 +318,29 @@ jobs:
       env: TESTNG_GROUPS='-DexcludedGroups=batch-index,perfect-rollup-parallel-batch-index,kafka-index,query,realtime-index'
       script: *run_integration_test
       after_failure: *integration_test_diags
+
+    - name: "security vulnerabilities"
+      stage: cron
+      install: skip
+      script: |-
+        ${MVN} dependency-check:check || { echo "
+
+        The OWASP dependency check has found security vulnerabilities. Please use a newer version
+        of the dependency that does not have vulnerabilities. If the analysis has false positives,
+        they can be suppressed by adding entries to owasp-dependency-check-suppressions.xml (for more
+        information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).
+
+        " && false; }
+
+# Travis CI only supports per build (and not per-job notifications): https://github.com/travis-ci/travis-ci/issues/9888
+notifications:
+  email:
+    if: type = cron
+    recipients:
+      # This is the string "dev@druid.apache.org" encrypted against the apache/druid repo so that forks are unable to
+      # use this notification:
+      # https://github.com/travis-ci/travis-ci/issues/1094#issuecomment-215019909
+      # https://github.com/travis-ci/travis-ci/issues/2711
+      - secure: "MupjX/0jLwh3XzHPl74BTk2/Kp5r+8TrEewfRhpQdWKFMBXLKNqu0k2VXf5C/NIg3uvPianq3REk+qeTHI8dL2ShjiWS/eIRkJOHLfObdNNBuos5fo4TxAuBQcXyT4VjAq5jnAkH84Pxf2Nl0rkisWoIhvwSX7+kNrjW1qdu7K0="
+    on_success: change
+    on_failure: change

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
         <zookeeper.version>3.4.14</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
         <com.google.apis.client.version>1.22.0</com.google.apis.client.version>
+
+        <dependency-check-maven.version>5.3.0</dependency-check-maven.version>
+        <dependency-check-maven.failBuildOnCVSS>7</dependency-check-maven.failBuildOnCVSS>
+
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
@@ -1507,10 +1511,10 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.2.4</version>
+                <version>${dependency-check-maven.version}</version>
                 <configuration>
                     <cveValidForHours>24</cveValidForHours>
-                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                    <failBuildOnCVSS>${dependency-check-maven.failBuildOnCVSS}</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
                     <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
@@ -1906,6 +1910,26 @@
                                 <phase>none</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.owasp</groupId>
+                      <artifactId>dependency-check-maven</artifactId>
+                      <version>${dependency-check-maven.version}</version>
+                      <configuration>
+                          <cveValidForHours>24</cveValidForHours>
+                          <failBuildOnCVSS>${dependency-check-maven.failBuildOnCVSS}</failBuildOnCVSS>
+                          <skipProvidedScope>true</skipProvidedScope>
+                          <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
+                          <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
+                      </configuration>
+                      <executions>
+                          <execution>
+                              <phase>compile</phase>
+                              <goals>
+                                  <goal>check</goal>
+                              </goals>
+                          </execution>
+                      </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,6 @@
         <checkerframework.version>2.5.7</checkerframework.version>
         <com.google.apis.client.version>1.22.0</com.google.apis.client.version>
 
-        <dependency-check-maven.version>5.3.0</dependency-check-maven.version>
-        <dependency-check-maven.failBuildOnCVSS>7</dependency-check-maven.failBuildOnCVSS>
-
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
@@ -1511,10 +1508,10 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>${dependency-check-maven.version}</version>
+                <version>5.3.0</version>
                 <configuration>
                     <cveValidForHours>24</cveValidForHours>
-                    <failBuildOnCVSS>${dependency-check-maven.failBuildOnCVSS}</failBuildOnCVSS>
+                    <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
                     <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
@@ -1914,14 +1911,6 @@
                     <plugin>
                       <groupId>org.owasp</groupId>
                       <artifactId>dependency-check-maven</artifactId>
-                      <version>${dependency-check-maven.version}</version>
-                      <configuration>
-                          <cveValidForHours>24</cveValidForHours>
-                          <failBuildOnCVSS>${dependency-check-maven.failBuildOnCVSS}</failBuildOnCVSS>
-                          <skipProvidedScope>true</skipProvidedScope>
-                          <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
-                          <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
-                      </configuration>
                       <executions>
                           <execution>
                               <phase>compile</phase>


### PR DESCRIPTION
### Description

Previously, when new CVEs were reported, the security vulnerability scan would unfortunately block PRs that did not modify any dependencies. To prevent this issue, the security scan is now run as a Travis cron job that runs on master and notifies the druid dev list if it fails. The security scan has also been added to the "apache-release" maven profile, to ensure that it passes before a release.

Also adjusted some Travis CI job failure help messages to not be folded in the Travis CI job logs.

After this PR is merged, I'll update the Apache Druid Travis CI settings to run a daily cronjob on master (which will run just the security scan job).

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been manually tested in my fork: https://github.com/ccaominh/druid
