### PR TITLE
Mark redundant casts as error in inspection

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -151,6 +151,7 @@
     <inspection_tool class="OverwrittenKey" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="RedundantCast" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantStringOperation" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantThrows" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantTypeArguments" enabled="true" level="ERROR" enabled_by_default="true" />

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/FloatCompressionBenchmarkFileGenerator.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/FloatCompressionBenchmarkFileGenerator.java
@@ -136,7 +136,7 @@ public class FloatCompressionBenchmarkFileGenerator
       dataFile.delete();
       try (Writer writer = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8)) {
         for (int i = 0; i < ROW_NUM; i++) {
-          writer.write((Float) entry.getValue().generateRowValue() + "\n");
+          writer.write(entry.getValue().generateRowValue() + "\n");
         }
       }
     }

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/datagen/BenchmarkColumnValueGenerator.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/datagen/BenchmarkColumnValueGenerator.java
@@ -184,7 +184,7 @@ public class BenchmarkColumnValueGenerator
           cardinality = schema.getEndInt() - startInt;
           ZipfDistribution zipf = new ZipfDistribution(cardinality, schema.getZipfExponent());
           for (int i = 0; i < cardinality; i++) {
-            probabilities.add(new Pair<>((Object) (i + startInt), zipf.probability(i)));
+            probabilities.add(new Pair<>(i + startInt, zipf.probability(i)));
           }
         } else {
           cardinality = enumeratedValues.size();

--- a/core/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
@@ -145,7 +145,7 @@ public class DefineClassUtils
     // set offset argument to 0, modifying the methodHandle as follows:
     // defineClass = (String className, byte[] byteCode, int length, Class targetClass) ->
     //   defineClass(className, byteCode, 0, length, targetClass)
-    defineClass = MethodHandles.insertArguments(defineClass, 2, (int) 0);
+    defineClass = MethodHandles.insertArguments(defineClass, 2, 0);
 
     // JDK8 does not implement MethodHandles.arrayLength so we have to roll our own
     MethodHandle arrayLength = lookup.findStatic(

--- a/core/src/main/java/org/apache/druid/java/util/metrics/AllocationMetricCollector.java
+++ b/core/src/main/java/org/apache/druid/java/util/metrics/AllocationMetricCollector.java
@@ -61,7 +61,7 @@ class AllocationMetricCollector
     try {
       long[] allThreadIds = threadMXBean.getAllThreadIds();
       // the call time depends on number of threads, for 500 threads the estimated time is 4 ms
-      long[] bytes = (long[]) getThreadAllocatedBytes.invoke(threadMXBean, (Object) allThreadIds);
+      long[] bytes = (long[]) getThreadAllocatedBytes.invoke(threadMXBean, allThreadIds);
       long sum = 0;
       Long2LongMap newResults = new Long2LongOpenHashMap();
       newResults.defaultReturnValue(NO_DATA);

--- a/core/src/main/java/org/apache/druid/java/util/metrics/AllocationMetricCollectors.java
+++ b/core/src/main/java/org/apache/druid/java/util/metrics/AllocationMetricCollectors.java
@@ -39,7 +39,7 @@ class AllocationMetricCollectors
       threadMXBean = ManagementFactory.getThreadMXBean();
       getThreadAllocatedBytes = threadMXBean.getClass().getMethod("getThreadAllocatedBytes", long[].class);
       getThreadAllocatedBytes.setAccessible(true);
-      getThreadAllocatedBytes.invoke(threadMXBean, (Object) threadMXBean.getAllThreadIds());
+      getThreadAllocatedBytes.invoke(threadMXBean, threadMXBean.getAllThreadIds());
       initialized = true;
     }
     catch (Exception e) {

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregator.java
@@ -70,12 +70,12 @@ public class DistinctCountAggregator implements Aggregator
   @Override
   public long getLong()
   {
-    return (long) mutableBitmap.size();
+    return mutableBitmap.size();
   }
 
   @Override
   public double getDouble()
   {
-    return (double) mutableBitmap.size();
+    return mutableBitmap.size();
   }
 }

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/NoopDistinctCountBufferAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/NoopDistinctCountBufferAggregator.java
@@ -66,7 +66,7 @@ public final class NoopDistinctCountBufferAggregator implements BufferAggregator
   @Override
   public long getLong(ByteBuffer buf, int position)
   {
-    return (long) 0;
+    return 0;
   }
 
   @Override

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/MomentSketchComplexMetricSerde.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/MomentSketchComplexMetricSerde.java
@@ -57,7 +57,7 @@ public class MomentSketchComplexMetricSerde extends ComplexMetricSerde
       @Override
       public Object extractValue(final InputRow inputRow, final String metricName)
       {
-        return (MomentSketchWrapper) inputRow.getRaw(metricName);
+        return inputRow.getRaw(metricName);
       }
     };
   }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/Histogram.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/Histogram.java
@@ -32,7 +32,7 @@ public class Histogram
   {
     double[] retVal = new double[breaks.length];
     for (int i = 0; i < breaks.length; ++i) {
-      retVal[i] = (double) breaks[i];
+      retVal[i] = breaks[i];
     }
 
     this.breaks = retVal;

--- a/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcStructConverter.java
+++ b/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcStructConverter.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.ShortWritable;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.mapred.OrcList;
@@ -115,7 +114,7 @@ class OrcStructConverter
       case STRING:
       case CHAR:
       case VARCHAR:
-        return ((Text) field).toString();
+        return field.toString();
       case BOOLEAN:
         return ((BooleanWritable) field).get();
       case BYTE:

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopyStringInputRowParser.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopyStringInputRowParser.java
@@ -47,7 +47,7 @@ public class HadoopyStringInputRowParser implements InputRowParser<Object>
   public List<InputRow> parseBatch(Object input)
   {
     if (input instanceof Text) {
-      return ImmutableList.of(parser.parse(((Text) input).toString()));
+      return ImmutableList.of(parser.parse(input.toString()));
     } else if (input instanceof BytesWritable) {
       BytesWritable valueBytes = (BytesWritable) input;
       return parser.parseBatch(ByteBuffer.wrap(valueBytes.getBytes(), 0, valueBytes.getLength()));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/RealtimeIndexTask.java
@@ -357,7 +357,7 @@ public class RealtimeIndexTask extends AbstractTask
 
     LookupNodeService lookupNodeService = getContextValue(CTX_KEY_LOOKUP_TIER) == null ?
                                           toolbox.getLookupNodeService() :
-                                          new LookupNodeService((String) getContextValue(CTX_KEY_LOOKUP_TIER));
+                                          new LookupNodeService(getContextValue(CTX_KEY_LOOKUP_TIER));
     DiscoveryDruidNode discoveryDruidNode = new DiscoveryDruidNode(
         toolbox.getDruidNode(),
         NodeRole.PEON,

--- a/processing/src/main/java/org/apache/druid/query/aggregation/Aggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/Aggregator.java
@@ -50,7 +50,7 @@ public interface Aggregator extends Closeable
    */
   default double getDouble()
   {
-    return (double) getFloat();
+    return getFloat();
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/BufferAggregator.java
@@ -148,7 +148,7 @@ public interface BufferAggregator extends HotLoopCallee
    */
   default double getDouble(ByteBuffer buf, int position)
   {
-    return (double) getFloat(buf, position);
+    return getFloat(buf, position);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregator.java
@@ -67,7 +67,7 @@ public class FloatMaxAggregator implements Aggregator
   @Override
   public double getDouble()
   {
-    return (double) max;
+    return max;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregator.java
@@ -67,7 +67,7 @@ public class FloatMinAggregator implements Aggregator
   @Override
   public double getDouble()
   {
-    return (double) min;
+    return min;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregator.java
@@ -80,7 +80,7 @@ public class FloatSumAggregator implements Aggregator
   @Override
   public double getDouble()
   {
-    return (double) sum;
+    return sum;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatBufferAggregator.java
@@ -64,7 +64,7 @@ public abstract class SimpleFloatBufferAggregator implements BufferAggregator
   @Override
   public double getDouble(ByteBuffer buffer, int position)
   {
-    return (double) buffer.getFloat(position);
+    return buffer.getFloat(position);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregator.java
@@ -74,7 +74,7 @@ public class FloatAnyAggregator implements Aggregator
   @Override
   public double getDouble()
   {
-    return (double) foundValue;
+    return foundValue;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyBufferAggregator.java
@@ -82,7 +82,7 @@ public class FloatAnyBufferAggregator implements BufferAggregator
   @Override
   public double getDouble(ByteBuffer buf, int position)
   {
-    return (double) buf.getFloat(position + Byte.BYTES);
+    return buf.getFloat(position + Byte.BYTES);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
@@ -198,7 +198,7 @@ public class DoubleFirstAggregatorFactory extends AggregatorFactory
           @Override
           public void aggregate(ByteBuffer buf, int position)
           {
-            SerializablePair<Long, Double> pair = (SerializablePair<Long, Double>) selector.getObject();
+            SerializablePair<Long, Double> pair = selector.getObject();
             long firstTime = buf.getLong(position);
             if (pair.lhs < firstTime) {
               if (pair.rhs != null) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
@@ -105,7 +105,7 @@ public class FinalizingFieldAccessPostAggregator implements PostAggregator
       theComparator = aggregators.get(fieldName).getComparator();
     } else {
       //noinspection unchecked
-      theComparator = (Comparator) Comparators.naturalNullsFirst();
+      theComparator = Comparators.naturalNullsFirst();
     }
 
     if (aggregators != null && aggregators.containsKey(fieldName)) {

--- a/processing/src/main/java/org/apache/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/BoundDimFilter.java
@@ -532,9 +532,10 @@ public class BoundDimFilter implements DimFilter
             hasUpperFloatBound,
             lowerStrict,
             upperStrict,
-            (double) lowerFloatBound,
-            (double) upperFloatBound);
-        return druidDoublePredicate.applyDouble((double) input);
+            lowerFloatBound,
+            upperFloatBound
+        );
+        return druidDoublePredicate.applyDouble(input);
       };
     }
   }

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryEngine.java
@@ -257,7 +257,7 @@ public class GroupByQueryEngine
         int max
     )
     {
-      this.nextVal = (long) start;
+      this.nextVal = start;
       this.increments = increments;
 
       int theIncrement = 0;

--- a/processing/src/main/java/org/apache/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -297,7 +297,7 @@ public class DefaultLimitSpec implements LimitSpec
     }
 
     //noinspection unchecked
-    return ordering != null ? ordering : (Ordering) Ordering.allEqual();
+    return ordering != null ? ordering : Ordering.allEqual();
   }
 
   private <T> Ordering<ResultRow> metricOrdering(final int column, final Comparator<T> comparator)

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
@@ -185,7 +185,7 @@ public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, Sca
         result -> {
           // Generics? Where we're going, we don't need generics.
           final List rows = (List) result.getEvents();
-          final Iterable arrays = Iterables.transform(rows, (Function) mapper);
+          final Iterable arrays = Iterables.transform(rows, mapper);
           return Sequences.simple(arrays);
         }
     );

--- a/processing/src/main/java/org/apache/druid/query/search/SearchQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/search/SearchQueryQueryToolChest.java
@@ -281,7 +281,7 @@ public class SearchQueryQueryToolChest extends QueryToolChest<Result<SearchResul
                                    String val;
                                    Integer count;
                                    if (input instanceof Map) {
-                                     dim = outputNameMap.get((String) ((Map) input).get("dimension"));
+                                     dim = outputNameMap.get(((Map) input).get("dimension"));
                                      val = (String) ((Map) input).get("value");
                                      count = (Integer) ((Map) input).get("count");
                                    } else if (input instanceof SearchHit) {

--- a/processing/src/main/java/org/apache/druid/segment/vector/BaseFloatVectorValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/BaseFloatVectorValueSelector.java
@@ -79,7 +79,7 @@ public abstract class BaseFloatVectorValueSelector implements VectorValueSelecto
 
     final float[] floatVector = getFloatVector();
     for (int i = 0; i < getCurrentVectorSize(); i++) {
-      doubleVector[i] = (double) floatVector[i];
+      doubleVector[i] = floatVector[i];
     }
 
     doubleId = offset.getId();

--- a/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
+++ b/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
@@ -236,7 +236,7 @@ public class CuratorDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvide
     {
       boolean nodeViewInitialized;
       try {
-        nodeViewInitialized = cacheInitialized.await((long) 30, TimeUnit.SECONDS);
+        nodeViewInitialized = cacheInitialized.await(30, TimeUnit.SECONDS);
       }
       catch (InterruptedException ex) {
         Thread.currentThread().interrupt();

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -439,8 +439,8 @@ public class DataSourcesResource
         if (intervalFilter.test(dataSegment.getInterval())) {
           Map<SimpleProperties, Object> properties =
               statsPerInterval.computeIfAbsent(dataSegment.getInterval(), i -> new EnumMap<>(SimpleProperties.class));
-          properties.merge(SimpleProperties.size, dataSegment.getSize(), (a, b) -> (Long) a + (Long) b);
-          properties.merge(SimpleProperties.count, 1, (a, b) -> (Integer) a + (Integer) b);
+          properties.merge(SimpleProperties.size, dataSegment.getSize(), (a, b) -> a + b);
+          properties.merge(SimpleProperties.count, 1, (a, b) -> a + b);
         }
       }
 

--- a/server/src/main/java/org/apache/druid/server/http/TiersResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/TiersResource.java
@@ -108,8 +108,8 @@ public class TiersResource
             Map<IntervalProperties, Object> properties = tierToStatsPerInterval
                 .computeIfAbsent(dataSegment.getDataSource(), dsName -> new HashMap<>())
                 .computeIfAbsent(dataSegment.getInterval(), interval -> new EnumMap<>(IntervalProperties.class));
-            properties.merge(IntervalProperties.size, dataSegment.getSize(), (a, b) -> (Long) a + (Long) b);
-            properties.merge(IntervalProperties.count, 1, (a, b) -> (Integer) a + (Integer) b);
+            properties.merge(IntervalProperties.size, dataSegment.getSize(), (a, b) -> a + b);
+            properties.merge(IntervalProperties.count, 1, (a, b) -> a + b);
           }
         }
       }


### PR DESCRIPTION
This makes the code less verbose, therefore easier to read.