### PR TITLE
Fix handling for columns that appear multiple times in join conditions

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/ColumnProcessors.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnProcessors.java
@@ -79,9 +79,9 @@ public class ColumnProcessors
       final ColumnSelectorFactory selectorFactory
   )
   {
-    if (expr.getIdentifierIfIdentifier() != null) {
+    if (expr.getBindingIfIdentifier() != null) {
       // If expr is an identifier, treat this the same way as a direct column reference.
-      return makeProcessor(expr.getIdentifierIfIdentifier(), processorFactory, selectorFactory);
+      return makeProcessor(expr.getBindingIfIdentifier(), processorFactory, selectorFactory);
     } else {
       return makeProcessorInternal(
           factory -> exprTypeHint,

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
@@ -113,9 +113,9 @@ public class JoinConditionAnalysis
 
         if (isLeftExprAndRightColumn(lhs, rhs, rightPrefix)) {
           // rhs is a right-hand column; lhs is an expression solely of the left-hand side.
-          equiConditions.add(new Equality(lhs, rhs.getIdentifierIfIdentifier().substring(rightPrefix.length())));
+          equiConditions.add(new Equality(lhs, rhs.getBindingIfIdentifier().substring(rightPrefix.length())));
         } else if (isLeftExprAndRightColumn(rhs, lhs, rightPrefix)) {
-          equiConditions.add(new Equality(rhs, lhs.getIdentifierIfIdentifier().substring(rightPrefix.length())));
+          equiConditions.add(new Equality(rhs, lhs.getBindingIfIdentifier().substring(rightPrefix.length())));
         } else {
           nonEquiConditions.add(childExpr);
         }
@@ -128,8 +128,8 @@ public class JoinConditionAnalysis
   private static boolean isLeftExprAndRightColumn(final Expr a, final Expr b, final String rightPrefix)
   {
     return a.analyzeInputs().getRequiredBindings().stream().noneMatch(c -> Joinables.isPrefixedBy(c, rightPrefix))
-           && b.getIdentifierIfIdentifier() != null
-           && Joinables.isPrefixedBy(b.getIdentifierIfIdentifier(), rightPrefix);
+           && b.getBindingIfIdentifier() != null
+           && Joinables.isPrefixedBy(b.getBindingIfIdentifier(), rightPrefix);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
@@ -99,8 +99,6 @@ public class JoinFilterAnalyzer
     // build the prefix and equicondition maps
     // We should check that the prefixes do not duplicate or shadow each other. This is not currently implemented,
     // but this is tracked at https://github.com/apache/druid/issues/9329
-    // We should also consider the case where one RHS column is joined to multiple columns:
-    // https://github.com/apache/druid/issues/9328
     Map<String, Set<Expr>> equiconditions = new HashMap<>();
     Map<String, JoinableClause> prefixes = new HashMap<>();
     for (JoinableClause clause : hashJoinSegmentStorageAdapter.getClauses()) {

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterColumnCorrelationAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterColumnCorrelationAnalysis.java
@@ -21,7 +21,9 @@ package org.apache.druid.segment.join.filter;
 
 import org.apache.druid.math.expr.Expr;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Represents an analysis of what base table columns, if any, can be correlated with a column that will
@@ -38,13 +40,14 @@ public class JoinFilterColumnCorrelationAnalysis
 
   public JoinFilterColumnCorrelationAnalysis(
       String joinColumn,
-      List<String> baseColumns,
-      List<Expr> baseExpressions
+      Set<String> baseColumns,
+      Set<Expr> baseExpressions
   )
   {
     this.joinColumn = joinColumn;
-    this.baseColumns = baseColumns;
-    this.baseExpressions = baseExpressions;
+    this.baseColumns = new ArrayList<>(baseColumns);
+    this.baseExpressions = new ArrayList<>(baseExpressions);
+    this.baseColumns.sort(String.CASE_INSENSITIVE_ORDER);
   }
 
   public String getJoinColumn()

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -47,7 +47,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_getInterval_factToCountry()
   {
     Assert.assertEquals(
-        Intervals.of("2015-09-12/2015-09-12T04:43:40.060Z"),
+        Intervals.of("2015-09-12/2015-09-12T05:21:00.060Z"),
         makeFactToCountrySegment().getInterval()
     );
   }
@@ -88,7 +88,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_getDimensionCardinality_factToCountryFactColumn()
   {
     Assert.assertEquals(
-        17,
+        18,
         makeFactToCountrySegment().getDimensionCardinality("countryIsoCode")
     );
   }
@@ -97,7 +97,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_getDimensionCardinality_factToCountryJoinColumn()
   {
     Assert.assertEquals(
-        17,
+        18,
         makeFactToCountrySegment().getDimensionCardinality(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName")
     );
   }
@@ -133,7 +133,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_getMaxTime_factToCountry()
   {
     Assert.assertEquals(
-        DateTimes.of("2015-09-12T04:43:40.059Z"),
+        DateTimes.of("2015-09-12T05:21:00.059Z"),
         makeFactToCountrySegment().getMaxTime()
     );
   }
@@ -268,7 +268,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_getMaxIngestedEventTime_factToCountry()
   {
     Assert.assertEquals(
-        DateTimes.of("2015-09-12T04:43:40.059Z"),
+        DateTimes.of("2015-09-12T05:21:00.059Z"),
         makeFactToCountrySegment().getMaxIngestedEventTime()
     );
   }
@@ -341,7 +341,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Gabinete Ministerial de Rafael Correa", "EC", "EC", "Ecuador", 4L},
             new Object[]{"Old Anatolian Turkish", "US", "US", "United States", 13L},
             new Object[]{"Cream Soda", "SU", "SU", "States United", 15L},
-            new Object[]{"Orange Soda", "MatchNothing", null, null, NULL_COUNTRY}
+            new Object[]{"Orange Soda", "MatchNothing", null, null, NULL_COUNTRY},
+            new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems", 205L}
         )
     );
   }
@@ -390,7 +391,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Алиса в Зазеркалье", "NO", "NO", "Norway", 11L},
             new Object[]{"Gabinete Ministerial de Rafael Correa", "EC", "EC", "Ecuador", 4L},
             new Object[]{"Old Anatolian Turkish", "US", "US", "United States", 13L},
-            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L}
+            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L},
+            new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems", 205L}
         )
     );
   }
@@ -438,7 +440,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Алиса в Зазеркалье", "NO", "NO", "Norway"},
             new Object[]{"Gabinete Ministerial de Rafael Correa", "EC", "EC", "Ecuador"},
             new Object[]{"Old Anatolian Turkish", "US", "US", "United States"},
-            new Object[]{"Cream Soda", "SU", "SU", "States United"}
+            new Object[]{"Cream Soda", "SU", "SU", "States United"},
+            new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems"}
         )
     );
   }
@@ -480,7 +483,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Giusy Ferreri discography", "IT", "IT", "Italy", 7L},
             new Object[]{"Roma-Bangkok", "IT", "IT", "Italy", 7L},
             new Object[]{"Old Anatolian Turkish", "US", "US", "United States", 13L},
-            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L}
+            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L},
+            new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems", 205L}
         ) :
         ImmutableList.of(
             new Object[]{"Talk:Oswald Tilghman", null, "AU", "Australia", 0L},
@@ -494,7 +498,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Giusy Ferreri discography", "IT", "IT", "Italy", 7L},
             new Object[]{"Roma-Bangkok", "IT", "IT", "Italy", 7L},
             new Object[]{"Old Anatolian Turkish", "US", "US", "United States", 13L},
-            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L}
+            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L},
+            new Object[][]{new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems", 205L}}
         )
     );
   }
@@ -534,7 +539,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Giusy Ferreri discography", "IT", "Italy"},
             new Object[]{"Roma-Bangkok", "IT", "Italy"},
             new Object[]{"Old Anatolian Turkish", "US", "United States"},
-            new Object[]{"Cream Soda", "SU", "States United"}
+            new Object[]{"Cream Soda", "SU", "States United"},
+            new Object[]{"History of Fourems", "MMMM", "Fourems"}
         ) :
         ImmutableList.of(
             new Object[]{"Talk:Oswald Tilghman", null, "Australia"},
@@ -548,7 +554,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Giusy Ferreri discography", "IT", "Italy"},
             new Object[]{"Roma-Bangkok", "IT", "Italy"},
             new Object[]{"Old Anatolian Turkish", "US", "United States"},
-            new Object[]{"Cream Soda", "SU", "States United"}
+            new Object[]{"Cream Soda", "SU", "States United"},
+            new Object[][]{new Object[]{"History of Fourems", "MMMM", "Fourems"}}
         )
     );
   }
@@ -800,7 +807,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Алиса в Зазеркалье", "NO", "NO", "Norway", 11L},
             new Object[]{"Gabinete Ministerial de Rafael Correa", "EC", "EC", "Ecuador", 4L},
             new Object[]{"Old Anatolian Turkish", "US", "US", "United States", 13L},
-            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L}
+            new Object[]{"Cream Soda", "SU", "SU", "States United", 15L},
+            new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems", 205L}
         )
     );
   }
@@ -856,7 +864,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Gabinete Ministerial de Rafael Correa", "Provincia del Guayas", "Ecuador"},
             new Object[]{"Old Anatolian Turkish", "Virginia", "United States"},
             new Object[]{"Cream Soda", "Ainigriv", "States United"},
-            new Object[]{"Orange Soda", null, null}
+            new Object[]{"Orange Soda", null, null},
+            new Object[]{"History of Fourems", "Fourems Province", "Fourems"}
         )
     );
   }
@@ -908,7 +917,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Diskussion:Sebastian Schulz", "United States"},
             new Object[]{"Diskussion:Sebastian Schulz", "Atlantis"},
             new Object[]{"Diskussion:Sebastian Schulz", "States United"},
-            new Object[]{"Diskussion:Sebastian Schulz", "Usca"}
+            new Object[]{"Diskussion:Sebastian Schulz", "Usca"},
+            new Object[]{"Diskussion:Sebastian Schulz", "Fourems"}
         )
     );
   }
@@ -996,7 +1006,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Diskussion:Sebastian Schulz", "United States"},
             new Object[]{"Diskussion:Sebastian Schulz", "Atlantis"},
             new Object[]{"Diskussion:Sebastian Schulz", "States United"},
-            new Object[]{"Diskussion:Sebastian Schulz", "Usca"}
+            new Object[]{"Diskussion:Sebastian Schulz", "Usca"},
+            new Object[]{"Diskussion:Sebastian Schulz", "Fourems"}
         )
     );
   }

--- a/processing/src/test/java/org/apache/druid/segment/join/table/RowBasedIndexedTableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/RowBasedIndexedTableTest.java
@@ -93,7 +93,7 @@ public class RowBasedIndexedTableTest
   @Test
   public void test_numRows_countries()
   {
-    Assert.assertEquals(17, countriesTable.numRows());
+    Assert.assertEquals(18, countriesTable.numRows());
   }
 
   @Test

--- a/processing/src/test/resources/wikipedia/countries.json
+++ b/processing/src/test/resources/wikipedia/countries.json
@@ -15,3 +15,4 @@
 {"countryNumber":14,"countryIsoCode":"AX","countryName":"Atlantis"}
 {"countryNumber":15,"countryIsoCode":"SU","countryName":"States United"}
 {"countryNumber":16,"countryIsoCode":"USCA","countryName":"Usca"}
+{"countryNumber":205,"countryIsoCode":"MMMM","countryName":"Fourems"}

--- a/processing/src/test/resources/wikipedia/data.json
+++ b/processing/src/test/resources/wikipedia/data.json
@@ -26,3 +26,4 @@
 {"time":"2015-09-12T02:33:40.059Z","channel":"#en.wikipedia","regionIsoCode":"VA","countryNumber":13,"countryIsoCode":"US","user":"68.100.166.227","delta":14,"isRobot":false,"isAnonymous":true,"page":"Old Anatolian Turkish","namespace":"Main"}
 {"time":"2015-09-12T03:43:40.059Z","channel":"#en.wikipedia","regionIsoCode":"AV","countryNumber":15,"countryIsoCode":"SU","user":"68.100.166.227","delta":14,"isRobot":false,"isAnonymous":true,"page":"Cream Soda","namespace":"Main"}
 {"time":"2015-09-12T04:43:40.059Z","channel":"#en.wikipedia","regionIsoCode":"MatchNothing","countryNumber":99,"countryIsoCode":"MatchNothing","user":"68.100.166.227","delta":14,"isRobot":false,"isAnonymous":true,"page":"Orange Soda","namespace":"Main"}
+{"time":"2015-09-12T05:21:00.059Z","channel":"#en.wikipedia","regionIsoCode":"MMMM","countryNumber":205,"countryIsoCode":"MMMM","user":"SomeUser","delta":14,"isRobot":false,"isAnonymous":true,"page":"History of Fourems","namespace":"Main"}

--- a/processing/src/test/resources/wikipedia/regions.json
+++ b/processing/src/test/resources/wikipedia/regions.json
@@ -17,3 +17,4 @@
 {"regionIsoCode":"VA","countryIsoCode":"US","regionName":"Virginia"}
 {"regionIsoCode":"AV","countryIsoCode":"SU","regionName":"Ainigriv"}
 {"regionIsoCode":"ZZ","countryIsoCode":"USCA","regionName":"Usca City"}
+{"regionIsoCode":"MMMM","countryIsoCode":"MMMM","regionName":"Fourems Province"}


### PR DESCRIPTION
Fixes #9327 and #9328 

This PR fixes #9327 by calling `getBindingIfIdentifier` on the expressions that appear in join equiconditions instead of `getIdentifierIfIdentifier` when creating the `Equality` objects.

This PR fixes #9328 by adjusting `JoinFilterAnalyzer`:
- The equicondition map now uses `Set<Expr>` for its values
- Uses a Set instead of List for the rhsColumns in `findCorrelatedBaseTableColumns` to avoid duplicates
- `findCorrelatedBaseTableColumns` has been adjusted to handle the mappings of RHS columns to expression sets, instead of just single expressions

Additionally, this fixes issues with join conditions where one LHS column is joined to two different RHS columns:
- Call `getBindingIfIdentifier` instead of `getIdentifierIfIdentifier` in `ColumnProcessor`
- Adds a correlation deduplication step to `findCorrelatedBaseTableColumns` (see `eliminateCorrelationDuplicates` for details)

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
