### PR TITLE
fix druid-sql Expressions.toQueryGranularity to be more correct

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -80,7 +80,10 @@ public interface Expr
   }
 
   /**
-   * Returns the string identifier of an {@link IdentifierExpr}, else null
+   * Returns the string identifier of an {@link IdentifierExpr}, else null. Use this method to analyze an {@link Expr}
+   * tree when trying to distinguish between different {@link IdentifierExpr} with the same
+   * {@link IdentifierExpr#binding}. Do NOT use this method to analyze the input binding (e.g. backing column name),
+   * use {@link #getBindingIfIdentifier} instead.
    */
   @Nullable
   default String getIdentifierIfIdentifier()
@@ -91,7 +94,7 @@ public interface Expr
 
   /**
    * Returns the string key to use to get a value from {@link Expr.ObjectBinding} of an {@link IdentifierExpr},
-   * else null
+   * else null. Use this method to analyze the inputs required to an {@link Expr} tree (e.g. backing column name).
    */
   @Nullable
   default String getBindingIfIdentifier()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
@@ -703,7 +703,7 @@ public class Expressions
     final Expr arg = expr.getArg();
     final Granularity granularity = expr.getGranularity();
 
-    if (ColumnHolder.TIME_COLUMN_NAME.equals(arg.getIdentifierIfIdentifier())) {
+    if (ColumnHolder.TIME_COLUMN_NAME.equals(arg.getBindingIfIdentifier())) {
       return granularity;
     } else {
       return null;


### PR DESCRIPTION
Also improves javadocs of `Expr.getIdentifierIfIdentifier` and `Expr.getBindingIfIdentifier`. This isn't an actual bug because the expressions that `Expressions.toQueryGranularity` can recognize and transform are limited to cases where the time floor expressions argument `Identifier.identifier` will always match `IdentifierExpr.binding`, but changed anyway to be more consistent with intention of the method.

Related #9362
