### PR TITLE
string -> expression -> string -> expression

### DIFF
--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -15,27 +15,27 @@
 
 grammar Expr;
 
-expr : 'null'                                         # null
-     | ('-'|'!') expr                                 # unaryOpExpr
-     |<assoc=right> expr '^' expr                     # powOpExpr
-     | expr ('*'|'/'|'%') expr                        # mulDivModuloExpr
-     | expr ('+'|'-') expr                            # addSubExpr
-     | expr ('<'|'<='|'>'|'>='|'=='|'!=') expr        # logicalOpExpr
-     | expr ('&&'|'||') expr                          # logicalAndOrExpr
-     | '(' expr ')'                                   # nestedExpr
-     | IDENTIFIER '(' lambda ',' fnArgs ')'           # applyFunctionExpr
-     | IDENTIFIER '(' fnArgs? ')'                     # functionExpr
-     | IDENTIFIER                                     # identifierExpr
-     | DOUBLE                                         # doubleExpr
-     | LONG                                           # longExpr
-     | STRING                                         # string
-     | '[' doubleElement  (',' doubleElement)* ']'    # doubleArray
-     | '[' longElement (',' longElement)* ']'         # longArray
-     | '[' stringElement (',' stringElement)* ']'     # stringArray
-     | '[]'                                           # emptyArray
-     | '<STRING>[]'                                   # emptyStringArray
-     | '<DOUBLE>[]'                                   # emptyDoubleArray
-     | '<LONG>[]'                                     # emptyLongArray
+expr : 'null'                                                       # null
+     | ('-'|'!') expr                                               # unaryOpExpr
+     |<assoc=right> expr '^' expr                                   # powOpExpr
+     | expr ('*'|'/'|'%') expr                                      # mulDivModuloExpr
+     | expr ('+'|'-') expr                                          # addSubExpr
+     | expr ('<'|'<='|'>'|'>='|'=='|'!=') expr                      # logicalOpExpr
+     | expr ('&&'|'||') expr                                        # logicalAndOrExpr
+     | '(' expr ')'                                                 # nestedExpr
+     | IDENTIFIER '(' lambda ',' fnArgs ')'                         # applyFunctionExpr
+     | IDENTIFIER '(' fnArgs? ')'                                   # functionExpr
+     | IDENTIFIER                                                   # identifierExpr
+     | DOUBLE                                                       # doubleExpr
+     | LONG                                                         # longExpr
+     | STRING                                                       # string
+     | '<STRING>'? '[' stringElement (',' stringElement)* ']'       # stringArray
+     | '<DOUBLE>'? '[' doubleElement  (',' doubleElement)* ']'      # doubleArray
+     | '<LONG>'? '[' longElement (',' longElement)* ']'             # longArray
+     | '[]'                                                         # emptyArray
+     | '<STRING>[]'                                                 # emptyStringArray
+     | '<DOUBLE>[]'                                                 # emptyDoubleArray
+     | '<LONG>[]'                                                   # emptyLongArray
      ;
 
 lambda : (IDENTIFIER | '(' ')' | '(' IDENTIFIER (',' IDENTIFIER)* ')') '->' expr

--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -29,10 +29,13 @@ expr : 'null'                                         # null
      | DOUBLE                                         # doubleExpr
      | LONG                                           # longExpr
      | STRING                                         # string
-     | '[' DOUBLE  (',' DOUBLE)* ']'                  # doubleArray
-     | '[' LONG (',' LONG)* ']'                       # longArray
-     | '[' STRING (',' STRING)* ']'                   # stringArray
+     | '[' doubleElement  (',' doubleElement)* ']'    # doubleArray
+     | '[' longElement (',' longElement)* ']'         # longArray
+     | '[' stringElement (',' stringElement)* ']'     # stringArray
      | '[]'                                           # emptyArray
+     | '<STRING>[]'                                   # emptyStringArray
+     | '<DOUBLE>[]'                                   # emptyDoubleArray
+     | '<LONG>[]'                                     # emptyLongArray
      ;
 
 lambda : (IDENTIFIER | '(' ')' | '(' IDENTIFIER (',' IDENTIFIER)* ')') '->' expr
@@ -40,6 +43,12 @@ lambda : (IDENTIFIER | '(' ')' | '(' IDENTIFIER (',' IDENTIFIER)* ')') '->' expr
 
 fnArgs : expr (',' expr)*                             # functionArgs
        ;
+
+longElement : (LONG | 'null');
+
+doubleElement : (DOUBLE | 'null');
+
+stringElement : (STRING | 'null');
 
 IDENTIFIER : [_$a-zA-Z][_$a-zA-Z0-9]* | '"' (ESC | ~ [\"\\])* '"';
 LONG : [0-9]+ ;

--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -15,7 +15,7 @@
 
 grammar Expr;
 
-expr : 'null'                                                       # null
+expr : NULL                                                         # null
      | ('-'|'!') expr                                               # unaryOpExpr
      |<assoc=right> expr '^' expr                                   # powOpExpr
      | expr ('*'|'/'|'%') expr                                      # mulDivModuloExpr
@@ -29,9 +29,11 @@ expr : 'null'                                                       # null
      | DOUBLE                                                       # doubleExpr
      | LONG                                                         # longExpr
      | STRING                                                       # string
-     | '<STRING>'? '[' stringArrayBody? ']'                         # stringArray
-     | '<DOUBLE>'? '[' doubleArrayBody? ']'                         # doubleArray
-     | '<LONG>'? '[' longArrayBody? ']'                             # longArray
+     | '[' (stringElement (',' stringElement)*)? ']'                # stringArray
+     | '[' longElement (',' longElement)*']'                        # longArray
+     | '<LONG>' '[' (numericElement (',' numericElement)*)? ']'     # explicitLongArray
+     | '<DOUBLE>'? '[' (numericElement (',' numericElement)*)? ']'  # doubleArray
+     | '<STRING>' '[' (literalElement (',' literalElement)*)? ']'   # explicitStringArray
      ;
 
 lambda : (IDENTIFIER | '(' ')' | '(' IDENTIFIER (',' IDENTIFIER)* ')') '->' expr
@@ -40,18 +42,15 @@ lambda : (IDENTIFIER | '(' ')' | '(' IDENTIFIER (',' IDENTIFIER)* ')') '->' expr
 fnArgs : expr (',' expr)*                                           # functionArgs
        ;
 
-stringArrayBody : stringElement (',' stringElement)*;
+stringElement : (STRING | NULL);
 
-doubleArrayBody : doubleElement (',' doubleElement)*;
+longElement : (LONG | NULL);
 
-longArrayBody : longElement (',' longElement)*;
+numericElement : (LONG | DOUBLE | NULL);
 
-longElement : (LONG | 'null');
+literalElement : (STRING | LONG | DOUBLE | NULL);
 
-doubleElement : (DOUBLE | 'null');
-
-stringElement : (STRING | 'null');
-
+NULL : 'null';
 IDENTIFIER : [_$a-zA-Z][_$a-zA-Z0-9]* | '"' (ESC | ~ [\"\\])* '"';
 LONG : [0-9]+ ;
 DOUBLE : [0-9]+ '.' [0-9]* ;

--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -29,20 +29,22 @@ expr : 'null'                                                       # null
      | DOUBLE                                                       # doubleExpr
      | LONG                                                         # longExpr
      | STRING                                                       # string
-     | '<STRING>'? '[' stringElement (',' stringElement)* ']'       # stringArray
-     | '<DOUBLE>'? '[' doubleElement  (',' doubleElement)* ']'      # doubleArray
-     | '<LONG>'? '[' longElement (',' longElement)* ']'             # longArray
-     | '[]'                                                         # emptyArray
-     | '<STRING>[]'                                                 # emptyStringArray
-     | '<DOUBLE>[]'                                                 # emptyDoubleArray
-     | '<LONG>[]'                                                   # emptyLongArray
+     | '<STRING>'? '[' stringArrayBody? ']'                         # stringArray
+     | '<DOUBLE>'? '[' doubleArrayBody? ']'                         # doubleArray
+     | '<LONG>'? '[' longArrayBody? ']'                             # longArray
      ;
 
 lambda : (IDENTIFIER | '(' ')' | '(' IDENTIFIER (',' IDENTIFIER)* ')') '->' expr
        ;
 
-fnArgs : expr (',' expr)*                             # functionArgs
+fnArgs : expr (',' expr)*                                           # functionArgs
        ;
+
+stringArrayBody : stringElement (',' stringElement)*;
+
+doubleArrayBody : doubleElement (',' doubleElement)*;
+
+longArrayBody : longElement (',' longElement)*;
 
 longElement : (LONG | 'null');
 

--- a/core/src/main/java/org/apache/druid/java/util/common/Numbers.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/Numbers.java
@@ -118,6 +118,7 @@ public final class Numbers
     }
   }
 
+
   /**
    * Try parsing the given Number or String object val as long.
    * @param val
@@ -165,6 +166,45 @@ public final class Numbers
     } else {
       throw new IAE("Unknown object type [%s]", val.getClass().getName());
     }
+  }
+
+  /**
+   * Like {@link #tryParseDouble}, but does not produce a primitive and will explode if unable to produce a Double
+   * similar to {@link Double#parseDouble}
+   */
+  @Nullable
+  public static Double parseDoubleObject(@Nullable String val)
+  {
+    if (val == null) {
+      return null;
+    }
+    Double d = Doubles.tryParse(val);
+    if (d != null) {
+      return d;
+    }
+    throw new NumberFormatException("Cannot parse string to double");
+  }
+
+  /**
+   * Like {@link #tryParseLong} but does not produce a primitive and will explode if unable to produce a Long
+   * similar to {@link Long#parseLong}
+   */
+  @Nullable
+  public static Long parseLongObject(@Nullable String val)
+  {
+    if (val == null) {
+      return null;
+    }
+    Long lobj = Longs.tryParse(val);
+    if (lobj != null) {
+      return lobj;
+    }
+    // try as a double, for "ddd.dd" , Longs.tryParse(..) returns null
+    Double dobj = Doubles.tryParse((String) val);
+    if (dobj != null) {
+      return dobj.longValue();
+    }
+    throw new NumberFormatException("Cannot parse string to long");
   }
 
   public static int toIntExact(long value, String error)

--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -564,7 +564,7 @@ class LongArrayExpr extends ConstantExpr
     if (value.length == 0) {
       return "<LONG>[]";
     }
-    return toString();
+    return StringUtils.format("<LONG>%s", toString());
   }
 }
 
@@ -638,7 +638,7 @@ class StringArrayExpr extends ConstantExpr
       return "<STRING>[]";
     }
     return StringUtils.format(
-        "[%s]",
+        "<STRING>[%s]",
         ARG_JOINER.join(
             Arrays.stream(value)
                   .map(s -> s == null
@@ -721,7 +721,7 @@ class DoubleArrayExpr extends ConstantExpr
     if (value.length == 0) {
       return "<DOUBLE>[]";
     }
-    return toString();
+    return StringUtils.format("<DOUBLE>%s", toString());
   }
 }
 

--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -603,6 +603,7 @@ class StringExpr extends ConstantExpr
   @Override
   public String stringify()
   {
+    // escape as javascript string since string literals are wrapped in single quotes
     return value == null ? NULL_LITERAL : StringUtils.format("'%s'", StringEscapeUtils.escapeJavaScript(value));
   }
 }
@@ -640,12 +641,14 @@ class StringArrayExpr extends ConstantExpr
     if (value.length == 0) {
       return "<STRING>[]";
     }
+
     return StringUtils.format(
         "<STRING>[%s]",
         ARG_JOINER.join(
             Arrays.stream(value)
                   .map(s -> s == null
                             ? NULL_LITERAL
+                            // escape as javascript string since string literals are wrapped in single quotes
                             : StringUtils.format("'%s'", StringEscapeUtils.escapeJavaScript(s))
                   )
                   .iterator()
@@ -819,6 +822,7 @@ class IdentifierExpr implements Expr
   @Override
   public String stringify()
   {
+    // escape as java strings since identifiers are wrapped in double quotes
     return StringUtils.format("\"%s\"", StringEscapeUtils.escapeJava(binding));
   }
 

--- a/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
@@ -112,7 +112,7 @@ public class ExprListenerImpl extends ExprBaseListener
   {
     Double[] values = new Double[ctx.doubleElement().size()];
     for (int i = 0; i < values.length; i++) {
-      if (ctx.doubleElement(i).getText().equalsIgnoreCase("null")) {
+      if (ctx.doubleElement(i).getText().equalsIgnoreCase(Expr.NULL_LITERAL)) {
         values[i] = null;
       } else {
         values[i] = Double.parseDouble(ctx.doubleElement(i).getText());
@@ -195,7 +195,7 @@ public class ExprListenerImpl extends ExprBaseListener
   {
     Long[] values = new Long[ctx.longElement().size()];
     for (int i = 0; i < values.length; i++) {
-      if (ctx.longElement(i).getText().equalsIgnoreCase("null")) {
+      if (ctx.longElement(i).getText().equalsIgnoreCase(Expr.NULL_LITERAL)) {
         values[i] = null;
       } else {
         values[i] = Long.parseLong(ctx.longElement(i).getText());
@@ -485,7 +485,7 @@ public class ExprListenerImpl extends ExprBaseListener
   @Nullable
   private static String escapeStringLiteral(String text)
   {
-    if (text.equalsIgnoreCase("null")) {
+    if (text.equalsIgnoreCase(Expr.NULL_LITERAL)) {
       return null;
     }
     String unquoted = text.substring(1, text.length() - 1);

--- a/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
@@ -297,7 +297,7 @@ public class ExprListenerImpl extends ExprBaseListener
         );
         break;
       default:
-        throw new RE("Unrecognized binary operator ", ctx.getChild(1).getText());
+        throw new RE("Unrecognized binary operator %s", ctx.getChild(1).getText());
     }
   }
 

--- a/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
@@ -110,12 +110,14 @@ public class ExprListenerImpl extends ExprBaseListener
   @Override
   public void exitDoubleArray(ExprParser.DoubleArrayContext ctx)
   {
-    Double[] values = new Double[ctx.doubleElement().size()];
+    Double[] values = ctx.doubleArrayBody() == null
+                      ? new Double[0]
+                      : new Double[ctx.doubleArrayBody().doubleElement().size()];
     for (int i = 0; i < values.length; i++) {
-      if (ctx.doubleElement(i).getText().equalsIgnoreCase(Expr.NULL_LITERAL)) {
+      if (ctx.doubleArrayBody().doubleElement(i).getText().equalsIgnoreCase(Expr.NULL_LITERAL)) {
         values[i] = null;
       } else {
-        values[i] = Double.parseDouble(ctx.doubleElement(i).getText());
+        values[i] = Double.parseDouble(ctx.doubleArrayBody().doubleElement(i).getText());
       }
     }
     nodes.put(ctx, new DoubleArrayExpr(values));
@@ -193,12 +195,14 @@ public class ExprListenerImpl extends ExprBaseListener
   @Override
   public void exitLongArray(ExprParser.LongArrayContext ctx)
   {
-    Long[] values = new Long[ctx.longElement().size()];
+    Long[] values = ctx.longArrayBody() == null
+                    ? new Long[0]
+                    : new Long[ctx.longArrayBody().longElement().size()];
     for (int i = 0; i < values.length; i++) {
-      if (ctx.longElement(i).getText().equalsIgnoreCase(Expr.NULL_LITERAL)) {
+      if (ctx.longArrayBody().longElement(i).getText().equalsIgnoreCase(Expr.NULL_LITERAL)) {
         values[i] = null;
       } else {
-        values[i] = Long.parseLong(ctx.longElement(i).getText());
+        values[i] = Long.parseLong(ctx.longArrayBody().longElement(i).getText());
       }
     }
     nodes.put(ctx, new LongArrayExpr(values));
@@ -415,35 +419,13 @@ public class ExprListenerImpl extends ExprBaseListener
   @Override
   public void exitStringArray(ExprParser.StringArrayContext ctx)
   {
-    String[] values = new String[ctx.stringElement().size()];
+    String[] values = ctx.stringArrayBody() == null
+                      ? new String[0]
+                      : new String[ctx.stringArrayBody().stringElement().size()];
     for (int i = 0; i < values.length; i++) {
-      values[i] = escapeStringLiteral(ctx.stringElement(i).getText());
+      values[i] = escapeStringLiteral(ctx.stringArrayBody().stringElement(i).getText());
     }
     nodes.put(ctx, new StringArrayExpr(values));
-  }
-
-  @Override
-  public void exitEmptyArray(ExprParser.EmptyArrayContext ctx)
-  {
-    nodes.put(ctx, new StringArrayExpr(new String[0]));
-  }
-
-  @Override
-  public void exitEmptyStringArray(ExprParser.EmptyStringArrayContext ctx)
-  {
-    nodes.put(ctx, new StringArrayExpr(new String[0]));
-  }
-
-  @Override
-  public void exitEmptyDoubleArray(ExprParser.EmptyDoubleArrayContext ctx)
-  {
-    nodes.put(ctx, new DoubleArrayExpr(new Double[0]));
-  }
-
-  @Override
-  public void exitEmptyLongArray(ExprParser.EmptyLongArrayContext ctx)
-  {
-    nodes.put(ctx, new LongArrayExpr(new Long[0]));
   }
 
   /**

--- a/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
@@ -109,9 +109,13 @@ public class ExprListenerImpl extends ExprBaseListener
   @Override
   public void exitDoubleArray(ExprParser.DoubleArrayContext ctx)
   {
-    Double[] values = new Double[ctx.DOUBLE().size()];
+    Double[] values = new Double[ctx.doubleElement().size()];
     for (int i = 0; i < values.length; i++) {
-      values[i] = Double.parseDouble(ctx.DOUBLE(i).getText());
+      if (ctx.doubleElement(i).getText().equalsIgnoreCase("null")) {
+        values[i] = null;
+      } else {
+        values[i] = Double.parseDouble(ctx.doubleElement(i).getText());
+      }
     }
     nodes.put(ctx, new DoubleArrayExpr(values));
   }
@@ -188,9 +192,13 @@ public class ExprListenerImpl extends ExprBaseListener
   @Override
   public void exitLongArray(ExprParser.LongArrayContext ctx)
   {
-    Long[] values = new Long[ctx.LONG().size()];
+    Long[] values = new Long[ctx.longElement().size()];
     for (int i = 0; i < values.length; i++) {
-      values[i] = Long.parseLong(ctx.LONG(i).getText());
+      if (ctx.longElement(i).getText().equalsIgnoreCase("null")) {
+        values[i] = null;
+      } else {
+        values[i] = Long.parseLong(ctx.longElement(i).getText());
+      }
     }
     nodes.put(ctx, new LongArrayExpr(values));
   }
@@ -406,9 +414,9 @@ public class ExprListenerImpl extends ExprBaseListener
   @Override
   public void exitStringArray(ExprParser.StringArrayContext ctx)
   {
-    String[] values = new String[ctx.STRING().size()];
+    String[] values = new String[ctx.stringElement().size()];
     for (int i = 0; i < values.length; i++) {
-      values[i] = escapeStringLiteral(ctx.STRING(i).getText());
+      values[i] = escapeStringLiteral(ctx.stringElement(i).getText());
     }
     nodes.put(ctx, new StringArrayExpr(values));
   }
@@ -417,6 +425,24 @@ public class ExprListenerImpl extends ExprBaseListener
   public void exitEmptyArray(ExprParser.EmptyArrayContext ctx)
   {
     nodes.put(ctx, new StringArrayExpr(new String[0]));
+  }
+
+  @Override
+  public void exitEmptyStringArray(ExprParser.EmptyStringArrayContext ctx)
+  {
+    nodes.put(ctx, new StringArrayExpr(new String[0]));
+  }
+
+  @Override
+  public void exitEmptyDoubleArray(ExprParser.EmptyDoubleArrayContext ctx)
+  {
+    nodes.put(ctx, new DoubleArrayExpr(new Double[0]));
+  }
+
+  @Override
+  public void exitEmptyLongArray(ExprParser.EmptyLongArrayContext ctx)
+  {
+    nodes.put(ctx, new LongArrayExpr(new Long[0]));
   }
 
   /**
@@ -457,6 +483,9 @@ public class ExprListenerImpl extends ExprBaseListener
    */
   private static String escapeStringLiteral(String text)
   {
+    if (text.equalsIgnoreCase("null")) {
+      return null;
+    }
     String unquoted = text.substring(1, text.length() - 1);
     return unquoted.indexOf('\\') >= 0 ? StringEscapeUtils.unescapeJava(unquoted) : unquoted;
   }

--- a/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
@@ -28,6 +28,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.antlr.ExprBaseListener;
 import org.apache.druid.math.expr.antlr.ExprParser;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -481,6 +482,7 @@ public class ExprListenerImpl extends ExprBaseListener
   /**
    * Remove single quote from a string literal, returning unquoted string value
    */
+  @Nullable
   private static String escapeStringLiteral(String text)
   {
     if (text.equalsIgnoreCase("null")) {

--- a/core/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.math.expr;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -160,7 +159,7 @@ public class ExprMacroTable
       return StringUtils.format(
           "%s(%s)",
           name,
-          Joiner.on(", ").join(args.stream().map(Expr::stringify).iterator())
+          Expr.ARG_JOINER.join(args.stream().map(Expr::stringify).iterator())
       );
     }
 

--- a/core/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.math.expr;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -97,13 +98,15 @@ public class ExprMacroTable
    */
   public abstract static class BaseScalarUnivariateMacroFunctionExpr implements Expr
   {
+    protected final String name;
     protected final Expr arg;
 
     // Use Supplier to memoize values as ExpressionSelectors#makeExprEvalSelector() can make repeated calls for them
     private final Supplier<BindingDetails> analyzeInputsSupplier;
 
-    public BaseScalarUnivariateMacroFunctionExpr(Expr arg)
+    public BaseScalarUnivariateMacroFunctionExpr(String name, Expr arg)
     {
+      this.name = name;
       this.arg = arg;
       analyzeInputsSupplier = Suppliers.memoize(this::supplyAnalyzeInputs);
     }
@@ -121,6 +124,12 @@ public class ExprMacroTable
       return analyzeInputsSupplier.get();
     }
 
+    @Override
+    public String stringify()
+    {
+      return StringUtils.format("%s(%s)", name, arg.stringify());
+    }
+
     private BindingDetails supplyAnalyzeInputs()
     {
       return arg.analyzeInputs().withScalarArguments(ImmutableSet.of(arg));
@@ -132,15 +141,27 @@ public class ExprMacroTable
    */
   public abstract static class BaseScalarMacroFunctionExpr implements Expr
   {
+    protected final String name;
     protected final List<Expr> args;
 
     // Use Supplier to memoize values as ExpressionSelectors#makeExprEvalSelector() can make repeated calls for them
     private final Supplier<BindingDetails> analyzeInputsSupplier;
 
-    public BaseScalarMacroFunctionExpr(final List<Expr> args)
+    public BaseScalarMacroFunctionExpr(String name, final List<Expr> args)
     {
+      this.name = name;
       this.args = args;
       analyzeInputsSupplier = Suppliers.memoize(this::supplyAnalyzeInputs);
+    }
+
+    @Override
+    public String stringify()
+    {
+      return StringUtils.format(
+          "%s(%s)",
+          name,
+          Joiner.on(", ").join(args.stream().map(Expr::stringify).iterator())
+      );
     }
 
     @Override

--- a/core/src/main/java/org/apache/druid/math/expr/Parser.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Parser.java
@@ -108,7 +108,7 @@ public class Parser
   }
 
   @VisibleForTesting
-  static Expr parse(String in, ExprMacroTable macroTable, boolean withFlatten)
+  public static Expr parse(String in, ExprMacroTable macroTable, boolean withFlatten)
   {
     ExprLexer lexer = new ExprLexer(new ANTLRInputStream(in));
     CommonTokenStream tokens = new CommonTokenStream(lexer);

--- a/core/src/main/java/org/apache/druid/math/expr/Parser.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Parser.java
@@ -118,7 +118,11 @@ public class Parser
     ParseTreeWalker walker = new ParseTreeWalker();
     ExprListenerImpl listener = new ExprListenerImpl(parseTree, macroTable);
     walker.walk(listener, parseTree);
-    return withFlatten ? flatten(listener.getAST()) : listener.getAST();
+    Expr parsed = listener.getAST();
+    if (parsed == null) {
+      throw new RE("Failed to parse expression: %s", in);
+    }
+    return withFlatten ? flatten(parsed) : parsed;
   }
 
   /**

--- a/core/src/test/java/org/apache/druid/java/util/common/NumbersTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/NumbersTest.java
@@ -127,4 +127,36 @@ public class NumbersTest
     expectedException.expectMessage(CoreMatchers.startsWith("Unknown type"));
     Numbers.parseBoolean(new Object());
   }
+
+  @Test
+  public void testParseLongObject()
+  {
+    Assert.assertEquals(null, Numbers.parseLongObject(null));
+    Assert.assertEquals((Long) 1L, Numbers.parseLongObject("1"));
+    Assert.assertEquals((Long) 32L, Numbers.parseLongObject("32.1243"));
+  }
+
+  @Test
+  public void testParseLongObjectUnparseable()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Cannot parse string to long");
+    Assert.assertEquals((Long) 1337L, Numbers.parseLongObject("'1'"));
+  }
+
+  @Test
+  public void testParseDoubleObject()
+  {
+    Assert.assertEquals(null, Numbers.parseLongObject(null));
+    Assert.assertEquals((Double) 1.0, Numbers.parseDoubleObject("1"));
+    Assert.assertEquals((Double) 32.1243, Numbers.parseDoubleObject("32.1243"));
+  }
+
+  @Test
+  public void testParseDoubleObjectUnparseable()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Cannot parse string to double");
+    Assert.assertEquals((Double) 300.0, Numbers.parseDoubleObject("'1.1'"));
+  }
 }

--- a/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
@@ -102,7 +102,7 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
     assertExpr("fold((b, acc) -> b * acc, map((b) -> b * 2, filter(b -> b > 3, b)), 1)", 80L);
     assertExpr("fold((a, acc) -> concat(a, acc), a, '')", "foobarbazbarfoo");
     assertExpr("fold((a, acc) -> array_append(acc, a), a, [])", new String[]{"foo", "bar", "baz", "foobar"});
-    assertExpr("fold((a, acc) -> array_append(acc, a), b, cast([], 'LONG_ARRAY'))", new Long[]{1L, 2L, 3L, 4L, 5L});
+    assertExpr("fold((a, acc) -> array_append(acc, a), b, <LONG>[])", new Long[]{1L, 2L, 3L, 4L, 5L});
   }
 
   @Test
@@ -161,6 +161,16 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
   {
     final Expr expr = Parser.parse(expression, ExprMacroTable.nil());
     Assert.assertEquals(expression, expectedResult, expr.eval(bindings).value());
+
+    final Expr exprNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
+    final Expr roundTrip = Parser.parse(exprNoFlatten.stringify(), ExprMacroTable.nil());
+    Assert.assertEquals(expr.stringify(), expectedResult, roundTrip.eval(bindings).value());
+
+    final Expr roundTripFlatten = Parser.parse(expr.stringify(), ExprMacroTable.nil());
+    Assert.assertEquals(expr.stringify(), expectedResult, roundTripFlatten.eval(bindings).value());
+
+    Assert.assertEquals(expr.stringify(), roundTrip.stringify());
+    Assert.assertEquals(expr.stringify(), roundTripFlatten.stringify());
   }
 
   private void assertExpr(final String expression, final Object[] expectedResult)
@@ -170,6 +180,22 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
     if (expectedResult.length != 0 || result == null || result.length != 0) {
       Assert.assertArrayEquals(expression, expectedResult, result);
     }
+
+    final Expr exprNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
+    final Expr roundTrip = Parser.parse(exprNoFlatten.stringify(), ExprMacroTable.nil());
+    final Object[] resultRoundTrip = roundTrip.eval(bindings).asArray();
+    if (expectedResult.length != 0 || resultRoundTrip == null || resultRoundTrip.length != 0) {
+      Assert.assertArrayEquals(expr.stringify(), expectedResult, resultRoundTrip);
+    }
+
+    final Expr roundTripFlatten = Parser.parse(expr.stringify(), ExprMacroTable.nil());
+    final Object[] resultRoundTripFlatten = roundTripFlatten.eval(bindings).asArray();
+    if (expectedResult.length != 0 || resultRoundTripFlatten == null || resultRoundTripFlatten.length != 0) {
+      Assert.assertArrayEquals(expr.stringify(), expectedResult, resultRoundTripFlatten);
+    }
+
+    Assert.assertEquals(expr.stringify(), roundTrip.stringify());
+    Assert.assertEquals(expr.stringify(), roundTripFlatten.stringify());
   }
 
   private void assertExpr(final String expression, final Double[] expectedResult)
@@ -180,5 +206,23 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
     for (int i = 0; i < result.length; i++) {
       Assert.assertEquals(expression, expectedResult[i], result[i], 0.00001); // something is lame somewhere..
     }
+
+    final Expr exprNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
+    final Expr roundTrip = Parser.parse(exprNoFlatten.stringify(), ExprMacroTable.nil());
+    Double[] resultRoundTrip = (Double[]) roundTrip.eval(bindings).value();
+    Assert.assertEquals(expectedResult.length, resultRoundTrip.length);
+    for (int i = 0; i < resultRoundTrip.length; i++) {
+      Assert.assertEquals(expression, expectedResult[i], resultRoundTrip[i], 0.00001);
+    }
+
+    final Expr roundTripFlatten = Parser.parse(expr.stringify(), ExprMacroTable.nil());
+    Double[] resultRoundTripFlatten= (Double[]) roundTripFlatten.eval(bindings).value();
+    Assert.assertEquals(expectedResult.length, resultRoundTripFlatten.length);
+    for (int i = 0; i < resultRoundTripFlatten.length; i++) {
+      Assert.assertEquals(expression, expectedResult[i], resultRoundTripFlatten[i], 0.00001);
+    }
+
+    Assert.assertEquals(expr.stringify(), roundTrip.stringify());
+    Assert.assertEquals(expr.stringify(), roundTripFlatten.stringify());
   }
 }

--- a/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
@@ -98,11 +98,11 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
   @Test
   public void testFold()
   {
-    assertExpr("fold((x, y) -> x + y, [1, 1, 1, 1, 1], 0)", 5L);
-    assertExpr("fold((b, acc) -> b * acc, map((b) -> b * 2, filter(b -> b > 3, b)), 1)", 80L);
-    assertExpr("fold((a, acc) -> concat(a, acc), a, '')", "foobarbazbarfoo");
+//    assertExpr("fold((x, y) -> x + y, [1, 1, 1, 1, 1], 0)", 5L);
+//    assertExpr("fold((b, acc) -> b * acc, map((b) -> b * 2, filter(b -> b > 3, b)), 1)", 80L);
+//    assertExpr("fold((a, acc) -> concat(a, acc), a, '')", "foobarbazbarfoo");
     assertExpr("fold((a, acc) -> array_append(acc, a), a, [])", new String[]{"foo", "bar", "baz", "foobar"});
-    assertExpr("fold((a, acc) -> array_append(acc, a), b, <LONG>[])", new Long[]{1L, 2L, 3L, 4L, 5L});
+//    assertExpr("fold((a, acc) -> array_append(acc, a), b, <LONG>[])", new Long[]{1L, 2L, 3L, 4L, 5L});
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
@@ -216,7 +216,7 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
     }
 
     final Expr roundTripFlatten = Parser.parse(expr.stringify(), ExprMacroTable.nil());
-    Double[] resultRoundTripFlatten= (Double[]) roundTripFlatten.eval(bindings).value();
+    Double[] resultRoundTripFlatten = (Double[]) roundTripFlatten.eval(bindings).value();
     Assert.assertEquals(expectedResult.length, resultRoundTripFlatten.length);
     for (int i = 0; i < resultRoundTripFlatten.length; i++) {
       Assert.assertEquals(expression, expectedResult[i], resultRoundTripFlatten[i], 0.00001);

--- a/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
@@ -98,11 +98,11 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
   @Test
   public void testFold()
   {
-//    assertExpr("fold((x, y) -> x + y, [1, 1, 1, 1, 1], 0)", 5L);
-//    assertExpr("fold((b, acc) -> b * acc, map((b) -> b * 2, filter(b -> b > 3, b)), 1)", 80L);
-//    assertExpr("fold((a, acc) -> concat(a, acc), a, '')", "foobarbazbarfoo");
+    assertExpr("fold((x, y) -> x + y, [1, 1, 1, 1, 1], 0)", 5L);
+    assertExpr("fold((b, acc) -> b * acc, map((b) -> b * 2, filter(b -> b > 3, b)), 1)", 80L);
+    assertExpr("fold((a, acc) -> concat(a, acc), a, '')", "foobarbazbarfoo");
     assertExpr("fold((a, acc) -> array_append(acc, a), a, [])", new String[]{"foo", "bar", "baz", "foobar"});
-//    assertExpr("fold((a, acc) -> array_append(acc, a), b, <LONG>[])", new Long[]{1L, 2L, 3L, 4L, 5L});
+    assertExpr("fold((a, acc) -> array_append(acc, a), b, <LONG>[])", new Long[]{1L, 2L, 3L, 4L, 5L});
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -206,7 +206,7 @@ public class ParserTest extends InitializedNullHandlingTest
     validateConstantExpression("<LONG>[null, null, null]", new Long[]{null, null, null});
     validateConstantExpression("<STRING>[null, null, null]", new String[]{null, null, null});
 
-    validateConstantExpression("<DOUBLE>[1, null, 2]", new Double[]{1.0, null, 2.0});
+    validateConstantExpression("<DOUBLE>[1.0, null, 2000.0]", new Double[]{1.0, null, 2000.0});
     validateConstantExpression("<LONG>[3, null, 4]", new Long[]{3L, null, 4L});
     validateConstantExpression("<STRING>['foo', 'bar', 'baz']", new String[]{"foo", "bar", "baz"});
   }

--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -200,6 +200,15 @@ public class ParserTest extends InitializedNullHandlingTest
     validateConstantExpression("<STRING>[]", new String[0]);
     validateConstantExpression("<DOUBLE>[]", new Double[0]);
     validateConstantExpression("<LONG>[]", new Long[0]);
+
+    validateConstantExpression("[null, null, null]", new String[]{null, null, null});
+    validateConstantExpression("<DOUBLE>[null, null, null]", new Double[]{null, null, null});
+    validateConstantExpression("<LONG>[null, null, null]", new Long[]{null, null, null});
+    validateConstantExpression("<STRING>[null, null, null]", new String[]{null, null, null});
+
+    validateConstantExpression("<DOUBLE>[1, null, 2]", new Double[]{1.0, null, 2.0});
+    validateConstantExpression("<LONG>[3, null, 4]", new Long[]{3L, null, 4L});
+    validateConstantExpression("<STRING>['foo', 'bar', 'baz']", new String[]{"foo", "bar", "baz"});
   }
 
   @Test
@@ -558,12 +567,14 @@ public class ParserTest extends InitializedNullHandlingTest
   private void validateConstantExpression(String expression, Object[] expected)
   {
     Expr parsed = Parser.parse(expression, ExprMacroTable.nil());
+    Object evaluated = parsed.eval(Parser.withMap(ImmutableMap.of())).value();
     Assert.assertArrayEquals(
         expression,
         expected,
-        (Object[]) parsed.eval(Parser.withMap(ImmutableMap.of())).value()
+        (Object[]) evaluated
     );
 
+    Assert.assertEquals(expected.getClass(), evaluated.getClass());
     final Expr parsedNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
     Expr roundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
     Assert.assertArrayEquals(

--- a/docs/misc/math-expr.md
+++ b/docs/misc/math-expr.md
@@ -37,28 +37,15 @@ This expression language supports the following operators (listed in decreasing 
 |<, <=, >, >=, ==, !=|Binary Comparison|
 |&&, &#124;&#124;|Binary Logical AND, OR|
 
-Long, double, and string data types are supported. If a number contains a dot, it is interpreted as a double, otherwise
-it is interpreted as a long. That means, always add a '.' to your number if you want it interpreted as a double value.
-String literals should be quoted by single quotation marks.
+Long, double, and string data types are supported. If a number contains a dot, it is interpreted as a double, otherwise it is interpreted as a long. That means, always add a '.' to your number if you want it interpreted as a double value. String literals should be quoted by single quotation marks.
 
-Additionally, the expression language supports long, double, and string arrays. Array literals are created by wrapping
-square brackets around a list of scalar literals values delimited by a comma or space character. All values in an array
-literal must be the same type.
+Additionally, the expression language supports long, double, and string arrays. Array literals are created by wrapping square brackets around a list of scalar literals values delimited by a comma or space character. All values in an array literal must be the same type, however null values are accepted. Typed empty arrays may be defined by prefixing with their type in angle brackets: `<STRING>[]`, `<DOUBLE>[]`, or `<LONG>[]`.
 
-Expressions can contain variables. Variable names may contain letters, digits, '\_' and '$'. Variable names must not
-begin with a digit. To escape other special characters, you can quote it with double quotation marks.
+Expressions can contain variables. Variable names may contain letters, digits, '\_' and '$'. Variable names must not begin with a digit. To escape other special characters, you can quote it with double quotation marks.
 
-For logical operators, a number is true if and only if it is positive (0 or negative value means false). For string
-type, it's the evaluation result of 'Boolean.valueOf(string)'.
+For logical operators, a number is true if and only if it is positive (0 or negative value means false). For string type, it's the evaluation result of 'Boolean.valueOf(string)'.
 
-[Multi-value string dimensions](../querying/multi-value-dimensions.html) are supported and may be treated as either
-scalar or array typed values. When treated as a scalar type, an expression will automatically be transformed to apply
-the scalar operation across all values of the multi-valued type, to mimic Druid's native behavior. Values that result in
-arrays will be coerced back into the native Druid string type for aggregation. Druid aggregations on multi-value string
-dimensions on the individual values, _not_ the 'array', behaving similar to the `UNNEST` operator available in many SQL
-dialects. However, by using the `array_to_string` function, aggregations may be done on a stringified version of the
-complete array, allowing the complete row to be preserved. Using `string_to_array` in an expression post-aggregator,
-allows transforming the stringified dimension back into the true native array type.
+[Multi-value string dimensions](../querying/multi-value-dimensions.html) are supported and may be treated as either scalar or array typed values. When treated as a scalar type, an expression will automatically be transformed to apply the scalar operation across all values of the multi-valued type, to mimic Druid's native behavior. Values that result in arrays will be coerced back into the native Druid string type for aggregation. Druid aggregations on multi-value string dimensions on the individual values, _not_ the 'array', behaving similar to the `UNNEST` operator available in many SQL dialects. However, by using the `array_to_string` function, aggregations may be done on a stringified version of the complete array, allowing the complete row to be preserved. Using `string_to_array` in an expression post-aggregator, allows transforming the stringified dimension back into the true native array type.
 
 
 The following built-in functions are available.
@@ -196,10 +183,7 @@ See javadoc of java.lang.Math for detailed explanation for each function.
 
 ## IP address functions
 
-For the IPv4 address functions, the `address` argument can either be an IPv4 dotted-decimal string
-(e.g., "192.168.0.1") or an IP address represented as a long (e.g., 3232235521). The `subnet`
-argument should be a string formatted as an IPv4 address subnet in CIDR notation (e.g.,
-"192.168.0.0/16").
+For the IPv4 address functions, the `address` argument can either be an IPv4 dotted-decimal string (e.g., "192.168.0.1") or an IP address represented as a long (e.g., 3232235521). The `subnet` argument should be a string formatted as an IPv4 address subnet in CIDR notation (e.g., "192.168.0.0/16").
 
 | function | description |
 | --- | --- |

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/expressions/BloomFilterExprMacro.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/expressions/BloomFilterExprMacro.java
@@ -71,7 +71,7 @@ public class BloomFilterExprMacro implements ExprMacroTable.ExprMacro
     {
       private BloomExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.expression;
 
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -52,13 +53,13 @@ import java.util.List;
  */
 public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
 {
-  public static final String NAME = "ipv4_match";
+  public static final String FN_NAME = "ipv4_match";
   private static final int ARG_SUBNET = 1;
 
   @Override
   public String name()
   {
-    return NAME;
+    return FN_NAME;
   }
 
   @Override
@@ -77,7 +78,7 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
 
       private IPv4AddressMatchExpr(Expr arg, SubnetUtils.SubnetInfo subnetInfo)
       {
-        super(arg);
+        super(FN_NAME, arg);
         this.subnetInfo = subnetInfo;
       }
 
@@ -115,6 +116,12 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
       {
         Expr newArg = arg.visit(shuttle);
         return shuttle.visit(new IPv4AddressMatchExpr(newArg, subnetInfo));
+      }
+
+      @Override
+      public String stringify()
+      {
+        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(ARG_SUBNET).stringify());
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressParseExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressParseExprMacro.java
@@ -47,12 +47,12 @@ import java.util.List;
  */
 public class IPv4AddressParseExprMacro implements ExprMacroTable.ExprMacro
 {
-  public static final String NAME = "ipv4_parse";
+  public static final String FN_NAME = "ipv4_parse";
 
   @Override
   public String name()
   {
-    return NAME;
+    return FN_NAME;
   }
 
   @Override
@@ -68,7 +68,7 @@ public class IPv4AddressParseExprMacro implements ExprMacroTable.ExprMacro
     {
       private IPv4AddressParseExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressStringifyExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressStringifyExprMacro.java
@@ -46,12 +46,12 @@ import java.util.List;
  */
 public class IPv4AddressStringifyExprMacro implements ExprMacroTable.ExprMacro
 {
-  public static final String NAME = "ipv4_stringify";
+  public static final String FN_NAME = "ipv4_stringify";
 
   @Override
   public String name()
   {
-    return NAME;
+    return FN_NAME;
   }
 
   @Override
@@ -67,7 +67,7 @@ public class IPv4AddressStringifyExprMacro implements ExprMacroTable.ExprMacro
     {
       private IPv4AddressStringifyExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull

--- a/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.expression;
 
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -32,10 +33,11 @@ import java.util.List;
 
 public class LikeExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "like";
   @Override
   public String name()
   {
-    return "like";
+    return FN_NAME;
   }
 
   @Override
@@ -71,7 +73,7 @@ public class LikeExprMacro implements ExprMacroTable.ExprMacro
     {
       private LikeExtractExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull
@@ -86,6 +88,21 @@ public class LikeExprMacro implements ExprMacroTable.ExprMacro
       {
         Expr newArg = arg.visit(shuttle);
         return shuttle.visit(new LikeExtractExpr(newArg));
+      }
+
+      @Override
+      public String stringify()
+      {
+        if (escapeExpr != null) {
+          return StringUtils.format(
+              "%s(%s, %s, %s)",
+              FN_NAME,
+              arg.stringify(),
+              patternExpr.stringify(),
+              escapeExpr.stringify()
+          );
+        }
+        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), patternExpr.stringify());
       }
     }
     return new LikeExtractExpr(arg);

--- a/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
@@ -34,6 +34,7 @@ import java.util.List;
 public class LikeExprMacro implements ExprMacroTable.ExprMacro
 {
   private static final String FN_NAME = "like";
+
   @Override
   public String name()
   {

--- a/processing/src/main/java/org/apache/druid/query/expression/LookupExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/LookupExprMacro.java
@@ -22,6 +22,7 @@ package org.apache.druid.query.expression;
 import com.google.inject.Inject;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -33,6 +34,7 @@ import java.util.List;
 
 public class LookupExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "lookup";
   private final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider;
 
   @Inject
@@ -44,7 +46,7 @@ public class LookupExprMacro implements ExprMacroTable.ExprMacro
   @Override
   public String name()
   {
-    return "lookup";
+    return FN_NAME;
   }
 
   @Override
@@ -75,7 +77,7 @@ public class LookupExprMacro implements ExprMacroTable.ExprMacro
     {
       private LookupExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull
@@ -90,6 +92,12 @@ public class LookupExprMacro implements ExprMacroTable.ExprMacro
       {
         Expr newArg = arg.visit(shuttle);
         return shuttle.visit(new LookupExpr(newArg));
+      }
+
+      @Override
+      public String stringify()
+      {
+        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), lookupExpr.stringify());
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/RegexpExtractExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/RegexpExtractExprMacro.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.expression;
 
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -32,10 +33,12 @@ import java.util.regex.Pattern;
 
 public class RegexpExtractExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "regexp_extract";
+
   @Override
   public String name()
   {
-    return "regexp_extract";
+    return FN_NAME;
   }
 
   @Override
@@ -62,7 +65,7 @@ public class RegexpExtractExprMacro implements ExprMacroTable.ExprMacro
     {
       private RegexpExtractExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull
@@ -80,6 +83,21 @@ public class RegexpExtractExprMacro implements ExprMacroTable.ExprMacro
       {
         Expr newArg = arg.visit(shuttle);
         return shuttle.visit(new RegexpExtractExpr(newArg));
+      }
+
+      @Override
+      public String stringify()
+      {
+        if (indexExpr != null) {
+          return StringUtils.format(
+              "%s(%s, %s, %s)",
+              FN_NAME,
+              arg.stringify(),
+              patternExpr.stringify(),
+              indexExpr.stringify()
+          );
+        }
+        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), patternExpr.stringify());
       }
     }
     return new RegexpExtractExpr(arg);

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
@@ -34,10 +34,12 @@ import java.util.stream.Collectors;
 
 public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "timestamp_ceil";
+
   @Override
   public String name()
   {
-    return "timestamp_ceil";
+    return FN_NAME;
   }
 
   @Override
@@ -60,7 +62,7 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
 
     TimestampCeilExpr(final List<Expr> args)
     {
-      super(args);
+      super(FN_NAME, args);
       this.granularity = getGranularity(args, ExprUtils.nilBindings());
     }
 
@@ -103,7 +105,7 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
   {
     TimestampCeilDynamicExpr(final List<Expr> args)
     {
-      super(args);
+      super(FN_NAME, args);
     }
 
     @Nonnull

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
@@ -34,6 +34,8 @@ import java.util.List;
 
 public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "timestamp_extract";
+
   public enum Unit
   {
     EPOCH,
@@ -59,7 +61,7 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
   @Override
   public String name()
   {
-    return "timestamp_extract";
+    return FN_NAME;
   }
 
   @Override
@@ -93,7 +95,7 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
     {
       private TimestampExtractExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull
@@ -158,6 +160,21 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
       {
         Expr newArg = arg.visit(shuttle);
         return shuttle.visit(new TimestampExtractExpr(newArg));
+      }
+
+      @Override
+      public String stringify()
+      {
+        if (args.size() > 2) {
+          return StringUtils.format(
+              "%s(%s, %s, %s)",
+              FN_NAME,
+              arg.stringify(),
+              args.get(1).stringify(),
+              args.get(2).stringify()
+          );
+        }
+        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(1).stringify());
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
@@ -32,10 +32,11 @@ import java.util.stream.Collectors;
 
 public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "timestamp_floor";
   @Override
   public String name()
   {
-    return "timestamp_floor";
+    return FN_NAME;
   }
 
   @Override
@@ -68,7 +69,7 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
 
     TimestampFloorExpr(final List<Expr> args)
     {
-      super(args);
+      super(FN_NAME, args);
       this.granularity = computeGranularity(args, ExprUtils.nilBindings());
     }
 
@@ -113,7 +114,7 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
   {
     TimestampFloorDynamicExpr(final List<Expr> args)
     {
-      super(args);
+      super(FN_NAME, args);
     }
 
     @Nonnull

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
 {
   private static final String FN_NAME = "timestamp_floor";
+
   @Override
   public String name()
   {

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFormatExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFormatExprMacro.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.expression;
 
 import com.google.common.base.Preconditions;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -34,10 +35,12 @@ import java.util.List;
 
 public class TimestampFormatExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "timestamp_format";
+
   @Override
   public String name()
   {
-    return "timestamp_format";
+    return FN_NAME;
   }
 
   @Override
@@ -72,7 +75,7 @@ public class TimestampFormatExprMacro implements ExprMacroTable.ExprMacro
     {
       private TimestampFormatExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull
@@ -92,6 +95,24 @@ public class TimestampFormatExprMacro implements ExprMacroTable.ExprMacro
       {
         Expr newArg = arg.visit(shuttle);
         return shuttle.visit(new TimestampFormatExpr(newArg));
+      }
+
+      @Override
+      public String stringify()
+      {
+        if (args.size() > 2) {
+          return StringUtils.format(
+              "%s(%s, %s, %s)",
+              FN_NAME,
+              arg.stringify(),
+              args.get(1).stringify(),
+              args.get(2).stringify()
+          );
+        }
+        if (args.size() > 1) {
+          return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(1).stringify());
+        }
+        return super.stringify();
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampParseExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampParseExprMacro.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.expression;
 
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -36,10 +37,12 @@ import java.util.List;
 
 public class TimestampParseExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "timestamp_parse";
+
   @Override
   public String name()
   {
-    return "timestamp_parse";
+    return FN_NAME;
   }
 
   @Override
@@ -68,7 +71,7 @@ public class TimestampParseExprMacro implements ExprMacroTable.ExprMacro
     {
       private TimestampParseExpr(Expr arg)
       {
-        super(arg);
+        super(FN_NAME, arg);
       }
 
       @Nonnull
@@ -95,6 +98,24 @@ public class TimestampParseExprMacro implements ExprMacroTable.ExprMacro
       {
         Expr newArg = arg.visit(shuttle);
         return shuttle.visit(new TimestampParseExpr(newArg));
+      }
+
+      @Override
+      public String stringify()
+      {
+        if (args.size() > 2) {
+          return StringUtils.format(
+              "%s(%s, %s, %s)",
+              FN_NAME,
+              arg.stringify(),
+              args.get(1).stringify(),
+              args.get(2).stringify()
+          );
+        }
+        if (args.size() > 1) {
+          return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(1).stringify());
+        }
+        return super.stringify();
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampShiftExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampShiftExprMacro.java
@@ -34,10 +34,12 @@ import java.util.stream.Collectors;
 
 public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
 {
+  private static final String FN_NAME = "timestamp_shift";
+
   @Override
   public String name()
   {
-    return "timestamp_shift";
+    return FN_NAME;
   }
 
   @Override
@@ -79,7 +81,7 @@ public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
 
     TimestampShiftExpr(final List<Expr> args)
     {
-      super(args);
+      super(FN_NAME, args);
       final PeriodGranularity granularity = getGranularity(args, ExprUtils.nilBindings());
       period = granularity.getPeriod();
       chronology = ISOChronology.getInstance(granularity.getTimeZone());
@@ -105,7 +107,7 @@ public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
   {
     TimestampShiftDynamicExpr(final List<Expr> args)
     {
-      super(args);
+      super(FN_NAME, args);
     }
 
     @Nonnull

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
@@ -193,7 +193,7 @@ public class IPv4AddressMatchExprMacroTest extends MacroTestBase
   {
     NotLiteralExpr(Expr arg)
     {
-      super(arg);
+      super("not", arg);
     }
 
     @Override

--- a/server/src/test/java/org/apache/druid/query/expression/ExprMacroTest.java
+++ b/server/src/test/java/org/apache/druid/query/expression/ExprMacroTest.java
@@ -232,5 +232,13 @@ public class ExprMacroTest
   {
     final Expr expr = Parser.parse(expression, LookupEnabledTestExprMacroTable.INSTANCE);
     Assert.assertEquals(expression, expectedResult, expr.eval(BINDINGS).value());
+
+    final Expr exprNotFlattened = Parser.parse(expression, LookupEnabledTestExprMacroTable.INSTANCE, false);
+    final Expr roundTripNotFlattened =
+        Parser.parse(exprNotFlattened.stringify(), LookupEnabledTestExprMacroTable.INSTANCE);
+    Assert.assertEquals(exprNotFlattened.stringify(), expectedResult, roundTripNotFlattened.eval(BINDINGS).value());
+
+    final Expr roundTrip = Parser.parse(expr.stringify(), LookupEnabledTestExprMacroTable.INSTANCE);
+    Assert.assertEquals(exprNotFlattened.stringify(), expectedResult, roundTrip.eval(BINDINGS).value());
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressMatchOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressMatchOperatorConversion.java
@@ -41,7 +41,7 @@ public class IPv4AddressMatchOperatorConversion extends DirectOperatorConversion
   private static final SqlSingleOperandTypeChecker SUBNET_OPERAND = OperandTypes.family(SqlTypeFamily.STRING);
 
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
-      .operatorBuilder(StringUtils.toUpperCase(IPv4AddressMatchExprMacro.NAME))
+      .operatorBuilder(StringUtils.toUpperCase(IPv4AddressMatchExprMacro.FN_NAME))
       .operandTypeChecker(OperandTypes.sequence("(expr,string)", ADDRESS_OPERAND, SUBNET_OPERAND))
       .returnTypeInference(ReturnTypes.BOOLEAN_NULLABLE)
       .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
@@ -49,7 +49,7 @@ public class IPv4AddressMatchOperatorConversion extends DirectOperatorConversion
 
   public IPv4AddressMatchOperatorConversion()
   {
-    super(SQL_FUNCTION, IPv4AddressMatchExprMacro.NAME);
+    super(SQL_FUNCTION, IPv4AddressMatchExprMacro.FN_NAME);
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressParseOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressParseOperatorConversion.java
@@ -33,7 +33,7 @@ import org.apache.druid.sql.calcite.expression.OperatorConversions;
 public class IPv4AddressParseOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
-      .operatorBuilder(StringUtils.toUpperCase(IPv4AddressParseExprMacro.NAME))
+      .operatorBuilder(StringUtils.toUpperCase(IPv4AddressParseExprMacro.FN_NAME))
       .operandTypeChecker(
           OperandTypes.or(
               OperandTypes.family(SqlTypeFamily.STRING),
@@ -45,7 +45,7 @@ public class IPv4AddressParseOperatorConversion extends DirectOperatorConversion
 
   public IPv4AddressParseOperatorConversion()
   {
-    super(SQL_FUNCTION, IPv4AddressParseExprMacro.NAME);
+    super(SQL_FUNCTION, IPv4AddressParseExprMacro.FN_NAME);
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressStringifyOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressStringifyOperatorConversion.java
@@ -33,7 +33,7 @@ import org.apache.druid.sql.calcite.expression.OperatorConversions;
 public class IPv4AddressStringifyOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
-      .operatorBuilder(StringUtils.toUpperCase(IPv4AddressStringifyExprMacro.NAME))
+      .operatorBuilder(StringUtils.toUpperCase(IPv4AddressStringifyExprMacro.FN_NAME))
       .operandTypeChecker(
           OperandTypes.or(
               OperandTypes.family(SqlTypeFamily.INTEGER),
@@ -45,7 +45,7 @@ public class IPv4AddressStringifyOperatorConversion extends DirectOperatorConver
 
   public IPv4AddressStringifyOperatorConversion()
   {
-    super(SQL_FUNCTION, IPv4AddressStringifyExprMacro.NAME);
+    super(SQL_FUNCTION, IPv4AddressStringifyExprMacro.FN_NAME);
   }
 
 


### PR DESCRIPTION
# Description

This PR adds a new method to the `Expr` interface, `Expr.stringify()`. which produces _parseable_ expression strings so that any `Expr` tree can be converted back into a `String` which can later be parsed into an equivalent expression.

Prior to this PR, not all `Expr` which could exist at evaluation time were actually parseable, specifically empty numeric arrays and arrays with null elements. To make all `Expr` able to satisfy the `stringify` contract, the grammar has been updated to support these constructs. Empty arrays may now be defined like so: `<STRING>[]`, `<DOUBLE>[]`, `<LONG>[]`, and arrays like `[null, 1, 2]` are now able to be correctly parsed from an expression string. The explicit typing syntax for arrays extends beyond empty arrays, so things like `<LONG>[1, 2, 3]` are also valid (and equivalent to `[1, 2, 3]`).

For testing, I modified the majority of expression unit tests assertions to also ensure that parsing the stringified form of a parsed expression produces the same results with and without flattening, so that nearly every expression that is tested also tests round tripping back to string.

Tagged with design review to discuss syntax for the empty arrays.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `Expr.java`
 * `Expr.g4`
 * `ExprListenerImpl.java`
