### PR TITLE
Add config option for namespacePrefix

### DIFF
--- a/docs/development/extensions-contrib/opentsdb-emitter.md
+++ b/docs/development/extensions-contrib/opentsdb-emitter.md
@@ -43,6 +43,7 @@ All the configuration parameters for the OpenTSDB emitter are under `druid.emitt
 |`druid.emitter.opentsdb.maxQueueSize`|Maximum size of the queue used to buffer events.|no|1000|
 |`druid.emitter.opentsdb.consumeDelay`|Queue consuming delay(in milliseconds). Actually, we use `ScheduledExecutorService` to schedule consuming events, so this `consumeDelay` means the delay between the termination of one execution and the commencement of the next. If your druid processes produce metric events fast, then you should decrease this `consumeDelay` or increase the `maxQueueSize`.|no|10000|
 |`druid.emitter.opentsdb.metricMapPath`|JSON file defining the desired metrics and dimensions for every Druid metric|no|./src/main/resources/defaultMetrics.json|
+|`druid.emitter.opentsdb.namespacePrefix`|Optional (string) prefix for metric names, for example the default metric name `query.count` with a namespacePrefix set to `druid` would be emitted as `druid.query.count` |no|null|
 
 ### Druid to OpenTSDB Event Converter
 

--- a/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
+++ b/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 
@@ -54,9 +55,14 @@ public class EventConverter
     return WHITESPACE.matcher(metric.trim()).replaceAll("_").replace('/', '.');
   }
 
-  private String buildNamespace()
+  private String buildMetric(String metric)
   {
-    return (namespacePrefix == null || "".equals(namespacePrefix)) ? "" : sanitize(namespacePrefix) + ".";
+    final String sanitized = sanitize(metric);
+    if (Strings.isNullOrEmpty(namespacePrefix)) {
+      return sanitized;
+    } else {
+      return StringUtils.format("%s.%s", sanitize(namespacePrefix), sanitized);
+    }
   }
 
   /**
@@ -95,7 +101,7 @@ public class EventConverter
       }
     }
 
-    return new OpentsdbEvent(buildNamespace() + sanitize(metric), timestamp, value, tags);
+    return new OpentsdbEvent(buildMetric(metric), timestamp, value, tags);
   }
 
   private Map<String, Set<String>> readMap(ObjectMapper mapper, String metricMapPath)

--- a/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
+++ b/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
@@ -56,7 +56,7 @@ public class EventConverter
 
   private String buildNamespace()
   {
-    return namespacePrefix == null ? "" : sanitize(namespacePrefix) + ".";
+    return (namespacePrefix == null || namespacePrefix == "") ? "" : sanitize(namespacePrefix) + ".";
   }
 
   /**

--- a/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
+++ b/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
@@ -58,7 +58,7 @@ public class EventConverter
   private String buildMetric(String metric)
   {
     final String sanitized = sanitize(metric);
-    if (Strings.isNullOrEmpty(namespacePrefix)) {
+    if (namespacePrefix == null) {
       return sanitized;
     } else {
       return StringUtils.format("%s.%s", sanitize(namespacePrefix), sanitized);

--- a/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
+++ b/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
@@ -41,15 +41,22 @@ public class EventConverter
   private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
 
   private final Map<String, Set<String>> metricMap;
+  private final String namespacePrefix;
 
-  public EventConverter(ObjectMapper mapper, String metricMapPath)
+  public EventConverter(ObjectMapper mapper, String metricMapPath, String namespacePrefix)
   {
     metricMap = readMap(mapper, metricMapPath);
+    this.namespacePrefix = namespacePrefix;
   }
 
   protected String sanitize(String metric)
   {
     return WHITESPACE.matcher(metric.trim()).replaceAll("_").replace('/', '.');
+  }
+
+  private String buildNamespace()
+  {
+    return namespacePrefix == null ? "" : sanitize(namespacePrefix) + ".";
   }
 
   /**
@@ -88,7 +95,7 @@ public class EventConverter
       }
     }
 
-    return new OpentsdbEvent(sanitize(metric), timestamp, value, tags);
+    return new OpentsdbEvent(buildNamespace() + sanitize(metric), timestamp, value, tags);
   }
 
   private Map<String, Set<String>> readMap(ObjectMapper mapper, String metricMapPath)

--- a/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
+++ b/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/EventConverter.java
@@ -56,7 +56,7 @@ public class EventConverter
 
   private String buildNamespace()
   {
-    return (namespacePrefix == null || namespacePrefix == "") ? "" : sanitize(namespacePrefix) + ".";
+    return (namespacePrefix == null || "".equals(namespacePrefix)) ? "" : sanitize(namespacePrefix) + ".";
   }
 
   /**

--- a/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitter.java
+++ b/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitter.java
@@ -47,7 +47,7 @@ public class OpentsdbEmitter implements Emitter
         config.getMaxQueueSize(),
         config.getConsumeDelay()
     );
-    this.converter = new EventConverter(mapper, config.getMetricMapPath());
+    this.converter = new EventConverter(mapper, config.getMetricMapPath(), config.getNamespacePrefix());
   }
 
   @Override

--- a/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfig.java
+++ b/extensions-contrib/opentsdb-emitter/src/main/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfig.java
@@ -22,6 +22,7 @@ package org.apache.druid.emitter.opentsdb;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 public class OpentsdbEmitterConfig
 {
@@ -55,6 +56,9 @@ public class OpentsdbEmitterConfig
   @JsonProperty
   private final String metricMapPath;
 
+  @JsonProperty
+  private final String namespacePrefix;
+
   @JsonCreator
   public OpentsdbEmitterConfig(
       @JsonProperty("host") String host,
@@ -64,7 +68,8 @@ public class OpentsdbEmitterConfig
       @JsonProperty("flushThreshold") Integer flushThreshold,
       @JsonProperty("maxQueueSize") Integer maxQueueSize,
       @JsonProperty("consumeDelay") Long consumeDelay,
-      @JsonProperty("metricMapPath") String metricMapPath
+      @JsonProperty("metricMapPath") String metricMapPath,
+      @JsonProperty("namespacePrefix") String namespacePrefix
   )
   {
     this.host = Preconditions.checkNotNull(host, "host can not be null.");
@@ -78,6 +83,7 @@ public class OpentsdbEmitterConfig
     this.maxQueueSize = (maxQueueSize == null || maxQueueSize < 0) ? DEFAULT_MAX_QUEUE_SIZE : maxQueueSize;
     this.consumeDelay = (consumeDelay == null || consumeDelay < 0) ? DEFAULT_CONSUME_DELAY_MILLIS : consumeDelay;
     this.metricMapPath = metricMapPath;
+    this.namespacePrefix = "".equals(namespacePrefix) ? null : namespacePrefix;
   }
 
   @Override
@@ -113,6 +119,9 @@ public class OpentsdbEmitterConfig
     if (consumeDelay != that.consumeDelay) {
       return false;
     }
+    if (!Objects.equals(namespacePrefix, that.namespacePrefix)) {
+      return false;
+    }
     return metricMapPath != null ? metricMapPath.equals(that.metricMapPath)
                                  : that.metricMapPath == null;
   }
@@ -128,6 +137,7 @@ public class OpentsdbEmitterConfig
     result = 31 * result + maxQueueSize;
     result = 31 * result + (int) consumeDelay;
     result = 31 * result + (metricMapPath != null ? metricMapPath.hashCode() : 0);
+    result = 31 * result + (namespacePrefix != null ? namespacePrefix.hashCode() : 0);
     return result;
   }
 
@@ -170,4 +180,10 @@ public class OpentsdbEmitterConfig
   {
     return metricMapPath;
   }
+
+  public String getNamespacePrefix()
+  {
+    return namespacePrefix;
+  }
+
 }

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/EventConverterTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/EventConverterTest.java
@@ -32,29 +32,29 @@ import java.util.Map;
 
 public class EventConverterTest
 {
-  private EventConverter converterWithPrefix;
-  private EventConverter converterWithPrefixContainingSpace;
-  private EventConverter converterWithoutPrefix;
+  private EventConverter converterWithNamespacePrefix;
+  private EventConverter converterWithNamespacePrefixContainingSpace;
+  private EventConverter converterWithoutNamespacePrefix;
 
   @Before
   public void setUp()
   {
-    converterWithPrefix = new EventConverter(new ObjectMapper(), null, "druid");
-    converterWithPrefixContainingSpace = new EventConverter(new ObjectMapper(), null, "legendary druid");
-    converterWithoutPrefix = new EventConverter(new ObjectMapper(), null, null);
+    converterWithNamespacePrefix = new EventConverter(new ObjectMapper(), null, "druid");
+    converterWithNamespacePrefixContainingSpace = new EventConverter(new ObjectMapper(), null, "legendary druid");
+    converterWithoutNamespacePrefix = new EventConverter(new ObjectMapper(), null, null);
   }
 
   @Test
   public void testSanitize()
   {
     String metric = " foo bar/baz";
-    Assert.assertEquals("foo_bar.baz", converterWithPrefix.sanitize(metric));
-    Assert.assertEquals("foo_bar.baz", converterWithPrefixContainingSpace.sanitize(metric));
-    Assert.assertEquals("foo_bar.baz", converterWithoutPrefix.sanitize(metric));
+    Assert.assertEquals("foo_bar.baz", converterWithNamespacePrefix.sanitize(metric));
+    Assert.assertEquals("foo_bar.baz", converterWithNamespacePrefixContainingSpace.sanitize(metric));
+    Assert.assertEquals("foo_bar.baz", converterWithoutNamespacePrefix.sanitize(metric));
   }
 
   @Test
-  public void testConvertWithPrefix()
+  public void testConvertWithNamespacePrefix()
   {
     DateTime dateTime = DateTimes.nowUtc();
     ServiceMetricEvent configuredEvent = new ServiceMetricEvent.Builder()
@@ -69,7 +69,7 @@ public class EventConverterTest
     expectedTags.put("dataSource", "foo_bar");
     expectedTags.put("type", "groupBy");
 
-    OpentsdbEvent opentsdbEvent = converterWithPrefix.convert(configuredEvent);
+    OpentsdbEvent opentsdbEvent = converterWithNamespacePrefix.convert(configuredEvent);
     Assert.assertEquals("druid.query.time", opentsdbEvent.getMetric());
     Assert.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
     Assert.assertEquals(10, opentsdbEvent.getValue());
@@ -80,11 +80,11 @@ public class EventConverterTest
         .setDimension("type", "groupBy")
         .build(dateTime, "foo/bar", 10)
         .build("broker", "brokerHost1");
-    Assert.assertNull(converterWithPrefix.convert(notConfiguredEvent));
+    Assert.assertNull(converterWithNamespacePrefix.convert(notConfiguredEvent));
   }
 
   @Test
-  public void testConvertWithPrefixContainingSpace()
+  public void testConvertWithNamespacePrefixContainingSpace()
   {
     DateTime dateTime = DateTimes.nowUtc();
     ServiceMetricEvent configuredEvent = new ServiceMetricEvent.Builder()
@@ -99,7 +99,7 @@ public class EventConverterTest
     expectedTags.put("dataSource", "foo_bar");
     expectedTags.put("type", "groupBy");
 
-    OpentsdbEvent opentsdbEvent = converterWithPrefixContainingSpace.convert(configuredEvent);
+    OpentsdbEvent opentsdbEvent = converterWithNamespacePrefixContainingSpace.convert(configuredEvent);
     Assert.assertEquals("legendary_druid.query.time", opentsdbEvent.getMetric());
     Assert.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
     Assert.assertEquals(10, opentsdbEvent.getValue());
@@ -110,11 +110,11 @@ public class EventConverterTest
         .setDimension("type", "groupBy")
         .build(dateTime, "foo/bar", 10)
         .build("broker", "brokerHost1");
-    Assert.assertNull(converterWithPrefixContainingSpace.convert(notConfiguredEvent));
+    Assert.assertNull(converterWithNamespacePrefixContainingSpace.convert(notConfiguredEvent));
   }
 
   @Test
-  public void testConvertWithoutPrefix()
+  public void testConvertWithoutNamespacePrefix()
   {
     DateTime dateTime = DateTimes.nowUtc();
     ServiceMetricEvent configuredEvent = new ServiceMetricEvent.Builder()
@@ -129,7 +129,7 @@ public class EventConverterTest
     expectedTags.put("dataSource", "foo_bar");
     expectedTags.put("type", "groupBy");
 
-    OpentsdbEvent opentsdbEvent = converterWithoutPrefix.convert(configuredEvent);
+    OpentsdbEvent opentsdbEvent = converterWithoutNamespacePrefix.convert(configuredEvent);
     Assert.assertEquals("query.time", opentsdbEvent.getMetric());
     Assert.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
     Assert.assertEquals(10, opentsdbEvent.getValue());
@@ -140,7 +140,7 @@ public class EventConverterTest
         .setDimension("type", "groupBy")
         .build(dateTime, "foo/bar", 10)
         .build("broker", "brokerHost1");
-    Assert.assertNull(converterWithoutPrefix.convert(notConfiguredEvent));
+    Assert.assertNull(converterWithoutNamespacePrefix.convert(notConfiguredEvent));
   }
 
 }

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/EventConverterTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/EventConverterTest.java
@@ -34,7 +34,6 @@ public class EventConverterTest
 {
   private EventConverter converterWithPrefix;
   private EventConverter converterWithPrefixContainingSpace;
-  private EventConverter converterWithPrefixContainingEmptyString;
   private EventConverter converterWithoutPrefix;
 
   @Before
@@ -42,7 +41,6 @@ public class EventConverterTest
   {
     converterWithPrefix = new EventConverter(new ObjectMapper(), null, "druid");
     converterWithPrefixContainingSpace = new EventConverter(new ObjectMapper(), null, "legendary druid");
-    converterWithPrefixContainingEmptyString = new EventConverter(new ObjectMapper(), null, "");
     converterWithoutPrefix = new EventConverter(new ObjectMapper(), null, null);
   }
 
@@ -113,36 +111,6 @@ public class EventConverterTest
         .build(dateTime, "foo/bar", 10)
         .build("broker", "brokerHost1");
     Assert.assertNull(converterWithPrefixContainingSpace.convert(notConfiguredEvent));
-  }
-
-  @Test
-  public void testConvertWithPrefixContainingEmptyString()
-  {
-    DateTime dateTime = DateTimes.nowUtc();
-    ServiceMetricEvent configuredEvent = new ServiceMetricEvent.Builder()
-        .setDimension("dataSource", "foo:bar")
-        .setDimension("type", "groupBy")
-        .build(dateTime, "query/time", 10)
-        .build("druid:broker", "127.0.0.1:8080");
-
-    Map<String, Object> expectedTags = new HashMap<>();
-    expectedTags.put("service", "druid_broker");
-    expectedTags.put("host", "127.0.0.1_8080");
-    expectedTags.put("dataSource", "foo_bar");
-    expectedTags.put("type", "groupBy");
-
-    OpentsdbEvent opentsdbEvent = converterWithPrefixContainingEmptyString.convert(configuredEvent);
-    Assert.assertEquals("query.time", opentsdbEvent.getMetric());
-    Assert.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
-    Assert.assertEquals(10, opentsdbEvent.getValue());
-    Assert.assertEquals(expectedTags, opentsdbEvent.getTags());
-
-    ServiceMetricEvent notConfiguredEvent = new ServiceMetricEvent.Builder()
-        .setDimension("dataSource", "data-source")
-        .setDimension("type", "groupBy")
-        .build(dateTime, "foo/bar", 10)
-        .build("broker", "brokerHost1");
-    Assert.assertNull(converterWithPrefixContainingEmptyString.convert(notConfiguredEvent));
   }
 
   @Test

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfigTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfigTest.java
@@ -39,10 +39,41 @@ public class OpentsdbEmitterConfigTest
   @Test
   public void testSerDeserOpentsdbEmitterConfig() throws Exception
   {
-    OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null);
+    OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null, "druid");
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
     OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
                                                                 .readValue(opentsdbEmitterConfigString);
     Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
   }
+
+  @Test
+  public void testSerDeserOpentsdbEmitterConfigWithSpaceNamespace() throws Exception
+  {
+    OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null, "legendary druid");
+    String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
+    OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
+                                                                .readValue(opentsdbEmitterConfigString);
+    Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
+  }
+
+  @Test
+  public void testSerDeserOpentsdbEmitterConfigWithNullNamespace() throws Exception
+  {
+    OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null, null);
+    String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
+    OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
+        .readValue(opentsdbEmitterConfigString);
+    Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
+  }
+
+  @Test
+  public void testSerDeserOpentsdbEmitterConfigWithoutNamespace() throws Exception
+  {
+    OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null, "");
+    String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
+    OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
+        .readValue(opentsdbEmitterConfigString);
+    Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
+  }
+
 }

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfigTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfigTest.java
@@ -47,7 +47,7 @@ public class OpentsdbEmitterConfigTest
   }
 
   @Test
-  public void testSerDeserOpentsdbEmitterConfigWithSpaceNamespace() throws Exception
+  public void testSerDeserOpentsdbEmitterConfigWithNamespacePrefixContainingSpace() throws Exception
   {
     OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null, "legendary druid");
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
@@ -57,7 +57,7 @@ public class OpentsdbEmitterConfigTest
   }
 
   @Test
-  public void testSerDeserOpentsdbEmitterConfigWithNullNamespace() throws Exception
+  public void testSerDeserOpentsdbEmitterConfigWithNullNamespacePrefix() throws Exception
   {
     OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null, null);
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
@@ -67,7 +67,7 @@ public class OpentsdbEmitterConfigTest
   }
 
   @Test
-  public void testSerDeserOpentsdbEmitterConfigWithoutNamespace() throws Exception
+  public void testSerDeserOpentsdbEmitterConfigWithEmptyNamespacePrefix() throws Exception
   {
     OpentsdbEmitterConfig opentsdbEmitterConfig = new OpentsdbEmitterConfig("localhost", 9999, 2000, 2000, 200, 2000, 10000L, null, "");
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);

--- a/website/.spelling
+++ b/website/.spelling
@@ -517,6 +517,7 @@ postAggregations
 postAveragers
  - ../docs/development/extensions-contrib/opentsdb-emitter.md
 defaultMetrics.json
+namespacePrefix
 src
  - ../docs/development/extensions-contrib/redis-cache.md
 loadList


### PR DESCRIPTION
opentsdb emitter sends metric names to opentsdb verbatim as what druid
names them, for example "query.count", this doesn't fit well with a
central opentsdb server which might have namespaced metrics, for example
"druid.query.count". This adds support for adding an optional prefix.

The prefix also gets a trailing dot (.), after it, so the metric name
becomes <namespacePrefix>.<metricname>

configureable as "druid.emitter.opentsdb.namespacePrefix", as
documented.

Co-authored-by: Martin Gerholm <martin.gerholm@deltaprojects.com>
Signed-off-by: Martin Gerholm <martin.gerholm@deltaprojects.com>
Signed-off-by: Björn Zettergren <bjorn.zettergren@deltaprojects.com>

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths.
