### PR TITLE
Fix join filter push down post-join virtual column handling

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.segment.join;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.druid.java.util.common.granularity.Granularity;
@@ -224,24 +223,14 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
       @Nullable final QueryMetrics<?> queryMetrics
   )
   {
-    final Set<String> baseColumns = new HashSet<>();
-    Iterables.addAll(baseColumns, baseAdapter.getAvailableDimensions());
-    Iterables.addAll(baseColumns, baseAdapter.getAvailableMetrics());
 
     final List<VirtualColumn> preJoinVirtualColumns = new ArrayList<>();
     final List<VirtualColumn> postJoinVirtualColumns = new ArrayList<>();
-
-    for (VirtualColumn virtualColumn : virtualColumns.getVirtualColumns()) {
-      // Virtual columns cannot depend on each other, so we don't need to check transitive dependencies.
-      if (baseColumns.containsAll(virtualColumn.requiredColumns())) {
-        preJoinVirtualColumns.add(virtualColumn);
-        // Since pre-join virtual columns can be computed using only base columns, we include them in the
-        // base column set.
-        baseColumns.add(virtualColumn.getOutputName());
-      } else {
-        postJoinVirtualColumns.add(virtualColumn);
-      }
-    }
+    final Set<String> baseColumns = determineBaseColumnsWithPreAndPostJoinVirtualColumns(
+        virtualColumns,
+        preJoinVirtualColumns,
+        postJoinVirtualColumns
+    );
 
     JoinFilterSplit joinFilterSplit = JoinFilterAnalyzer.splitFilter(
         this,
@@ -302,16 +291,42 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
     return enableFilterPushDown;
   }
 
-  @VisibleForTesting
-  public Set<String> getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns virtualColumns)
+  /**
+   * Return a String set containing the name of columns that belong to the base table (including any pre-join virtual
+   * columns as well).
+   *
+   * Additionally, if the preJoinVirtualColumns and/or postJoinVirtualColumns arguments are provided, this method
+   * will add each VirtualColumn in the provided virtualColumns to either preJoinVirtualColumns or
+   * postJoinVirtualColumns based on whether the virtual column is pre-join or post-join.
+   *
+   * @param virtualColumns List of virtual columns from the query
+   * @param preJoinVirtualColumns If provided, virtual columns determined to be pre-join will be added to this list
+   * @param postJoinVirtualColumns If provided, virtual columns determined to be post-join will be added to this list
+   * @return The set of base column names, including any pre-join virtual columns.
+   */
+  public Set<String> determineBaseColumnsWithPreAndPostJoinVirtualColumns(
+      VirtualColumns virtualColumns,
+      @Nullable List<VirtualColumn> preJoinVirtualColumns,
+      @Nullable List<VirtualColumn> postJoinVirtualColumns
+  )
   {
     final Set<String> baseColumns = new HashSet<>();
     Iterables.addAll(baseColumns, baseAdapter.getAvailableDimensions());
     Iterables.addAll(baseColumns, baseAdapter.getAvailableMetrics());
 
     for (VirtualColumn virtualColumn : virtualColumns.getVirtualColumns()) {
+      // Virtual columns cannot depend on each other, so we don't need to check transitive dependencies.
       if (baseColumns.containsAll(virtualColumn.requiredColumns())) {
+        // Since pre-join virtual columns can be computed using only base columns, we include them in the
+        // base column set.
         baseColumns.add(virtualColumn.getOutputName());
+        if (preJoinVirtualColumns != null) {
+          preJoinVirtualColumns.add(virtualColumn);
+        }
+      } else {
+        if (postJoinVirtualColumns != null) {
+          postJoinVirtualColumns.add(virtualColumn);
+        }
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
@@ -51,7 +51,7 @@ import java.util.Set;
  * When there is a filter in a join query, we can sometimes improve performance by applying parts of the filter
  * when we first read from the base table instead of after the join.
  *
- * This class provides a {@link #splitFilter(HashJoinSegmentStorageAdapter, Filter, boolean)} method that
+ * This class provides a {@link #splitFilter(HashJoinSegmentStorageAdapter, Set, Filter, boolean)} method that
  * takes a filter and splits it into a portion that should be applied to the base table prior to the join, and a
  * portion that should be applied after the join.
  *
@@ -74,6 +74,7 @@ public class JoinFilterAnalyzer
 
   public static JoinFilterSplit splitFilter(
       HashJoinSegmentStorageAdapter hashJoinSegmentStorageAdapter,
+      Set<String> baseColumnNames,
       @Nullable Filter originalFilter,
       boolean enableFilterPushDown
   )
@@ -134,6 +135,7 @@ public class JoinFilterAnalyzer
     for (Filter orClause : normalizedOrClauses) {
       JoinFilterAnalysis joinFilterAnalysis = analyzeJoinFilterClause(
           hashJoinSegmentStorageAdapter,
+          baseColumnNames,
           orClause,
           prefixes,
           equiconditions,
@@ -173,6 +175,7 @@ public class JoinFilterAnalyzer
    */
   private static JoinFilterAnalysis analyzeJoinFilterClause(
       HashJoinSegmentStorageAdapter adapter,
+      Set<String> baseColumnNames,
       Filter filterClause,
       Map<String, JoinableClause> prefixes,
       Map<String, Set<Expr>> equiconditions,
@@ -190,6 +193,7 @@ public class JoinFilterAnalyzer
     if (filterClause instanceof SelectorFilter) {
       return rewriteSelectorFilter(
           adapter,
+          baseColumnNames,
           (SelectorFilter) filterClause,
           prefixes,
           equiconditions,
@@ -200,6 +204,7 @@ public class JoinFilterAnalyzer
     if (filterClause instanceof OrFilter) {
       return rewriteOrFilter(
           adapter,
+          baseColumnNames,
           (OrFilter) filterClause,
           prefixes,
           equiconditions,
@@ -208,7 +213,7 @@ public class JoinFilterAnalyzer
     }
 
     for (String requiredColumn : filterClause.getRequiredColumns()) {
-      if (!adapter.isBaseColumn(requiredColumn)) {
+      if (!baseColumnNames.contains(requiredColumn)) {
         return JoinFilterAnalysis.createNoPushdownFilterAnalysis(filterClause);
       }
     }
@@ -235,6 +240,7 @@ public class JoinFilterAnalyzer
    */
   private static JoinFilterAnalysis rewriteOrFilter(
       HashJoinSegmentStorageAdapter adapter,
+      Set<String> baseColumnNames,
       OrFilter orFilter,
       Map<String, JoinableClause> prefixes,
       Map<String, Set<Expr>> equiconditions,
@@ -247,7 +253,7 @@ public class JoinFilterAnalyzer
     for (Filter filter : orFilter.getFilters()) {
       boolean allBaseColumns = true;
       for (String requiredColumn : filter.getRequiredColumns()) {
-        if (!adapter.isBaseColumn(requiredColumn)) {
+        if (!baseColumnNames.contains(requiredColumn)) {
           allBaseColumns = false;
         }
       }
@@ -257,6 +263,7 @@ public class JoinFilterAnalyzer
         if (filter instanceof SelectorFilter) {
           JoinFilterAnalysis rewritten = rewriteSelectorFilter(
               adapter,
+              baseColumnNames,
               (SelectorFilter) filter,
               prefixes,
               equiconditions,
@@ -297,6 +304,7 @@ public class JoinFilterAnalyzer
    */
   private static JoinFilterAnalysis rewriteSelectorFilter(
       HashJoinSegmentStorageAdapter baseAdapter,
+      Set<String> baseColumnNames,
       SelectorFilter selectorFilter,
       Map<String, JoinableClause> prefixes,
       Map<String, Set<Expr>> equiconditions,
@@ -310,6 +318,7 @@ public class JoinFilterAnalyzer
             prefixAndClause.getKey(),
             p -> findCorrelatedBaseTableColumns(
                 baseAdapter,
+                baseColumnNames,
                 p,
                 prefixes.get(p),
                 equiconditions
@@ -385,12 +394,21 @@ public class JoinFilterAnalyzer
         );
       }
     }
-    return new JoinFilterAnalysis(
-        false,
-        selectorFilter,
-        selectorFilter,
-        ImmutableList.of()
-    );
+
+    // We're not filtering directly on a column from one of the join tables, but
+    // we might be filtering on a post-join virtual column (which won't have a join prefix). We cannot
+    // push down such filters, so check that the filtering column appears in the set of base column names (which
+    // includes pre-join virtual columns).
+    if (baseColumnNames.contains(filteringColumn)) {
+      return new JoinFilterAnalysis(
+          false,
+          selectorFilter,
+          selectorFilter,
+          ImmutableList.of()
+      );
+    } else {
+      return JoinFilterAnalysis.createNoPushdownFilterAnalysis(selectorFilter);
+    }
   }
 
   private static String getCorrelatedBaseExprVirtualColumnName(int counter)
@@ -462,6 +480,7 @@ public class JoinFilterAnalyzer
    */
   private static Optional<List<JoinFilterColumnCorrelationAnalysis>> findCorrelatedBaseTableColumns(
       HashJoinSegmentStorageAdapter adapter,
+      Set<String> baseColumnNames,
       String tablePrefix,
       JoinableClause clauseForTablePrefix,
       Map<String, Set<Expr>> equiConditions
@@ -481,7 +500,7 @@ public class JoinFilterAnalyzer
       Set<Expr> correlatedBaseExpressions = new HashSet<>();
 
       getCorrelationForRHSColumn(
-          adapter,
+          baseColumnNames,
           equiConditions,
           rhsColumn,
           correlatedBaseColumns,
@@ -511,7 +530,6 @@ public class JoinFilterAnalyzer
    * and/or expressions for a single RHS column and adds them to the provided sets as it traverses the
    * equicondition column relationships.
    *
-   * @param adapter The adapter for the join. Used to determine if a column is a base table column.
    * @param equiConditions Map of equiconditions, keyed by the right hand columns
    * @param rhsColumn RHS column to find base table correlations for
    * @param correlatedBaseColumns Set of correlated base column names for the provided RHS column. Will be modified.
@@ -519,7 +537,7 @@ public class JoinFilterAnalyzer
    *                                  modified.
    */
   private static void getCorrelationForRHSColumn(
-      HashJoinSegmentStorageAdapter adapter,
+      Set<String> baseColumnNames,
       Map<String, Set<Expr>> equiConditions,
       String rhsColumn,
       Set<String> correlatedBaseColumns,
@@ -538,18 +556,18 @@ public class JoinFilterAnalyzer
         // We push down if the function only requires base table columns
         Expr.BindingDetails bindingDetails = lhsExpr.analyzeInputs();
         Set<String> requiredBindings = bindingDetails.getRequiredBindings();
-        if (!requiredBindings.stream().allMatch(requiredBinding -> adapter.isBaseColumn(requiredBinding))) {
+        if (!requiredBindings.stream().allMatch(requiredBinding -> baseColumnNames.contains(requiredBinding))) {
           break;
         }
         correlatedBaseExpressions.add(lhsExpr);
       } else {
         // simple identifier, see if we can correlate it with a column on the base table
         findMappingFor = identifier;
-        if (adapter.isBaseColumn(identifier)) {
+        if (baseColumnNames.contains(identifier)) {
           correlatedBaseColumns.add(findMappingFor);
         } else {
           getCorrelationForRHSColumn(
-              adapter,
+              baseColumnNames,
               equiConditions,
               findMappingFor,
               correlatedBaseColumns,

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
@@ -146,7 +146,6 @@ public class JoinFilterAnalyzer
 
     for (Filter orClause : normalizedOrClauses) {
       JoinFilterAnalysis joinFilterAnalysis = analyzeJoinFilterClause(
-          hashJoinSegmentStorageAdapter,
           baseColumnNames,
           orClause,
           prefixes,
@@ -177,7 +176,6 @@ public class JoinFilterAnalyzer
    * Analyze a filter clause from a filter that is in conjunctive normal form (AND of ORs).
    * The clause is expected to be an OR filter or a leaf filter.
    *
-   * @param adapter          Adapter for the join
    * @param baseColumnNames  Set of names of columns that belong to the base table, including pre-join virtual columns
    * @param filterClause     Individual filter clause (an OR filter or a leaf filter) from a filter that is in CNF
    * @param prefixes         Map of table prefixes
@@ -187,7 +185,6 @@ public class JoinFilterAnalyzer
    * @return a JoinFilterAnalysis that contains a possible filter rewrite and information on how to handle the filter.
    */
   private static JoinFilterAnalysis analyzeJoinFilterClause(
-      HashJoinSegmentStorageAdapter adapter,
       Set<String> baseColumnNames,
       Filter filterClause,
       Map<String, JoinableClause> prefixes,
@@ -205,7 +202,6 @@ public class JoinFilterAnalyzer
     // Currently we only support rewrites of selector filters and selector filters within OR filters.
     if (filterClause instanceof SelectorFilter) {
       return rewriteSelectorFilter(
-          adapter,
           baseColumnNames,
           (SelectorFilter) filterClause,
           prefixes,
@@ -216,7 +212,6 @@ public class JoinFilterAnalyzer
 
     if (filterClause instanceof OrFilter) {
       return rewriteOrFilter(
-          adapter,
           baseColumnNames,
           (OrFilter) filterClause,
           prefixes,
@@ -242,7 +237,6 @@ public class JoinFilterAnalyzer
    * Potentially rewrite the subfilters of an OR filter so that the whole OR filter can be pushed down to
    * the base table.
    *
-   * @param adapter          Adapter for the join
    * @param baseColumnNames  Set of names of columns that belong to the base table, including pre-join virtual columns
    * @param orFilter         OrFilter to be rewritten
    * @param prefixes         Map of table prefixes to clauses
@@ -253,7 +247,6 @@ public class JoinFilterAnalyzer
    * @return A JoinFilterAnalysis indicating how to handle the potentially rewritten filter
    */
   private static JoinFilterAnalysis rewriteOrFilter(
-      HashJoinSegmentStorageAdapter adapter,
       Set<String> baseColumnNames,
       OrFilter orFilter,
       Map<String, JoinableClause> prefixes,
@@ -276,7 +269,6 @@ public class JoinFilterAnalyzer
         retainRhs = true;
         if (filter instanceof SelectorFilter) {
           JoinFilterAnalysis rewritten = rewriteSelectorFilter(
-              adapter,
               baseColumnNames,
               (SelectorFilter) filter,
               prefixes,
@@ -307,7 +299,6 @@ public class JoinFilterAnalyzer
   /**
    * Rewrites a selector filter on a join table into an IN filter on the base table.
    *
-   * @param baseAdapter      The adapter for the join
    * @param baseColumnNames  Set of names of columns that belong to the base table, including pre-join virtual
    *                         columns
    * @param selectorFilter   SelectorFilter to be rewritten
@@ -319,7 +310,6 @@ public class JoinFilterAnalyzer
    * @return A JoinFilterAnalysis that indicates how to handle the potentially rewritten filter
    */
   private static JoinFilterAnalysis rewriteSelectorFilter(
-      HashJoinSegmentStorageAdapter baseAdapter,
       Set<String> baseColumnNames,
       SelectorFilter selectorFilter,
       Map<String, JoinableClause> prefixes,

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
@@ -66,7 +66,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -138,7 +138,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -193,7 +193,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -256,7 +256,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -313,7 +313,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -370,7 +370,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(virtualColumns),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(virtualColumns, null, null),
         originalFilter,
         true
     );
@@ -440,7 +440,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(virtualColumns),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(virtualColumns, null, null),
         originalFilter,
         true
     );
@@ -599,7 +599,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -670,7 +670,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -828,7 +828,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -906,7 +906,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         filter,
         true
     );
@@ -969,7 +969,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -1024,7 +1024,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -1077,7 +1077,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -1138,7 +1138,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -1190,7 +1190,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         filter,
         true
     );
@@ -1245,7 +1245,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -1310,7 +1310,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -1368,7 +1368,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         true
     );
@@ -1413,7 +1413,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(
         adapter,
-        adapter.getAdapterBaseColumnNamesWithVirtualColumns(VirtualColumns.EMPTY),
+        adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(VirtualColumns.EMPTY, null, null),
         originalFilter,
         adapter.isEnableFilterPushDown()
     );


### PR DESCRIPTION
This PR fixes an issue in JoinFilterAnalyzer where post-join virtual columns were incorrectly identified as belonging to the base table column set, leading to filters on such virtual columns being pushed down incorrectly.

The PR fixes the issue by passing in the set of base table columns (including any pre-join virtual columns) to JoinFilterAnalyzer.splitFilter instead of checking prefixes.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
