### PR TITLE
Make java version check work on all shells

### DIFF
--- a/examples/bin/java-util
+++ b/examples/bin/java-util
@@ -33,7 +33,7 @@ get_java_bin_dir() {
     elif [ ! -z "$(command -v java)" ]; then
       # Strip /java from the location of where java is installed
       JAVA_ON_PATH="$(command -v java)"
-      echo -n "${JAVA_ON_PATH%/java}"
+      printf "${JAVA_ON_PATH%/java}"
     else
       printf ""
     fi

--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -52,7 +52,7 @@ if ($skip_var && $skip_var ne "0" && $skip_var ne "false" && $skip_var ne "f") {
 }
 
 my $cwd =  dirname(__FILE__);
-my $java_bin_dir = `source $cwd/java-util && get_java_bin_dir 2>&1`;
+my $java_bin_dir = `. $cwd/java-util && get_java_bin_dir 2>&1`;
 
 # If we could not find java
 if ($java_bin_dir eq "") {


### PR DESCRIPTION
Fixes #9276.

### Description

Previously, `perl verify-java` would fail on shells like zsh, which would cause the quickstart scripts (e.g., bin/start-micro-quickstart) to fail unless the DRUID_SKIP_JAVA_SKIP environment variable is set.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] manually tested with sh, bash, csh, tcsh, ksh, zsh, dash.