### PR TITLE
Suppress CVE-2020-8840 for htrace-core-4.0.1

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -197,5 +197,6 @@
     <cve>CVE-2019-17267</cve>
     <cve>CVE-2019-17531</cve>
     <cve>CVE-2019-20330</cve>
+    <cve>CVE-2020-8840</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Description

CVE-2020-8840 was updated on 19 Feb 2020, which now gets flagged by the security vulnerability scan. Since the CVE is for jackson-databind, via htrace-core-4.0.1, it can be added to the existing list of security vulnerability suppressions for that dependency.

<hr>

This PR has:
- [x] been self-reviewed.