### PR TITLE
Add join prefix duplicate/shadowing check

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
@@ -42,6 +42,12 @@ public class HashJoinSegment extends AbstractSegment
   private final List<JoinableClause> clauses;
   private final boolean enableFilterPushDown;
 
+  /**
+   * @param baseSegment The left-hand side base segment
+   * @param clauses The right-hand side clauses. The caller is responsible for ensuring that there are no
+   *                duplicate prefixes or prefixes that shadow each other across the clauses
+   * @param enableFilterPushDown Whether to enable filter push down optimizations to the base segment
+   */
   public HashJoinSegment(
       Segment baseSegment,
       List<JoinableClause> clauses,

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -56,16 +56,12 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
   private final List<JoinableClause> clauses;
   private final boolean enableFilterPushDown;
 
-  HashJoinSegmentStorageAdapter(
-      StorageAdapter baseAdapter,
-      List<JoinableClause> clauses
-  )
-  {
-    this.baseAdapter = baseAdapter;
-    this.clauses = clauses;
-    this.enableFilterPushDown = QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN;
-  }
-
+  /**
+   * @param baseAdapter A StorageAdapter for the left-hand side base segment
+   * @param clauses The right-hand side clauses. The caller is responsible for ensuring that there are no
+   *                duplicate prefixes or prefixes that shadow each other across the clauses
+   * @param enableFilterPushDown Whether to enable filter push down optimizations to the base segment
+   */
   HashJoinSegmentStorageAdapter(
       StorageAdapter baseAdapter,
       List<JoinableClause> clauses,
@@ -75,6 +71,14 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
     this.baseAdapter = baseAdapter;
     this.clauses = clauses;
     this.enableFilterPushDown = enableFilterPushDown;
+  }
+
+  HashJoinSegmentStorageAdapter(
+      StorageAdapter baseAdapter,
+      List<JoinableClause> clauses
+  )
+  {
+    this(baseAdapter, clauses, QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.join;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.druid.java.util.common.granularity.Granularity;
@@ -73,6 +74,7 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
     this.enableFilterPushDown = enableFilterPushDown;
   }
 
+  @VisibleForTesting
   HashJoinSegmentStorageAdapter(
       StorageAdapter baseAdapter,
       List<JoinableClause> clauses

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
@@ -40,15 +40,8 @@ import java.util.stream.Collectors;
  */
 public class Joinables
 {
-  private static final Comparator<String> DESCENDING_LENGTH_STRING_COMPARATOR = (s1, s2) -> {
-    if (s1.length() > s2.length()) {
-      return -1;
-    } else if (s1.length() < s2.length()) {
-      return 1;
-    } else {
-      return 0;
-    }
-  };
+  private static final Comparator<String> DESCENDING_LENGTH_STRING_COMPARATOR = (s1, s2) ->
+      Integer.compare(s2.length(), s1.length());
 
   /**
    * Checks that "prefix" is a valid prefix for a join clause (see {@link JoinableClause#getPrefix()}) and, if so,

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
@@ -149,16 +149,13 @@ public class Joinables
     prefixes.sort(DESCENDING_LENGTH_STRING_COMPARATOR);
     for (int i = 0; i < prefixes.size(); i++) {
       String prefix = prefixes.get(i);
-      for (int k = i; k < prefixes.size(); k++) {
-        if (i != k) {
-          String otherPrefix = prefixes.get(k);
-          if (prefix.equals(otherPrefix)) {
-            throw new IAE("Detected duplicate prefix in join clauses: [%s]", prefix);
-          }
-
-          if (isPrefixedBy(prefix, otherPrefix)) {
-            throw new IAE("Detected conflicting prefixes in join clauses: [%s, %s]", prefix, otherPrefix);
-          }
+      for (int k = i + 1; k < prefixes.size(); k++) {
+        String otherPrefix = prefixes.get(k);
+        if (prefix.equals(otherPrefix)) {
+          throw new IAE("Detected duplicate prefix in join clauses: [%s]", prefix);
+        }
+        if (isPrefixedBy(prefix, otherPrefix)) {
+          throw new IAE("Detected conflicting prefixes in join clauses: [%s, %s]", prefix, otherPrefix);
         }
       }
     }

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
@@ -141,7 +141,7 @@ public class Joinables
         if (i != k) {
           String otherPrefix = prefixes.get(k);
           if (prefix1.equals(otherPrefix)) {
-            throw new IAE("Detected duplicate prefix in join clauses: [%]", prefix1);
+            throw new IAE("Detected duplicate prefix in join clauses: [%s]", prefix1);
           }
 
           if (isPrefixedBy(prefix1, otherPrefix)) {

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
@@ -28,6 +28,7 @@ import org.apache.druid.utils.JvmUtils;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -39,6 +40,16 @@ import java.util.stream.Collectors;
  */
 public class Joinables
 {
+  private static final Comparator<String> DESCENDING_LENGTH_STRING_COMPARATOR = (s1, s2) -> {
+    if (s1.length() > s2.length()) {
+      return -1;
+    } else if (s1.length() < s2.length()) {
+      return 1;
+    } else {
+      return 0;
+    }
+  };
+
   /**
    * Checks that "prefix" is a valid prefix for a join clause (see {@link JoinableClause#getPrefix()}) and, if so,
    * returns it. Otherwise, throws an exception.
@@ -60,7 +71,7 @@ public class Joinables
 
   public static boolean isPrefixedBy(final String columnName, final String prefix)
   {
-    return columnName.startsWith(prefix) && columnName.length() > prefix.length();
+    return columnName.length() > prefix.length() && columnName.startsWith(prefix);
   }
 
   /**
@@ -119,7 +130,7 @@ public class Joinables
     }).collect(Collectors.toList());
   }
 
-  public static void checkPreJoinableClausesForDuplicatesAndShadowing(
+  private static void checkPreJoinableClausesForDuplicatesAndShadowing(
       final List<PreJoinableClause> preJoinableClauses
   )
   {
@@ -131,21 +142,29 @@ public class Joinables
     checkPrefixesForDuplicatesAndShadowing(prefixes);
   }
 
+  /**
+   * Check if any prefixes in the provided list duplicate or shadow each other.
+   *
+   * @param prefixes A mutable list containing the prefixes to check. This list will be sorted by descending
+   *                 string length.
+   */
   public static void checkPrefixesForDuplicatesAndShadowing(
       final List<String> prefixes
   )
   {
+    // this is a naive approach that assumes we'll typically handle only a small number of prefixes
+    prefixes.sort(DESCENDING_LENGTH_STRING_COMPARATOR);
     for (int i = 0; i < prefixes.size(); i++) {
-      String prefix1 = prefixes.get(i);
-      for (int k = 0; k < prefixes.size(); k++) {
+      String prefix = prefixes.get(i);
+      for (int k = i; k < prefixes.size(); k++) {
         if (i != k) {
           String otherPrefix = prefixes.get(k);
-          if (prefix1.equals(otherPrefix)) {
-            throw new IAE("Detected duplicate prefix in join clauses: [%s]", prefix1);
+          if (prefix.equals(otherPrefix)) {
+            throw new IAE("Detected duplicate prefix in join clauses: [%s]", prefix);
           }
 
-          if (isPrefixedBy(prefix1, otherPrefix)) {
-            throw new IAE("Detected conflicting prefixes in join clauses: [%s, %s]", prefix1, otherPrefix);
+          if (isPrefixedBy(prefix, otherPrefix)) {
+            throw new IAE("Detected conflicting prefixes in join clauses: [%s, %s]", prefix, otherPrefix);
           }
         }
       }

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
@@ -35,6 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -162,7 +163,7 @@ public class JoinablesTest
   @Test
   public void test_checkClausePrefixesForDuplicatesAndShadowing_noConflicts()
   {
-    List<String> prefixes = ImmutableList.of(
+    List<String> prefixes = Arrays.asList(
         "AA",
         "AB",
         "AC",
@@ -181,7 +182,7 @@ public class JoinablesTest
     expectedException.expect(IAE.class);
     expectedException.expectMessage("Detected duplicate prefix in join clauses: [AA]");
 
-    List<String> prefixes = ImmutableList.of(
+    List<String> prefixes = Arrays.asList(
         "AA",
         "AA",
         "ABCD"
@@ -196,7 +197,7 @@ public class JoinablesTest
     expectedException.expect(IAE.class);
     expectedException.expectMessage("Detected conflicting prefixes in join clauses: [ABC.DEF, ABC.]");
 
-    List<String> prefixes = ImmutableList.of(
+    List<String> prefixes = Arrays.asList(
         "BASE.",
         "BASEBALL",
         "123.456",

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.join;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.LookupDataSource;
 import org.apache.druid.query.QueryContexts;
@@ -34,6 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -155,5 +157,54 @@ public class JoinablesTest
     );
 
     Assert.assertNotSame(Function.identity(), segmentMapFn);
+  }
+
+  @Test
+  public void test_checkClausePrefixesForDuplicatesAndShadowing_noConflicts()
+  {
+    List<String> prefixes = ImmutableList.of(
+        "AA",
+        "AB",
+        "AC",
+        "aa",
+        "ab",
+        "ac",
+        "BA"
+    );
+
+    Joinables.checkPrefixesForDuplicatesAndShadowing(prefixes);
+  }
+
+  @Test
+  public void test_checkClausePrefixesForDuplicatesAndShadowing_duplicate()
+  {
+    expectedException.expect(IAE.class);
+    expectedException.expectMessage("Detected duplicate prefix in join clauses: [AA]");
+
+    List<String> prefixes = ImmutableList.of(
+        "AA",
+        "AA",
+        "ABCD"
+    );
+
+    Joinables.checkPrefixesForDuplicatesAndShadowing(prefixes);
+  }
+
+  @Test
+  public void test_checkClausePrefixesForDuplicatesAndShadowing_shadowing()
+  {
+    expectedException.expect(IAE.class);
+    expectedException.expectMessage("Detected conflicting prefixes in join clauses: [ABC.DEF, ABC.]");
+
+    List<String> prefixes = ImmutableList.of(
+        "BASE.",
+        "BASEBALL",
+        "123.456",
+        "23.45",
+        "ABC.",
+        "ABC.DEF"
+    );
+
+    Joinables.checkPrefixesForDuplicatesAndShadowing(prefixes);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/9329

This PR adds a sanity check for join clause prefix duplication and shadowing, addressing the followng PR comment: https://github.com/apache/druid/pull/9301#discussion_r375009323

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.