### PR TITLE
Improves on the fix for 8918

### DIFF
--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/EventReceiverFirehoseTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/EventReceiverFirehoseTestClient.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.StatusResponseHandler;
@@ -41,9 +42,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public class EventReceiverFirehoseTestClient
 {
+  private static final Logger LOG = new Logger(EventReceiverFirehoseTestClient.class);
+
+  static final int NUM_RETRIES = 30;
+  static final long DELAY_FOR_RETRIES_MS = 10000;
+
   private final String host;
   private final ObjectMapper jsonMapper;
   private final HttpClient httpClient;
@@ -82,31 +89,45 @@ public class EventReceiverFirehoseTestClient
    * @return
    */
   public int postEvents(Collection<Map<String, Object>> events, ObjectMapper objectMapper, String mediaType)
+      throws InterruptedException
   {
-    try {
-      StatusResponseHolder response = httpClient.go(
-          new Request(HttpMethod.POST, new URL(getURL()))
-              .setContent(mediaType, objectMapper.writeValueAsBytes(events)),
-          StatusResponseHandler.getInstance()
-      ).get();
+    int retryCount = 0;
+    while (true) {
+      try {
+        StatusResponseHolder response = httpClient.go(
+            new Request(HttpMethod.POST, new URL(getURL()))
+                .setContent(mediaType, objectMapper.writeValueAsBytes(events)),
+            StatusResponseHandler.getInstance()
+        ).get();
 
-      if (!response.getStatus().equals(HttpResponseStatus.OK)) {
-        throw new ISE(
-            "Error while posting events to url[%s] status[%s] content[%s]",
-            getURL(),
-            response.getStatus(),
-            response.getContent()
+        if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+          throw new ISE(
+              "Error while posting events to url[%s] status[%s] content[%s]",
+              getURL(),
+              response.getStatus(),
+              response.getContent()
+          );
+        }
+        Map<String, Integer> responseData = objectMapper.readValue(
+            response.getContent(), new TypeReference<Map<String, Integer>>()
+            {
+            }
         );
+        return responseData.get("eventCount");
       }
-      Map<String, Integer> responseData = objectMapper.readValue(
-          response.getContent(), new TypeReference<Map<String, Integer>>()
-          {
-          }
-      );
-      return responseData.get("eventCount");
-    }
-    catch (Exception e) {
-      throw new RuntimeException(e);
+      // adding retries to flaky tests using channels
+      catch (ExecutionException e) {
+        if (retryCount > NUM_RETRIES) {
+          throw new RuntimeException(e); //giving up now
+        } else {
+          LOG.info(e,"received exception, sleeping and retrying");
+          retryCount++;
+          Thread.sleep(DELAY_FOR_RETRIES_MS);
+        }
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/EventReceiverFirehoseTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/EventReceiverFirehoseTestClient.java
@@ -120,7 +120,7 @@ public class EventReceiverFirehoseTestClient
         if (retryCount > NUM_RETRIES) {
           throw new RuntimeException(e); //giving up now
         } else {
-          LOG.info(e,"received exception, sleeping and retrying");
+          LOG.info(e, "received exception, sleeping and retrying");
           retryCount++;
           Thread.sleep(DELAY_FOR_RETRIES_MS);
         }

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/HttpUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/HttpUtil.java
@@ -39,6 +39,9 @@ public class HttpUtil
   private static final Logger LOG = new Logger(AbstractQueryResourceTestClient.class);
   private static final StatusResponseHandler RESPONSE_HANDLER = StatusResponseHandler.getInstance();
 
+  static final int NUM_RETRIES = 30;
+  static final long DELAY_FOR_RETRIES_MS = 10000;
+
   public static StatusResponseHolder makeRequest(HttpClient httpClient, HttpMethod method, String url, byte[] content)
   {
     return makeRequestWithExpectedStatus(
@@ -78,13 +81,13 @@ public class HttpUtil
               response.getContent()
           );
           // it can take time for the auth config to propagate, so we retry
-          if (retryCount > 10) {
+          if (retryCount > NUM_RETRIES) {
             throw new ISE(errMsg);
           } else {
             LOG.error(errMsg);
             LOG.error("retrying in 3000ms, retryCount: " + retryCount);
             retryCount++;
-            Thread.sleep(3000);
+            Thread.sleep(DELAY_FOR_RETRIES_MS);
           }
         } else {
           break;

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
@@ -106,11 +106,14 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
       postEvents();
 
       // wait for a while to let the events be ingested
-      ITRetryUtil.retryUntilTrue(
+      ITRetryUtil.retryUntil(
           () -> {
             final int countRows = queryHelper.countRows(fullDatasourceName, Intervals.ETERNITY.toString());
             return countRows == getNumExpectedRowsIngested();
           },
+          true,
+          10000,
+          100,
           "Waiting all events are ingested"
       );
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
@@ -69,6 +69,9 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
   DateTime dtLast;             // timestamp of last event
   DateTime dtGroupBy;          // timestamp for expected response for groupBy query
 
+  static final int NUM_RETRIES = 60;
+  static final long DELAY_FOR_RETRIES_MS = 10000;
+
   @Inject
   ServerDiscoveryFactory factory;
   @Inject
@@ -112,8 +115,8 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
             return countRows == getNumExpectedRowsIngested();
           },
           true,
-          10000,
-          100,
+          DELAY_FOR_RETRIES_MS,
+          NUM_RETRIES,
           "Waiting all events are ingested"
       );
 
@@ -155,8 +158,8 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
       ITRetryUtil.retryUntil(
           () -> coordinator.areSegmentsLoaded(fullDatasourceName),
           true,
-          10000,
-          60,
+          DELAY_FOR_RETRIES_MS,
+          NUM_RETRIES,
           "Real-time generated segments loaded"
       );
 


### PR DESCRIPTION
Improves on the fixes for #8918

### Description

It just changes the `ITRetryUtil.retryUntilTrue` with a `ITRetryUtil.retryUntil` in order to increase the amount of retries — a little change on top of https://github.com/apache/druid/pull/8999 —, moreover it changes the number of retries and delay between retries in the `HttpUtil` to deal with the sporadic 401 errors.

<hr>

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
