### PR TITLE
[bugfix]fix sequences ArrayIndexOutOfBoundsException in SeekableStreamIndexTaskRunner

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1229,8 +1229,9 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
 
   private SequenceMetadata<PartitionIdType, SequenceOffsetType> getLastSequenceMetadata()
   {
-    Preconditions.checkState(!sequences.isEmpty(), "Empty sequences");
-    return sequences.get(sequences.size() - 1);
+    final CopyOnWriteArrayList<SequenceMetadata<PartitionIdType, SequenceOffsetType>> sequencesSnapshot = new CopyOnWriteArrayList<>(sequences);
+    Preconditions.checkState(!sequencesSnapshot.isEmpty(), "Empty sequences");
+    return sequencesSnapshot.get(sequencesSnapshot.size() - 1);
   }
 
   /**


### PR DESCRIPTION
### Description

getLastSequenceMetadata in SeekableStreamIndexTaskRunner

```java
private SequenceMetadata<PartitionIdType, SequenceOffsetType> getLastSequenceMetadata()
  {
    Preconditions.checkState(!sequences.isEmpty(), "Empty sequences");
    return sequences.get(sequences.size() - 1);
  }
```
**items in sequences may be removed during size() and get()**

**In our version, we meet error like this**
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at java.util.concurrent.CopyOnWriteArrayList.elementAt(CopyOnWriteArrayList.java:386) ~[?:?]
	at java.util.concurrent.CopyOnWriteArrayList.get(CopyOnWriteArrayList.java:399) ~[?:?]
	at io.druid.indexing.kafka.KafkaIndexTask.run(KafkaIndexTask.java:639) ~[druid-kafka-indexing-service-0.12.0.jar:0.12.0]
	at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:457) [druid-indexing-service-0.12.0.jar:0.12.0]
	at io.druid.indexing.overlord.ThreadPoolTaskRunner$ThreadPoolTaskRunnerCallable.call(ThreadPoolTaskRunner.java:429) [druid-indexing-service-0.12.0.jar:0.12.0]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]

**so  we can make a copy first, and create a CopyOnWriteArrayList from a CopyOnWriteArrayList will not really copy data, so the overhead is acceptable.**
```java
 private SequenceMetadata<PartitionIdType, SequenceOffsetType> getLastSequenceMetadata()
  {
    final CopyOnWriteArrayList<SequenceMetadata<PartitionIdType, SequenceOffsetType>> sequencesSnapshot = new CopyOnWriteArrayList<>(sequences);
    Preconditions.checkState(!sequencesSnapshot.isEmpty(), "Empty sequences");
    return sequencesSnapshot.get(sequencesSnapshot.size() - 1);
  }
```
This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.



