### PR TITLE
fix cursor position after function autocomplete

### DIFF
--- a/web-console/src/views/query-view/query-input/query-input.tsx
+++ b/web-console/src/views/query-view/query-input/query-input.tsx
@@ -93,8 +93,6 @@ export class QueryInput extends React.PureComponent<QueryInputProps, QueryInputS
         completer: {
           insertMatch: (editor: any, data: any) => {
             editor.completer.insertMatch({ value: data.caption });
-            const pos = editor.getCursorPosition();
-            editor.gotoLine(pos.row + 1, pos.column - 1);
           },
         },
       };


### PR DESCRIPTION
Fixes #9395.

### Description

Removed unnecessary editor.goToLine call after function name is inserted into the UI of SQL editor via auto-complete.
The small patch fixes the issue of cursor moving inside the inserted word after insertion.

This PR has:
- [x] been self-reviewed.
