### PR TITLE
Add common optional dependencies for extensions

### DIFF
--- a/docs/development/extensions-core/druid-lookups.md
+++ b/docs/development/extensions-core/druid-lookups.md
@@ -34,10 +34,9 @@ This module can be used side to side with other lookup module like the global ca
 To use this extension please make sure to  [include](../../development/extensions.md#loading-extensions) `druid-lookups-cached-single` as an extension.
 
 > If using JDBC, you will need to add your database's client JAR files to the extension's directory.
-> For MySQL, you can get it from https://dev.mysql.com/downloads/connector/j/, and for Postgres, from
-> https://jdbc.postgresql.org/download.html or from `extensions/postgresql-metadata-storage/`.
-> Copy or symlink the downloaded file to
-> `extensions/druid-lookups-cached-single` under the distribution root directory.
+> For Postgres, the connector JAR is already included.
+> For MySQL, you can get it from https://dev.mysql.com/downloads/connector/j/.
+> Copy or symlink the downloaded file to `extensions/druid-lookups-cached-single` under the distribution root directory.
 
 ## Architecture
 Generally speaking this module can be divided into two main component, namely, the data fetcher layer and caching layer.

--- a/docs/development/extensions-core/lookups-cached-global.md
+++ b/docs/development/extensions-core/lookups-cached-global.md
@@ -369,10 +369,9 @@ The JDBC lookups will poll a database to populate its local cache. If the `tsCol
 ```
 
 > If using JDBC, you will need to add your database's client JAR files to the extension's directory.
-> For MySQL, you can get it from https://dev.mysql.com/downloads/connector/j/, and for Postgres, from
-> https://jdbc.postgresql.org/download.html or from `extensions/postgresql-metadata-storage/`.
-> Copy or symlink the downloaded file to
-> `extensions/druid-lookups-cached-global` under the distribution root directory.
+> For Postgres, the connector JAR is already included.
+> For MySQL, you can get it from https://dev.mysql.com/downloads/connector/j/.
+> Copy or symlink the downloaded file to `extensions/druid-lookups-cached-global` under the distribution root directory.
 
 ## Introspection
 

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -261,7 +261,7 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-aws</artifactId>
           <version>${hadoop.compile.version}</version>
-          <scope>provided</scope>
+          <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/extensions-core/lookups-cached-global/pom.xml
+++ b/extensions-core/lookups-cached-global/pom.xml
@@ -112,6 +112,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Included to improve the out-of-the-box experience for supported JDBC connectors -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Tests -->
     <dependency>
       <groupId>junit</groupId>

--- a/extensions-core/lookups-cached-single/pom.xml
+++ b/extensions-core/lookups-cached-single/pom.xml
@@ -97,6 +97,14 @@
       <artifactId>guava</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Included to improve the out-of-the-box experience for supported JDBC connectors -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Tests -->
     <dependency>
       <groupId>junit</groupId>

--- a/extensions-core/postgresql-metadata-storage/pom.xml
+++ b/extensions-core/postgresql-metadata-storage/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.8</version>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3469,6 +3469,30 @@ libraries:
 
 name: PostgreSQL JDBC Driver
 license_category: binary
+module: extensions/druid-lookups-cached-single
+license_name: BSD-2-Clause License
+version: 42.2.8
+copyright: PostgreSQL Global Development Group
+license_file_path: licenses/bin/postgresql.BSD2
+libraries:
+  - org.postgresql: postgresql
+
+---
+
+name: PostgreSQL JDBC Driver
+license_category: binary
+module: extensions/druid-lookups-cached-global
+license_name: BSD-2-Clause License
+version: 42.2.8
+copyright: PostgreSQL Global Development Group
+license_file_path: licenses/bin/postgresql.BSD2
+libraries:
+  - org.postgresql: postgresql
+
+---
+
+name: PostgreSQL JDBC Driver
+license_category: binary
 module: extensions/postgresql-metadata-storage
 license_name: BSD-2-Clause License
 version: 42.2.8

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <netty4.version>4.1.45.Final</netty4.version>
         <node.version>v10.14.2</node.version>
         <npm.version>6.5.0</npm.version>
-        <postgreql.version>42.2.8</postgreql.version>
+        <postgresql.version>42.2.8</postgresql.version>
         <protobuf.version>3.11.0</protobuf.version>
         <slf4j.version>1.7.12</slf4j.version>
         <!-- If compiling with different hadoop version also modify default hadoop coordinates in TaskConfig.java -->
@@ -1115,7 +1115,7 @@
            <dependency>
                <groupId>org.postgresql</groupId>
                <artifactId>postgresql</artifactId>
-               <version>${postgreql.version}</version>
+               <version>${postgresql.version}</version>
            </dependency>
 
             <!-- GCP -->

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <netty4.version>4.1.45.Final</netty4.version>
         <node.version>v10.14.2</node.version>
         <npm.version>6.5.0</npm.version>
+        <postgreql.version>42.2.8</postgreql.version>
         <protobuf.version>3.11.0</protobuf.version>
         <slf4j.version>1.7.12</slf4j.version>
         <!-- If compiling with different hadoop version also modify default hadoop coordinates in TaskConfig.java -->
@@ -1114,7 +1115,7 @@
            <dependency>
                <groupId>org.postgresql</groupId>
                <artifactId>postgresql</artifactId>
-               <version>42.2.8</version>
+               <version>${postgreql.version}</version>
            </dependency>
 
             <!-- GCP -->

--- a/pom.xml
+++ b/pom.xml
@@ -1111,6 +1111,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+           <dependency>
+               <groupId>org.postgresql</groupId>
+               <artifactId>postgresql</artifactId>
+               <version>42.2.8</version>
+           </dependency>
 
             <!-- GCP -->
             <dependency>


### PR DESCRIPTION
Fixes #3435.

### Description

Include hadoop-aws and postgres JDBC connector jar to improve out-of-the-box experience for extensions. The mysql JDBC connector jar is not bundled as it is GPL.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.