### PR TITLE
Don't exclude null dimension values from the map based query response

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/ResultRow.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/ResultRow.java
@@ -163,10 +163,7 @@ public final class ResultRow
 
     for (int i = query.getResultRowDimensionStart(); i < row.length; i++) {
       final String columnName = resultRowOrder.get(i);
-
-      if (row[i] != null) {
-        map.put(columnName, row[i]);
-      }
+      map.put(columnName, row[i]);
     }
 
     return map;


### PR DESCRIPTION
Fixes #8631 

This PR has:
- [X ] been self-reviewed.
   - [X] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [X ] added unit tests or modified existing tests to cover new code paths.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * ResultRow.java
 * ResultRowTest.java
