### PR TITLE
add password provider reference to s3 optional cred docs

### DIFF
--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -854,8 +854,8 @@ Properties Object:
 
 |property|description|default|required?|
 |--------|-----------|-------|---------|
-|accessKeyId|S3 access key for this S3 InputSource|None|yes if secretAccessKey is given|
-|secretAccessKey|S3 secret key for this S3 InputSource|None|yes if accessKeyId is given|
+|accessKeyId|The [Password Provider](../operations/password-provider.md) or plain text string of this S3 InputSource's access key|None|yes if secretAccessKey is given|
+|secretAccessKey|The [Password Provider](../operations/password-provider.md) or plain text string of this S3 InputSource's secret key|None|yes if accessKeyId is given|
 
 **Note :** *If accessKeyId and secretAccessKey are not given, the default [S3 credentials provider chain](../development/extensions-core/s3.md#s3-authentication-methods) is used.*
 


### PR DESCRIPTION
Add password provider reference to s3 optional credential docs

### Description

This is a doc change PR. https://github.com/apache/druid/pull/9375 s3 optional credential support using password provider, however, the doc failed to mention this. Update the doc to include the option of using password provider for s3 optional credentials.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
