### PR TITLE
Improve OvershadowableManager performance

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
@@ -67,7 +67,7 @@ public class VersionedIntervalTimelineBenchmark
   @Param({"10", "100", "1000"})
   private int numInitialRootGenSegmentsPerInterval;
 
-  @Param({"1", "5"})
+  @Param({"1", "2"})
   private int numNonRootGenerations;
 
   @Param({"false", "true"})

--- a/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -362,7 +362,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
         entry.getTrueInterval(),
         entry.getTrueInterval(),
         entry.getVersion(),
-        PartitionHolder.copyVisibleChunks(entry.getPartitionHolder())
+        PartitionHolder.copyWithOnlyVisibleChunks(entry.getPartitionHolder())
     );
   }
 
@@ -381,9 +381,13 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
       final Set<TimelineObjectHolder<VersionType, ObjectType>> overshadowedObjects = overshadowedPartitionsTimeline
           .values()
           .stream()
-          .flatMap(
-              (Map<VersionType, TimelineEntry> entry) -> entry.values().stream().map(this::timelineEntryToObjectHolder)
-          )
+          .flatMap((Map<VersionType, TimelineEntry> entry) -> entry.values().stream())
+          .map(entry -> new TimelineObjectHolder<>(
+              entry.getTrueInterval(),
+              entry.getTrueInterval(),
+              entry.getVersion(),
+              PartitionHolder.deepCopy(entry.getPartitionHolder())
+          ))
           .collect(Collectors.toSet());
 
       // 2. Visible timelineEntries can also have overshadowed objects. Add them to the result too.
@@ -729,7 +733,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
                 timelineInterval,
                 val.getTrueInterval(),
                 val.getVersion(),
-                PartitionHolder.copyVisibleChunks(val.getPartitionHolder())
+                PartitionHolder.copyWithOnlyVisibleChunks(val.getPartitionHolder())
             )
         );
       }

--- a/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -158,6 +158,9 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
   /**
    * Computes a set with all objects falling within the specified interval which are at least partially "visible" in
    * this interval (that is, are not fully overshadowed within this interval).
+   *
+   * Note that this method returns a set of {@link ObjectType}. Duplicate objects in different time chunks will be
+   * removed in the result.
    */
   public Set<ObjectType> findNonOvershadowedObjectsInInterval(Interval interval, Partitions completeness)
   {

--- a/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -28,7 +28,6 @@ import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.guava.Comparators;
-import org.apache.druid.timeline.partition.ImmutablePartitionHolder;
 import org.apache.druid.timeline.partition.PartitionChunk;
 import org.apache.druid.timeline.partition.PartitionHolder;
 import org.apache.druid.utils.CollectionUtils;
@@ -279,7 +278,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
         if (entry.getKey().equals(interval) || entry.getKey().contains(interval)) {
           TimelineEntry foundEntry = entry.getValue().get(version);
           if (foundEntry != null) {
-            return new ImmutablePartitionHolder<>(foundEntry.getPartitionHolder());
+            return foundEntry.getPartitionHolder().asImmutable();
           }
         }
       }
@@ -363,7 +362,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
         entry.getTrueInterval(),
         entry.getTrueInterval(),
         entry.getVersion(),
-        new PartitionHolder<>(entry.getPartitionHolder())
+        PartitionHolder.copyVisibleChunks(entry.getPartitionHolder())
     );
   }
 
@@ -730,7 +729,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
                 timelineInterval,
                 val.getTrueInterval(),
                 val.getVersion(),
-                new PartitionHolder<>(val.getPartitionHolder())
+                PartitionHolder.copyVisibleChunks(val.getPartitionHolder())
             )
         );
       }

--- a/core/src/main/java/org/apache/druid/timeline/partition/AtomicUpdateGroup.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/AtomicUpdateGroup.java
@@ -45,9 +45,19 @@ class AtomicUpdateGroup<T extends Overshadowable<T>> implements Overshadowable<A
   // This may matter if there are a lot of segments to keep in memory as in brokers or the coordinator.
   private final List<PartitionChunk<T>> chunks = new ArrayList<>();
 
+  static <T extends Overshadowable<T>> AtomicUpdateGroup<T> copy(AtomicUpdateGroup<T> group)
+  {
+    return new AtomicUpdateGroup<>(group.chunks);
+  }
+
   AtomicUpdateGroup(PartitionChunk<T> chunk)
   {
     this.chunks.add(chunk);
+  }
+
+  private AtomicUpdateGroup(List<PartitionChunk<T>> chunks)
+  {
+    this.chunks.addAll(chunks);
   }
 
   public void add(PartitionChunk<T> chunk)

--- a/core/src/main/java/org/apache/druid/timeline/partition/ImmutablePartitionHolder.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/ImmutablePartitionHolder.java
@@ -25,9 +25,9 @@ import org.apache.druid.timeline.Overshadowable;
  */
 public class ImmutablePartitionHolder<T extends Overshadowable<T>> extends PartitionHolder<T>
 {
-  public ImmutablePartitionHolder(PartitionHolder<T> partitionHolder)
+  protected ImmutablePartitionHolder(OvershadowableManager<T> overshadowableManager)
   {
-    super(partitionHolder);
+    super(overshadowableManager);
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
@@ -105,10 +105,10 @@ class OvershadowableManager<T extends Overshadowable<T>>
     this.overshadowedGroups = new TreeMap<>();
   }
 
-  public OvershadowableManager<T> copyVisible()
+  public static <T extends Overshadowable<T>> OvershadowableManager<T> copyVisible(OvershadowableManager<T> original)
   {
     final OvershadowableManager<T> copy = new OvershadowableManager<>();
-    visibleGroupPerRange.forEach((partitionRange, versionToGroups) -> {
+    original.visibleGroupPerRange.forEach((partitionRange, versionToGroups) -> {
       // There should be only one group per partition range
       final AtomicUpdateGroup<T> group = versionToGroups.values().iterator().next();
       group.getChunks().forEach(chunk -> copy.knownPartitionChunks.put(chunk.getChunkNumber(), chunk));
@@ -121,10 +121,10 @@ class OvershadowableManager<T extends Overshadowable<T>>
     return copy;
   }
 
-  public OvershadowableManager<T> deepCopy()
+  public static <T extends Overshadowable<T>> OvershadowableManager<T> deepCopy(OvershadowableManager<T> original)
   {
-    final OvershadowableManager<T> copy = copyVisible();
-    overshadowedGroups.forEach((partitionRange, versionToGroups) -> {
+    final OvershadowableManager<T> copy = copyVisible(original);
+    original.overshadowedGroups.forEach((partitionRange, versionToGroups) -> {
       // There should be only one group per partition range
       final AtomicUpdateGroup<T> group = versionToGroups.values().iterator().next();
       group.getChunks().forEach(chunk -> copy.knownPartitionChunks.put(chunk.getChunkNumber(), chunk));
@@ -134,7 +134,7 @@ class OvershadowableManager<T extends Overshadowable<T>>
           new SingleEntryShort2ObjectSortedMap<>(group.getMinorVersion(), AtomicUpdateGroup.copy(group))
       );
     });
-    standbyGroups.forEach((partitionRange, versionToGroups) -> {
+    original.standbyGroups.forEach((partitionRange, versionToGroups) -> {
       // There should be only one group per partition range
       final AtomicUpdateGroup<T> group = versionToGroups.values().iterator().next();
       group.getChunks().forEach(chunk -> copy.knownPartitionChunks.put(chunk.getChunkNumber(), chunk));

--- a/core/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
@@ -113,6 +113,22 @@ class OvershadowableManager<T extends Overshadowable<T>>
     this.overshadowedGroups = new TreeMap<>(other.overshadowedGroups);
   }
 
+  public OvershadowableManager<T> copyVisible()
+  {
+    final OvershadowableManager<T> copy = new OvershadowableManager<>();
+    visibleGroupPerRange.forEach((partitionRange, versionToGroups) -> {
+      // There should be only one group per partition range
+      final AtomicUpdateGroup<T> group = versionToGroups.values().iterator().next();
+      group.getChunks().forEach(chunk -> copy.knownPartitionChunks.put(chunk.getChunkNumber(), chunk));
+
+      copy.visibleGroupPerRange.put(
+          partitionRange,
+          new SingleEntryShort2ObjectSortedMap<>(group.getMinorVersion(), AtomicUpdateGroup.copy(group))
+      );
+    });
+    return copy;
+  }
+
   private TreeMap<RootPartitionRange, Short2ObjectSortedMap<AtomicUpdateGroup<T>>> getStateMap(State state)
   {
     switch (state) {
@@ -1088,6 +1104,12 @@ class OvershadowableManager<T extends Overshadowable<T>>
     {
       key = -1;
       val = null;
+    }
+
+    private SingleEntryShort2ObjectSortedMap(short key, V val)
+    {
+      this.key = key;
+      this.val = val;
     }
 
     @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
@@ -34,6 +34,11 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
 {
   private final OvershadowableManager<T> overshadowableManager;
 
+  public static <T extends Overshadowable<T>> PartitionHolder<T> copyVisibleChunks(PartitionHolder<T> partitionHolder)
+  {
+    return new PartitionHolder<>(partitionHolder.overshadowableManager.copyVisible());
+  }
+
   public PartitionHolder(PartitionChunk<T> initialChunk)
   {
     this.overshadowableManager = new OvershadowableManager<>();
@@ -48,9 +53,14 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
     }
   }
 
-  public PartitionHolder(PartitionHolder<T> partitionHolder)
+  protected PartitionHolder(OvershadowableManager<T> overshadowableManager)
   {
-    this.overshadowableManager = new OvershadowableManager<>(partitionHolder.overshadowableManager);
+    this.overshadowableManager = overshadowableManager;
+  }
+
+  public ImmutablePartitionHolder<T> asImmutable()
+  {
+    return new ImmutablePartitionHolder<>(overshadowableManager.copyVisible());
   }
 
   public boolean add(PartitionChunk<T> chunk)

--- a/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
@@ -26,8 +26,6 @@ import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Spliterator;
-import java.util.stream.Stream;
 
 /**
  * An object that clumps together multiple other objects which each represent a shard of some space.
@@ -112,18 +110,7 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
   @Override
   public Iterator<PartitionChunk<T>> iterator()
   {
-    return stream().iterator();
-  }
-
-  @Override
-  public Spliterator<PartitionChunk<T>> spliterator()
-  {
-    return stream().spliterator();
-  }
-
-  public Stream<PartitionChunk<T>> stream()
-  {
-    return overshadowableManager.createVisibleChunksStream();
+    return overshadowableManager.visibleChunksIterator();
   }
 
   public List<PartitionChunk<T>> getOvershadowed()

--- a/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
@@ -38,12 +38,12 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
       PartitionHolder<T> partitionHolder
   )
   {
-    return new PartitionHolder<>(partitionHolder.overshadowableManager.copyVisible());
+    return new PartitionHolder<>(OvershadowableManager.copyVisible(partitionHolder.overshadowableManager));
   }
 
   public static <T extends Overshadowable<T>> PartitionHolder<T> deepCopy(PartitionHolder<T> partitionHolder)
   {
-    return new PartitionHolder<>(partitionHolder.overshadowableManager.deepCopy());
+    return new PartitionHolder<>(OvershadowableManager.deepCopy(partitionHolder.overshadowableManager));
   }
 
   public PartitionHolder(PartitionChunk<T> initialChunk)
@@ -67,7 +67,7 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
 
   public ImmutablePartitionHolder<T> asImmutable()
   {
-    return new ImmutablePartitionHolder<>(overshadowableManager.copyVisible());
+    return new ImmutablePartitionHolder<>(OvershadowableManager.copyVisible(overshadowableManager));
   }
 
   public boolean add(PartitionChunk<T> chunk)

--- a/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
@@ -34,9 +34,16 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
 {
   private final OvershadowableManager<T> overshadowableManager;
 
-  public static <T extends Overshadowable<T>> PartitionHolder<T> copyVisibleChunks(PartitionHolder<T> partitionHolder)
+  public static <T extends Overshadowable<T>> PartitionHolder<T> copyWithOnlyVisibleChunks(
+      PartitionHolder<T> partitionHolder
+  )
   {
     return new PartitionHolder<>(partitionHolder.overshadowableManager.copyVisible());
+  }
+
+  public static <T extends Overshadowable<T>> PartitionHolder<T> deepCopy(PartitionHolder<T> partitionHolder)
+  {
+    return new PartitionHolder<>(partitionHolder.overshadowableManager.deepCopy());
   }
 
   public PartitionHolder(PartitionChunk<T> initialChunk)

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineSpecificDataTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineSpecificDataTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.timeline.partition.ImmutablePartitionHolder;
 import org.apache.druid.timeline.partition.IntegerPartitionChunk;
 import org.apache.druid.timeline.partition.OvershadowableInteger;
 import org.apache.druid.timeline.partition.PartitionHolder;
@@ -225,22 +224,22 @@ public class VersionedIntervalTimelineSpecificDataTest extends VersionedInterval
   public void testFindEntry()
   {
     Assert.assertEquals(
-        new ImmutablePartitionHolder<>(new PartitionHolder<>(makeSingle("1", 1))),
+        new PartitionHolder<>(makeSingle("1", 1)).asImmutable(),
         timeline.findEntry(Intervals.of("2011-10-01/2011-10-02"), "1")
     );
 
     Assert.assertEquals(
-        new ImmutablePartitionHolder<>(new PartitionHolder<>(makeSingle("1", 1))),
+        new PartitionHolder<>(makeSingle("1", 1)).asImmutable(),
         timeline.findEntry(Intervals.of("2011-10-01/2011-10-01T10"), "1")
     );
 
     Assert.assertEquals(
-        new ImmutablePartitionHolder<>(new PartitionHolder<>(makeSingle("1", 1))),
+        new PartitionHolder<>(makeSingle("1", 1)).asImmutable(),
         timeline.findEntry(Intervals.of("2011-10-01T02/2011-10-02"), "1")
     );
 
     Assert.assertEquals(
-        new ImmutablePartitionHolder<>(new PartitionHolder<>(makeSingle("1", 1))),
+        new PartitionHolder<>(makeSingle("1", 1)).asImmutable(),
         timeline.findEntry(Intervals.of("2011-10-01T04/2011-10-01T17"), "1")
     );
 

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
@@ -1406,9 +1406,7 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
                 new PartitionHolder<>(
                     ImmutableList.of(
                         makeNumbered("1", 0, 0),
-                        makeNumbered("1", 1, 0),
-                        makeNumberedOverwriting("1", 0, 1, 0, 2, 1, 3),
-                        makeNumberedOverwriting("1", 1, 1, 0, 2, 1, 3)
+                        makeNumbered("1", 1, 0)
                     )
                 )
             )

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.timeline.partition.ImmutablePartitionHolder;
 import org.apache.druid.timeline.partition.IntegerPartitionChunk;
 import org.apache.druid.timeline.partition.OvershadowableInteger;
 import org.apache.druid.timeline.partition.PartitionHolder;
@@ -58,7 +57,7 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
     add("2011-01-02/2011-01-05", "2", 1);
 
     Assert.assertEquals(
-        new ImmutablePartitionHolder<>(new PartitionHolder<>(makeSingle("1", 1))),
+        new PartitionHolder<>(makeSingle("1", 1)).asImmutable(),
         timeline.findEntry(Intervals.of("2011-01-02T02/2011-01-04"), "1")
     );
   }

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
@@ -1510,8 +1510,8 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
     add("2019-01-02/2019-01-03", "0", makeNumbered("0", 1, 0));
 
     // Incomplete partitions
-    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 0, 3, 0));
-    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 1, 3, 0));
+    add("2019-01-03/2019-01-04", "0", makeNumbered("2", 0, 3, 0));
+    add("2019-01-03/2019-01-04", "0", makeNumbered("2", 1, 3, 0));
 
     // Overwrite 2019-01-01/2019-01-02
     add("2019-01-01/2019-01-02", "1", makeNumbered("1", 0, 0));
@@ -1530,7 +1530,7 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
             makeNumbered("0", 0, 0).getObject(),
             makeNumbered("0", 1, 0).getObject()
         ),
-        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2019-01-01/2019-01-03"), Partitions.ONLY_COMPLETE)
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2019-01-01/2019-01-04"), Partitions.ONLY_COMPLETE)
     );
   }
 
@@ -1547,8 +1547,8 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
     add("2019-01-02/2019-01-03", "0", makeNumbered("0", 1, 0));
 
     // Incomplete partitions
-    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 0, 3, 0));
-    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 1, 3, 0));
+    add("2019-01-03/2019-01-04", "0", makeNumbered("2", 0, 3, 0));
+    add("2019-01-03/2019-01-04", "0", makeNumbered("2", 1, 3, 0));
 
     // Overwrite 2019-01-01/2019-01-02
     add("2019-01-01/2019-01-02", "1", makeNumbered("1", 0, 0));
@@ -1566,10 +1566,10 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
             makeNumberedOverwriting("1", 2, 1, 0, 2, 1, 3).getObject(),
             makeNumbered("0", 0, 0).getObject(),
             makeNumbered("0", 1, 0).getObject(),
-            makeNumbered("0", 0, 3, 0).getObject(),
-            makeNumbered("0", 1, 3, 0).getObject()
+            makeNumbered("2", 0, 3, 0).getObject(),
+            makeNumbered("2", 1, 3, 0).getObject()
         ),
-        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2019-01-01/2019-01-03"), Partitions.ONLY_COMPLETE)
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2019-01-01/2019-01-04"), Partitions.INCOMPLETE_OK)
     );
   }
 }

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
@@ -1497,4 +1497,79 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
     Assert.assertEquals(2, Lists.newArrayList(overshadowableIntegers.iterator()).size());
   }
 
+  @Test
+  public void testFindNonOvershadowedObjectsInIntervalWithOnlyCompletePartitionsReturningValidResult()
+  {
+    // 2019-01-01/2019-01-02
+    add("2019-01-01/2019-01-02", "0", makeNumbered("0", 0, 0));
+    add("2019-01-01/2019-01-02", "0", makeNumbered("0", 1, 0));
+    add("2019-01-01/2019-01-02", "0", makeNumbered("0", 2, 0));
+
+    // 2019-01-02/2019-01-03
+    add("2019-01-02/2019-01-03", "0", makeNumbered("0", 0, 0));
+    add("2019-01-02/2019-01-03", "0", makeNumbered("0", 1, 0));
+
+    // Incomplete partitions
+    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 0, 3, 0));
+    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 1, 3, 0));
+
+    // Overwrite 2019-01-01/2019-01-02
+    add("2019-01-01/2019-01-02", "1", makeNumbered("1", 0, 0));
+    add("2019-01-01/2019-01-02", "1", makeNumbered("1", 1, 0));
+
+    // Overwrite 2019-01-01/2019-01-02
+    add("2019-01-01/2019-01-02", "1", makeNumberedOverwriting("1", 0, 1, 0, 2, 1, 3));
+    add("2019-01-01/2019-01-02", "1", makeNumberedOverwriting("1", 1, 1, 0, 2, 1, 3));
+    add("2019-01-01/2019-01-02", "1", makeNumberedOverwriting("1", 2, 1, 0, 2, 1, 3));
+
+    Assert.assertEquals(
+        ImmutableSet.of(
+            makeNumberedOverwriting("1", 0, 1, 0, 2, 1, 3).getObject(),
+            makeNumberedOverwriting("1", 1, 1, 0, 2, 1, 3).getObject(),
+            makeNumberedOverwriting("1", 2, 1, 0, 2, 1, 3).getObject(),
+            makeNumbered("0", 0, 0).getObject(),
+            makeNumbered("0", 1, 0).getObject()
+        ),
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2019-01-01/2019-01-03"), Partitions.ONLY_COMPLETE)
+    );
+  }
+
+  @Test
+  public void testFindNonOvershadowedObjectsInIntervalWithIncompleteOkReturningValidResult()
+  {
+    // 2019-01-01/2019-01-02
+    add("2019-01-01/2019-01-02", "0", makeNumbered("0", 0, 0));
+    add("2019-01-01/2019-01-02", "0", makeNumbered("0", 1, 0));
+    add("2019-01-01/2019-01-02", "0", makeNumbered("0", 2, 0));
+
+    // 2019-01-02/2019-01-03
+    add("2019-01-02/2019-01-03", "0", makeNumbered("0", 0, 0));
+    add("2019-01-02/2019-01-03", "0", makeNumbered("0", 1, 0));
+
+    // Incomplete partitions
+    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 0, 3, 0));
+    add("2019-01-03/2019-01-04", "0", makeNumbered("0", 1, 3, 0));
+
+    // Overwrite 2019-01-01/2019-01-02
+    add("2019-01-01/2019-01-02", "1", makeNumbered("1", 0, 0));
+    add("2019-01-01/2019-01-02", "1", makeNumbered("1", 1, 0));
+
+    // Overwrite 2019-01-01/2019-01-02
+    add("2019-01-01/2019-01-02", "1", makeNumberedOverwriting("1", 0, 1, 0, 2, 1, 3));
+    add("2019-01-01/2019-01-02", "1", makeNumberedOverwriting("1", 1, 1, 0, 2, 1, 3));
+    add("2019-01-01/2019-01-02", "1", makeNumberedOverwriting("1", 2, 1, 0, 2, 1, 3));
+
+    Assert.assertEquals(
+        ImmutableSet.of(
+            makeNumberedOverwriting("1", 0, 1, 0, 2, 1, 3).getObject(),
+            makeNumberedOverwriting("1", 1, 1, 0, 2, 1, 3).getObject(),
+            makeNumberedOverwriting("1", 2, 1, 0, 2, 1, 3).getObject(),
+            makeNumbered("0", 0, 0).getObject(),
+            makeNumbered("0", 1, 0).getObject(),
+            makeNumbered("0", 0, 3, 0).getObject(),
+            makeNumbered("0", 1, 3, 0).getObject()
+        ),
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2019-01-01/2019-01-03"), Partitions.ONLY_COMPLETE)
+    );
+  }
 }

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTestBase.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTestBase.java
@@ -170,9 +170,14 @@ public class VersionedIntervalTimelineTestBase
 
   PartitionChunk<OvershadowableInteger> makeNumbered(String majorVersion, int partitionNum, int val)
   {
+    return makeNumbered(majorVersion, partitionNum, 0, val);
+  }
+
+  PartitionChunk<OvershadowableInteger> makeNumbered(String majorVersion, int partitionNum, int chunks, int val)
+  {
     return new NumberedPartitionChunk<>(
         partitionNum,
-        0,
+        chunks,
         new OvershadowableInteger(majorVersion, partitionNum, val)
     );
   }

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTestBase.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTestBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.timeline;
 
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -107,7 +108,10 @@ public class VersionedIntervalTimelineTestBase
   void checkRemove()
   {
     for (TimelineObjectHolder<String, OvershadowableInteger> holder : timeline.findFullyOvershadowed()) {
-      for (PartitionChunk<OvershadowableInteger> chunk : holder.getObject()) {
+      // Copy chunks to avoid the ConcurrentModificationException.
+      // Note that timeline.remove() modifies the PartitionHolder.
+      List<PartitionChunk<OvershadowableInteger>> chunks = FluentIterable.from(holder.getObject()).toList();
+      for (PartitionChunk<OvershadowableInteger> chunk : chunks) {
         timeline.remove(holder.getInterval(), holder.getVersion(), chunk);
       }
     }

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTestBase.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTestBase.java
@@ -158,22 +158,27 @@ public class VersionedIntervalTimelineTestBase
     );
   }
 
-  PartitionChunk<OvershadowableInteger> makeSingle(String majorVersion, int value)
+  public static PartitionChunk<OvershadowableInteger> makeSingle(String majorVersion, int value)
   {
     return makeSingle(majorVersion, 0, value);
   }
 
-  private PartitionChunk<OvershadowableInteger> makeSingle(String majorVersion, int partitionNum, int val)
+  public static PartitionChunk<OvershadowableInteger> makeSingle(String majorVersion, int partitionNum, int val)
   {
     return new SingleElementPartitionChunk<>(new OvershadowableInteger(majorVersion, partitionNum, val));
   }
 
-  PartitionChunk<OvershadowableInteger> makeNumbered(String majorVersion, int partitionNum, int val)
+  public static PartitionChunk<OvershadowableInteger> makeNumbered(String majorVersion, int partitionNum, int val)
   {
     return makeNumbered(majorVersion, partitionNum, 0, val);
   }
 
-  PartitionChunk<OvershadowableInteger> makeNumbered(String majorVersion, int partitionNum, int chunks, int val)
+  public static PartitionChunk<OvershadowableInteger> makeNumbered(
+      String majorVersion,
+      int partitionNum,
+      int chunks,
+      int val
+  )
   {
     return new NumberedPartitionChunk<>(
         partitionNum,
@@ -182,7 +187,7 @@ public class VersionedIntervalTimelineTestBase
     );
   }
 
-  PartitionChunk<OvershadowableInteger> makeNumberedOverwriting(
+  public static PartitionChunk<OvershadowableInteger> makeNumberedOverwriting(
       String majorVersion,
       int partitionNumOrdinal,
       int val,

--- a/core/src/test/java/org/apache/druid/timeline/partition/AtomicUpdateGroupTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/AtomicUpdateGroupTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.timeline.partition;
+
+import org.apache.druid.timeline.VersionedIntervalTimelineTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+public class AtomicUpdateGroupTest
+{
+  @Test
+  public void testCopy()
+  {
+    AtomicUpdateGroup<OvershadowableInteger> original = new AtomicUpdateGroup<>(
+        VersionedIntervalTimelineTestBase.makeNumberedOverwriting(
+            "0",
+            0,
+            0,
+            0,
+            10,
+            0,
+            10
+        )
+    );
+    IntStream.range(1, 10).forEach(
+        i -> original.add(
+            VersionedIntervalTimelineTestBase.makeNumberedOverwriting(
+                "0",
+                i,
+                0,
+                0,
+                10,
+                0,
+                10
+            )
+        )
+    );
+
+    Assert.assertEquals(AtomicUpdateGroup.copy(original), original);
+  }
+}

--- a/core/src/test/java/org/apache/druid/timeline/partition/AtomicUpdateGroupTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/AtomicUpdateGroupTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.timeline.partition;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.timeline.VersionedIntervalTimelineTestBase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,5 +57,11 @@ public class AtomicUpdateGroupTest
     );
 
     Assert.assertEquals(AtomicUpdateGroup.copy(original), original);
+  }
+
+  @Test
+  public void testEqualAndHashCodeContract()
+  {
+    EqualsVerifier.forClass(AtomicUpdateGroup.class).usingGetClass().verify();
   }
 }

--- a/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.timeline.partition;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.druid.timeline.partition.OvershadowableManager.RootPartitionRange;
 import org.apache.druid.timeline.partition.OvershadowableManager.State;
@@ -61,6 +62,57 @@ public class OvershadowableManagerTest
     expectedVisibleChunks = new ArrayList<>();
     expectedOvershadowedChunks = new ArrayList<>();
     expectedStandbyChunks = new ArrayList<>();
+  }
+
+  @Test
+  public void testCopyVisible()
+  {
+    // chunks of partition id 0 and 1
+    manager.addChunk(newRootChunk());
+    manager.addChunk(newRootChunk());
+
+    // chunks to overshadow the partition id range [0, 2)
+    manager.addChunk(newNonRootChunk(0, 2, 1, 3));
+    manager.addChunk(newNonRootChunk(0, 2, 1, 3));
+    manager.addChunk(newNonRootChunk(0, 2, 1, 3));
+
+    // chunks of partition id 3 and 4
+    manager.addChunk(newRootChunk());
+    manager.addChunk(newRootChunk());
+
+    // standby chunk
+    manager.addChunk(newNonRootChunk(2, 4, 1, 3));
+
+    OvershadowableManager<OvershadowableInteger> copy = OvershadowableManager.copyVisible(manager);
+    Assert.assertTrue(copy.getOvershadowedChunks().isEmpty());
+    Assert.assertTrue(copy.getStandbyChunks().isEmpty());
+    Assert.assertEquals(
+        Lists.newArrayList(manager.visibleChunksIterator()),
+        Lists.newArrayList(copy.visibleChunksIterator())
+    );
+  }
+
+  @Test
+  public void testDeepCopy()
+  {
+    // chunks of partition id 0 and 1
+    manager.addChunk(newRootChunk());
+    manager.addChunk(newRootChunk());
+
+    // chunks to overshadow the partition id range [0, 2)
+    manager.addChunk(newNonRootChunk(0, 2, 1, 3));
+    manager.addChunk(newNonRootChunk(0, 2, 1, 3));
+    manager.addChunk(newNonRootChunk(0, 2, 1, 3));
+
+    // chunks of partition id 3 and 4
+    manager.addChunk(newRootChunk());
+    manager.addChunk(newRootChunk());
+
+    // standby chunk
+    manager.addChunk(newNonRootChunk(2, 4, 1, 3));
+
+    OvershadowableManager<OvershadowableInteger> copy = OvershadowableManager.deepCopy(manager);
+    Assert.assertEquals(manager, copy);
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
@@ -981,7 +981,7 @@ public class OvershadowableManagerTest
     Assert.assertEquals(
         "Mismatched visible chunks",
         new HashSet<>(expectedVisibleChunks),
-        Sets.newHashSet(manager.createVisibleChunksStream().iterator())
+        Sets.newHashSet(manager.visibleChunksIterator())
     );
     Assert.assertEquals(
         "Mismatched overshadowed chunks",

--- a/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.timeline.partition;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.timeline.partition.OvershadowableManager.RootPartitionRange;
 import org.apache.druid.timeline.partition.OvershadowableManager.State;
 import org.junit.Assert;
@@ -113,6 +114,12 @@ public class OvershadowableManagerTest
 
     OvershadowableManager<OvershadowableInteger> copy = OvershadowableManager.deepCopy(manager);
     Assert.assertEquals(manager, copy);
+  }
+
+  @Test
+  public void testEqualAndHashCodeContract()
+  {
+    EqualsVerifier.forClass(OvershadowableManager.class).usingGetClass().verify();
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -168,8 +168,9 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     runTestTask(inputInterval, Granularities.DAY);
 
     final Interval interval = inputInterval == null ? Intervals.ETERNITY : inputInterval;
-    final Collection<DataSegment> allSegments =
-        getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", interval, Segments.ONLY_VISIBLE);
+    final Collection<DataSegment> allSegments = new HashSet<>(
+        getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", interval, Segments.ONLY_VISIBLE)
+    );
 
     // Reingest the same data. Each segment should get replaced by a segment with a newer version.
     runTestTask(inputInterval, secondSegmentGranularity);

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.tests.indexer;
 
+import com.google.common.collect.FluentIterable;
 import com.google.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.indexing.common.task.batch.parallel.PartialDimensionDistributionTask;
@@ -250,11 +251,13 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
             );
 
             final List<TimelineObjectHolder<String, DataSegment>> holders = timeline.lookup(Intervals.ETERNITY);
-            return holders
-                .stream()
-                .flatMap(holder -> holder.getObject().stream())
-                .anyMatch(chunk -> oldVersions.stream()
-                                              .anyMatch(oldSegment -> chunk.getObject().overshadows(oldSegment)));
+            return FluentIterable
+                .from(holders)
+                .transformAndConcat(TimelineObjectHolder::getObject)
+                .anyMatch(
+                    chunk -> FluentIterable.from(oldVersions)
+                                           .anyMatch(oldSegment -> chunk.getObject().overshadows(oldSegment))
+                );
           },
           "See a new version"
       );

--- a/server/src/main/java/org/apache/druid/client/DataSourcesSnapshot.java
+++ b/server/src/main/java/org/apache/druid/client/DataSourcesSnapshot.java
@@ -169,5 +169,4 @@ public class DataSourcesSnapshot
     }
     return overshadowedSegments;
   }
-
 }

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -22,6 +22,7 @@ package org.apache.druid.metadata;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -71,13 +72,11 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.StreamSupport;
 
 /**
  */
@@ -811,9 +810,10 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
       return null;
 
     } else {
-      if (existingChunks
-          .stream()
-          .flatMap(holder -> StreamSupport.stream(holder.getObject().spliterator(), false))
+      //noinspection ConstantConditions
+      if (FluentIterable
+          .from(existingChunks)
+          .transformAndConcat(TimelineObjectHolder::getObject)
           .anyMatch(chunk -> !chunk.getObject().getShardSpec().isCompatible(partialShardSpec.getShardSpecClass()))) {
         // All existing segments should have a compatible shardSpec with partialShardSpec.
         return null;
@@ -825,15 +825,19 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
       if (!existingChunks.isEmpty()) {
         TimelineObjectHolder<String, DataSegment> existingHolder = Iterables.getOnlyElement(existingChunks);
 
-        maxId = StreamSupport
-            .stream(existingHolder.getObject().spliterator(), false)
+        //noinspection ConstantConditions
+        for (DataSegment segment : FluentIterable
+            .from(existingHolder.getObject())
+            .transform(PartitionChunk::getObject)
             // Here we check only the segments of the same shardSpec to find out the max partitionId.
             // Note that OverwriteShardSpec has the higher range for partitionId than others.
             // See PartitionIds.
-            .filter(chunk -> chunk.getObject().getShardSpec().getClass() == partialShardSpec.getShardSpecClass())
-            .max(Comparator.comparing(chunk -> chunk.getObject().getShardSpec().getPartitionNum()))
-            .map(chunk -> SegmentIdWithShardSpec.fromDataSegment(chunk.getObject()))
-            .orElse(null);
+            .filter(segment -> segment.getShardSpec().getClass() == partialShardSpec.getShardSpecClass())) {
+          // Don't use the stream API for performance.
+          if (maxId == null || maxId.getShardSpec().getPartitionNum() < segment.getShardSpec().getPartitionNum()) {
+            maxId = SegmentIdWithShardSpec.fromDataSegment(segment);
+          }
+        }
       }
 
       final List<SegmentIdWithShardSpec> pendings = getPendingSegmentsForIntervalWithHandle(

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -509,12 +509,13 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     private QueueEntry(List<DataSegment> segments)
     {
       Preconditions.checkArgument(segments != null && !segments.isEmpty());
-      Collections.sort(segments);
+      final List<DataSegment> segmentsToSort = new ArrayList<>(segments);
+      Collections.sort(segmentsToSort);
       this.interval = new Interval(
-          segments.get(0).getInterval().getStart(),
-          segments.get(segments.size() - 1).getInterval().getEnd()
+          segmentsToSort.get(0).getInterval().getStart(),
+          segmentsToSort.get(segmentsToSort.size() - 1).getInterval().getEnd()
       );
-      this.segments = segments;
+      this.segments = segmentsToSort;
     }
 
     private String getDataSource()


### PR DESCRIPTION
Fixes #9383.

### Description

Two key changes:
- Using the `Iterator` instead of `higherKey()` or `higherEntry()`.
- Using the `Iterator` API instead of `Stream`.

Here are the benchmark results.

master


| Benchmark | numInitialRootGenSegmentsPerInterval | numNonRootGenerations | segmentGranularity | useSegmentLock | Score | Score Error (99.9%) | Unit |
| -- | -- | -- | -- | -- | -- | -- | -- |
| org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | MONTH | FALSE | 74.593736 | 0.157821 | ops/s |
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | MONTH | TRUE | 61.296126 | 0.289691 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | DAY | FALSE | 4.027792 | 0.050178 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | DAY | TRUE | 2.214782 | 0.009032 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | MONTH | FALSE | 69.753337 | 0.118109 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | MONTH | TRUE | 62.510767 | 0.249751 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | DAY | FALSE | 3.355433 | 0.013972 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | DAY | TRUE | 2.141556 | 0.00617 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | MONTH | FALSE | 3911.931702 | 14.962425 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | MONTH | TRUE | 187.36298 | 0.75218 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | DAY | FALSE | 94.90354 | 0.287476 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | DAY | TRUE | 5.258894 | 0.020194 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | MONTH | FALSE | 2366.365056 | 2.69362 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | MONTH | TRUE | 599.976444 | 1.165907 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | DAY | FALSE | 59.840876 | 0.178956 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | DAY | TRUE | 15.444807 | 0.038935 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | MONTH | FALSE | 320817.4244 | 934.954223 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | MONTH | TRUE | 476919.8161 | 1121.243296 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | DAY | FALSE | 263759.8788 | 3747.8076 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | DAY | TRUE | 326754.8762 | 7650.798385 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | MONTH | FALSE | 449372.3674 | 1293.973306 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | MONTH | TRUE | 577509.4054 | 1953.6536 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | DAY | FALSE | 281385.7145 | 11966.14959 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | DAY | TRUE | 389066.6441 | 6112.571051 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | MONTH | FALSE | 113573.3886 | 179.29859 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | MONTH | TRUE | 51644.26753 | 159.035054 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | DAY | FALSE | 71691.90114 | 3125.221368 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | DAY | TRUE | 23271.51767 | 902.091057 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | MONTH | FALSE | 111247.1351 | 174.299341 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | MONTH | TRUE | 36208.02057 | 48.240014 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | DAY | FALSE | 73012.95922 | 482.553345 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | DAY | TRUE | 15486.10912 | 976.58672 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | MONTH | FALSE | 91.150018 | 0.442367 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | MONTH | TRUE | 23.28416 | 0.177942 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | DAY | FALSE | 2.865762 | 0.0207 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | DAY | TRUE | 0.722529 | 0.007548 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | MONTH | FALSE | 99.904202 | 0.830639 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | MONTH | TRUE | 1.562742 | 0.089012 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | DAY | FALSE | 2.142417 | 0.017723 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | DAY | TRUE | 0.047155 | 0.001535 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  


After PR

|Benchmark | Param: numInitialRootGenSegmentsPerInterval | Param: numNonRootGenerations | Param: segmentGranularity | Param: useSegmentLock | Score | Score Error (99.9%) | Unit |
| -- | -- | -- | -- | -- | -- | -- | -- |
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | MONTH | FALSE | 423.598695 | 3.520175 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | MONTH | TRUE | 165.432408 | 1.179293 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | DAY | FALSE | 15.926139 | 0.051969 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 1 | DAY | TRUE | 4.787306 | 0.011304 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | MONTH | FALSE | 296.005812 | 2.672103 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | MONTH | TRUE | 150.081513 | 0.39904 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | DAY | FALSE | 12.446414 | 0.085265 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchAdd | 100 | 2 | DAY | TRUE | 4.223133 | 0.007413 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | MONTH | FALSE | 4348.161344 | 3.31101 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | MONTH | TRUE | 946.35651 | 4.968384 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | DAY | FALSE | 103.790997 | 0.711689 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 1 | DAY | TRUE | 25.720033 | 0.147587 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | MONTH | FALSE | 2638.004319 | 2.163262 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | MONTH | TRUE | 659.062763 | 2.468865 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | DAY | FALSE | 63.55069 | 0.170092 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchFindFullyOvershadowed | 100 | 2 | DAY | TRUE | 19.008214 | 0.135881 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | MONTH | FALSE | 705123.9855 | 3619.138328 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | MONTH | TRUE | 806885.8445 | 1038.68212 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | DAY | FALSE | 409478.6873 | 21179.31478 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 1 | DAY | TRUE | 486011.2014 | 22202.02013 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | MONTH | FALSE | 890916.9849 | 1583.87703 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | MONTH | TRUE | 1028235.656 | 4183.111624 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | DAY | FALSE | 460951.8017 | 17596.90437 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchIsOvershadowed | 100 | 2 | DAY | TRUE | 540136.4034 | 21796.82371 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | MONTH | FALSE | 135469.5003 | 367.690318 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | MONTH | TRUE | 57444.90682 | 109.662664 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | DAY | FALSE | 67781.1601 | 1669.652261 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 1 | DAY | TRUE | 19968.74589 | 1366.281118 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | MONTH | FALSE | 132912.5099 | 182.816225 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | MONTH | TRUE | 34443.96685 | 127.638394 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | DAY | FALSE | 66278.64465 | 2923.865498 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchLookup | 100 | 2 | DAY | TRUE | 15643.27084 | 449.80444 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | MONTH | FALSE | 479.409132 | 9.566923 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | MONTH | TRUE | 118.908165 | 0.309454 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | DAY | FALSE | 5.717129 | 0.034974 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 1 | DAY | TRUE | 2.408836 | 0.029314 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | MONTH | FALSE | 345.903707 | 1.457845 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | MONTH | TRUE | 107.075497 | 0.771716 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | DAY | FALSE | 3.769484 | 0.057692 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  
org.apache.druid.timeline.VersionedIntervalTimelineBenchmark.benchRemove | 100 | 2 | DAY | TRUE | 1.986003 | 0.008282 | ops/s |   |   |   |   |   |   |   |   |   |   |   |  

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `OvershadowableManager`