### PR TITLE
Add tests timestamp parser

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/granularity/PeriodGranularity.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/granularity/PeriodGranularity.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonSerializable;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.google.common.base.Preconditions;
+import org.apache.druid.CoverageTool;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -227,53 +228,74 @@ public class PeriodGranularity extends Granularity implements JsonSerializable
   private long truncate(long t)
   {
     if (isCompound) {
+      CoverageTool.setBranch(0);
       try {
+        CoverageTool.setBranch(2);
         return truncateMillisPeriod(t);
       }
       catch (UnsupportedOperationException e) {
+        CoverageTool.setBranch(3);
         return truncateCompoundPeriod(t);
       }
+    } else {
+      CoverageTool.setBranch(1);
     }
 
     final int years = period.getYears();
     if (years > 0) {
       if (years > 1 || hasOrigin) {
+        CoverageTool.setBranch(5);
         int y = chronology.years().getDifference(t, origin);
         y -= y % years;
         long tt = chronology.years().add(origin, y);
         // always round down to the previous period (for timestamps prior to origin)
         if (t < tt) {
+          CoverageTool.setBranch(7);
           t = chronology.years().add(tt, -years);
         } else {
+          CoverageTool.setBranch(8);
           t = tt;
         }
+        int id = 10;
         return t;
       } else {
+        CoverageTool.setBranch(6);
         return chronology.year().roundFloor(t);
       }
+    } else {
+      CoverageTool.setBranch(4);
     }
 
     final int months = period.getMonths();
     if (months > 0) {
+      CoverageTool.setBranch(9);
       if (months > 1 || hasOrigin) {
+        CoverageTool.setBranch(11);
         int m = chronology.months().getDifference(t, origin);
         m -= m % months;
         long tt = chronology.months().add(origin, m);
         // always round down to the previous period (for timestamps prior to origin)
         if (t < tt) {
+          CoverageTool.setBranch(12);
           t = chronology.months().add(tt, -months);
         } else {
+          CoverageTool.setBranch(13);
           t = tt;
         }
         return t;
       } else {
+        CoverageTool.setBranch(10);
         return chronology.monthOfYear().roundFloor(t);
       }
+    } else {
+      CoverageTool.setBranch(18);
     }
 
     final int weeks = period.getWeeks();
     if (weeks > 0) {
+      CoverageTool.setBranch(14);
       if (weeks > 1 || hasOrigin) {
+        CoverageTool.setBranch(16);
         // align on multiples from origin
         int w = chronology.weeks().getDifference(t, origin);
         w -= w % weeks;
@@ -288,105 +310,143 @@ public class PeriodGranularity extends Granularity implements JsonSerializable
       } else {
         t = chronology.dayOfWeek().roundFloor(t);
         // default to Monday as beginning of the week
+        CoverageTool.setBranch(15);
         return chronology.dayOfWeek().set(t, 1);
       }
+    } else {
+      CoverageTool.setBranch(17);
     }
 
     final int days = period.getDays();
     if (days > 0) {
+      CoverageTool.setBranch(19);
       if (days > 1 || hasOrigin) {
+        CoverageTool.setBranch(21);
         // align on multiples from origin
         int d = chronology.days().getDifference(t, origin);
         d -= d % days;
         long tt = chronology.days().add(origin, d);
         // always round down to the previous period (for timestamps prior to origin)
         if (t < tt) {
+          CoverageTool.setBranch(23);
           t = chronology.days().add(tt, -days);
         } else {
+          CoverageTool.setBranch(24);
           t = tt;
         }
         return t;
       } else {
+        CoverageTool.setBranch(22);
         return chronology.dayOfMonth().roundFloor(t);
       }
+    } else {
+      CoverageTool.setBranch(20);
     }
 
     final int hours = period.getHours();
     if (hours > 0) {
+      CoverageTool.setBranch(25);
       if (hours > 1 || hasOrigin) {
+        CoverageTool.setBranch(27);
         // align on multiples from origin
         long h = chronology.hours().getDifferenceAsLong(t, origin);
         h -= h % hours;
         long tt = chronology.hours().add(origin, h);
         // always round down to the previous period (for timestamps prior to origin)
         if (t < tt && origin > 0) {
+          CoverageTool.setBranch(29);
           t = chronology.hours().add(tt, -hours);
         } else if (t > tt && origin < 0) {
+          CoverageTool.setBranch(30);
           t = chronology.minuteOfHour().roundFloor(tt);
           t = chronology.minuteOfHour().set(t, 0);
         } else {
+          CoverageTool.setBranch(28);
           t = tt;
         }
         return t;
       } else {
         return chronology.hourOfDay().roundFloor(t);
       }
+    } else {
+      CoverageTool.setBranch(26);
     }
 
     final int minutes = period.getMinutes();
     if (minutes > 0) {
+      CoverageTool.setBranch(31);
       // align on multiples from origin
       if (minutes > 1 || hasOrigin) {
+        CoverageTool.setBranch(33);
         long m = chronology.minutes().getDifferenceAsLong(t, origin);
         m -= m % minutes;
         long tt = chronology.minutes().add(origin, m);
         // always round down to the previous period (for timestamps prior to origin)
         if (t < tt) {
+          CoverageTool.setBranch(35);
           t = chronology.minutes().add(tt, -minutes);
         } else {
+          CoverageTool.setBranch(36);
           t = tt;
         }
         return t;
       } else {
+        CoverageTool.setBranch(34);
         return chronology.minuteOfHour().roundFloor(t);
       }
+    } else {
+      CoverageTool.setBranch(32);
     }
 
     final int seconds = period.getSeconds();
     if (seconds > 0) {
+      CoverageTool.setBranch(38);
       // align on multiples from origin
       if (seconds > 1 || hasOrigin) {
+        CoverageTool.setBranch(40);
         long s = chronology.seconds().getDifferenceAsLong(t, origin);
         s -= s % seconds;
         long tt = chronology.seconds().add(origin, s);
         // always round down to the previous period (for timestamps prior to origin)
         if (t < tt) {
+          CoverageTool.setBranch(42);
           t = chronology.seconds().add(tt, -seconds);
         } else {
+          CoverageTool.setBranch(43);
           t = tt;
         }
         return t;
       } else {
+        CoverageTool.setBranch(41);
         return chronology.millisOfSecond().set(t, 0);
       }
+    } else {
+      CoverageTool.setBranch(39);
     }
 
     final int millis = period.getMillis();
     if (millis > 0) {
+      CoverageTool.setBranch(44);
       if (millis > 1) {
+        CoverageTool.setBranch(46);
         long ms = chronology.millis().getDifferenceAsLong(t, origin);
         ms -= ms % millis;
         long tt = chronology.millis().add(origin, ms);
         // always round down to the previous period (for timestamps prior to origin)
         if (t < tt) {
+          CoverageTool.setBranch(48);
           t = chronology.millis().add(tt, -millis);
         } else {
+          CoverageTool.setBranch(49);
           t = tt;
         }
         return t;
       } else {
+        CoverageTool.setBranch(47);
         return t;
       }
+    } else {
+      CoverageTool.setBranch(45);
     }
 
     return t;

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/TimestampParserTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/TimestampParserTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.java.util.common.parsers;
 
 import com.google.common.base.Function;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.IAE;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
@@ -37,22 +38,17 @@ public class TimestampParserTest
   public ExpectedException expectedException = ExpectedException.none();
 
   @Test
-  public void TestCreateNumericTimestampParserTest()
+  public void TestcreateTimestampParserISO()
   {
     Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
-            TimestampParser.createNumericTimestampParser("posix").apply(1));
+            TimestampParser.createTimestampParser("iso").apply("1970-01-01T00:00:01.000Z"));
+  }
 
-    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
-            TimestampParser.createNumericTimestampParser("micro").apply(1000000));
-
-    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
-            TimestampParser.createNumericTimestampParser("nano").apply(1000000000));
-
-    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
-            TimestampParser.createNumericTimestampParser("ruby").apply(1));
-
-    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
-            TimestampParser.createNumericTimestampParser("").apply(1000));
+  @Test
+  public void TestcreateTimestampParserException()
+  {
+    expectedException.expect(IAE.class);
+    TimestampParser.createTimestampParser("").apply("2002");
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/TimestampParserTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/TimestampParserTest.java
@@ -28,12 +28,32 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Date;
 import java.util.TimeZone;
 
 public class TimestampParserTest
 {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void TestCreateNumericTimestampParserTest()
+  {
+    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
+            TimestampParser.createNumericTimestampParser("posix").apply(1));
+
+    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
+            TimestampParser.createNumericTimestampParser("micro").apply(1000000));
+
+    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
+            TimestampParser.createNumericTimestampParser("nano").apply(1000000000));
+
+    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
+            TimestampParser.createNumericTimestampParser("ruby").apply(1));
+
+    Assert.assertEquals(DateTimes.of("1970-01-01T00:00:01.000Z"),
+            TimestampParser.createNumericTimestampParser("").apply(1000));
+  }
 
   @Test
   public void testStripQuotes()

--- a/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.druid.CoverageTool;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -43,8 +44,10 @@ import org.joda.time.Months;
 import org.joda.time.Period;
 import org.joda.time.Weeks;
 import org.joda.time.Years;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -55,6 +58,11 @@ import java.util.TimeZone;
  */
 public class QueryGranularityTest
 {
+  @AfterAll
+  public void printResult() {
+    CoverageTool.getResult();
+  }
+
   @Test
   public void testIterableNone()
   {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
