### PR TITLE
Fix superbatch merge last partition boundaries

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -780,7 +780,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
    * Partition items into as evenly-sized splits as possible.
    *
    * @param index  index of partition
-   * @param total  number of items to partitions
+   * @param total  number of items to partition
    * @param splits number of desired partitions
    *
    * @return partition range: [lhs, rhs)
@@ -789,8 +789,12 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   {
     int chunk = total / splits;
     int remainder = total % splits;
+
+    // Distribute the remainder across the first few partitions. For example total=8 and splits=5, will give partitions
+    // of sizes (starting from i=0): 2, 2, 2, 1, 1
     int start = index * chunk + (index < remainder ? index : remainder);
     int stop = start + chunk + (index < remainder ? 1 : 0);
+
     return Pair.of(start, stop);
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.Pair;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RunWith(Enclosed.class)
+public class ParallelIndexSupervisorTaskTest
+{
+  @RunWith(Parameterized.class)
+  public static class CreateMergeIoConfigsTest
+  {
+    private static final Function<List<HashPartitionLocation>, PartialHashSegmentMergeIOConfig>
+        CREATE_PARTIAL_SEGMENT_MERGE_IO_CONFIG = PartialHashSegmentMergeIOConfig::new;
+
+    @Parameterized.Parameters(name = "count = {0}")
+    public static Iterable<? extends Object> data()
+    {
+      // different scenarios for last (index = 10 - 1 = 9) partition:
+      return Arrays.asList(
+          20,  // even partitions per task: round(20 / 10) * (10 - 1) = 2 * 9 = 18 < 20
+          24,  // round down:               round(24 / 10) * (10 - 1) = 2 * 9 = 18 < 24
+          25,  // round up to greater:      round(25 / 10) * (10 - 1) = 3 * 9 = 27 > 25 (index out of bounds)
+          27   // round up to equal:        round(27 / 10) * (10 - 1) = 3 * 9 = 27 == 27 (empty partition)
+      );
+    }
+
+    @Parameterized.Parameter
+    public int count;
+
+    @Test
+    public void handlesLastPartitionCorrectly()
+    {
+      List<PartialHashSegmentMergeIOConfig> assignedPartitionLocation = ParallelIndexSupervisorTask.createMergeIOConfigs(
+          10,
+          createPartitionToLocations(count),
+          CREATE_PARTIAL_SEGMENT_MERGE_IO_CONFIG
+      );
+
+      assertNoMissingPartitions(count, assignedPartitionLocation);
+    }
+
+    private static Map<Pair<Interval, Integer>, List<HashPartitionLocation>> createPartitionToLocations(int count)
+    {
+      return IntStream.range(0, count).boxed().collect(
+          Collectors.toMap(
+              i -> Pair.of(createInterval(i), i),
+              i -> Collections.singletonList(createPartitionLocation(i))
+          )
+      );
+    }
+
+    private static HashPartitionLocation createPartitionLocation(int id)
+    {
+      return new HashPartitionLocation(
+          "host",
+          0,
+          false,
+          "subTaskId",
+          createInterval(id),
+          id
+      );
+    }
+
+    private static Interval createInterval(int id)
+    {
+      return Intervals.utc(id, id + 1);
+    }
+
+    private static void assertNoMissingPartitions(
+        int count,
+        List<PartialHashSegmentMergeIOConfig> assignedPartitionLocation
+    )
+    {
+      List<Integer> expectedIds = IntStream.range(0, count).boxed().collect(Collectors.toList());
+
+      List<Integer> actualIds = assignedPartitionLocation.stream()
+                                                         .flatMap(
+                                                             i -> i.getPartitionLocations()
+                                                                   .stream()
+                                                                   .map(HashPartitionLocation::getPartitionId)
+                                                         )
+                                                         .sorted()
+                                                         .collect(Collectors.toList());
+
+      Assert.assertEquals(expectedIds, actualIds);
+    }
+  }
+}


### PR DESCRIPTION
### Description

A bug in the computation for the last parallel merge partition could cause an `IndexOutOfBoundsException` or precondition failure due to an empty partition.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
