### PR TITLE
Add OnHeapMemorySegmentWriteOutMediumFactory

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1235,8 +1235,8 @@ If the peon is running in remote mode, there must be an Overlord up and running.
 
 ##### SegmentWriteOutMediumFactory
 
-When new segments are created, Druid temporarily stores some preprocessed data in some buffers. Currently two types of
-*medium* exist for those buffers: *temporary files* and *off-heap memory*.
+When new segments are created, Druid temporarily stores some preprocessed data in some buffers. Currently three types of
+*medium* exist for those buffers: *temporary files*, *off-heap memory*, and *on-heap memory*.
 
 *Temporary files* (`tmpFile`) are stored under the task working directory (see `druid.indexer.task.baseTaskDir`
 configuration above) and thus share it's mounting properties, e. g. they could be backed by HDD, SSD or memory (tmpfs).
@@ -1248,13 +1248,18 @@ This type of medium is preferred, but it may require to allow the JVM to have mo
 to the size of the segments being created. But definitely it doesn't make sense to add more extra off-heap memory,
 than the configured maximum *heap* size (`-Xmx`) for the same JVM.
 
+*On-heap memory medium* (`onHeapMemory`) creates buffers using the allocated heap memory of the JVM process running a task.
+Using on-heap memory introduces garbage collection overhead and so is not recommended in most cases. This type of medium is
+most helpful for tasks run on external clusters where it may be difficult to allocate and work with direct memory
+effectively.
+
 For most types of tasks SegmentWriteOutMediumFactory could be configured per-task (see [Tasks](../ingestion/tasks.md)
 page, "TuningConfig" section), but if it's not specified for a task, or it's not supported for a particular task type,
 then the value from the configuration below is used:
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.peon.defaultSegmentWriteOutMediumFactory.type`|`tmpFile` or `offHeapMemory`, see explanation above|`tmpFile`|
+|`druid.peon.defaultSegmentWriteOutMediumFactory.type`|`tmpFile`, `offHeapMemory`, or `onHeapMemory`, see explanation above|`tmpFile`|
 
 ### Indexer
 

--- a/processing/src/main/java/org/apache/druid/segment/writeout/OnHeapMemorySegmentWriteOutMediumFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/OnHeapMemorySegmentWriteOutMediumFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.writeout;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.io.File;
+import java.io.IOException;
+
+public class OnHeapMemorySegmentWriteOutMediumFactory implements SegmentWriteOutMediumFactory
+{
+  private static final OnHeapMemorySegmentWriteOutMediumFactory INSTANCE =
+      new OnHeapMemorySegmentWriteOutMediumFactory();
+
+  @JsonCreator
+  public static OnHeapMemorySegmentWriteOutMediumFactory instance()
+  {
+    return INSTANCE;
+  }
+
+  private OnHeapMemorySegmentWriteOutMediumFactory()
+  {
+
+  }
+
+  @Override
+  public SegmentWriteOutMedium makeSegmentWriteOutMedium(File outDir) throws IOException
+  {
+    return new OnHeapMemorySegmentWriteOutMedium();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/writeout/OnHeapMemorySegmentWriteOutMediumFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/OnHeapMemorySegmentWriteOutMediumFactory.java
@@ -22,7 +22,6 @@ package org.apache.druid.segment.writeout;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.io.File;
-import java.io.IOException;
 
 public class OnHeapMemorySegmentWriteOutMediumFactory implements SegmentWriteOutMediumFactory
 {
@@ -41,7 +40,7 @@ public class OnHeapMemorySegmentWriteOutMediumFactory implements SegmentWriteOut
   }
 
   @Override
-  public SegmentWriteOutMedium makeSegmentWriteOutMedium(File outDir) throws IOException
+  public SegmentWriteOutMedium makeSegmentWriteOutMedium(File outDir)
   {
     return new OnHeapMemorySegmentWriteOutMedium();
   }

--- a/processing/src/main/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumFactory.java
@@ -31,6 +31,7 @@ import java.util.Set;
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "tmpFile", value = TmpFileSegmentWriteOutMediumFactory.class),
     @JsonSubTypes.Type(name = "offHeapMemory", value = OffHeapMemorySegmentWriteOutMediumFactory.class),
+    @JsonSubTypes.Type(name = "onHeapMemory", value = OnHeapMemorySegmentWriteOutMediumFactory.class),
 })
 public interface SegmentWriteOutMediumFactory
 {
@@ -38,7 +39,8 @@ public interface SegmentWriteOutMediumFactory
   {
     return ImmutableSet.of(
         TmpFileSegmentWriteOutMediumFactory.instance(),
-        OffHeapMemorySegmentWriteOutMediumFactory.instance()
+        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
+        OnHeapMemorySegmentWriteOutMediumFactory.instance()
     );
   }
 


### PR DESCRIPTION
Add a factory for OnHeapMemorySegmentWriteOutMedium to support direct writing via Spark.

### Description

As part of the ongoing discussions on the Druid dev list, Slack channels, and other fora (including #9342), there appears to be significant community desire for writing directly from Spark to Druid. In order to support this, we should expose the ability to write segments using on-heap memory. While less efficient than using off-heap memory, on-heap memory is much easier to manage in Spark and common resource managers (e.g. YARN, Mesos, etc.). This factory is almost exactly the same as the existing OffHeapMemorySegmentWriteOutMediumFactory, with OnHeapMemorySegmentWriteOutMedium substituted for OffHeapMemorySegmentWriteOutMedium.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `OnHeapMemorySegmentWriteOutMediumFactory`
