### PR TITLE
Modify check java version script to indicate experimental support for Java 11

### DIFF
--- a/docs/tutorials/cluster.md
+++ b/docs/tutorials/cluster.md
@@ -132,9 +132,9 @@ The [basic cluster tuning guide](../operations/basic-cluster-tuning.md) has info
 
 We recommend running your favorite Linux distribution. You will also need:
 
-  * **Java 8**
+  * **Java 8 or later**
 
-> **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
+> **Warning:** Druid only officially supports Java 8. Any Java version later than 8 is still experimental.
 >
 > If needed, you can specify where to find Java using the environment variables `DRUID_JAVA_HOME` or `JAVA_HOME`. For more details run the verify-java script.
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -35,10 +35,10 @@ Before beginning the quickstart, it is helpful to read the [general Druid overvi
 
 You will need:
 
-* **Java 8 (8u92+)**
+* **Java 8 (8u92+) or later**
 * Linux, Mac OS X, or other Unix-like OS (Windows is not supported)
 
-> **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
+> **Warning:** Druid only officially supports Java 8. Any Java version later than 8 is still experimental.
 >
 > If needed, you can specify where to find Java using the environment variables `DRUID_JAVA_HOME` or `JAVA_HOME`. For more details run the verify-java script.
 

--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -28,10 +28,10 @@ sub fail_check {
     : "Make sure that \"java\" is installed and on your PATH.";
 
   print STDERR <<"EOT";
-Druid requires Java 8. $current_version_text
+Druid only officially supports Java 8. Any Java version later than 8 is still experimental. $current_version_text
 
-If you believe this check is in error, you can skip it using an
-environment variable:
+If you believe this check is in error or you still want to proceed with Java version other than 8,
+you can skip this check using an environment variable:
 
   export DRUID_SKIP_JAVA_CHECK=1
 


### PR DESCRIPTION
Modify check java version script to indicate experimental support for Java 11
### Description

We have verify that Druid (compile with both Java 8 AND java 11) can run with Java 11. We have verified this with added integration tests, local cluster and production cluster. This change is to modify the check java version script to indicate experimental support for running in version later than 8.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

