### PR TITLE
Open the licenses.yaml with an explicit encoding

### DIFF
--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -323,8 +323,8 @@ def check_licenses(license_yaml, dependency_reports_root):
     # Build registered license dictionary.
     registered_dep_to_licenses = {}
     skipping_licenses = {}
-    with open(license_yaml) as registry_file:
-        licenses_list = list(yaml.load_all(registry_file))
+    with open(license_yaml, encoding='utf-8') as registry_file:
+        licenses_list = list(yaml.load_all(registry_file, Loader=yaml.FullLoader))
     for license in licenses_list:
         if 'libraries' in license:
             for library in license['libraries']:


### PR DESCRIPTION
The license check sometimes fails with the below error.

```
distribution/bin/check-licenses.py:329: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  licenses_list = list(yaml.load_all(registry_file))
Traceback (most recent call last):
  File "distribution/bin/check-licenses.py", line 417, in <module>
    check_licenses(license_yaml, dependency_reports_root)
  File "distribution/bin/check-licenses.py", line 329, in check_licenses
    licenses_list = list(yaml.load_all(registry_file))
  File "/usr/local/lib/python3.6/dist-packages/yaml/__init__.py", line 130, in load_all
    yield loader.get_data()
  File "/usr/local/lib/python3.6/dist-packages/yaml/constructor.py", line 37, in get_data
    return self.construct_document(self.get_node())
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 27, in get_node
    return self.compose_document()
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 82, in compose_node
    node = self.compose_sequence_node(anchor)
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 111, in compose_sequence_node
    node.value.append(self.compose_node(node, index))
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/usr/local/lib/python3.6/dist-packages/yaml/composer.py", line 64, in compose_node
    if self.check_event(AliasEvent):
  File "/usr/local/lib/python3.6/dist-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/usr/local/lib/python3.6/dist-packages/yaml/parser.py", line 449, in parse_block_mapping_value
    if not self.check_token(KeyToken, ValueToken, BlockEndToken):
  File "/usr/local/lib/python3.6/dist-packages/yaml/scanner.py", line 116, in check_token
    self.fetch_more_tokens()
  File "/usr/local/lib/python3.6/dist-packages/yaml/scanner.py", line 255, in fetch_more_tokens
    return self.fetch_plain()
  File "/usr/local/lib/python3.6/dist-packages/yaml/scanner.py", line 679, in fetch_plain
    self.tokens.append(self.scan_plain())
  File "/usr/local/lib/python3.6/dist-packages/yaml/scanner.py", line 1305, in scan_plain
    spaces = self.scan_plain_spaces(indent, start_mark)
  File "/usr/local/lib/python3.6/dist-packages/yaml/scanner.py", line 1323, in scan_plain_spaces
    line_break = self.scan_line_break()
  File "/usr/local/lib/python3.6/dist-packages/yaml/scanner.py", line 1427, in scan_line_break
    if self.prefix(2) == '\r\n':
  File "/usr/local/lib/python3.6/dist-packages/yaml/reader.py", line 96, in prefix
    self.update(length)
  File "/usr/local/lib/python3.6/dist-packages/yaml/reader.py", line 153, in update
    self.update_raw()
  File "/usr/local/lib/python3.6/dist-packages/yaml/reader.py", line 178, in update_raw
    data = self.stream.read(size)
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 8090: ordinal not in range(128)
```

Seems like the script thought it's encoded with ascii which is actually encoded with utf-8. This PR changes to explicitly set the encoding method when it opens the file. Also passes the `Loader` type when it loads the yaml file to avoid the deprecation warning message (https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.