### PR TITLE
Fix maxRowsPerSegment tool tip

### DIFF
--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -109,14 +109,7 @@ export class CompactionDialog extends React.PureComponent<
               name: 'maxRowsPerSegment',
               type: 'number',
               defaultValue: CompactionDialog.DEFAULT_MAX_ROWS_PER_SEGMENT,
-              info: (
-                <p>
-                  The target segment size, for each segment, after compaction. The actual sizes of
-                  compacted segments might be slightly larger or smaller than this value. Each
-                  compaction task may generate more than one output segment, and it will try to keep
-                  each output segment close to this configured size.
-                </p>
-              ),
+              info: <p>Determines how many rows are in each segment.</p>,
             },
             {
               name: 'taskContext',


### PR DESCRIPTION
Previously the tooltip text for "Max Rows per Segment" in the compaction config UI was wrong, it shows the description for "targetCompactionSizeBytes" instead. Now it has the same tool tip as "Max Rows per Segment" in the ingestion flow. 

<img width="497" alt="Screen Shot 2020-03-06 at 9 46 51 AM" src="https://user-images.githubusercontent.com/37322608/76108895-48d3f080-5f90-11ea-818a-7ee613a5f5e2.png">
