### PR TITLE
Fix history dialog overflow

### DIFF
--- a/web-console/src/dialogs/history-dialog/__snapshots__/history-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/history-dialog/__snapshots__/history-dialog.spec.tsx.snap
@@ -16,121 +16,125 @@ exports[`history dialog matches snapshot 1`] = `
       tabindex="0"
     >
       <div
-        class="bp3-dialog history-dialog"
+        class="bp3-dialog"
       >
         <div
-          class="bp3-dialog-body history-record-container"
+          class="history-dialog"
         >
-          <span
-            class="history-dialog-title"
-          >
-            History
-          </span>
           <div
-            class="history-record-entries"
+            class="bp3-dialog-body history-record-container"
           >
+            <span
+              class="history-dialog-title"
+            >
+              History
+            </span>
             <div
-              class="history-record-entry"
+              class="history-record-entries"
             >
               <div
-                class="bp3-card bp3-elevation-0"
+                class="history-record-entry"
               >
                 <div
-                  class="history-record-title"
+                  class="bp3-card bp3-elevation-0"
                 >
-                  <span
-                    class="history-record-title-change"
-                  >
-                    Change
-                  </span>
-                  <span />
-                </div>
-                <div
-                  class="bp3-divider"
-                />
-                <p />
-                <div
-                  class="json-collapse"
-                >
-                  <button
-                    class="bp3-button bp3-minimal"
-                    type="button"
+                  <div
+                    class="history-record-title"
                   >
                     <span
-                      class="bp3-button-text"
+                      class="history-record-title-change"
                     >
-                      Payload
+                      Change
                     </span>
-                  </button>
-                  <div>
-                    <div
-                      class="bp3-collapse"
+                    <span />
+                  </div>
+                  <div
+                    class="bp3-divider"
+                  />
+                  <p />
+                  <div
+                    class="json-collapse"
+                  >
+                    <button
+                      class="bp3-button bp3-minimal"
+                      type="button"
                     >
+                      <span
+                        class="bp3-button-text"
+                      >
+                        Payload
+                      </span>
+                    </button>
+                    <div>
                       <div
-                        aria-hidden="false"
-                        class="bp3-collapse-body"
-                        style="transform: translateY(-0px);"
-                      />
+                        class="bp3-collapse"
+                      >
+                        <div
+                          aria-hidden="false"
+                          class="bp3-collapse-body"
+                          style="transform: translateY(-0px);"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="history-record-entry"
-            >
               <div
-                class="bp3-card bp3-elevation-0"
+                class="history-record-entry"
               >
                 <div
-                  class="history-record-title"
+                  class="bp3-card bp3-elevation-0"
                 >
-                  <span
-                    class="history-record-title-change"
-                  >
-                    Change
-                  </span>
-                  <span />
-                </div>
-                <div
-                  class="bp3-divider"
-                />
-                <p />
-                <div
-                  class="json-collapse"
-                >
-                  <button
-                    class="bp3-button bp3-minimal"
-                    type="button"
+                  <div
+                    class="history-record-title"
                   >
                     <span
-                      class="bp3-button-text"
+                      class="history-record-title-change"
                     >
-                      Payload
+                      Change
                     </span>
-                  </button>
-                  <div>
-                    <div
-                      class="bp3-collapse"
+                    <span />
+                  </div>
+                  <div
+                    class="bp3-divider"
+                  />
+                  <p />
+                  <div
+                    class="json-collapse"
+                  >
+                    <button
+                      class="bp3-button bp3-minimal"
+                      type="button"
                     >
+                      <span
+                        class="bp3-button-text"
+                      >
+                        Payload
+                      </span>
+                    </button>
+                    <div>
                       <div
-                        aria-hidden="false"
-                        class="bp3-collapse-body"
-                        style="transform: translateY(-0px);"
-                      />
+                        class="bp3-collapse"
+                      >
+                        <div
+                          aria-hidden="false"
+                          class="bp3-collapse-body"
+                          style="transform: translateY(-0px);"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="bp3-dialog-footer"
-        >
           <div
-            class="bp3-dialog-footer-actions"
-          />
+            class="bp3-dialog-footer"
+          >
+            <div
+              class="bp3-dialog-footer-actions"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/web-console/src/dialogs/history-dialog/history-dialog.tsx
+++ b/web-console/src/dialogs/history-dialog/history-dialog.tsx
@@ -65,10 +65,12 @@ export const HistoryDialog = React.memo(function HistoryDialog(props: HistoryDia
   }
 
   return (
-    <Dialog className="history-dialog" isOpen {...props}>
-      <div className={classNames(Classes.DIALOG_BODY, 'history-record-container')}>{content}</div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>{buttons}</div>
+    <Dialog isOpen {...props}>
+      <div className="history-dialog">
+        <div className={classNames(Classes.DIALOG_BODY, 'history-record-container')}>{content}</div>
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>{buttons}</div>
+        </div>
       </div>
     </Dialog>
   );


### PR DESCRIPTION
The class name for the history dialog wasn't being rendered by bluepint.js causing the css to be lost. Adding the classname as a separate div renders the css and prevents the dialog from overflowing. 

<img width="524" alt="Screen Shot 2020-03-06 at 11 22 34 AM" src="https://user-images.githubusercontent.com/37322608/76115469-0a90fe00-5f9d-11ea-89ea-59737c3371d3.png">
