### PR TITLE
remove ServerDiscoverySelector from DruidLeaderClient

### DIFF
--- a/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
@@ -22,8 +22,6 @@ package org.apache.druid.discovery;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
-import org.apache.druid.client.selector.DiscoverySelector;
-import org.apache.druid.client.selector.Server;
 import org.apache.druid.concurrent.LifecycleLock;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.ISE;
@@ -72,9 +70,6 @@ public class DruidLeaderClient
 
   private final String leaderRequestPath;
 
-  //Note: This is kept for back compatibility with pre 0.11.0 releases and should be removed in future.
-  private final DiscoverySelector<Server> serverDiscoverySelector;
-
   private LifecycleLock lifecycleLock = new LifecycleLock();
   private DruidNodeDiscovery druidNodeDiscovery;
   private AtomicReference<String> currentKnownLeader = new AtomicReference<>();
@@ -83,15 +78,13 @@ public class DruidLeaderClient
       HttpClient httpClient,
       DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
       NodeRole nodeRoleToWatch,
-      String leaderRequestPath,
-      DiscoverySelector<Server> serverDiscoverySelector
+      String leaderRequestPath
   )
   {
     this.httpClient = httpClient;
     this.druidNodeDiscoveryProvider = druidNodeDiscoveryProvider;
     this.nodeRoleToWatch = nodeRoleToWatch;
     this.leaderRequestPath = leaderRequestPath;
-    this.serverDiscoverySelector = serverDiscoverySelector;
   }
 
   @LifecycleStart
@@ -303,16 +296,6 @@ public class DruidLeaderClient
   @Nullable
   private String pickOneHost()
   {
-    Server server = serverDiscoverySelector.pick();
-    if (server != null) {
-      return StringUtils.format(
-          "%s://%s:%s",
-          server.getScheme(),
-          server.getAddress(),
-          server.getPort()
-      );
-    }
-
     Iterator<DiscoveryDruidNode> iter = druidNodeDiscovery.getAllNodes().iterator();
     if (iter.hasNext()) {
       DiscoveryDruidNode node = iter.next();

--- a/server/src/main/java/org/apache/druid/guice/CoordinatorDiscoveryModule.java
+++ b/server/src/main/java/org/apache/druid/guice/CoordinatorDiscoveryModule.java
@@ -24,8 +24,6 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.coordinator.CoordinatorSelectorConfig;
-import org.apache.druid.curator.discovery.ServerDiscoveryFactory;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
@@ -45,29 +43,16 @@ public class CoordinatorDiscoveryModule implements Module
   @Provides
   @Coordinator
   @ManageLifecycle
-  public ServerDiscoverySelector getServiceProvider(
-      CoordinatorSelectorConfig config,
-      ServerDiscoveryFactory serverDiscoveryFactory
-  )
-  {
-    return serverDiscoveryFactory.createSelector(config.getServiceName());
-  }
-
-  @Provides
-  @Coordinator
-  @ManageLifecycle
   public DruidLeaderClient getLeaderHttpClient(
       @EscalatedGlobal HttpClient httpClient,
-      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
-      @Coordinator ServerDiscoverySelector serverDiscoverySelector
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider
   )
   {
     return new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.COORDINATOR,
-        "/druid/coordinator/v1/leader",
-        serverDiscoverySelector
+        "/druid/coordinator/v1/leader"
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/guice/IndexingServiceDiscoveryModule.java
+++ b/server/src/main/java/org/apache/druid/guice/IndexingServiceDiscoveryModule.java
@@ -24,8 +24,6 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.client.indexing.IndexingServiceSelectorConfig;
-import org.apache.druid.curator.discovery.ServerDiscoveryFactory;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
@@ -45,29 +43,16 @@ public class IndexingServiceDiscoveryModule implements Module
   @Provides
   @IndexingService
   @ManageLifecycle
-  public ServerDiscoverySelector getServiceProvider(
-      IndexingServiceSelectorConfig config,
-      ServerDiscoveryFactory serverDiscoveryFactory
-  )
-  {
-    return serverDiscoveryFactory.createSelector(config.getServiceName());
-  }
-
-  @Provides
-  @IndexingService
-  @ManageLifecycle
   public DruidLeaderClient getLeaderHttpClient(
       @EscalatedGlobal HttpClient httpClient,
-      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
-      @IndexingService ServerDiscoverySelector serverDiscoverySelector
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider
   )
   {
     return new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.OVERLORD,
-        "/druid/indexer/v1/leader",
-        serverDiscoverySelector
+        "/druid/indexer/v1/leader"
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
@@ -29,7 +29,6 @@ import com.google.inject.Module;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.servlet.GuiceFilter;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.Jerseys;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -123,8 +122,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -148,8 +146,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -175,8 +172,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -188,9 +184,6 @@ public class DruidLeaderClientTest extends BaseJettyTest
   @Test
   public void testServerFailureAndRedirect() throws Exception
   {
-    ServerDiscoverySelector serverDiscoverySelector = EasyMock.createMock(ServerDiscoverySelector.class);
-    EasyMock.expect(serverDiscoverySelector.pick()).andReturn(null).anyTimes();
-
     DruidNodeDiscovery druidNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
     DiscoveryDruidNode dummyNode = new DiscoveryDruidNode(
         new DruidNode("test", "dummyhost", false, 64231, null, true, false),
@@ -203,14 +196,13 @@ public class DruidLeaderClientTest extends BaseJettyTest
     DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
     EasyMock.expect(druidNodeDiscoveryProvider.getForNodeRole(NodeRole.PEON)).andReturn(druidNodeDiscovery).anyTimes();
 
-    EasyMock.replay(serverDiscoverySelector, druidNodeDiscovery, druidNodeDiscoveryProvider);
+    EasyMock.replay(druidNodeDiscovery, druidNodeDiscoveryProvider);
 
     DruidLeaderClient druidLeaderClient = new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        serverDiscoverySelector
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -236,8 +228,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -879,10 +879,7 @@ public class CalciteTests
         new FakeHttpClient(),
         provider,
         NodeRole.COORDINATOR,
-        "/simple/leader",
-        () -> {
-          throw new UnsupportedOperationException();
-        }
+        "/simple/leader"
     );
 
     return new SystemSchema(


### PR DESCRIPTION
Paving Path Towards #9053

### Description

This patch removes hard coded use of Zookeeper from `DruidLeaderClient`. This was originally kept to allow rolling upgrade transition to http based leader finder.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

