### PR TITLE
Fix NPE when using IndexedTable and all left rows are filtered out

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcher.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcher.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 
 public class IndexedTableJoinMatcher implements JoinMatcher
 {
-  private final static int UNINITIALIZED_CURRENT_ROW = -1;
+  private static final int UNINITIALIZED_CURRENT_ROW = -1;
 
   private final IndexedTable table;
   private final List<Supplier<IntIterator>> conditionMatchers;

--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcher.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcher.java
@@ -81,6 +81,7 @@ public class IndexedTableJoinMatcher implements JoinMatcher
   )
   {
     this.table = table;
+    this.currentRow = -1;
 
     if (condition.isAlwaysTrue()) {
       this.conditionMatchers = Collections.singletonList(() -> IntIterators.fromTo(0, table.numRows()));

--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcher.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcher.java
@@ -59,6 +59,8 @@ import java.util.stream.Collectors;
 
 public class IndexedTableJoinMatcher implements JoinMatcher
 {
+  private final static int UNINITIALIZED_CURRENT_ROW = -1;
+
   private final IndexedTable table;
   private final List<Supplier<IntIterator>> conditionMatchers;
   private final IntIterator[] currentMatchedRows;
@@ -81,7 +83,7 @@ public class IndexedTableJoinMatcher implements JoinMatcher
   )
   {
     this.table = table;
-    this.currentRow = -1;
+    this.currentRow = UNINITIALIZED_CURRENT_ROW;
 
     if (condition.isAlwaysTrue()) {
       this.conditionMatchers = Collections.singletonList(() -> IntIterators.fromTo(0, table.numRows()));
@@ -232,7 +234,7 @@ public class IndexedTableJoinMatcher implements JoinMatcher
     // Do not reset matchedRows; we want to remember it across reset() calls so the 'remainder' is anything
     // that was unmatched across _all_ cursor walks.
     currentIterator = null;
-    currentRow = -1;
+    currentRow = UNINITIALIZED_CURRENT_ROW;
     matchingRemainder = false;
   }
 
@@ -242,7 +244,7 @@ public class IndexedTableJoinMatcher implements JoinMatcher
       currentRow = currentIterator.nextInt();
     } else {
       currentIterator = null;
-      currentRow = -1;
+      currentRow = UNINITIALIZED_CURRENT_ROW;
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.filter.SelectorFilter;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
@@ -1254,6 +1255,33 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             Granularities.ALL,
             false,
             null
+        ),
+        ImmutableList.of()
+    );
+  }
+
+  @Test
+  public void test_makeCursors_factToCountryLeft_filterExcludesAllLeftRows()
+  {
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT)),
+            true
+        ).makeCursors(
+            new SelectorFilter("page", "this matches nothing"),
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryNumber"
         ),
         ImmutableList.of()
     );

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -1266,8 +1266,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
-            ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT)),
-            true
+            ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT))
         ).makeCursors(
             new SelectorFilter("page", "this matches nothing"),
             Intervals.ETERNITY,


### PR DESCRIPTION
This PR fixes an NPE that can occur with joins on RHS tables backed by IndexedTable, where if `IndexedTableJoinMatcher` never gets `reset`, `matchRemainder`, or `matchCondition` called (this can occur when all left rows have been filtered out), the `IndexedTableJoinMatcher` will incorrectly return true for `hasMatch` because the `currentRow` variable was never initialized.

This PR initializes `currentRow` in the constructor.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.