### PR TITLE
Integration test compile with Java 8 and run with Java 8 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -371,39 +371,7 @@ jobs:
       name: "(Compile=openjdk8, Run=openjdk11) other integration test"
       jdk: openjdk8
       env: TESTNG_GROUPS='-DexcludedGroups=batch-index,perfect-rollup-parallel-batch-index,kafka-index,query,realtime-index' JVM_RUNTIME='-Djvm.runtime=11'
-    # END - Integration tests for Compile with Java 11 and Run with Java 11
-
-    # START - Integration tests for Compile with Java 11 and Run with Java 8
-    - <<: *integration_batch_index
-      name: "(Compile=openjdk11, Run=openjdk8) batch index integration test"
-      jdk: openjdk11
-      env: TESTNG_GROUPS='-Dgroups=batch-index' JVM_RUNTIME='-Djvm.runtime=8'
-
-    - <<: *integration_perfect_rollup_parallel_batch_index
-      name: "(Compile=openjdk11, Run=openjdk8) perfect rollup parallel batch index integration test"
-      jdk: openjdk11
-      env: TESTNG_GROUPS='-Dgroups=perfect-rollup-parallel-batch-index' JVM_RUNTIME='-Djvm.runtime=8'
-
-    - <<: *integration_kafka_index
-      name: "(Compile=openjdk11, Run=openjdk8) kafka index integration test"
-      jdk: openjdk11
-      env: TESTNG_GROUPS='-Dgroups=kafka-index' JVM_RUNTIME='-Djvm.runtime=8'
-
-    - <<: *integration_query
-      name: "(Compile=openjdk11, Run=openjdk8) query integration test"
-      jdk: openjdk11
-      env: TESTNG_GROUPS='-Dgroups=query' JVM_RUNTIME='-Djvm.runtime=8'
-
-    - <<: *integration_realtime_index
-      name: "(Compile=openjdk11, Run=openjdk8) realtime index integration test"
-      jdk: openjdk11
-      env: TESTNG_GROUPS='-Dgroups=realtime-index' JVM_RUNTIME='-Djvm.runtime=8'
-
-    - <<: *integration_tests
-      name: "(Compile=openjdk11, Run=openjdk8) other integration test"
-      jdk: openjdk11
-      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,perfect-rollup-parallel-batch-index,kafka-index,query,realtime-index' JVM_RUNTIME='-Djvm.runtime=8'
-    # END - Integration tests for Compile with Java 11 and Run with Java 8
+    # END - Integration tests for Compile with Java 8 and Run with Java 11
     
     - name: "security vulnerabilities"
       stage: cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -341,35 +341,35 @@ jobs:
       after_failure: *integration_test_diags
     # END - Integration tests for Compile with Java 8 and Run with Java 8
 
-    # START - Integration tests for Compile with Java 11 and Run with Java 11
+    # START - Integration tests for Compile with Java 8 and Run with Java 11
     - <<: *integration_batch_index
-      name: "(Compile=openjdk11, Run=openjdk11) batch index integration test"
-      jdk: openjdk11
+      name: "(Compile=openjdk8, Run=openjdk11) batch index integration test"
+      jdk: openjdk8
       env: TESTNG_GROUPS='-Dgroups=batch-index' JVM_RUNTIME='-Djvm.runtime=11'
 
     - <<: *integration_perfect_rollup_parallel_batch_index
-      name: "(Compile=openjdk11, Run=openjdk11) perfect rollup parallel batch index integration test"
-      jdk: openjdk11
+      name: "(Compile=openjdk8, Run=openjdk11) perfect rollup parallel batch index integration test"
+      jdk: openjdk8
       env: TESTNG_GROUPS='-Dgroups=perfect-rollup-parallel-batch-index' JVM_RUNTIME='-Djvm.runtime=11'
 
     - <<: *integration_kafka_index
-      name: "(Compile=openjdk11, Run=openjdk11) kafka index integration test"
-      jdk: openjdk11
+      name: "(Compile=openjdk8, Run=openjdk11) kafka index integration test"
+      jdk: openjdk8
       env: TESTNG_GROUPS='-Dgroups=kafka-index' JVM_RUNTIME='-Djvm.runtime=11'
 
     - <<: *integration_query
-      name: "(Compile=openjdk11, Run=openjdk11) query integration test"
-      jdk: openjdk11
+      name: "(Compile=openjdk8, Run=openjdk11) query integration test"
+      jdk: openjdk8
       env: TESTNG_GROUPS='-Dgroups=query' JVM_RUNTIME='-Djvm.runtime=11'
 
     - <<: *integration_realtime_index
-      name: "(Compile=openjdk11, Run=openjdk11) realtime index integration test"
-      jdk: openjdk11
+      name: "(Compile=openjdk8, Run=openjdk11) realtime index integration test"
+      jdk: openjdk8
       env: TESTNG_GROUPS='-Dgroups=realtime-index' JVM_RUNTIME='-Djvm.runtime=11'
 
     - <<: *integration_tests
-      name: "(Compile=openjdk11, Run=openjdk11) other integration test"
-      jdk: openjdk11
+      name: "(Compile=openjdk8, Run=openjdk11) other integration test"
+      jdk: openjdk8
       env: TESTNG_GROUPS='-DexcludedGroups=batch-index,perfect-rollup-parallel-batch-index,kafka-index,query,realtime-index' JVM_RUNTIME='-Djvm.runtime=11'
     # END - Integration tests for Compile with Java 11 and Run with Java 11
 


### PR DESCRIPTION
Integration test compile with Java 8 and run with Java 8 and 11

Removed integration tests compiling with Java 11 as we have no plan to release Druid compiling with Java 11. Added integration test for compiling with Java 8 and running with Java 11 in addition to existing integration tests that compile with Java 8 and run with Java 8. 


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
