### PR TITLE
Web console: add config control for the query context

### DIFF
--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -41,6 +41,8 @@ import './console-application.scss';
 
 export interface ConsoleApplicationProps {
   exampleManifestsUrl?: string;
+  defaultQueryContext?: Record<string, any>;
+  mandatoryQueryContext?: Record<string, any>;
 }
 
 export interface ConsoleApplicationState {
@@ -202,7 +204,16 @@ export class ConsoleApplication extends React.PureComponent<
   };
 
   private wrappedQueryView = () => {
-    return this.wrapInViewContainer('query', <QueryView initQuery={this.initQuery} />);
+    const { defaultQueryContext, mandatoryQueryContext } = this.props;
+
+    return this.wrapInViewContainer(
+      'query',
+      <QueryView
+        initQuery={this.initQuery}
+        defaultQueryContext={defaultQueryContext}
+        mandatoryQueryContext={mandatoryQueryContext}
+      />,
+    );
   };
 
   private wrappedDatasourcesView = () => {

--- a/web-console/src/entry.ts
+++ b/web-console/src/entry.ts
@@ -43,6 +43,8 @@ interface ConsoleConfig {
   customHeaderValue?: string;
   customHeaders?: Record<string, string>;
   exampleManifestsUrl?: string;
+  defaultQueryContext?: Record<string, any>;
+  mandatoryQueryContext?: Record<string, any>;
 }
 
 const consoleConfig: ConsoleConfig = (window as any).consoleConfig;
@@ -64,6 +66,8 @@ if (consoleConfig.customHeaders) {
 ReactDOM.render(
   React.createElement(ConsoleApplication, {
     exampleManifestsUrl: consoleConfig.exampleManifestsUrl,
+    defaultQueryContext: consoleConfig.defaultQueryContext,
+    mandatoryQueryContext: consoleConfig.mandatoryQueryContext,
   }) as any,
   container,
 );

--- a/web-console/src/entry.ts
+++ b/web-console/src/entry.ts
@@ -37,13 +37,26 @@ const container = document.getElementsByClassName('app-container')[0];
 if (!container) throw new Error('container not found');
 
 interface ConsoleConfig {
+  // A custom title for the page
   title?: string;
+
+  // An alternative URL which to use for the stem of an AJAX call
   baseURL?: string;
+
+  // A custom header name/value to set on every AJAX request
   customHeaderName?: string;
   customHeaderValue?: string;
+
+  // A set of custom headers name/value to set on every AJAX request
   customHeaders?: Record<string, string>;
+
+  // The URL for where to load the example manifest, a JSON document that tells the console where to find all the example datasets
   exampleManifestsUrl?: string;
+
+  // The query context to set if the user does not have one saved in local storage, defaults to {}
   defaultQueryContext?: Record<string, any>;
+
+  // Extra context properties that will be added to all query requests
   mandatoryQueryContext?: Record<string, any>;
 }
 

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -81,6 +81,8 @@ interface QueryWithContext {
 
 export interface QueryViewProps {
   initQuery: string | undefined;
+  defaultQueryContext?: Record<string, any>;
+  mandatoryQueryContext?: Record<string, any>;
 }
 
 export interface QueryViewState {
@@ -175,11 +177,13 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
 
   constructor(props: QueryViewProps, context: any) {
     super(props, context);
+    const { mandatoryQueryContext } = props;
 
     const queryString = props.initQuery || localStorageGet(LocalStorageKeys.QUERY_KEY) || '';
     const parsedQuery = queryString ? parser(queryString) : undefined;
 
-    const queryContext = localStorageGetJson(LocalStorageKeys.QUERY_CONTEXT) || {};
+    const queryContext =
+      localStorageGetJson(LocalStorageKeys.QUERY_CONTEXT) || props.defaultQueryContext || {};
 
     const possibleQueryHistory = localStorageGetJson(LocalStorageKeys.QUERY_HISTORY);
     const queryHistory = Array.isArray(possibleQueryHistory) ? possibleQueryHistory : [];
@@ -251,8 +255,13 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
           };
         }
 
-        if (!isEmptyContext(queryContext) || wrapQueryLimit) {
-          jsonQuery.context = Object.assign({}, jsonQuery.context || {}, queryContext);
+        if (!isEmptyContext(queryContext) || wrapQueryLimit || mandatoryQueryContext) {
+          jsonQuery.context = Object.assign(
+            {},
+            jsonQuery.context || {},
+            queryContext,
+            mandatoryQueryContext || {},
+          );
           jsonQuery.context.sqlOuterLimit = wrapQueryLimit;
         }
 


### PR DESCRIPTION
Allow the console config to pass in default / mandatory query contexts.