### PR TITLE
fix worker category on Indexer node

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -168,7 +168,7 @@ public class CliIndexer extends ServerRunnable
                 config.getIp(),
                 config.getCapacity(),
                 config.getVersion(),
-                WorkerConfig.DEFAULT_CATEGORY
+                config.getCategory()
             );
           }
 
@@ -180,7 +180,7 @@ public class CliIndexer extends ServerRunnable
                 workerConfig.getIp(),
                 workerConfig.getCapacity(),
                 workerConfig.getVersion(),
-                WorkerConfig.DEFAULT_CATEGORY
+                workerConfig.getCategory()
             );
           }
 


### PR DESCRIPTION
Fixes #9451

### Description

Fixes worker announcement in CliIndexer to publish configured worker category.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

