### PR TITLE
Add the option to start Hadoop docker container when running integration tests

### DIFF
--- a/integration-tests/docker/environment-configs/common
+++ b/integration-tests/docker/environment-configs/common
@@ -23,7 +23,7 @@ LC_ALL=C.UTF-8
 
 # JAVA OPTS
 COMMON_DRUID_JAVA_OPTS=-Duser.timezone=UTC -Dfile.encoding=UTF-8 -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-DRUID_DEP_LIB_DIR=/shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
+DRUID_DEP_LIB_DIR=/shared/hadoop_xml/*:/shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
 
 # Druid configs
 druid_auth_authenticator_basic_authorizerName=basic

--- a/integration-tests/docker/environment-configs/common
+++ b/integration-tests/docker/environment-configs/common
@@ -62,3 +62,4 @@ druid_zk_service_host=druid-zookeeper-kafka
 druid_auth_basic_common_maxSyncRetries=20
 druid_indexer_logs_directory=/shared/tasklogs
 druid_sql_enable=true
+druid_extensions_hadoopDependenciesDir=/shared/hadoop-dependencies

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -266,6 +266,7 @@
         <profile>
             <id>integration-tests</id>
             <properties>
+                <start.hadoop.docker>false</start.hadoop.docker>
                 <override.config.path></override.config.path>
             </properties>
             <build>
@@ -282,6 +283,7 @@
                                 <phase>pre-integration-test</phase>
                                 <configuration>
                                     <environmentVariables>
+                                    <DRUID_INTEGRATION_TEST_START_HADOOP_DOCKER>${start.hadoop.docker}</DRUID_INTEGRATION_TEST_START_HADOOP_DOCKER>
                                     <DRUID_INTEGRATION_TEST_JVM_RUNTIME>${jvm.runtime}</DRUID_INTEGRATION_TEST_JVM_RUNTIME>
                                     <DRUID_INTEGRATION_TEST_GROUP>${groups}</DRUID_INTEGRATION_TEST_GROUP>
                                     <DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH>${override.config.path}</DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH>

--- a/integration-tests/run_cluster.sh
+++ b/integration-tests/run_cluster.sh
@@ -16,7 +16,7 @@
 
 # Cleanup old images/containers
 {
-  for node in druid-historical druid-coordinator druid-overlord druid-router druid-router-permissive-tls druid-router-no-client-auth-tls druid-router-custom-check-tls druid-broker druid-middlemanager druid-zookeeper-kafka druid-metadata-storage;
+  for node in druid-historical druid-coordinator druid-overlord druid-router druid-router-permissive-tls druid-router-no-client-auth-tls druid-router-custom-check-tls druid-broker druid-middlemanager druid-zookeeper-kafka druid-metadata-storage druid-it-hadoop;
   do
   docker stop $node
   docker rm $node
@@ -29,6 +29,7 @@
 {
   # environment variables
   DIR=$(cd $(dirname $0) && pwd)
+  HADOOP_DOCKER_DIR=$DIR/../examples/quickstart/tutorial/hadoop/docker
   DOCKERDIR=$DIR/docker
   SERVICE_SUPERVISORDS_DIR=$DOCKERDIR/service-supervisords
   ENVIRONMENT_CONFIGS_DIR=$DOCKERDIR/environment-configs
@@ -45,6 +46,7 @@
   cp -r client_tls docker/client_tls
 
   # Make directories if they dont exist
+  mkdir -p $SHARED_DIR/hadoop_xml
   mkdir -p $SHARED_DIR/logs
   mkdir -p $SHARED_DIR/tasklogs
 
@@ -114,6 +116,12 @@ else
       esac
 fi
 
+# Build Hadoop docker if needed
+if [ -n "$DRUID_INTEGRATION_TEST_START_HADOOP_DOCKER" ]
+then
+  docker build -t druid-it/hadoop:2.8.5 $HADOOP_DOCKER_DIR
+fi
+
 
 # Start docker containers for all Druid processes and dependencies
 {
@@ -149,5 +157,48 @@ fi
 
   # Start Router with custom TLS cert checkers
   docker run -d --privileged --net druid-it-net --ip 172.172.172.12 ${COMMON_ENV} ${ROUTER_CUSTOM_CHECK_TLS_ENV} ${OVERRIDE_ENV} --hostname druid-router-custom-check-tls --name druid-router-custom-check-tls -p 8891:8891 -p 9091:9091 -v $SHARED_DIR:/shared -v $SERVICE_SUPERVISORDS_DIR/druid.conf:$SUPERVISORDIR/druid.conf --link druid-zookeeper-kafka:druid-zookeeper-kafka --link druid-coordinator:druid-coordinator --link druid-broker:druid-broker druid/cluster
+
+  # Start Hadoop docker if needed
+  if [ -n "$DRUID_INTEGRATION_TEST_START_HADOOP_DOCKER" ]
+  then
+    docker run -dt -h druid-it-hadoop --name druid-it-hadoop -p 2049:2049 -p 2122:2122 -p 8020:8020 -p 8021:8021 -p 8030:8030 -p 8031:8031 -p 8032:8032 -p 8033:8033 -p 8040:8040 -p 8042:8042 -p 8088:8088 -p 8443:8443 -p 9000:9000 -p 10020:10020 -p 19888:19888 -p 34455:34455 -p 49707:49707 -p 50010:50010 -p 50020:50020 -p 50030:50030 -p 50060:50060 -p 50070:50070 -p 50075:50075 -p 50090:50090 -p 51111:51111 -v $SHARED_DIR:/shared druid-it/hadoop:2.8.5 sh -c "/etc/bootstrap.sh && tail -f /dev/null"
+    wait_for_hadoop_namenode_up
+    setup_hadoop_druid_dirs
+  fi
 }
 
+wait_for_hadoop_namenode_up()
+{
+  if [ -n "$DRUID_INTEGRATION_TEST_START_HADOOP_DOCKER" ]
+  then
+    docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -mkdir -p /druid"
+    while [ $? -ne 0 ]
+    do
+       sleep 2
+       docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -mkdir -p /druid"
+    done
+    echo "Finished waiting for Hadoop namenode"
+  fi
+}
+
+setup_hadoop_druid_dirs()
+{
+  if [ -n "$DRUID_INTEGRATION_TEST_START_HADOOP_DOCKER" ]
+  then
+      echo "Setting up druid hadoop dirs"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -mkdir -p /druid"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -mkdir -p /druid/segments"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -mkdir -p /quickstart"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -chmod 777 /druid"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -chmod 777 /druid/segments"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -chmod 777 /quickstart"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -chmod -R 777 /tmp"
+      docker exec -t druid-it-hadoop sh -c "./usr/local/hadoop/bin/hdfs dfs -chmod -R 777 /user"
+      echo "Finished setting up druid hadoop dirs"
+
+      echo "Copying Hadoop XML files to shared"
+      mkdir -p $SHARED_DIR/hadoop_xml
+      docker exec -t druid-it-hadoop sh -c "cp /usr/local/hadoop/etc/hadoop/*.xml /shared/hadoop_xml"
+      echo "Copied Hadoop XML files to shared"
+  fi
+}

--- a/integration-tests/stop_cluster.sh
+++ b/integration-tests/stop_cluster.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-for node in druid-historical druid-coordinator druid-overlord druid-router druid-router-permissive-tls druid-router-no-client-auth-tls druid-router-custom-check-tls druid-broker druid-middlemanager druid-zookeeper-kafka druid-metadata-storage;
+for node in druid-historical druid-coordinator druid-overlord druid-router druid-router-permissive-tls druid-router-no-client-auth-tls druid-router-custom-check-tls druid-broker druid-middlemanager druid-zookeeper-kafka druid-metadata-storage druid-it-hadoop;
 
 do
 docker stop $node


### PR DESCRIPTION
Add the option to start Hadoop docker container when running integration tests

Hadoop docker container can easily be start when running any integration test by passing in the -Dstart.hadoop.docker=true
By default Hadoop container is not build nor start.
Hadoop docker container is build and setup by the same scripts that is use in our examples/quickstart/tutorial/hadoop/docker for the following reasons:
1) Only maintains one set of Hadoop docker build/setup/startup scripts.
2)  We should be able to easily test against what we give Druid user in our docs/tutorial and make sure they always work to ensure a pleasant user experience. 

Tested and verified to be working:
Use the -Dstart.hadoop.docker=true when running mvn to bring the Hadoop container up (this will setup all the xml, env, hadoop-dependencies, etc.).
Once it is up, I can submit ingestion task to druid running in the other container which then submit map/reduce to the Hadoop container and ingest data successfully.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

