### PR TITLE
Update to mysql connector 5.1.48

### DIFF
--- a/distribution/docker/Dockerfile.mysql
+++ b/distribution/docker/Dockerfile.mysql
@@ -22,10 +22,10 @@ FROM $DRUID_RELEASE
 
 WORKDIR /opt/druid/extensions/mysql-metadata-storage
 
-ARG MYSQL_URL=https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar
-ARG MYSQL_JAR=mysql-connector-java-5.1.38.jar
-# https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar.sha1
-ARG MYSQL_SHA=dbbd7cd309ce167ec8367de4e41c63c2c8593cc5
+ARG MYSQL_URL=https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar
+ARG MYSQL_JAR=mysql-connector-java-5.1.48.jar
+# https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar.sha1
+ARG MYSQL_SHA=9140be77aafa5050bf4bb936d560cbacb5a6b5c1
 
 RUN wget -q ${MYSQL_URL} \
  && echo "${MYSQL_SHA}  ${MYSQL_JAR}" | sha1sum -c \

--- a/docs/development/extensions-core/mysql.md
+++ b/docs/development/extensions-core/mysql.md
@@ -34,7 +34,7 @@ This extension uses Oracle's MySQL JDBC driver which is not included in the Drui
 installed separately. There are a few ways to obtain this library:
 
 - It can be downloaded from the MySQL site at: https://dev.mysql.com/downloads/connector/j/
-- It can be fetched from Maven Central at: https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar
+- It can be fetched from Maven Central at: https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar
 - It may be available through your package manager, e.g. as `libmysql-java` on APT for a Debian-based OS
 
 This should fetch a JAR file named similar to 'mysql-connector-java-x.x.xx.jar'.

--- a/extensions-core/mysql-metadata-storage/pom.xml
+++ b/extensions-core/mysql-metadata-storage/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.38</version>
+            <version>${mysql.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -65,7 +65,7 @@ public class MySQLConnector extends SQLMetadataConnector
     catch (ClassNotFoundException e) {
       throw new ISE(e, "Could not find %s on the classpath. The MySQL Connector library is not included in the Druid "
                    + "distribution but is required to use MySQL. Please download a compatible library (for example "
-                   + "'mysql-connector-java-5.1.38.jar') and place it under 'extensions/mysql-metadata-storage/'. See "
+                   + "'mysql-connector-java-5.1.48.jar') and place it under 'extensions/mysql-metadata-storage/'. See "
                    + "https://druid.apache.org/downloads for more details.",
                 MYSQL_JDBC_DRIVER_CLASS_NAME
       );

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <jackson.version>2.10.2</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.8.2</log4j.version>
+        <mysql.version>5.1.48</mysql.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <!-- Spark updated in https://github.com/apache/spark/pull/19884 -->


### PR DESCRIPTION
### Description

Update mysql connector to latest 5.1.x version to get latest fixes.

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.