### PR TITLE
Ability to Delete task logs and segments from Azure Storage

### DIFF
--- a/extensions-core/azure-extensions/pom.xml
+++ b/extensions-core/azure-extensions/pom.xml
@@ -180,27 +180,27 @@
                                 <limit>
                                     <counter>INSTRUCTION</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.85</minimum>
+                                    <minimum>0.86</minimum>
                                 </limit>
                                 <limit>
                                     <counter>LINE</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.84</minimum>
+                                    <minimum>0.86</minimum>
                                 </limit>
                                 <limit>
                                     <counter>BRANCH</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.87</minimum>
+                                    <minimum>0.89</minimum>
                                 </limit>
                                 <limit>
                                     <counter>COMPLEXITY</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.79</minimum>
+                                    <minimum>0.80</minimum>
                                 </limit>
                                 <limit>
                                     <counter>METHOD</counter>
                                     <value>COVEREDRATIO</value>
-                                    <minimum>0.78</minimum>
+                                    <minimum>0.79</minimum>
                                 </limit>
                                 <limit>
                                     <counter>CLASS</counter>

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.azure;
 
+import com.google.common.base.Predicates;
 import com.google.inject.Inject;
 import com.microsoft.azure.storage.StorageException;
 import org.apache.druid.java.util.common.MapUtils;
@@ -27,6 +28,7 @@ import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.timeline.DataSegment;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -38,14 +40,26 @@ public class AzureDataSegmentKiller implements DataSegmentKiller
 {
   private static final Logger log = new Logger(AzureDataSegmentKiller.class);
 
+  private final AzureDataSegmentConfig segmentConfig;
+  private final AzureInputDataConfig inputDataConfig;
+  private final AzureAccountConfig accountConfig;
   private final AzureStorage azureStorage;
+  private final AzureCloudBlobIterableFactory azureCloudBlobIterableFactory;
 
   @Inject
   public AzureDataSegmentKiller(
-      final AzureStorage azureStorage
+      AzureDataSegmentConfig segmentConfig,
+      AzureInputDataConfig inputDataConfig,
+      AzureAccountConfig accountConfig,
+      final AzureStorage azureStorage,
+      AzureCloudBlobIterableFactory azureCloudBlobIterableFactory
   )
   {
+    this.segmentConfig = segmentConfig;
+    this.inputDataConfig = inputDataConfig;
+    this.accountConfig = accountConfig;
     this.azureStorage = azureStorage;
+    this.azureCloudBlobIterableFactory = azureCloudBlobIterableFactory;
   }
 
   @Override
@@ -72,9 +86,26 @@ public class AzureDataSegmentKiller implements DataSegmentKiller
   }
 
   @Override
-  public void killAll()
+  public void killAll() throws IOException
   {
-    throw new UnsupportedOperationException("not implemented");
+    log.info("Deleting all segment files from Azure storage location [bucket: '%s' prefix: '%s']",
+             segmentConfig.getContainer(), segmentConfig.getPrefix()
+    );
+    try {
+      AzureUtils.deleteObjectsInPath(
+          azureStorage,
+          inputDataConfig,
+          accountConfig,
+          azureCloudBlobIterableFactory,
+          segmentConfig.getContainer(),
+          segmentConfig.getPrefix(),
+          Predicates.alwaysTrue()
+      );
+    }
+    catch (Exception e) {
+      log.error("Error occurred while deleting segment files from s3. Error: %s", e.getMessage());
+      throw new IOException(e);
+    }
   }
 
 }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
@@ -88,8 +88,10 @@ public class AzureDataSegmentKiller implements DataSegmentKiller
   @Override
   public void killAll() throws IOException
   {
-    log.info("Deleting all segment files from Azure storage location [bucket: '%s' prefix: '%s']",
-             segmentConfig.getContainer(), segmentConfig.getPrefix()
+    log.info(
+        "Deleting all segment files from Azure storage location [bucket: '%s' prefix: '%s']",
+        segmentConfig.getContainer(),
+        segmentConfig.getPrefix()
     );
     try {
       AzureUtils.deleteObjectsInPath(
@@ -103,7 +105,7 @@ public class AzureDataSegmentKiller implements DataSegmentKiller
       );
     }
     catch (Exception e) {
-      log.error("Error occurred while deleting segment files from s3. Error: %s", e.getMessage());
+      log.error("Error occurred while deleting segment files from Azure. Error: %s", e.getMessage());
       throw new IOException(e);
     }
   }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureTaskLogs.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureTaskLogs.java
@@ -169,8 +169,10 @@ public class AzureTaskLogs implements TaskLogs
   @Override
   public void killAll() throws IOException
   {
-    log.info("Deleting all task logs from Azure storage location [bucket: %s    prefix: %s].",
-             config.getContainer(), config.getPrefix()
+    log.info(
+        "Deleting all task logs from Azure storage location [bucket: %s    prefix: %s].",
+        config.getContainer(),
+        config.getPrefix()
     );
 
     long now = timeSupplier.getAsLong();
@@ -180,8 +182,11 @@ public class AzureTaskLogs implements TaskLogs
   @Override
   public void killOlderThan(long timestamp) throws IOException
   {
-    log.info("Deleting all task logs from Azure storage location [bucket: '%s' prefix: '%s'] older than %s.",
-             config.getContainer(), config.getPrefix(), new Date(timestamp)
+    log.info(
+        "Deleting all task logs from Azure storage location [bucket: '%s' prefix: '%s'] older than %s.",
+        config.getContainer(),
+        config.getPrefix(),
+        new Date(timestamp)
     );
     try {
       AzureUtils.deleteObjectsInPath(
@@ -195,7 +200,7 @@ public class AzureTaskLogs implements TaskLogs
       );
     }
     catch (Exception e) {
-      log.error("Error occurred while deleting task log files from s3. Error: %s", e.getMessage());
+      log.error("Error occurred while deleting task log files from Azure. Error: %s", e.getMessage());
       throw new IOException(e);
     }
   }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureTaskLogs.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureTaskLogs.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import com.google.common.io.ByteSource;
 import com.google.inject.Inject;
 import com.microsoft.azure.storage.StorageException;
+import org.apache.druid.common.utils.CurrentTimeMillisSupplier;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -32,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.util.Date;
 
 /**
  * Deals with reading and writing task logs stored in Azure.
@@ -42,13 +44,27 @@ public class AzureTaskLogs implements TaskLogs
   private static final Logger log = new Logger(AzureTaskLogs.class);
 
   private final AzureTaskLogsConfig config;
+  private final AzureInputDataConfig inputDataConfig;
+  private final AzureAccountConfig accountConfig;
   private final AzureStorage azureStorage;
+  private final AzureCloudBlobIterableFactory azureCloudBlobIterableFactory;
+  private final CurrentTimeMillisSupplier timeSupplier;
 
   @Inject
-  public AzureTaskLogs(AzureTaskLogsConfig config, AzureStorage azureStorage)
+  public AzureTaskLogs(
+      AzureTaskLogsConfig config,
+      AzureInputDataConfig inputDataConfig,
+      AzureAccountConfig accountConfig,
+      AzureStorage azureStorage,
+      AzureCloudBlobIterableFactory azureCloudBlobIterableFactory,
+      CurrentTimeMillisSupplier timeSupplier)
   {
     this.config = config;
+    this.inputDataConfig = inputDataConfig;
     this.azureStorage = azureStorage;
+    this.accountConfig = accountConfig;
+    this.azureCloudBlobIterableFactory = azureCloudBlobIterableFactory;
+    this.timeSupplier = timeSupplier;
   }
 
   @Override
@@ -151,14 +167,36 @@ public class AzureTaskLogs implements TaskLogs
   }
 
   @Override
-  public void killAll()
+  public void killAll() throws IOException
   {
-    throw new UnsupportedOperationException("not implemented");
+    log.info("Deleting all task logs from Azure storage location [bucket: %s    prefix: %s].",
+             config.getContainer(), config.getPrefix()
+    );
+
+    long now = timeSupplier.getAsLong();
+    killOlderThan(now);
   }
 
   @Override
-  public void killOlderThan(long timestamp)
+  public void killOlderThan(long timestamp) throws IOException
   {
-    throw new UnsupportedOperationException("not implemented");
+    log.info("Deleting all task logs from Azure storage location [bucket: '%s' prefix: '%s'] older than %s.",
+             config.getContainer(), config.getPrefix(), new Date(timestamp)
+    );
+    try {
+      AzureUtils.deleteObjectsInPath(
+          azureStorage,
+          inputDataConfig,
+          accountConfig,
+          azureCloudBlobIterableFactory,
+          config.getContainer(),
+          config.getPrefix(),
+          (object) -> object.getLastModifed().getTime() < timestamp
+      );
+    }
+    catch (Exception e) {
+      log.error("Error occurred while deleting task log files from s3. Error: %s", e.getMessage());
+      throw new IOException(e);
+    }
   }
 }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/blob/CloudBlobHolder.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/blob/CloudBlobHolder.java
@@ -23,6 +23,7 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlob;
 
 import java.net.URISyntaxException;
+import java.util.Date;
 
 /**
  * Wrapper for {@link CloudBlob}. Used to make testing easier, since {@link CloudBlob}
@@ -50,5 +51,10 @@ public class CloudBlobHolder
   public long getBlobLength()
   {
     return delegate.getProperties().getLength();
+  }
+
+  public Date getLastModifed()
+  {
+    return delegate.getProperties().getLastModified();
   }
 }

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentKillerTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentKillerTest.java
@@ -19,18 +19,24 @@
 
 package org.apache.druid.storage.azure;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.StorageExtendedErrorInformation;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
+import org.apache.druid.storage.azure.blob.CloudBlobHolder;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -39,7 +45,20 @@ import java.util.List;
 public class AzureDataSegmentKillerTest extends EasyMockSupport
 {
   private static final String CONTAINER_NAME = "container";
+  private static final String CONTAINER = "test";
+  private static final String PREFIX = "test/log";
+  private static final int MAX_TRIES = 3;
   private static final String BLOB_PATH = "test/2015-04-12T00:00:00.000Z_2015-04-13T00:00:00.000Z/1/0/index.zip";
+  private static final int MAX_KEYS = 1;
+  private static final long TIME_0 = 0L;
+  private static final long TIME_1 = 1L;
+  private static final long TIME_NOW = 2L;
+  private static final long TIME_FUTURE = 3L;
+  private static final String KEY_1 = "key1";
+  private static final String KEY_2 = "key2";
+  private static final URI PREFIX_URI = URI.create(StringUtils.format("azure://%s/%s", CONTAINER, PREFIX));
+  private static final Exception RECOVERABLE_EXCEPTION = new StorageException("", "", null);
+  private static final Exception NON_RECOVERABLE_EXCEPTION = new URISyntaxException("", "");
 
   private static final DataSegment DATA_SEGMENT = new DataSegment(
       "test",
@@ -56,12 +75,20 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
   private static final StorageExtendedErrorInformation NULL_STORAGE_EXTENDED_ERROR_INFORMATION = null;
   private static final StorageExtendedErrorInformation STORAGE_EXTENDED_ERROR_INFORMATION = new StorageExtendedErrorInformation();
 
+  private AzureDataSegmentConfig segmentConfig;
+  private AzureInputDataConfig inputDataConfig;
+  private AzureAccountConfig accountConfig;
   private AzureStorage azureStorage;
+  private AzureCloudBlobIterableFactory azureCloudBlobIterableFactory;
 
   @Before
   public void before()
   {
+    segmentConfig = createMock(AzureDataSegmentConfig.class);
+    inputDataConfig = createMock(AzureInputDataConfig.class);
+    accountConfig = createMock(AzureAccountConfig.class);
     azureStorage = createMock(AzureStorage.class);
+    azureCloudBlobIterableFactory = createMock(AzureCloudBlobIterableFactory.class);
   }
 
   @Test
@@ -75,7 +102,7 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
 
     replayAll();
 
-    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(azureStorage);
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(segmentConfig, inputDataConfig, accountConfig, azureStorage, azureCloudBlobIterableFactory);
 
     killer.kill(DATA_SEGMENT);
 
@@ -114,18 +141,127 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
 
     replayAll();
 
-    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(azureStorage);
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(segmentConfig, inputDataConfig, accountConfig, azureStorage, azureCloudBlobIterableFactory);
 
     killer.kill(DATA_SEGMENT);
 
     verifyAll();
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void test_killAll_throwsUnsupportedOperationException()
+  @Test
+  public void test_killAll_noException_deletesAllSegments() throws Exception
   {
-    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(azureStorage);
+    EasyMock.expect(segmentConfig.getContainer()).andReturn(CONTAINER).atLeastOnce();
+    EasyMock.expect(segmentConfig.getPrefix()).andReturn(PREFIX).atLeastOnce();
+    EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
+    EasyMock.expect(accountConfig.getMaxTries()).andReturn(MAX_TRIES).atLeastOnce();
+
+    CloudBlobHolder object1 = AzureTestUtils.newCloudBlobHolder(CONTAINER, KEY_1, TIME_0);
+    CloudBlobHolder object2 = AzureTestUtils.newCloudBlobHolder(CONTAINER, KEY_2, TIME_1);
+
+    AzureCloudBlobIterable azureCloudBlobIterable = AzureTestUtils.expectListObjects(
+        azureCloudBlobIterableFactory,
+        MAX_KEYS,
+        PREFIX_URI,
+        ImmutableList.of(object1, object2));
+
+    EasyMock.replay(object1, object2);
+    AzureTestUtils.expectDeleteObjects(
+        azureStorage,
+        ImmutableList.of(object1, object2),
+        ImmutableMap.of());
+    EasyMock.replay(segmentConfig, inputDataConfig, accountConfig, azureCloudBlobIterable, azureCloudBlobIterableFactory, azureStorage);
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(segmentConfig, inputDataConfig, accountConfig, azureStorage, azureCloudBlobIterableFactory);
     killer.killAll();
+    EasyMock.verify(segmentConfig, inputDataConfig, accountConfig, object1, object2, azureCloudBlobIterable, azureCloudBlobIterableFactory, azureStorage);
+  }
+
+  @Test
+  public void test_killAll_recoverableExceptionWhenListingObjects_deletesAllSegments() throws Exception
+  {
+    EasyMock.expect(segmentConfig.getContainer()).andReturn(CONTAINER).atLeastOnce();
+    EasyMock.expect(segmentConfig.getPrefix()).andReturn(PREFIX).atLeastOnce();
+    EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
+    EasyMock.expect(accountConfig.getMaxTries()).andReturn(MAX_TRIES).atLeastOnce();
+
+    CloudBlobHolder object1 = AzureTestUtils.newCloudBlobHolder(CONTAINER, KEY_1, TIME_0);
+
+    AzureCloudBlobIterable azureCloudBlobIterable = AzureTestUtils.expectListObjects(
+        azureCloudBlobIterableFactory,
+        MAX_KEYS,
+        PREFIX_URI,
+        ImmutableList.of(object1));
+
+    EasyMock.replay(object1);
+    AzureTestUtils.expectDeleteObjects(
+        azureStorage,
+        ImmutableList.of(object1),
+        ImmutableMap.of(object1, RECOVERABLE_EXCEPTION));
+    EasyMock.replay(segmentConfig, inputDataConfig, accountConfig, azureCloudBlobIterable, azureCloudBlobIterableFactory, azureStorage);
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(segmentConfig, inputDataConfig, accountConfig, azureStorage, azureCloudBlobIterableFactory);
+    killer.killAll();
+    EasyMock.verify(segmentConfig, inputDataConfig, accountConfig, object1, azureCloudBlobIterable, azureCloudBlobIterableFactory, azureStorage);
+  }
+
+  @Test
+  public void test_killAll_nonrecoverableExceptionWhenListingObjects_deletesAllSegments() throws Exception
+  {
+    boolean ioExceptionThrown = false;
+    CloudBlobHolder object1 = null;
+    AzureCloudBlobIterable azureCloudBlobIterable = null;
+    try {
+      EasyMock.expect(segmentConfig.getContainer()).andReturn(CONTAINER).atLeastOnce();
+      EasyMock.expect(segmentConfig.getPrefix()).andReturn(PREFIX).atLeastOnce();
+      EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
+      EasyMock.expect(accountConfig.getMaxTries()).andReturn(MAX_TRIES).atLeastOnce();
+
+      object1 = AzureTestUtils.newCloudBlobHolder(CONTAINER, KEY_1, TIME_0);
+
+      azureCloudBlobIterable = AzureTestUtils.expectListObjects(
+          azureCloudBlobIterableFactory,
+          MAX_KEYS,
+          PREFIX_URI,
+          ImmutableList.of(object1)
+      );
+
+      EasyMock.replay(object1);
+      AzureTestUtils.expectDeleteObjects(
+          azureStorage,
+          ImmutableList.of(),
+          ImmutableMap.of(object1, NON_RECOVERABLE_EXCEPTION)
+      );
+      EasyMock.replay(
+          segmentConfig,
+          inputDataConfig,
+          accountConfig,
+          azureCloudBlobIterable,
+          azureCloudBlobIterableFactory,
+          azureStorage
+      );
+      AzureDataSegmentKiller killer = new AzureDataSegmentKiller(
+          segmentConfig,
+          inputDataConfig,
+          accountConfig,
+          azureStorage,
+          azureCloudBlobIterableFactory
+      );
+      killer.killAll();
+    }
+    catch (IOException e) {
+      ioExceptionThrown = true;
+    }
+
+    Assert.assertTrue(ioExceptionThrown);
+
+    EasyMock.verify(
+        segmentConfig,
+        inputDataConfig,
+        accountConfig,
+        object1,
+        azureCloudBlobIterable,
+        azureCloudBlobIterableFactory,
+        azureStorage
+    );
   }
 
   private void common_test_kill_StorageExceptionExtendedError_throwsException(StorageExtendedErrorInformation storageExtendedErrorInformation)
@@ -145,7 +281,7 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
 
     replayAll();
 
-    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(azureStorage);
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(segmentConfig, inputDataConfig, accountConfig, azureStorage, azureCloudBlobIterableFactory);
 
     killer.kill(DATA_SEGMENT);
 


### PR DESCRIPTION
### Description

* implement ability to delete all tasks logs or all task logs
  written before a particular date when written to Azure storage

* implement ability to delete all segments from Azure deep storage

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.