### PR TITLE
Update docker.md readme to note memory requirements

### DIFF
--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -80,4 +80,4 @@ It takes a few seconds for all the Druid processes to fully start up. If you ope
 From here you can follow along with the [standard tutorials](./index.md#loading-data), or elaborate on your `docker-compose.yml` to add any additional external service dependencies as necessary.
 
 ## Docker Memory Requirements
-If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6gb may be a good place to start. 
+If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6 GB may be a good place to start. 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -78,3 +78,6 @@ The [Druid router process](../design/router.md), which serves the [Druid console
 It takes a few seconds for all the Druid processes to fully start up. If you open the console immediately after starting the services, you may see some errors that you can safely ignore.
 
 From here you can follow along with the [standard tutorials](./index.md#loading-data), or elaborate on your `docker-compose.yml` to add any additional external service dependencies as necessary.
+
+## Docker Memory Requirements
+If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6gb may be a good place to start. 


### PR DESCRIPTION
### Description

When attempting to get druid running inside Docker Desktop via the docker-compose file (both built from source and referencing the 0.17.0 published image), I experienced repeated crashing of the `broker` process with a 137 error code. 137 indicates an OOM error, so I notched up Docker's memory resource in 1gb increments (I believe the default is 2gb), landing on 6gb as a setting that works reliably. 

As a newcomer with little knowledge of druid, it was quite difficult to identify exactly what the issue was initially. A note like this would have helped point me in the right direction. 

<hr>

This PR has:
- [x] added documentation for new or modified features or behaviors.