### PR TITLE
fix issue where total limit was being applied even when not configured

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1532,7 +1532,7 @@ This laning strategy is best suited for cases where one or more external applica
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.query.scheduler.laning.lanes.{name}`|Maximum percent or exact limit of queries that can concurrently run in the defined lanes. Any number of lanes may be defined like this.|No default, must define at least one lane with a limit above 0. If `druid.query.scheduler.laning.isLimitPercent` is set to `true`, values must be integers in the range of 1 to 100.|
+|`druid.query.scheduler.laning.lanes.{name}`|Maximum percent or exact limit of queries that can concurrently run in the defined lanes. Any number of lanes may be defined like this. The lane names 'total' and 'default' are reserved for internal use.|No default, must define at least one lane with a limit above 0. If `druid.query.scheduler.laning.isLimitPercent` is set to `true`, values must be integers in the range of 1 to 100.|
 |`druid.query.scheduler.laning.isLimitPercent`|If set to `true`, the values set for `druid.query.scheduler.laning.lanes` will be treated as a percent of the smaller number of `druid.server.http.numThreads` or `druid.query.scheduler.numThreads`. Note that in this mode, these lane values across lanes are _not_ required to add up to, and can exceed, 100%.|`false`|
 
 ##### Server Configuration

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1487,7 +1487,7 @@ These Broker configurations can be defined in the `broker/runtime.properties` fi
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.query.scheduler.numThreads`|Maximum number of HTTP threads to dedicate to query processing. To save HTTP thread capacity, this should be lower than `druid.server.http.numThreads`.|Unbounded|
+|`druid.query.scheduler.numThreads`|Maximum number of HTTP threads to dedicate to query processing. To save HTTP thread capacity, this should be lower than `druid.server.http.numThreads`, but it is worth noting that like `druid.server.http.enableRequestLimit` is set that query requests over this limit will be denied instead of waiting in the Jetty HTTP request queue.|Unbounded|
 |`druid.query.scheduler.laning.strategy`|Query laning strategy to use to assign queries to a lane in order to control capacities for certain classes of queries.|`none`|
 |`druid.query.scheduler.prioritization.strategy`|Query prioritization strategy to automatically assign priorities.|`manual`|
 

--- a/server/src/main/java/org/apache/druid/server/QueryScheduler.java
+++ b/server/src/main/java/org/apache/druid/server/QueryScheduler.java
@@ -56,7 +56,7 @@ import java.util.Set;
 public class QueryScheduler implements QueryWatcher
 {
   public static final int UNAVAILABLE = -1;
-  static final String TOTAL = "default";
+  static final String TOTAL = "total";
   private final int totalCapacity;
   private final QueryPrioritizationStrategy prioritizationStrategy;
   private final QueryLaningStrategy laningStrategy;

--- a/server/src/main/java/org/apache/druid/server/QueryScheduler.java
+++ b/server/src/main/java/org/apache/druid/server/QueryScheduler.java
@@ -56,7 +56,7 @@ import java.util.Set;
 public class QueryScheduler implements QueryWatcher
 {
   public static final int UNAVAILABLE = -1;
-  static final String TOTAL = "total";
+  public static final String TOTAL = "total";
   private final int totalCapacity;
   private final QueryPrioritizationStrategy prioritizationStrategy;
   private final QueryLaningStrategy laningStrategy;

--- a/server/src/main/java/org/apache/druid/server/scheduling/ManualQueryLaningStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ManualQueryLaningStrategy.java
@@ -28,6 +28,7 @@ import org.apache.druid.client.SegmentServerSelector;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryPlus;
 import org.apache.druid.server.QueryLaningStrategy;
+import org.apache.druid.server.QueryScheduler;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -54,6 +55,17 @@ public class ManualQueryLaningStrategy implements QueryLaningStrategy
     Preconditions.checkArgument(
         lanes.values().stream().allMatch(x -> this.isLimitPercent ? 0 < x && x <= 100 : x > 0),
         this.isLimitPercent ? "All lane limits must be in the range 1 to 100" : "All lane limits must be greater than 0"
+    );
+    Preconditions.checkArgument(
+        lanes.keySet().stream().noneMatch(QueryScheduler.TOTAL::equals),
+        "Lane cannot be named 'total'"
+    );
+
+    // 'default' has special meaning for resilience4j bulkhead used by query scheduler, this restriction
+    // can potentially be relaxed if we ever change enforcement mechanism
+    Preconditions.checkArgument(
+        lanes.keySet().stream().noneMatch("default"::equals),
+        "Lane cannot be named 'default'"
     );
   }
 

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -310,7 +310,7 @@ public class QuerySchedulerTest
   }
 
   @Test
-  public void testNotLimitedByDefaultLimiterIfNoTotalIsSet() throws InterruptedException
+  public void testNotLimitedByDefaultLimiterIfNoTotalIsSet()
   {
     scheduler = new ObservableQueryScheduler(
         0,

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -55,6 +55,7 @@ import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.scheduling.HiLoQueryLaningStrategy;
 import org.apache.druid.server.scheduling.ManualQueryPrioritizationStrategy;
+import org.apache.druid.server.scheduling.NoQueryLaningStrategy;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
@@ -76,74 +77,29 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class QuerySchedulerTest
 {
-  private static final int NUM_CONCURRENT_QUERIES = 10000;
+  private static final int NUM_QUERIES = 10000;
   private static final int NUM_ROWS = 10000;
+  private static final int TEST_HI_CAPACITY = 5;
+  private static final int TEST_LO_CAPACITY = 2;
 
   @Rule
   public ExpectedException expected = ExpectedException.none();
 
   private ListeningExecutorService executorService;
-  private QueryScheduler scheduler;
-
-  private AtomicLong totalAcquired;
-  private AtomicLong totalReleased;
-  private AtomicLong laneAcquired;
-  private AtomicLong laneNotAcquired;
-  private AtomicLong laneReleased;
+  private ObservableQueryScheduler scheduler;
 
   @Before
   public void setup()
   {
     executorService = MoreExecutors.listeningDecorator(
-        Execs.multiThreaded(8, "test_query_scheduler_%s")
+        Execs.multiThreaded(64, "test_query_scheduler_%s")
     );
-    totalAcquired = new AtomicLong();
-    totalReleased = new AtomicLong();
-    laneAcquired = new AtomicLong();
-    laneNotAcquired = new AtomicLong();
-    laneReleased = new AtomicLong();
-    scheduler = new QueryScheduler(5, ManualQueryPrioritizationStrategy.INSTANCE, new HiLoQueryLaningStrategy(40), new ServerConfig()) {
-      @Override
-      List<Bulkhead> acquireLanes(Query<?> query)
-      {
-        List<Bulkhead> bulkheads = super.acquireLanes(query);
-        if (bulkheads.stream().anyMatch(b -> b.getName().equals(QueryScheduler.TOTAL))) {
-          totalAcquired.incrementAndGet();
-        }
-        if (bulkheads.stream().anyMatch(b -> !b.getName().equals(QueryScheduler.TOTAL))) {
-          laneAcquired.incrementAndGet();
-        }
-
-        return bulkheads;
-      }
-
-      @Override
-      void releaseLanes(List<Bulkhead> bulkheads)
-      {
-        super.releaseLanes(bulkheads);
-        if (bulkheads.stream().anyMatch(b -> b.getName().equals(QueryScheduler.TOTAL))) {
-          totalReleased.incrementAndGet();
-        }
-        if (bulkheads.stream().anyMatch(b -> !b.getName().equals(QueryScheduler.TOTAL))) {
-          laneReleased.incrementAndGet();
-          if (bulkheads.size() == 1) {
-            laneNotAcquired.incrementAndGet();
-          }
-        }
-      }
-
-      @Override
-      void finishLanes(List<Bulkhead> bulkheads)
-      {
-        super.finishLanes(bulkheads);
-        if (bulkheads.stream().anyMatch(b -> b.getName().equals(QueryScheduler.TOTAL))) {
-          totalReleased.incrementAndGet();
-        }
-        if (bulkheads.stream().anyMatch(b -> !b.getName().equals(QueryScheduler.TOTAL))) {
-          laneReleased.incrementAndGet();
-        }
-      }
-    };
+    scheduler = new ObservableQueryScheduler(
+        TEST_HI_CAPACITY,
+        ManualQueryPrioritizationStrategy.INSTANCE,
+        new HiLoQueryLaningStrategy(40),
+        new ServerConfig()
+    );
   }
 
   @After
@@ -182,7 +138,7 @@ public class QuerySchedulerTest
       }
     });
     future.get();
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
+    Assert.assertEquals(TEST_HI_CAPACITY, scheduler.getTotalAvailableCapacity());
     Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
@@ -216,8 +172,7 @@ public class QuerySchedulerTest
       }
     });
     future.get();
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    assertHiLoHasAllCapacity(TEST_HI_CAPACITY, TEST_LO_CAPACITY);
     Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
@@ -321,34 +276,53 @@ public class QuerySchedulerTest
   @Test
   public void testConcurrency() throws Exception
   {
-    List<Future<?>> futures = new ArrayList<>(NUM_CONCURRENT_QUERIES);
-    for (int i = 0; i < NUM_CONCURRENT_QUERIES; i++) {
+    List<Future<?>> futures = new ArrayList<>(NUM_QUERIES);
+    for (int i = 0; i < NUM_QUERIES; i++) {
       futures.add(makeQueryFuture(executorService, scheduler, makeRandomQuery(), NUM_ROWS));
       maybeDelayNextIteration(i);
     }
-    getFuturesAndAssertAftermathIsChill(futures, scheduler, false);
+    getFuturesAndAssertAftermathIsChill(futures, scheduler, false, false);
+    assertHiLoHasAllCapacity(TEST_HI_CAPACITY, TEST_LO_CAPACITY);
   }
 
   @Test
   public void testConcurrencyLo() throws Exception
   {
-    List<Future<?>> futures = new ArrayList<>(NUM_CONCURRENT_QUERIES);
-    for (int i = 0; i < NUM_CONCURRENT_QUERIES; i++) {
+    List<Future<?>> futures = new ArrayList<>(NUM_QUERIES);
+    for (int i = 0; i < NUM_QUERIES; i++) {
       futures.add(makeQueryFuture(executorService, scheduler, makeReportQuery(), NUM_ROWS));
       maybeDelayNextIteration(i);
     }
-    getFuturesAndAssertAftermathIsChill(futures, scheduler, false);
+    getFuturesAndAssertAftermathIsChill(futures, scheduler, false, false);
+    assertHiLoHasAllCapacity(TEST_HI_CAPACITY, TEST_LO_CAPACITY);
   }
 
   @Test
   public void testConcurrencyHi() throws Exception
   {
-    List<Future<?>> futures = new ArrayList<>(NUM_CONCURRENT_QUERIES);
-    for (int i = 0; i < NUM_CONCURRENT_QUERIES; i++) {
+    List<Future<?>> futures = new ArrayList<>(NUM_QUERIES);
+    for (int i = 0; i < NUM_QUERIES; i++) {
       futures.add(makeQueryFuture(executorService, scheduler, makeInteractiveQuery(), NUM_ROWS));
       maybeDelayNextIteration(i);
     }
-    getFuturesAndAssertAftermathIsChill(futures, scheduler, true);
+    getFuturesAndAssertAftermathIsChill(futures, scheduler, true, false);
+    assertHiLoHasAllCapacity(TEST_HI_CAPACITY, TEST_LO_CAPACITY);
+  }
+
+  @Test
+  public void testNotLimitedByDefaultLimiterIfNoTotalIsSet() throws InterruptedException
+  {
+    scheduler = new ObservableQueryScheduler(
+        0,
+        ManualQueryPrioritizationStrategy.INSTANCE,
+        new NoQueryLaningStrategy(),
+        new ServerConfig()
+    );
+    List<Future<?>> futures = new ArrayList<>(NUM_QUERIES);
+    for (int i = 0; i < NUM_QUERIES; i++) {
+      futures.add(makeQueryFuture(executorService, scheduler, makeInteractiveQuery(), NUM_ROWS));
+    }
+    getFuturesAndAssertAftermathIsChill(futures, scheduler, true, true);
   }
 
   @Test
@@ -668,8 +642,9 @@ public class QuerySchedulerTest
 
   private void getFuturesAndAssertAftermathIsChill(
       List<Future<?>> futures,
-      QueryScheduler scheduler,
-      boolean successEqualsTotal
+      ObservableQueryScheduler scheduler,
+      boolean successEqualsTotal,
+      boolean expectNoneLimited
   )
   {
     int success = 0;
@@ -692,16 +667,30 @@ public class QuerySchedulerTest
       }
     }
     Assert.assertEquals(0, other);
-    if (successEqualsTotal) {
-      Assert.assertEquals(success, totalAcquired.get());
+    if (expectNoneLimited) {
+      Assert.assertEquals(0, denied);
+      Assert.assertEquals(NUM_QUERIES, success);
+      Assert.assertEquals(0, scheduler.getTotalAcquired().get());
+      Assert.assertEquals(0, scheduler.getLaneAcquired().get());
     } else {
-      Assert.assertTrue(success > 0 && success <= totalAcquired.get());
+      Assert.assertTrue(denied > 0);
+      if (successEqualsTotal) {
+        Assert.assertEquals(success, scheduler.getTotalAcquired().get());
+      } else {
+        Assert.assertTrue(success > 0 && success <= scheduler.getTotalAcquired().get());
+      }
+      Assert.assertEquals(scheduler.getTotalReleased().get(), scheduler.getTotalAcquired().get());
+      Assert.assertEquals(
+          scheduler.getLaneReleased().get(),
+          scheduler.getLaneAcquired().get() + scheduler.getLaneNotAcquired().get()
+      );
     }
-    Assert.assertTrue(denied > 0);
-    Assert.assertEquals(totalReleased.get(), totalAcquired.get());
-    Assert.assertEquals(laneReleased.get(), laneAcquired.get() + laneNotAcquired.get());
-    Assert.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
+  }
+
+  private void assertHiLoHasAllCapacity(int hi, int lo)
+  {
+    Assert.assertEquals(lo, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assert.assertEquals(hi, scheduler.getTotalAvailableCapacity());
   }
 
   private Injector createInjector()
@@ -719,5 +708,96 @@ public class QuerySchedulerTest
         new InjectableValues.Std().addValue(ServerConfig.class, injector.getInstance(ServerConfig.class))
     );
     return injector;
+  }
+
+  private static class ObservableQueryScheduler extends QueryScheduler
+  {
+    private final AtomicLong totalAcquired;
+    private final AtomicLong totalReleased;
+    private final AtomicLong laneAcquired;
+    private final AtomicLong laneNotAcquired;
+    private final AtomicLong laneReleased;
+
+    public ObservableQueryScheduler(
+        int totalNumThreads,
+        QueryPrioritizationStrategy prioritizationStrategy,
+        QueryLaningStrategy laningStrategy,
+        ServerConfig serverConfig
+    )
+    {
+      super(totalNumThreads, prioritizationStrategy, laningStrategy, serverConfig);
+
+      totalAcquired = new AtomicLong();
+      totalReleased = new AtomicLong();
+      laneAcquired = new AtomicLong();
+      laneNotAcquired = new AtomicLong();
+      laneReleased = new AtomicLong();
+    }
+
+    @Override
+    List<Bulkhead> acquireLanes(Query<?> query)
+    {
+      List<Bulkhead> bulkheads = super.acquireLanes(query);
+      if (bulkheads.stream().anyMatch(b -> b.getName().equals(QueryScheduler.TOTAL))) {
+        totalAcquired.incrementAndGet();
+      }
+      if (bulkheads.stream().anyMatch(b -> !b.getName().equals(QueryScheduler.TOTAL))) {
+        laneAcquired.incrementAndGet();
+      }
+
+      return bulkheads;
+    }
+
+    @Override
+    void releaseLanes(List<Bulkhead> bulkheads)
+    {
+      super.releaseLanes(bulkheads);
+      if (bulkheads.stream().anyMatch(b -> b.getName().equals(QueryScheduler.TOTAL))) {
+        totalReleased.incrementAndGet();
+      }
+      if (bulkheads.stream().anyMatch(b -> !b.getName().equals(QueryScheduler.TOTAL))) {
+        laneReleased.incrementAndGet();
+        if (bulkheads.size() == 1) {
+          laneNotAcquired.incrementAndGet();
+        }
+      }
+    }
+
+    @Override
+    void finishLanes(List<Bulkhead> bulkheads)
+    {
+      super.finishLanes(bulkheads);
+      if (bulkheads.stream().anyMatch(b -> b.getName().equals(QueryScheduler.TOTAL))) {
+        totalReleased.incrementAndGet();
+      }
+      if (bulkheads.stream().anyMatch(b -> !b.getName().equals(QueryScheduler.TOTAL))) {
+        laneReleased.incrementAndGet();
+      }
+    }
+
+    public AtomicLong getTotalAcquired()
+    {
+      return totalAcquired;
+    }
+
+    public AtomicLong getTotalReleased()
+    {
+      return totalReleased;
+    }
+
+    public AtomicLong getLaneAcquired()
+    {
+      return laneAcquired;
+    }
+
+    public AtomicLong getLaneNotAcquired()
+    {
+      return laneNotAcquired;
+    }
+
+    public AtomicLong getLaneReleased()
+    {
+      return laneReleased;
+    }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/scheduling/ManualQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ManualQueryLaningStrategyTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.query.QueryPlus;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.server.QueryLaningStrategy;
+import org.apache.druid.server.QueryScheduler;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,6 +76,22 @@ public class ManualQueryLaningStrategyTest
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("lanes must define at least one lane");
     new ManualQueryLaningStrategy(ImmutableMap.of(), null);
+  }
+
+  @Test
+  public void testMustNotUseTotalName()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Lane cannot be named 'total'");
+    new ManualQueryLaningStrategy(ImmutableMap.of(QueryScheduler.TOTAL, 12), null);
+  }
+
+  @Test
+  public void testMustNotUseDefaultName()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Lane cannot be named 'default'");
+    new ManualQueryLaningStrategy(ImmutableMap.of("default", 12), null);
   }
 
   @Test


### PR DESCRIPTION
### Description
This PR fixes a mistake in `QueryScheduler` where a [default resilience4j bulkhead config](https://github.com/resilience4j/resilience4j/blob/master/resilience4j-core/src/main/java/io/github/resilience4j/core/registry/AbstractRegistry.java#L38) was applying a [default limit of 25](https://github.com/resilience4j/resilience4j/blob/master/resilience4j-bulkhead/src/main/java/io/github/resilience4j/bulkhead/BulkheadConfig.java#L30) to the 'total' capacity limit which is supposed to come from `druid.query.scheduler.numThreads`, but since was using the same "default" key for the config, it would be set to the resilience4j default if this value was not configured.

I also slightly updated the documentation to clarify the behavior of `druid.query.scheduler.numThreads` and its similarity to `druid.server.http.enableRequestLimit`.

The added test would fail prior to the changes in `QueryScheduler` in this PR.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths.
