### PR TITLE
Web console: Clean up spec before reopening in data loader

### DIFF
--- a/web-console/src/utils/ingestion-spec.spec.ts
+++ b/web-console/src/utils/ingestion-spec.spec.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { downgradeSpec, upgradeSpec } from './ingestion-spec';
+import { cleanSpec, downgradeSpec, upgradeSpec } from './ingestion-spec';
 
 describe('ingestion-spec', () => {
   const oldSpec = {
@@ -97,5 +97,27 @@ describe('ingestion-spec', () => {
 
   it('round trips', () => {
     expect(downgradeSpec(upgradeSpec(oldSpec))).toMatchObject(oldSpec);
+  });
+
+  it('cleanSpec', () => {
+    expect(
+      cleanSpec({
+        type: 'index_parallel',
+        id: 'index_parallel_coronavirus_hamlcmea_2020-03-19T00:56:12.175Z',
+        groupId: 'index_parallel_coronavirus_hamlcmea_2020-03-19T00:56:12.175Z',
+        resource: {
+          availabilityGroup: 'index_parallel_coronavirus_hamlcmea_2020-03-19T00:56:12.175Z',
+          requiredCapacity: 1,
+        },
+        spec: {
+          dataSchema: {},
+        },
+      } as any),
+    ).toEqual({
+      type: 'index_parallel',
+      spec: {
+        dataSchema: {},
+      },
+    });
   });
 });

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -294,6 +294,17 @@ export function normalizeSpec(spec: Partial<IngestionSpec>): IngestionSpec {
   return spec as IngestionSpec;
 }
 
+/**
+ * Make sure that any extra junk in the spec other than 'type' and 'spec' is removed
+ * @param spec
+ */
+export function cleanSpec(spec: IngestionSpec): IngestionSpec {
+  return {
+    type: spec.type,
+    spec: spec.spec,
+  };
+}
+
 const INPUT_FORMAT_FORM_FIELDS: Field<InputFormat>[] = [
   {
     name: 'type',

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -71,6 +71,7 @@ import { updateSchemaWithSample } from '../../utils/druid-type';
 import {
   adjustIngestionSpec,
   adjustTuningConfig,
+  cleanSpec,
   DimensionMode,
   DimensionSpec,
   DimensionsSpec,
@@ -2951,7 +2952,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
     try {
       const resp = await axios.get(`/druid/indexer/v1/supervisor/${initSupervisorId}`);
-      this.updateSpec(resp.data);
+      this.updateSpec(cleanSpec(resp.data));
       this.setState({ continueToSpec: true });
       this.updateStep('spec');
     } catch (e) {
@@ -2967,7 +2968,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
     try {
       const resp = await axios.get(`/druid/indexer/v1/task/${initTaskId}`);
-      this.updateSpec(resp.data.payload);
+      this.updateSpec(cleanSpec(resp.data.payload));
       this.setState({ continueToSpec: true });
       this.updateStep('spec');
     } catch (e) {


### PR DESCRIPTION
fix an issue that a spec re-opened in the data loader comes with a bunch of junk (such as `id`) that prevents if from being resubmitted.

![image](https://user-images.githubusercontent.com/177816/77023746-f14b6280-6949-11ea-93d3-ee5489786c06.png)
