### PR TITLE
support schemaless ingestion for transformed dimensions

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -1059,7 +1059,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
                 new SelectorDimFilter("dim1", "b", null),
                 ImmutableList.of(
                     new ExpressionTransform("dim1t", "concat(dim1,dim1)", ExprMacroTable.nil())
-                )
+                ),
+                null
             )
         ),
         new KafkaIndexTaskIOConfig(
@@ -2375,7 +2376,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         NEW_DATA_SCHEMA.withTransformSpec(
             new TransformSpec(
                 null,
-                ImmutableList.of(new ExpressionTransform("beep", "nofunc()", ExprMacroTable.nil()))
+                ImmutableList.of(new ExpressionTransform("beep", "nofunc()", ExprMacroTable.nil())),
+                null
             )
         ),
         new KafkaIndexTaskIOConfig(

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -934,7 +934,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
                 new SelectorDimFilter("dim1", "b", null),
                 ImmutableList.of(
                     new ExpressionTransform("dim1t", "concat(dim1,dim1)", ExprMacroTable.nil())
-                )
+                ),
+                null
             )
         ),
         new KinesisIndexTaskIOConfig(

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerMapperTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerMapperTest.java
@@ -131,7 +131,8 @@ public class HadoopDruidIndexerMapperTest
                     new SelectorDimFilter("dim1", "foo", null),
                     ImmutableList.of(
                         new ExpressionTransform("dim1t", "concat(dim1,dim1)", ExprMacroTable.nil())
-                    )
+                    ),
+                    null
                 )
             ),
             IO_CONFIG,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -596,7 +596,8 @@ public class AppenderatorDriverRealtimeIndexTaskTest
         new SelectorDimFilter("dim1", "foo", null),
         ImmutableList.of(
             new ExpressionTransform("dim1t", "concat(dim1,dim1)", ExprMacroTable.nil())
-        )
+        ),
+        null
     );
     final AppenderatorDriverRealtimeIndexTask task = makeRealtimeTask(null, transformSpec, true, 0, true, 0, 1);
     final ListenableFuture<TaskStatus> statusFuture = runTask(task);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -293,7 +293,8 @@ public class IndexTaskTest extends IngestionTestBase
                     new ExpressionTransform("dimtarray1", "array(dim, dim)", ExprMacroTable.nil()),
                     new ExpressionTransform("dimtarray2", "map(d -> concat(d, 'foo'), dim_array)", ExprMacroTable.nil()),
                     new ExpressionTransform("dimtnum_array", "map(d -> d + 3, dim_num_array)", ExprMacroTable.nil())
-                )
+                ),
+                null
             ),
             null,
             createTuningConfigWithMaxRowsPerSegment(2, false),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -298,7 +298,8 @@ public class RealtimeIndexTaskTest
         new SelectorDimFilter("dim1", "foo", null),
         ImmutableList.of(
             new ExpressionTransform("dim1t", "concat(dim1,dim1)", ExprMacroTable.nil())
-        )
+        ),
+        null
     );
     final RealtimeIndexTask task = makeRealtimeTask(null, transformSpec, true, 0);
     final TaskToolbox taskToolbox = makeToolbox(task, mdc, tempFolder.newFolder());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -510,7 +510,7 @@ public class IngestSegmentFirehoseFactoryTest
           skipped++;
           continue;
         }
-        Assert.assertArrayEquals(new String[]{DIM_NAME, METRIC_FLOAT_NAME}, row.getDimensions().toArray());
+        Assert.assertArrayEquals(new String[]{DIM_NAME}, row.getDimensions().toArray());
         Assert.assertArrayEquals(new String[]{DIM_VALUE}, row.getDimension(DIM_NAME).toArray());
         Assert.assertEquals(METRIC_LONG_VALUE.longValue(), row.getMetric(METRIC_LONG_NAME).longValue());
         Assert.assertEquals(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -509,7 +509,7 @@ public class IngestSegmentFirehoseFactoryTest
           skipped++;
           continue;
         }
-        Assert.assertArrayEquals(new String[]{DIM_NAME}, row.getDimensions().toArray());
+        Assert.assertArrayEquals(new String[]{DIM_NAME, METRIC_FLOAT_NAME}, row.getDimensions().toArray());
         Assert.assertArrayEquals(new String[]{DIM_VALUE}, row.getDimension(DIM_NAME).toArray());
         Assert.assertEquals(METRIC_LONG_VALUE.longValue(), row.getMetric(METRIC_LONG_NAME).longValue());
         Assert.assertEquals(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -498,7 +498,8 @@ public class IngestSegmentFirehoseFactoryTest
         new SelectorDimFilter(ColumnHolder.TIME_COLUMN_NAME, "1", null),
         ImmutableList.of(
             new ExpressionTransform(METRIC_FLOAT_NAME, METRIC_FLOAT_NAME + " * 10", ExprMacroTable.nil())
-        )
+        ),
+        null
     );
     int skipped = 0;
     try (final Firehose firehose =

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
@@ -872,6 +872,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
                 .put("dim1", "foo")
                 .put("dim2", null)
                 .put("met1", 6L)
+                .put("dim1PlusBar", "foobar")
                 .build(),
             null,
             null
@@ -886,6 +887,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
                 .put("dim1", "foo2")
                 .put("dim2", null)
                 .put("met1", 4L)
+                .put("dim1PlusBar", "foo2bar")
                 .build(),
             null,
             null
@@ -900,6 +902,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
                 .put("dim1", "foo")
                 .put("dim2", "bar")
                 .put("met1", 5L)
+                .put("dim1PlusBar", "foobar")
                 .build(),
             null,
             null

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
@@ -837,7 +837,8 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
     final DimensionsSpec dimensionsSpec = new DimensionsSpec(null);
     final TransformSpec transformSpec = new TransformSpec(
         null,
-        ImmutableList.of(new ExpressionTransform("dim1PlusBar", "concat(dim1, 'bar')", TestExprMacroTable.INSTANCE))
+        ImmutableList.of(new ExpressionTransform("dim1PlusBar", "concat(dim1, 'bar')", TestExprMacroTable.INSTANCE)),
+        null
     );
     final AggregatorFactory[] aggregatorFactories = {new LongSumAggregatorFactory("met1", "met1")};
     final GranularitySpec granularitySpec = new UniformGranularitySpec(
@@ -929,7 +930,8 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
     );
     final TransformSpec transformSpec = new TransformSpec(
         null,
-        ImmutableList.of(new ExpressionTransform("dim1PlusBar", "concat(dim1 + 'bar')", TestExprMacroTable.INSTANCE))
+        ImmutableList.of(new ExpressionTransform("dim1PlusBar", "concat(dim1 + 'bar')", TestExprMacroTable.INSTANCE)),
+        null
     );
     final AggregatorFactory[] aggregatorFactories = {new LongSumAggregatorFactory("met1", "met1")};
     final GranularitySpec granularitySpec = new UniformGranularitySpec(
@@ -998,7 +1000,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
   {
     final TimestampSpec timestampSpec = new TimestampSpec("t", null, null);
     final DimensionsSpec dimensionsSpec = new DimensionsSpec(null);
-    final TransformSpec transformSpec = new TransformSpec(new SelectorDimFilter("dim1", "foo", null), null);
+    final TransformSpec transformSpec = new TransformSpec(new SelectorDimFilter("dim1", "foo", null), null, null);
     final AggregatorFactory[] aggregatorFactories = {new LongSumAggregatorFactory("met1", "met1")};
     final GranularitySpec granularitySpec = new UniformGranularitySpec(
         Granularities.DAY,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
@@ -837,8 +837,9 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
     final DimensionsSpec dimensionsSpec = new DimensionsSpec(null);
     final TransformSpec transformSpec = new TransformSpec(
         null,
-        ImmutableList.of(new ExpressionTransform("dim1PlusBar", "concat(dim1, 'bar')", TestExprMacroTable.INSTANCE)),
-        null
+        ImmutableList.of(new ExpressionTransform("dim1PlusFoo", "concat(dim1, 'foo')", TestExprMacroTable.INSTANCE),
+                         new ExpressionTransform("dim1PlusBar", "concat(dim1, 'bar')", TestExprMacroTable.INSTANCE)),
+        ImmutableList.of("dim1PlusBar")
     );
     final AggregatorFactory[] aggregatorFactories = {new LongSumAggregatorFactory("met1", "met1")};
     final GranularitySpec granularitySpec = new UniformGranularitySpec(

--- a/processing/src/main/java/org/apache/druid/segment/transform/TransformSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/TransformSpec.java
@@ -69,6 +69,11 @@ public class TransformSpec
         throw new ISE("Transform name '%s' cannot be used twice", transform.getName());
       }
     }
+    for (String dim : this.addDimensions) {
+      if (!seen.contains(dim)) {
+        throw new ISE("Transform dimension '%s' is not defined in transforms", dim);
+      }
+    }
   }
 
   public static <T> TransformSpec fromInputRowParser(final InputRowParser<T> parser)

--- a/processing/src/main/java/org/apache/druid/segment/transform/TransformSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/TransformSpec.java
@@ -44,19 +44,23 @@ import java.util.Set;
  */
 public class TransformSpec
 {
-  public static final TransformSpec NONE = new TransformSpec(null, null);
+  public static final TransformSpec NONE = new TransformSpec(null, null, null);
 
   private final DimFilter filter;
   private final List<Transform> transforms;
+  private final List<String> addDimensions;
+
 
   @JsonCreator
   public TransformSpec(
       @JsonProperty("filter") final DimFilter filter,
-      @JsonProperty("transforms") final List<Transform> transforms
+      @JsonProperty("transforms") final List<Transform> transforms,
+      @JsonProperty("addDimensions") final List<String> addDimensions
   )
   {
     this.filter = filter;
     this.transforms = transforms == null ? ImmutableList.of() : transforms;
+    this.addDimensions = addDimensions == null ? ImmutableList.of() : addDimensions;
 
     // Check for name collisions.
     final Set<String> seen = new HashSet<>();
@@ -93,6 +97,11 @@ public class TransformSpec
   public List<Transform> getTransforms()
   {
     return transforms;
+  }
+
+  public List<String> getAddDimensions()
+  {
+    return addDimensions;
   }
 
   public <T> InputRowParser<T> decorate(final InputRowParser<T> parser)

--- a/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.transform;
 
+import com.google.common.collect.Sets;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.Row;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  *
@@ -138,17 +140,32 @@ public class Transformer
   {
     private final InputRow row;
     private final Map<String, RowFunction> transforms;
+    private final List<String> dimensions;
 
     public TransformedInputRow(final InputRow row, final Map<String, RowFunction> transforms)
     {
       this.row = row;
       this.transforms = transforms;
+
+      Set<String> transformedDims = Sets.newHashSet(transforms.keySet());
+
+      for (String dim : row.getDimensions()) {
+        transformedDims.remove(dim);
+      }
+
+      if (transformedDims.isEmpty()) {
+        this.dimensions = row.getDimensions();
+      } else {
+        this.dimensions = new ArrayList<>(row.getDimensions().size() + transforms.size());
+        dimensions.addAll(row.getDimensions());
+        dimensions.addAll(transformedDims);
+      }
     }
 
     @Override
     public List<String> getDimensions()
     {
-      return row.getDimensions();
+      return dimensions;
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
@@ -48,6 +48,7 @@ public class Transformer
   private final Map<String, RowFunction> transforms = new HashMap<>();
   private final ThreadLocal<Row> rowSupplierForValueMatcher = new ThreadLocal<>();
   private final ValueMatcher valueMatcher;
+  private final List<String> addDimensions;
 
   Transformer(final TransformSpec transformSpec)
   {
@@ -68,6 +69,8 @@ public class Transformer
     } else {
       valueMatcher = null;
     }
+
+    addDimensions = transformSpec.getAddDimensions();
   }
 
   /**
@@ -87,7 +90,7 @@ public class Transformer
     if (transforms.isEmpty()) {
       transformedRow = row;
     } else {
-      transformedRow = new TransformedInputRow(row, transforms);
+      transformedRow = new TransformedInputRow(row, transforms, addDimensions);
     }
 
     if (valueMatcher != null) {
@@ -115,7 +118,7 @@ public class Transformer
       final List<InputRow> originalRows = row.getInputRows();
       final List<InputRow> transformedRows = new ArrayList<>(originalRows.size());
       for (InputRow originalRow : originalRows) {
-        transformedRows.add(new TransformedInputRow(originalRow, transforms));
+        transformedRows.add(new TransformedInputRow(originalRow, transforms, addDimensions));
       }
       inputRowListPlusRawValues = InputRowListPlusRawValues.of(transformedRows, row.getRawValues());
     }
@@ -142,12 +145,12 @@ public class Transformer
     private final Map<String, RowFunction> transforms;
     private final List<String> dimensions;
 
-    public TransformedInputRow(final InputRow row, final Map<String, RowFunction> transforms)
+    public TransformedInputRow(final InputRow row, final Map<String, RowFunction> transforms, List<String> addDimensions)
     {
       this.row = row;
       this.transforms = transforms;
 
-      Set<String> transformedDims = Sets.newHashSet(transforms.keySet());
+      Set<String> transformedDims = Sets.newHashSet(addDimensions);
 
       for (String dim : row.getDimensions()) {
         transformedDims.remove(dim);

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -164,7 +164,8 @@ public class DataSchemaTest
             new SelectorDimFilter("dimA", "foo", null),
             ImmutableList.of(
                 new ExpressionTransform("expr", "concat(dimA,dimA)", TestExprMacroTable.INSTANCE)
-            )
+            ),
+            null
         ),
         jsonMapper
     );

--- a/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
@@ -85,7 +85,7 @@ public class TransformSpecTest
     Assert.assertNotNull(row);
     Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), row.getTimestampFromEpoch());
     Assert.assertEquals(DateTimes.of("2000-01-01"), row.getTimestamp());
-    Assert.assertEquals(ImmutableList.of("f", "x", "y"), row.getDimensions());
+    Assert.assertEquals(ImmutableList.of("f", "x", "y", "g", "h"), row.getDimensions());
     Assert.assertEquals(ImmutableList.of("foo"), row.getDimension("x"));
     Assert.assertEquals(3.0, row.getMetric("b").doubleValue(), 0);
     Assert.assertEquals("foobar", row.getRaw("f"));

--- a/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.indexing;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.InputRowParser;
@@ -42,6 +43,10 @@ import java.util.Map;
 
 public class TransformSpecTest
 {
+  static {
+    NullHandling.initializeForTests();
+  }
+
   private static final MapInputRowParser PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
           new TimestampSpec("t", "auto", DateTimes.of("2000-01-01")),

--- a/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
@@ -86,7 +86,36 @@ public class TransformSpecTest
     Assert.assertNotNull(row);
     Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), row.getTimestampFromEpoch());
     Assert.assertEquals(DateTimes.of("2000-01-01"), row.getTimestamp());
-    Assert.assertEquals(ImmutableList.of("f", "x", "y", "g", "h"), row.getDimensions());
+    Assert.assertEquals(ImmutableList.of("f", "x", "y"), row.getDimensions());
+    Assert.assertEquals(ImmutableList.of("foo"), row.getDimension("x"));
+    Assert.assertEquals(3.0, row.getMetric("b").doubleValue(), 0);
+    Assert.assertEquals("foobar", row.getRaw("f"));
+    Assert.assertEquals(ImmutableList.of("foobar"), row.getDimension("f"));
+    Assert.assertEquals(ImmutableList.of("5.0"), row.getDimension("g"));
+    Assert.assertEquals(ImmutableList.of(), row.getDimension("h"));
+    Assert.assertEquals(5L, row.getMetric("g").longValue());
+  }
+
+  @Test
+  public void testTransformsWithAddedDimensions()
+  {
+    final TransformSpec transformSpec = new TransformSpec(
+        null,
+        ImmutableList.of(
+            new ExpressionTransform("f", "concat(x,y)", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("g", "a + b", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("h", "concat(f,g)", TestExprMacroTable.INSTANCE)
+        ),
+        ImmutableList.of("h")
+    );
+
+    final InputRowParser<Map<String, Object>> parser = transformSpec.decorate(PARSER);
+    final InputRow row = parser.parseBatch(ROW1).get(0);
+
+    Assert.assertNotNull(row);
+    Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), row.getTimestampFromEpoch());
+    Assert.assertEquals(DateTimes.of("2000-01-01"), row.getTimestamp());
+    Assert.assertEquals(ImmutableList.of("f", "x", "y", "h"), row.getDimensions());
     Assert.assertEquals(ImmutableList.of("foo"), row.getDimension("x"));
     Assert.assertEquals(3.0, row.getMetric("b").doubleValue(), 0);
     Assert.assertEquals("foobar", row.getRaw("f"));

--- a/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/TransformSpecTest.java
@@ -76,7 +76,8 @@ public class TransformSpecTest
             new ExpressionTransform("f", "concat(x,y)", TestExprMacroTable.INSTANCE),
             new ExpressionTransform("g", "a + b", TestExprMacroTable.INSTANCE),
             new ExpressionTransform("h", "concat(f,g)", TestExprMacroTable.INSTANCE)
-        )
+        ),
+        null
     );
 
     final InputRowParser<Map<String, Object>> parser = transformSpec.decorate(PARSER);
@@ -104,7 +105,8 @@ public class TransformSpecTest
         null,
         ImmutableList.of(
             new ExpressionTransform("x", "concat(x,y)", TestExprMacroTable.INSTANCE)
-        )
+        ),
+        null
     );
 
     final InputRowParser<Map<String, Object>> parser = transformSpec.decorate(PARSER);
@@ -135,7 +137,8 @@ public class TransformSpecTest
         ImmutableList.of(
             new ExpressionTransform("f", "concat(x,y)", TestExprMacroTable.INSTANCE),
             new ExpressionTransform("g", "a + b", TestExprMacroTable.INSTANCE)
-        )
+        ),
+        null
     );
 
     final InputRowParser<Map<String, Object>> parser = transformSpec.decorate(PARSER);
@@ -150,7 +153,8 @@ public class TransformSpecTest
         null,
         ImmutableList.of(
             new ExpressionTransform("__time", "(a + b) * 3600000", TestExprMacroTable.INSTANCE)
-        )
+        ),
+        null
     );
 
     final InputRowParser<Map<String, Object>> parser = transformSpec.decorate(PARSER);
@@ -168,7 +172,8 @@ public class TransformSpecTest
         null,
         ImmutableList.of(
             new ExpressionTransform("__time", "__time + 3600000", TestExprMacroTable.INSTANCE)
-        )
+        ),
+        null
     );
 
     final InputRowParser<Map<String, Object>> parser = transformSpec.decorate(PARSER);
@@ -193,7 +198,8 @@ public class TransformSpecTest
         ImmutableList.of(
             new ExpressionTransform("f", "concat(x,y)", TestExprMacroTable.INSTANCE),
             new ExpressionTransform("g", "a + b", TestExprMacroTable.INSTANCE)
-        )
+        ),
+        null
     );
 
     final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseTest.java
@@ -197,7 +197,8 @@ public class SqlFirehoseTest
             null,
             ImmutableList.of(
                 new ExpressionTransform("xfoo", "concat(x,'foo')", ExprMacroTable.nil())
-            )
+            ),
+            null
         )
     );
 


### PR DESCRIPTION
I might be missing some subtleties or edge cases, but I'm wondering if this is all it takes to support adding schemaless ingestion for dimensions created by transformspecs?

~~Of course this doesn't address the backwards incompatibility concerns. We can discuss whether we feel it is important to maintain the old behavior or not.~~

I updated `TransformSpec` to take a new `addDimensions` field, to indicate which dimensions created by the transforms should be added to the schema. This new field should only be used for schema-less ingestion, since the added dimensions cannot be excluded by `dimensionExclusions`.

Taking suggestions for a better name than `addDimensions` :)

fixes #7952