### PR TITLE
fix Hadoop ingestion fails due to error 'JavaScript is disabled' on certain config

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
@@ -96,7 +96,7 @@ public class DetermineHashedPartitionsJob implements Jobby
           StringUtils.format("%s-determine_partitions_hashed-%s", config.getDataSource(), config.getIntervals())
       );
 
-      JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config.getAllowedHadoopPrefix());
+      JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config);
       config.addJobProperties(groupByJob);
       groupByJob.setMapperClass(DetermineCardinalityMapper.class);
       groupByJob.setMapOutputKeyClass(LongWritable.class);

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
@@ -96,7 +96,7 @@ public class DetermineHashedPartitionsJob implements Jobby
           StringUtils.format("%s-determine_partitions_hashed-%s", config.getDataSource(), config.getIntervals())
       );
 
-      JobHelper.injectSystemProperties(groupByJob);
+      JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config.getAllowedHadoopPrefix());
       config.addJobProperties(groupByJob);
       groupByJob.setMapperClass(DetermineCardinalityMapper.class);
       groupByJob.setMapOutputKeyClass(LongWritable.class);

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
@@ -135,7 +135,7 @@ public class DeterminePartitionsJob implements Jobby
             StringUtils.format("%s-determine_partitions_groupby-%s", config.getDataSource(), config.getIntervals())
         );
 
-        JobHelper.injectSystemProperties(groupByJob);
+        JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config.getAllowedHadoopPrefix());
         config.addJobProperties(groupByJob);
 
         groupByJob.setMapperClass(DeterminePartitionsGroupByMapper.class);
@@ -191,7 +191,7 @@ public class DeterminePartitionsJob implements Jobby
 
       dimSelectionJob.getConfiguration().set("io.sort.record.percent", "0.19");
 
-      JobHelper.injectSystemProperties(dimSelectionJob);
+      JobHelper.injectSystemProperties(dimSelectionJob.getConfiguration(), config.getAllowedHadoopPrefix());
       config.addJobProperties(dimSelectionJob);
 
       if (!partitionsSpec.isAssumeGrouped()) {

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
@@ -135,7 +135,7 @@ public class DeterminePartitionsJob implements Jobby
             StringUtils.format("%s-determine_partitions_groupby-%s", config.getDataSource(), config.getIntervals())
         );
 
-        JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config.getAllowedHadoopPrefix());
+        JobHelper.injectSystemProperties(groupByJob.getConfiguration(), config);
         config.addJobProperties(groupByJob);
 
         groupByJob.setMapperClass(DeterminePartitionsGroupByMapper.class);
@@ -191,7 +191,7 @@ public class DeterminePartitionsJob implements Jobby
 
       dimSelectionJob.getConfiguration().set("io.sort.record.percent", "0.19");
 
-      JobHelper.injectSystemProperties(dimSelectionJob.getConfiguration(), config.getAllowedHadoopPrefix());
+      JobHelper.injectSystemProperties(dimSelectionJob.getConfiguration(), config);
       config.addJobProperties(dimSelectionJob);
 
       if (!partitionsSpec.isAssumeGrouped()) {

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
@@ -138,20 +138,6 @@ public class HadoopDruidIndexerConfig
     ROWS_THROWN_AWAY_COUNTER
   }
 
-  public static Map<String, String> getAllowedProperties(List<String> listOfAllowedPrefix)
-  {
-    Map<String, String> allowedPropertiesMap = new HashMap<>();
-    for (String propName : PROPERTIES.stringPropertyNames()) {
-      for (String prefix : listOfAllowedPrefix) {
-        if (propName.equals(prefix) || propName.startsWith(prefix + ".")) {
-          allowedPropertiesMap.put(propName, PROPERTIES.getProperty(propName));
-          break;
-        }
-      }
-    }
-    return allowedPropertiesMap;
-  }
-
   public static HadoopDruidIndexerConfig fromSpec(HadoopIngestionSpec spec)
   {
     return new HadoopDruidIndexerConfig(spec);
@@ -393,6 +379,20 @@ public class HadoopDruidIndexerConfig
     return schema.getTuningConfig().getMaxParseExceptions();
   }
 
+  public Map<String, String> getAllowedProperties()
+  {
+    Map<String, String> allowedPropertiesMap = new HashMap<>();
+    for (String propName : PROPERTIES.stringPropertyNames()) {
+      for (String prefix : allowedHadoopPrefix) {
+        if (propName.equals(prefix) || propName.startsWith(prefix + ".")) {
+          allowedPropertiesMap.put(propName, PROPERTIES.getProperty(propName));
+          break;
+        }
+      }
+    }
+    return allowedPropertiesMap;
+  }
+
   boolean isUseYarnRMJobStatusFallback()
   {
     return schema.getTuningConfig().isUseYarnRMJobStatusFallback();
@@ -609,10 +609,5 @@ public class HadoopDruidIndexerConfig
     Preconditions.checkNotNull(schema.getTuningConfig().getWorkingPath(), "workingPath");
     Preconditions.checkNotNull(schema.getIOConfig().getSegmentOutputPath(), "segmentOutputPath");
     Preconditions.checkNotNull(schema.getTuningConfig().getVersion(), "version");
-  }
-
-  List<String> getAllowedHadoopPrefix()
-  {
-    return allowedHadoopPrefix;
   }
 }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
@@ -138,6 +138,20 @@ public class HadoopDruidIndexerConfig
     ROWS_THROWN_AWAY_COUNTER
   }
 
+  public static Map<String, String> getAllowedProperties(List<String> listOfAllowedPrefix)
+  {
+    Map<String, String> allowedPropertiesMap = new HashMap<>();
+    for (String propName : PROPERTIES.stringPropertyNames()) {
+      for (String prefix : listOfAllowedPrefix) {
+        if (propName.equals(prefix) || propName.startsWith(prefix + ".")) {
+          allowedPropertiesMap.put(propName, PROPERTIES.getProperty(propName));
+          break;
+        }
+      }
+    }
+    return allowedPropertiesMap;
+  }
+
   public static HadoopDruidIndexerConfig fromSpec(HadoopIngestionSpec spec)
   {
     return new HadoopDruidIndexerConfig(spec);
@@ -383,7 +397,6 @@ public class HadoopDruidIndexerConfig
   {
     return schema.getTuningConfig().isUseYarnRMJobStatusFallback();
   }
-
 
   void setHadoopJobIdFileName(String hadoopJobIdFileName)
   {

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -105,7 +105,7 @@ public class IndexGeneratorJob implements Jobby
 
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
-    final Configuration conf = JobHelper.injectSystemProperties(new Configuration(), config.getAllowedHadoopPrefix());
+    final Configuration conf = JobHelper.injectSystemProperties(new Configuration(), config);
     config.addJobProperties(conf);
 
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
@@ -167,10 +167,10 @@ public class IndexGeneratorJob implements Jobby
 
       job.getConfiguration().set("io.sort.record.percent", "0.23");
 
-      JobHelper.injectSystemProperties(job.getConfiguration(), config.getAllowedHadoopPrefix());
+      JobHelper.injectSystemProperties(job.getConfiguration(), config);
       config.addJobProperties(job);
       // inject druid properties like deep storage bindings
-      JobHelper.injectDruidProperties(job.getConfiguration(), config.getAllowedHadoopPrefix());
+      JobHelper.injectDruidProperties(job.getConfiguration(), config);
 
       job.setMapperClass(IndexGeneratorMapper.class);
       job.setMapOutputValueClass(BytesWritable.class);

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -105,7 +105,7 @@ public class IndexGeneratorJob implements Jobby
 
   public static List<DataSegment> getPublishedSegments(HadoopDruidIndexerConfig config)
   {
-    final Configuration conf = JobHelper.injectSystemProperties(new Configuration());
+    final Configuration conf = JobHelper.injectSystemProperties(new Configuration(), config.getAllowedHadoopPrefix());
     config.addJobProperties(conf);
 
     final ObjectMapper jsonMapper = HadoopDruidIndexerConfig.JSON_MAPPER;
@@ -167,7 +167,7 @@ public class IndexGeneratorJob implements Jobby
 
       job.getConfiguration().set("io.sort.record.percent", "0.23");
 
-      JobHelper.injectSystemProperties(job);
+      JobHelper.injectSystemProperties(job.getConfiguration(), config.getAllowedHadoopPrefix());
       config.addJobProperties(job);
       // inject druid properties like deep storage bindings
       JobHelper.injectDruidProperties(job.getConfiguration(), config.getAllowedHadoopPrefix());

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
@@ -310,26 +310,21 @@ public class JobHelper
     String mapJavaOpts = StringUtils.nullToEmptyNonDruidDataString(configuration.get(MRJobConfig.MAP_JAVA_OPTS));
     String reduceJavaOpts = StringUtils.nullToEmptyNonDruidDataString(configuration.get(MRJobConfig.REDUCE_JAVA_OPTS));
 
-    for (String propName : HadoopDruidIndexerConfig.PROPERTIES.stringPropertyNames()) {
-      for (String prefix : listOfAllowedPrefix) {
-        if (propName.equals(prefix) || propName.startsWith(prefix + ".")) {
-          mapJavaOpts = StringUtils.format(
-              "%s -D%s=%s",
-              mapJavaOpts,
-              propName,
-              HadoopDruidIndexerConfig.PROPERTIES.getProperty(propName)
-          );
-          reduceJavaOpts = StringUtils.format(
-              "%s -D%s=%s",
-              reduceJavaOpts,
-              propName,
-              HadoopDruidIndexerConfig.PROPERTIES.getProperty(propName)
-          );
-          break;
-        }
-      }
-
+    for (Map.Entry<String, String> allowedProperties : HadoopDruidIndexerConfig.getAllowedProperties(listOfAllowedPrefix).entrySet()) {
+      mapJavaOpts = StringUtils.format(
+          "%s -D%s=%s",
+          mapJavaOpts,
+          allowedProperties.getKey(),
+          allowedProperties.getValue()
+      );
+      reduceJavaOpts = StringUtils.format(
+          "%s -D%s=%s",
+          reduceJavaOpts,
+          allowedProperties.getKey(),
+          allowedProperties.getValue()
+      );
     }
+
     if (!Strings.isNullOrEmpty(mapJavaOpts)) {
       configuration.set(MRJobConfig.MAP_JAVA_OPTS, mapJavaOpts);
     }
@@ -343,15 +338,13 @@ public class JobHelper
     for (String propName : HadoopDruidIndexerConfig.PROPERTIES.stringPropertyNames()) {
       if (propName.startsWith("hadoop.")) {
         conf.set(propName.substring("hadoop.".length()), HadoopDruidIndexerConfig.PROPERTIES.getProperty(propName));
-      } else {
-        for (String prefix : listOfAllowedPrefix) {
-          if (propName.equals(prefix) || propName.startsWith(prefix + ".")) {
-            conf.set(propName, HadoopDruidIndexerConfig.PROPERTIES.getProperty(propName));
-            break;
-          }
-        }
       }
     }
+
+    for (Map.Entry<String, String> allowedProperties : HadoopDruidIndexerConfig.getAllowedProperties(listOfAllowedPrefix).entrySet()) {
+      conf.set(allowedProperties.getKey(), allowedProperties.getValue());
+    }
+
     return conf;
   }
 

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
@@ -305,12 +305,12 @@ public class JobHelper
     return SNAPSHOT_JAR.matcher(jarFile.getName()).matches();
   }
 
-  public static void injectDruidProperties(Configuration configuration, List<String> listOfAllowedPrefix)
+  public static void injectDruidProperties(Configuration configuration, HadoopDruidIndexerConfig hadoopDruidIndexerConfig)
   {
     String mapJavaOpts = StringUtils.nullToEmptyNonDruidDataString(configuration.get(MRJobConfig.MAP_JAVA_OPTS));
     String reduceJavaOpts = StringUtils.nullToEmptyNonDruidDataString(configuration.get(MRJobConfig.REDUCE_JAVA_OPTS));
 
-    for (Map.Entry<String, String> allowedProperties : HadoopDruidIndexerConfig.getAllowedProperties(listOfAllowedPrefix).entrySet()) {
+    for (Map.Entry<String, String> allowedProperties : hadoopDruidIndexerConfig.getAllowedProperties().entrySet()) {
       mapJavaOpts = StringUtils.format(
           "%s -D%s=%s",
           mapJavaOpts,
@@ -333,7 +333,7 @@ public class JobHelper
     }
   }
 
-  public static Configuration injectSystemProperties(Configuration conf, List<String> listOfAllowedPrefix)
+  public static Configuration injectSystemProperties(Configuration conf, HadoopDruidIndexerConfig hadoopDruidIndexerConfig)
   {
     for (String propName : HadoopDruidIndexerConfig.PROPERTIES.stringPropertyNames()) {
       if (propName.startsWith("hadoop.")) {
@@ -341,7 +341,7 @@ public class JobHelper
       }
     }
 
-    for (Map.Entry<String, String> allowedProperties : HadoopDruidIndexerConfig.getAllowedProperties(listOfAllowedPrefix).entrySet()) {
+    for (Map.Entry<String, String> allowedProperties : hadoopDruidIndexerConfig.getAllowedProperties().entrySet()) {
       conf.set(allowedProperties.getKey(), allowedProperties.getValue());
     }
 
@@ -359,7 +359,7 @@ public class JobHelper
       );
 
       job.getConfiguration().set("io.sort.record.percent", "0.19");
-      injectSystemProperties(job.getConfiguration(), config.getAllowedHadoopPrefix());
+      injectSystemProperties(job.getConfiguration(), config);
       config.addJobProperties(job);
 
       config.addInputPaths(job);
@@ -396,7 +396,7 @@ public class JobHelper
         Path workingPath = config.makeIntermediatePath();
         log.info("Deleting path[%s]", workingPath);
         try {
-          Configuration conf = injectSystemProperties(new Configuration(), config.getAllowedHadoopPrefix());
+          Configuration conf = injectSystemProperties(new Configuration(), config);
           config.addJobProperties(conf);
           workingPath.getFileSystem(conf).delete(workingPath, true);
         }
@@ -424,7 +424,7 @@ public class JobHelper
         Path workingPath = config.makeIntermediatePath();
         log.info("Deleting path[%s]", workingPath);
         try {
-          Configuration conf = injectSystemProperties(new Configuration(), config.getAllowedHadoopPrefix());
+          Configuration conf = injectSystemProperties(new Configuration(), config);
           config.addJobProperties(conf);
           workingPath.getFileSystem(conf).delete(workingPath, true);
         }

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
@@ -57,9 +57,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 /**
  */
 public class JobHelperTest
@@ -155,7 +152,8 @@ public class JobHelperTest
   }
 
   @After
-  public void teardown() {
+  public void teardown()
+  {
     HadoopDruidIndexerConfig.PROPERTIES.remove(VALID_DRUID_PROP);
     HadoopDruidIndexerConfig.PROPERTIES.remove(VALID_HADOOP_PREFIX + VALID_HADOOP_PROP);
     HadoopDruidIndexerConfig.PROPERTIES.remove(INVALID_PROP);
@@ -181,7 +179,8 @@ public class JobHelperTest
   }
 
   @Test
-  public void testInjectSystemProperties() throws Exception {
+  public void testInjectSystemProperties()
+  {
     ArrayList<String> allowedHadoopPrefix = new ArrayList<>();
     allowedHadoopPrefix.add("druid.storage");
     allowedHadoopPrefix.add("druid.javascript");
@@ -189,11 +188,11 @@ public class JobHelperTest
     JobHelper.injectSystemProperties(config, allowedHadoopPrefix);
 
     // This should be injected
-    assertNotNull(config.get(VALID_DRUID_PROP));
+    Assert.assertNotNull(config.get(VALID_DRUID_PROP));
     // This should be injected
-    assertNotNull(config.get(VALID_HADOOP_PROP));
+    Assert.assertNotNull(config.get(VALID_HADOOP_PROP));
     // This should not be injected
-    assertNull(config.get(INVALID_PROP));
+    Assert.assertNull(config.get(INVALID_PROP));
   }
 
   @Test


### PR DESCRIPTION
Fixes Hadoop ingestion fails due to error "JavaScript is disabled", if determine partition map reduce job is run and "mapreduce.reduce.java.opts" + "mapreduce.map.java.opts" is not set with druid.javascript.enabled=true

### Description

The root cause of the failure is depending on if the determine_partitions map reduce job needs to be run or not. If the determine_partitions map reduce job needs to be run, then it will fail with the "JavaScript is disabled" error if "mapreduce.reduce.java.opts" + "mapreduce.map.java.opts" is not set with druid.javascript.enabled=true. This is due to peon not sending the druid.javascript.enabled value (that is set in the _common/common.runtime.properties) to hadoop when running the determine_partitions map reduce job

The determine_partitions is run for many configuration settings. For example, if "maxRowsPerSegment" is null but numShard is also null, then maxRowsPerSegment is internally set to default value of 5000000 and the determine_partitions job is run.

The fix is simply to include the druid.javascript.enabled prop when running the determine_partitions map reduce job (similar to how we do when we send the index-generator map reduce job. (Note that the druid.javascript.enabled is inject correctly for index-generator job).

Current workaround is to pass the druid.javascript.enabled=true in "mapreduce.map.java.opts" and "mapreduce.reduce.java.opts" in addition to setting druid.javascript.enabled=true in _common/common.runtime.properties

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

