### PR TITLE
Remove unnecessary apis

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -22,15 +22,12 @@ com.google.common.collect.Sets#newTreeSet() @ Create java.util.TreeSet directly
 com.google.common.collect.Sets#newTreeSet(java.util.Comparator) @ Create java.util.TreeSet directly
 com.google.common.io.Files#createTempDir() @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
 com.google.common.util.concurrent.MoreExecutors#sameThreadExecutor() @ Use org.apache.druid.java.util.common.concurrent.Execs#directExecutor()
-com.google.common.util.concurrent.MoreExecutors#newDirectExecutorService() @ Use org.apache.druid.java.util.common.concurrent.Execs#directExecutor()
-com.google.common.util.concurrent.MoreExecutors#directExecutor() @ Use org.apache.druid.java.util.common.concurrent.Execs#directExecutor()
 com.google.common.util.concurrent.Futures#transform(com.google.common.util.concurrent.ListenableFuture, com.google.common.util.concurrent.AsyncFunction) @ Use org.apache.druid.java.util.common.concurrent.ListenableFutures#transformAsync
 java.io.File#toURL() @ Use java.io.File#toURI() and java.net.URI#toURL() instead
 java.lang.String#matches(java.lang.String) @ Use startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 java.lang.String#replace(java.lang.CharSequence,java.lang.CharSequence) @ Use one of the appropriate methods in StringUtils instead
 java.lang.String#replaceAll(java.lang.String,java.lang.String) @ Use one of the appropriate methods in StringUtils instead, or compile and cache a Pattern explicitly
 java.lang.String#replaceFirst(java.lang.String,java.lang.String) @ Use String.indexOf() and substring methods, or compile and cache a Pattern explicitly
-java.nio.file.Files#createTempDirectory(java.lang.String prefix,java.nio.file.FileAttribute...) @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
 java.util.HashMap#<init>(int) @ Use com.google.common.collect.Maps#newHashMapWithExpectedSize(int) instead
 java.util.HashMap#<init>(int, float) @ Use com.google.common.collect.Maps#newHashMapWithExpectedSize(int) instead
 java.util.LinkedHashMap#<init>(int) @ Use org.apache.druid.utils.CollectionUtils#newLinkedHashMapWithExpectedSize(int) instead
@@ -44,19 +41,5 @@ java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor w
 java.lang.Math#random() @ Use ThreadLocalRandom.current()
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead
-org.apache.commons.io.FileUtils#deleteDirectory() @ Use org.apache.druid.java.util.common.FileUtils#deleteDirectory()
 java.lang.Class#getCanonicalName() @ Class.getCanonicalName can return null for anonymous types, use Class.getName instead.
 com.google.common.base.Objects#firstNonNull(java.lang.Object, java.lang.Object) @ Use org.apache.druid.common.guava.GuavaUtils#firstNonNull(java.lang.Object, java.lang.Object) instead (probably... the GuavaUtils method return object is nullable)
-
-@defaultMessage Use Locale.ENGLISH
-com.ibm.icu.text.DateFormatSymbols#<init>()
-com.ibm.icu.text.SimpleDateFormat#<init>()
-com.ibm.icu.text.SimpleDateFormat#<init>(java.lang.String)
-
-@defaultMessage For performance reasons, use the utf8Base64 / encodeBase64 / encodeBase64String / decodeBase64 / decodeBase64String methods in StringUtils
-org.apache.commons.codec.binary.Base64
-com.google.common.io.BaseEncoding.base64
-
-@defaultMessage Use com.google.errorprone.annotations.concurrent.GuardedBy
-javax.annotations.concurrent.GuardedBy
-com.amazonaws.annotation.GuardedBy


### PR DESCRIPTION
### Description

When building with `mvn clean test`, the following WARNING message is displayed for each project test.

```
[INFO] Reading API signatures: /mnt/c/Users/jgb71/git/druid/codestyle/joda-time-forbidden-apis.txt
[INFO] Reading API signatures: /mnt/c/Users/jgb71/git/druid/codestyle/druid-forbidden-apis.txt
[WARNING] Method not found while parsing signature: com.google.common.util.concurrent.MoreExecutors#newDirectExecutorService() [signature ignored]
[WARNING] Method not found while parsing signature: com.google.common.util.concurrent.MoreExecutors#directExecutor() [signature ignored]
[WARNING] Method not found while parsing signature: java.nio.file.Files#createTempDirectory(java.lang.String prefix,java.nio.file.FileAttribute...) [signature ignored]
[WARNING] Method not found while parsing signature: org.apache.commons.io.FileUtils#deleteDirectory() [signature ignored]
[WARNING] Some signatures were ignored because the following classes were not found on classpath:
[WARNING]   com.amazonaws.annotation.GuardedBy, com.google.common.io.BaseEncoding.base64,... (and 2 more).
[INFO] Loading classes to check...
[INFO] Scanning classes for violations...
```

Even if the WARNING message is shown, it does not affect the build, but I think it's wrong to see the WARNING message for each project build. Methods that were not found after reading the API signatures were removed. So the warning message was no longer appear.

<hr>

This PR has:
- [x] been self-reviewed.