### PR TITLE
fix global filter input

### DIFF
--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2111,7 +2111,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 );
                 const newFilter = joinFilter(deepSet(curFilter, `restFilter`, newFilterValue));
                 this.updateSpec(deepSet(spec, 'spec.dataSchema.transformSpec.filter', newFilter));
-                this.queryForFilter();
+                this.setState({ showGlobalFilter: false, newFilterValue: undefined });
               }}
             />
             <Button text="Cancel" onClick={() => this.setState({ showGlobalFilter: false })} />
@@ -2123,7 +2123,12 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         <FormGroup>
           <Button
             text={`${hasGlobalFilter ? 'Edit' : 'Add'} global filter`}
-            onClick={() => this.setState({ showGlobalFilter: true })}
+            onClick={() =>
+              this.setState({
+                showGlobalFilter: true,
+                newFilterValue: deepGet(spec, 'spec.dataSchema.transformSpec.filter'),
+              })
+            }
           />
         </FormGroup>
       );

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2069,9 +2069,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
   renderGlobalFilterControls() {
     const { spec, showGlobalFilter, newFilterValue } = this.state;
     const intervals: string[] = deepGet(spec, 'spec.dataSchema.granularitySpec.intervals');
-    const hasGlobalFilter = Boolean(
-      intervals || splitFilter(deepGet(spec, 'spec.dataSchema.transformSpec.filter')),
-    );
+    const { restFilter } = splitFilter(deepGet(spec, 'spec.dataSchema.transformSpec.filter'));
+    const hasGlobalFilter = Boolean(intervals || restFilter);
 
     if (showGlobalFilter) {
       return (
@@ -2126,7 +2125,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             onClick={() =>
               this.setState({
                 showGlobalFilter: true,
-                newFilterValue: deepGet(spec, 'spec.dataSchema.transformSpec.filter'),
+                newFilterValue: restFilter,
               })
             }
           />

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2111,7 +2111,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 );
                 const newFilter = joinFilter(deepSet(curFilter, `restFilter`, newFilterValue));
                 this.updateSpec(deepSet(spec, 'spec.dataSchema.transformSpec.filter', newFilter));
-                this.setState({ newFilterValue: undefined });
                 this.queryForFilter();
               }}
             />

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -313,6 +313,7 @@ export interface LoadDataViewState {
   selectedFilterIndex: number;
   selectedFilter?: DruidFilter;
   showGlobalFilter: boolean;
+  newFilterValue?: Record<string, any>;
 
   // for schema
   schemaQueryState: QueryState<{
@@ -2066,10 +2067,11 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
   }
 
   renderGlobalFilterControls() {
-    const { spec, showGlobalFilter } = this.state;
+    const { spec, showGlobalFilter, newFilterValue } = this.state;
     const intervals: string[] = deepGet(spec, 'spec.dataSchema.granularitySpec.intervals');
-    const { restFilter } = splitFilter(deepGet(spec, 'spec.dataSchema.transformSpec.filter'));
-    const hasGlobalFilter = Boolean(intervals || restFilter);
+    const hasGlobalFilter = Boolean(
+      intervals || splitFilter(deepGet(spec, 'spec.dataSchema.transformSpec.filter')),
+    );
 
     if (showGlobalFilter) {
       return (
@@ -2094,19 +2096,25 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           />
           <FormGroup label="Extra filter">
             <JsonInput
-              value={restFilter}
-              onChange={f => {
-                const curFilter = splitFilter(
-                  deepGet(spec, 'spec.dataSchema.transformSpec.filter'),
-                );
-                const newFilter = joinFilter(deepSet(curFilter, `restFilter`, f));
-                this.updateSpec(deepSet(spec, 'spec.dataSchema.transformSpec.filter', newFilter));
-              }}
+              value={newFilterValue}
+              onChange={f => this.setState({ newFilterValue: f })}
               height="200px"
             />
           </FormGroup>
           <div className="control-buttons">
-            <Button text="Apply" intent={Intent.PRIMARY} onClick={() => this.queryForFilter()} />
+            <Button
+              text="Apply"
+              intent={Intent.PRIMARY}
+              onClick={() => {
+                const curFilter = splitFilter(
+                  deepGet(spec, 'spec.dataSchema.transformSpec.filter'),
+                );
+                const newFilter = joinFilter(deepSet(curFilter, `restFilter`, newFilterValue));
+                this.updateSpec(deepSet(spec, 'spec.dataSchema.transformSpec.filter', newFilter));
+                this.setState({ newFilterValue: undefined });
+                this.queryForFilter();
+              }}
+            />
             <Button text="Cancel" onClick={() => this.setState({ showGlobalFilter: false })} />
           </div>
         </div>


### PR DESCRIPTION
<img width="394" alt="Screen Shot 2020-03-25 at 7 03 26 PM" src="https://user-images.githubusercontent.com/37322608/77599750-57486480-6ecb-11ea-97a9-e9b7bf148734.png">

Previously the filters would be applied as soon as they passed the try catch of the jsonInput component, not when the user hit apply. The user must now actually click apply for the filter to work. Additionally, I have changed it so now the jsonInput is a controlled component which will allow for the input to be reset upon clicking apply.