### PR TITLE
Fix some flaws of KafkaEmitter

### DIFF
--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -56,7 +56,6 @@ public class KafkaEmitter implements Emitter
 
   private final KafkaEmitterConfig config;
   private final Producer<String, String> producer;
-  private final Callback producerCallback;
   private final ObjectMapper jsonMapper;
   private final MemoryBoundLinkedBlockingQueue<String> metricQueue;
   private final MemoryBoundLinkedBlockingQueue<String> alertQueue;
@@ -67,7 +66,6 @@ public class KafkaEmitter implements Emitter
     this.config = config;
     this.jsonMapper = jsonMapper;
     this.producer = setKafkaProducer();
-    this.producerCallback = setProducerCallback();
     // same with kafka producer's buffer.memory
     long queueMemoryBound = Long.parseLong(this.config.getKafkaProducerConfig()
                                                       .getOrDefault(ProducerConfig.BUFFER_MEMORY_CONFIG, "33554432"));
@@ -79,15 +77,13 @@ public class KafkaEmitter implements Emitter
     this.invalidLost = new AtomicLong(0L);
   }
 
-  private Callback setProducerCallback()
+  private Callback setProducerCallback(AtomicLong counter, String topic)
   {
     return (recordMetadata, e) -> {
       if (e != null) {
         log.debug("Event send failed [%s]", e.getMessage());
-        if (recordMetadata.topic().equals(config.getMetricTopic())) {
-          metricLost.incrementAndGet();
-        } else if (recordMetadata.topic().equals(config.getAlertTopic())) {
-          alertLost.incrementAndGet();
+        if (recordMetadata != null && recordMetadata.topic().equals(topic)) {
+          counter.incrementAndGet();
         } else {
           invalidLost.incrementAndGet();
         }
@@ -116,11 +112,10 @@ public class KafkaEmitter implements Emitter
   }
 
   @Override
-  @LifecycleStart
   public void start()
   {
-    scheduler.scheduleWithFixedDelay(this::sendMetricToKafka, 10, 10, TimeUnit.SECONDS);
-    scheduler.scheduleWithFixedDelay(this::sendAlertToKafka, 10, 10, TimeUnit.SECONDS);
+    scheduler.schedule(this::sendMetricToKafka, 10, TimeUnit.SECONDS);
+    scheduler.schedule(this::sendAlertToKafka, 10, TimeUnit.SECONDS);
     scheduler.scheduleWithFixedDelay(() -> {
       log.info("Message lost counter: metricLost=[%d], alertLost=[%d], invalidLost=[%d]",
                metricLost.get(), alertLost.get(), invalidLost.get());
@@ -130,21 +125,21 @@ public class KafkaEmitter implements Emitter
 
   private void sendMetricToKafka()
   {
-    sendToKafka(config.getMetricTopic(), metricQueue);
+    sendToKafka(config.getMetricTopic(), metricQueue, setProducerCallback(metricLost, config.getMetricTopic()));
   }
 
   private void sendAlertToKafka()
   {
-    sendToKafka(config.getAlertTopic(), alertQueue);
+    sendToKafka(config.getAlertTopic(), alertQueue, setProducerCallback(alertLost, config.getAlertTopic()));
   }
 
-  private void sendToKafka(final String topic, MemoryBoundLinkedBlockingQueue<String> recordQueue)
+  private void sendToKafka(final String topic, MemoryBoundLinkedBlockingQueue<String> recordQueue, Callback callback)
   {
     ObjectContainer<String> objectToSend;
     try {
       while (true) {
         objectToSend = recordQueue.take();
-        producer.send(new ProducerRecord<>(topic, objectToSend.getData()), producerCallback);
+        producer.send(new ProducerRecord<>(topic, objectToSend.getData()), callback);
       }
     }
     catch (InterruptedException e) {

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -76,16 +76,12 @@ public class KafkaEmitter implements Emitter
     this.invalidLost = new AtomicLong(0L);
   }
 
-  private Callback setProducerCallback(AtomicLong counter, String topic)
+  private Callback setProducerCallback(AtomicLong lostCouter)
   {
     return (recordMetadata, e) -> {
       if (e != null) {
         log.debug("Event send failed [%s]", e.getMessage());
-        if (recordMetadata != null && recordMetadata.topic().equals(topic)) {
-          counter.incrementAndGet();
-        } else {
-          invalidLost.incrementAndGet();
-        }
+        lostCouter.incrementAndGet();
       }
     };
   }
@@ -124,12 +120,12 @@ public class KafkaEmitter implements Emitter
 
   private void sendMetricToKafka()
   {
-    sendToKafka(config.getMetricTopic(), metricQueue, setProducerCallback(metricLost, config.getMetricTopic()));
+    sendToKafka(config.getMetricTopic(), metricQueue, setProducerCallback(metricLost));
   }
 
   private void sendAlertToKafka()
   {
-    sendToKafka(config.getAlertTopic(), alertQueue, setProducerCallback(alertLost, config.getAlertTopic()));
+    sendToKafka(config.getAlertTopic(), alertQueue, setProducerCallback(alertLost));
   }
 
   private void sendToKafka(final String topic, MemoryBoundLinkedBlockingQueue<String> recordQueue, Callback callback)

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.emitter.kafka.MemoryBoundLinkedBlockingQueue.ObjectContainer;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.core.Emitter;

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -137,7 +137,7 @@ public class KafkaEmitter implements Emitter
         producer.send(new ProducerRecord<>(topic, objectToSend.getData()), callback);
       }
     }
-    catch (InterruptedException e) {
+    catch (Throwable e) {
       log.warn(e, "Failed to take record from queue!");
     }
   }

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -138,7 +138,7 @@ public class KafkaEmitter implements Emitter
       }
     }
     catch (Throwable e) {
-      log.warn(e, "Failed to take record from queue!");
+      log.warn(e, "Exception while getting record from queue or producer send, Events would not be emitted anymore.");
     }
   }
 


### PR DESCRIPTION

### Description
There are some flaws in `KafkaEmitter`:
1. annoying error logs(see [KAFKA-4854](https://issues.apache.org/jira/browse/KAFKA-4854)), like this 
`2020-03-27T09:53:02,057 ERROR [kafka-producer-network-thread | producer-1] org.apache.kafka.clients.producer.internals.RecordBatch - Error executing user-provided callback on message for topic-partition 'druid_metrics_test-0'
java.lang.NullPointerException`
2. the `start` method is called twice by the `LifecycleStart` framework
3. redundant periodic scheduling of send tasks


<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed class in this PR
 * `KafkaEmitter `
