### PR TITLE
Fix Build: remove commons-lang3  usage from DoubleMeanAggregatorFactoryTest

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanHolder.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanHolder.java
@@ -27,6 +27,7 @@ import com.google.common.primitives.Doubles;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
+import java.util.Objects;
 
 public class DoubleMeanHolder
 {
@@ -66,6 +67,26 @@ public class DoubleMeanHolder
     buf.putDouble(0, sum);
     buf.putLong(Double.BYTES, count);
     return buf.array();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DoubleMeanHolder that = (DoubleMeanHolder) o;
+    return Double.compare(that.sum, sum) == 0 &&
+           count == that.count;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(sum, count);
   }
 
   public static DoubleMeanHolder fromBytes(byte[] data)

--- a/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactoryTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query.aggregation.mean;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,10 +39,10 @@ public class DoubleMeanAggregatorFactoryTest
     DoubleMeanHolder expectedHolder = new DoubleMeanHolder(50.0, 10L);
 
     DoubleMeanHolder actualHolder = (DoubleMeanHolder) factory.deserialize(expectedHolder);
-    Assert.assertTrue(EqualsBuilder.reflectionEquals(expectedHolder, actualHolder));
+    Assert.assertEquals(expectedHolder, actualHolder);
 
     actualHolder = (DoubleMeanHolder) factory.deserialize(expectedHolder.toBytes());
-    Assert.assertTrue(EqualsBuilder.reflectionEquals(expectedHolder, actualHolder));
+    Assert.assertEquals(expectedHolder, actualHolder);
   }
 
   @Test


### PR DESCRIPTION
This fixes the "analyze dependency" build failure caused by #9568 which I merged without realizing the failure.

This commit is also backported to 0.18.0 branch along with #9568, in #9577 .