### PR TITLE
DruidInputSource can add new dimensions during re-ingestion

### DIFF
--- a/examples/quickstart/tutorial/transform-index.json
+++ b/examples/quickstart/tutorial/transform-index.json
@@ -55,7 +55,7 @@
         "baseDir" : "quickstart/tutorial",
         "filter" : "transform-data.json"
       },
-      "inpuFormat" : {
+      "inputFormat" : {
         "type" : "json"
       },
       "appendToExisting" : false

--- a/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
@@ -214,18 +214,11 @@ public class IngestSegmentFirehoseFactory implements FiniteFirehoseFactory<Input
       }
     }
 
-    final List<String> dims;
-    if (dimensions != null) {
-      dims = dimensions;
-    } else if (inputRowParser.getParseSpec().getDimensionsSpec().hasCustomDimensions()) {
-      dims = inputRowParser.getParseSpec().getDimensionsSpec().getDimensionNames();
-    } else {
-      dims = ReingestionTimelineUtils.getUniqueDimensions(
-        timeLineSegments,
-        inputRowParser.getParseSpec().getDimensionsSpec().getDimensionExclusions()
-      );
-    }
-
+    final List<String> dims = ReingestionTimelineUtils.getDimensionsToReingest(
+        dimensions,
+        inputRowParser.getParseSpec().getDimensionsSpec(),
+        timeLineSegments
+    );
     final List<String> metricsList = metrics == null
                                      ? ReingestionTimelineUtils.getUniqueMetrics(timeLineSegments)
                                      : metrics;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
@@ -181,17 +181,11 @@ public class DruidInputSource extends AbstractInputSource implements SplittableI
               .from(partitionHolder)
               .transform(chunk -> new DruidSegmentInputEntity(segmentLoader, chunk.getObject(), holder.getInterval()));
         }).iterator();
-    final List<String> effectiveDimensions;
-    if (dimensions == null) {
-      effectiveDimensions = ReingestionTimelineUtils.getUniqueDimensions(
-          timeline,
-          inputRowSchema.getDimensionsSpec().getDimensionExclusions()
-      );
-    } else if (inputRowSchema.getDimensionsSpec().hasCustomDimensions()) {
-      effectiveDimensions = inputRowSchema.getDimensionsSpec().getDimensionNames();
-    } else {
-      effectiveDimensions = dimensions;
-    }
+    final List<String> effectiveDimensions = ReingestionTimelineUtils.getDimensionsToReingest(
+      dimensions,
+      inputRowSchema.getDimensionsSpec(),
+      timeline
+  );
 
     List<String> effectiveMetrics;
     if (metrics == null) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
@@ -182,10 +182,10 @@ public class DruidInputSource extends AbstractInputSource implements SplittableI
               .transform(chunk -> new DruidSegmentInputEntity(segmentLoader, chunk.getObject(), holder.getInterval()));
         }).iterator();
     final List<String> effectiveDimensions = ReingestionTimelineUtils.getDimensionsToReingest(
-      dimensions,
-      inputRowSchema.getDimensionsSpec(),
-      timeline
-  );
+        dimensions,
+        inputRowSchema.getDimensionsSpec(),
+        timeline
+    );
 
     List<String> effectiveMetrics;
     if (metrics == null) {

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -51,20 +51,20 @@ public class ITTransformTest extends AbstractITBatchIndexTest
         final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
         final Closeable ignored2 = unloader(reindexDatasourceWithDruidInputSource + config.getExtraDatasourceNameSuffix())
     ) {
-    doIndexTest(
-        INDEX_DATASOURCE,
-        INDEX_TASK_WITH_INPUT_SOURCE,
-        INDEX_QUERIES_RESOURCE,
-        false,
-        true,
-        true
-    );
-    doReindexTest(
-        INDEX_DATASOURCE,
-        reindexDatasourceWithDruidInputSource,
-        REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
-        REINDEX_QUERIES_RESOURCE
-    );
+      doIndexTest(
+          INDEX_DATASOURCE,
+          INDEX_TASK_WITH_INPUT_SOURCE,
+          INDEX_QUERIES_RESOURCE,
+          false,
+          true,
+          true
+      );
+      doReindexTest(
+          INDEX_DATASOURCE,
+          reindexDatasourceWithDruidInputSource,
+          REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
+          REINDEX_QUERIES_RESOURCE
+      );
     }
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -24,25 +24,88 @@ import org.apache.druid.tests.TestNGGroup;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
-import java.io.Closeable;
+import java.io.IOException;
 
 @Test(groups = {TestNGGroup.BATCH_INDEX, TestNGGroup.QUICKSTART_COMPATIBLE})
 @Guice(moduleFactory = DruidTestModuleFactory.class)
 public class ITTransformTest extends AbstractITBatchIndexTest
 {
-  private static final String INDEX_TASK = "/indexer/wikipedia_index_task_with_transform.json";
+  private static final String INDEX_TASK_WITH_FIREHOSE = "/indexer/wikipedia_index_task_with_transform.json";
+  private static final String INDEX_TASK_WITH_INPUT_SOURCE = "/indexer/wikipedia_index_task_with_inputsource_transform.json";
   private static final String INDEX_QUERIES_RESOURCE = "/indexer/wikipedia_index_queries_with_transform.json";
   private static final String INDEX_DATASOURCE = "wikipedia_index_test";
 
+  private static final String REINDEX_TASK = "/indexer/wikipedia_reindex_task_with_transforms.json";
+  private static final String REINDEX_TASK_WITH_DRUID_INPUT_SOURCE = "/indexer/wikipedia_reindex_druid_input_source_task_with_transforms.json";
+  private static final String REINDEX_QUERIES_RESOURCE = "/indexer/wikipedia_reindex_queries_with_transforms.json";
+  private static final String REINDEX_DATASOURCE = "wikipedia_reindex_test";
+
   @Test
-  public void testIndexAndReIndexWithTransformSpec() throws Exception
+  public void testIndexAndReIndexWithTransformSpec() throws IOException
   {
+    final String reindexDatasourceWithDruidInputSource = REINDEX_DATASOURCE + "-druidInputSource";
+
+    //try (
+    //    final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
+    //    final Closeable ignored2 = unloader(reindexDatasourceWithDruidInputSource + config.getExtraDatasourceNameSuffix())
+    //) {
+    doIndexTest(
+        INDEX_DATASOURCE,
+        INDEX_TASK_WITH_INPUT_SOURCE,
+        INDEX_QUERIES_RESOURCE,
+        false,
+        true,
+        true
+    );
+    doReindexTest(
+        INDEX_DATASOURCE,
+        reindexDatasourceWithDruidInputSource,
+        REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
+        REINDEX_QUERIES_RESOURCE
+    );
+    //}
+  }
+
+  /*
+  // TODO: re-instate this test when https://github.com/apache/druid/issues/9591 is fixed
+  // Move the re-index step into testIndexAndReIndexWithTransformSpec for faster tests!
+  @Test
+  @Ignore
+  public void testIndexAndReIndexUsingIngestSegmentWithTransforms() throws IOException
+  {
+    final String reindexDatasource = REINDEX_DATASOURCE + "-testIndexData";
     try (
-        final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix())
+        final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
+        final Closeable ignored2 = unloader(reindexDatasource + config.getExtraDatasourceNameSuffix())
     ) {
       doIndexTest(
           INDEX_DATASOURCE,
-          INDEX_TASK,
+          INDEX_TASK_WITH_INPUT_SOURCE,
+          INDEX_QUERIES_RESOURCE,
+          false,
+          true,
+          true
+      );
+      doReindexTest(
+          INDEX_DATASOURCE,
+          reindexDatasource,
+          REINDEX_TASK,
+          REINDEX_QUERIES_RESOURCE
+      );
+    }
+  }
+
+  // TODO: re-instate this test when https://github.com/apache/druid/issues/9589 is fixed
+  @Test
+  @Ignore
+  public void testIndexWithFirehoseAndTransforms() throws IOException
+  {
+    try (
+        final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
+    ) {
+      doIndexTest(
+          INDEX_DATASOURCE,
+          INDEX_TASK_WITH_FIREHOSE,
           INDEX_QUERIES_RESOURCE,
           false,
           true,
@@ -50,4 +113,5 @@ public class ITTransformTest extends AbstractITBatchIndexTest
       );
     }
   }
+   */
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.tests.indexer;
+
+import org.apache.druid.testing.guice.DruidTestModuleFactory;
+import org.apache.druid.tests.TestNGGroup;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+
+@Test(groups = {TestNGGroup.BATCH_INDEX, TestNGGroup.QUICKSTART_COMPATIBLE})
+@Guice(moduleFactory = DruidTestModuleFactory.class)
+public class ITTransformTest extends AbstractITBatchIndexTest
+{
+  private static final String INDEX_TASK = "/indexer/wikipedia_index_task_with_transform.json";
+  private static final String INDEX_QUERIES_RESOURCE = "/indexer/wikipedia_index_queries_with_transform.json";
+  private static final String INDEX_DATASOURCE = "wikipedia_index_test";
+
+  private static final String REINDEX_TASK = "/indexer/wikipedia_reindex_task.json";
+  private static final String REINDEX_TASK_WITH_DRUID_INPUT_SOURCE = "/indexer/wikipedia_reindex_druid_input_source_task.json";
+  private static final String REINDEX_QUERIES_RESOURCE = "/indexer/wikipedia_reindex_queries.json";
+  private static final String REINDEX_DATASOURCE = "wikipedia_reindex_test";
+
+  @Test
+  public void testIndexAndReIndexWithTransformSpec() throws Exception
+  {
+    final String reindexDatasource = REINDEX_DATASOURCE + "-testIndexData";
+    //final String reindexDatasourceWithDruidInputSource = REINDEX_DATASOURCE + "-testIndexData-druidInputSource";
+
+    try (
+        //final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
+        final Closeable ignored2 = unloader(reindexDatasource + config.getExtraDatasourceNameSuffix());
+        //final Closeable ignored3 = unloader(reindexDatasourceWithDruidInputSource + config.getExtraDatasourceNameSuffix())
+    ) {
+      doIndexTest(
+          INDEX_DATASOURCE,
+          INDEX_TASK,
+          INDEX_QUERIES_RESOURCE,
+          false,
+          true,
+          true
+      );
+      /*
+      doReindexTest(
+          INDEX_DATASOURCE,
+          reindexDatasource,
+          REINDEX_TASK,
+          REINDEX_QUERIES_RESOURCE
+      );
+      doReindexTest(
+          INDEX_DATASOURCE,
+          reindexDatasourceWithDruidInputSource,
+          REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
+          REINDEX_QUERIES_RESOURCE
+      );
+       */
+    }
+  }
+}

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -21,9 +21,11 @@ package org.apache.druid.tests.indexer;
 
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
 import org.apache.druid.tests.TestNGGroup;
+import org.junit.Ignore;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 @Test(groups = {TestNGGroup.BATCH_INDEX, TestNGGroup.QUICKSTART_COMPATIBLE})
@@ -45,10 +47,10 @@ public class ITTransformTest extends AbstractITBatchIndexTest
   {
     final String reindexDatasourceWithDruidInputSource = REINDEX_DATASOURCE + "-druidInputSource";
 
-    //try (
-    //    final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
-    //    final Closeable ignored2 = unloader(reindexDatasourceWithDruidInputSource + config.getExtraDatasourceNameSuffix())
-    //) {
+    try (
+        final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
+        final Closeable ignored2 = unloader(reindexDatasourceWithDruidInputSource + config.getExtraDatasourceNameSuffix())
+    ) {
     doIndexTest(
         INDEX_DATASOURCE,
         INDEX_TASK_WITH_INPUT_SOURCE,
@@ -63,10 +65,9 @@ public class ITTransformTest extends AbstractITBatchIndexTest
         REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
         REINDEX_QUERIES_RESOURCE
     );
-    //}
+    }
   }
 
-  /*
   // TODO: re-instate this test when https://github.com/apache/druid/issues/9591 is fixed
   // Move the re-index step into testIndexAndReIndexWithTransformSpec for faster tests!
   @Test
@@ -113,5 +114,4 @@ public class ITTransformTest extends AbstractITBatchIndexTest
       );
     }
   }
-   */
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -34,21 +34,11 @@ public class ITTransformTest extends AbstractITBatchIndexTest
   private static final String INDEX_QUERIES_RESOURCE = "/indexer/wikipedia_index_queries_with_transform.json";
   private static final String INDEX_DATASOURCE = "wikipedia_index_test";
 
-  private static final String REINDEX_TASK = "/indexer/wikipedia_reindex_task.json";
-  private static final String REINDEX_TASK_WITH_DRUID_INPUT_SOURCE = "/indexer/wikipedia_reindex_druid_input_source_task.json";
-  private static final String REINDEX_QUERIES_RESOURCE = "/indexer/wikipedia_reindex_queries.json";
-  private static final String REINDEX_DATASOURCE = "wikipedia_reindex_test";
-
   @Test
   public void testIndexAndReIndexWithTransformSpec() throws Exception
   {
-    final String reindexDatasource = REINDEX_DATASOURCE + "-testIndexData";
-    //final String reindexDatasourceWithDruidInputSource = REINDEX_DATASOURCE + "-testIndexData-druidInputSource";
-
     try (
-        //final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
-        final Closeable ignored2 = unloader(reindexDatasource + config.getExtraDatasourceNameSuffix());
-        //final Closeable ignored3 = unloader(reindexDatasourceWithDruidInputSource + config.getExtraDatasourceNameSuffix())
+        final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix())
     ) {
       doIndexTest(
           INDEX_DATASOURCE,
@@ -58,20 +48,6 @@ public class ITTransformTest extends AbstractITBatchIndexTest
           true,
           true
       );
-      /*
-      doReindexTest(
-          INDEX_DATASOURCE,
-          reindexDatasource,
-          REINDEX_TASK,
-          REINDEX_QUERIES_RESOURCE
-      );
-      doReindexTest(
-          INDEX_DATASOURCE,
-          reindexDatasourceWithDruidInputSource,
-          REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
-          REINDEX_QUERIES_RESOURCE
-      );
-       */
     }
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -51,20 +51,20 @@ public class ITTransformTest extends AbstractITBatchIndexTest
         final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
         final Closeable ignored2 = unloader(reindexDatasourceWithDruidInputSource + config.getExtraDatasourceNameSuffix())
     ) {
-      doIndexTest(
-          INDEX_DATASOURCE,
-          INDEX_TASK_WITH_INPUT_SOURCE,
-          INDEX_QUERIES_RESOURCE,
-          false,
-          true,
-          true
-      );
-      doReindexTest(
-          INDEX_DATASOURCE,
-          reindexDatasourceWithDruidInputSource,
-          REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
-          REINDEX_QUERIES_RESOURCE
-      );
+    doIndexTest(
+        INDEX_DATASOURCE,
+        INDEX_TASK_WITH_INPUT_SOURCE,
+        INDEX_QUERIES_RESOURCE,
+        false,
+        true,
+        true
+    );
+    doReindexTest(
+        INDEX_DATASOURCE,
+        reindexDatasourceWithDruidInputSource,
+        REINDEX_TASK_WITH_DRUID_INPUT_SOURCE,
+        REINDEX_QUERIES_RESOURCE
+    );
     }
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.tests.indexer;
 
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
 import org.apache.druid.tests.TestNGGroup;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
@@ -68,12 +69,13 @@ public class ITTransformTest extends AbstractITBatchIndexTest
     }
   }
 
-  // TODO: re-instate this test when https://github.com/apache/druid/issues/9591 is fixed
-  // Move the re-index step into testIndexAndReIndexWithTransformSpec for faster tests!
   @Test
   @Ignore
   public void testIndexAndReIndexUsingIngestSegmentWithTransforms() throws IOException
   {
+    // TODO: re-instate this test when https://github.com/apache/druid/issues/9591 is fixed
+    // Move the re-index step into testIndexAndReIndexWithTransformSpec for faster tests!
+    Assert.fail();
     final String reindexDatasource = REINDEX_DATASOURCE + "-testIndexData";
     try (
         final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
@@ -96,16 +98,18 @@ public class ITTransformTest extends AbstractITBatchIndexTest
     }
   }
 
-  // TODO: re-instate this test when https://github.com/apache/druid/issues/9589 is fixed
   @Test
   @Ignore
   public void testIndexWithFirehoseAndTransforms() throws IOException
   {
+    // TODO: re-instate this test when https://github.com/apache/druid/issues/9589 is fixed
+    Assert.fail();
+    final String indexDatasource = INDEX_DATASOURCE + "-firehose";
     try (
-        final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
+        final Closeable ignored1 = unloader(indexDatasource + config.getExtraDatasourceNameSuffix());
     ) {
       doIndexTest(
-          INDEX_DATASOURCE,
+          indexDatasource,
           INDEX_TASK_WITH_FIREHOSE,
           INDEX_QUERIES_RESOURCE,
           false,

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.tests.indexer;
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
 import org.apache.druid.tests.TestNGGroup;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
@@ -69,8 +68,7 @@ public class ITTransformTest extends AbstractITBatchIndexTest
     }
   }
 
-  @Test
-  @Ignore
+  @Test(enabled = false)
   public void testIndexAndReIndexUsingIngestSegmentWithTransforms() throws IOException
   {
     // TODO: re-instate this test when https://github.com/apache/druid/issues/9591 is fixed
@@ -98,8 +96,7 @@ public class ITTransformTest extends AbstractITBatchIndexTest
     }
   }
 
-  @Test
-  @Ignore
+  @Test(enabled = false)
   public void testIndexWithFirehoseAndTransforms() throws IOException
   {
     // TODO: re-instate this test when https://github.com/apache/druid/issues/9589 is fixed

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITTransformTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.tests.indexer;
 
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
 import org.apache.druid.tests.TestNGGroup;
-import org.junit.Assert;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
@@ -73,7 +72,6 @@ public class ITTransformTest extends AbstractITBatchIndexTest
   {
     // TODO: re-instate this test when https://github.com/apache/druid/issues/9591 is fixed
     // Move the re-index step into testIndexAndReIndexWithTransformSpec for faster tests!
-    Assert.fail();
     final String reindexDatasource = REINDEX_DATASOURCE + "-testIndexData";
     try (
         final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
@@ -100,7 +98,6 @@ public class ITTransformTest extends AbstractITBatchIndexTest
   public void testIndexWithFirehoseAndTransforms() throws IOException
   {
     // TODO: re-instate this test when https://github.com/apache/druid/issues/9589 is fixed
-    Assert.fail();
     final String indexDatasource = INDEX_DATASOURCE + "-firehose";
     try (
         final Closeable ignored1 = unloader(indexDatasource + config.getExtraDatasourceNameSuffix());

--- a/integration-tests/src/test/resources/indexer/wikipedia_index_queries_with_transform.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_index_queries_with_transform.json
@@ -1,0 +1,54 @@
+[
+    {
+        "description":"having spec on post aggregation",
+        "query":{
+            "queryType":"groupBy",
+            "dataSource":"%%DATASOURCE%%",
+            "granularity":"day",
+            "dimensions":[
+                "page"
+            ],
+            "filter":{
+                "type":"selector",
+                "dimension":"language",
+                "value":"language-zh"
+            },
+            "aggregations":[
+                {
+                    "type":"count",
+                    "name":"rows"
+                },
+                {
+                    "type":"longSum",
+                    "fieldName":"triple-added",
+                    "name":"added_count"
+                }
+            ],
+            "postAggregations": [
+                {
+                    "type":"arithmetic",
+                    "name":"added_count_times_ten",
+                    "fn":"*",
+                    "fields":[
+                        {"type":"fieldAccess", "name":"added_count", "fieldName":"added_count"},
+                        {"type":"constant", "name":"const", "value":10}
+                    ]
+                }
+            ],
+            "having":{"type":"greaterThan", "aggregation":"added_count_times_ten", "value":9000},
+            "intervals":[
+                "2013-08-31T00:00/2013-09-01T00:00"
+            ]
+        },
+        "expectedResults":[ {
+            "version" : "v1",
+            "timestamp" : "2013-08-31T00:00:00.000Z",
+            "event" : {
+                "added_count_times_ten" : 9050.0,
+                "page" : "Crimson Typhoon",
+                "added_count" : 2715,
+                "rows" : 1
+            }
+        } ]
+    }
+]

--- a/integration-tests/src/test/resources/indexer/wikipedia_index_queries_with_transform.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_index_queries_with_transform.json
@@ -6,7 +6,8 @@
             "dataSource":"%%DATASOURCE%%",
             "granularity":"day",
             "dimensions":[
-                "page"
+                "page",
+                "city"
             ],
             "filter":{
                 "type":"selector",
@@ -22,6 +23,11 @@
                     "type":"longSum",
                     "fieldName":"triple-added",
                     "name":"added_count"
+                },
+                {
+                    "type":"longSum",
+                    "fieldName":"delta",
+                    "name":"delta_sum"
                 }
             ],
             "postAggregations": [
@@ -46,7 +52,9 @@
             "event" : {
                 "added_count_times_ten" : 27150.0,
                 "page" : "Crimson Typhoon",
+                "city" : "Taiyuan",
                 "added_count" : 2715,
+                "delta_sum" : 900,
                 "rows" : 1
             }
         } ]

--- a/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_inputsource_transform.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_inputsource_transform.json
@@ -1,0 +1,103 @@
+{
+    "type" : "index",
+    "spec" : {
+        "dataSchema" : {
+            "dataSource" : "%%DATASOURCE%%",
+            "timestampSpec": {
+                "column": "timestamp"
+            },
+            "metricsSpec": [
+                {
+                    "type": "count",
+                    "name": "count"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "added",
+                    "fieldName": "added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "triple-added",
+                    "fieldName": "triple-added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "deleted",
+                    "fieldName": "deleted"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "delta",
+                    "fieldName": "delta"
+                },
+                {
+                    "name": "thetaSketch",
+                    "type": "thetaSketch",
+                    "fieldName": "user"
+                },
+                {
+                    "name": "quantilesDoublesSketch",
+                    "type": "quantilesDoublesSketch",
+                    "fieldName": "delta"
+                },
+                {
+                    "name": "HLLSketchBuild",
+                    "type": "HLLSketchBuild",
+                    "fieldName": "user"
+                }
+            ],
+            "granularitySpec": {
+                "segmentGranularity": "DAY",
+                "queryGranularity": "second",
+                "intervals" : [ "2013-08-31/2013-09-02" ]
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    "page",
+                    {"type": "string", "name": "language", "createBitmapIndex": false},
+                    "user",
+                    "unpatrolled",
+                    "robot",
+                    "anonymous",
+                    "namespace",
+                    "continent",
+                    "country",
+                    "region",
+                    "city"
+                ]
+            },
+            "transformSpec": {
+                "transforms": [
+                    {
+                        "type": "expression",
+                        "name": "language",
+                        "expression": "concat('language-', language)"
+                    },
+                    {
+                        "type": "expression",
+                        "name": "triple-added",
+                        "expression": "added * 3"
+                    }
+                ]
+            }
+        },
+        "ioConfig" : {
+            "type" : "index",
+            "inputSource" : {
+                "type" : "local",
+                "baseDir" : "/resources/data/batch_index",
+                "filter" : "wikipedia_index_data*"
+            },
+            "inputFormat" : {
+                "type" : "json"
+            },
+            "appendToExisting" : false
+        },
+        "tuningConfig" : {
+            "type" : "index",
+            "maxRowsPerSegment" : 5000000,
+            "maxRowsInMemory" : 25000
+        }
+    }
+}

--- a/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_transform.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_transform.json
@@ -61,7 +61,6 @@
                             {"type": "string", "name": "language", "createBitmapIndex": false},
                             "user",
                             "unpatrolled",
-                            "newPage",
                             "robot",
                             "anonymous",
                             "namespace",

--- a/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_transform.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_transform.json
@@ -15,6 +15,11 @@
                 },
                 {
                     "type": "doubleSum",
+                    "name": "triple-added",
+                    "fieldName": "triple-added"
+                },
+                {
+                    "type": "doubleSum",
                     "name": "deleted",
                     "fieldName": "deleted"
                 },
@@ -80,14 +85,7 @@
                         "name": "triple-added",
                         "expression": "added * 3"
                     }
-                ],
-                "filter": {
-                    "type":"or",
-                    "fields": [
-                        { "type": "selector", "dimension": "language", "value": "language-zh" },
-                        { "type": "selector", "dimension": "page", "value": "Crimson Typhoon" }
-                    ]
-                }
+                ]
             }
         },
         "ioConfig": {

--- a/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_transform.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_index_task_with_transform.json
@@ -1,0 +1,106 @@
+{
+    "type": "index",
+    "spec": {
+        "dataSchema": {
+            "dataSource": "%%DATASOURCE%%",
+            "metricsSpec": [
+                {
+                    "type": "count",
+                    "name": "count"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "added",
+                    "fieldName": "added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "deleted",
+                    "fieldName": "deleted"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "delta",
+                    "fieldName": "delta"
+                },
+                {
+                    "name": "thetaSketch",
+                    "type": "thetaSketch",
+                    "fieldName": "user"
+                },
+                {
+                    "name": "quantilesDoublesSketch",
+                    "type": "quantilesDoublesSketch",
+                    "fieldName": "delta"
+                },
+                {
+                    "name": "HLLSketchBuild",
+                    "type": "HLLSketchBuild",
+                    "fieldName": "user"
+                }
+            ],
+            "granularitySpec": {
+                "segmentGranularity": "DAY",
+                "queryGranularity": "second",
+                "intervals" : [ "2013-08-31/2013-09-02" ]
+            },
+            "parser": {
+                "parseSpec": {
+                    "format" : "json",
+                    "timestampSpec": {
+                        "column": "timestamp"
+                    },
+                    "dimensionsSpec": {
+                        "dimensions": [
+                            "page",
+                            {"type": "string", "name": "language", "createBitmapIndex": false},
+                            "user",
+                            "unpatrolled",
+                            "newPage",
+                            "robot",
+                            "anonymous",
+                            "namespace",
+                            "continent",
+                            "country",
+                            "region",
+                            "city"
+                        ]
+                    }
+                }
+            },
+            "transformSpec": {
+                "transforms": [
+                    {
+                        "type": "expression",
+                        "name": "language",
+                        "expression": "concat('language-', language)"
+                    },
+                    {
+                        "type": "expression",
+                        "name": "triple-added",
+                        "expression": "added * 3"
+                    }
+                ],
+                "filter": {
+                    "type":"or",
+                    "fields": [
+                        { "type": "selector", "dimension": "language", "value": "language-zh" },
+                        { "type": "selector", "dimension": "page", "value": "Crimson Typhoon" }
+                    ]
+                }
+            }
+        },
+        "ioConfig": {
+            "type": "index",
+            "firehose": {
+                "type": "local",
+                "baseDir": "/resources/data/batch_index",
+                "filter": "wikipedia_index_data*"
+            }
+        },
+        "tuningConfig": {
+            "type": "index",
+            "maxRowsPerSegment": 3
+        }
+    }
+}

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_druid_input_source_task_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_druid_input_source_task_with_transforms.json
@@ -1,0 +1,96 @@
+{
+    "type": "index",
+    "spec": {
+        "ioConfig": {
+            "type": "index",
+            "inputSource": {
+                "type": "druid",
+                "dataSource": "%%DATASOURCE%%",
+                "interval": "2013-08-31/2013-09-01"
+            }
+        },
+        "tuningConfig": {
+            "type": "index",
+            "partitionsSpec": {
+                "type": "dynamic"
+            }
+        },
+        "dataSchema": {
+            "dataSource": "%%REINDEX_DATASOURCE%%",
+            "granularitySpec": {
+                "type": "uniform",
+                "queryGranularity": "SECOND",
+                "segmentGranularity": "DAY"
+            },
+            "timestampSpec": {
+                "column": "__time",
+                "format": "iso"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    "page",
+                    {"type": "string", "name": "language", "createBitmapIndex": false},
+                    "user",
+                    "unpatrolled",
+                    "newPage",
+                    "anonymous",
+                    "namespace",
+                    "country",
+                    "region",
+                    "city"
+                ]
+            },
+            "transformSpec": {
+                "transforms": [
+                    {
+                        "type": "expression",
+                        "name": "newPage",
+                        "expression": "page"
+                    },
+                    {
+                        "type": "expression",
+                        "name": "one-plus-triple-added",
+                        "expression": "\"triple-added\" + 1"
+                    },
+                    {
+                        "type": "expression",
+                        "name": "double-deleted",
+                        "expression": "deleted * 2"
+                    }
+                ]
+            },
+            "metricsSpec": [
+                {
+                    "type": "doubleSum",
+                    "name": "added",
+                    "fieldName": "added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "triple-added",
+                    "fieldName": "triple-added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "one-plus-triple-added",
+                    "fieldName": "one-plus-triple-added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "deleted",
+                    "fieldName": "deleted"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "double-deleted",
+                    "fieldName": "double-deleted"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "delta",
+                    "fieldName": "delta"
+                }
+            ]
+        }
+    }
+}

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_druid_input_source_task_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_druid_input_source_task_with_transforms.json
@@ -32,25 +32,35 @@
                     "user",
                     "unpatrolled",
                     "page",
+                    "newPage",
                     "anonymous",
                     "namespace",
                     "country",
                     "region",
                     "city"
-                ],
-                "dimensionExclusions" : ["robot", "continent"]
+                ]
             },
             "transformSpec": {
                 "transforms": [
                     {
                         "type": "expression",
-                        "name": "page",
-                        "expression": "concat('tf_', page)"
+                        "name": "newPage",
+                        "expression": "page"
+                    },
+                    {
+                        "type": "expression",
+                        "name": "city",
+                        "expression": "concat('city-', city)"
                     },
                     {
                         "type": "expression",
                         "name": "one-plus-triple-added",
                         "expression": "\"triple-added\" + 1"
+                    },
+                    {
+                        "type": "expression",
+                        "name": "delta",
+                        "expression": "\"delta\" / 2"
                     },
                     {
                         "type": "expression",

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_druid_input_source_task_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_druid_input_source_task_with_transforms.json
@@ -28,24 +28,24 @@
             },
             "dimensionsSpec": {
                 "dimensions": [
-                    "page",
                     {"type": "string", "name": "language", "createBitmapIndex": false},
                     "user",
                     "unpatrolled",
-                    "newPage",
+                    "page",
                     "anonymous",
                     "namespace",
                     "country",
                     "region",
                     "city"
-                ]
+                ],
+                "dimensionExclusions" : ["robot", "continent"]
             },
             "transformSpec": {
                 "transforms": [
                     {
                         "type": "expression",
-                        "name": "newPage",
-                        "expression": "page"
+                        "name": "page",
+                        "expression": "concat('tf_', page)"
                     },
                     {
                         "type": "expression",

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
@@ -23,7 +23,8 @@
             "dataSource":"%%DATASOURCE%%",
             "granularity":"day",
             "dimensions":[
-                "page"
+                "newPage",
+                "city"
             ],
             "filter":{
                 "type":"selector",
@@ -40,6 +41,11 @@
                     "type":"longSum",
                     "fieldName":"double-deleted",
                     "name":"double_deleted_count"
+                },
+                {
+                    "type":"longSum",
+                    "fieldName":"delta",
+                    "name":"delta_overshadowed"
                 }
             ],
             "postAggregations": [
@@ -63,8 +69,10 @@
             "timestamp" : "2013-08-31T00:00:00.000Z",
             "event" : {
                 "added_count_times_ten" : 27160.0,
-                "page" : "tf_Crimson Typhoon",
+                "newPage" : "Crimson Typhoon",
+                "city" : "city-Taiyuan",
                 "double_deleted_count" : 10,
+                "delta_overshadowed" : 450,
                 "added_count" : 2716
             }
         } ]

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
@@ -63,7 +63,7 @@
             "timestamp" : "2013-08-31T00:00:00.000Z",
             "event" : {
                 "added_count_times_ten" : 27160.0,
-                "page" : "Crimson Typhoon",
+                "page" : "tf_Crimson Typhoon",
                 "double_deleted_count" : 10,
                 "added_count" : 2716
             }

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
@@ -1,12 +1,29 @@
 [
     {
+        "description": "timeseries, 1 agg, all",
+        "query":{
+            "queryType" : "timeBoundary",
+            "dataSource": "%%DATASOURCE%%"
+        },
+        "expectedResults":[
+            {
+                "timestamp" : "2013-08-31T01:02:33.000Z",
+                "result" : {
+                    "minTime" : "2013-08-31T01:02:33.000Z",
+                    "maxTime" : "2013-08-31T12:41:27.000Z"
+                }
+            }
+        ]
+    },
+
+    {
         "description":"having spec on post aggregation",
         "query":{
             "queryType":"groupBy",
             "dataSource":"%%DATASOURCE%%",
             "granularity":"day",
             "dimensions":[
-                "page"
+                "newPage"
             ],
             "filter":{
                 "type":"selector",
@@ -15,13 +32,14 @@
             },
             "aggregations":[
                 {
-                    "type":"count",
-                    "name":"rows"
+                    "type":"longSum",
+                    "fieldName":"one-plus-triple-added",
+                    "name":"added_count"
                 },
                 {
                     "type":"longSum",
-                    "fieldName":"triple-added",
-                    "name":"added_count"
+                    "fieldName":"double-deleted",
+                    "name":"double_deleted_count"
                 }
             ],
             "postAggregations": [
@@ -44,10 +62,10 @@
             "version" : "v1",
             "timestamp" : "2013-08-31T00:00:00.000Z",
             "event" : {
-                "added_count_times_ten" : 27150.0,
-                "page" : "Crimson Typhoon",
-                "added_count" : 2715,
-                "rows" : 1
+                "added_count_times_ten" : 27160.0,
+                "newPage" : "Crimson Typhoon",
+                "double_deleted_count" : 10,
+                "added_count" : 2716
             }
         } ]
     }

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries_with_transforms.json
@@ -23,7 +23,7 @@
             "dataSource":"%%DATASOURCE%%",
             "granularity":"day",
             "dimensions":[
-                "newPage"
+                "page"
             ],
             "filter":{
                 "type":"selector",
@@ -63,7 +63,7 @@
             "timestamp" : "2013-08-31T00:00:00.000Z",
             "event" : {
                 "added_count_times_ten" : 27160.0,
-                "newPage" : "Crimson Typhoon",
+                "page" : "Crimson Typhoon",
                 "double_deleted_count" : 10,
                 "added_count" : 2716
             }

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_task_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_task_with_transforms.json
@@ -1,0 +1,103 @@
+{
+    "type": "index",
+    "spec": {
+        "dataSchema": {
+            "dataSource": "%%REINDEX_DATASOURCE%%",
+            "metricsSpec": [
+                {
+                    "type": "doubleSum",
+                    "name": "added",
+                    "fieldName": "added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "triple-added",
+                    "fieldName": "triple-added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "one-plus-triple-added",
+                    "fieldName": "one-plus-triple-added"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "deleted",
+                    "fieldName": "deleted"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "double-deleted",
+                    "fieldName": "double-deleted"
+                },
+                {
+                    "type": "doubleSum",
+                    "name": "delta",
+                    "fieldName": "delta"
+                }
+            ],
+            "granularitySpec": {
+                "segmentGranularity": "DAY",
+                "queryGranularity": "second",
+                "intervals" : [ "2013-08-31/2013-09-01" ]
+            },
+            "parser": {
+                "parseSpec": {
+                    "format" : "json",
+                    "timestampSpec": {
+                        "column": "timestamp",
+                        "format": "iso"
+                    },
+                    "dimensionsSpec": {
+                        "dimensions": [
+                            "page",
+                            {"type": "string", "name": "language", "createBitmapIndex": false},
+                            "user",
+                            "unpatrolled",
+                            "newPage",
+                            "anonymous",
+                            "namespace",
+                            "country",
+                            "region",
+                            "city"
+                        ]
+                    },
+                    "transformSpec": {
+                        "transforms": [
+                            {
+                                "type": "expression",
+                                "name": "newPage",
+                                "expression": "page"
+                            },
+                            {
+                                "type": "expression",
+                                "name": "country",
+                                "expression": "concat(\"country-\", country)"
+                            },
+                            {
+                                "type": "expression",
+                                "name": "one-plus-triple-added",
+                                "expression": "\"triple-added\" + 1"
+                            },
+                            {
+                                "type": "expression",
+                                "name": "double-deleted",
+                                "expression": "deleted * 2"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "ioConfig": {
+            "type": "index",
+            "firehose": {
+                "type": "ingestSegment",
+                "dataSource": "%%DATASOURCE%%",
+                "interval": "2013-08-31/2013-09-01"
+            }
+        },
+        "tuningConfig": {
+            "type": "index"
+        }
+    }
+}

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_task_with_transforms.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_task_with_transforms.json
@@ -49,10 +49,10 @@
                     },
                     "dimensionsSpec": {
                         "dimensions": [
-                            "page",
                             {"type": "string", "name": "language", "createBitmapIndex": false},
                             "user",
                             "unpatrolled",
+                            "page",
                             "newPage",
                             "anonymous",
                             "namespace",
@@ -70,13 +70,18 @@
                             },
                             {
                                 "type": "expression",
-                                "name": "country",
-                                "expression": "concat(\"country-\", country)"
+                                "name": "city",
+                                "expression": "concat('city-', city)"
                             },
                             {
                                 "type": "expression",
                                 "name": "one-plus-triple-added",
                                 "expression": "\"triple-added\" + 1"
+                            },
+                            {
+                                "type": "expression",
+                                "name": "delta",
+                                "expression": "\"delta\" / 2"
                             },
                             {
                                 "type": "expression",


### PR DESCRIPTION
Fixes #9593 #9592 

### Description

Add integration tests for using transformSpec during ingestion. The tests test transformSpecs that add metrics and dimensions using both a Druid InputSource and the deprecated ingestSegmentFirehose.

Writing these tests surfaced #9589 #9591 When these issues are fixed, those tests can be re-enabled.