### PR TITLE
Add new round robin strategy for loading segments.

### DIFF
--- a/server/src/main/java/org/apache/druid/client/ImmutableDruidDataSource.java
+++ b/server/src/main/java/org/apache/druid/client/ImmutableDruidDataSource.java
@@ -53,7 +53,10 @@ public class ImmutableDruidDataSource
   {
     this.name = Preconditions.checkNotNull(name);
     this.properties = ImmutableMap.copyOf(properties);
-    this.idToSegments = ImmutableSortedMap.copyOf(idToSegments);
+    // By setting the order to reverse, for a datasource, newer segments will be ordered before older ones.
+    // See the compareTo method of SegmentId class.
+    ImmutableSortedMap.Builder<SegmentId, DataSegment> idToSegmentsBuilder = ImmutableSortedMap.reverseOrder();
+    this.idToSegments = idToSegmentsBuilder.putAll(idToSegments).build();
     this.totalSizeOfSegments = idToSegments.values().stream().mapToLong(DataSegment::getSize).sum();
   }
 
@@ -66,8 +69,9 @@ public class ImmutableDruidDataSource
   {
     this.name = Preconditions.checkNotNull(name);
     this.properties = ImmutableMap.copyOf(properties);
-
-    final ImmutableSortedMap.Builder<SegmentId, DataSegment> idToSegmentsBuilder = ImmutableSortedMap.naturalOrder();
+    // By setting the order to reverse, for a datasource, newer segments will be ordered before older ones.
+    // See the compareTo method of SegmentId class.
+    final ImmutableSortedMap.Builder<SegmentId, DataSegment> idToSegmentsBuilder = ImmutableSortedMap.reverseOrder();
     long totalSizeOfSegments = 0;
     for (DataSegment segment : segments) {
       idToSegmentsBuilder.put(segment.getId(), segment);

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -92,4 +92,10 @@ public abstract class DruidCoordinatorConfig
   {
     return 1;
   }
+
+  @Config("druid.coordinator.load.segment.strategy")
+  public String getLoadSegmentStrategy()
+  {
+    return "newFirst";
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -22,7 +22,10 @@ package org.apache.druid.server.coordinator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.druid.client.DataSourcesSnapshot;
+import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.metadata.MetadataRuleManager;
@@ -31,10 +34,15 @@ import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
@@ -56,11 +64,50 @@ public class DruidCoordinatorRuntimeParams
     return segmentsSet;
   }
 
+  /**
+   * Creates a {@link Set} by choosing used segments from each datasource in a round robin fashion.
+   * The order of segments picked for a datasource is dependent on the iteration order of
+   * {@link ImmutableDruidDataSource#getSegments()}. So if it is desired to have newer segments
+   * be picked up before the older ones, the {@link Collection} returned by {@link ImmutableDruidDataSource#getSegments()}
+   * needs to be setup accordingly.
+   */
+  private static Set<DataSegment> createUsedSegmentSetInRoundRobinFashion(Map<String, ImmutableDruidDataSource> dataSourcesWithAllUsedSegments)
+  {
+    Set<String> datasourcesSet = dataSourcesWithAllUsedSegments.keySet();
+    Map<String, Iterator<DataSegment>> iterators = Maps.newHashMapWithExpectedSize(datasourcesSet.size());
+    List<String> datasources = new ArrayList<>(datasourcesSet);
+    int numDatasources = datasources.size();
+    Set<String> exhaustedDatasources = Sets.newHashSetWithExpectedSize(numDatasources);
+    Set<DataSegment> segments = new LinkedHashSet<>();
+    int i = 0;
+    String datasource;
+    Iterator<DataSegment> iterator;
+    while (exhaustedDatasources.size() < numDatasources) {
+      datasource = datasources.get(i);
+      if (exhaustedDatasources.contains(datasource)) {
+        i = (i + 1) % numDatasources;
+        continue;
+      }
+      String finalDatasource = datasource;
+      iterator = iterators.computeIfAbsent(
+          datasource,
+          s -> dataSourcesWithAllUsedSegments.get(finalDatasource).getSegments().iterator()
+      );
+      if (iterator.hasNext()) {
+        segments.add(iterator.next());
+      } else {
+        exhaustedDatasources.add(datasource);
+      }
+      i = (i + 1) % numDatasources;
+    }
+    return segments;
+  }
+
   private final long startTimeNanos;
   private final DruidCluster druidCluster;
   private final MetadataRuleManager databaseRuleManager;
   private final SegmentReplicantLookup segmentReplicantLookup;
-  private final @Nullable TreeSet<DataSegment> usedSegments;
+  private final @Nullable Set<DataSegment> usedSegments;
   private final @Nullable DataSourcesSnapshot dataSourcesSnapshot;
   private final Map<String, LoadQueuePeon> loadManagementPeons;
   private final ReplicationThrottler replicationManager;
@@ -76,7 +123,7 @@ public class DruidCoordinatorRuntimeParams
       DruidCluster druidCluster,
       MetadataRuleManager databaseRuleManager,
       SegmentReplicantLookup segmentReplicantLookup,
-      @Nullable TreeSet<DataSegment> usedSegments,
+      @Nullable Set<DataSegment> usedSegments,
       @Nullable DataSourcesSnapshot dataSourcesSnapshot,
       Map<String, LoadQueuePeon> loadManagementPeons,
       ReplicationThrottler replicationManager,
@@ -134,7 +181,7 @@ public class DruidCoordinatorRuntimeParams
     return dataSourcesSnapshot.getUsedSegmentsTimelinesPerDataSource();
   }
 
-  public TreeSet<DataSegment> getUsedSegments()
+  public Set<DataSegment> getUsedSegments()
   {
     Preconditions.checkState(usedSegments != null, "usedSegments or dataSourcesSnapshot must be set");
     return usedSegments;
@@ -246,7 +293,7 @@ public class DruidCoordinatorRuntimeParams
     private DruidCluster druidCluster;
     private MetadataRuleManager databaseRuleManager;
     private SegmentReplicantLookup segmentReplicantLookup;
-    private @Nullable TreeSet<DataSegment> usedSegments;
+    private @Nullable Set<DataSegment> usedSegments;
     private @Nullable DataSourcesSnapshot dataSourcesSnapshot;
     private final Map<String, LoadQueuePeon> loadManagementPeons;
     private ReplicationThrottler replicationManager;
@@ -279,7 +326,7 @@ public class DruidCoordinatorRuntimeParams
         DruidCluster cluster,
         MetadataRuleManager databaseRuleManager,
         SegmentReplicantLookup segmentReplicantLookup,
-        @Nullable TreeSet<DataSegment> usedSegments,
+        @Nullable Set<DataSegment> usedSegments,
         @Nullable DataSourcesSnapshot dataSourcesSnapshot,
         Map<String, LoadQueuePeon> loadManagementPeons,
         ReplicationThrottler replicationManager,
@@ -355,6 +402,14 @@ public class DruidCoordinatorRuntimeParams
     public Builder withSnapshotOfDataSourcesWithAllUsedSegments(DataSourcesSnapshot snapshot)
     {
       this.usedSegments = createUsedSegmentsSet(snapshot.iterateAllUsedSegmentsInSnapshot());
+      this.dataSourcesSnapshot = snapshot;
+      return this;
+    }
+
+    @VisibleForTesting
+    public Builder withUsedSegmentsPickedInRoundRobinFashion(DataSourcesSnapshot snapshot)
+    {
+      this.usedSegments = createUsedSegmentSetInRoundRobinFashion(snapshot.getDataSourcesMap());
       this.dataSourcesSnapshot = snapshot;
       return this;
     }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -972,26 +972,26 @@ public class SystemSchemaTest extends CalciteTestBase
 
     //server_segments table is the join of servers and segments table
     // it will have 5 rows as follows
-    // localhost:0000 |  test1_2010-01-01T00:00:00.000Z_2011-01-01T00:00:00.000Z_version1(segment1)
     // localhost:0000 |  test2_2011-01-01T00:00:00.000Z_2012-01-01T00:00:00.000Z_version2(segment2)
-    // server2:1234   |  test3_2012-01-01T00:00:00.000Z_2013-01-01T00:00:00.000Z_version3(segment3)
-    // server2:1234   |  test4_2017-01-01T00:00:00.000Z_2018-01-01T00:00:00.000Z_version4(segment4)
+    // localhost:0000 |  test1_2010-01-01T00:00:00.000Z_2011-01-01T00:00:00.000Z_version1(segment1)
     // server2:1234   |  test5_2017-01-01T00:00:00.000Z_2018-01-01T00:00:00.000Z_version5(segment5)
+    // server2:1234   |  test4_2017-01-01T00:00:00.000Z_2018-01-01T00:00:00.000Z_version4(segment4)
+    // server2:1234   |  test3_2012-01-01T00:00:00.000Z_2013-01-01T00:00:00.000Z_version3(segment3)
 
     final List<Object[]> rows = serverSegmentsTable.scan(dataContext).toList();
     Assert.assertEquals(5, rows.size());
 
     Object[] row0 = rows.get(0);
     Assert.assertEquals("localhost:0000", row0[0]);
-    Assert.assertEquals("test1_2010-01-01T00:00:00.000Z_2011-01-01T00:00:00.000Z_version1", row0[1].toString());
+    Assert.assertEquals("test2_2011-01-01T00:00:00.000Z_2012-01-01T00:00:00.000Z_version2", row0[1].toString());
 
     Object[] row1 = rows.get(1);
     Assert.assertEquals("localhost:0000", row1[0]);
-    Assert.assertEquals("test2_2011-01-01T00:00:00.000Z_2012-01-01T00:00:00.000Z_version2", row1[1].toString());
+    Assert.assertEquals("test1_2010-01-01T00:00:00.000Z_2011-01-01T00:00:00.000Z_version1", row1[1].toString());
 
     Object[] row2 = rows.get(2);
     Assert.assertEquals("server2:1234", row2[0]);
-    Assert.assertEquals("test3_2012-01-01T00:00:00.000Z_2013-01-01T00:00:00.000Z_version3_2", row2[1].toString());
+    Assert.assertEquals("test5_2015-01-01T00:00:00.000Z_2016-01-01T00:00:00.000Z_version5", row2[1].toString());
 
     Object[] row3 = rows.get(3);
     Assert.assertEquals("server2:1234", row3[0]);
@@ -999,7 +999,7 @@ public class SystemSchemaTest extends CalciteTestBase
 
     Object[] row4 = rows.get(4);
     Assert.assertEquals("server2:1234", row4[0]);
-    Assert.assertEquals("test5_2015-01-01T00:00:00.000Z_2016-01-01T00:00:00.000Z_version5", row4[1].toString());
+    Assert.assertEquals("test3_2012-01-01T00:00:00.000Z_2013-01-01T00:00:00.000Z_version3_2", row4[1].toString());
 
     // Verify value types.
     verifyTypes(rows, SystemSchema.SERVER_SEGMENTS_SIGNATURE);


### PR DESCRIPTION
This strategy aims to address situations where datasources that had older
data restated often wait a long time before their segments are loaded on the cluster.
This behavior happens because Druid by default prefers loading newer data. With this
new strategy segments are loaded by selecting datasources in a round-robin fashion.
For each datasource, the strategy ensures that the newer segments are loaded before the older ones.

This PR has:
- [X] been self-reviewed.
   - [X] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [X] added documentation for new or modified features or behaviors.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths.
- [X] been tested in a test Druid cluster.

 * `DruidCoordinatorRuntimeParams.java`
 * `ImmutableDruidDataSource.java`
