### PR TITLE
Use primitives instead of boxed variables when possible

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Function.java
@@ -1910,16 +1910,10 @@ public interface Function
     @Override
     public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
     {
-      Long left = args.get(0).eval(bindings).asLong();
-      Long right = args.get(1).eval(bindings).asLong();
+      long left = args.get(0).eval(bindings).asLong();
+      long right = args.get(1).eval(bindings).asLong();
       DateTimeZone timeZone = DateTimes.inferTzFromString(args.get(2).eval(bindings).asString());
-
-      if (left == null || right == null) {
-        return ExprEval.of(null);
-      } else {
-        return ExprEval.of(DateTimes.subMonths(right, left, timeZone));
-      }
-
+      return ExprEval.of(DateTimes.subMonths(right, left, timeZone));
     }
 
     @Override

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregator.java
@@ -77,7 +77,7 @@ public class FixedBucketsHistogramBufferAggregator implements BufferAggregator
     } else if (val instanceof FixedBucketsHistogram) {
       h0.combineHistogram((FixedBucketsHistogram) val);
     } else {
-      Double x = ((Number) val).doubleValue();
+      double x = ((Number) val).doubleValue();
       h0.add(x);
     }
 

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/parquet/avro/DruidParquetAvroReadSupport.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/parquet/avro/DruidParquetAvroReadSupport.java
@@ -112,7 +112,7 @@ public class DruidParquetAvroReadSupport extends AvroReadSupport<GenericRecord>
     // coercing this value to false by default here to be friendlier default behavior
     // see https://github.com/apache/druid/issues/5433#issuecomment-388539306
     String jobProp = "parquet.avro.add-list-element-records";
-    Boolean explicitlySet = configuration.getBoolean(jobProp, false);
+    boolean explicitlySet = configuration.getBoolean(jobProp, false);
     if (!explicitlySet) {
       configuration.setBoolean(jobProp, false);
     }


### PR DESCRIPTION
Fix LGTM warning about using boxed variables instead of primitives when the
variable being assigned is never null.
This change should have no visible production impact, but cleans up the code
a little bit.