### PR TITLE
Change Hadoop inputSource integration tests to use parallel batch ingestion

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractHdfsInputSourceParallelIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractHdfsInputSourceParallelIndexTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.tests.indexer;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.testng.annotations.DataProvider;
@@ -29,9 +30,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 
-public abstract class AbstractHdfsInputSourceSimpleIndexTest extends AbstractITBatchIndexTest
+public abstract class AbstractHdfsInputSourceParallelIndexTest extends AbstractITBatchIndexTest
 {
-  private static final String INDEX_TASK = "/indexer/wikipedia_cloud_simple_index_task.json";
+  private static final String INDEX_TASK = "/indexer/wikipedia_cloud_index_task.json";
   private static final String INDEX_QUERIES_RESOURCE = "/indexer/wikipedia_index_queries.json";
   private static final String INDEX_DATASOURCE = "wikipedia_index_test_" + UUID.randomUUID();
   private static final String INPUT_SOURCE_PATHS_KEY = "paths";
@@ -69,6 +70,11 @@ public abstract class AbstractHdfsInputSourceSimpleIndexTest extends AbstractITB
               spec,
               "%%INPUT_SOURCE_TYPE%%",
               "hdfs"
+          );
+          spec = StringUtils.replace(
+              spec,
+              "%%PARTITIONS_SPEC%%",
+              jsonMapper.writeValueAsString(new DynamicPartitionsSpec(null, null))
           );
           spec = StringUtils.replace(
               spec,

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToAzureParallelIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToAzureParallelIndexTest.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 @Test(groups = TestNGGroup.AZURE_DEEP_STORAGE)
 @Guice(moduleFactory = DruidTestModuleFactory.class)
-public class ITHdfsToAzureSimpleIndexTest extends AbstractHdfsInputSourceSimpleIndexTest
+public class ITHdfsToAzureParallelIndexTest extends AbstractHdfsInputSourceParallelIndexTest
 {
   @Test(dataProvider = "resources")
   public void testHdfsIndexData(Pair<String, List> hdfsInputSource) throws Exception

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToGcsParallelIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToGcsParallelIndexTest.java
@@ -38,7 +38,7 @@ import java.util.List;
  */
 @Test(groups = TestNGGroup.GCS_DEEP_STORAGE)
 @Guice(moduleFactory = DruidTestModuleFactory.class)
-public class ITHdfsToGcsSimpleIndexTest extends AbstractHdfsInputSourceSimpleIndexTest
+public class ITHdfsToGcsParallelIndexTest extends AbstractHdfsInputSourceParallelIndexTest
 {
   @Test(dataProvider = "resources")
   public void testHdfsIndexData(Pair<String, List> hdfsInputSource) throws Exception

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToHdfsParallelIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToHdfsParallelIndexTest.java
@@ -31,13 +31,12 @@ import java.util.List;
  * IMPORTANT:
  * To run this test, you must:
  * 1) Run the test with -Dstart.hadoop.docker=true in the mvn command
- * 2) Provide -Doverride.config.path=<PATH_TO_FILE> with s3 credentials/configs set. See
- *    integration-tests/docker/environment-configs/override-examples/s3 for env vars to provide.
- *    You will also need to include "druid-hdfs-storage" to druid_extensions_loadList in this file.
+ * 2) Provide -Doverride.config.path=<PATH_TO_FILE> with hdfs configs set. See
+ *    integration-tests/docker/environment-configs/override-examples/hdfs for env vars to provide.
  */
-@Test(groups = TestNGGroup.S3_DEEP_STORAGE)
+@Test(groups = TestNGGroup.HDFS_DEEP_STORAGE)
 @Guice(moduleFactory = DruidTestModuleFactory.class)
-public class ITHdfsToS3SimpleIndexTest extends AbstractHdfsInputSourceSimpleIndexTest
+public class ITHdfsToHdfsParallelIndexTest extends AbstractHdfsInputSourceParallelIndexTest
 {
   @Test(dataProvider = "resources")
   public void testHdfsIndexData(Pair<String, List> hdfsInputSource) throws Exception

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToS3ParallelIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITHdfsToS3ParallelIndexTest.java
@@ -31,12 +31,13 @@ import java.util.List;
  * IMPORTANT:
  * To run this test, you must:
  * 1) Run the test with -Dstart.hadoop.docker=true in the mvn command
- * 2) Provide -Doverride.config.path=<PATH_TO_FILE> with hdfs configs set. See
- *    integration-tests/docker/environment-configs/override-examples/hdfs for env vars to provide.
+ * 2) Provide -Doverride.config.path=<PATH_TO_FILE> with s3 credentials/configs set. See
+ *    integration-tests/docker/environment-configs/override-examples/s3 for env vars to provide.
+ *    You will also need to include "druid-hdfs-storage" to druid_extensions_loadList in this file.
  */
-@Test(groups = TestNGGroup.HDFS_DEEP_STORAGE)
+@Test(groups = TestNGGroup.S3_DEEP_STORAGE)
 @Guice(moduleFactory = DruidTestModuleFactory.class)
-public class ITHdfsToHdfsSimpleIndexTest extends AbstractHdfsInputSourceSimpleIndexTest
+public class ITHdfsToS3ParallelIndexTest extends AbstractHdfsInputSourceParallelIndexTest
 {
   @Test(dataProvider = "resources")
   public void testHdfsIndexData(Pair<String, List> hdfsInputSource) throws Exception


### PR DESCRIPTION
Change Hadoop inputSource integration tests to use parallel batch ingestion

### Description

Previously we were forced to use the simple batch ingestion for Hadoop InputSource integration tests because of https://github.com/apache/druid/pull/9574
However, now that https://github.com/apache/druid/pull/9574 is fixed, we can switch Hadoop InputSource integration test to use parallel batch ingestion which is a more comprehensive test case (creating sub task, etc.)

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [x] added integration tests.
- [ ] been tested in a test Druid cluster.
