### PR TITLE
pac4j: be noop if a previous authenticator in chain has successfully authenticated

### DIFF
--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
@@ -79,6 +79,13 @@ public class Pac4jFilter implements Filter
   public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
       throws IOException, ServletException
   {
+    // If there's already an auth result, then we have authenticated already, skip this or else caller
+    // could get HTTP redirect even if one of the druid authenticators in chain has successfully authenticated.
+    if (servletRequest.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT) != null) {
+      filterChain.doFilter(servletRequest, servletResponse);
+      return;
+    }
+
     HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
     HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
     J2EContext context = new J2EContext(httpServletRequest, httpServletResponse, sessionStore);


### PR DESCRIPTION
This is to allow other programmatic clients to send requests to Druid process, alongside OpenId Connect  auth flow for web console,  which would be using another authenticator.

This is same as in https://github.com/apache/druid/blob/master/extensions-core/druid-kerberos/src/main/java/org/apache/druid/security/kerberos/KerberosAuthenticator.java#L211