### PR TITLE
Add context to AuthenticationResult [WIP]

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/BasicHTTPAuthenticator.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/BasicHTTPAuthenticator.java
@@ -33,6 +33,7 @@ import org.apache.druid.security.basic.authentication.db.cache.BasicAuthenticato
 import org.apache.druid.security.basic.authentication.validator.CredentialsValidator;
 import org.apache.druid.security.basic.authentication.validator.MetadataStoreCredentialsValidator;
 import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.server.security.AuthenticationContextEnricher;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Authenticator;
 
@@ -204,6 +205,8 @@ public class BasicHTTPAuthenticator implements Authenticator
             user,
             password
         );
+        authenticationResult.setContext(AuthenticationContextEnricher.enrichContext(servletRequest));
+
         if (authenticationResult != null) {
           servletRequest.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
           filterChain.doFilter(servletRequest, servletResponse);

--- a/extensions-core/druid-kerberos/src/main/java/org/apache/druid/security/kerberos/KerberosAuthenticator.java
+++ b/extensions-core/druid-kerberos/src/main/java/org/apache/druid/security/kerberos/KerberosAuthenticator.java
@@ -78,6 +78,8 @@ import java.util.TimeZone;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import static org.apache.druid.server.security.AuthenticationContextEnricher.enrichContext;
+
 
 @JsonTypeName("kerberos")
 public class KerberosAuthenticator implements Authenticator
@@ -315,7 +317,7 @@ public class KerberosAuthenticator implements Authenticator
               // Since this request is validated also set DRUID_AUTHENTICATION_RESULT
               request.setAttribute(
                   AuthConfig.DRUID_AUTHENTICATION_RESULT,
-                  new AuthenticationResult(token.getName(), authorizerName, name, null)
+                  new AuthenticationResult(token.getName(), authorizerName, name, enrichContext(request))
               );
               doFilter(filterChain, httpRequest, httpResponse);
             }

--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
@@ -43,6 +43,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collection;
 
+import static org.apache.druid.server.security.AuthenticationContextEnricher.enrichContext;
+
 public class Pac4jFilter implements Filter
 {
   private static final Logger LOGGER = new Logger(Pac4jFilter.class);
@@ -106,7 +108,12 @@ public class Pac4jFilter implements Filter
           null, null, null, null);
 
       if (uid != null) {
-        AuthenticationResult authenticationResult = new AuthenticationResult(uid, authorizerName, name, null);
+        AuthenticationResult authenticationResult = new AuthenticationResult(
+            uid,
+            authorizerName,
+            name,
+            enrichContext(servletRequest)
+        );
         servletRequest.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
         filterChain.doFilter(servletRequest, servletResponse);
       }

--- a/server/src/main/java/org/apache/druid/server/security/AnonymousAuthenticator.java
+++ b/server/src/main/java/org/apache/druid/server/security/AnonymousAuthenticator.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Map;
 
+import static org.apache.druid.server.security.AuthenticationContextEnricher.enrichContext;
+
 /**
  * Authenticates all requests and directs them to an authorizer.
  */
@@ -97,6 +99,7 @@ public class AnonymousAuthenticator implements Authenticator
       public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
           throws IOException, ServletException
       {
+        anonymousResult.setContext(enrichContext(request));
         request.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, anonymousResult);
         chain.doFilter(request, response);
       }

--- a/server/src/main/java/org/apache/druid/server/security/AuthenticationContextEnricher.java
+++ b/server/src/main/java/org/apache/druid/server/security/AuthenticationContextEnricher.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.security;
+
+import com.google.common.base.Strings;
+
+import javax.annotation.Nullable;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AuthenticationContextEnricher
+{
+  public static final String CONTEXT_CLIENT_IPADDRESS = "clientIpAddress";
+  public static final String CONTEXT_FORWARDED_ADDRESSES = "forwardedAddresses";
+  public static final String CONTEXT_REMOTE_ADDRESS = "remoteAddress";
+
+  private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+  private static final String X_REAL_IP = "X-Real-IP";
+
+  @Nullable
+  private static List<String> getForwardedAddresses(ServletRequest request)
+  {
+    if (request instanceof HttpServletRequest) {
+      String forwarded_for = ((HttpServletRequest) request).getHeader(X_FORWARDED_FOR);
+      if (!Strings.isNullOrEmpty(forwarded_for)) {
+        return Arrays.asList(forwarded_for.split(","));
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Enriches the context with information received from the servlet request like
+   * remote address and proxies.
+   * @param request The servlet request
+   */
+  public static Map<String, Object> enrichContext(ServletRequest request)
+  {
+    Map<String, Object> context = new HashMap<>();
+
+    List<String> forwardedAddresses = getForwardedAddresses(request);
+    if (forwardedAddresses != null) {
+      context.put(CONTEXT_REMOTE_ADDRESS, forwardedAddresses.get(0));
+    } else if (request instanceof HttpServletRequest) {
+      String realIp = ((HttpServletRequest) request).getHeader(X_REAL_IP);
+      if (!Strings.isNullOrEmpty(realIp)) {
+        context.put(CONTEXT_REMOTE_ADDRESS, realIp);
+      }
+    }
+    context.put(CONTEXT_FORWARDED_ADDRESSES, forwardedAddresses);
+    context.put(CONTEXT_CLIENT_IPADDRESS, request.getRemoteAddr());
+
+    return context;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/security/AuthenticationResult.java
+++ b/server/src/main/java/org/apache/druid/server/security/AuthenticationResult.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.security;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -51,7 +52,7 @@ public class AuthenticationResult
    * parameter containing additional context information from an Authenticator
    */
   @Nullable
-  private final Map<String, Object> context;
+  private Map<String, Object> context;
 
   public AuthenticationResult(
       final String identity,
@@ -88,6 +89,11 @@ public class AuthenticationResult
     return authenticatedBy;
   }
 
+  public void setContext(final Map<String, Object> context)
+  {
+    this.context = context;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -109,4 +115,5 @@ public class AuthenticationResult
   {
     return Objects.hash(getIdentity(), getAuthorizerName(), getAuthenticatedBy(), getContext());
   }
+
 }

--- a/server/src/main/java/org/apache/druid/server/security/TrustedDomainAuthenticator.java
+++ b/server/src/main/java/org/apache/druid/server/security/TrustedDomainAuthenticator.java
@@ -39,6 +39,8 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Map;
 
+import static org.apache.druid.server.security.AuthenticationContextEnricher.enrichContext;
+
 /**
  * Authenticates requests coming from a specific domain and directs them to an authorizer.
  */
@@ -124,6 +126,7 @@ public class TrustedDomainAuthenticator implements Authenticator
           }
         }
         if (remoteAddr.endsWith(domain)) {
+          authenticationResult.setContext(enrichContext(request));
           request.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
         }
         chain.doFilter(request, response);


### PR DESCRIPTION
### Description

Looking for feedback.

Proper authorization needs to be context aware. Context like IP Address, Proxy addresses etc. This PR adds context obtained from the servlet request and adds this to the authenticationResult. 

Note:

* At the moment I tried to stay away from adjusting AuthenticationResult as much as possible. Hence, it requires the "authenticator" to call enrichContext. Maybe we should consider doing the enrichment in AuthenticationResult

##### Key changed/added classes in this PR
 * AuthenticationContextEnricher

cc @jon-wei @Fokko 
