### PR TITLE
Integration-tests: typo

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -182,7 +182,7 @@ of the integration test run discussed above.  This is because druid
 test clusters might not, in general, have access to hadoop.
 This also applies to integration test that uses Hadoop HDFS as an inputSource or as a deep storage. 
 To run integration test that uses Hadoop, you will have to run a Hadoop cluster. This can be done in two ways:
-1) Run your own Druid + Haddop cluster and specified Hadoop configs in the configuration file (CONFIG_FILE).
+1) Run your own Druid + Hadoop cluster and specified Hadoop configs in the configuration file (CONFIG_FILE).
 2) Run Druid Docker test clusters with Hadoop container by passing -Dstart.hadoop.docker=true to the mvn command. 
 
 Currently, hdfs-deep-storage and other <cloud>-deep-storage integration test groups can only be run with 
@@ -192,7 +192,7 @@ See integration-tests/docker/environment-configs/override-examples/hdfs director
 Note that if the integration test you are running also uses other cloud extension (S3, Azure, GCS), additional
 credentials/configs may need to be set in the same file as your Druid's Hadoop configs set. 
 
-Currently, ITHadoopIndexTest can only be run with your own Druid + Haddop cluster by following the below steps:
+Currently, ITHadoopIndexTest can only be run with your own Druid + Hadoop cluster by following the below steps:
 Create a directory called batchHadoop1 in the hadoop file system
 (anywhere you want) and put batch_hadoop.data (integration-tests/src/test/resources/hadoop/batch_hadoop.data) 
 into that directory (as its only file).

--- a/integration-tests/run_cluster.sh
+++ b/integration-tests/run_cluster.sh
@@ -68,7 +68,7 @@
   # For druid-google-extensions
   mkdir -p $SHARED_DIR/docker/extensions/druid-google-extensions
   mv $SHARED_DIR/docker/lib/druid-google-extensions-* $SHARED_DIR/docker/extensions/druid-google-extensions
-  $ For druid-hdfs-storage
+  # For druid-hdfs-storage
   mkdir -p $SHARED_DIR/docker/extensions/druid-hdfs-storage
   mv $SHARED_DIR/docker/lib/druid-hdfs-storage-* $SHARED_DIR/docker/extensions/druid-hdfs-storage
 


### PR DESCRIPTION
### Description
I fixed a couple typos in code with this PR

/integration-tests/run_cluster.sh:71 replace $ with # 
/integration-tests/Readme.md - haddop -> hadoop

no functionality was affected 