### PR TITLE
Suppress LGTM warnings about stack trace exposure

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+queries:
+  # Exclude stack trace exposure warnings because this project is open source.
+  - exclude: java/stack-trace-exposure
 extraction:
   java:
     index:


### PR DESCRIPTION
Since Druid is an open source project, these warnings are not concerning
as the information it may potentially leak is already available in the open.