### PR TITLE
Align library version 

### DIFF
--- a/extendedset/pom.xml
+++ b/extendedset/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extendedset/pom.xml
+++ b/extendedset/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-contrib/dropwizard-emitter/pom.xml
+++ b/extensions-contrib/dropwizard-emitter/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
-      <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-contrib/dropwizard-emitter/pom.xml
+++ b/extensions-contrib/dropwizard-emitter/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
-      <version>1.0.4</version>
+      <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Align junit and jUnitParams versions to avoid inconsistency. Update version in one module to make library version consistent with that in  other modules.
