### PR TITLE
add new text to lookup action dialog

### DIFF
--- a/web-console/src/components/lookup-values-table/lookup-values-table.tsx
+++ b/web-console/src/components/lookup-values-table/lookup-values-table.tsx
@@ -90,7 +90,11 @@ export class LookupValuesTable extends React.PureComponent<
             accessor: 'v',
           },
         ]}
-        noDataText={error ? error : 'No data found'}
+        noDataText={
+          error
+            ? error
+            : 'Lookup data not found. If this is a new lookup it might not have propagated yet.'
+        }
       />
     );
   }


### PR DESCRIPTION
Updates the text in in the lookup action dialog as it takes a little bit of time for a look up to propagate. 

<img width="1561" alt="Screen Shot 2020-04-07 at 8 30 10 PM" src="https://user-images.githubusercontent.com/37322608/78738354-e499a900-790e-11ea-82ad-b6b6ac68f112.png">
