### PR TITLE
Add missing integration tests for the compaction by the coordinator

### DIFF
--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -362,7 +362,7 @@ Returns total size and count for each interval within given isointerval.
 
 Returns total size and count for each datasource for each interval within given isointerval.
 
-#### Compaction Duty
+#### Compaction Status
 
 ##### GET
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -362,6 +362,15 @@ Returns total size and count for each interval within given isointerval.
 
 Returns total size and count for each datasource for each interval within given isointerval.
 
+#### Compaction Duty
+
+##### GET
+
+* `/druid/coordinator/v1/compaction/progress?dataSource={dataSource}`
+
+Returns the total size of segments awaiting compaction for the given dataSource. 
+This is only valid for dataSource which has compaction enabled. 
+
 #### Compaction Configuration
 
 ##### GET

--- a/integration-tests/docker/environment-configs/coordinator
+++ b/integration-tests/docker/environment-configs/coordinator
@@ -35,3 +35,4 @@ druid_manager_lookups_threadPoolSize=2
 druid_auth_basic_common_cacheDirectory=/tmp/authCache/coordinator
 druid_auth_unsecuredPaths=["/druid/coordinator/v1/loadqueue"]
 druid_server_https_crlPath=/tls/revocations.crl
+druid_coordinator_period_indexingPeriod=PT180000S

--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -37,4 +37,4 @@ druid_indexer_task_chathandler_type=announce
 druid_auth_basic_common_cacheDirectory=/tmp/authCache/middleManager
 druid_startup_logging_logProperties=true
 druid_server_https_crlPath=/tls/revocations.crl
-druid_worker_capacity=16
+druid_worker_capacity=20

--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -37,3 +37,4 @@ druid_indexer_task_chathandler_type=announce
 druid_auth_basic_common_cacheDirectory=/tmp/authCache/middleManager
 druid_startup_logging_logProperties=true
 druid_server_https_crlPath=/tls/revocations.crl
+druid_worker_capacity=16

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
@@ -37,6 +37,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.ws.rs.QueryParam;
 import java.net.URL;
+import java.util.Map;
 
 public class CompactionResourceTestClient
 {
@@ -158,5 +159,21 @@ public class CompactionResourceTestClient
           response.getContent()
       );
     }
+  }
+
+  public Map<String, String> getCompactionProgress(String dataSource) throws Exception
+  {
+    String url = StringUtils.format("%scompaction/progress?dataSource=%s", getCoordinatorURL(), StringUtils.urlEncode(dataSource));
+    StatusResponseHolder response = httpClient.go(
+        new Request(HttpMethod.GET, new URL(url)), responseHandler
+    ).get();
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while getting compaction progress status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+    return jsonMapper.readValue(response.getContent(), new TypeReference<Map<String, String>>() {});
   }
 }

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
@@ -35,7 +35,6 @@ import org.apache.druid.testing.guice.TestClient;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import javax.ws.rs.QueryParam;
 import java.net.URL;
 import java.util.Map;
 
@@ -154,7 +153,7 @@ public class CompactionResourceTestClient
     StatusResponseHolder response = httpClient.go(new Request(HttpMethod.POST, new URL(url)), responseHandler).get();
     if (!response.getStatus().equals(HttpResponseStatus.OK)) {
       throw new ISE(
-          "Error while force trigger auto compaction status[%s] content[%s]",
+          "Error while updating compaction task slot status[%s] content[%s]",
           response.getStatus(),
           response.getContent()
       );

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testing.clients;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.StatusResponseHandler;
+import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
+import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
+import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+import org.apache.druid.testing.IntegrationTestingConfig;
+import org.apache.druid.testing.guice.TestClient;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.ws.rs.QueryParam;
+import java.net.URL;
+
+public class CompactionResourceTestClient
+{
+  private final ObjectMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final String coordinator;
+  private final StatusResponseHandler responseHandler;
+
+  @Inject
+  CompactionResourceTestClient(
+      ObjectMapper jsonMapper,
+      @TestClient HttpClient httpClient,
+      IntegrationTestingConfig config
+  )
+  {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    this.coordinator = config.getCoordinatorUrl();
+    this.responseHandler = StatusResponseHandler.getInstance();
+  }
+
+  private String getCoordinatorURL()
+  {
+    return StringUtils.format(
+        "%s/druid/coordinator/v1/",
+        coordinator
+    );
+  }
+
+  public void submitCompactionConfig(final DataSourceCompactionConfig dataSourceCompactionConfig) throws Exception
+  {
+    String url = StringUtils.format("%sconfig/compaction", getCoordinatorURL());
+    StatusResponseHolder response = httpClient.go(
+        new Request(HttpMethod.POST, new URL(url)).setContent(
+            "application/json",
+            jsonMapper.writeValueAsBytes(dataSourceCompactionConfig)
+        ), responseHandler
+    ).get();
+
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while submiting compaction config status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+  }
+
+  public void deleteCompactionConfig(final String dataSource) throws Exception
+  {
+    String url = StringUtils.format("%sconfig/compaction/%s", getCoordinatorURL(), StringUtils.urlEncode(dataSource));
+    StatusResponseHolder response = httpClient.go(new Request(HttpMethod.DELETE, new URL(url)), responseHandler).get();
+
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while deleting compaction config status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+  }
+
+  public CoordinatorCompactionConfig getCoordinatorCompactionConfigs() throws Exception
+  {
+    String url = StringUtils.format("%sconfig/compaction", getCoordinatorURL());
+    StatusResponseHolder response = httpClient.go(
+        new Request(HttpMethod.GET, new URL(url)), responseHandler
+    ).get();
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while getting compaction config status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+    return jsonMapper.readValue(response.getContent(), new TypeReference<CoordinatorCompactionConfig>() {});
+  }
+
+  public DataSourceCompactionConfig getDataSourceCompactionConfig(String dataSource) throws Exception
+  {
+    String url = StringUtils.format("%sconfig/compaction/%s", getCoordinatorURL(), StringUtils.urlEncode(dataSource));
+    StatusResponseHolder response = httpClient.go(
+        new Request(HttpMethod.GET, new URL(url)), responseHandler
+    ).get();
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while getting compaction config status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+    return jsonMapper.readValue(response.getContent(), new TypeReference<DataSourceCompactionConfig>() {});
+  }
+
+  public void forceTriggerAutoCompaction() throws Exception
+  {
+    String url = StringUtils.format("%scompaction/compact", getCoordinatorURL());
+    StatusResponseHolder response = httpClient.go(new Request(HttpMethod.POST, new URL(url)), responseHandler).get();
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while force trigger auto compaction status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+  }
+
+  public void updateCompactionTaskSlot(Double compactionTaskSlotRatio, Integer maxCompactionTaskSlots) throws Exception
+  {
+    String url = StringUtils.format("%sconfig/compaction/taskslots?ratio=%s&max=%s",
+                                    getCoordinatorURL(),
+                                    StringUtils.urlEncode(compactionTaskSlotRatio.toString()),
+                                    StringUtils.urlEncode(maxCompactionTaskSlots.toString()));
+    StatusResponseHolder response = httpClient.go(new Request(HttpMethod.POST, new URL(url)), responseHandler).get();
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while force trigger auto compaction status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+  }
+}

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/CoordinatorResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/CoordinatorResourceTestClient.java
@@ -79,6 +79,11 @@ public class CoordinatorResourceTestClient
     return StringUtils.format("%smetadata/datasources/%s/segments", getCoordinatorURL(), StringUtils.urlEncode(dataSource));
   }
 
+  private String getFullSegmentsMetadataURL(String dataSource)
+  {
+    return StringUtils.format("%smetadata/datasources/%s/segments?full", getCoordinatorURL(), StringUtils.urlEncode(dataSource));
+  }
+
   private String getIntervalsURL(String dataSource)
   {
     return StringUtils.format("%sdatasources/%s/intervals", getCoordinatorURL(), StringUtils.urlEncode(dataSource));
@@ -113,42 +118,22 @@ public class CoordinatorResourceTestClient
     return segments;
   }
 
-  public void submitCompactionConfig(final String dataSource) throws Exception
+  public List<DataSegment> getFullSegmentsMetadata(final String dataSource)
   {
-    Map<String, String> compactionConfig = ImmutableMap.<String, String>builder()
-                                                       .put("dataSource", dataSource)
-                                                       .put("maxRowsPerSegment", "1000000")
-                                                       .put("skipOffsetFromLatest", "PT0S")
-                                                       .build();
+    List<DataSegment> segments;
+    try {
+      StatusResponseHolder response = makeRequest(HttpMethod.GET, getFullSegmentsMetadataURL(dataSource));
 
-    String url = StringUtils.format("%sconfig/compaction", getCoordinatorURL());
-    StatusResponseHolder response = httpClient.go(
-        new Request(HttpMethod.POST, new URL(url)).setContent(
-            "application/json",
-            jsonMapper.writeValueAsBytes(compactionConfig)
-        ), responseHandler
-    ).get();
-
-    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
-      throw new ISE(
-          "Error while submiting compaction config status[%s] content[%s]",
-          response.getStatus(),
-          response.getContent()
+      segments = jsonMapper.readValue(
+          response.getContent(), new TypeReference<List<DataSegment>>()
+          {
+          }
       );
     }
-  }
-
-  public void forceTriggerAutoCompaction() throws Exception
-  {
-    String url = StringUtils.format("%scompaction/compact", getCoordinatorURL());
-    StatusResponseHolder response = httpClient.go(new Request(HttpMethod.POST, new URL(url)), responseHandler).get();
-    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
-      throw new ISE(
-          "Error while force trigger auto compaction status[%s] content[%s]",
-          response.getStatus(),
-          response.getContent()
-      );
+    catch (Exception e) {
+      throw new RuntimeException(e);
     }
+    return segments;
   }
 
   // return a list of the segment dates for the specified datasource

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.tests.coordinator.duty;
+
+import com.google.inject.Inject;
+import org.apache.commons.io.IOUtils;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.testing.IntegrationTestingConfig;
+import org.apache.druid.testing.guice.DruidTestModuleFactory;
+import org.apache.druid.testing.utils.ITRetryUtil;
+import org.apache.druid.tests.TestNGGroup;
+import org.apache.druid.tests.indexer.AbstractITBatchIndexTest;
+import org.apache.druid.tests.indexer.AbstractIndexerTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+@Test(groups = {TestNGGroup.OTHER_INDEX})
+@Guice(moduleFactory = DruidTestModuleFactory.class)
+public class ITAutoCompactionTest extends AbstractIndexerTest
+{
+  private static final Logger LOG = new Logger(ITAutoCompactionTest.class);
+  private static final String INDEX_TASK = "/indexer/wikipedia_index_task.json";
+  private static final String INDEX_QUERIES_RESOURCE = "/indexer/wikipedia_index_queries.json";
+
+  @Inject
+  private IntegrationTestingConfig config;
+
+  private String fullDatasourceName;
+
+  @BeforeMethod
+  public void setFullDatasourceName()
+  {
+    fullDatasourceName = "wikipedia_index_test_" + UUID.randomUUID() + config.getExtraDatasourceNameSuffix();
+  }
+
+  @Test
+  public void testAutoCompaction() throws Exception
+  {
+    loadData(INDEX_TASK);
+    // 4 segments across 2 days (4 total)
+    verifySegmentsCount(4);
+    final List<String> intervalsBeforeCompaction = coordinator.getSegmentIntervals(fullDatasourceName);
+    intervalsBeforeCompaction.sort(null);
+    try (final Closeable ignored = unloader(fullDatasourceName)) {
+      String queryResponseTemplate;
+      try {
+        InputStream is = AbstractITBatchIndexTest.class.getResourceAsStream(INDEX_QUERIES_RESOURCE);
+        queryResponseTemplate = IOUtils.toString(is, StandardCharsets.UTF_8);
+      }
+      catch (IOException e) {
+        throw new ISE(e, "could not read query file: %s", INDEX_QUERIES_RESOURCE);
+      }
+
+      queryResponseTemplate = StringUtils.replace(
+          queryResponseTemplate,
+          "%%DATASOURCE%%",
+          fullDatasourceName
+      );
+
+
+      queryHelper.testQueriesFromString(queryResponseTemplate, 2);
+      submitCompactionConfigAndTriggerAutoCompaction();
+
+      // 4 segments across 2 days, compacted into 1 new segments (5 total)
+      verifySegmentsCount(5);
+      queryHelper.testQueriesFromString(queryResponseTemplate, 2);
+
+      checkCompactionIntervals(intervalsBeforeCompaction);
+    }
+  }
+
+  private void loadData(String indexTask) throws Exception
+  {
+    String taskSpec = getResourceAsString(indexTask);
+    taskSpec = StringUtils.replace(taskSpec, "%%DATASOURCE%%", fullDatasourceName);
+    final String taskID = indexer.submitTask(taskSpec);
+    LOG.info("TaskID for loading index task %s", taskID);
+    indexer.waitUntilTaskCompletes(taskID);
+
+    ITRetryUtil.retryUntilTrue(
+        () -> coordinator.areSegmentsLoaded(fullDatasourceName),
+        "Segment Load"
+    );
+  }
+
+  private void submitCompactionConfigAndTriggerAutoCompaction() throws Exception
+  {
+    coordinator.submitCompactionConfig(fullDatasourceName);
+    coordinator.forceTriggerAutoCompaction();
+    waitForAllTasksToComplete();
+    ITRetryUtil.retryUntilTrue(
+        () -> coordinator.areSegmentsLoaded(fullDatasourceName),
+        "Segment Compaction"
+    );
+  }
+
+  private void verifySegmentsCount(int numExpectedSegments)
+  {
+    ITRetryUtil.retryUntilTrue(
+        () -> {
+          int metadataSegmentCount = coordinator.getSegments(fullDatasourceName).size();
+          LOG.info("Current metadata segment count: %d, expected: %d", metadataSegmentCount, numExpectedSegments);
+          return metadataSegmentCount == numExpectedSegments;
+        },
+        "Compaction segment count check"
+    );
+  }
+
+  private void checkCompactionIntervals(List<String> expectedIntervals)
+  {
+    ITRetryUtil.retryUntilTrue(
+        () -> {
+          final List<String> actualIntervals = coordinator.getSegmentIntervals(fullDatasourceName);
+          actualIntervals.sort(null);
+          return actualIntervals.equals(expectedIntervals);
+        },
+        "Compaction interval check"
+    );
+  }
+}

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -125,7 +125,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       //...compacted into 10 new segments across 2 days. 5 new segments each day (14 total)
       verifySegmentsCount(14);
       verifyQuery(INDEX_QUERIES_RESOURCE);
-      verifySegmentsCompacted(10, 2);
+      verifySegmentsCompacted(10, 1);
 
       checkCompactionIntervals(intervalsBeforeCompaction);
     }
@@ -203,7 +203,6 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(2, MAX_ROWS_PER_SEGMENT_COMPACTED);
       checkCompactionIntervals(intervalsBeforeCompaction);
-//      Assert.assertEquals(compactionResource.getCompactionProgress(fullDatasourceName).get("remainingSegmentSize"), "0");
     }
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -224,15 +224,6 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(0, null);
       checkCompactionIntervals(intervalsBeforeCompaction);
-
-      // Set compactionTaskSlotRatio and maxCompactionTaskSlots to allows only one task slot for compaction
-      updateCompactionTaskSlot(0.5, 1);
-      forceTriggerAutoCompaction();
-      // One day compacted (1 new segment) and one day remains uncompacted. (5 total)
-      verifySegmentsCount(5);
-      verifyQuery(INDEX_QUERIES_RESOURCE);
-      verifySegmentsCompacted(1, MAX_ROWS_PER_SEGMENT_COMPACTED);
-      checkCompactionIntervals(intervalsBeforeCompaction);
     }
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
@@ -91,11 +90,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -513,6 +513,12 @@ public class DruidCoordinator
     }
   }
 
+  public DutiesRunnable getCompactSegmentDutiesRunnable()
+  {
+    final int startingLeaderCounter = coordLeaderSelector.localTerm();
+    return new DutiesRunnable(makeCompactSegmentsDuty(), startingLeaderCounter);
+  }
+
   private void becomeLeader()
   {
     synchronized (lock) {
@@ -611,13 +617,20 @@ public class DruidCoordinator
   {
     List<CoordinatorDuty> duties = new ArrayList<>();
     duties.add(new LogUsedSegments());
-    duties.add(compactSegments);
+    duties.addAll(makeCompactSegmentsDuty());
     duties.addAll(indexingServiceDuties);
 
     log.debug(
         "Done making indexing service duties %s",
         duties.stream().map(duty -> duty.getClass().getName()).collect(Collectors.toList())
     );
+    return ImmutableList.copyOf(duties);
+  }
+
+  private List<CoordinatorDuty> makeCompactSegmentsDuty()
+  {
+    List<CoordinatorDuty> duties = new ArrayList<>();
+    duties.add(compactSegments);
     return ImmutableList.copyOf(duties);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -630,9 +630,7 @@ public class DruidCoordinator
 
   private List<CoordinatorDuty> makeCompactSegmentsDuty()
   {
-    List<CoordinatorDuty> duties = new ArrayList<>();
-    duties.add(compactSegments);
-    return ImmutableList.copyOf(duties);
+    return ImmutableList.of(compactSegments);
   }
 
   private class DutiesRunnable implements Runnable

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -26,7 +26,6 @@ import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.http.security.ConfigResourceFilter;
 import org.apache.druid.server.http.security.StateResourceFilter;
 
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.http;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import org.apache.druid.server.coordinator.DruidCoordinator;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/druid/coordinator/v1/compaction")
+public class CompactionResource
+{
+  private final DruidCoordinator coordinator;
+
+  @Inject
+  public CompactionResource(
+      DruidCoordinator coordinator
+  )
+  {
+    this.coordinator = coordinator;
+  }
+
+  @POST
+  @Path("/compact")
+  public Response forceTriggerCompaction()
+  {
+    DruidCoordinator.DutiesRunnable compactSegmentDutiesRunnable = coordinator.getCompactSegmentDutiesRunnable();
+    compactSegmentDutiesRunnable.run();
+    return Response.ok().build();
+  }
+
+  @GET
+  @Path("/remainingSegmentSize")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getTotalSizeOfSegmentsAwaitingCompaction(
+      @QueryParam("dataSource") String dataSource
+  )
+  {
+    final Long notCompactedSegmentSizeBytes = coordinator.getTotalSizeOfSegmentsAwaitingCompaction(dataSource);
+    if (notCompactedSegmentSizeBytes == null) {
+      return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", "unknown dataSource")).build();
+    } else {
+      return Response.ok(ImmutableMap.of("remainingSegmentSize", notCompactedSegmentSizeBytes)).build();
+    }
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -21,8 +21,12 @@ package org.apache.druid.server.http;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import com.sun.jersey.spi.container.ResourceFilters;
 import org.apache.druid.server.coordinator.DruidCoordinator;
+import org.apache.druid.server.http.security.ConfigResourceFilter;
+import org.apache.druid.server.http.security.StateResourceFilter;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -46,17 +50,18 @@ public class CompactionResource
 
   @POST
   @Path("/compact")
+  @ResourceFilters(ConfigResourceFilter.class)
   public Response forceTriggerCompaction()
   {
-    DruidCoordinator.DutiesRunnable compactSegmentDutiesRunnable = coordinator.getCompactSegmentDutiesRunnable();
-    compactSegmentDutiesRunnable.run();
+    coordinator.runCompactSegmentsDuty();
     return Response.ok().build();
   }
 
   @GET
-  @Path("/remainingSegmentSize")
+  @Path("/progress")
   @Produces(MediaType.APPLICATION_JSON)
-  public Response getTotalSizeOfSegmentsAwaitingCompaction(
+  @ResourceFilters(StateResourceFilter.class)
+  public Response getCompactionProgress(
       @QueryParam("dataSource") String dataSource
   )
   {

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.http;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
@@ -47,9 +48,13 @@ public class CompactionResource
     this.coordinator = coordinator;
   }
 
+  /**
+   * This API is meant to only be used by Druid's integration tests.
+   */
   @POST
   @Path("/compact")
   @ResourceFilters(ConfigResourceFilter.class)
+  @VisibleForTesting
   public Response forceTriggerCompaction()
   {
     coordinator.runCompactSegmentsDuty();

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorResource.java
@@ -161,19 +161,4 @@ public class CoordinatorResource
         )
     ).build();
   }
-
-  @GET
-  @Path("/remainingSegmentSizeForCompaction")
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response getTotalSizeOfSegmentsAwaitingCompaction(
-      @QueryParam("dataSource") String dataSource
-  )
-  {
-    final Long notCompactedSegmentSizeBytes = coordinator.getTotalSizeOfSegmentsAwaitingCompaction(dataSource);
-    if (notCompactedSegmentSizeBytes == null) {
-      return Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", "unknown dataSource")).build();
-    } else {
-      return Response.ok(ImmutableMap.of("remainingSegmentSize", notCompactedSegmentSizeBytes)).build();
-    }
-  }
 }

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorResource.java
@@ -36,7 +36,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import java.util.Map;
 
 /**

--- a/server/src/test/java/org/apache/druid/server/http/security/SecurityResourceFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/security/SecurityResourceFilterTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.server.ClientInfoResource;
 import org.apache.druid.server.QueryResource;
 import org.apache.druid.server.StatusResource;
 import org.apache.druid.server.http.BrokerResource;
+import org.apache.druid.server.http.CompactionResource;
 import org.apache.druid.server.http.CoordinatorDynamicConfigsResource;
 import org.apache.druid.server.http.CoordinatorResource;
 import org.apache.druid.server.http.DataSourcesResource;
@@ -72,8 +73,9 @@ public class SecurityResourceFilterTest extends ResourceFilterTestHelper
             getRequestPathsWithAuthorizer(StatusResource.class),
             getRequestPathsWithAuthorizer(SelfDiscoveryResource.class),
             getRequestPathsWithAuthorizer(BrokerQueryResource.class),
-            getRequestPathsWithAuthorizer(RouterResource.class)
-        )
+            getRequestPathsWithAuthorizer(RouterResource.class),
+            getRequestPathsWithAuthorizer(CompactionResource.class)
+            )
     );
   }
 

--- a/server/src/test/java/org/apache/druid/server/http/security/SecurityResourceFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/security/SecurityResourceFilterTest.java
@@ -75,7 +75,7 @@ public class SecurityResourceFilterTest extends ResourceFilterTestHelper
             getRequestPathsWithAuthorizer(BrokerQueryResource.class),
             getRequestPathsWithAuthorizer(RouterResource.class),
             getRequestPathsWithAuthorizer(CompactionResource.class)
-            )
+        )
     );
   }
 

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -72,6 +72,7 @@ import org.apache.druid.server.coordinator.LoadQueueTaskMaster;
 import org.apache.druid.server.coordinator.duty.CoordinatorDuty;
 import org.apache.druid.server.coordinator.duty.KillUnusedSegments;
 import org.apache.druid.server.http.ClusterResource;
+import org.apache.druid.server.http.CompactionResource;
 import org.apache.druid.server.http.CoordinatorCompactionConfigsResource;
 import org.apache.druid.server.http.CoordinatorDynamicConfigsResource;
 import org.apache.druid.server.http.CoordinatorRedirectInfo;
@@ -196,6 +197,7 @@ public class CliCoordinator extends ServerRunnable
                   .to(CoordinatorJettyServerInitializer.class);
 
             Jerseys.addResource(binder, CoordinatorResource.class);
+            Jerseys.addResource(binder, CompactionResource.class);
             Jerseys.addResource(binder, CoordinatorDynamicConfigsResource.class);
             Jerseys.addResource(binder, CoordinatorCompactionConfigsResource.class);
             Jerseys.addResource(binder, TiersResource.class);


### PR DESCRIPTION
Add API to trigger a compaction by the coordinator for integration tests and add new integration tests for the auto compaction on the coordinator.

### Description

The new API to manually trigger a compaction by the coordinator
- Need to add a new CompactionResource
- Move /remainingSegmentSizeForCompaction from CoordinatorResource to CompactionResource and rename it properly
- Add a new API /compact to CompactionResource to trigger a compaction by the coordinator for integration tests
- Document /remainingSegmentSizeForCompaction (/compact will not be documented as it is meant to be use only in integration tests)

Integration tests flow
- Test auto compaction successfully merge segment
- Test auto compaction successfully slit segment
- Test auto compaction successfully skip using the skipOffsetFromLatest
- Test successfully update compaction config
- Test successfully remove compaction config
- Test successfully update compaction slots

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.

