### PR TITLE
SQL: More straightforward handling of join planning.

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
@@ -244,7 +244,7 @@ public abstract class ExprEval<T>
   {
     private DoubleExprEval(@Nullable Number value)
     {
-      super(value == null ? NullHandling.defaultDoubleValue() : value);
+      super(value == null ? NullHandling.defaultDoubleValue() : (Double) value.doubleValue());
     }
 
     @Override
@@ -304,7 +304,7 @@ public abstract class ExprEval<T>
   {
     private LongExprEval(@Nullable Number value)
     {
-      super(value == null ? NullHandling.defaultLongValue() : value);
+      super(value == null ? NullHandling.defaultLongValue() : (Long) value.longValue());
     }
 
     @Override

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -175,7 +175,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   public void testArrayLength()
   {
     assertExpr("array_length([1,2,3])", 3L);
-    assertExpr("array_length(a)", 4);
+    assertExpr("array_length(a)", 4L);
   }
 
   @Test
@@ -199,7 +199,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   {
     assertExpr("array_offset_of([1, 2, 3], 3)", 2L);
     assertExpr("array_offset_of([1, 2, 3], 4)", NullHandling.replaceWithDefault() ? -1L : null);
-    assertExpr("array_offset_of(a, 'baz')", 2);
+    assertExpr("array_offset_of(a, 'baz')", 2L);
   }
 
   @Test
@@ -207,7 +207,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   {
     assertExpr("array_ordinal_of([1, 2, 3], 3)", 3L);
     assertExpr("array_ordinal_of([1, 2, 3], 4)", NullHandling.replaceWithDefault() ? -1L : null);
-    assertExpr("array_ordinal_of(a, 'baz')", 3);
+    assertExpr("array_ordinal_of(a, 'baz')", 3L);
   }
 
   @Test

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/CostEstimates.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/CostEstimates.java
@@ -74,13 +74,19 @@ public class CostEstimates
    * Multiplier to apply to an outer query via {@link DruidOuterQueryRel}. Encourages pushing down time-saving
    * operations to the lowest level of the query stack, because they'll have bigger impact there.
    */
-  static final double MULTIPLIER_OUTER_QUERY = 0.1;
+  static final double MULTIPLIER_OUTER_QUERY = .1;
 
   /**
-   * Multiplier to apply to a join when the left-hand side is a subquery. Encourages avoiding subqueries. Subqueries
-   * inside joins must be inlined, which incurs substantial reduction in scalability, so this high number is justified.
+   * Cost to add to a join when either side is a subquery. Strongly encourages avoiding subqueries, since they must be
+   * inlined and then the join must run on the Broker.
    */
-  static final double MULTIPLIER_JOIN_SUBQUERY = 1000000000;
+  static final double COST_JOIN_SUBQUERY = 1e5;
+
+  /**
+   * Cost to perform a cross join. Strongly encourages pushing down filters into join conditions, even if it means
+   * we need to add a subquery (this is higher than {@link #COST_JOIN_SUBQUERY}).
+   */
+  static final double COST_JOIN_CROSS = 1e8;
 
   private CostEstimates()
   {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
@@ -114,12 +114,6 @@ public class DruidOuterQueryRel extends DruidRel<DruidOuterQueryRel>
   }
 
   @Override
-  public int getQueryCount()
-  {
-    return 1 + ((DruidRel) sourceRel).getQueryCount();
-  }
-
-  @Override
   public DruidQuery toDruidQuery(final boolean finalizeAggregations)
   {
     // Must finalize aggregations on subqueries.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -112,7 +112,6 @@ public class DruidQuery
   private final Sorting sorting;
 
   private final Query query;
-  private final RowSignature sourceRowSignature;
   private final RowSignature outputRowSignature;
   private final RelDataType outputRowType;
   private final VirtualColumnRegistry virtualColumnRegistry;
@@ -135,7 +134,6 @@ public class DruidQuery
     this.selectProjection = selectProjection;
     this.grouping = grouping;
     this.sorting = sorting;
-    this.sourceRowSignature = Preconditions.checkNotNull(sourceRowSignature, "sourceRowSignature");
     this.outputRowSignature = computeOutputRowSignature(sourceRowSignature, selectProjection, grouping, sorting);
     this.outputRowType = Preconditions.checkNotNull(outputRowType, "outputRowType");
     this.virtualColumnRegistry = Preconditions.checkNotNull(virtualColumnRegistry, "virtualColumnRegistry");
@@ -976,6 +974,7 @@ public class DruidQuery
 
     // Compute the list of columns to select.
     final Set<String> columns = new HashSet<>(outputRowSignature.getColumnNames());
+
     if (order != ScanQuery.Order.NONE) {
       columns.add(ColumnHolder.TIME_COLUMN_NAME);
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
@@ -137,12 +137,6 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
   }
 
   @Override
-  public int getQueryCount()
-  {
-    return 1;
-  }
-
-  @Override
   public Sequence<Object[]> runQuery()
   {
     // runQuery doesn't need to finalize aggregations, because the fact that runQuery is happening suggests this

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidRel.java
@@ -45,13 +45,6 @@ public abstract class DruidRel<T extends DruidRel> extends AbstractRelNode
   @Nullable
   public abstract PartialDruidQuery getPartialDruidQuery();
 
-  /**
-   * Return the number of Druid queries this rel involves, including sub-queries. Simple queries will return 1.
-   *
-   * @return number of nested queries
-   */
-  public abstract int getQueryCount();
-
   public abstract Sequence<Object[]> runQuery();
 
   public abstract T withPartialQuery(PartialDruidQuery newQueryBuilder);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionRel.java
@@ -88,12 +88,6 @@ public class DruidUnionRel extends DruidRel<DruidUnionRel>
   }
 
   @Override
-  public int getQueryCount()
-  {
-    return rels.stream().mapToInt(rel -> ((DruidRel) rel).getQueryCount()).sum();
-  }
-
-  @Override
   @SuppressWarnings("unchecked")
   public Sequence<Object[]> runQuery()
   {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidJoinRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidJoinRule.java
@@ -21,22 +21,35 @@ package org.apache.druid.sql.calcite.rule;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.sql.calcite.rel.DruidJoinQueryRel;
 import org.apache.druid.sql.calcite.rel.DruidRel;
+import org.apache.druid.sql.calcite.rel.PartialDruidQuery;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Stack;
+import java.util.stream.Collectors;
 
 public class DruidJoinRule extends RelOptRule
 {
@@ -47,8 +60,8 @@ public class DruidJoinRule extends RelOptRule
     super(
         operand(
             Join.class,
-            operand(DruidRel.class, none()),
-            operand(DruidRel.class, none())
+            operand(DruidRel.class, any()),
+            operand(DruidRel.class, any())
         )
     );
   }
@@ -62,12 +75,7 @@ public class DruidJoinRule extends RelOptRule
   public boolean matches(RelOptRuleCall call)
   {
     final Join join = call.rel(0);
-    final DruidRel<?> right = call.rel(2);
-
-    // 1) Condition must be handleable.
-    // 2) Right cannot be a join; we want to generate left-heavy trees.
-    return canHandleCondition(join.getCondition(), join.getLeft().getRowType())
-           && !(right instanceof DruidJoinQueryRel);
+    return canHandleCondition(join.getCondition(), join.getLeft().getRowType());
   }
 
   @Override
@@ -77,50 +85,139 @@ public class DruidJoinRule extends RelOptRule
     final DruidRel<?> left = call.rel(1);
     final DruidRel<?> right = call.rel(2);
 
-    // Preconditions were already verified in "matches".
-    call.transformTo(DruidJoinQueryRel.create(join, left, right));
+    final RexBuilder rexBuilder = join.getCluster().getRexBuilder();
+
+    final DruidRel<?> newLeft;
+    final DruidRel<?> newRight;
+    final List<RexNode> newProjectExprs = new ArrayList<>();
+
+    // Already verified to be present in "matches", so just call "get".
+    ConditionAnalysis conditionAnalysis = analyzeCondition(join.getCondition(), join.getLeft().getRowType()).get();
+
+    if (left.getPartialDruidQuery().stage() == PartialDruidQuery.Stage.SELECT_PROJECT
+        && left.getPartialDruidQuery().getWhereFilter() == null) {
+      // Swap the left-side projection above the join, so the left side is a simple scan or mapping. This helps us
+      // avoid subqueries.
+      final RelNode leftScan = left.getPartialDruidQuery().getScan();
+      final Project leftProject = left.getPartialDruidQuery().getSelectProject();
+
+      // Left-side projection expressions rewritten to be on top of the join.
+      newProjectExprs.addAll(leftProject.getProjects());
+      newLeft = left.withPartialQuery(PartialDruidQuery.create(leftScan));
+      conditionAnalysis = conditionAnalysis.pushThroughLeftProject(leftProject);
+    } else {
+      // Leave left as-is. Write input refs that do nothing.
+      for (int i = 0; i < left.getRowType().getFieldCount(); i++) {
+        newProjectExprs.add(rexBuilder.makeInputRef(join.getRowType().getFieldList().get(i).getType(), i));
+      }
+
+      newLeft = left;
+    }
+
+    if (right.getPartialDruidQuery().stage() == PartialDruidQuery.Stage.SELECT_PROJECT
+        && right.getPartialDruidQuery().getWhereFilter() == null
+        && !right.getPartialDruidQuery().getSelectProject().isMapping()
+        && conditionAnalysis.onlyUsesMappingsFromRightProject(right.getPartialDruidQuery().getSelectProject())) {
+      // Swap the right-side projection above the join, so the right side is a simple scan or mapping. This helps us
+      // avoid subqueries.
+      final RelNode rightScan = right.getPartialDruidQuery().getScan();
+      final Project rightProject = right.getPartialDruidQuery().getSelectProject();
+
+      // Right-side projection expressions rewritten to be on top of the join.
+      Iterables.addAll(
+          newProjectExprs,
+          RexUtil.shift(rightProject.getProjects(), newLeft.getRowType().getFieldCount())
+      );
+      newRight = right.withPartialQuery(PartialDruidQuery.create(rightScan));
+      conditionAnalysis = conditionAnalysis.pushThroughRightProject(rightProject);
+    } else {
+      // Leave right as-is. Write input refs that do nothing.
+      for (int i = 0; i < right.getRowType().getFieldCount(); i++) {
+        newProjectExprs.add(
+            rexBuilder.makeInputRef(
+                join.getRowType().getFieldList().get(left.getRowType().getFieldCount() + i).getType(),
+                newLeft.getRowType().getFieldCount() + i
+            )
+        );
+      }
+
+      newRight = right;
+    }
+
+    // Druid join rewritten to be on top of the left scan. Right side is unchanged.
+    final DruidJoinQueryRel druidJoin = DruidJoinQueryRel.create(
+        join.copy(
+            join.getTraitSet(),
+            conditionAnalysis.getCondition(rexBuilder),
+            newLeft,
+            newRight,
+            join.getJoinType(),
+            join.isSemiJoinDone()
+        ),
+        left.getQueryMaker()
+    );
+
+    final RelBuilder relBuilder =
+        call.builder()
+            .push(druidJoin)
+            .project(
+                RexUtil.fixUp(
+                    rexBuilder,
+                    newProjectExprs,
+                    RelOptUtil.getFieldTypeList(druidJoin.getRowType())
+                )
+            );
+
+    call.transformTo(relBuilder.build());
   }
 
   /**
-   * Returns true if this condition is an AND of equality conditions of the form: f(LeftRel) = RightColumn.
-   *
-   * @see org.apache.druid.segment.join.JoinConditionAnalysis where "equiCondition" is the same concept.
+   * Returns whether {@link #analyzeCondition} would return something.
    */
   @VisibleForTesting
   static boolean canHandleCondition(final RexNode condition, final RelDataType leftRowType)
   {
+    return analyzeCondition(condition, leftRowType).isPresent();
+  }
+
+  /**
+   * If this condition is an AND of some combination of (1) literals; (2) equality conditions of the form
+   * {@code f(LeftRel) = RightColumn}, then return a {@link ConditionAnalysis}.
+   */
+  private static Optional<ConditionAnalysis> analyzeCondition(final RexNode condition, final RelDataType leftRowType)
+  {
     final List<RexNode> subConditions = decomposeAnd(condition);
+    final List<Pair<RexNode, RexInputRef>> equalitySubConditions = new ArrayList<>();
+    final List<RexLiteral> literalSubConditions = new ArrayList<>();
+    final int numLeftFields = leftRowType.getFieldCount();
 
     for (RexNode subCondition : subConditions) {
       if (subCondition.isA(SqlKind.LITERAL)) {
         // Literals are always OK.
+        literalSubConditions.add((RexLiteral) subCondition);
         continue;
       }
 
       if (!subCondition.isA(SqlKind.EQUALS)) {
         // If it's not EQUALS, it's not supported.
-        return false;
+        return Optional.empty();
       }
 
       final List<RexNode> operands = ((RexCall) subCondition).getOperands();
       Preconditions.checkState(operands.size() == 2, "Expected 2 operands, got[%,d]", operands.size());
 
-      final int numLeftFields = leftRowType.getFieldList().size();
-
-      final boolean rhsIsFieldOfRightRel =
-          operands.get(1).isA(SqlKind.INPUT_REF)
-          && ((RexInputRef) operands.get(1)).getIndex() >= numLeftFields;
-
-      final boolean lhsIsExpressionOfLeftRel =
-          RelOptUtil.InputFinder.bits(operands.get(0)).intersects(ImmutableBitSet.range(numLeftFields));
-
-      if (!(lhsIsExpressionOfLeftRel && rhsIsFieldOfRightRel)) {
+      if (isLeftExpression(operands.get(0), numLeftFields) && isRightInputRef(operands.get(1), numLeftFields)) {
+        equalitySubConditions.add(Pair.of(operands.get(0), (RexInputRef) operands.get(1)));
+      } else if (isRightInputRef(operands.get(0), numLeftFields)
+                 && isLeftExpression(operands.get(1), numLeftFields)) {
+        equalitySubConditions.add(Pair.of(operands.get(1), (RexInputRef) operands.get(0)));
+      } else {
         // Cannot handle this condition.
-        return false;
+        return Optional.empty();
       }
     }
 
-    return true;
+    return Optional.of(new ConditionAnalysis(numLeftFields, equalitySubConditions, literalSubConditions));
   }
 
   @VisibleForTesting
@@ -147,5 +244,149 @@ public class DruidJoinRule extends RelOptRule
     }
 
     return retVal;
+  }
+
+  private static boolean isLeftExpression(final RexNode rexNode, final int numLeftFields)
+  {
+    return ImmutableBitSet.range(numLeftFields).contains(RelOptUtil.InputFinder.bits(rexNode));
+  }
+
+  private static boolean isRightInputRef(final RexNode rexNode, final int numLeftFields)
+  {
+    return rexNode.isA(SqlKind.INPUT_REF) && ((RexInputRef) rexNode).getIndex() >= numLeftFields;
+  }
+
+  @VisibleForTesting
+  static class ConditionAnalysis
+  {
+    /**
+     * Number of fields on the left-hand side. Useful for identifying if a particular field is from on the left
+     * or right side of a join.
+     */
+    private final int numLeftFields;
+
+    /**
+     * Each equality subcondition is an equality of the form f(LeftRel) = g(RightRel).
+     */
+    private final List<Pair<RexNode, RexInputRef>> equalitySubConditions;
+
+    /**
+     * Each literal subcondition is... a literal.
+     */
+    private final List<RexLiteral> literalSubConditions;
+
+    ConditionAnalysis(
+        int numLeftFields,
+        List<Pair<RexNode, RexInputRef>> equalitySubConditions,
+        List<RexLiteral> literalSubConditions
+    )
+    {
+      this.numLeftFields = numLeftFields;
+      this.equalitySubConditions = equalitySubConditions;
+      this.literalSubConditions = literalSubConditions;
+    }
+
+    public ConditionAnalysis pushThroughLeftProject(final Project leftProject)
+    {
+      // Pushing through the project will shift right-hand field references by this amount.
+      final int rhsShift =
+          leftProject.getInput().getRowType().getFieldCount() - leftProject.getRowType().getFieldCount();
+
+      return new ConditionAnalysis(
+          leftProject.getInput().getRowType().getFieldCount(),
+          equalitySubConditions
+              .stream()
+              .map(
+                  equality -> Pair.of(
+                      RelOptUtil.pushPastProject(equality.lhs, leftProject),
+                      (RexInputRef) RexUtil.shift(equality.rhs, rhsShift)
+                  )
+              )
+              .collect(Collectors.toList()),
+          literalSubConditions
+      );
+    }
+
+    public ConditionAnalysis pushThroughRightProject(final Project rightProject)
+    {
+      Preconditions.checkArgument(onlyUsesMappingsFromRightProject(rightProject), "Cannot push through");
+
+      return new ConditionAnalysis(
+          numLeftFields,
+          equalitySubConditions
+              .stream()
+              .map(
+                  equality -> Pair.of(
+                      equality.lhs,
+                      (RexInputRef) RexUtil.shift(
+                          RelOptUtil.pushPastProject(
+                              RexUtil.shift(equality.rhs, -numLeftFields),
+                              rightProject
+                          ),
+                          numLeftFields
+                      )
+                  )
+              )
+              .collect(Collectors.toList()),
+          literalSubConditions
+      );
+    }
+
+    public boolean onlyUsesMappingsFromRightProject(final Project rightProject)
+    {
+      for (Pair<RexNode, RexInputRef> equality : equalitySubConditions) {
+        final int rightIndex = equality.rhs.getIndex() - numLeftFields;
+
+        if (!rightProject.getProjects().get(rightIndex).isA(SqlKind.INPUT_REF)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    public RexNode getCondition(final RexBuilder rexBuilder)
+    {
+      return RexUtil.composeConjunction(
+          rexBuilder,
+          Iterables.concat(
+              literalSubConditions,
+              equalitySubConditions
+                  .stream()
+                  .map(equality -> rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, equality.lhs, equality.rhs))
+                  .collect(Collectors.toList())
+          ),
+          false
+      );
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ConditionAnalysis that = (ConditionAnalysis) o;
+      return Objects.equals(equalitySubConditions, that.equalitySubConditions) &&
+             Objects.equals(literalSubConditions, that.literalSubConditions);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(equalitySubConditions, literalSubConditions);
+    }
+
+    @Override
+    public String toString()
+    {
+      return "ConditionAnalysis{" +
+             "equalitySubConditions=" + equalitySubConditions +
+             ", literalSubConditions=" + literalSubConditions +
+             '}';
+    }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidJoinRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidJoinRule.java
@@ -92,6 +92,7 @@ public class DruidJoinRule extends RelOptRule
     final List<RexNode> newProjectExprs = new ArrayList<>();
 
     // Already verified to be present in "matches", so just call "get".
+    // Can't be final, because we're going to reassign it up to a couple of times.
     ConditionAnalysis conditionAnalysis = analyzeCondition(join.getCondition(), join.getLeft().getRowType()).get();
 
     if (left.getPartialDruidQuery().stage() == PartialDruidQuery.Stage.SELECT_PROJECT
@@ -144,7 +145,7 @@ public class DruidJoinRule extends RelOptRule
       newRight = right;
     }
 
-    // Druid join rewritten to be on top of the left scan. Right side is unchanged.
+    // Druid join written on top of the new left and right sides.
     final DruidJoinQueryRel druidJoin = DruidJoinQueryRel.create(
         join.copy(
             join.getTraitSet(),


### PR DESCRIPTION
Two changes that simplify how joins are planned:

1) Stop using JoinProjectTransposeRule as a way of guiding subquery
removal. Instead, add logic to DruidJoinRule that identifies removable
subqueries and removes them at the point of creating a DruidJoinQueryRel.
This approach reduces the size of the planning space and allows the
planner to complete quickly.

2) Remove rules that reorder joins. Not because of an impact on the
planning time (it seems minimal), but because the decisions that the
planner was making in the new tests were sometimes worse than the
user-provided order. I think we'll need to go with the user-provided
order for now, and revisit reordering when we can add more smarts to
the cost estimator.

A third change updates numeric ExprEval classes to store their
value as a boxed type that corresponds to what it is supposed to be.
This is useful because it affects the behavior of "asString", and
is included in this patch because it is needed for the new test
"testInnerJoinTwoLookupsToTableUsingNumericColumnInReverse". This
test relies on CAST('6', 'DOUBLE') stringifying to "6.0" like an
actual double would.

Fixes #9646.