### PR TITLE
Document possible vulnerabilities for the druid-ranger-security

### DIFF
--- a/docs/development/extensions-core/druid-ranger-security.md
+++ b/docs/development/extensions-core/druid-ranger-security.md
@@ -30,6 +30,16 @@ Make sure to [include](../../development/extensions.md#loading-extensions) `drui
 
 Please see [Authentication and Authorization](../../design/auth.md) for more information on the extension interfaces being implemented.
 
+---
+**NOTE**
+
+The latest release of Apache Ranger is at the time of writing version 2.0. This version has a dependency
+on `log4j 1.2.17` which has a vulnerability if you configure it to use a `SocketServer` (CVE-2019-17571). Next to that,
+it also includes Kafka 2.0.0 which has 2 known vulnerabilities (CVE-2019-12399, CVE-2018-17196). Kafka can be used
+by the audit component in Ranger, but is not required. 
+
+---
+
 ## Configuration
 
 Support for Apache Ranger authorization consists of three elements: configuration of the extension 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -187,4 +187,36 @@
      <packageUrl regex="true">^pkg:npm/node\-sass@.*$</packageUrl>
      <vulnerabilityName>CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')</vulnerabilityName>
   </suppress>
+  <suppress>
+    <!--
+      ~ TODO: Fix when Apache Ranger 2.1 is released
+      -->
+    <notes><![CDATA[
+    file name: kafka_2.11-2.0.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka_2.11@2.0.0$</packageUrl>
+    <cve>CVE-2019-12399</cve>
+    <cve>CVE-2018-17196</cve>
+  </suppress>
+  <suppress>
+    <!--
+      ~ TODO: Fix when Apache Ranger 2.1 is released
+      -->
+    <notes><![CDATA[
+    file name: kafka-clients-2.0.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka-clients@2.0.0$</packageUrl>
+    <cve>CVE-2019-12399</cve>
+    <cve>CVE-2018-17196</cve>
+  </suppress>
+  <suppress>
+    <!--
+      ~ TODO: Fix when Apache Ranger is released with updated log4j
+      -->
+    <notes><![CDATA[
+    file name: log4j-1.2.17.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/log4j/log4j@1.2.17$</packageUrl>
+    <cve>CVE-2019-17571</cve>
+  </suppress>
 </suppressions>

--- a/website/.spelling
+++ b/website/.spelling
@@ -1727,3 +1727,6 @@ regionName
 json
 metastore
 UserGroupInformation
+CVE-2019-17571
+CVE-2019-12399
+CVE-2018-17196


### PR DESCRIPTION
In certain configurations the ranger plugin can expose vulnerabilities due
to some of its dependencies having CVEs.

@ccaominh @himanshug I have chosen to document rather than exclude. For log4j it seems not to be a full drop in replacement. In both it will only manifest itself in certain configurations which are non default.

In the mean time I am pushing Ranger to have a new release which will remove these issues.
