### PR TITLE
Upgrade netty 4 to fix CVE-2020-11612

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -917,7 +917,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.45.Final
+version: 4.1.48.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <netty3.version>3.10.6.Final</netty3.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <!-- Spark updated in https://github.com/apache/spark/pull/19884 -->
-        <netty4.version>4.1.45.Final</netty4.version>
+        <netty4.version>4.1.48.Final</netty4.version>
         <node.version>v10.14.2</node.version>
         <npm.version>6.5.0</npm.version>
         <postgresql.version>42.2.8</postgresql.version>


### PR DESCRIPTION
### Description

CVE-2020-11612 affects netty 4 versions 4.1.45 or older. Current latest version is 4.41.48.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
