### PR TITLE
Fix wrong cardinality computation in BufferArrayGrouper

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
@@ -73,7 +73,7 @@ public class BufferArrayGrouper implements VectorGrouper, IntGrouper
    * Computes required buffer capacity for a grouping key of the given cardinaltiy and aggregatorFactories.
    * This method assumes that the given cardinality doesn't count nulls.
    *
-   * Returns -1 if it cardinality + 1 (for null) = Integer.MAX_VALUE. Returns computed required buffer capacity
+   * Returns -1 if cardinality + 1 (for null) > Integer.MAX_VALUE. Returns computed required buffer capacity
    * otherwise.
    */
   static long requiredBufferCapacity(int cardinality, AggregatorFactory[] aggregatorFactories)

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -300,7 +300,11 @@ public class GroupByQueryEngineV2
       );
 
       // Check that all keys and aggregated values can be contained in the buffer
-      return requiredBufferCapacity <= buffer.capacity() ? cardinality : -1;
+      if (requiredBufferCapacity < 0 || requiredBufferCapacity > buffer.capacity()) {
+        return -1;
+      } else {
+        return cardinality;
+      }
     } else {
       return -1;
     }

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouperTest.java
@@ -110,20 +110,17 @@ public class BufferArrayGrouperTest
     final long[] requiredSizes;
 
     if (NullHandling.sqlCompatible()) {
-      // We need additional size to store nullability information.
-      requiredSizes = new long[]{19, 101, 19595788279L, 19595788288L};
+      // We need additional space to store nulls.
+      requiredSizes = new long[]{19, 101, 19595788279L, -1};
     } else {
-      requiredSizes = new long[]{17, 90, 17448304632L, 17448304640L};
+      requiredSizes = new long[]{17, 90, 17448304632L, -1};
     }
 
     for (int i = 0; i < cardinalityArray.length; i++) {
       Assert.assertEquals(
           StringUtils.format("cardinality[%d]", cardinalityArray[i]),
           requiredSizes[i],
-          BufferArrayGrouper.requiredBufferCapacity(
-              cardinalityArray[i],
-              aggregatorFactories
-          )
+          BufferArrayGrouper.requiredBufferCapacity(cardinalityArray[i], aggregatorFactories)
       );
     }
   }


### PR DESCRIPTION
### Description

The below query fails with an integer overflow because of wrong cardinality computation in `BufferArrayGrouper`.

```
> select count(*) from wikitikcer where page in (select k from lookup.lu);

Caused by: java.lang.IllegalArgumentException: Out of range: 2147483648
        at com.google.common.primitives.Ints.checkedCast(Ints.java:91) ~[guava-16.0.1.jar:?]
        at org.apache.druid.query.groupby.epinephelinae.BufferArrayGrouper.<init>(BufferArrayGrouper.java:111) ~[druid-processing-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2$ArrayAggregateIterator.newGrouper(GroupByQueryEngineV2.java:750) ~[druid-processing-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2$ArrayAggregateIterator.newGrouper(GroupByQueryEngineV2.java:712) ~[druid-processing-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2$GroupByEngineIterator.initNewDelegate(GroupByQueryEngineV2.java:411) ~[druid-processing-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2$GroupByEngineIterator.hasNext(GroupByQueryEngineV2.java:469) ~[druid-processing-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.BaseSequence.accumulate(BaseSequence.java:43) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.ConcatSequence.lambda$accumulate$0(ConcatSequence.java:41) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.MappingAccumulator.accumulate(MappingAccumulator.java:40) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.BaseSequence.accumulate(BaseSequence.java:44) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.MappedSequence.accumulate(MappedSequence.java:43) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.ConcatSequence.accumulate(ConcatSequence.java:41) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.WrappingSequence$1.get(WrappingSequence.java:50) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.SequenceWrapper.wrap(SequenceWrapper.java:55) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.java.util.common.guava.WrappingSequence.accumulate(WrappingSequence.java:45) ~[druid-core-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1$1.call(GroupByMergingQueryRunnerV2.java:246) ~[druid-processing-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1$1.call(GroupByMergingQueryRunnerV2.java:233) ~[druid-processing-0.19.0-SNAPSHOT.jar:0.19.0-SNAPSHOT]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_242]
```

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.