### PR TITLE
Add 0.18.0 to .backportrc.json to facilitate backport.

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,6 +2,7 @@
   "upstream": "apache/druid",
   "branches": [
     { "name": "0.16.1-incubating", "checked": true },
-    { "name": "0.17.0", "checked": true }
+    { "name": "0.17.0", "checked": true },
+    { "name": "0.18.0", "checked": true }
   ]
 }


### PR DESCRIPTION
@suneet-s, I found the `backport.md` doc useful when trying to backport [this fix](https://github.com/apache/druid/pull/9660) to `0.18.0`. Adding `0.18.0` to the config, so we could just run `backport` from the repo's working directory. Thanks!