### PR TITLE
[0.18.0] Fix potential integer overflow in BufferArrayGrouper (#9605)

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
@@ -191,6 +191,10 @@ public class BufferArrayGrouper implements VectorGrouper, IntGrouper
       throw new ISE("keySpace too large to handle");
     }
 
+    if (vAggregationPositions == null || vAggregationRows == null) {
+      throw new ISE("Grouper was not initialized for vectorization");
+    }
+
     if (keySpace.getCapacity() == 0) {
       // Empty key space, assume keys are all zeroes.
       final int dimIndex = 1;
@@ -206,7 +210,7 @@ public class BufferArrayGrouper implements VectorGrouper, IntGrouper
     } else {
       for (int i = 0; i < numRows; i++) {
         // +1 matches what hashFunction() would do.
-        final int dimIndex = keySpace.getInt(i * Integer.BYTES) + 1;
+        final int dimIndex = keySpace.getInt(((long) i) * Integer.BYTES) + 1;
 
         if (dimIndex < 0 || dimIndex >= cardinalityWithMissingValue) {
           throw new IAE("Invalid dimIndex[%s]", dimIndex);

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/collection/HashTableUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/collection/HashTableUtils.java
@@ -65,19 +65,19 @@ public class HashTableUtils
 
       case 9:
         return 31 * (31 * (31 + memory.getInt(position)) + memory.getInt(position + Integer.BYTES))
-               + memory.getByte(position + 2 * Integer.BYTES);
+               + memory.getByte(position + 2L * Integer.BYTES);
 
       case 12:
         return 31 * (31 * (31 + memory.getInt(position)) + memory.getInt(position + Integer.BYTES))
-               + memory.getInt(position + 2 * Integer.BYTES);
+               + memory.getInt(position + 2L * Integer.BYTES);
 
       case 13:
         return 31 * (31 * (31 * (31 + memory.getInt(position)) + memory.getInt(position + Integer.BYTES))
-                     + memory.getInt(position + 2 * Integer.BYTES)) + memory.getByte(position + 3 * Integer.BYTES);
+                     + memory.getInt(position + 2L * Integer.BYTES)) + memory.getByte(position + 3L * Integer.BYTES);
 
       case 16:
         return 31 * (31 * (31 * (31 + memory.getInt(position)) + memory.getInt(position + Integer.BYTES))
-                     + memory.getInt(position + 2 * Integer.BYTES)) + memory.getInt(position + 3 * Integer.BYTES);
+                     + memory.getInt(position + 2L * Integer.BYTES)) + memory.getInt(position + 3L * Integer.BYTES);
 
       default:
         int hashCode = 1;


### PR DESCRIPTION
Backports the following commits to 0.18.0:
 - Fix potential integer overflow in BufferArrayGrouper (#9605)