### PR TITLE
[Backport] Missing license changes for sources in licenses.yaml

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -21,7 +21,7 @@ license_category: source
 module: java-core
 license_name: Apache License version 2.0
 source_paths:
-  - processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+  - processing/src/main/java/org/apache/druid/segment/filter/cnf/HiveCnfHelper.java
   - extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregatorCollector.java
   - extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilter.java
 
@@ -42,6 +42,7 @@ module: java-core
 license_name: Apache License version 2.0
 source_paths:
   - sql/src/main/java/org/apache/druid/sql/calcite/
+  - processing/src/main/java/org/apache/druid/segment/filter/cnf/CalciteCnfHelper.java
 
 ---
 


### PR DESCRIPTION
Backport of #9678 to 0.18.0.