### PR TITLE
Fix flaky web console end-to-end test

### DIFF
--- a/web-console/e2e-tests/component/load-data/data-loader.ts
+++ b/web-console/e2e-tests/component/load-data/data-loader.ts
@@ -101,8 +101,12 @@ export class DataLoader {
     const rollupChecked = await rollup!.evaluate(el => (el as HTMLInputElement).checked);
     if (rollupChecked !== configureSchemaConfig.rollup) {
       await rollup!.click();
+      const confirmationDialogSelector = '//*[contains(@class,"bp3-alert-body")]';
+      await this.page.waitFor(confirmationDialogSelector);
       await this.clickButton('Yes');
-      await this.page.waitFor('.recipe-toaster');
+      const statusMessageSelector = '.recipe-toaster';
+      await this.page.waitFor(statusMessageSelector);
+      await this.page.click(`${statusMessageSelector} button`);
     }
   }
 

--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -56,7 +56,8 @@ function _get_zookeeper_version() {
 
 function _download_zookeeper() {
   local dest="$1"
-  local zk_version="$(_get_zookeeper_version)"
+  local zk_version
+  zk_version="$(_get_zookeeper_version)"
 
   _log "Downloading zookeeper"
   curl -s "https://archive.apache.org/dist/zookeeper/zookeeper-${zk_version}/zookeeper-${zk_version}.tar.gz" \
@@ -85,13 +86,13 @@ function _wait_for_200_response() {
 
   _log "Waiting for 200 response from ${url}"
 
-  until $(curl --output /dev/null --silent --head --fail "${url}"); do
-    if [ ${counter} -eq ${tries} ];then
+  until curl --output /dev/null --silent --head --fail "${url}"; do
+    if [ "${counter}" -eq "${tries}" ];then
       _error "Max of ${tries} tries exceeded"
     fi
 
     printf '.'
-    counter=$(($counter+1))
+    counter=$((counter+1))
     sleep "$delay"
   done
 
@@ -127,7 +128,8 @@ function start() {
 function stop() {
   _log "Stopping druid"
   if [ -f "${DRUID_PID_FILE}" ]; then
-    local pid="$(<${DRUID_PID_FILE})"
+    local pid
+    pid="$(<${DRUID_PID_FILE})"
     kill "$pid"
     rm "${DRUID_PID_FILE}"
     _log "Stopped pid ${pid}"
@@ -136,4 +138,5 @@ function stop() {
   fi
 }
 
-$@
+# Execute public method (passed as script argument)
+"$@"


### PR DESCRIPTION
### Description

`web-console/e2e-tests/tutorial-batch.spec.ts` would occasionally timeout between the transition from the data loader "configure schema" and "partition" steps due to missing waits when toggling the rollup setting.

Also, fix shellcheck warnings for `web-console/script/druid`.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested by running 50 times in Travis CI: https://travis-ci.org/github/ccaominh/druid/builds/673698848