### PR TITLE
Allow bootstrap.servers to be provided for Kafka ingestion.

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -194,7 +194,8 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
       String propertyKey = entry.getKey();
       if (propertyKey.equals(KafkaSupervisorIOConfig.TRUST_STORE_PASSWORD_KEY)
           || propertyKey.equals(KafkaSupervisorIOConfig.KEY_STORE_PASSWORD_KEY)
-          || propertyKey.equals(KafkaSupervisorIOConfig.KEY_PASSWORD_KEY)) {
+          || propertyKey.equals(KafkaSupervisorIOConfig.KEY_PASSWORD_KEY)
+          || propertyKey.equals(KafkaSupervisorIOConfig.BOOTSTRAP_SERVERS_KEY)) {
         PasswordProvider configPasswordProvider = configMapper.convertValue(
             entry.getValue(),
             PasswordProvider.class

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
@@ -171,7 +171,7 @@ public class KafkaSupervisorIOConfigTest
     String jsonStr = "{\n"
                      + "  \"type\": \"kafka\",\n"
                      + "  \"topic\": \"my-topic\",\n"
-                     + "  \"consumerProperties\": {\"bootstrap.servers\":\"localhost:9092\",\n"
+                     + "  \"consumerProperties\": {\"bootstrap.servers\":{\"type\": \"default\", \"password\": \"localhost:9092\"},\n"
                      + "   \"ssl.truststore.password\":{\"type\": \"default\", \"password\": \"mytruststorepassword\"},\n"
                      + "   \"ssl.keystore.password\":{\"type\": \"default\", \"password\": \"mykeystorepassword\"},\n"
                      + "   \"ssl.key.password\":\"mykeypassword\"}\n"


### PR DESCRIPTION
Addresses #8685, allowing for `bootstrap.servers` to be provided by a PasswordProvider instead of hard-coded.

### Description

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
Modified `KafkaRecordSupplier.addConsumerPropertiesFromConfig` to check for a password provider when deserializing `bootstrap.servers` as it currently does when deserializing trust and key store passwords. This does not implement the further suggestion on #8685 to allow any field to be provided by a PasswordProvider because #6666 is still an open issue.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `KafkaRecordSupplier`
