### PR TITLE
fixes for inline subqueries when multi-value dimension is present

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -333,7 +333,7 @@ public class GroupByQueryEngineV2
 
               // Now check column capabilities.
               final ColumnCapabilities columnCapabilities = capabilitiesFunction.apply(dimension.getDimension());
-              return columnCapabilities == null || !columnCapabilities.hasMultipleValues();
+              return columnCapabilities != null && !columnCapabilities.hasMultipleValues();
             });
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -227,7 +227,7 @@ public class GroupByQueryEngineV2
                       processingBuffer,
                       fudgeTimestamp,
                       dims,
-                      isAllSingleValueDims(columnSelectorFactory::getColumnCapabilities, query.getDimensions()),
+                      isAllSingleValueDims(columnSelectorFactory::getColumnCapabilities, query.getDimensions(), false),
                       cardinalityForArrayAggregation
                   );
                 } else {
@@ -238,7 +238,7 @@ public class GroupByQueryEngineV2
                       processingBuffer,
                       fudgeTimestamp,
                       dims,
-                      isAllSingleValueDims(columnSelectorFactory::getColumnCapabilities, query.getDimensions())
+                      isAllSingleValueDims(columnSelectorFactory::getColumnCapabilities, query.getDimensions(), false)
                   );
                 }
               }
@@ -313,12 +313,15 @@ public class GroupByQueryEngineV2
   }
 
   /**
-   * Checks whether all "dimensions" are either single-valued or nonexistent (which is just as good as single-valued,
-   * since their selectors will show up as full of nulls).
+   * Checks whether all "dimensions" are either single-valued, or if allowed, nonexistent. Since non-existent column
+   * selectors will show up as full of nulls they are effectively single valued, however they can also be null during
+   * broker merge, for example with an 'inline' datasource subquery. 'missingMeansNonexistent' is sort of a hack to let
+   * the vectorized engine, which only operates on actual segments, to still work in this case for non-existent columns.
    */
   public static boolean isAllSingleValueDims(
       final Function<String, ColumnCapabilities> capabilitiesFunction,
-      final List<DimensionSpec> dimensions
+      final List<DimensionSpec> dimensions,
+      final boolean missingMeansNonexistent
   )
   {
     return dimensions
@@ -333,7 +336,8 @@ public class GroupByQueryEngineV2
 
               // Now check column capabilities.
               final ColumnCapabilities columnCapabilities = capabilitiesFunction.apply(dimension.getDimension());
-              return columnCapabilities != null && !columnCapabilities.hasMultipleValues();
+              return (columnCapabilities != null && !columnCapabilities.hasMultipleValues()) ||
+                     (missingMeansNonexistent && columnCapabilities == null);
             });
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/vector/VectorGroupByEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/vector/VectorGroupByEngine.java
@@ -83,7 +83,7 @@ public class VectorGroupByEngine
     // This situation should sort itself out pretty well once this engine supports multi-valued columns. Then we
     // won't have to worry about having this all-single-value-dims check here.
 
-    return GroupByQueryEngineV2.isAllSingleValueDims(adapter::getColumnCapabilities, query.getDimensions())
+    return GroupByQueryEngineV2.isAllSingleValueDims(adapter::getColumnCapabilities, query.getDimensions(), true)
            && query.getDimensions().stream().allMatch(DimensionSpec::canVectorize)
            && query.getAggregatorSpecs().stream().allMatch(AggregatorFactory::canVectorize)
            && adapter.canVectorize(filter, query.getVirtualColumns(), false);

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -132,7 +132,7 @@ public class TopNQueryEngine
       topNAlgorithm = new TimeExtractionTopNAlgorithm(adapter, query);
     } else if (selector.isHasExtractionFn()) {
       topNAlgorithm = new HeapBasedTopNAlgorithm(adapter, query);
-    } else if (columnCapabilities != null && !(columnCapabilities.getType() == ValueType.STRING
+    } else if (columnCapabilities == null || !(columnCapabilities.getType() == ValueType.STRING
                                                && columnCapabilities.isDictionaryEncoded())) {
       // Use HeapBasedTopNAlgorithm for non-Strings and for non-dictionary-encoded Strings.
       topNAlgorithm = new HeapBasedTopNAlgorithm(adapter, query);

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -134,7 +134,8 @@ public class TopNQueryEngine
       topNAlgorithm = new HeapBasedTopNAlgorithm(adapter, query);
     } else if (columnCapabilities == null || !(columnCapabilities.getType() == ValueType.STRING
                                                && columnCapabilities.isDictionaryEncoded())) {
-      // Use HeapBasedTopNAlgorithm for non-Strings and for non-dictionary-encoded Strings.
+      // Use HeapBasedTopNAlgorithm for non-Strings and for non-dictionary-encoded Strings, and for things we don't know
+      // which can happen for 'inline' data sources when this is run on the broker
       topNAlgorithm = new HeapBasedTopNAlgorithm(adapter, query);
     } else if (query.getDimensionSpec().getOutputType() != ValueType.STRING) {
       // Use HeapBasedTopNAlgorithm when the dimension output type is a non-String. (It's like an extractionFn: there can be

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -4551,8 +4551,6 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithNonexistentDimension()
   {
-    // column capabilities are null so is treated as potentially multi-value
-    cannotVectorize();
     GroupByQuery.Builder builder = makeQueryBuilder()
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setInterval("2011-04-02/2011-04-04")
@@ -8081,8 +8079,6 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithExtractionDimFilterKeyisNull()
   {
-    // column capabilities are null so is treated as potentially multi-value
-    cannotVectorize();
     Map<String, String> extractionMap = new HashMap<>();
 
 
@@ -8349,8 +8345,6 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithExtractionDimFilterNullDims()
   {
-    // column capabilities are null so is treated as potentially multi-value
-    cannotVectorize();
     Map<String, String> extractionMap = new HashMap<>();
     extractionMap.put("", "EMPTY");
 
@@ -8479,8 +8473,6 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithAllFiltersOnNullDimsWithExtractionFns()
   {
-    // column capabilities are null so is treated as potentially multi-value
-    cannotVectorize();
     Map<String, String> extractionMap = new HashMap<>();
     extractionMap.put("", "EMPTY");
     extractionMap.put(null, "EMPTY");

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -4551,6 +4551,8 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithNonexistentDimension()
   {
+    // column capabilities are null so is treated as potentially multi-value
+    cannotVectorize();
     GroupByQuery.Builder builder = makeQueryBuilder()
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setInterval("2011-04-02/2011-04-04")
@@ -8079,6 +8081,8 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithExtractionDimFilterKeyisNull()
   {
+    // column capabilities are null so is treated as potentially multi-value
+    cannotVectorize();
     Map<String, String> extractionMap = new HashMap<>();
 
 
@@ -8345,6 +8349,8 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithExtractionDimFilterNullDims()
   {
+    // column capabilities are null so is treated as potentially multi-value
+    cannotVectorize();
     Map<String, String> extractionMap = new HashMap<>();
     extractionMap.put("", "EMPTY");
 
@@ -8473,6 +8479,8 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByWithAllFiltersOnNullDimsWithExtractionFns()
   {
+    // column capabilities are null so is treated as potentially multi-value
+    cannotVectorize();
     Map<String, String> extractionMap = new HashMap<>();
     extractionMap.put("", "EMPTY");
     extractionMap.put(null, "EMPTY");


### PR DESCRIPTION
Fixes #9697.

### Description
Modifies Group By queries to treat unknown column capabilities as potentially multi-value dimensions, and TopN query to use `HeapBasedTopNAlgorithm` when capabilities are unknown to handle strings without known cardinality and numbers.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `GroupByQueryEngineV2`
 * `TopNQueryEngine`