### PR TITLE
Revert "remove ServerDiscoverySelector from DruidLeaderClient (#9481)"

### DIFF
--- a/server/src/main/java/org/apache/druid/guice/IndexingServiceDiscoveryModule.java
+++ b/server/src/main/java/org/apache/druid/guice/IndexingServiceDiscoveryModule.java
@@ -24,6 +24,8 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.client.indexing.IndexingServiceSelectorConfig;
+import org.apache.druid.curator.discovery.ServerDiscoveryFactory;
+import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
@@ -43,16 +45,29 @@ public class IndexingServiceDiscoveryModule implements Module
   @Provides
   @IndexingService
   @ManageLifecycle
+  public ServerDiscoverySelector getServiceProvider(
+      IndexingServiceSelectorConfig config,
+      ServerDiscoveryFactory serverDiscoveryFactory
+  )
+  {
+    return serverDiscoveryFactory.createSelector(config.getServiceName());
+  }
+
+  @Provides
+  @IndexingService
+  @ManageLifecycle
   public DruidLeaderClient getLeaderHttpClient(
       @EscalatedGlobal HttpClient httpClient,
-      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
+      @IndexingService ServerDiscoverySelector serverDiscoverySelector
   )
   {
     return new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.OVERLORD,
-        "/druid/indexer/v1/leader"
+        "/druid/indexer/v1/leader",
+        serverDiscoverySelector
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
@@ -29,6 +29,7 @@ import com.google.inject.Module;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.servlet.GuiceFilter;
+import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.Jerseys;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -122,7 +123,8 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader"
+        "/simple/leader",
+        EasyMock.createNiceMock(ServerDiscoverySelector.class)
     );
     druidLeaderClient.start();
 
@@ -146,7 +148,8 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader"
+        "/simple/leader",
+        EasyMock.createNiceMock(ServerDiscoverySelector.class)
     );
     druidLeaderClient.start();
 
@@ -172,7 +175,8 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader"
+        "/simple/leader",
+        EasyMock.createNiceMock(ServerDiscoverySelector.class)
     );
     druidLeaderClient.start();
 
@@ -184,6 +188,9 @@ public class DruidLeaderClientTest extends BaseJettyTest
   @Test
   public void testServerFailureAndRedirect() throws Exception
   {
+    ServerDiscoverySelector serverDiscoverySelector = EasyMock.createMock(ServerDiscoverySelector.class);
+    EasyMock.expect(serverDiscoverySelector.pick()).andReturn(null).anyTimes();
+
     DruidNodeDiscovery druidNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
     DiscoveryDruidNode dummyNode = new DiscoveryDruidNode(
         new DruidNode("test", "dummyhost", false, 64231, null, true, false),
@@ -196,13 +203,14 @@ public class DruidLeaderClientTest extends BaseJettyTest
     DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
     EasyMock.expect(druidNodeDiscoveryProvider.getForNodeRole(NodeRole.PEON)).andReturn(druidNodeDiscovery).anyTimes();
 
-    EasyMock.replay(druidNodeDiscovery, druidNodeDiscoveryProvider);
+    EasyMock.replay(serverDiscoverySelector, druidNodeDiscovery, druidNodeDiscoveryProvider);
 
     DruidLeaderClient druidLeaderClient = new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader"
+        "/simple/leader",
+        serverDiscoverySelector
     );
     druidLeaderClient.start();
 
@@ -228,7 +236,8 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader"
+        "/simple/leader",
+        EasyMock.createNiceMock(ServerDiscoverySelector.class)
     );
     druidLeaderClient.start();
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -360,7 +360,7 @@ public class CompactSegmentsTest
 
     private TestDruidLeaderClient(ObjectMapper jsonMapper)
     {
-      super(null, new TestNodeDiscoveryProvider(), null, null);
+      super(null, new TestNodeDiscoveryProvider(), null, null, null);
       this.jsonMapper = jsonMapper;
     }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -773,7 +773,10 @@ public class CalciteTests
         new FakeHttpClient(),
         provider,
         NodeRole.COORDINATOR,
-        "/simple/leader"
+        "/simple/leader",
+        () -> {
+          throw new UnsupportedOperationException();
+        }
     );
 
     return new SystemSchema(


### PR DESCRIPTION
This reverts commit 072bbe210f162228e85391b464f114da448df24a.

Fixes https://github.com/apache/druid/issues/9701.