### PR TITLE
add joins to column tree menu

### DIFF
--- a/web-console/lib/keywords.js
+++ b/web-console/lib/keywords.js
@@ -40,7 +40,7 @@ exports.SQL_KEYWORDS = [
   'ON',
   'RIGHT',
   'OUTER',
-  'Full'
+  'FULL'
 ];
 
 exports.SQL_EXPRESSION_PARTS = [

--- a/web-console/lib/keywords.js
+++ b/web-console/lib/keywords.js
@@ -38,6 +38,9 @@ exports.SQL_KEYWORDS = [
   'LEFT',
   'INNER',
   'ON',
+  'RIGHT',
+  'OUTER',
+  'Full'
 ];
 
 exports.SQL_EXPRESSION_PARTS = [

--- a/web-console/lib/keywords.js
+++ b/web-console/lib/keywords.js
@@ -34,6 +34,10 @@ exports.SQL_KEYWORDS = [
   'DESC',
   'LIMIT',
   'UNION ALL',
+  'JOIN',
+  'LEFT',
+  'INNER',
+  'ON',
 ];
 
 exports.SQL_EXPRESSION_PARTS = [

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -4237,9 +4237,9 @@
       }
     },
     "druid-query-toolkit": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.4.3.tgz",
-      "integrity": "sha512-g2xHaD9lhpTZjM9UEiOQBpgBvO1hm0/cVgqymbUIUf6cgBCm7C1o20fHQzCEK4FBhVmWQSt63pjhRaQ+OM4FGQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.5.1.tgz",
+      "integrity": "sha512-oI1YddnzIbkcelI93qaRtonu3PLGw65fDqLLK6e35gD4Ef/Yf8bOZvFK9wDYNAXcA6SDy7UDarfWsgD2dDWsjg==",
       "requires": {
         "tslib": "^1.10.0"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -65,7 +65,7 @@
     "d3-axis": "^1.0.12",
     "d3-scale": "^3.2.0",
     "d3-selection": "^1.4.0",
-    "druid-query-toolkit": "^0.4.3",
+    "druid-query-toolkit": "^0.5.1",
     "file-saver": "^2.0.2",
     "has-own-prop": "^2.0.0",
     "hjson": "^3.2.1",

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
@@ -28,6 +28,8 @@ describe('number menu', () => {
   it('matches snapshot when menu is opened for column not inside group by', () => {
     const numberMenu = (
       <NumberMenuItems
+        schema="schema"
+        table="table"
         columnName={'added'}
         parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
@@ -41,6 +43,8 @@ describe('number menu', () => {
   it('matches snapshot when menu is opened for column inside group by', () => {
     const numberMenu = (
       <NumberMenuItems
+        schema="schema"
+        table="table"
         columnName={'added'}
         parsedQuery={parser(`SELECT added, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
@@ -196,11 +196,11 @@ export const NumberMenuItems = React.memo(function NumberMenuItems(props: Number
       <>
         <MenuItem
           icon={IconNames.JOIN_TABLE}
-          text={parsedQuery.joinTable ? `Replace Join` : `Join`}
+          text={parsedQuery.joinTable ? `Replace join` : `Join`}
         >
           <MenuItem
             icon={IconNames.LEFT_JOIN}
-            text={`Left Join`}
+            text={`Left join`}
             onClick={() => {
               onQueryChange(
                 parsedQuery.addJoin(
@@ -220,7 +220,7 @@ export const NumberMenuItems = React.memo(function NumberMenuItems(props: Number
           />
           <MenuItem
             icon={IconNames.INNER_JOIN}
-            text={`Inner Join`}
+            text={`Inner join`}
             onClick={() => {
               onQueryChange(
                 parsedQuery.addJoin(
@@ -244,7 +244,7 @@ export const NumberMenuItems = React.memo(function NumberMenuItems(props: Number
           parsedQuery.onExpression.containsColumn(columnName) && (
             <MenuItem
               icon={IconNames.EXCHANGE}
-              text={`Remove Join`}
+              text={`Remove join`}
               onClick={() => onQueryChange(parsedQuery.removeJoin())}
             />
           )}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
@@ -28,6 +28,8 @@ import {
 } from 'druid-query-toolkit';
 import React from 'react';
 
+import { getCurrentColumns } from '../../column-tree';
+
 export interface NumberMenuItemsProps {
   table: string;
   schema: string;
@@ -188,6 +190,8 @@ export const NumberMenuItems = React.memo(function NumberMenuItems(props: Number
     const { schema, table, columnName, parsedQuery, onQueryChange } = props;
     if (schema !== 'lookup' || !parsedQuery) return;
 
+    const { originalTableColumn, lookupColumn } = getCurrentColumns(parsedQuery, table);
+
     return (
       <>
         <MenuItem
@@ -204,7 +208,10 @@ export const NumberMenuItems = React.memo(function NumberMenuItems(props: Number
                   SqlRef.fromString(table, schema).upgrade(),
                   SqlMulti.sqlMultiFactory('=', [
                     SqlRef.fromString(columnName, table, 'lookup'),
-                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                    SqlRef.fromString(
+                      lookupColumn === columnName ? originalTableColumn : 'XXX',
+                      parsedQuery.getTableName(),
+                    ),
                   ]),
                 ),
                 false,
@@ -221,7 +228,10 @@ export const NumberMenuItems = React.memo(function NumberMenuItems(props: Number
                   SqlRef.fromString(table, schema).upgrade(),
                   SqlMulti.sqlMultiFactory('=', [
                     SqlRef.fromString(columnName, table, 'lookup'),
-                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                    SqlRef.fromString(
+                      lookupColumn === columnName ? originalTableColumn : 'XXX',
+                      parsedQuery.getTableName(),
+                    ),
                   ]),
                 ),
                 false,

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
@@ -234,7 +234,7 @@ export const NumberMenuItems = React.memo(function NumberMenuItems(props: Number
           parsedQuery.onExpression.containsColumn(columnName) && (
             <MenuItem
               icon={IconNames.EXCHANGE}
-              text={`Remove join`}
+              text={`Remove Join`}
               onClick={() => onQueryChange(parsedQuery.removeJoin())}
             />
           )}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
@@ -28,6 +28,8 @@ describe('string menu', () => {
   it('matches snapshot when menu is opened for column not inside group by', () => {
     const stringMenu = (
       <StringMenuItems
+        table={'table'}
+        schema={'schema'}
         columnName={'cityName'}
         parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
@@ -41,6 +43,8 @@ describe('string menu', () => {
   it('matches snapshot when menu is opened for column inside group by', () => {
     const stringMenu = (
       <StringMenuItems
+        table={'table'}
+        schema={'schema'}
         columnName={'channel'}
         parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
@@ -215,7 +215,7 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
           parsedQuery.onExpression.containsColumn(columnName) && (
             <MenuItem
               icon={IconNames.EXCHANGE}
-              text={`Remove join`}
+              text={`Remove Join`}
               onClick={() => onQueryChange(parsedQuery.removeJoin())}
             />
           )}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
@@ -28,6 +28,8 @@ import {
 } from 'druid-query-toolkit';
 import React from 'react';
 
+import { getCurrentColumns } from '../../column-tree';
+
 export interface StringMenuItemsProps {
   schema: string;
   table: string;
@@ -169,6 +171,8 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
     const { schema, table, columnName, parsedQuery, onQueryChange } = props;
     if (schema !== 'lookup' || !parsedQuery) return;
 
+    const { originalTableColumn, lookupColumn } = getCurrentColumns(parsedQuery, table);
+
     return (
       <>
         <MenuItem
@@ -185,7 +189,10 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
                   SqlRef.fromString(table, schema).upgrade(),
                   SqlMulti.sqlMultiFactory('=', [
                     SqlRef.fromString(columnName, table, 'lookup'),
-                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                    SqlRef.fromString(
+                      lookupColumn === columnName ? originalTableColumn : 'XXX',
+                      parsedQuery.getTableName(),
+                    ),
                   ]),
                 ),
                 false,
@@ -202,7 +209,10 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
                   SqlRef.fromString(table, schema).upgrade(),
                   SqlMulti.sqlMultiFactory('=', [
                     SqlRef.fromString(columnName, table, 'lookup'),
-                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                    SqlRef.fromString(
+                      lookupColumn === columnName ? originalTableColumn : 'XXX',
+                      parsedQuery.getTableName(),
+                    ),
                   ]),
                 ),
                 false,

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
@@ -29,6 +29,8 @@ import {
 import React from 'react';
 
 export interface StringMenuItemsProps {
+  schema: string;
+  table: string;
   columnName: string;
   parsedQuery: SqlQuery;
   onQueryChange: (queryString: SqlQuery, run?: boolean) => void;
@@ -95,7 +97,7 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
           text={`"${columnName}"`}
           onClick={() => {
             onQueryChange(
-              parsedQuery.addToGroupBy(SqlRef.fromNameWithDoubleQuotes(columnName)),
+              parsedQuery.addToGroupBy(SqlRef.fromStringWithDoubleQuotes(columnName)),
               true,
             );
           }}
@@ -107,7 +109,7 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
               parsedQuery.addToGroupBy(
                 SqlAliasRef.sqlAliasFactory(
                   SqlFunction.sqlFunctionFactory('SUBSTRING', [
-                    SqlRef.fromNameWithDoubleQuotes(columnName),
+                    SqlRef.fromStringWithDoubleQuotes(columnName),
                     SqlLiteral.fromInput(1),
                     SqlLiteral.fromInput(2),
                   ]),
@@ -133,7 +135,7 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
           onClick={() =>
             onQueryChange(
               parsedQuery.addAggregateColumn(
-                [SqlRef.fromNameWithDoubleQuotes(columnName)],
+                [SqlRef.fromStringWithDoubleQuotes(columnName)],
                 'COUNT',
                 `dist_${columnName}`,
                 undefined,
@@ -148,11 +150,11 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
           onClick={() => {
             onQueryChange(
               parsedQuery.addAggregateColumn(
-                [SqlRef.fromName('*')],
+                [SqlRef.fromString('*')],
                 'COUNT',
                 `${columnName}_filtered_count`,
                 SqlMulti.sqlMultiFactory('=', [
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   SqlLiteral.fromInput('xxx'),
                 ]),
               ),
@@ -163,6 +165,64 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
     );
   }
 
+  function renderJoinMenu(): JSX.Element | undefined {
+    const { schema, table, columnName, parsedQuery, onQueryChange } = props;
+    if (schema !== 'lookup' || !parsedQuery) return;
+
+    return (
+      <>
+        <MenuItem
+          icon={IconNames.JOIN_TABLE}
+          text={parsedQuery.joinTable ? `Replace Join` : `Join`}
+        >
+          <MenuItem
+            icon={IconNames.LEFT_JOIN}
+            text={`Left Join`}
+            onClick={() => {
+              onQueryChange(
+                parsedQuery.addJoin(
+                  'LEFT',
+                  SqlRef.fromString(table, schema).upgrade(),
+                  SqlMulti.sqlMultiFactory('=', [
+                    SqlRef.fromString(columnName, table, 'lookup'),
+                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                  ]),
+                ),
+                false,
+              );
+            }}
+          />
+          <MenuItem
+            icon={IconNames.INNER_JOIN}
+            text={`Inner Join`}
+            onClick={() => {
+              onQueryChange(
+                parsedQuery.addJoin(
+                  'INNER',
+                  SqlRef.fromString(table, schema).upgrade(),
+                  SqlMulti.sqlMultiFactory('=', [
+                    SqlRef.fromString(columnName, table, 'lookup'),
+                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                  ]),
+                ),
+                false,
+              );
+            }}
+          />
+        </MenuItem>
+        {parsedQuery.onExpression &&
+          parsedQuery.onExpression instanceof SqlMulti &&
+          parsedQuery.onExpression.containsColumn(columnName) && (
+            <MenuItem
+              icon={IconNames.EXCHANGE}
+              text={`Remove join`}
+              onClick={() => onQueryChange(parsedQuery.removeJoin())}
+            />
+          )}
+      </>
+    );
+  }
+
   return (
     <>
       {renderFilterMenu()}
@@ -170,6 +230,7 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
       {renderGroupByMenu()}
       {renderRemoveGroupBy()}
       {renderAggregateMenu()}
+      {renderJoinMenu()}
     </>
   );
 });

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
@@ -177,11 +177,11 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
       <>
         <MenuItem
           icon={IconNames.JOIN_TABLE}
-          text={parsedQuery.joinTable ? `Replace Join` : `Join`}
+          text={parsedQuery.joinTable ? `Replace join` : `Join`}
         >
           <MenuItem
             icon={IconNames.LEFT_JOIN}
-            text={`Left Join`}
+            text={`Left join`}
             onClick={() => {
               onQueryChange(
                 parsedQuery.addJoin(
@@ -201,7 +201,7 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
           />
           <MenuItem
             icon={IconNames.INNER_JOIN}
-            text={`Inner Join`}
+            text={`Inner join`}
             onClick={() => {
               onQueryChange(
                 parsedQuery.addJoin(
@@ -225,7 +225,7 @@ export const StringMenuItems = React.memo(function StringMenuItems(props: String
           parsedQuery.onExpression.containsColumn(columnName) && (
             <MenuItem
               icon={IconNames.EXCHANGE}
-              text={`Remove Join`}
+              text={`Remove join`}
               onClick={() => onQueryChange(parsedQuery.removeJoin())}
             />
           )}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
@@ -28,6 +28,8 @@ describe('time menu', () => {
   it('matches snapshot when menu is opened for column not inside group by', () => {
     const timeMenu = (
       <TimeMenuItems
+        table={'table'}
+        schema={'schema'}
         columnName={'__time'}
         parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
@@ -41,6 +43,8 @@ describe('time menu', () => {
   it('matches snapshot when menu is opened for column inside group by', () => {
     const timeMenu = (
       <TimeMenuItems
+        table={'table'}
+        schema={'schema'}
         columnName={'__time'}
         parsedQuery={parser(`SELECT __time, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
@@ -91,6 +91,8 @@ function nextYear(dt: Date): Date {
 }
 
 export interface TimeMenuItemsProps {
+  table: string;
+  schema: string;
   columnName: string;
   parsedQuery: SqlQuery;
   onQueryChange: (queryString: SqlQuery, run?: boolean) => void;
@@ -113,7 +115,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
                   columnName,
                   '>=',
                   SqlMulti.sqlMultiFactory('-', [
-                    SqlRef.fromName('CURRENT_TIMESTAMP'),
+                    SqlRef.fromString('CURRENT_TIMESTAMP'),
                     SqlInterval.sqlIntervalFactory('HOUR', 1),
                   ]),
                 ),
@@ -131,7 +133,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
                   columnName,
                   '>=',
                   SqlMulti.sqlMultiFactory('-', [
-                    SqlRef.fromName('CURRENT_TIMESTAMP'),
+                    SqlRef.fromString('CURRENT_TIMESTAMP'),
                     SqlInterval.sqlIntervalFactory('Day', 1),
                   ]),
                 ),
@@ -149,7 +151,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
                   columnName,
                   '>=',
                   SqlMulti.sqlMultiFactory('-', [
-                    SqlRef.fromName('CURRENT_TIMESTAMP'),
+                    SqlRef.fromString('CURRENT_TIMESTAMP'),
                     SqlInterval.sqlIntervalFactory('Day', 7),
                   ]),
                 ),
@@ -167,7 +169,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
                   columnName,
                   '>=',
                   SqlMulti.sqlMultiFactory('-', [
-                    SqlRef.fromName('CURRENT_TIMESTAMP'),
+                    SqlRef.fromString('CURRENT_TIMESTAMP'),
                     SqlInterval.sqlIntervalFactory('MONTH', 1),
                   ]),
                 ),
@@ -185,7 +187,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
                   columnName,
                   '>=',
                   SqlMulti.sqlMultiFactory('-', [
-                    SqlRef.fromName('CURRENT_TIMESTAMP'),
+                    SqlRef.fromString('CURRENT_TIMESTAMP'),
                     SqlInterval.sqlIntervalFactory('YEAR', 1),
                   ]),
                 ),
@@ -202,12 +204,12 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
               parsedQuery
                 .removeFilter(columnName)
                 .addWhereFilter(
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   '>=',
                   dateToTimestamp(hourStart),
                 )
                 .addWhereFilter(
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   '<',
                   dateToTimestamp(nextHour(hourStart)),
                 ),
@@ -223,12 +225,12 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
               parsedQuery
                 .removeFilter(columnName)
                 .addWhereFilter(
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   '>=',
                   dateToTimestamp(dayStart),
                 )
                 .addWhereFilter(
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   '<',
                   dateToTimestamp(nextDay(dayStart)),
                 ),
@@ -244,12 +246,12 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
               parsedQuery
                 .removeFilter(columnName)
                 .addWhereFilter(
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   '>=',
                   dateToTimestamp(monthStart),
                 )
                 .addWhereFilter(
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   '<',
                   dateToTimestamp(nextMonth(monthStart)),
                 ),
@@ -265,7 +267,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
               parsedQuery
                 .removeFilter(columnName)
                 .addWhereFilter(
-                  SqlRef.fromNameWithDoubleQuotes(columnName),
+                  SqlRef.fromStringWithDoubleQuotes(columnName),
                   '<=',
                   dateToTimestamp(yearStart),
                 )
@@ -324,7 +326,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
               parsedQuery.addToGroupBy(
                 SqlAliasRef.sqlAliasFactory(
                   SqlFunction.sqlFunctionFactory('TIME_FLOOR', [
-                    SqlRef.fromName(columnName),
+                    SqlRef.fromString(columnName),
                     SqlLiteral.fromInput('PT1h'),
                   ]),
                   `${columnName}_time_floor`,
@@ -341,7 +343,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
               parsedQuery.addToGroupBy(
                 SqlAliasRef.sqlAliasFactory(
                   SqlFunction.sqlFunctionFactory('TIME_FLOOR', [
-                    SqlRef.fromName(columnName),
+                    SqlRef.fromString(columnName),
                     SqlLiteral.fromInput('P1D'),
                   ]),
                   `${columnName}_time_floor`,
@@ -358,7 +360,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
               parsedQuery.addToGroupBy(
                 SqlAliasRef.sqlAliasFactory(
                   SqlFunction.sqlFunctionFactory('TIME_FLOOR', [
-                    SqlRef.fromName(columnName),
+                    SqlRef.fromString(columnName),
                     SqlLiteral.fromInput('P7D'),
                   ]),
                   `${columnName}_time_floor`,
@@ -383,7 +385,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
           onClick={() => {
             onQueryChange(
               parsedQuery.addAggregateColumn(
-                [SqlRef.fromNameWithDoubleQuotes(columnName)],
+                [SqlRef.fromStringWithDoubleQuotes(columnName)],
                 'MAX',
                 `max_${columnName}`,
               ),
@@ -396,7 +398,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
           onClick={() => {
             onQueryChange(
               parsedQuery.addAggregateColumn(
-                [SqlRef.fromNameWithDoubleQuotes(columnName)],
+                [SqlRef.fromStringWithDoubleQuotes(columnName)],
                 'MIN',
                 `min_${columnName}`,
               ),
@@ -408,6 +410,64 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
     );
   }
 
+  function renderJoinMenu(): JSX.Element | undefined {
+    const { schema, table, columnName, parsedQuery, onQueryChange } = props;
+    if (schema !== 'lookup' || !parsedQuery) return;
+
+    return (
+      <>
+        <MenuItem
+          icon={IconNames.JOIN_TABLE}
+          text={parsedQuery.joinTable ? `Replace Join` : `Join`}
+        >
+          <MenuItem
+            icon={IconNames.LEFT_JOIN}
+            text={`Left Join`}
+            onClick={() => {
+              onQueryChange(
+                parsedQuery.addJoin(
+                  'LEFT',
+                  SqlRef.fromString(table, schema).upgrade(),
+                  SqlMulti.sqlMultiFactory('=', [
+                    SqlRef.fromString(columnName, table, 'lookup'),
+                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                  ]),
+                ),
+                false,
+              );
+            }}
+          />
+          <MenuItem
+            icon={IconNames.INNER_JOIN}
+            text={`Inner Join`}
+            onClick={() => {
+              onQueryChange(
+                parsedQuery.addJoin(
+                  'INNER',
+                  SqlRef.fromString(table, schema).upgrade(),
+                  SqlMulti.sqlMultiFactory('=', [
+                    SqlRef.fromString(columnName, table, 'lookup'),
+                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                  ]),
+                ),
+                false,
+              );
+            }}
+          />
+        </MenuItem>
+        {parsedQuery.onExpression &&
+          parsedQuery.onExpression instanceof SqlMulti &&
+          parsedQuery.onExpression.containsColumn(columnName) && (
+            <MenuItem
+              icon={IconNames.EXCHANGE}
+              text={`Remove join`}
+              onClick={() => onQueryChange(parsedQuery.removeJoin())}
+            />
+          )}
+      </>
+    );
+  }
+
   return (
     <>
       {renderFilterMenu()}
@@ -415,6 +475,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
       {renderGroupByMenu()}
       {renderRemoveGroupBy()}
       {renderAggregateMenu()}
+      {renderJoinMenu()}
     </>
   );
 });

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
@@ -460,7 +460,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
           parsedQuery.onExpression.containsColumn(columnName) && (
             <MenuItem
               icon={IconNames.EXCHANGE}
-              text={`Remove join`}
+              text={`Remove Join`}
               onClick={() => onQueryChange(parsedQuery.removeJoin())}
             />
           )}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
@@ -30,6 +30,8 @@ import {
 } from 'druid-query-toolkit';
 import React from 'react';
 
+import { getCurrentColumns } from '../../column-tree';
+
 function dateToTimestamp(date: Date): SqlTimestamp {
   return SqlTimestamp.sqlTimestampFactory(
     date
@@ -414,6 +416,8 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
     const { schema, table, columnName, parsedQuery, onQueryChange } = props;
     if (schema !== 'lookup' || !parsedQuery) return;
 
+    const { originalTableColumn, lookupColumn } = getCurrentColumns(parsedQuery, table);
+
     return (
       <>
         <MenuItem
@@ -430,7 +434,10 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
                   SqlRef.fromString(table, schema).upgrade(),
                   SqlMulti.sqlMultiFactory('=', [
                     SqlRef.fromString(columnName, table, 'lookup'),
-                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                    SqlRef.fromString(
+                      lookupColumn === columnName ? originalTableColumn : 'XXX',
+                      parsedQuery.getTableName(),
+                    ),
                   ]),
                 ),
                 false,
@@ -447,7 +454,10 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
                   SqlRef.fromString(table, schema).upgrade(),
                   SqlMulti.sqlMultiFactory('=', [
                     SqlRef.fromString(columnName, table, 'lookup'),
-                    SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                    SqlRef.fromString(
+                      lookupColumn === columnName ? originalTableColumn : 'XXX',
+                      parsedQuery.getTableName(),
+                    ),
                   ]),
                 ),
                 false,

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
@@ -422,11 +422,11 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
       <>
         <MenuItem
           icon={IconNames.JOIN_TABLE}
-          text={parsedQuery.joinTable ? `Replace Join` : `Join`}
+          text={parsedQuery.joinTable ? `Replace join` : `Join`}
         >
           <MenuItem
             icon={IconNames.LEFT_JOIN}
-            text={`Left Join`}
+            text={`Left join`}
             onClick={() => {
               onQueryChange(
                 parsedQuery.addJoin(
@@ -446,7 +446,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
           />
           <MenuItem
             icon={IconNames.INNER_JOIN}
-            text={`Inner Join`}
+            text={`Inner join`}
             onClick={() => {
               onQueryChange(
                 parsedQuery.addJoin(
@@ -470,7 +470,7 @@ export const TimeMenuItems = React.memo(function TimeMenuItems(props: TimeMenuIt
           parsedQuery.onExpression.containsColumn(columnName) && (
             <MenuItem
               icon={IconNames.EXCHANGE}
-              text={`Remove Join`}
+              text={`Remove join`}
               onClick={() => onQueryChange(parsedQuery.removeJoin())}
             />
           )}

--- a/web-console/src/views/query-view/column-tree/column-tree.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree.tsx
@@ -235,7 +235,7 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                               parsedQuery.joinTable.table === table && (
                                 <MenuItem
                                   icon={IconNames.EXCHANGE}
-                                  text={`Remove join`}
+                                  text={`Remove Join`}
                                   onClick={() =>
                                     props.onQueryStringChange(parsedQuery.removeJoin())
                                   }

--- a/web-console/src/views/query-view/column-tree/column-tree.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree.tsx
@@ -27,7 +27,7 @@ import {
   Tree,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { SqlQuery } from 'druid-query-toolkit';
+import { SqlMulti, SqlQuery, SqlRef } from 'druid-query-toolkit';
 import React, { ChangeEvent } from 'react';
 
 import { Loader } from '../../../components';
@@ -188,6 +188,59 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                                 }}
                               />
                             )}
+                            {parsedQuery && schema === 'lookup' && (
+                              <MenuItem
+                                popoverProps={{ openOnTargetFocus: false }}
+                                icon={IconNames.JOIN_TABLE}
+                                text={parsedQuery.joinTable ? `Replace Join` : `Join`}
+                              >
+                                <MenuItem
+                                  icon={IconNames.LEFT_JOIN}
+                                  text={`Left Join`}
+                                  onClick={() => {
+                                    props.onQueryStringChange(
+                                      parsedQuery.addJoin(
+                                        'LEFT',
+                                        SqlRef.fromString(table, schema).upgrade(),
+                                        SqlMulti.sqlMultiFactory('=', [
+                                          SqlRef.fromString('XXX', table, 'lookup'),
+                                          SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                                        ]),
+                                      ),
+                                      false,
+                                    );
+                                  }}
+                                />
+                                <MenuItem
+                                  icon={IconNames.INNER_JOIN}
+                                  text={`Inner Join`}
+                                  onClick={() => {
+                                    props.onQueryStringChange(
+                                      parsedQuery.addJoin(
+                                        'INNER',
+                                        SqlRef.fromString(table, schema).upgrade(),
+                                        SqlMulti.sqlMultiFactory('=', [
+                                          SqlRef.fromString('XXX', table, 'lookup'),
+                                          SqlRef.fromString('XXX', parsedQuery.getTableName()),
+                                        ]),
+                                      ),
+                                      false,
+                                    );
+                                  }}
+                                />
+                              </MenuItem>
+                            )}
+                            {parsedQuery &&
+                              parsedQuery.joinTable &&
+                              parsedQuery.joinTable.table === table && (
+                                <MenuItem
+                                  icon={IconNames.EXCHANGE}
+                                  text={`Remove join`}
+                                  onClick={() =>
+                                    props.onQueryStringChange(parsedQuery.removeJoin())
+                                  }
+                                />
+                              )}
                           </Menu>
                         );
                       }}
@@ -234,6 +287,8 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                                     (columnData.DATA_TYPE === 'BIGINT' ||
                                       columnData.DATA_TYPE === 'FLOAT') && (
                                       <NumberMenuItems
+                                        table={table}
+                                        schema={schema}
                                         columnName={columnData.COLUMN_NAME}
                                         parsedQuery={parsedQuery}
                                         onQueryChange={props.onQueryStringChange}
@@ -241,6 +296,8 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                                     )}
                                   {parsedQuery && columnData.DATA_TYPE === 'VARCHAR' && (
                                     <StringMenuItems
+                                      table={table}
+                                      schema={schema}
                                       columnName={columnData.COLUMN_NAME}
                                       parsedQuery={parsedQuery}
                                       onQueryChange={props.onQueryStringChange}
@@ -248,6 +305,8 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                                   )}
                                   {parsedQuery && columnData.DATA_TYPE === 'TIMESTAMP' && (
                                     <TimeMenuItems
+                                      table={table}
+                                      schema={schema}
                                       columnName={columnData.COLUMN_NAME}
                                       parsedQuery={parsedQuery}
                                       onQueryChange={props.onQueryStringChange}

--- a/web-console/src/views/query-view/column-tree/column-tree.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree.tsx
@@ -218,11 +218,11 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                               <MenuItem
                                 popoverProps={{ openOnTargetFocus: false }}
                                 icon={IconNames.JOIN_TABLE}
-                                text={parsedQuery.joinTable ? `Replace Join` : `Join`}
+                                text={parsedQuery.joinTable ? `Replace join` : `Join`}
                               >
                                 <MenuItem
                                   icon={IconNames.LEFT_JOIN}
-                                  text={`Left Join`}
+                                  text={`Left join`}
                                   onClick={() => {
                                     const { lookupColumn, originalTableColumn } = getCurrentColumns(
                                       parsedQuery,
@@ -246,7 +246,7 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                                 />
                                 <MenuItem
                                   icon={IconNames.INNER_JOIN}
-                                  text={`Inner Join`}
+                                  text={`Inner join`}
                                   onClick={() => {
                                     const { lookupColumn, originalTableColumn } = getCurrentColumns(
                                       parsedQuery,
@@ -275,7 +275,7 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                               parsedQuery.joinTable.table === table && (
                                 <MenuItem
                                   icon={IconNames.EXCHANGE}
-                                  text={`Remove Join`}
+                                  text={`Remove join`}
                                   onClick={() =>
                                     props.onQueryStringChange(parsedQuery.removeJoin())
                                   }


### PR DESCRIPTION
For datasources and dimensions in the lookup schema, the user now has the option to add a LEFT or INNER join to the current query. 

The added clause will be :

`<JOINTYPE> JOIN lookup.<datasource> ON lookup.<datasource>.<placeholderXXXOrColumn> = <currentDatasource>.XXX`


<img width="1608" alt="Screen Shot 2020-04-15 at 11 28 03 AM" src="https://user-images.githubusercontent.com/37322608/79368345-76f00d00-7f0c-11ea-82e6-f364ee9b8f7d.png">
