### PR TITLE
Clarifying uri value for URI lookup

### DIFF
--- a/docs/development/extensions-core/lookups-cached-global.md
+++ b/docs/development/extensions-core/lookups-cached-global.md
@@ -208,12 +208,14 @@ The remapping values for each globally cached lookup can be specified by a JSON 
 |Property|Description|Required|Default|
 |--------|-----------|--------|-------|
 |`pollPeriod`|Period between polling for updates|No|0 (only once)|
-|`uri`|URI for the file of interest|No|Use `uriPrefix`|
-|`uriPrefix`|A URI which specifies a directory (or other searchable resource) in which to search for files|No|Use `uri`|
+|`uri`|URI path for the file of interest, specified as either a file, hdfs, or s3 location|No|Use `uriPrefix`|
+|`uriPrefix`|A URI that specifies a directory (or other searchable resource) in which to search for files|No|Use `uri`|
 |`fileRegex`|Optional regex for matching the file name under `uriPrefix`. Only used if `uriPrefix` is used|No|`".*"`|
 |`namespaceParseSpec`|How to interpret the data at the URI|Yes||
 
-One of either `uri` xor `uriPrefix` must be specified.
+One of either `uri` or `uriPrefix` must be specified. 
+
+Note that the value of `uri` or `uriPrefix` must be a file, hdfs location, or s3 location (as shown in the example). HTTP values for `uri` are not currently supported. 
 
 The `pollPeriod` value specifies the period in ISO 8601 format between checks for replacement data for the lookup. If the source of the lookup is capable of providing a timestamp, the lookup will only be updated if it has changed since the prior tick of `pollPeriod`. A value of 0, an absent parameter, or `null` all mean populate once and do not attempt to look for new data later. Whenever an poll occurs, the updating system will look for a file with the most recent timestamp and assume that one with the most recent data set, replacing the local cache of the lookup data.
 


### PR DESCRIPTION
Clarifying that HTTP URIs are not supported as `uri` value for URI lookups, which has surfaced as a point of confusion. 
