### PR TITLE
Manually copy static css files for website

### DIFF
--- a/website/script/build-to-docs
+++ b/website/script/build-to-docs
@@ -52,6 +52,9 @@ mkdir -p $WEBSRC/docs/$URL_VERSION/
 cp -r ./build/ApacheDruid/docs/* $WEBSRC/docs/$URL_VERSION/
 
 mkdir -p $WEBSRC/css
+# 'npm run build' command is supposed to copy these files to build/ApacheDruid/css as well,
+# but somehow they are missing. We maunally copy them for now.
+cp ./static/css/* ./build/ApacheDruid/css
 cp ./build/ApacheDruid/css/* $WEBSRC/css
 
 mkdir -p $WEBSRC/js


### PR DESCRIPTION
## Description

When you run Druid website locally, you can see the below error.

```
> npm start

...

[2020-04-15 16:54:01] ERROR `/css/code-block-buttons.css' not found.
[2020-04-15 16:54:01] ERROR `/css/code-block-buttons.css' not found.
[2020-04-15 16:54:18] ERROR `/css/code-block-buttons.css' not found.
```

This is because the `code-block-buttons.css` file in Druid repo is somehow not copied into druid-website-src. This PR adds a manual copy of missing files.

I don't think this is a release blocker since the website seems working even without this file.