### PR TITLE
web-console clean coverage report on build clean

### DIFF
--- a/web-console/script/clean
+++ b/web-console/script/clean
@@ -18,6 +18,7 @@
 
 # remove lib/sql-function-doc.* for back compat cleanup
 rm -rf \
+  coverage \
   lib/react-table.css \
   lib/sql-docs.js \
   lib/sql-function-doc.* \


### PR DESCRIPTION
### Description

We missed cleaning `web-console/coverage` reports generated when running `npm run coverage` in the `web-console` project as part of `mvn clean`, so this PR adds them to the script.
