### PR TITLE
Fix misuse of Integer.SIZE in FileWriteOutBytes.writeInt

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
@@ -71,7 +71,7 @@ final class FileWriteOutBytes extends WriteOutBytes
   @Override
   public void writeInt(int v) throws IOException
   {
-    flushIfNeeded(Integer.SIZE);
+    flushIfNeeded(Integer.BYTES);
     buffer.putInt(v);
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.segment.writeout;
 
 import org.easymock.EasyMock;

--- a/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
@@ -1,0 +1,44 @@
+package org.apache.druid.segment.writeout;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+public class FileWriteOutBytesTest
+{
+  private FileWriteOutBytes fileWriteOutBytes;
+  private FileChannel mockFileChannel;
+
+  @Before
+  public void setUp()
+  {
+    this.mockFileChannel = EasyMock.mock(FileChannel.class);
+    this.fileWriteOutBytes = new FileWriteOutBytes(EasyMock.mock(File.class), mockFileChannel);
+  }
+
+  @Test
+  public void testWrite4KBInts() throws IOException
+  {
+    // Write 4KB of ints and expect the write operation of the file channel will be triggered only once.
+    EasyMock.expect(this.mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              int remaining = buffer.remaining();
+              buffer.position(remaining);
+              return remaining;
+            }).times(1);
+    EasyMock.replay(this.mockFileChannel);
+    final int writeBytes = 4096;
+    final int numOfInt = writeBytes / Integer.BYTES;
+    for (int i = 0; i < numOfInt; i++) {
+      this.fileWriteOutBytes.writeInt(i);
+    }
+    this.fileWriteOutBytes.flush();
+    EasyMock.verify(this.mockFileChannel);
+  }
+}


### PR DESCRIPTION
### Description

In the `FileWriteOutBytes#writeInt(int)` method, the argument passed to `flushIfNeeded()` is `Integer.SIZE` while the `Integer.BYTES` should be used.  

**Problem**
This bug will incur one extra file write operation in some cases.  For example, if we would like to write 4 KB of ints using `FileWriteOutBytes#writeInt(int)`, the `flush()` method will be called twice.  After fixing this bug, the `flush()` method will be called only one.



<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.

<hr>

##### Key changed/added classes in this PR
 * `FileWriteOutBytes`
 * `FileWriteOutBytesTest`
