### PR TITLE
Introduce CompositeQueryLaningStrategy

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -37,6 +37,7 @@ public class QueryContexts
   public static final String FINALIZE_KEY = "finalize";
   public static final String PRIORITY_KEY = "priority";
   public static final String LANE_KEY = "lane";
+  public static final String COMPOSITE_LANE_STRATEGY_KEY = "laneStrategy";
   public static final String TIMEOUT_KEY = "timeout";
   public static final String MAX_SCATTER_GATHER_BYTES_KEY = "maxScatterGatherBytes";
   public static final String MAX_QUEUED_BYTES_KEY = "maxQueuedBytes";
@@ -219,6 +220,15 @@ public class QueryContexts
   public static <T> String getLane(Query<T> query)
   {
     return (String) query.getContextValue(LANE_KEY);
+  }
+
+  /**
+   * Returns the laning strategy specified in the query context.
+   * This strategy only applies if Druid is running with CompositeQueryLaningStrategy.
+   */
+  public static <T> String getCompositeLaneStrategy(Query<T> query)
+  {
+    return (String) query.getContextValue(COMPOSITE_LANE_STRATEGY_KEY);
   }
 
   public static <T> boolean getEnableParallelMerges(Query<T> query)

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -343,6 +343,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-core</artifactId>
             <version>${project.parent.version}</version>

--- a/server/src/main/java/org/apache/druid/server/QueryLaningStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLaningStrategy.java
@@ -25,6 +25,7 @@ import com.google.common.primitives.Ints;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.apache.druid.client.SegmentServerSelector;
 import org.apache.druid.query.QueryPlus;
+import org.apache.druid.server.scheduling.CompositeQueryLaningStrategy;
 import org.apache.druid.server.scheduling.HiLoQueryLaningStrategy;
 import org.apache.druid.server.scheduling.ManualQueryLaningStrategy;
 import org.apache.druid.server.scheduling.NoQueryLaningStrategy;
@@ -37,7 +38,8 @@ import java.util.Set;
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "none", value = NoQueryLaningStrategy.class),
     @JsonSubTypes.Type(name = "hilo", value = HiLoQueryLaningStrategy.class),
-    @JsonSubTypes.Type(name = "manual", value = ManualQueryLaningStrategy.class)
+    @JsonSubTypes.Type(name = "manual", value = ManualQueryLaningStrategy.class),
+    @JsonSubTypes.Type(name = "composite", value = CompositeQueryLaningStrategy.class)
 })
 public interface QueryLaningStrategy
 {

--- a/server/src/main/java/org/apache/druid/server/scheduling/CompositeQueryLaningStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/CompositeQueryLaningStrategy.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.scheduling;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.apache.druid.client.SegmentServerSelector;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.query.QueryPlus;
+import org.apache.druid.server.QueryLaningStrategy;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A laning strategy that allows you to combine multiple {@link QueryLaningStrategy}. To use this strategy,
+ * an admin must configure lane groups and their associated strategy.
+ *
+ * For example:
+ * druid.query.scheduler.laning.strategy=composite
+ * druid.query.scheduler.laning.strategies={"manualLanes": {"strategy":"manual", "lanes":{"one": 1}},"hiLoLanes": {"strategy":"hilo", "maxLowPercent":1}}
+ *
+ * This strategy does *not* support nesting a composite strategy within this strategy.
+ */
+public class CompositeQueryLaningStrategy implements QueryLaningStrategy
+{
+  @JsonProperty
+  private final Map<String, QueryLaningStrategy> strategies;
+
+  @JsonCreator
+  public CompositeQueryLaningStrategy(@JsonProperty("strategies") Map<String, QueryLaningStrategy> strategies)
+  {
+    this.strategies = Preconditions.checkNotNull(strategies, "strategies must be set.");
+    Preconditions.checkArgument(!strategies.isEmpty(), "strategies must define at least one strategy.");
+    Preconditions.checkArgument(
+        strategies.values().stream().noneMatch(s -> s instanceof CompositeQueryLaningStrategy),
+        "strategies can not contain a composite strategy."
+    );
+  }
+
+  @Override
+  public Object2IntMap<String> getLaneLimits(int totalLimit)
+  {
+    Object2IntArrayMap<String> laneLimits = new Object2IntArrayMap<>();
+    for (QueryLaningStrategy strategy : strategies.values()) {
+      laneLimits.putAll(strategy.getLaneLimits(totalLimit));
+    }
+    return laneLimits;
+  }
+
+  @Override
+  public <T> Optional<String> computeLane(QueryPlus<T> query, Set<SegmentServerSelector> segments)
+  {
+    String laneStrategyKey = QueryContexts.getCompositeLaneStrategy(query.getQuery());
+    if (laneStrategyKey == null) {
+      return Optional.empty();
+    }
+    QueryLaningStrategy strategy = strategies.get(laneStrategyKey);
+    if (strategy == null) {
+      return Optional.empty();
+    }
+    return strategy.computeLane(query, segments);
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/scheduling/CompositeQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/CompositeQueryLaningStrategyTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.scheduling;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.apache.druid.client.SegmentServerSelector;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.query.QueryPlus;
+import org.apache.druid.server.QueryLaningStrategy;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompositeQueryLaningStrategyTest
+{
+  private static final int TOTAL_LIMIT = 1000;
+  private static final String STRATEGY_ONE_LANE_ONE = "s1-l1";
+  private static final String STRATEGY_ONE_LANE_TWO = "s1-l2";
+  private static final String STRATEGY_ONE_LANE_THREE = "s1-l3";
+  private static final String STRATEGY_TWO_LANE_ONE = "s2-l1";
+  private static final String STRATEGY_TWO_LANE_TWO = "s2-l2";
+  private static final List<String> ALL_LANES = ImmutableList.of(
+      STRATEGY_ONE_LANE_ONE,
+      STRATEGY_ONE_LANE_TWO,
+      STRATEGY_ONE_LANE_THREE,
+      STRATEGY_TWO_LANE_ONE,
+      STRATEGY_TWO_LANE_TWO
+  );
+  private static final Object2IntMap<String> STRATEGY_ONE_LIMITS = new Object2IntArrayMap<>();
+  private static final Object2IntMap<String> STRATEGY_TWO_LIMITS = new Object2IntArrayMap<>();
+  private static final Optional<String> STRATEGY_ONE_COMPUTED_LANE = Optional.of("STRATEGY_ONE_COMPUTED_LANE");
+  private static final Optional<String> STRATEGY_TWO_COMPUTED_LANE = Optional.of("STRATEGY_TWO_COMPUTED_LANE");
+
+  static {
+    STRATEGY_ONE_LIMITS.put(STRATEGY_ONE_LANE_ONE, 2);
+    STRATEGY_ONE_LIMITS.put(STRATEGY_ONE_LANE_TWO, 3);
+    STRATEGY_ONE_LIMITS.put(STRATEGY_ONE_LANE_THREE, 4);
+    STRATEGY_TWO_LIMITS.put(STRATEGY_TWO_LANE_ONE, 30);
+    STRATEGY_TWO_LIMITS.put(STRATEGY_TWO_LANE_TWO, 40);
+  }
+
+  @Mock
+  private CompositeQueryLaningStrategy subCompositeStrategy;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private QueryLaningStrategy strategyOne;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private QueryLaningStrategy strategyTwo;
+  @Mock
+  private Query<String> query;
+  @Mock
+  private Set<SegmentServerSelector> segments;
+
+  private QueryPlus<String> queryPlus;
+  private CompositeQueryLaningStrategy target;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setup()
+  {
+    queryPlus = QueryPlus.wrap(query);
+    Mockito.doReturn(STRATEGY_ONE_COMPUTED_LANE).when(strategyOne).computeLane(queryPlus, segments);
+    Mockito.doReturn(STRATEGY_TWO_COMPUTED_LANE).when(strategyTwo).computeLane(queryPlus, segments);
+    mockLimits();
+    target = new CompositeQueryLaningStrategy(
+        ImmutableMap.of(
+            "one", strategyOne,
+            "two", strategyTwo
+        )
+    );
+  }
+
+  @Test
+  public void initStrategiesMustBeSet()
+  {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("strategies must be set.");
+    target = new CompositeQueryLaningStrategy(null);
+  }
+
+  @Test
+  public void initMinimumNumberOfExpectedStrategies()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("strategies must define at least one strategy.");
+    target = new CompositeQueryLaningStrategy(Collections.emptyMap());
+  }
+
+  @Test
+  public void initNestedCompositeQueryLaningStrategiesAreNotAllowed()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("strategies can not contain a composite strategy.");
+    target = new CompositeQueryLaningStrategy(ImmutableMap.of("composite", subCompositeStrategy));
+  }
+
+  @Test
+  public void initNestedCompositeQueryLaningStrategiesWithOtherValidStrategiesAreNotAllowed()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("strategies can not contain a composite strategy.");
+    target = new CompositeQueryLaningStrategy(
+        ImmutableMap.of(
+            "one", strategyOne,
+            "composite", subCompositeStrategy,
+            "two", strategyTwo
+        )
+    );
+  }
+
+  @Test
+  public void getLaneLimitsShouldIncludeAllLaneLimits()
+  {
+    Object2IntMap<String> laneLimits = target.getLaneLimits(TOTAL_LIMIT);
+    Assert.assertEquals(5, laneLimits.size());
+    Assert.assertTrue(laneLimits.keySet().containsAll(ALL_LANES));
+    Assert.assertEquals(79, laneLimits.values().stream().reduce(0, Integer::sum).intValue());
+  }
+
+  @Test
+  public void computeLaneWithoutLateStrategyShouldReturnEmpty()
+  {
+    Optional<String> lane = target.computeLane(queryPlus, segments);
+    Assert.assertFalse(lane.isPresent());
+  }
+
+  @Test
+  public void computeLaneWithNonExistentLateStrategyShouldReturnEmpty()
+  {
+    mockQueryStrategy("unknown");
+    Optional<String> lane = target.computeLane(queryPlus, segments);
+    Assert.assertFalse(lane.isPresent());
+  }
+
+  @Test
+  public void computeLaneWithLateStrategyShouldReturnStrategyFromSelectedStrategy()
+  {
+    mockQueryStrategy("one");
+    Optional<String> lane = target.computeLane(queryPlus, segments);
+    Assert.assertEquals(STRATEGY_ONE_COMPUTED_LANE, lane);
+    mockQueryStrategy("two");
+    lane = target.computeLane(queryPlus, segments);
+    Assert.assertEquals(STRATEGY_TWO_COMPUTED_LANE, lane);
+  }
+
+  private void mockQueryStrategy(String strategy)
+  {
+    Mockito.doReturn(strategy).when(query).getContextValue(QueryContexts.COMPOSITE_LANE_STRATEGY_KEY);
+  }
+
+  private void mockLimits()
+  {
+    Mockito.doReturn(STRATEGY_ONE_LIMITS).when(strategyOne).getLaneLimits(TOTAL_LIMIT);
+    Mockito.doReturn(STRATEGY_TWO_LIMITS).when(strategyTwo).getLaneLimits(TOTAL_LIMIT);
+  }
+}


### PR DESCRIPTION
A CompositeQueryLaningStrategy allows a Druid operator to specify a laning
strategy that's made up of one or more base strategies.

The primary motivation for this strategy is to enable integration tests
without requiring multiple Druid clusters.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
