### PR TITLE
Add QueryResource to log4j2 template.

### DIFF
--- a/examples/conf/druid/cluster/_common/log4j2.xml
+++ b/examples/conf/druid/cluster/_common/log4j2.xml
@@ -30,6 +30,9 @@
     </Root>
 
     <!-- Set level="debug" to see stack traces for query errors -->
+    <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">
+      <Appender-ref ref="Console"/>
+    </Logger>
     <Logger name="org.apache.druid.server.QueryLifecycle" level="info" additivity="false">
       <Appender-ref ref="Console"/>
     </Logger>


### PR DESCRIPTION
It is also something that suppresses stack traces by default, so you'd need to set it to `debug` to see stack traces.