### PR TITLE
revert datasketches-java version to 1.1.0-incubating until new version is released

### DIFF
--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -485,25 +485,23 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
             "\"AgEHDAMIBgC1EYgH1mlHBwsKPwu5SK8MIiUxB7iZVwU=\"",
             2L,
             "### HLL SKETCH SUMMARY: \n"
-              + "  Log Config K   : 12\n"
-              + "  Hll Target     : HLL_4\n"
-              + "  Current Mode   : LIST\n"
-              + "  Memory         : false\n"
-              + "  LB             : 2.0\n"
-              + "  Estimate       : 2.000000004967054\n"
-              + "  UB             : 2.000099863468538\n"
-              + "  OutOfOrder Flag: false\n"
-              + "  Coupon Count   : 2\n",
+            + "  Log Config K   : 12\n"
+            + "  Hll Target     : HLL_4\n"
+            + "  Current Mode   : LIST\n"
+            + "  LB             : 2.0\n"
+            + "  Estimate       : 2.000000004967054\n"
+            + "  UB             : 2.000099863468538\n"
+            + "  OutOfOrder Flag: false\n"
+            + "  Coupon Count   : 2\n",
             "### HLL SKETCH SUMMARY: \n"
-              + "  LOG CONFIG K   : 12\n"
-              + "  HLL TARGET     : HLL_4\n"
-              + "  CURRENT MODE   : LIST\n"
-              + "  MEMORY         : FALSE\n"
-              + "  LB             : 2.0\n"
-              + "  ESTIMATE       : 2.000000004967054\n"
-              + "  UB             : 2.000099863468538\n"
-              + "  OUTOFORDER FLAG: FALSE\n"
-              + "  COUPON COUNT   : 2\n",
+            + "  LOG CONFIG K   : 12\n"
+            + "  HLL TARGET     : HLL_4\n"
+            + "  CURRENT MODE   : LIST\n"
+            + "  LB             : 2.0\n"
+            + "  ESTIMATE       : 2.000000004967054\n"
+            + "  UB             : 2.000099863468538\n"
+            + "  OUTOFORDER FLAG: FALSE\n"
+            + "  COUPON COUNT   : 2\n",
             2.0
         }
     );
@@ -629,15 +627,14 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
         new Object[]{
             2.000000004967054d,
             "### HLL SKETCH SUMMARY: \n"
-              + "  Log Config K   : 12\n"
-              + "  Hll Target     : HLL_4\n"
-              + "  Current Mode   : LIST\n"
-              + "  Memory         : false\n"
-              + "  LB             : 2.0\n"
-              + "  Estimate       : 2.000000004967054\n"
-              + "  UB             : 2.000099863468538\n"
-              + "  OutOfOrder Flag: false\n"
-              + "  Coupon Count   : 2\n"
+            + "  Log Config K   : 12\n"
+            + "  Hll Target     : HLL_4\n"
+            + "  Current Mode   : LIST\n"
+            + "  LB             : 2.0\n"
+            + "  Estimate       : 2.000000004967054\n"
+            + "  UB             : 2.000099863468538\n"
+            + "  OutOfOrder Flag: false\n"
+            + "  Coupon Count   : 2\n"
         }
     );
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -94,13 +94,21 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
 {
   private static final String DATA_SOURCE = "foo";
   private static final boolean ROUND = true;
-
-  private static QueryRunnerFactoryConglomerate conglomerate;
-  private static Closer resourceCloser;
-  private static AuthenticationResult authenticationResult = CalciteTests.REGULAR_USER_AUTH_RESULT;
   private static final Map<String, Object> QUERY_CONTEXT_DEFAULT = ImmutableMap.of(
       PlannerContext.CTX_SQL_QUERY_ID, "dummy"
   );
+  private static QueryRunnerFactoryConglomerate conglomerate;
+  private static Closer resourceCloser;
+  private static AuthenticationResult authenticationResult = CalciteTests.REGULAR_USER_AUTH_RESULT;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public QueryLogHook queryLogHook = QueryLogHook.create(TestHelper.JSON_MAPPER);
+  
+  private SpecificSegmentsQuerySegmentWalker walker;
+  private SqlLifecycleFactory sqlLifecycleFactory;
 
   @BeforeClass
   public static void setUpClass()
@@ -114,15 +122,6 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
   {
     resourceCloser.close();
   }
-
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public QueryLogHook queryLogHook = QueryLogHook.create(TestHelper.JSON_MAPPER);
-
-  private SpecificSegmentsQuerySegmentWalker walker;
-  private SqlLifecycleFactory sqlLifecycleFactory;
 
   @Before
   public void setUp() throws Exception
@@ -485,23 +484,23 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
             "\"AgEHDAMIBgC1EYgH1mlHBwsKPwu5SK8MIiUxB7iZVwU=\"",
             2L,
             "### HLL SKETCH SUMMARY: \n"
-            + "  Log Config K   : 12\n"
-            + "  Hll Target     : HLL_4\n"
-            + "  Current Mode   : LIST\n"
-            + "  LB             : 2.0\n"
-            + "  Estimate       : 2.000000004967054\n"
-            + "  UB             : 2.000099863468538\n"
-            + "  OutOfOrder Flag: false\n"
-            + "  Coupon Count   : 2\n",
+              + "  Log Config K   : 12\n"
+              + "  Hll Target     : HLL_4\n"
+              + "  Current Mode   : LIST\n"
+              + "  LB             : 2.0\n"
+              + "  Estimate       : 2.000000004967054\n"
+              + "  UB             : 2.000099863468538\n"
+              + "  OutOfOrder Flag: false\n"
+              + "  Coupon Count   : 2\n",
             "### HLL SKETCH SUMMARY: \n"
-            + "  LOG CONFIG K   : 12\n"
-            + "  HLL TARGET     : HLL_4\n"
-            + "  CURRENT MODE   : LIST\n"
-            + "  LB             : 2.0\n"
-            + "  ESTIMATE       : 2.000000004967054\n"
-            + "  UB             : 2.000099863468538\n"
-            + "  OUTOFORDER FLAG: FALSE\n"
-            + "  COUPON COUNT   : 2\n",
+              + "  LOG CONFIG K   : 12\n"
+              + "  HLL TARGET     : HLL_4\n"
+              + "  CURRENT MODE   : LIST\n"
+              + "  LB             : 2.0\n"
+              + "  ESTIMATE       : 2.000000004967054\n"
+              + "  UB             : 2.000099863468538\n"
+              + "  OUTOFORDER FLAG: FALSE\n"
+              + "  COUPON COUNT   : 2\n",
             2.0
         }
     );
@@ -627,14 +626,14 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
         new Object[]{
             2.000000004967054d,
             "### HLL SKETCH SUMMARY: \n"
-            + "  Log Config K   : 12\n"
-            + "  Hll Target     : HLL_4\n"
-            + "  Current Mode   : LIST\n"
-            + "  LB             : 2.0\n"
-            + "  Estimate       : 2.000000004967054\n"
-            + "  UB             : 2.000099863468538\n"
-            + "  OutOfOrder Flag: false\n"
-            + "  Coupon Count   : 2\n"
+              + "  Log Config K   : 12\n"
+              + "  Hll Target     : HLL_4\n"
+              + "  Current Mode   : LIST\n"
+              + "  LB             : 2.0\n"
+              + "  Estimate       : 2.000000004967054\n"
+              + "  UB             : 2.000099863468538\n"
+              + "  OutOfOrder Flag: false\n"
+              + "  Coupon Count   : 2\n"
         }
     );
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3211,7 +3211,7 @@ name: DataSketches
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.2.0-incubating
+version: 1.1.0-incubating
 libraries:
   - org.apache.datasketches: datasketches-java
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,8 @@
         <avatica.version>1.15.0</avatica.version>
         <avro.version>1.9.2</avro.version>
         <calcite.version>1.21.0</calcite.version>
-        <datasketches.version>1.2.0-incubating</datasketches.version>
+        <datasketches.version>1.1.0-incubating</datasketches.version>
+        <datasketches.memory.version>1.2.0-incubating</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <guava.version>16.0.1</guava.version>
@@ -1014,7 +1015,7 @@
             <dependency>
                 <groupId>org.apache.datasketches</groupId>
                 <artifactId>datasketches-memory</artifactId>
-                <version>${datasketches.version}</version>
+                <version>${datasketches.memory.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.calcite</groupId>


### PR DESCRIPTION
Temporarily switch `datasketches-java` back to `1.1.0-incubating` in case the new version with the fix for #9736 doesn't make it in on the timescale we release `0.18.1`.