### PR TITLE
Fix NPE when running IncrementalIndexReadBenchmark

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -198,7 +198,7 @@ public class IncrementalIndexReadBenchmark
   private Sequence<Cursor> makeCursors(IncrementalIndexStorageAdapter sa, DimFilter filter)
   {
     return sa.makeCursors(
-        filter.toFilter(),
+        filter == null ? null : filter.toFilter(),
         schemaInfo.getDataInterval(),
         VirtualColumns.EMPTY,
         Granularities.ALL,


### PR DESCRIPTION
### Description

When running IncrementalIndexReadBenchmark, we got the following NPE:

```
java.lang.NullPointerException
        at org.apache.druid.benchmark.indexing.IncrementalIndexReadBenchmark.makeCursors(IncrementalIndexReadBenchmark.java:201)
        at org.apache.druid.benchmark.indexing.IncrementalIndexReadBenchmark.read(IncrementalIndexReadBenchmark.java:144)
        at org.apache.druid.benchmark.indexing.generated.IncrementalIndexReadBenchmark_read_jmhTest.read_avgt_jmhStub(IncrementalIndexReadBenchmark_read_jmhTest.java:232)
        at org.apache.druid.benchmark.indexing.generated.IncrementalIndexReadBenchmark_read_jmhTest.read_AverageTime(IncrementalIndexReadBenchmark_read_jmhTest.java:173)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

This PR has:
- [x] been self-reviewed.
- [x] been tested locally.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `IncrementalIndexReadBenchmark`
