### PR TITLE
Improve "waiting for tasks complete" logic in integration tests

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -282,7 +282,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
   private void forceTriggerAutoCompaction(int numExpectedSegmentsAfterCompaction) throws Exception
   {
     compactionResource.forceTriggerAutoCompaction();
-    waitForAllTasksToComplete();
+    waitForAllTasksToComplete(fullDatasourceName);
     verifySegmentsCount(numExpectedSegmentsAfterCompaction);
     ITRetryUtil.retryUntilTrue(
         () -> coordinator.areSegmentsLoaded(fullDatasourceName),

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -282,7 +282,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
   private void forceTriggerAutoCompaction(int numExpectedSegmentsAfterCompaction) throws Exception
   {
     compactionResource.forceTriggerAutoCompaction();
-    waitForAllTasksToComplete(fullDatasourceName);
+    waitForAllTasksToCompleteForDataSource(fullDatasourceName);
     verifySegmentsCount(numExpectedSegmentsAfterCompaction);
     ITRetryUtil.retryUntilTrue(
         () -> coordinator.areSegmentsLoaded(fullDatasourceName),

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.clients.CoordinatorResourceTestClient;
 import org.apache.druid.testing.clients.OverlordResourceTestClient;
@@ -104,7 +105,7 @@ public abstract class AbstractIndexerTest
   {
     ITRetryUtil.retryUntilTrue(
         () -> (indexer.getUncompletedTasksForDataSource(dataSource).size() == 0),
-        String.format("Waiting for all tasks of [%s] to complete", dataSource)
+        StringUtils.format("Waiting for all tasks of [%s] to complete", dataSource)
     );
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractIndexerTest
   {
     // Wait for any existing index tasks to complete before disabling the datasource otherwise
     // realtime tasks can get stuck waiting for handoff. https://github.com/apache/druid/issues/1729
-    waitForAllTasksToComplete(dataSource);
+    waitForAllTasksToCompleteForDataSource(dataSource);
     Interval interval = Intervals.of(start + "/" + end);
     coordinator.unloadSegmentsForDataSource(dataSource);
     ITRetryUtil.retryUntilFalse(
@@ -97,10 +97,10 @@ public abstract class AbstractIndexerTest
         }, "Segment Unloading"
     );
     coordinator.deleteSegmentsDataSource(dataSource, interval);
-    waitForAllTasksToComplete(dataSource);
+    waitForAllTasksToCompleteForDataSource(dataSource);
   }
 
-  protected void waitForAllTasksToComplete(final String dataSource)
+  protected void waitForAllTasksToCompleteForDataSource(final String dataSource)
   {
     ITRetryUtil.retryUntilTrue(
         () -> (indexer.getUncompletedTasksForDataSource(dataSource).size() == 0),


### PR DESCRIPTION
Improve "waiting for tasks complete" logic in integration tests

### Description

Currently, the "waiting for tasks complete" logic in integration tests waits for all tasks regardless of the datasource of those tasks. This should never be use in integration test since integration test should be self contained, know which datasources it is testing/managing and only wait for those particular datasource(s)' tasks to complete. The previous logic of waiting for all tasks regardless of the datasource have two problem:
1) If integration tests are run in parallel (https://github.com/apache/druid/blob/master/integration-tests/README.md#running-test-methods-in-parallel), then the old logic can be waiting (and failing from) tasks of unrelated integration tests.
2) if other random integration tests fail to clean up properly (such as leaving a long running task or a supervisor running), then other integration test using the old logic can fail mysteriously (from task that has no relation with current test method or test class at all)

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
