### PR TITLE
fix issue where CloseableIterator.flatMap does not close inner CloseableIterator

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/CloseableIterator.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/CloseableIterator.java
@@ -75,6 +75,7 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable
           if (iterator != null) {
             try {
               iterator.close();
+              iterator = null;
             }
             catch (IOException e) {
               throw new UncheckedIOException(e);
@@ -112,6 +113,10 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable
       public void close() throws IOException
       {
         delegate.close();
+        if (iterator != null) {
+          iterator.close();
+          iterator = null;
+        }
       }
     };
   }

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/CloseableIteratorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/CloseableIteratorTest.java
@@ -102,14 +102,17 @@ public class CloseableIteratorTest
         .flatMap(i -> IntStream.range(0, i))
         .iterator();
 
-    // burn halfway through
+    // burn through the first few iterators
     int cnt = 0;
-    while (expected.hasNext() && actual.hasNext() && cnt++ < (numIterations / 2)) {
+    int numFlatIterations = 5;
+    while (expected.hasNext() && actual.hasNext() && cnt++ < numFlatIterations) {
       Assert.assertEquals(expected.next(), actual.next());
     }
-    // but stop while we still have an open iterator
+    // but stop while we still have an open current inner iterator and a few remaining inner iterators
     Assert.assertTrue(actual.hasNext());
     Assert.assertTrue(expected.hasNext());
+    Assert.assertEquals(4, innerIterators.size());
+    Assert.assertTrue(innerIterators.get(innerIterators.size() - 1).hasNext());
     actual.close();
     Assert.assertEquals(1, actual.closeCount);
     for (CloseTrackingCloseableIterator iter : innerIterators) {

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/CloseableIteratorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/CloseableIteratorTest.java
@@ -104,7 +104,7 @@ public class CloseableIteratorTest
 
     // burn halfway through
     int cnt = 0;
-    while (expected.hasNext() && actual.hasNext() && cnt++ < numIterations/2) {
+    while (expected.hasNext() && actual.hasNext() && cnt++ < (numIterations / 2)) {
       Assert.assertEquals(expected.next(), actual.next());
     }
     // but stop while we still have an open iterator


### PR DESCRIPTION
### Description
This PR fixes an issue with `CloseableIterator.flatMap` does not ensure any inner `CloseableIterator` it creates during iteration is closed when it's own `close` method is explicitly called. I noticed this looking into the `TimedShutoffInputSourceReader`, after noticing if I set a breakpoint at a particular place that an underlying s3 file stream was not being closed when the timeout occurred. Looking closer, this also occurs with the last inner iterator of the call to `flatMap`, which is also not closed. The `flatMap` test has been modified to ensure that close is called on all closeable iterators, and fails prior to the changes of this PR. The added test also covers the case when the outer iterator is closed early.

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `CloseableIterator`
