### PR TITLE
Fix problem when running single integration test using -Dit.test=

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -405,6 +405,12 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <properties>
+                                <property>
+                                    <name>testrunfactory</name>
+                                    <value>org.testng.DruidTestRunnerFactory</value>
+                                </property>
+                            </properties>
                             <argLine>
                                 -Duser.timezone=UTC
                                 -Dfile.encoding=UTF-8
@@ -457,6 +463,12 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <properties>
+                                <property>
+                                    <name>testrunfactory</name>
+                                    <value>org.testng.DruidTestRunnerFactory</value>
+                                </property>
+                            </properties>
                             <argLine>
                                 -Duser.timezone=UTC
                                 -Dfile.encoding=UTF-8

--- a/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
+++ b/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package /*CHECKSTYLE.OFF: PackageName*/org.testng/*CHECKSTYLE.ON: PackageName*/;
+
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.testing.utils.SuiteListener;
+import org.testng.internal.IConfiguration;
+import org.testng.internal.Systematiser;
+import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.xml.XmlTest;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class must be in package org.testng to access protected methods like TestNG.getDefault().getConfiguration()
+ */
+public class DruidTestRunnerFactory implements ITestRunnerFactory
+{
+  private static final Logger LOG = new Logger(DruidTestRunnerFactory.class);
+  private static final SuiteListener SUITE_LISTENER = new SuiteListener();
+
+  @Override
+  public TestRunner newTestRunner(ISuite suite,
+                                  XmlTest test,
+                                  Collection<IInvokedMethodListener> methodListeners,
+                                  List<IClassListener> classListeners)
+  {
+    IConfiguration configuration = TestNG.getDefault().getConfiguration();
+    String outputDirectory = suite.getOutputDirectory();
+    IAnnotationFinder annotationFinder = configuration.getAnnotationFinder();
+    Boolean skipFailedInvocationCounts = suite.getXmlSuite().skipFailedInvocationCounts();
+    return new DruidTestRunner(
+        configuration,
+        suite,
+        test,
+        outputDirectory,
+        annotationFinder,
+        skipFailedInvocationCounts,
+        methodListeners,
+        classListeners
+    );
+  }
+
+  private static class DruidTestRunner extends TestRunner
+  {
+    DruidTestRunner(
+        IConfiguration configuration,
+        ISuite suite,
+        XmlTest test,
+        String outputDirectory,
+        IAnnotationFinder finder,
+        boolean skipFailedInvocationCounts,
+        Collection<IInvokedMethodListener> methodListeners,
+        List<IClassListener> classListeners
+    )
+    {
+      super(configuration, suite, test, outputDirectory, finder, skipFailedInvocationCounts, methodListeners, classListeners, Systematiser.getComparator(), Collections.emptyMap());
+    }
+
+    @Override
+    public void run()
+    {
+      try {
+        // IntegrationTestSuite is run when -Dit.test is not specify in maven command.
+        // IntegrationTestSuite uses the configuration from integration-tests/src/test/resources/testng.xml
+        // which already handle suite onStart and onFinish automatically
+        if (!"IntegrationTestSuite".equals(getSuite().getName())) {
+          SUITE_LISTENER.onStart(getSuite());
+        }
+        runTests();
+      }
+      catch (Exception e) {
+        LOG.error(e, "");
+        throw new RuntimeException(e);
+      }
+      finally {
+        // IntegrationTestSuite uses the configuration from integration-tests/src/test/resources/testng.xml
+        // which already handle suite onStart and onFinish automatically
+        if (!"IntegrationTestSuite".equals(getSuite().getName())) {
+          SUITE_LISTENER.onFinish(getSuite());
+        }
+      }
+    }
+
+    private void runTests()
+    {
+      super.run();
+    }
+  }
+}

--- a/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
+++ b/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
@@ -88,10 +88,6 @@ public class DruidTestRunnerFactory implements ITestRunnerFactory
         }
         runTests();
       }
-      catch (Exception e) {
-        LOG.error(e, "");
-        throw new RuntimeException(e);
-      }
       finally {
         // IntegrationTestSuite uses the configuration from integration-tests/src/test/resources/testng.xml
         // which already handle suite onStart and onFinish automatically


### PR DESCRIPTION
Fix problem when running single integration test using -Dit.test=

### Description

Fix problem when running single integration test using -Dit.test
Due to refactoring of the integration test setup, when running integration test using -Dit.test, we no longer waits for Druid to be ready.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

