### PR TITLE
Remove inventoryKey in BatchServerInventoryView when historical is down

### DIFF
--- a/server/src/main/java/org/apache/druid/client/AbstractCuratorServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/AbstractCuratorServerInventoryView.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -53,6 +54,7 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
 
   private final ConcurrentMap<ServerRemovedCallback, Executor> serverRemovedCallbacks = new ConcurrentHashMap<>();
   private final ConcurrentMap<SegmentCallback, Executor> segmentCallbacks = new ConcurrentHashMap<>();
+  protected final ExecutorService exec = Execs.singleThreaded("ServerInventoryView-%s");
 
   public AbstractCuratorServerInventoryView(
       final EmittingLogger log,
@@ -80,7 +82,7 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
             return inventoryPath;
           }
         },
-        Execs.singleThreaded("ServerInventoryView-%s"),
+        exec,
         new CuratorInventoryManagerStrategy<DruidServer, InventoryType>()
         {
           @Override


### PR DESCRIPTION
### Description

The inventoryKey in BatchServerInventoryView will not be removed when historical node is down.
Because `InventoryCacheListener ` will not remove inventoryKey when the corresponding `ContainerHolder` is removed.

So if the historical is restarted or temporarily disconnect from ZK because of FullGC, the memory of coordinator and brokers which use the BatchServerInventoryView will leak.

The PR remove inventoryKey in BatchServerInventoryView when historical is down in case of the leak of memory  in coordinator and broker.

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.





