### PR TITLE
Add javadoc for stream ingestion integration tests

### DIFF
--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaEventWriter.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaEventWriter.java
@@ -66,6 +66,12 @@ public class KafkaEventWriter implements StreamEventWriter
   }
 
   @Override
+  public boolean supportTransaction()
+  {
+    return true;
+  }
+
+  @Override
   public boolean isTransactionEnabled()
   {
     return txnEnabled;

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KinesisEventWriter.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KinesisEventWriter.java
@@ -60,21 +60,27 @@ public class KinesisEventWriter implements StreamEventWriter
   }
 
   @Override
-  public boolean isTransactionEnabled()
+  public boolean supportTransaction()
   {
     return false;
   }
 
   @Override
+  public boolean isTransactionEnabled()
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void initTransaction()
   {
-    // No-Op as Kinesis does not support transaction
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public void commitTransaction()
   {
-    // No-Op as Kinesis does not support transaction
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/StreamEventWriter.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/StreamEventWriter.java
@@ -28,22 +28,43 @@ import java.io.Closeable;
  */
 public interface StreamEventWriter extends Closeable
 {
+  /**
+   * Returns true if the stream supports transactions.
+   */
+  boolean supportTransaction();
+
+  /**
+   * Returns true if the transaction is enabled for this writer. Callers should check {@link #supportTransaction()}
+   * before calling this method.
+   *
+   * @throws UnsupportedOperationException if {@link #supportTransaction()} returns false.
+   */
   boolean isTransactionEnabled();
 
+  /**
+   * Initializes a transaction for this writer.
+   *
+   * @throws UnsupportedOperationException if {@link #supportTransaction()} returns false.
+   */
   void initTransaction();
 
+  /**
+   * Commits a transaction.
+   *
+   * @throws UnsupportedOperationException if {@link #supportTransaction()} returns false.
+   */
   void commitTransaction();
 
   void write(String topic, byte[] event);
 
   /**
-   * Flush pending writes on the underlying stream. This method is synchronous and waits until the flush completes.
+   * Flushes pending writes on the underlying stream. This method is synchronous and waits until the flush completes.
    * Note that this method is not interruptible
    */
   void flush();
 
   /**
-   * Close this writer. Any resource should be cleaned up when this method is called.
+   * Closes this writer. Any resource should be cleaned up when this method is called.
    * Implementations must call {@link #flush()} before closing the writer.
    */
   @Override

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/SyntheticStreamGenerator.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/SyntheticStreamGenerator.java
@@ -81,7 +81,7 @@ public abstract class SyntheticStreamGenerator implements StreamGenerator
             nowCeilingToSecond.plusSeconds(1).minus(cyclePaddingMs)
         );
 
-        if (streamEventWriter.isTransactionEnabled()) {
+        if (streamEventWriter.supportTransaction() && streamEventWriter.isTransactionEnabled()) {
           streamEventWriter.initTransaction();
         }
 
@@ -98,7 +98,7 @@ public abstract class SyntheticStreamGenerator implements StreamGenerator
           }
         }
 
-        if (streamEventWriter.isTransactionEnabled()) {
+        if (streamEventWriter.supportTransaction() && streamEventWriter.isTransactionEnabled()) {
           streamEventWriter.commitTransaction();
         }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKafkaIndexingServiceTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKafkaIndexingServiceTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.tests.indexer;
 
+import com.google.common.base.Preconditions;
 import org.apache.druid.indexing.kafka.KafkaConsumerConfigs;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.IntegrationTestingConfig;
@@ -40,9 +41,9 @@ public abstract class AbstractKafkaIndexingServiceTest extends AbstractStreamInd
   }
 
   @Override
-  public StreamEventWriter createStreamEventWriter(IntegrationTestingConfig config, boolean transactionEnabled)
+  public StreamEventWriter createStreamEventWriter(IntegrationTestingConfig config, Boolean transactionEnabled)
   {
-    return new KafkaEventWriter(config, transactionEnabled);
+    return new KafkaEventWriter(config, Preconditions.checkNotNull(transactionEnabled, "transactionEnabled"));
   }
 
   @Override

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKinesisIndexingServiceTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKinesisIndexingServiceTest.java
@@ -20,16 +20,20 @@
 package org.apache.druid.tests.indexer;
 
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.utils.KinesisAdminClient;
 import org.apache.druid.testing.utils.KinesisEventWriter;
 import org.apache.druid.testing.utils.StreamAdminClient;
 import org.apache.druid.testing.utils.StreamEventWriter;
 
+import javax.annotation.Nullable;
 import java.util.function.Function;
 
 public abstract class AbstractKinesisIndexingServiceTest extends AbstractStreamIndexingTest
 {
+  private static final Logger LOG = new Logger(AbstractKinesisIndexingServiceTest.class);
+
   @Override
   StreamAdminClient createStreamAdminClient(IntegrationTestingConfig config) throws Exception
   {
@@ -37,9 +41,15 @@ public abstract class AbstractKinesisIndexingServiceTest extends AbstractStreamI
   }
 
   @Override
-  StreamEventWriter createStreamEventWriter(IntegrationTestingConfig config, boolean transactionEnabled)
+  StreamEventWriter createStreamEventWriter(IntegrationTestingConfig config, @Nullable Boolean transactionEnabled)
       throws Exception
   {
+    if (transactionEnabled != null) {
+      LOG.warn(
+          "Kinesis event writer doesn't support transaction. Ignoring the given parameter transactionEnabled[%s]",
+          transactionEnabled
+      );
+    }
     return new KinesisEventWriter(config.getStreamEndpoint(), false);
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITKinesisIndexingServiceSerializedTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITKinesisIndexingServiceSerializedTest.java
@@ -47,7 +47,7 @@ public class ITKinesisIndexingServiceSerializedTest extends AbstractKinesisIndex
   @Test
   public void testKinesisIndexDataWithLosingCoordinator() throws Exception
   {
-    doTestIndexDataWithLosingCoordinator(false);
+    doTestIndexDataWithLosingCoordinator(null);
   }
 
   /**
@@ -56,7 +56,7 @@ public class ITKinesisIndexingServiceSerializedTest extends AbstractKinesisIndex
   @Test
   public void testKinesisIndexDataWithLosingOverlord() throws Exception
   {
-    doTestIndexDataWithLosingOverlord(false);
+    doTestIndexDataWithLosingOverlord(null);
   }
 
   /**
@@ -65,6 +65,6 @@ public class ITKinesisIndexingServiceSerializedTest extends AbstractKinesisIndex
   @Test
   public void testKinesisIndexDataWithLosingHistorical() throws Exception
   {
-    doTestIndexDataWithLosingHistorical(false);
+    doTestIndexDataWithLosingHistorical(null);
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKinesisIndexingServiceDataFormatTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKinesisIndexingServiceDataFormatTest.java
@@ -85,7 +85,7 @@ public class ITKinesisIndexingServiceDataFormatTest extends AbstractKinesisIndex
   public void testIndexData(String serializerPath, String parserType, String specPath)
       throws Exception
   {
-    doTestIndexDataStableState(false, serializerPath, parserType, specPath);
+    doTestIndexDataStableState(null, serializerPath, parserType, specPath);
   }
 
   @Override

--- a/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKinesisIndexingServiceParallelizedTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKinesisIndexingServiceParallelizedTest.java
@@ -49,7 +49,7 @@ public class ITKinesisIndexingServiceParallelizedTest extends AbstractKinesisInd
   @Test
   public void testKinesisIndexDataWithStartStopSupervisor() throws Exception
   {
-    doTestIndexDataWithStartStopSupervisor(false);
+    doTestIndexDataWithStartStopSupervisor(null);
   }
 
   /**
@@ -59,7 +59,7 @@ public class ITKinesisIndexingServiceParallelizedTest extends AbstractKinesisInd
   @Test
   public void testKinesisIndexDataWithKinesisReshardSplit() throws Exception
   {
-    doTestIndexDataWithStreamReshardSplit(false);
+    doTestIndexDataWithStreamReshardSplit(null);
   }
 
   /**
@@ -69,6 +69,6 @@ public class ITKinesisIndexingServiceParallelizedTest extends AbstractKinesisInd
   @Test
   public void testKinesisIndexDataWithKinesisReshardMerge() throws Exception
   {
-    doTestIndexDataWithStreamReshardMerge(false);
+    doTestIndexDataWithStreamReshardMerge();
   }
 }


### PR DESCRIPTION
### Description

Add Javadoc for `AbstractStreamIndexingTest.createStreamEventWriter()`. Also added a new interface and Javadoc for `StreamEventWriter`.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.