### PR TITLE
disable null column skipping

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/AbstractInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/AbstractInputSource.java
@@ -38,11 +38,23 @@ public abstract class AbstractInputSource implements InputSource
       File temporaryDirectory
   )
   {
+    return reader(inputRowSchema, inputFormat, temporaryDirectory, false);
+  }
+
+  @Override
+  public InputSourceReader reader(
+      InputRowSchema inputRowSchema,
+      @Nullable InputFormat inputFormat,
+      File temporaryDirectory,
+      Boolean disableNullColumnSkipping
+  )
+  {
     if (needsFormat()) {
       return formattableReader(
           inputRowSchema,
           Preconditions.checkNotNull(inputFormat, "inputFormat"),
-          temporaryDirectory
+          temporaryDirectory,
+          disableNullColumnSkipping
       );
     } else {
       return fixedFormatReader(inputRowSchema, temporaryDirectory);
@@ -52,7 +64,8 @@ public abstract class AbstractInputSource implements InputSource
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      File temporaryDirectory
+      File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     throw new UnsupportedOperationException("Implement this method properly if needsFormat() = true");

--- a/core/src/main/java/org/apache/druid/data/input/InputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/InputFormat.java
@@ -63,6 +63,7 @@ public interface InputFormat
   InputEntityReader createReader(
       InputRowSchema inputRowSchema,
       InputEntity source,
-      File temporaryDirectory
+      File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   ) throws IOException;
 }

--- a/core/src/main/java/org/apache/druid/data/input/InputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/InputSource.java
@@ -76,5 +76,7 @@ public interface InputSource
    * @param inputFormat        to parse data. It can be null if {@link #needsFormat()} = true
    * @param temporaryDirectory to store temp data. It will be cleaned up automatically once the task is finished.
    */
+  InputSourceReader reader(InputRowSchema inputRowSchema, @Nullable InputFormat inputFormat, File temporaryDirectory, Boolean disableNullColumnSkipping);
   InputSourceReader reader(InputRowSchema inputRowSchema, @Nullable InputFormat inputFormat, File temporaryDirectory);
+
 }

--- a/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectInputSource.java
@@ -143,7 +143,8 @@ public abstract class CloudObjectInputSource extends AbstractInputSource
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      Boolean nullIndex
   )
   {
     return new InputEntityIteratingReader(

--- a/core/src/main/java/org/apache/druid/data/input/impl/CsvInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/CsvInputFormat.java
@@ -66,7 +66,7 @@ public class CsvInputFormat extends FlatTextInputFormat
   }
 
   @Override
-  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory, Boolean disableNullColumnSkipping)
   {
     return new DelimitedValueReader(
         inputRowSchema,

--- a/core/src/main/java/org/apache/druid/data/input/impl/DelimitedInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/DelimitedInputFormat.java
@@ -69,7 +69,7 @@ public class DelimitedInputFormat extends FlatTextInputFormat
   }
 
   @Override
-  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory, Boolean disableNullColumnSkipping)
   {
     return new DelimitedValueReader(
         inputRowSchema,

--- a/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSource.java
@@ -105,7 +105,8 @@ public class HttpInputSource extends AbstractInputSource implements SplittableIn
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     return new InputEntityIteratingReader(

--- a/core/src/main/java/org/apache/druid/data/input/impl/InlineInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/InlineInputSource.java
@@ -65,14 +65,16 @@ public class InlineInputSource extends AbstractInputSource
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     return new InputEntityIteratingReader(
         inputRowSchema,
         inputFormat,
         Stream.of(new ByteEntity(StringUtils.toUtf8(data))).iterator(),
-        temporaryDirectory
+        temporaryDirectory,
+        disableNullColumnSkipping
     );
   }
 }

--- a/core/src/main/java/org/apache/druid/data/input/impl/InputEntityIteratingReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/InputEntityIteratingReader.java
@@ -44,6 +44,7 @@ public class InputEntityIteratingReader implements InputSourceReader
   private final InputFormat inputFormat;
   private final CloseableIterator<InputEntity> sourceIterator;
   private final File temporaryDirectory;
+  private final Boolean disableNullColumnSkipping;
 
   public InputEntityIteratingReader(
       InputRowSchema inputRowSchema,
@@ -52,20 +53,33 @@ public class InputEntityIteratingReader implements InputSourceReader
       File temporaryDirectory
   )
   {
-    this(inputRowSchema, inputFormat, CloseableIterators.withEmptyBaggage(sourceIterator), temporaryDirectory);
+    this(inputRowSchema, inputFormat, CloseableIterators.withEmptyBaggage(sourceIterator), temporaryDirectory, false);
   }
+
+  public InputEntityIteratingReader(
+         InputRowSchema inputRowSchema,
+         InputFormat inputFormat,
+         Iterator<? extends InputEntity> sourceIterator,
+         File temporaryDirectory,
+         Boolean disableNullColumnSkipping
+     )
+     {
+       this(inputRowSchema, inputFormat, CloseableIterators.withEmptyBaggage(sourceIterator), temporaryDirectory, disableNullColumnSkipping);
+     }
 
   public InputEntityIteratingReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
       CloseableIterator<? extends InputEntity> sourceCloseableIterator,
-      File temporaryDirectory
+      File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     this.inputRowSchema = inputRowSchema;
     this.inputFormat = inputFormat;
     this.sourceIterator = (CloseableIterator<InputEntity>) sourceCloseableIterator;
     this.temporaryDirectory = temporaryDirectory;
+    this.disableNullColumnSkipping = disableNullColumnSkipping;
   }
 
   @Override
@@ -74,7 +88,7 @@ public class InputEntityIteratingReader implements InputSourceReader
     return createIterator(entity -> {
       // InputEntityReader is stateful and so a new one should be created per entity.
       try {
-        final InputEntityReader reader = inputFormat.createReader(inputRowSchema, entity, temporaryDirectory);
+        final InputEntityReader reader = inputFormat.createReader(inputRowSchema, entity, temporaryDirectory, disableNullColumnSkipping);
         return reader.read();
       }
       catch (IOException e) {
@@ -89,7 +103,7 @@ public class InputEntityIteratingReader implements InputSourceReader
     return createIterator(entity -> {
       // InputEntityReader is stateful and so a new one should be created per entity.
       try {
-        final InputEntityReader reader = inputFormat.createReader(inputRowSchema, entity, temporaryDirectory);
+        final InputEntityReader reader = inputFormat.createReader(inputRowSchema, entity, temporaryDirectory, disableNullColumnSkipping);
         return reader.sample();
       }
       catch (IOException e) {

--- a/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
@@ -68,9 +68,9 @@ public class JsonInputFormat extends NestedInputFormat
   }
 
   @Override
-  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory, Boolean disableNullColumnSkipping)
   {
-    return new JsonReader(inputRowSchema, source, getFlattenSpec(), objectMapper);
+    return new JsonReader(inputRowSchema, source, getFlattenSpec(), objectMapper, disableNullColumnSkipping);
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/data/input/impl/JsonReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/JsonReader.java
@@ -40,24 +40,27 @@ public class JsonReader extends TextReader
 {
   private final ObjectFlattener<JsonNode> flattener;
   private final ObjectMapper mapper;
+  private final boolean disableNullColumnSkipping;
 
   JsonReader(
       InputRowSchema inputRowSchema,
       InputEntity source,
       JSONPathSpec flattenSpec,
-      ObjectMapper mapper
+      ObjectMapper mapper,
+      Boolean disableNullColumnSkipping
   )
   {
     super(inputRowSchema, source);
     this.flattener = ObjectFlatteners.create(flattenSpec, new JSONFlattenerMaker());
     this.mapper = mapper;
+    this.disableNullColumnSkipping = disableNullColumnSkipping;
   }
 
   @Override
   public List<InputRow> parseInputRows(String line) throws IOException, ParseException
   {
     final JsonNode document = mapper.readValue(line, JsonNode.class);
-    final Map<String, Object> flattened = flattener.flatten(document);
+    final Map<String, Object> flattened = disableNullColumnSkipping ? flattener.toMap(document) : flattener.flatten(document);
     return Collections.singletonList(MapInputRowParser.parse(getInputRowSchema(), flattened));
   }
 

--- a/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
@@ -184,7 +184,8 @@ public class LocalInputSource extends AbstractInputSource implements SplittableI
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      Boolean nullIndex
   )
   {
     //noinspection ConstantConditions

--- a/core/src/main/java/org/apache/druid/data/input/impl/RegexInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/RegexInputFormat.java
@@ -82,7 +82,7 @@ public class RegexInputFormat implements InputFormat
   }
 
   @Override
-  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory, Boolean disableNullColumnSkipping)
   {
     return new RegexReader(inputRowSchema, source, pattern, compiledPatternSupplier.get(), listDelimiter, columns);
   }

--- a/core/src/test/java/org/apache/druid/data/input/impl/CsvReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/CsvReaderTest.java
@@ -128,7 +128,7 @@ public class CsvReaderTest
         )
     );
     final CsvInputFormat format = new CsvInputFormat(ImmutableList.of(), "|", null, true, 0);
-    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null);
+    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null, false);
     int numResults = 0;
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       while (iterator.hasNext()) {
@@ -232,7 +232,8 @@ public class CsvReaderTest
             Collections.emptyList()
         ),
         source,
-        null
+        null,
+        false
     );
 
     try (CloseableIterator<InputRow> iterator = reader.read()) {
@@ -253,7 +254,7 @@ public class CsvReaderTest
         )
     );
     final CsvInputFormat format = new CsvInputFormat(ImmutableList.of("ts", "name", "Comment"), null, null, false, 0);
-    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null);
+    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null, false);
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       Assert.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
@@ -283,7 +284,7 @@ public class CsvReaderTest
 
   private void assertResult(ByteEntity source, CsvInputFormat format) throws IOException
   {
-    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null);
+    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null, false);
     int numResults = 0;
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       while (iterator.hasNext()) {

--- a/core/src/test/java/org/apache/druid/data/input/impl/DelimitedReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/DelimitedReaderTest.java
@@ -139,7 +139,7 @@ public class DelimitedReaderTest
         )
     );
     final DelimitedInputFormat format = new DelimitedInputFormat(ImmutableList.of(), "|", null, null, true, 0);
-    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null);
+    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null, false);
     int numResults = 0;
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       while (iterator.hasNext()) {
@@ -174,7 +174,7 @@ public class DelimitedReaderTest
         )
     );
     final DelimitedInputFormat format = new DelimitedInputFormat(ImmutableList.of(), "\t", "|", null, true, 0);
-    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null);
+    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null, false);
     int numResults = 0;
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       while (iterator.hasNext()) {
@@ -213,7 +213,7 @@ public class DelimitedReaderTest
         false,
         0
     );
-    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null);
+    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null, false);
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       Assert.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
@@ -243,7 +243,7 @@ public class DelimitedReaderTest
 
   private void assertResult(ByteEntity source, DelimitedInputFormat format) throws IOException
   {
-    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null);
+    final InputEntityReader reader = format.createReader(INPUT_ROW_SCHEMA, source, null, false);
     int numResults = 0;
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       while (iterator.hasNext()) {

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
@@ -67,7 +67,8 @@ public class JsonReaderTest
             Collections.emptyList()
         ),
         source,
-        null
+        null,
+        false
     );
     final int numExpectedIterations = 1;
     try (CloseableIterator<InputRow> iterator = reader.read()) {
@@ -116,7 +117,8 @@ public class JsonReaderTest
             Collections.emptyList()
         ),
         source,
-        null
+        null,
+        false
     );
 
     final int numExpectedIterations = 1;

--- a/core/src/test/java/org/apache/druid/data/input/impl/NoopInputFormat.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/NoopInputFormat.java
@@ -35,7 +35,7 @@ public class NoopInputFormat implements InputFormat
   }
 
   @Override
-  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory, Boolean disableNullColumnSkipping)
   {
     throw new UnsupportedOperationException();
   }

--- a/core/src/test/java/org/apache/druid/data/input/impl/NoopInputSource.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/NoopInputSource.java
@@ -51,7 +51,18 @@ public class NoopInputSource implements InputSource
   public InputSourceReader reader(
       InputRowSchema inputRowSchema,
       @Nullable InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      File temporaryDirectory
+  )
+  {
+    return reader(inputRowSchema, inputFormat, temporaryDirectory, false);
+  }
+
+  @Override
+  public InputSourceReader reader(
+      InputRowSchema inputRowSchema,
+      @Nullable InputFormat inputFormat,
+      @Nullable File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     throw new UnsupportedOperationException();

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/inputsource/hdfs/HdfsInputSource.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/inputsource/hdfs/HdfsInputSource.java
@@ -154,7 +154,8 @@ public class HdfsInputSource extends AbstractInputSource implements SplittableIn
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     try {

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
@@ -234,7 +234,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     @Test
     public void readsSplitsCorrectly() throws IOException
     {
-      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null);
+      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null, false);
 
       Map<Long, String> actualTimestampToValue = new HashMap<>();
       try (CloseableIterator<InputRow> iterator = reader.read()) {
@@ -311,7 +311,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     @Test
     public void readsSplitsCorrectly() throws IOException
     {
-      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null);
+      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null, false);
 
       try (CloseableIterator<InputRow> iterator = reader.read()) {
         Assert.assertFalse(iterator.hasNext());

--- a/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcInputFormat.java
+++ b/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcInputFormat.java
@@ -58,7 +58,7 @@ public class OrcInputFormat extends NestedInputFormat
   }
 
   @Override
-  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory, Boolean disableNullColumnSkipping)
   {
     return new OrcReader(conf, inputRowSchema, source, temporaryDirectory, getFlattenSpec(), binaryAsString);
   }

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
@@ -261,6 +261,6 @@ public class OrcReaderTest
   {
     final InputRowSchema schema = new InputRowSchema(timestampSpec, dimensionsSpec, Collections.emptyList());
     final FileEntity entity = new FileEntity(new File(dataFile));
-    return inputFormat.createReader(schema, entity, temporaryFolder.newFolder());
+    return inputFormat.createReader(schema, entity, temporaryFolder.newFolder(), false);
   }
 }

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
@@ -68,7 +68,8 @@ public class ParquetInputFormat extends NestedInputFormat
   public InputEntityReader createReader(
       InputRowSchema inputRowSchema,
       InputEntity source,
-      File temporaryDirectory
+      File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   ) throws IOException
   {
     return new ParquetReader(conf, inputRowSchema, source, temporaryDirectory, getFlattenSpec(), binaryAsString);

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetReaderTest.java
@@ -53,7 +53,7 @@ class BaseParquetReaderTest
   {
     FileEntity entity = new FileEntity(new File(parquetFile));
     ParquetInputFormat parquet = new ParquetInputFormat(flattenSpec, binaryAsString, new Configuration());
-    return parquet.createReader(schema, entity, null);
+    return parquet.createReader(schema, entity, null, false);
   }
 
   List<InputRow> readAllRows(InputEntityReader reader) throws IOException

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -598,7 +598,7 @@ public class IndexGeneratorJob implements Jobby
     ) throws IOException
     {
       return HadoopDruidIndexerConfig.INDEX_MERGER_V9
-          .persist(index, interval, file, config.getIndexSpecForIntermediatePersists(), progressIndicator, null);
+          .persist(index, interval, file, config.getIndexSpecForIntermediatePersists(), progressIndicator, null, false);
     }
 
     protected File mergeQueryableIndex(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -278,7 +278,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
 
     DiscoveryDruidNode discoveryDruidNode = createDiscoveryDruidNode(toolbox);
 
-    appenderator = newAppenderator(dataSchema, tuningConfig, metrics, toolbox);
+    appenderator = newAppenderator(dataSchema, tuningConfig, metrics, toolbox, false);
     StreamAppenderatorDriver driver = newDriver(dataSchema, appenderator, toolbox, metrics);
 
     try {
@@ -756,7 +756,8 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
       final DataSchema dataSchema,
       final RealtimeAppenderatorTuningConfig tuningConfig,
       final FireDepartmentMetrics metrics,
-      final TaskToolbox toolbox
+      final TaskToolbox toolbox,
+      final boolean disableNullColumnSkipping
   )
   {
     return appenderatorsManager.createRealtimeAppenderatorForTask(
@@ -775,7 +776,8 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
         toolbox.getJoinableFactory(),
         toolbox.getCache(),
         toolbox.getCacheConfig(),
-        toolbox.getCachePopulatorStats()
+        toolbox.getCachePopulatorStats(),
+        disableNullColumnSkipping
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/BatchAppenderators.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/BatchAppenderators.java
@@ -39,7 +39,8 @@ public final class BatchAppenderators
       TaskToolbox toolbox,
       DataSchema dataSchema,
       AppenderatorConfig appenderatorConfig,
-      boolean storeCompactionState
+      boolean storeCompactionState,
+      boolean disableNullColumnSkipping
   )
   {
     return newAppenderator(
@@ -50,7 +51,8 @@ public final class BatchAppenderators
         dataSchema,
         appenderatorConfig,
         toolbox.getSegmentPusher(),
-        storeCompactionState
+        storeCompactionState,
+        disableNullColumnSkipping
     );
   }
 
@@ -62,7 +64,8 @@ public final class BatchAppenderators
       DataSchema dataSchema,
       AppenderatorConfig appenderatorConfig,
       DataSegmentPusher segmentPusher,
-      boolean storeCompactionState
+      boolean storeCompactionState,
+      boolean disableNullColumnSkipping
   )
   {
     return appenderatorsManager.createOfflineAppenderatorForTask(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -606,6 +606,7 @@ public class CompactionTask extends AbstractBatchIndexTask
             retryPolicyFactory
         ),
         null,
+        false,
         false
     );
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
@@ -63,6 +63,7 @@ public class InputSourceProcessor
   private final int maxParseExceptions;
   private final long pushTimeout;
   private final IndexTaskInputRowIteratorBuilder inputRowIteratorBuilder;
+  private final boolean disableNullColumnSkipping;
 
   public InputSourceProcessor(
       RowIngestionMeters buildSegmentsMeters,
@@ -70,7 +71,8 @@ public class InputSourceProcessor
       boolean logParseExceptions,
       int maxParseExceptions,
       long pushTimeout,
-      IndexTaskInputRowIteratorBuilder inputRowIteratorBuilder
+      IndexTaskInputRowIteratorBuilder inputRowIteratorBuilder,
+      boolean disableNullColumnSkipping
   )
   {
     this.buildSegmentsMeters = buildSegmentsMeters;
@@ -79,6 +81,7 @@ public class InputSourceProcessor
     this.maxParseExceptions = maxParseExceptions;
     this.pushTimeout = pushTimeout;
     this.inputRowIteratorBuilder = inputRowIteratorBuilder;
+    this.disableNullColumnSkipping = disableNullColumnSkipping;
   }
 
   /**
@@ -115,7 +118,8 @@ public class InputSourceProcessor
                 metricsNames
             ),
             inputFormat,
-            tmpDir
+            tmpDir,
+            disableNullColumnSkipping
         )
     );
     try (

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/InputSourceSplitParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/InputSourceSplitParallelIndexTaskRunner.java
@@ -100,7 +100,8 @@ abstract class InputSourceSplitParallelIndexTaskRunner<T extends Task, R extends
             firehoseFactory,
             inputSource,
             ingestionSchema.getIOConfig().getInputFormat(),
-            ingestionSchema.getIOConfig().isAppendToExisting()
+            ingestionSchema.getIOConfig().isAppendToExisting(),
+            ingestionSchema.getIOConfig().isDisableNullColumnSkipping()
         ),
         ingestionSchema.getTuningConfig()
     );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIOConfig.java
@@ -40,16 +40,17 @@ public class ParallelIndexIOConfig extends IndexIOConfig
       @JsonProperty("firehose") @Nullable FirehoseFactory firehoseFactory,
       @JsonProperty("inputSource") @Nullable InputSource inputSource,
       @JsonProperty("inputFormat") @Nullable InputFormat inputFormat,
-      @JsonProperty("appendToExisting") @Nullable Boolean appendToExisting
+      @JsonProperty("appendToExisting") @Nullable Boolean appendToExisting,
+      @JsonProperty("disableNullColumnSkipping") @Nullable Boolean disableNullColumnSkipping
   )
   {
-    super(firehoseFactory, inputSource, inputFormat, appendToExisting);
+    super(firehoseFactory, inputSource, inputFormat, appendToExisting, disableNullColumnSkipping);
   }
 
   // old constructor for backward compatibility
   @Deprecated
   public ParallelIndexIOConfig(FirehoseFactory firehoseFactory, @Nullable Boolean appendToExisting)
   {
-    this(firehoseFactory, null, null, appendToExisting);
+    this(firehoseFactory, null, null, appendToExisting, false);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
@@ -185,7 +185,8 @@ abstract class PartialSegmentGenerateTask<T extends GeneratedPartitionsReport> e
         dataSchema,
         tuningConfig,
         new ShuffleDataSegmentPusher(supervisorTaskId, getId(), toolbox.getIntermediaryDataManager()),
-        getContextValue(Tasks.STORE_COMPACTION_STATE_KEY, Tasks.DEFAULT_STORE_COMPACTION_STATE)
+        getContextValue(Tasks.STORE_COMPACTION_STATE_KEY, Tasks.DEFAULT_STORE_COMPACTION_STATE),
+        ingestionSchema.getIOConfig().isDisableNullColumnSkipping()
     );
     boolean exceptionOccurred = false;
     try (final BatchAppenderatorDriver driver = BatchAppenderators.newDriver(appenderator, toolbox, segmentAllocator)) {
@@ -197,7 +198,8 @@ abstract class PartialSegmentGenerateTask<T extends GeneratedPartitionsReport> e
           tuningConfig.isLogParseExceptions(),
           tuningConfig.getMaxParseExceptions(),
           pushTimeout,
-          inputRowIteratorBuilder
+          inputRowIteratorBuilder,
+          ingestionSchema.getIOConfig().isDisableNullColumnSkipping()
       );
       final SegmentsAndCommitMetadata pushed = inputSourceProcessor.process(
           dataSchema,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
@@ -122,7 +122,8 @@ class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner<Single
                 firehoseFactory,
                 inputSource,
                 ingestionSchema.getIOConfig().getInputFormat(),
-                ingestionSchema.getIOConfig().isAppendToExisting()
+                ingestionSchema.getIOConfig().isAppendToExisting(),
+                ingestionSchema.getIOConfig().isDisableNullColumnSkipping()
             ),
             ingestionSchema.getTuningConfig()
         ),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -330,7 +330,8 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
         toolbox,
         dataSchema,
         tuningConfig,
-        getContextValue(Tasks.STORE_COMPACTION_STATE_KEY, Tasks.DEFAULT_STORE_COMPACTION_STATE)
+        getContextValue(Tasks.STORE_COMPACTION_STATE_KEY, Tasks.DEFAULT_STORE_COMPACTION_STATE),
+        false
     );
     final List<String> metricsNames = Arrays.stream(ingestionSchema.getDataSchema().getAggregators())
                                             .map(AggregatorFactory::getName)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentInputFormat.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentInputFormat.java
@@ -59,7 +59,8 @@ public class DruidSegmentInputFormat implements InputFormat
   public InputEntityReader createReader(
       InputRowSchema inputRowSchema,
       InputEntity source,
-      File temporaryDirectory
+      File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     return new DruidSegmentReader(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/IndexTaskSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/IndexTaskSamplerSpec.java
@@ -47,6 +47,7 @@ public class IndexTaskSamplerSpec implements SamplerSpec
   @Nullable
   private final SamplerConfig samplerConfig;
   private final InputSourceSampler inputSourceSampler;
+  private final Boolean disableNullColumnSkipping;
 
   @JsonCreator
   public IndexTaskSamplerSpec(
@@ -56,9 +57,8 @@ public class IndexTaskSamplerSpec implements SamplerSpec
   )
   {
     this.dataSchema = Preconditions.checkNotNull(ingestionSpec, "[spec] is required").getDataSchema();
-
     Preconditions.checkNotNull(ingestionSpec.getIOConfig(), "[spec.ioConfig] is required");
-
+    this.disableNullColumnSkipping = ingestionSpec.getIOConfig().isDisableNullColumnSkipping();
     if (ingestionSpec.getIOConfig().getInputSource() != null) {
       this.inputSource = ingestionSpec.getIOConfig().getInputSource();
       if (ingestionSpec.getIOConfig().getInputSource().needsFormat()) {
@@ -91,6 +91,6 @@ public class IndexTaskSamplerSpec implements SamplerSpec
   @Override
   public SamplerResponse sample()
   {
-    return inputSourceSampler.sample(inputSource, inputFormat, dataSchema, samplerConfig);
+    return inputSourceSampler.sample(inputSource, inputFormat, dataSchema, samplerConfig, disableNullColumnSkipping);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSource.java
@@ -99,7 +99,8 @@ public class RecordSupplierInputSource<PartitionIdType, SequenceOffsetType> exte
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      Boolean disableNullColumnSkipping
   )
   {
     return new InputEntityIteratingReader(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -209,7 +209,8 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
         toolbox.getJoinableFactory(),
         toolbox.getCache(),
         toolbox.getCacheConfig(),
-        toolbox.getCachePopulatorStats()
+        toolbox.getCachePopulatorStats(),
+        false
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SettableByteEntityReader.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SettableByteEntityReader.java
@@ -65,7 +65,7 @@ class SettableByteEntityReader implements InputEntityReader
     this.delegate = new TransformingInputEntityReader(
         // Yes, we are creating a new reader for every stream chunk.
         // This should be fine as long as initializing a reader is cheap which it is for now.
-        inputFormat.createReader(inputRowSchema, entity, indexingTmpDir),
+        inputFormat.createReader(inputRowSchema, entity, indexingTmpDir, false),
         transformer
     );
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexIngestionSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexIngestionSpecTest.java
@@ -60,7 +60,8 @@ public class IndexIngestionSpecTest
             null,
             new NoopInputSource(),
             new NoopInputFormat(),
-            null
+            null,
+            false
         ),
         null
     );
@@ -84,7 +85,8 @@ public class IndexIngestionSpecTest
             null,
             new NoopInputSource(),
             null,
-            null
+            null,
+            false
         ),
         null
     );
@@ -110,7 +112,8 @@ public class IndexIngestionSpecTest
             new NoopFirehoseFactory(),
             new NoopInputSource(),
             null,
-            null
+            null,
+            false
         ),
         null
     );
@@ -134,7 +137,8 @@ public class IndexIngestionSpecTest
             new NoopFirehoseFactory(),
             null,
             new NoopInputFormat(),
-            null
+            null,
+            false
         ),
         null
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -1835,7 +1835,8 @@ public class IndexTaskTest extends IngestionTestBase
               null,
               new LocalInputSource(baseDir, "druid*"),
               parseSpec == null ? DEFAULT_INPUT_FORMAT : parseSpec.toInputFormat(),
-              appendToExisting
+              appendToExisting,
+              false
           ),
           tuningConfig
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -204,7 +204,7 @@ public class TaskSerdeTest
                 ),
                 null
             ),
-            new IndexIOConfig(null, new LocalInputSource(new File("lol"), "rofl"), new NoopInputFormat(), true),
+            new IndexIOConfig(null, new LocalInputSource(new File("lol"), "rofl"), new NoopInputFormat(), true, false),
             new IndexTuningConfig(
                 null,
                 null,
@@ -288,7 +288,7 @@ public class TaskSerdeTest
                 ),
                 null
             ),
-            new IndexIOConfig(null, new LocalInputSource(new File("lol"), "rofl"), new NoopInputFormat(), true),
+            new IndexIOConfig(null, new LocalInputSource(new File("lol"), "rofl"), new NoopInputFormat(), true, false),
             new IndexTuningConfig(
                 null,
                 null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TestAppenderatorsManager.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TestAppenderatorsManager.java
@@ -64,7 +64,8 @@ public class TestAppenderatorsManager implements AppenderatorsManager
       JoinableFactory joinableFactory,
       Cache cache,
       CacheConfig cacheConfig,
-      CachePopulatorStats cachePopulatorStats
+      CachePopulatorStats cachePopulatorStats,
+      boolean disableNullColumnSkipping
   )
   {
     realtimeAppenderator = Appenderators.createRealtime(
@@ -83,7 +84,8 @@ public class TestAppenderatorsManager implements AppenderatorsManager
         joinableFactory,
         cache,
         cacheConfig,
-        cachePopulatorStats
+        cachePopulatorStats,
+        disableNullColumnSkipping
     );
     return realtimeAppenderator;
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
@@ -158,6 +158,7 @@ abstract class AbstractMultiPhaseParallelIndexingTest extends AbstractParallelIn
           null,
           new LocalInputSource(inputDir, filter),
           parseSpec.toInputFormat(),
+          false,
           false
       );
       ingestionSpec = new ParallelIndexIngestionSpec(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -80,6 +80,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
             // Sub tasks would run forever
             new TestInputSource(Pair.of(new TestInput(Integer.MAX_VALUE, TaskState.SUCCESS), 4)),
             new NoopInputFormat(),
+            false,
             false
         )
     );
@@ -112,6 +113,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
                 Pair.of(new TestInput(Integer.MAX_VALUE, TaskState.FAILED), 3)
             ),
             new NoopInputFormat(),
+            false,
             false
         )
     );
@@ -328,7 +330,8 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
                   null,
                   baseInputSource.withSplit(split),
                   getIngestionSchema().getIOConfig().getInputFormat(),
-                  getIngestionSchema().getIOConfig().isAppendToExisting()
+                  getIngestionSchema().getIOConfig().isAppendToExisting(),
+                  getIngestionSchema().getIOConfig().isDisableNullColumnSkipping()
               ),
               getIngestionSchema().getTuningConfig()
           ),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -126,6 +126,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
             null,
             new TestInputSource(IntStream.range(0, NUM_SUB_TASKS).boxed().collect(Collectors.toList())),
             new NoopInputFormat(),
+            false,
             false
         )
     );
@@ -554,7 +555,8 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
                   null,
                   baseInputSource.withSplit(split),
                   getIngestionSchema().getIOConfig().getInputFormat(),
-                  getIngestionSchema().getIOConfig().isAppendToExisting()
+                  getIngestionSchema().getIOConfig().isAppendToExisting(),
+                  getIngestionSchema().getIOConfig().isDisableNullColumnSkipping()
               ),
               getIngestionSchema().getTuningConfig()
           ),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
@@ -233,6 +233,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
         null,
         new LocalInputSource(new File("tmp"), "test_*"),
         new CsvInputFormat(Arrays.asList("ts", "dim", "val"), null, null, false, 0),
+        false,
         false
     );
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
@@ -212,7 +212,7 @@ class ParallelIndexTestingFactory
       DataSchema dataSchema
   )
   {
-    ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(null, inputSource, inputFormat, false);
+    ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(null, inputSource, inputFormat, false, false);
 
     return new ParallelIndexIngestionSpec(dataSchema, ioConfig, tuningConfig);
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -340,7 +340,8 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
               null,
               new SettableSplittableLocalInputSource(inputDir, "test_*", splittableInputSource),
               DEFAULT_INPUT_FORMAT,
-              appendToExisting
+              appendToExisting,
+              false
           ),
           tuningConfig
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTaskSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTaskSpecTest.java
@@ -55,6 +55,7 @@ public class SinglePhaseSubTaskSpecTest
               null,
               new LocalInputSource(new File("baseDir"), "filter"),
               new JsonInputFormat(null, null),
+              null,
               null
           ),
           null

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -738,7 +738,7 @@ public class TaskLifecycleTest
                 ),
                 null
             ),
-            new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false),
+            new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false, false),
             new IndexTuningConfig(
                 null,
                 10000,
@@ -822,7 +822,7 @@ public class TaskLifecycleTest
                 null,
                 mapper
             ),
-            new IndexIOConfig(null, new MockExceptionInputSource(), new NoopInputFormat(), false),
+            new IndexIOConfig(null, new MockExceptionInputSource(), new NoopInputFormat(), false, false),
             new IndexTuningConfig(
                 null,
                 10000,
@@ -1251,7 +1251,7 @@ public class TaskLifecycleTest
                 ),
                 null
             ),
-            new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false),
+            new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false, false),
             new IndexTuningConfig(
                 null,
                 10000,
@@ -1358,7 +1358,7 @@ public class TaskLifecycleTest
                 ),
                 null
             ),
-            new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false),
+            new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false, false),
             new IndexTuningConfig(
                 null,
                 10000,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkParserTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkParserTest.java
@@ -167,10 +167,10 @@ public class StreamChunkParserTest
     }
 
     @Override
-    public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+    public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory, Boolean disableNullColumnSkipping)
     {
       used = true;
-      return super.createReader(inputRowSchema, source, temporaryDirectory);
+      return super.createReader(inputRowSchema, source, temporaryDirectory, disableNullColumnSkipping);
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1360,7 +1360,7 @@
                         <signaturesFile>${project.parent.basedir}/codestyle/druid-forbidden-apis.txt</signaturesFile>
                     </signaturesFiles>
                     <excludes>
-                      <exclude>**/SomeAvroDatum.class</exclude>
+                        <exclude>**/SomeAvroDatum.class</exclude>
                     </excludes>
                     <suppressAnnotations>
                         <annotation>**.SuppressForbidden</annotation>

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -72,8 +72,18 @@ public final class DimensionHandlerUtils
       @Nullable MultiValueHandling multiValueHandling
   )
   {
+    return getHandlerFromCapabilities(dimensionName, capabilities, multiValueHandling, false);
+  }
+
+  public static DimensionHandler<?, ?, ?> getHandlerFromCapabilities(
+      String dimensionName,
+      @Nullable ColumnCapabilities capabilities,
+      @Nullable MultiValueHandling multiValueHandling,
+      boolean disableNullColumnSkipping
+  )
+  {
     if (capabilities == null) {
-      return new StringDimensionHandler(dimensionName, multiValueHandling, true);
+      return new StringDimensionHandler(dimensionName, multiValueHandling, true, disableNullColumnSkipping);
     }
 
     multiValueHandling = multiValueHandling == null ? MultiValueHandling.ofDefault() : multiValueHandling;
@@ -82,7 +92,7 @@ public final class DimensionHandlerUtils
       if (!capabilities.isDictionaryEncoded()) {
         throw new IAE("String column must have dictionary encoding.");
       }
-      return new StringDimensionHandler(dimensionName, multiValueHandling, capabilities.hasBitmapIndexes());
+      return new StringDimensionHandler(dimensionName, multiValueHandling, capabilities.hasBitmapIndexes(), disableNullColumnSkipping);
     }
 
     if (capabilities.getType() == ValueType.LONG) {
@@ -98,7 +108,7 @@ public final class DimensionHandlerUtils
     }
 
     // Return a StringDimensionHandler by default (null columns will be treated as String typed)
-    return new StringDimensionHandler(dimensionName, multiValueHandling, true);
+    return new StringDimensionHandler(dimensionName, multiValueHandling, true, disableNullColumnSkipping);
   }
 
   public static List<ValueType> getValueTypesFromDimensionSpecs(List<DimensionSpec> dimSpecs)

--- a/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
@@ -178,7 +178,8 @@ public interface IndexMerger
       Interval dataInterval,
       File outDir,
       IndexSpec indexSpec,
-      @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
+      @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+      boolean disableNullColumnSkipping
   ) throws IOException;
 
   File persist(
@@ -187,7 +188,8 @@ public interface IndexMerger
       File outDir,
       IndexSpec indexSpec,
       ProgressIndicator progress,
-      @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
+      @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+      boolean disableNullColumnSkipping
   ) throws IOException;
 
   File mergeQueryableIndex(

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
@@ -98,12 +98,14 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
   private final String dimensionName;
   private final MultiValueHandling multiValueHandling;
   private final boolean hasBitmapIndexes;
+  private final boolean disableNullColumnSkipping;
 
-  public StringDimensionHandler(String dimensionName, MultiValueHandling multiValueHandling, boolean hasBitmapIndexes)
+  public StringDimensionHandler(String dimensionName, MultiValueHandling multiValueHandling, boolean hasBitmapIndexes, boolean disableNullColumnSkipping)
   {
     this.dimensionName = dimensionName;
     this.multiValueHandling = multiValueHandling;
     this.hasBitmapIndexes = hasBitmapIndexes;
+    this.disableNullColumnSkipping = disableNullColumnSkipping;
   }
 
   @Override
@@ -160,6 +162,6 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
       );
     }
 
-    return new StringDimensionMergerV9(dimensionName, indexSpec, segmentWriteOutMedium, capabilities, progress, closer);
+    return new StringDimensionMergerV9(dimensionName, indexSpec, segmentWriteOutMedium, capabilities, progress, closer, disableNullColumnSkipping);
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionMergerV9.java
@@ -84,6 +84,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9
   private final SegmentWriteOutMedium segmentWriteOutMedium;
   private final MutableBitmap nullRowsBitmap;
   private final ColumnCapabilities capabilities;
+  private final boolean disableNullColumnSkipping;
 
   private int dictionarySize;
   private int rowCount = 0;
@@ -114,7 +115,8 @@ public class StringDimensionMergerV9 implements DimensionMergerV9
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
-      Closer closer
+      Closer closer,
+      boolean disableNullColumnSkipping
   )
   {
     this.dimensionName = dimensionName;
@@ -125,6 +127,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9
 
     this.progress = progress;
     this.closer = closer;
+    this.disableNullColumnSkipping = disableNullColumnSkipping;
   }
 
   @Override
@@ -526,7 +529,7 @@ public class StringDimensionMergerV9 implements DimensionMergerV9
   @Override
   public boolean canSkip()
   {
-    return cardinality == 0;
+    return !disableNullColumnSkipping && cardinality == 0;
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -495,9 +495,9 @@ public class IndexMergerV9WithSpatialIndexTest
       thirdFile.mkdirs();
       mergedFile.mkdirs();
 
-      indexMergerV9.persist(first, DATA_INTERVAL, firstFile, indexSpec, null);
-      indexMergerV9.persist(second, DATA_INTERVAL, secondFile, indexSpec, null);
-      indexMergerV9.persist(third, DATA_INTERVAL, thirdFile, indexSpec, null);
+      indexMergerV9.persist(first, DATA_INTERVAL, firstFile, indexSpec, null, false);
+      indexMergerV9.persist(second, DATA_INTERVAL, secondFile, indexSpec, null, false);
+      indexMergerV9.persist(third, DATA_INTERVAL, thirdFile, indexSpec, null, false);
 
       try {
         QueryableIndex mergedRealtime = indexIO.loadIndex(

--- a/processing/src/test/java/org/apache/druid/segment/TestIndex.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestIndex.java
@@ -197,8 +197,8 @@ public class TestIndex
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      INDEX_MERGER.persist(top, DATA_INTERVAL, topFile, INDEX_SPEC, null);
-      INDEX_MERGER.persist(bottom, DATA_INTERVAL, bottomFile, INDEX_SPEC, null);
+      INDEX_MERGER.persist(top, DATA_INTERVAL, topFile, INDEX_SPEC, null, false);
+      INDEX_MERGER.persist(bottom, DATA_INTERVAL, bottomFile, INDEX_SPEC, null, false);
 
       return INDEX_IO.loadIndex(
           INDEX_MERGER.mergeQueryableIndex(

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
@@ -445,9 +445,9 @@ public class SpatialFilterBonusTest
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      indexMerger.persist(first, DATA_INTERVAL, firstFile, indexSpec, null);
-      indexMerger.persist(second, DATA_INTERVAL, secondFile, indexSpec, null);
-      indexMerger.persist(third, DATA_INTERVAL, thirdFile, indexSpec, null);
+      indexMerger.persist(first, DATA_INTERVAL, firstFile, indexSpec, null, false);
+      indexMerger.persist(second, DATA_INTERVAL, secondFile, indexSpec, null, false);
+      indexMerger.persist(third, DATA_INTERVAL, thirdFile, indexSpec, null, false);
 
       QueryableIndex mergedRealtime = indexIO.loadIndex(
           indexMerger.mergeQueryableIndex(

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
@@ -498,9 +498,9 @@ public class SpatialFilterTest
       mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
-      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, indexSpec, null);
-      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, indexSpec, null);
-      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, indexSpec, null);
+      INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, indexSpec, null, false);
+      INDEX_MERGER.persist(second, DATA_INTERVAL, secondFile, indexSpec, null, false);
+      INDEX_MERGER.persist(third, DATA_INTERVAL, thirdFile, indexSpec, null, false);
 
       QueryableIndex mergedRealtime = INDEX_IO.loadIndex(
           INDEX_MERGER.mergeQueryableIndex(

--- a/server/src/main/java/org/apache/druid/segment/indexing/BatchIOConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/BatchIOConfig.java
@@ -32,4 +32,7 @@ public interface BatchIOConfig extends IOConfig
   InputFormat getInputFormat();
 
   boolean isAppendToExisting();
+
+  boolean isDisableNullColumnSkipping();
+
 }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -117,6 +117,7 @@ public class AppenderatorImpl implements Appenderator
   private final IndexIO indexIO;
   private final IndexMerger indexMerger;
   private final Cache cache;
+  private final boolean disableNullColumnSkipping;
   /**
    * This map needs to be concurrent because it's accessed and mutated from multiple threads: both the thread from where
    * this Appenderator is used (and methods like {@link #add(SegmentIdWithShardSpec, InputRow, Supplier, boolean)} are
@@ -172,7 +173,8 @@ public class AppenderatorImpl implements Appenderator
       @Nullable SinkQuerySegmentWalker sinkQuerySegmentWalker,
       IndexIO indexIO,
       IndexMerger indexMerger,
-      Cache cache
+      Cache cache,
+      boolean disableNullColumnSkipping
   )
   {
     this.myId = id;
@@ -187,6 +189,8 @@ public class AppenderatorImpl implements Appenderator
     this.indexMerger = Preconditions.checkNotNull(indexMerger, "indexMerger");
     this.cache = cache;
     this.texasRanger = sinkQuerySegmentWalker;
+    this.disableNullColumnSkipping = disableNullColumnSkipping;
+
 
     if (sinkQuerySegmentWalker == null) {
       this.sinkTimeline = new VersionedIntervalTimeline<>(
@@ -1334,7 +1338,8 @@ public class AppenderatorImpl implements Appenderator
             identifier.getInterval(),
             new File(persistDir, String.valueOf(indexToPersist.getCount())),
             tuningConfig.getIndexSpecForIntermediatePersists(),
-            tuningConfig.getSegmentWriteOutMediumFactory()
+            tuningConfig.getSegmentWriteOutMediumFactory(),
+            disableNullColumnSkipping
         );
 
         log.info(

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderators.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderators.java
@@ -56,7 +56,8 @@ public class Appenderators
       JoinableFactory joinableFactory,
       Cache cache,
       CacheConfig cacheConfig,
-      CachePopulatorStats cachePopulatorStats
+      CachePopulatorStats cachePopulatorStats,
+      boolean disableNullColumnSkipping
   )
   {
     return new AppenderatorImpl(
@@ -84,7 +85,8 @@ public class Appenderators
         ),
         indexIO,
         indexMerger,
-        cache
+        cache,
+        disableNullColumnSkipping
     );
   }
 
@@ -137,7 +139,8 @@ public class Appenderators
         null,
         indexIO,
         indexMerger,
-        null
+        null,
+        false
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorsManager.java
@@ -78,7 +78,8 @@ public interface AppenderatorsManager
       JoinableFactory joinableFactory,
       Cache cache,
       CacheConfig cacheConfig,
-      CachePopulatorStats cachePopulatorStats
+      CachePopulatorStats cachePopulatorStats,
+      boolean disableNullColumnSkipping
   );
 
   /**

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/DefaultRealtimeAppenderatorFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/DefaultRealtimeAppenderatorFactory.java
@@ -114,7 +114,8 @@ public class DefaultRealtimeAppenderatorFactory implements AppenderatorFactory
         joinableFactory,
         cache,
         cacheConfig,
-        cachePopulatorStats
+        cachePopulatorStats,
+        false
     );
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/DummyForInjectionAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/DummyForInjectionAppenderatorsManager.java
@@ -69,7 +69,8 @@ public class DummyForInjectionAppenderatorsManager implements AppenderatorsManag
       JoinableFactory joinableFactory,
       Cache cache,
       CacheConfig cacheConfig,
-      CachePopulatorStats cachePopulatorStats
+      CachePopulatorStats cachePopulatorStats,
+      boolean disableNullColumnSkipping
   )
   {
     throw new UOE(ERROR_MSG);

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/PeonAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/PeonAppenderatorsManager.java
@@ -75,7 +75,8 @@ public class PeonAppenderatorsManager implements AppenderatorsManager
       JoinableFactory joinableFactory,
       Cache cache,
       CacheConfig cacheConfig,
-      CachePopulatorStats cachePopulatorStats
+      CachePopulatorStats cachePopulatorStats,
+      boolean disableNullColumnSkipping
   )
   {
     if (realtimeAppenderator != null) {
@@ -99,7 +100,8 @@ public class PeonAppenderatorsManager implements AppenderatorsManager
           joinableFactory,
           cache,
           cacheConfig,
-          cachePopulatorStats
+          cachePopulatorStats,
+          disableNullColumnSkipping
       );
     }
     return realtimeAppenderator;

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
@@ -158,7 +158,8 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
       JoinableFactory joinableFactory,
       Cache cache,
       CacheConfig cacheConfig,
-      CachePopulatorStats cachePopulatorStats
+      CachePopulatorStats cachePopulatorStats,
+      boolean disableNullColumnSkipping
   )
   {
     synchronized (this) {
@@ -179,7 +180,8 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
           datasourceBundle.getWalker(),
           indexIO,
           wrapIndexMerger(indexMerger),
-          cache
+          cache,
+          disableNullColumnSkipping
       );
 
       datasourceBundle.addAppenderator(taskId, appenderator);
@@ -526,7 +528,8 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
         Interval dataInterval,
         File outDir,
         IndexSpec indexSpec,
-        @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
+        @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+        boolean disableNullColumnSkipping
     )
     {
       ListenableFuture<File> mergeFuture = mergeExecutor.submit(
@@ -541,7 +544,8 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
                     dataInterval,
                     outDir,
                     indexSpec,
-                    segmentWriteOutMediumFactory
+                    segmentWriteOutMediumFactory,
+                    false
                 );
               }
               catch (IOException ioe) {
@@ -611,7 +615,8 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
         File outDir,
         IndexSpec indexSpec,
         ProgressIndicator progress,
-        @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
+        @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+        boolean disableNullColumnSkipping
     )
     {
       throw new UOE(ERROR_MSG);

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -966,7 +966,8 @@ public class RealtimePlumber implements Plumber
             interval,
             new File(computePersistDir(schema, interval), String.valueOf(indexToPersist.getCount())),
             config.getIndexSpecForIntermediatePersists(),
-            config.getSegmentWriteOutMediumFactory()
+            config.getSegmentWriteOutMediumFactory(),
+            false
         );
 
         indexToPersist.swapSegment(

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -285,7 +285,8 @@ public class AppenderatorTester implements AutoCloseable
         NoopJoinableFactory.INSTANCE,
         MapCache.create(2048),
         new CacheConfig(),
-        new CachePopulatorStats()
+        new CachePopulatorStats(),
+        false
     );
   }
 

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -1174,12 +1174,14 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 );
               }
 
+              newSpec = deepSet(newSpec, 'spec.ioConfig.disableNullColumnSkipping', true);
+
               this.updateSpec(fillDataSourceNameIfNeeded(newSpec));
             } else {
               this.updateSpec(
                 fillDataSourceNameIfNeeded(
                   fillInputFormat(
-                    spec,
+                    deepSet(spec, 'spec.ioConfig.disableNullColumnSkipping', true),
                     filterMap(inputQueryState.data.data, l =>
                       l.parsed ? l.parsed.raw : undefined,
                     ),


### PR DESCRIPTION
Fixes #9658

### Description

Currently, any columns with all null values are not processed by the sampler. There should be a parameter on the IOConfig that allows the user to specify that that they to keep columns with all null values. This feature should be implemented in the web-console. 

I am pretty new to this so my approach might be hilariously wrong, just know I know. 

The problem is happening because columns with all null column values are treated as stringDimensions, and then fail the canSkip() in StringDimensionHandler and are subsequently skipped. To fix this, I added the JsonProperty disableNullColumnSkipping to the IOConfig and created the getter isDisableNullColumnSkipping(). If the values is not set then it will default to false which means null columns will be skipped and there should be no change to the current functionality. 

The values disableNullColumnSkipping is used in two places. It is used in  stringDimensionMergerV6 CanSkip() so that it will always return false if disableNullColumnSkipping. Secondly, it is used in JsonReader to prevent the flattening of an inline datasource, this is necessary because flattening it will literally remove the null columns from the row so they never even end up in the incrementalIndex. 

The rest of the changes are all there in order to pass the value from indexTask to JsonReader and IndexMergerV6 or updating tests to include the new value.

I also changed LoadDataView.tsx so that the web-console always used this by default by setting disableNullColumnSkipping to true on the IoConfig; 

This PR has:
- [ x] been self-reviewed.
- [ x] added unit tests or modified existing tests to cover new code paths.
- [ x] been tested in a test Druid cluster.

##### Key changed/added classes in this PR
 * `IndexTask`
 * `JsonReader`
 * `stringDimensionMergerV6`
* `IndexMergerV6`
