### PR TITLE
Ignore druid-processing benchmarks in tests

### DIFF
--- a/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapBenchmark.java
@@ -25,6 +25,7 @@ import com.carrotsearch.junitbenchmarks.Clock;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.extendedset.intset.ImmutableConciseSet;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -42,8 +43,10 @@ import java.util.Random;
 
 /**
  * TODO rewrite this benchmark to JMH
+ * If you want to run locally, remove @Ignore on the class.
  */
 @BenchmarkOptions(clock = Clock.NANO_TIME, benchmarkRounds = 50)
+@Ignore
 public class BitmapBenchmark
 {
   public static final int LENGTH = 500_000;

--- a/processing/src/test/java/org/apache/druid/collections/bitmap/RangeBitmapBenchmarkTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/bitmap/RangeBitmapBenchmarkTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.extendedset.intset.ConciseSet;
 import org.apache.druid.extendedset.intset.ImmutableConciseSet;
 import org.apache.druid.java.util.common.StringUtils;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -33,9 +34,11 @@ import java.util.BitSet;
 
 /**
  * TODO rewrite this benchmark to JMH
+ * If you want to run locally, remove @Ignore on the class.
  */
 @Category({Benchmark.class})
 @BenchmarkHistoryChart(labelWith = LabelType.CUSTOM_KEY, maxRuns = 20)
+@Ignore
 public class RangeBitmapBenchmarkTest extends BitmapBenchmark
 {
 

--- a/processing/src/test/java/org/apache/druid/collections/bitmap/UniformBitmapBenchmarkTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/bitmap/UniformBitmapBenchmarkTest.java
@@ -26,16 +26,19 @@ import org.apache.druid.extendedset.intset.ConciseSet;
 import org.apache.druid.extendedset.intset.ImmutableConciseSet;
 import org.apache.druid.java.util.common.StringUtils;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 import java.util.BitSet;
 
 /**
- * TODO rewrite this benchmark to JMH
+ * TODO rewrite this benchmark to JMH.
+ * If you want to run locally, remove @Ignore on the class.
  */
 @Category({Benchmark.class})
 @BenchmarkHistoryChart(labelWith = LabelType.CUSTOM_KEY, maxRuns = 20)
+@Ignore
 public class UniformBitmapBenchmarkTest extends BitmapBenchmark
 {
 


### PR DESCRIPTION
Use JUnit's `@Ignore` to ignore benchmarks when running tests. This is useful when a developer uses an IDE to run all the tests. Travis `processing module test` is already configured to ignore these benchmarks, so this change should be a no-op, but makes it a lot faster to run all tests locally to see line/ branch coverage.

```
[INFO] jacocoArgLine set to -javaagent:/home/travis/.m2/repository/org/jacoco/org.jacoco.agent/0.8.4/org.jacoco.agent-0.8.4-runtime.jar=destfile=/home/travis/build/apache/druid/processing/target/jacoco.exec,excludes=org/apache/druid/math/expr/antlr/Expr*:org/apache/druid/**/generated/*Benchmark*:org/apache/druid/data/input/influx/InfluxLineProtocol*:org/apache/druid/benchmark/**/*:org/apache/druid/**/*Benchmark*:org/apache/druid/testing/**/*
```