### PR TITLE
Rollback kinesis lag metric for 0.18.1

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -50,13 +50,14 @@ import org.apache.druid.indexing.seekablestream.common.StreamPartition;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorReportPayload;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.server.metrics.DruidMonitorSchedulerConfig;
 import org.joda.time.DateTime;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -64,6 +65,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -82,6 +85,9 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
       };
 
   private static final EmittingLogger log = new EmittingLogger(KafkaSupervisor.class);
+  private static final long MINIMUM_GET_OFFSET_PERIOD_MILLIS = 5000;
+  private static final long INITIAL_GET_OFFSET_DELAY_MILLIS = 15000;
+  private static final long INITIAL_EMIT_LAG_METRIC_DELAY_MILLIS = 25000;
   private static final Long NOT_SET = -1L;
   private static final Long END_OF_PARTITION = Long.MAX_VALUE;
 
@@ -127,6 +133,28 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
   }
 
   @Override
+  protected void scheduleReporting(ScheduledExecutorService reportingExec)
+  {
+    KafkaSupervisorIOConfig ioConfig = spec.getIoConfig();
+    KafkaSupervisorTuningConfig tuningConfig = spec.getTuningConfig();
+    reportingExec.scheduleAtFixedRate(
+        updateCurrentAndLatestOffsets(),
+        ioConfig.getStartDelay().getMillis() + INITIAL_GET_OFFSET_DELAY_MILLIS, // wait for tasks to start up
+        Math.max(
+            tuningConfig.getOffsetFetchPeriod().getMillis(), MINIMUM_GET_OFFSET_PERIOD_MILLIS
+        ),
+        TimeUnit.MILLISECONDS
+    );
+
+    reportingExec.scheduleAtFixedRate(
+        emitLag(),
+        ioConfig.getStartDelay().getMillis() + INITIAL_EMIT_LAG_METRIC_DELAY_MILLIS, // wait for tasks to start up
+        monitorSchedulerConfig.getEmitterPeriod().getMillis(),
+        TimeUnit.MILLISECONDS
+    );
+  }
+
+  @Override
   protected int getTaskGroupIdForPartition(Integer partitionId)
   {
     return partitionId % spec.getIoConfig().getTaskCount();
@@ -151,7 +179,7 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
   )
   {
     KafkaSupervisorIOConfig ioConfig = spec.getIoConfig();
-    Map<Integer, Long> partitionLag = getRecordLagPerPartition(getHighestCurrentOffsets());
+    Map<Integer, Long> partitionLag = getLagPerPartition(getHighestCurrentOffsets());
     return new KafkaSupervisorReportPayload(
         spec.getDataSchema().getDataSource(),
         ioConfig.getTopic(),
@@ -239,38 +267,11 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
     return taskList;
   }
 
-  @Override
-  protected Map<Integer, Long> getPartitionRecordLag()
-  {
-    Map<Integer, Long> highestCurrentOffsets = getHighestCurrentOffsets();
-
-    if (latestSequenceFromStream == null) {
-      return null;
-    }
-
-    if (!latestSequenceFromStream.keySet().equals(highestCurrentOffsets.keySet())) {
-      log.warn(
-          "Lag metric: Kafka partitions %s do not match task partitions %s",
-          latestSequenceFromStream.keySet(),
-          highestCurrentOffsets.keySet()
-      );
-    }
-
-    return getRecordLagPerPartition(highestCurrentOffsets);
-  }
-
-  @Nullable
-  @Override
-  protected Map<Integer, Long> getPartitionTimeLag()
-  {
-    // time lag not currently support with kafka
-    return null;
-  }
 
   @Override
   // suppress use of CollectionUtils.mapValues() since the valueMapper function is dependent on map key here
   @SuppressWarnings("SSBasedInspection")
-  protected Map<Integer, Long> getRecordLagPerPartition(Map<Integer, Long> currentOffsets)
+  protected Map<Integer, Long> getLagPerPartition(Map<Integer, Long> currentOffsets)
   {
     return currentOffsets
         .entrySet()
@@ -288,12 +289,6 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
   }
 
   @Override
-  protected Map<Integer, Long> getTimeLagPerPartition(Map<Integer, Long> currentOffsets)
-  {
-    return null;
-  }
-
-  @Override
   protected KafkaDataSourceMetadata createDataSourceMetaDataForReset(String topic, Map<Integer, Long> map)
   {
     return new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, map));
@@ -303,6 +298,51 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
   protected OrderedSequenceNumber<Long> makeSequenceNumber(Long seq, boolean isExclusive)
   {
     return KafkaSequenceNumber.of(seq);
+  }
+
+  private Runnable emitLag()
+  {
+    return () -> {
+      try {
+        Map<Integer, Long> highestCurrentOffsets = getHighestCurrentOffsets();
+        String dataSource = spec.getDataSchema().getDataSource();
+
+        if (latestSequenceFromStream == null) {
+          throw new ISE("Latest offsets from Kafka have not been fetched");
+        }
+
+        if (!latestSequenceFromStream.keySet().equals(highestCurrentOffsets.keySet())) {
+          log.warn(
+              "Lag metric: Kafka partitions %s do not match task partitions %s",
+              latestSequenceFromStream.keySet(),
+              highestCurrentOffsets.keySet()
+          );
+        }
+
+        Map<Integer, Long> partitionLags = getLagPerPartition(highestCurrentOffsets);
+        long maxLag = 0, totalLag = 0, avgLag;
+        for (long lag : partitionLags.values()) {
+          if (lag > maxLag) {
+            maxLag = lag;
+          }
+          totalLag += lag;
+        }
+        avgLag = partitionLags.size() == 0 ? 0 : totalLag / partitionLags.size();
+
+        emitter.emit(
+            ServiceMetricEvent.builder().setDimension("dataSource", dataSource).build("ingest/kafka/lag", totalLag)
+        );
+        emitter.emit(
+            ServiceMetricEvent.builder().setDimension("dataSource", dataSource).build("ingest/kafka/maxLag", maxLag)
+        );
+        emitter.emit(
+            ServiceMetricEvent.builder().setDimension("dataSource", dataSource).build("ingest/kafka/avgLag", avgLag)
+        );
+      }
+      catch (Exception e) {
+        log.warn(e, "Unable to compute Kafka lag");
+      }
+    };
   }
 
   @Override

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorReportPayload.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorReportPayload.java
@@ -55,8 +55,6 @@ public class KafkaSupervisorReportPayload extends SeekableStreamSupervisorReport
         latestOffsets,
         minimumLag,
         aggregateLag,
-        null,
-        null,
         offsetsLastUpdated,
         suspended,
         healthy,

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
@@ -34,6 +34,8 @@ import java.io.File;
 public class KafkaSupervisorTuningConfig extends KafkaIndexTaskTuningConfig
     implements SeekableStreamSupervisorTuningConfig
 {
+  private static final String DEFAULT_OFFSET_FETCH_PERIOD = "PT30S";
+
   private final Integer workerThreads;
   private final Integer chatThreads;
   private final Long chatRetries;
@@ -179,7 +181,6 @@ public class KafkaSupervisorTuningConfig extends KafkaIndexTaskTuningConfig
     );
   }
 
-  @Override
   @JsonProperty
   public Duration getOffsetFetchPeriod()
   {

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1371,7 +1371,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     supervisor.runInternal();
-    supervisor.updateCurrentAndLatestOffsets();
+    supervisor.updateCurrentAndLatestOffsets().run();
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
@@ -1481,7 +1481,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     supervisor.runInternal();
-    supervisor.updateCurrentAndLatestOffsets();
+    supervisor.updateCurrentAndLatestOffsets().run();
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
@@ -1625,7 +1625,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     supervisor.runInternal();
-    supervisor.updateCurrentAndLatestOffsets();
+    supervisor.updateCurrentAndLatestOffsets().run();
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -44,11 +44,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import org.apache.druid.common.aws.AWSCredentialsConfig;
 import org.apache.druid.common.aws.AWSCredentialsUtils;
-import org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisor;
 import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.common.StreamException;
@@ -115,9 +113,9 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
     private volatile boolean started;
     private volatile boolean stopRequested;
 
-    private volatile long currentLagMillis;
-
-    PartitionResource(StreamPartition<String> streamPartition)
+    PartitionResource(
+        StreamPartition<String> streamPartition
+    )
     {
       this.streamPartition = streamPartition;
     }
@@ -150,53 +148,6 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
       stopRequested = true;
     }
 
-    long getPartitionTimeLag()
-    {
-      return currentLagMillis;
-    }
-
-    long getPartitionTimeLag(String offset)
-    {
-      // if not started (fetching records in background), fetch lag ourself with a throw-away iterator
-      if (!started) {
-        try {
-          final String iteratorType;
-          final String offsetToUse;
-          if (offset == null || KinesisSupervisor.NOT_SET.equals(offset)) {
-            // this should probably check if will start processing earliest or latest rather than assuming earliest
-            // if latest we could skip this because latest will not be behind latest so lag is 0.
-            iteratorType = ShardIteratorType.TRIM_HORIZON.toString();
-            offsetToUse = null;
-          } else {
-            iteratorType = ShardIteratorType.AT_SEQUENCE_NUMBER.toString();
-            offsetToUse = offset;
-          }
-          String shardIterator = kinesis.getShardIterator(
-              streamPartition.getStream(),
-              streamPartition.getPartitionId(),
-              iteratorType,
-              offsetToUse
-          ).getShardIterator();
-
-          GetRecordsResult recordsResult = kinesis.getRecords(
-              new GetRecordsRequest().withShardIterator(shardIterator).withLimit(recordsPerFetch)
-          );
-
-          currentLagMillis = recordsResult.getMillisBehindLatest();
-          return currentLagMillis;
-        }
-        catch (Exception ex) {
-          // eat it
-          log.warn(
-              ex,
-              "Failed to determine partition lag for partition %s of stream %s",
-              streamPartition.getPartitionId(),
-              streamPartition.getStream()
-          );
-        }
-      }
-      return currentLagMillis;
-    }
 
     private Runnable getRecordRunnable()
     {
@@ -240,13 +191,10 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
           recordsResult = kinesis.getRecords(new GetRecordsRequest().withShardIterator(
               shardIterator).withLimit(recordsPerFetch));
 
-          currentLagMillis = recordsResult.getMillisBehindLatest();
-
           // list will come back empty if there are no records
           for (Record kinesisRecord : recordsResult.getRecords()) {
 
             final List<byte[]> data;
-
 
             if (deaggregate) {
               if (deaggregateHandle == null || getDataHandle == null) {
@@ -687,27 +635,6 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
     }
 
     this.closed = true;
-  }
-
-  // this is only used for tests
-  @VisibleForTesting
-  Map<String, Long> getPartitionTimeLag()
-  {
-    return partitionResources.entrySet()
-                             .stream()
-                             .collect(
-                                 Collectors.toMap(k -> k.getKey().getPartitionId(), k -> k.getValue().getPartitionTimeLag())
-                             );
-  }
-
-  public Map<String, Long> getPartitionTimeLag(Map<String, String> currentOffsets)
-  {
-    Map<String, Long> partitionLag = Maps.newHashMapWithExpectedSize(currentOffsets.size());
-    for (Map.Entry<StreamPartition<String>, PartitionResource> partition : partitionResources.entrySet()) {
-      final String partitionId = partition.getKey().getPartitionId();
-      partitionLag.put(partitionId, partition.getValue().getPartitionTimeLag(currentOffsets.get(partitionId)));
-    }
-    return partitionLag;
   }
 
   private void seekInternal(StreamPartition<String> partition, String sequenceNumber, ShardIteratorType iteratorEnum)

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorReportPayload.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorReportPayload.java
@@ -22,9 +22,8 @@ package org.apache.druid.indexing.kinesis.supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManager;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorReportPayload;
 
-import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class KinesisSupervisorReportPayload extends SeekableStreamSupervisorReportPayload<String, String>
 {
@@ -38,9 +37,7 @@ public class KinesisSupervisorReportPayload extends SeekableStreamSupervisorRepo
       boolean healthy,
       SupervisorStateManager.State state,
       SupervisorStateManager.State detailedState,
-      List<SupervisorStateManager.ExceptionEvent> recentErrors,
-      @Nullable Map<String, Long> minimumLagMillis,
-      @Nullable Long aggregateLagMillis
+      List<SupervisorStateManager.ExceptionEvent> recentErrors
   )
   {
     super(
@@ -49,11 +46,9 @@ public class KinesisSupervisorReportPayload extends SeekableStreamSupervisorRepo
         partitions,
         replicas,
         durationSeconds,
+        Collections.emptyMap(),
+        Collections.emptyMap(),
         null,
-        null,
-        null,
-        minimumLagMillis,
-        aggregateLagMillis,
         null,
         suspended,
         healthy,
@@ -79,8 +74,7 @@ public class KinesisSupervisorReportPayload extends SeekableStreamSupervisorRepo
            ", state=" + getState() +
            ", detailedState=" + getDetailedState() +
            ", recentErrors=" + getRecentErrors() +
-           (getMinimumLagMillis() != null ? ", minimumLagMillis=" + getMinimumLagMillis() : "") +
-           (getAggregateLagMillis() != null ? ", aggregateLagMillis=" + getAggregateLagMillis() : "") +
            '}';
   }
+
 }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
@@ -39,12 +39,10 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
   private final Duration httpTimeout;
   private final Duration shutdownTimeout;
   private final Duration repartitionTransitionDuration;
-  private final Duration offsetFetchPeriod;
 
   public static KinesisSupervisorTuningConfig defaultConfig()
   {
     return new KinesisSupervisorTuningConfig(
-        null,
         null,
         null,
         null,
@@ -110,8 +108,7 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
       @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
       @JsonProperty("maxRecordsPerPoll") @Nullable Integer maxRecordsPerPoll,
       @JsonProperty("intermediateHandoffPeriod") Period intermediateHandoffPeriod,
-      @JsonProperty("repartitionTransitionDuration") Period repartitionTransitionDuration,
-      @JsonProperty("offsetFetchPeriod") Period offsetFetchPeriod
+      @JsonProperty("repartitionTransitionDuration") Period repartitionTransitionDuration
   )
   {
     super(
@@ -154,10 +151,6 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
         repartitionTransitionDuration,
         DEFAULT_REPARTITION_TRANSITION_DURATION
     );
-    this.offsetFetchPeriod = SeekableStreamSupervisorTuningConfig.defaultDuration(
-        offsetFetchPeriod,
-        DEFAULT_OFFSET_FETCH_PERIOD
-    );
   }
 
   @Override
@@ -199,13 +192,6 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
   public Duration getRepartitionTransitionDuration()
   {
     return repartitionTransitionDuration;
-  }
-
-  @Override
-  @JsonProperty
-  public Duration getOffsetFetchPeriod()
-  {
-    return offsetFetchPeriod;
   }
 
   @Override
@@ -275,4 +261,5 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
         getIntermediateHandoffPeriod()
     );
   }
+
 }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -2034,12 +2034,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             .andReturn(Collections.emptyList())
             .anyTimes();
 
-    EasyMock.expect(recordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(null)
-            .anyTimes();
-
     replayAll();
-
 
     final KinesisIndexTask task1 = createTask(
         "task1",

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
@@ -312,7 +312,6 @@ public class KinesisIndexTaskTuningConfigTest
         null,
         null,
         null,
-        null,
         null
     );
     KinesisIndexTaskTuningConfig copy = (KinesisIndexTaskTuningConfig) original.convertToTaskTuningConfig();

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -128,7 +128,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
   private static final StreamPartition<String> SHARD0_PARTITION = StreamPartition.of(STREAM, SHARD_ID0);
   private static final StreamPartition<String> SHARD1_PARTITION = StreamPartition.of(STREAM, SHARD_ID1);
   private static final StreamPartition<String> SHARD2_PARTITION = StreamPartition.of(STREAM, SHARD_ID2);
-  private static final Map<String, Long> TIME_LAG = ImmutableMap.of(SHARD_ID1, 9000L, SHARD_ID0, 1234L);
+
   private static DataSchema dataSchema;
   private KinesisRecordSupplier supervisorRecordSupplier;
 
@@ -198,7 +198,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
-        null,
         null
     );
     rowIngestionMetersFactory = new TestUtils().getRowIngestionMetersFactory();
@@ -231,9 +230,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject())).andReturn("0").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<KinesisIndexTask> captured = Capture.newInstance();
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -301,9 +297,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject())).andReturn("0").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<KinesisIndexTask> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -363,9 +356,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject())).andReturn("0").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<KinesisIndexTask> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -443,9 +433,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject())).andReturn("0").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<KinesisIndexTask> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -498,9 +485,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject())).andReturn("0").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<KinesisIndexTask> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -560,9 +544,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<KinesisIndexTask> captured = Capture.newInstance();
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -660,9 +641,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     // non KinesisIndexTask (don't kill)
     Task id2 = new RealtimeIndexTask(
@@ -729,9 +707,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Task id1 = createKinesisIndexTask(
         "id1",
@@ -844,9 +819,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
+
 
     Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -958,9 +931,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     DateTime now = DateTimes.nowUtc();
     DateTime maxi = now.plusMinutes(60);
@@ -1098,9 +1068,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -1227,9 +1194,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     final Capture<Task> firstTasks = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -1341,7 +1305,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
   public void testDiscoverExistingPublishingTask() throws Exception
   {
     final TaskLocation location = new TaskLocation("testHost", 1234, -1);
-    final Map<String, Long> timeLag = ImmutableMap.of(SHARD_ID1, 0L, SHARD_ID0, 20000000L);
 
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
 
@@ -1360,9 +1323,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(timeLag)
-            .atLeastOnce();
 
     Task task = createKinesisIndexTask(
         "id1",
@@ -1434,7 +1394,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     supervisor.runInternal();
-    supervisor.updateCurrentAndLatestOffsets();
+    supervisor.updateCurrentAndLatestOffsets().run();
     SupervisorReport<KinesisSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
@@ -1451,9 +1411,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     Assert.assertEquals(1, payload.getPublishingTasks().size());
     Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
     Assert.assertEquals(0, payload.getRecentErrors().size());
-
-    Assert.assertEquals(timeLag, payload.getMinimumLagMillis());
-    Assert.assertEquals(20000000L, (long) payload.getAggregateLagMillis());
 
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
@@ -1506,7 +1463,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
   public void testDiscoverExistingPublishingTaskWithDifferentPartitionAllocation() throws Exception
   {
     final TaskLocation location = new TaskLocation("testHost", 1234, -1);
-    final Map<String, Long> timeLag = ImmutableMap.of(SHARD_ID1, 9000L, SHARD_ID0, 1234L);
 
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
     supervisorRecordSupplier.assign(EasyMock.anyObject());
@@ -1524,9 +1480,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(timeLag)
-            .atLeastOnce();
 
     Task task = createKinesisIndexTask(
         "id1",
@@ -1587,7 +1540,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     supervisor.runInternal();
-    supervisor.updateCurrentAndLatestOffsets();
+    supervisor.updateCurrentAndLatestOffsets().run();
     SupervisorReport<KinesisSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
@@ -1604,9 +1557,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     Assert.assertEquals(1, payload.getPublishingTasks().size());
     Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
     Assert.assertEquals(0, payload.getRecentErrors().size());
-    Assert.assertEquals(timeLag, payload.getMinimumLagMillis());
-    Assert.assertEquals(9000L + 1234L, (long) payload.getAggregateLagMillis());
-
 
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
@@ -1661,7 +1611,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     final TaskLocation location1 = new TaskLocation("testHost", 1234, -1);
     final TaskLocation location2 = new TaskLocation("testHost2", 145, -1);
     final DateTime startTime = DateTimes.nowUtc();
-    final Map<String, Long> timeLag = ImmutableMap.of(SHARD_ID0, 100L, SHARD_ID1, 200L);
 
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
 
@@ -1680,9 +1629,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(timeLag)
-            .atLeastOnce();
     Task id1 = createKinesisIndexTask(
         "id1",
         DATASOURCE,
@@ -1787,7 +1733,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     supervisor.runInternal();
-    supervisor.updateCurrentAndLatestOffsets();
+    supervisor.updateCurrentAndLatestOffsets().run();
     SupervisorReport<KinesisSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
@@ -1822,7 +1768,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
         SHARD_ID0,
         "1"
     ), activeReport.getCurrentOffsets());
-    Assert.assertEquals(timeLag, activeReport.getLagMillis());
 
     Assert.assertEquals("id1", publishingReport.getId());
     Assert.assertEquals(ImmutableMap.of(
@@ -1858,9 +1803,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -1943,9 +1885,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -2054,10 +1993,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -2206,9 +2141,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Task id1 = createKinesisIndexTask(
         "id1",
@@ -2617,9 +2549,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Task id1 = createKinesisIndexTask(
         "id1",
@@ -2846,10 +2775,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
-
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
@@ -3004,9 +2929,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -3260,9 +3182,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(SHARD0_PARTITION)).andReturn("1").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
+
 
     Task id1 = createKinesisIndexTask(
         "id1",
@@ -3511,9 +3431,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Task task = createKinesisIndexTask(
         "id2",
@@ -3610,9 +3527,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Task task = createKinesisIndexTask(
         "id1",
@@ -3728,7 +3642,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         42, // This property is different from tuningConfig
-        null,
         null,
         null
     );
@@ -3855,9 +3768,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -3966,9 +3876,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> postSplitCaptured = Capture.newInstance(CaptureType.ALL);
 
@@ -4144,9 +4051,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> postSplitCaptured = Capture.newInstance(CaptureType.ALL);
 
@@ -4310,9 +4214,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("100").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -4432,9 +4333,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> postMergeCaptured = Capture.newInstance(CaptureType.ALL);
 
@@ -4589,9 +4487,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getPartitionTimeLag(EasyMock.anyObject()))
-            .andReturn(TIME_LAG)
-            .atLeastOnce();
 
     Capture<Task> postSplitCaptured = Capture.newInstance(CaptureType.ALL);
 
@@ -4793,7 +4688,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         5000,
-        null,
         null,
         null,
         null,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -77,8 +77,6 @@ import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.java.util.emitter.service.ServiceEmitter;
-import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.metadata.EntryExistsException;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.joda.time.DateTime;
@@ -108,7 +106,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -130,10 +127,6 @@ import java.util.stream.Stream;
 public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetType> implements Supervisor
 {
   public static final String CHECKPOINTS_CTX_KEY = "checkpoints";
-
-  private static final long MINIMUM_GET_OFFSET_PERIOD_MILLIS = 5000;
-  private static final long INITIAL_GET_OFFSET_DELAY_MILLIS = 15000;
-  private static final long INITIAL_EMIT_LAG_METRIC_DELAY_MILLIS = 25000;
 
   private static final long MAX_RUN_FREQUENCY_MILLIS = 1000;
   private static final long MINIMUM_FUTURE_TIMEOUT_IN_SECONDS = 120;
@@ -487,11 +480,10 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   private int initRetryCounter = 0;
   private volatile DateTime firstRunTime;
   private volatile DateTime earlyStopTime = null;
-  protected volatile RecordSupplier<PartitionIdType, SequenceOffsetType> recordSupplier;
+  private volatile RecordSupplier<PartitionIdType, SequenceOffsetType> recordSupplier;
   private volatile boolean started = false;
   private volatile boolean stopped = false;
   private volatile boolean lifecycleStarted = false;
-  private final ServiceEmitter emitter;
 
   public SeekableStreamSupervisor(
       final String supervisorId,
@@ -510,7 +502,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     this.indexerMetadataStorageCoordinator = indexerMetadataStorageCoordinator;
     this.sortingMapper = mapper.copy().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
     this.spec = spec;
-    this.emitter = spec.getEmitter();
     this.rowIngestionMetersFactory = rowIngestionMetersFactory;
     this.useExclusiveStartingSequence = useExclusiveStartingSequence;
     this.dataSource = spec.getDataSchema().getDataSource();
@@ -848,8 +839,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                   startTime,
                   remainingSeconds,
                   TaskReportData.TaskType.ACTIVE,
-                  includeOffsets ? getRecordLagPerPartition(currentOffsets) : null,
-                  includeOffsets ? getTimeLagPerPartition(currentOffsets) : null
+                  includeOffsets ? getLagPerPartition(currentOffsets) : null
               )
           );
         }
@@ -876,7 +866,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                     startTime,
                     remainingSeconds,
                     TaskReportData.TaskType.PUBLISHING,
-                    null,
                     null
                 )
             );
@@ -3101,16 +3090,18 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   }
 
   @VisibleForTesting
-  public void updateCurrentAndLatestOffsets()
+  public Runnable updateCurrentAndLatestOffsets()
   {
-    try {
-      updateCurrentOffsets();
-      updateLatestOffsetsFromStream();
-      sequenceLastUpdated = DateTimes.nowUtc();
-    }
-    catch (Exception e) {
-      log.warn(e, "Exception while getting current/latest sequences");
-    }
+    return () -> {
+      try {
+        updateCurrentOffsets();
+        updateLatestOffsetsFromStream();
+        sequenceLastUpdated = DateTimes.nowUtc();
+      }
+      catch (Exception e) {
+        log.warn(e, "Exception while getting current/latest sequences");
+      }
+    };
   }
 
   private void updateCurrentOffsets() throws InterruptedException, ExecutionException, TimeoutException
@@ -3167,35 +3158,18 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       Set<StreamPartition<PartitionIdType>> partitions
   );
 
-  /**
-   * Gets 'lag' of currently processed offset behind latest offset as a measure of difference between offsets.
-   */
-  @Nullable
-  protected abstract Map<PartitionIdType, Long> getPartitionRecordLag();
-
-  /**
-   * Gets 'lag' of currently processed offset behind latest offset as a measure of the difference in time inserted.
-   */
-  @Nullable
-  protected abstract Map<PartitionIdType, Long> getPartitionTimeLag();
-
   protected Map<PartitionIdType, SequenceOffsetType> getHighestCurrentOffsets()
   {
-    if (!spec.isSuspended() || activelyReadingTaskGroups.size() > 0 || pendingCompletionTaskGroups.size() > 0) {
-      return activelyReadingTaskGroups
-          .values()
-          .stream()
-          .flatMap(taskGroup -> taskGroup.tasks.entrySet().stream())
-          .flatMap(taskData -> taskData.getValue().currentSequences.entrySet().stream())
-          .collect(Collectors.toMap(
-              Entry::getKey,
-              Entry::getValue,
-              (v1, v2) -> makeSequenceNumber(v1).compareTo(makeSequenceNumber(v2)) > 0 ? v1 : v2
-          ));
-    } else {
-      // if supervisor is suspended, no tasks are likely running so use offsets in metadata, if exist
-      return getOffsetsFromMetadataStorage();
-    }
+    return activelyReadingTaskGroups
+        .values()
+        .stream()
+        .flatMap(taskGroup -> taskGroup.tasks.entrySet().stream())
+        .flatMap(taskData -> taskData.getValue().currentSequences.entrySet().stream())
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            Entry::getValue,
+            (v1, v2) -> makeSequenceNumber(v1).compareTo(makeSequenceNumber(v2)) > 0 ? v1 : v2
+        ));
   }
 
   private OrderedSequenceNumber<SequenceOffsetType> makeSequenceNumber(SequenceOffsetType seq)
@@ -3378,42 +3352,18 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   );
 
   /**
-   * default implementation, schedules periodic fetch of latest offsets and {@link #emitLag} reporting for Kafka and Kinesis
+   * schedules periodic emitLag() reporting for Kafka, not yet implemented in Kinesis,
+   * but will be in the future
    */
-  protected void scheduleReporting(ScheduledExecutorService reportingExec)
-  {
-    SeekableStreamSupervisorIOConfig ioConfig = spec.getIoConfig();
-    SeekableStreamSupervisorTuningConfig tuningConfig = spec.getTuningConfig();
-    reportingExec.scheduleAtFixedRate(
-        this::updateCurrentAndLatestOffsets,
-        ioConfig.getStartDelay().getMillis() + INITIAL_GET_OFFSET_DELAY_MILLIS, // wait for tasks to start up
-        Math.max(
-            tuningConfig.getOffsetFetchPeriod().getMillis(), MINIMUM_GET_OFFSET_PERIOD_MILLIS
-        ),
-        TimeUnit.MILLISECONDS
-    );
-
-    reportingExec.scheduleAtFixedRate(
-        this::emitLag,
-        ioConfig.getStartDelay().getMillis() + INITIAL_EMIT_LAG_METRIC_DELAY_MILLIS, // wait for tasks to start up
-        spec.getMonitorSchedulerConfig().getEmitterPeriod().getMillis(),
-        TimeUnit.MILLISECONDS
-    );
-  }
+  protected abstract void scheduleReporting(ScheduledExecutorService reportingExec);
 
   /**
-   * calculate lag per partition for kafka as a measure of message count, kinesis implementation returns an empty
+   * calculate lag per partition for kafka, kinesis implementation returns an empty
    * map
    *
    * @return map of partition id -> lag
    */
-  protected abstract Map<PartitionIdType, Long> getRecordLagPerPartition(
-      Map<PartitionIdType, SequenceOffsetType> currentOffsets
-  );
-
-  protected abstract Map<PartitionIdType, Long> getTimeLagPerPartition(
-      Map<PartitionIdType, SequenceOffsetType> currentOffsets
-  );
+  protected abstract Map<PartitionIdType, SequenceOffsetType> getLagPerPartition(Map<PartitionIdType, SequenceOffsetType> currentOffsets);
 
   /**
    * returns an instance of a specific Kinesis/Kafka recordSupplier
@@ -3445,61 +3395,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     final SequenceOffsetType earliestOffset = getOffsetFromStreamForPartition(partition, true);
     return earliestOffset != null
            && makeSequenceNumber(earliestOffset).compareTo(makeSequenceNumber(offsetFromMetadata)) <= 0;
-  }
-
-  protected void emitLag()
-  {
-    if (spec.isSuspended()) {
-      // don't emit metrics if supervisor is suspended (lag should still available in status report)
-      return;
-    }
-    try {
-      Map<PartitionIdType, Long> partitionRecordLags = getPartitionRecordLag();
-      Map<PartitionIdType, Long> partitionTimeLags = getPartitionTimeLag();
-
-      if (partitionRecordLags == null && partitionTimeLags == null) {
-        throw new ISE("Latest offsets have not been fetched");
-      }
-      final String type = spec.getType();
-
-      BiConsumer<Map<PartitionIdType, Long>, String> emitFn = (partitionLags, suffix) -> {
-        if (partitionLags == null) {
-          return;
-        }
-
-        long maxLag = 0, totalLag = 0, avgLag;
-        for (long lag : partitionLags.values()) {
-          if (lag > maxLag) {
-            maxLag = lag;
-          }
-          totalLag += lag;
-        }
-        avgLag = partitionLags.size() == 0 ? 0 : totalLag / partitionLags.size();
-
-        emitter.emit(
-            ServiceMetricEvent.builder()
-                              .setDimension("dataSource", dataSource)
-                              .build(StringUtils.format("ingest/%s/lag%s", type, suffix), totalLag)
-        );
-        emitter.emit(
-            ServiceMetricEvent.builder()
-                              .setDimension("dataSource", dataSource)
-                              .build(StringUtils.format("ingest/%s/maxLag%s", type, suffix), maxLag)
-        );
-        emitter.emit(
-            ServiceMetricEvent.builder()
-                              .setDimension("dataSource", dataSource)
-                              .build(StringUtils.format("ingest/%s/avgLag%s", type, suffix), avgLag)
-        );
-      };
-
-      // this should probably really be /count or /records or something.. but keeping like this for backwards compat
-      emitFn.accept(partitionRecordLags, "");
-      emitFn.accept(partitionTimeLags, "/time");
-    }
-    catch (Exception e) {
-      log.warn(e, "Unable to compute lag");
-    }
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorReportPayload.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorReportPayload.java
@@ -41,10 +41,8 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
   private final List<TaskReportData> activeTasks;
   private final List<TaskReportData> publishingTasks;
   private final Map<PartitionIdType, SequenceOffsetType> latestOffsets;
-  private final Map<PartitionIdType, Long> minimumLag;
+  private final Map<PartitionIdType, SequenceOffsetType> minimumLag;
   private final Long aggregateLag;
-  private final Map<PartitionIdType, Long> minimumLagMillis;
-  private final Long aggregateLagMillis;
   private final DateTime offsetsLastUpdated;
   private final boolean suspended;
   private final boolean healthy;
@@ -59,10 +57,8 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
       int replicas,
       long durationSeconds,
       @Nullable Map<PartitionIdType, SequenceOffsetType> latestOffsets,
-      @Nullable Map<PartitionIdType, Long> minimumLag,
+      @Nullable Map<PartitionIdType, SequenceOffsetType> minimumLag,
       @Nullable Long aggregateLag,
-      @Nullable Map<PartitionIdType, Long> minimumLagMillis,
-      @Nullable Long aggregateLagMillis,
       @Nullable DateTime offsetsLastUpdated,
       boolean suspended,
       boolean healthy,
@@ -81,8 +77,6 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
     this.latestOffsets = latestOffsets;
     this.minimumLag = minimumLag;
     this.aggregateLag = aggregateLag;
-    this.minimumLagMillis = minimumLagMillis;
-    this.aggregateLagMillis = aggregateLagMillis;
     this.offsetsLastUpdated = offsetsLastUpdated;
     this.suspended = suspended;
     this.healthy = healthy;
@@ -163,7 +157,7 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
   }
 
   @JsonProperty
-  public Map<PartitionIdType, Long> getMinimumLag()
+  public Map<PartitionIdType, SequenceOffsetType> getMinimumLag()
   {
     return minimumLag;
   }
@@ -172,19 +166,6 @@ public abstract class SeekableStreamSupervisorReportPayload<PartitionIdType, Seq
   public Long getAggregateLag()
   {
     return aggregateLag;
-  }
-
-  @JsonProperty
-  public Long getAggregateLagMillis()
-  {
-    return aggregateLagMillis;
-  }
-
-
-  @JsonProperty
-  public Map<PartitionIdType, Long> getMinimumLagMillis()
-  {
-    return minimumLagMillis;
   }
 
   @JsonProperty

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorTuningConfig.java
@@ -26,7 +26,7 @@ import org.joda.time.Period;
 
 public interface SeekableStreamSupervisorTuningConfig
 {
-  String DEFAULT_OFFSET_FETCH_PERIOD = "PT30S";
+
   int DEFAULT_CHAT_RETRIES = 8;
   String DEFAULT_HTTP_TIMEOUT = "PT10S";
   String DEFAULT_SHUTDOWN_TIMEOUT = "PT80S";
@@ -54,9 +54,6 @@ public interface SeekableStreamSupervisorTuningConfig
 
   @JsonProperty
   Duration getRepartitionTransitionDuration();
-
-  @JsonProperty
-  Duration getOffsetFetchPeriod();
 
   SeekableStreamIndexTaskTuningConfig convertToTaskTuningConfig();
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/TaskReportData.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/TaskReportData.java
@@ -34,8 +34,7 @@ public class TaskReportData<PartitionIdType, SequenceOffsetType>
   private final Long remainingSeconds;
   private final TaskType type;
   private final Map<PartitionIdType, SequenceOffsetType> currentOffsets;
-  private final Map<PartitionIdType, Long> lag;
-  private final Map<PartitionIdType, Long> lagMillis;
+  private final Map<PartitionIdType, SequenceOffsetType> lag;
 
   public TaskReportData(
       String id,
@@ -44,8 +43,7 @@ public class TaskReportData<PartitionIdType, SequenceOffsetType>
       @Nullable DateTime startTime,
       Long remainingSeconds,
       TaskType type,
-      @Nullable Map<PartitionIdType, Long> lag,
-      @Nullable Map<PartitionIdType, Long> lagMillis
+      @Nullable Map<PartitionIdType, SequenceOffsetType> lag
   )
   {
     this.id = id;
@@ -55,7 +53,6 @@ public class TaskReportData<PartitionIdType, SequenceOffsetType>
     this.remainingSeconds = remainingSeconds;
     this.type = type;
     this.lag = lag;
-    this.lagMillis = lagMillis;
   }
 
   @JsonProperty
@@ -98,16 +95,9 @@ public class TaskReportData<PartitionIdType, SequenceOffsetType>
 
   @JsonProperty
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  public Map<PartitionIdType, Long> getLag()
+  public Map<PartitionIdType, SequenceOffsetType> getLag()
   {
     return lag;
-  }
-
-  @JsonProperty
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  public Map<PartitionIdType, Long> getLagMillis()
-  {
-    return lagMillis;
   }
 
   @Override
@@ -120,7 +110,6 @@ public class TaskReportData<PartitionIdType, SequenceOffsetType>
            ", startTime=" + startTime +
            ", remainingSeconds=" + remainingSeconds +
            (lag != null ? ", lag=" + lag : "") +
-           (lagMillis != null ? ", lagMillis=" + lagMillis : "") +
            '}';
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -61,16 +61,12 @@ import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervi
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.apache.druid.java.util.emitter.core.Event;
-import org.apache.druid.metadata.EntryExistsException;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
 import org.apache.druid.segment.realtime.firehose.ChatHandlerProvider;
-import org.apache.druid.server.metrics.DruidMonitorSchedulerConfig;
-import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
@@ -89,10 +85,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 {
@@ -116,8 +110,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   private RowIngestionMetersFactory rowIngestionMetersFactory;
   private SupervisorStateManagerConfig supervisorConfig;
 
-  private TestEmitter emitter;
-
   @Before
   public void setupTest()
   {
@@ -135,14 +127,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisorConfig = new SupervisorStateManagerConfig();
 
-    emitter = new TestEmitter();
-
     EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
 
     EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
     EasyMock.expect(spec.getIoConfig()).andReturn(getIOConfig()).anyTimes();
     EasyMock.expect(spec.getTuningConfig()).andReturn(getTuningConfig()).anyTimes();
-    EasyMock.expect(spec.getEmitter()).andReturn(emitter).anyTimes();
 
     EasyMock.expect(taskClientFactory.build(
         EasyMock.anyObject(),
@@ -563,173 +552,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     verifyAll();
   }
 
-
-  @Test
-  public void testEmitBothLag() throws Exception
-  {
-    expectEmitterSupervisor(false);
-
-    CountDownLatch latch = new CountDownLatch(1);
-    TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
-        latch,
-        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L),
-        ImmutableMap.of("1", 10000L, "2", 15000L, "3", 20000L)
-    );
-
-
-    supervisor.start();
-
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
-
-
-    latch.await();
-    Assert.assertEquals(6, emitter.getEvents().size());
-    Assert.assertEquals("ingest/test/lag", emitter.getEvents().get(0).toMap().get("metric"));
-    Assert.assertEquals(850L, emitter.getEvents().get(0).toMap().get("value"));
-    Assert.assertEquals("ingest/test/maxLag", emitter.getEvents().get(1).toMap().get("metric"));
-    Assert.assertEquals(500L, emitter.getEvents().get(1).toMap().get("value"));
-    Assert.assertEquals("ingest/test/avgLag", emitter.getEvents().get(2).toMap().get("metric"));
-    Assert.assertEquals(283L, emitter.getEvents().get(2).toMap().get("value"));
-    Assert.assertEquals("ingest/test/lag/time", emitter.getEvents().get(3).toMap().get("metric"));
-    Assert.assertEquals(45000L, emitter.getEvents().get(3).toMap().get("value"));
-    Assert.assertEquals("ingest/test/maxLag/time", emitter.getEvents().get(4).toMap().get("metric"));
-    Assert.assertEquals(20000L, emitter.getEvents().get(4).toMap().get("value"));
-    Assert.assertEquals("ingest/test/avgLag/time", emitter.getEvents().get(5).toMap().get("metric"));
-    Assert.assertEquals(15000L, emitter.getEvents().get(5).toMap().get("value"));
-    verifyAll();
-  }
-
-  @Test
-  public void testEmitRecordLag() throws Exception
-  {
-    expectEmitterSupervisor(false);
-
-    CountDownLatch latch = new CountDownLatch(1);
-    TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
-        latch,
-        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L),
-        null
-    );
-
-
-    supervisor.start();
-
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
-
-
-    latch.await();
-    Assert.assertEquals(3, emitter.getEvents().size());
-    Assert.assertEquals("ingest/test/lag", emitter.getEvents().get(0).toMap().get("metric"));
-    Assert.assertEquals(850L, emitter.getEvents().get(0).toMap().get("value"));
-    Assert.assertEquals("ingest/test/maxLag", emitter.getEvents().get(1).toMap().get("metric"));
-    Assert.assertEquals(500L, emitter.getEvents().get(1).toMap().get("value"));
-    Assert.assertEquals("ingest/test/avgLag", emitter.getEvents().get(2).toMap().get("metric"));
-    Assert.assertEquals(283L, emitter.getEvents().get(2).toMap().get("value"));
-    verifyAll();
-  }
-
-  @Test
-  public void testEmitTimeLag() throws Exception
-  {
-    expectEmitterSupervisor(false);
-
-    CountDownLatch latch = new CountDownLatch(1);
-    TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
-        latch,
-        null,
-        ImmutableMap.of("1", 10000L, "2", 15000L, "3", 20000L)
-    );
-
-
-    supervisor.start();
-
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
-
-
-    latch.await();
-    Assert.assertEquals(3, emitter.getEvents().size());
-    Assert.assertEquals("ingest/test/lag/time", emitter.getEvents().get(0).toMap().get("metric"));
-    Assert.assertEquals(45000L, emitter.getEvents().get(0).toMap().get("value"));
-    Assert.assertEquals("ingest/test/maxLag/time", emitter.getEvents().get(1).toMap().get("metric"));
-    Assert.assertEquals(20000L, emitter.getEvents().get(1).toMap().get("value"));
-    Assert.assertEquals("ingest/test/avgLag/time", emitter.getEvents().get(2).toMap().get("metric"));
-    Assert.assertEquals(15000L, emitter.getEvents().get(2).toMap().get("value"));
-    verifyAll();
-  }
-
-  @Test
-  public void testEmitNoLagWhenSuspended() throws Exception
-  {
-    expectEmitterSupervisor(true);
-
-    CountDownLatch latch = new CountDownLatch(1);
-    TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
-        latch,
-        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L),
-        ImmutableMap.of("1", 10000L, "2", 15000L, "3", 20000L)
-    );
-
-
-    supervisor.start();
-    supervisor.runInternal();
-
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-
-
-    latch.await();
-    Assert.assertEquals(0, emitter.getEvents().size());
-    verifyAll();
-  }
-
-  private void expectEmitterSupervisor(boolean suspended) throws EntryExistsException
-  {
-    spec = createMock(SeekableStreamSupervisorSpec.class);
-    EasyMock.expect(spec.getSupervisorStateManagerConfig()).andReturn(supervisorConfig).anyTimes();
-
-    EasyMock.expect(spec.getDataSchema()).andReturn(getDataSchema()).anyTimes();
-    EasyMock.expect(spec.getIoConfig()).andReturn(new SeekableStreamSupervisorIOConfig(
-        "stream",
-        new JsonInputFormat(new JSONPathSpec(true, ImmutableList.of()), ImmutableMap.of()),
-        1,
-        1,
-        new Period("PT1H"),
-        new Period("PT1S"),
-        new Period("PT30S"),
-        false,
-        new Period("PT30M"),
-        null,
-        null, null
-    )
-    {
-    }).anyTimes();
-    EasyMock.expect(spec.getTuningConfig()).andReturn(getTuningConfig()).anyTimes();
-    EasyMock.expect(spec.getEmitter()).andReturn(emitter).anyTimes();
-    EasyMock.expect(spec.getMonitorSchedulerConfig()).andReturn(new DruidMonitorSchedulerConfig()).anyTimes();
-    EasyMock.expect(spec.isSuspended()).andReturn(suspended).anyTimes();
-    EasyMock.expect(spec.getType()).andReturn("test").anyTimes();
-
-    EasyMock.expect(recordSupplier.getPartitionIds(STREAM)).andReturn(ImmutableSet.of(SHARD_ID)).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).anyTimes();
-    EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).anyTimes();
-
-    replayAll();
-  }
-
   private static DataSchema getDataSchema()
   {
     List<DimensionSchema> dimensions = new ArrayList<>();
@@ -811,12 +633,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
       public Duration getRepartitionTransitionDuration()
       {
         return new Period("PT2M").toStandardDuration();
-      }
-
-      @Override
-      public Duration getOffsetFetchPeriod()
-      {
-        return new Period("PT5M").toStandardDuration();
       }
 
       @Override
@@ -909,9 +725,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     }
   }
 
-  private abstract class BaseTestSeekableStreamSupervisor extends SeekableStreamSupervisor<String, String>
+  private class TestSeekableStreamSupervisor extends SeekableStreamSupervisor<String, String>
   {
-    private BaseTestSeekableStreamSupervisor()
+    private TestSeekableStreamSupervisor()
     {
       super(
           "testSupervisorId",
@@ -938,20 +754,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     )
     {
       // do nothing
-    }
-
-    @Nullable
-    @Override
-    protected Map<String, Long> getPartitionRecordLag()
-    {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    protected Map<String, Long> getPartitionTimeLag()
-    {
-      return null;
     }
 
     @Override
@@ -1048,13 +850,13 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     }
 
     @Override
-    protected Map<String, Long> getRecordLagPerPartition(Map<String, String> currentOffsets)
+    protected void scheduleReporting(ScheduledExecutorService reportingExec)
     {
-      return null;
+      // do nothing
     }
 
     @Override
-    protected Map<String, Long> getTimeLagPerPartition(Map<String, String> currentOffsets)
+    protected Map<String, String> getLagPerPartition(Map<String, String> currentOffsets)
     {
       return null;
     }
@@ -1062,7 +864,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     @Override
     protected RecordSupplier<String, String> setupRecordSupplier()
     {
-      return SeekableStreamSupervisorStateTest.this.recordSupplier;
+      return recordSupplier;
     }
 
     @Override
@@ -1077,8 +879,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
           1,
           1,
           1L,
-          null,
-          null,
           null,
           null,
           null,
@@ -1121,82 +921,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     protected boolean useExclusiveStartSequenceNumberForNonFirstSequence()
     {
       return false;
-    }
-  }
-
-  private class TestSeekableStreamSupervisor extends BaseTestSeekableStreamSupervisor
-  {
-    @Override
-    protected void scheduleReporting(ScheduledExecutorService reportingExec)
-    {
-      // do nothing
-    }
-  }
-
-  private class TestEmittingTestSeekableStreamSupervisor extends BaseTestSeekableStreamSupervisor
-  {
-    private final CountDownLatch latch;
-    private final Map<String, Long> partitionsRecordLag;
-    private final Map<String, Long> partitionsTimeLag;
-
-    TestEmittingTestSeekableStreamSupervisor(
-        CountDownLatch latch,
-        Map<String, Long> partitionsRecordLag,
-        Map<String, Long> partitionsTimeLag
-    )
-    {
-      this.latch = latch;
-      this.partitionsRecordLag = partitionsRecordLag;
-      this.partitionsTimeLag = partitionsTimeLag;
-    }
-
-    @Nullable
-    @Override
-    protected Map<String, Long> getPartitionRecordLag()
-    {
-      return partitionsRecordLag;
-    }
-
-    @Nullable
-    @Override
-    protected Map<String, Long> getPartitionTimeLag()
-    {
-      return partitionsTimeLag;
-    }
-
-    @Override
-    protected void emitLag()
-    {
-      super.emitLag();
-      latch.countDown();
-    }
-
-    @Override
-    protected void scheduleReporting(ScheduledExecutorService reportingExec)
-    {
-      SeekableStreamSupervisorIOConfig ioConfig = spec.getIoConfig();
-      reportingExec.scheduleAtFixedRate(
-          this::emitLag,
-          ioConfig.getStartDelay().getMillis(),
-          spec.getMonitorSchedulerConfig().getEmitterPeriod().getMillis(),
-          TimeUnit.MILLISECONDS
-      );
-    }
-  }
-
-  private static class TestEmitter extends NoopServiceEmitter
-  {
-    private final List<Event> events = new ArrayList<>();
-
-    @Override
-    public void emit(Event event)
-    {
-      events.add(event);
-    }
-
-    public List<Event> getEvents()
-    {
-      return events;
     }
   }
 }


### PR DESCRIPTION
### Description

This PR reverts #9509 for 0.18.1. The lag metric for Kinesis was first introduced in 0.18.0, but it turns out there are a couple of flaws in the `RecordSupplier` and `SeekableStreamSupervisor` which can freeze the Kinesis supervisor for minutes due to lock contentions. https://github.com/apache/druid/pull/9819 is to fix such flaws, but I think we should roll back this feature for the minor release since the fix doesn't look simple enough.