### PR TITLE
Optimise the union operation of concise bitmap

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/BitmapUnionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/BitmapUnionBenchmark.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.collections.bitmap.ConciseBitmapFactory;
+import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.collections.bitmap.MutableBitmap;
+import org.apache.druid.collections.bitmap.RoaringBitmapFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Benchmarks of bitmap union copied from {@link BitmapIterationBenchmark}.
+ *
+ * @see #union(BitmapsForUnion, Blackhole)
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+public class BitmapUnionBenchmark
+{
+  @Param({"concise", "roaring"})
+  public String bitmapAlgo;
+
+  /**
+   * Fraction of set bits in the bitmaps to iterate. For {@link #union(BitmapsForUnion, Blackhole)} and
+   * {@link #union(BitmapsForUnion, Blackhole)}, this is the fraction of set bits in the final result of intersection or union.
+   */
+  @Param({"0.0", "0.001", "0.1", "0.5", "0.99", "1.0"})
+  public double prob;
+
+  /**
+   * The size of all bitmaps, i. e. the number of rows in a segment for the most bitmap use cases.
+   */
+  @Param({"1000000", "5000000", "10000000"})
+  public int size;
+
+  private BitmapFactory makeFactory()
+  {
+    switch (bitmapAlgo) {
+      case "concise":
+        return new ConciseBitmapFactory();
+      case "roaring":
+        return new RoaringBitmapFactory();
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  private BitmapFactory factory;
+
+  @Setup
+  public void setup()
+  {
+    factory = makeFactory();
+  }
+
+  @State(Scope.Benchmark)
+  public static class BitmapsForUnion
+  {
+    /**
+     * Number of bitmaps to union.
+     */
+    @Param({"10", "30", "100", "1000", "10000", "100000"})
+    public int n;
+
+    private ImmutableBitmap[] bitmaps;
+
+    @Setup
+    public void setup(BitmapUnionBenchmark state)
+    {
+      double prob = Math.pow(state.prob, 1.0 / n);
+      MutableBitmap[] mutableBitmaps = new MutableBitmap[n];
+      for (int i = 0; i < n; i++) {
+        mutableBitmaps[i] = state.factory.makeEmptyMutableBitmap();
+      }
+      Random r = ThreadLocalRandom.current();
+      for (int i = 0; i < state.size; i++) {
+        // unions are usually search/filter/select of multiple values of one dimension, so making bitmaps disjoint will
+        // make benchmarks closer to actual workloads
+        MutableBitmap bitmap = mutableBitmaps[r.nextInt(n)];
+        // In one selected bitmap, set the bit with probability=prob, to have the same fraction of set bit in the union
+        if (r.nextDouble() < prob) {
+          bitmap.add(i);
+        }
+      }
+      bitmaps = new ImmutableBitmap[n];
+      for (int i = 0; i < n; i++) {
+        bitmaps[i] = state.factory.makeImmutableBitmap(mutableBitmaps[i]);
+      }
+    }
+  }
+
+  @Benchmark
+  public void union(BitmapsForUnion state, Blackhole blackhole)
+  {
+    ImmutableBitmap union = factory.union(Arrays.asList(state.bitmaps));
+    blackhole.consume(union);
+  }
+
+}

--- a/extendedset/src/test/java/org/apache/druid/extendedset/intset/ImmutableConciseSetTest.java
+++ b/extendedset/src/test/java/org/apache/druid/extendedset/intset/ImmutableConciseSetTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -1125,6 +1126,28 @@ public class ImmutableConciseSetTest
     }
 
     verifyUnion(expected, sets);
+  }
+
+  @Test
+  public void testUnion24()
+  {
+    List<ConciseSet> sets = new ArrayList<>();
+    final Random random = new Random(37L);
+    int count = ImmutableConciseSet.UNION_BY_COUNTING_SORT_THRESHOLD + 11;
+    for (int i = 0; i < count; i++) {
+      sets.add(new ConciseSet());
+    }
+    for (int i = 0; i < 1000; i++) {
+      sets.get(random.nextInt(count)).add(i);
+    }
+    List<Integer> expected = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      expected.add(i);
+    }
+    List<ImmutableConciseSet> immutableConciseSets = sets.stream()
+                                                         .map(s -> ImmutableConciseSet.newImmutableFromMutable(s))
+                                                         .collect(Collectors.toList());
+    verifyUnion(expected, immutableConciseSets);
   }
 
   private void verifyUnion(List<Integer> expected, List<ImmutableConciseSet> sets)


### PR DESCRIPTION
### Description

Currently the implementation of concise bitmap unifies bitmaps by construct a new bitmap with the help of heap sort. And the union operation is quite slow when encountering a large number of bitmaps to unify.

This PR tries to improve the performance of the union operation of concise bitmap. It optimises the heap sort to counting sort when the number of bitmaps to unify reaches a certain threshold. And the counting sort used here is based on the implementation of roaring bitmap.

According to the benchmark report, the performance is improved by 4~10 times when unifying more than 100 bitmaps. See the visual jmh report [here](https://jmh.morethan.io/?gists=781a537f485f55c8403093419c13cdb5,513102af06bc77f70b8db6b9711b88c0)


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `ImmutableConciseSet`
