### PR TITLE
Add equivalent test coverage for all RHS join impls

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -365,6 +365,74 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   }
 
   @Test
+  public void test_makeCursors_factToCountryLeftUsingLookup()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        null,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            null,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
+        ),
+        ImmutableList.of(
+            new Object[]{"Talk:Oswald Tilghman", null, null, null},
+            new Object[]{"Rallicula", null, null, null},
+            new Object[]{"Peremptory norm", "AU", "AU", "Australia"},
+            new Object[]{"Apamea abruzzorum", null, null, null},
+            new Object[]{"Atractus flammigerus", null, null, null},
+            new Object[]{"Agama mossambica", null, null, null},
+            new Object[]{"Mathis Bolly", "MX", "MX", "Mexico"},
+            new Object[]{"유희왕 GX", "KR", "KR", "Republic of Korea"},
+            new Object[]{"青野武", "JP", "JP", "Japan"},
+            new Object[]{"Golpe de Estado en Chile de 1973", "CL", "CL", "Chile"},
+            new Object[]{"President of India", "US", "US", "United States"},
+            new Object[]{"Diskussion:Sebastian Schulz", "DE", "DE", "Germany"},
+            new Object[]{"Saison 9 de Secret Story", "FR", "FR", "France"},
+            new Object[]{"Glasgow", "GB", "GB", "United Kingdom"},
+            new Object[]{"Didier Leclair", "CA", "CA", "Canada"},
+            new Object[]{"Les Argonautes", "CA", "CA", "Canada"},
+            new Object[]{"Otjiwarongo Airport", "US", "US", "United States"},
+            new Object[]{"Sarah Michelle Gellar", "CA", "CA", "Canada"},
+            new Object[]{"DirecTV", "US", "US", "United States"},
+            new Object[]{"Carlo Curti", "US", "US", "United States"},
+            new Object[]{"Giusy Ferreri discography", "IT", "IT", "Italy"},
+            new Object[]{"Roma-Bangkok", "IT", "IT", "Italy"},
+            new Object[]{"Wendigo", "SV", "SV", "El Salvador"},
+            new Object[]{"Алиса в Зазеркалье", "NO", "NO", "Norway"},
+            new Object[]{"Gabinete Ministerial de Rafael Correa", "EC", "EC", "Ecuador"},
+            new Object[]{"Old Anatolian Turkish", "US", "US", "United States"},
+            new Object[]{"Cream Soda", "SU", "SU", "States United"},
+            new Object[]{"Orange Soda", "MatchNothing", null, null},
+            new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems"}
+        )
+    );
+  }
+
+  @Test
   public void test_makeCursors_factToCountryInner()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.INNER));
@@ -667,6 +735,46 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   }
 
   @Test
+  public void test_makeCursors_factToCountryLeftWithFilterOnFactsUsingLookup()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
+    Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        filter,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            filter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
+        ),
+        ImmutableList.of(
+            new Object[]{"Diskussion:Sebastian Schulz", "DE", "DE", "Germany"}
+        )
+    );
+  }
+
+  @Test
   public void test_makeCursors_factToCountryRightWithFilterOnLeftIsNull()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.RIGHT));
@@ -705,6 +813,48 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         ImmutableList.of(
             new Object[]{null, null, NullHandling.sqlCompatible() ? null : 0L, "AX", "Atlantis", 14L},
             new Object[]{null, null, NullHandling.sqlCompatible() ? null : 0L, "USCA", "Usca", 16L}
+        )
+    );
+  }
+
+  @Test
+  public void test_makeCursors_factToCountryRightWithFilterOnLeftIsNullUsingLookup()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.RIGHT));
+    Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        filter,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            filter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            "countryNumber",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
+        ),
+        ImmutableList.of(
+            new Object[]{null, null, NullHandling.sqlCompatible() ? null : 0L, "AX", "Atlantis"},
+            new Object[]{null, null, NullHandling.sqlCompatible() ? null : 0L, "USCA", "Usca"}
         )
     );
   }
@@ -753,6 +903,48 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   }
 
   @Test
+  public void test_makeCursors_factToCountryFullWithFilterOnLeftIsNullUsingLookup()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.FULL));
+    Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        filter,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            filter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            "countryNumber",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
+        ),
+        ImmutableList.of(
+            new Object[]{null, null, NullHandling.sqlCompatible() ? null : 0L, "AX", "Atlantis"},
+            new Object[]{null, null, NullHandling.sqlCompatible() ? null : 0L, "USCA", "Usca"}
+        )
+    );
+  }
+
+  @Test
   public void test_makeCursors_factToCountryRightWithFilterOnJoinable()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.RIGHT));
@@ -795,6 +987,52 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         ),
         ImmutableList.of(
             new Object[]{"Diskussion:Sebastian Schulz", "DE", 3L, "DE", "Germany", 3L}
+        )
+    );
+  }
+
+  @Test
+  public void test_makeCursors_factToCountryRightWithFilterOnJoinableUsingLookup()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.RIGHT));
+    Filter filter = new SelectorDimFilter(
+        FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v",
+        "Germany",
+        null
+    ).toFilter();
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        filter,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            filter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            "countryNumber",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
+        ),
+        ImmutableList.of(
+            new Object[]{"Diskussion:Sebastian Schulz", "DE", 3L, "DE", "Germany"}
         )
     );
   }
@@ -971,6 +1209,87 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             new Object[]{"Old Anatolian Turkish", "US", "US", "United States", 13L},
             new Object[]{"Cream Soda", "SU", "SU", "States United", 15L},
             new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems", 205L}
+        )
+    );
+  }
+
+  @Test
+  public void test_makeCursors_factToCountryInnerWithFilterInsteadOfRealJoinConditionUsingLookup()
+  {
+    // Join condition => always true.
+    // Filter => Fact to countries on countryIsoCode.
+
+    List<JoinableClause> joinableClauses = ImmutableList.of(
+        new JoinableClause(
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+            LookupJoinable.wrap(countryIsoCodeToNameLookup),
+            JoinType.INNER,
+            JoinConditionAnalysis.forExpression(
+                "1",
+                FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+                ExprMacroTable.nil()
+            )
+        )
+    );
+
+    Filter filter = new ExpressionDimFilter(
+        StringUtils.format("\"%sk\" == countryIsoCode", FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX),
+        ExprMacroTable.nil()
+    ).toFilter();
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        filter,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            filter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
+        ),
+        ImmutableList.of(
+            new Object[]{"Peremptory norm", "AU", "AU", "Australia"},
+            new Object[]{"Mathis Bolly", "MX", "MX", "Mexico"},
+            new Object[]{"유희왕 GX", "KR", "KR", "Republic of Korea"},
+            new Object[]{"青野武", "JP", "JP", "Japan"},
+            new Object[]{"Golpe de Estado en Chile de 1973", "CL", "CL", "Chile"},
+            new Object[]{"President of India", "US", "US", "United States"},
+            new Object[]{"Diskussion:Sebastian Schulz", "DE", "DE", "Germany"},
+            new Object[]{"Saison 9 de Secret Story", "FR", "FR", "France"},
+            new Object[]{"Glasgow", "GB", "GB", "United Kingdom"},
+            new Object[]{"Didier Leclair", "CA", "CA", "Canada"},
+            new Object[]{"Les Argonautes", "CA", "CA", "Canada"},
+            new Object[]{"Otjiwarongo Airport", "US", "US", "United States"},
+            new Object[]{"Sarah Michelle Gellar", "CA", "CA", "Canada"},
+            new Object[]{"DirecTV", "US", "US", "United States"},
+            new Object[]{"Carlo Curti", "US", "US", "United States"},
+            new Object[]{"Giusy Ferreri discography", "IT", "IT", "Italy"},
+            new Object[]{"Roma-Bangkok", "IT", "IT", "Italy"},
+            new Object[]{"Wendigo", "SV", "SV", "El Salvador"},
+            new Object[]{"Алиса в Зазеркалье", "NO", "NO", "Norway"},
+            new Object[]{"Gabinete Ministerial de Rafael Correa", "EC", "EC", "Ecuador"},
+            new Object[]{"Old Anatolian Turkish", "US", "US", "United States"},
+            new Object[]{"Cream Soda", "SU", "SU", "States United"},
+            new Object[]{"History of Fourems", "MMMM", "MMMM", "Fourems"}
         )
     );
   }
@@ -1348,6 +1667,72 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   }
 
   @Test
+  public void test_makeCursors_factToCountryUsingVirtualColumnUsingLookup()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(
+        new JoinableClause(
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+            LookupJoinable.wrap(countryIsoCodeToNameLookup),
+            JoinType.INNER,
+            JoinConditionAnalysis.forExpression(
+                StringUtils.format("\"%sk\" == virtual", FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX),
+                FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+                ExprMacroTable.nil()
+            )
+        )
+    );
+
+    VirtualColumns virtualColumns = VirtualColumns.create(
+        Collections.singletonList(
+            new ExpressionVirtualColumn(
+                "virtual",
+                "concat(substring(countryIsoCode, 0, 1),'L')",
+                ValueType.STRING,
+                ExprMacroTable.nil()
+            )
+        )
+    );
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        virtualColumns,
+        null,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            null,
+            Intervals.ETERNITY,
+            virtualColumns,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            "virtual",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
+        ),
+        ImmutableList.of(
+            new Object[]{"Golpe de Estado en Chile de 1973", "CL", "CL", "CL", "Chile"},
+            new Object[]{"Didier Leclair", "CA", "CL", "CL", "Chile"},
+            new Object[]{"Les Argonautes", "CA", "CL", "CL", "Chile"},
+            new Object[]{"Sarah Michelle Gellar", "CA", "CL", "CL", "Chile"}
+        )
+    );
+  }
+
+  @Test
   public void test_makeCursors_factToCountryUsingExpression()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(
@@ -1394,6 +1779,63 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             "countryIsoCode",
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryIsoCode",
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName"
+        ),
+        ImmutableList.of(
+            new Object[]{"Golpe de Estado en Chile de 1973", "CL", "CL", "Chile"},
+            new Object[]{"Didier Leclair", "CA", "CL", "Chile"},
+            new Object[]{"Les Argonautes", "CA", "CL", "Chile"},
+            new Object[]{"Sarah Michelle Gellar", "CA", "CL", "Chile"}
+        )
+    );
+  }
+
+  @Test
+  public void test_makeCursors_factToCountryUsingExpressionUsingLookup()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(
+        new JoinableClause(
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+            LookupJoinable.wrap(countryIsoCodeToNameLookup),
+            JoinType.INNER,
+            JoinConditionAnalysis.forExpression(
+                StringUtils.format(
+                    "\"%sk\" == concat(substring(countryIsoCode, 0, 1),'L')",
+                    FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX
+                ),
+                FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+                ExprMacroTable.nil()
+            )
+        )
+    );
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        null,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            null,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
         ),
         ImmutableList.of(
             new Object[]{"Golpe de Estado en Chile de 1973", "CL", "CL", "Chile"},
@@ -1514,6 +1956,52 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   }
 
   @Test
+  public void test_makeCursors_errorOnNonEquiJoinUsingLookup()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Cannot join lookup with non-equi condition: x == y");
+
+    List<JoinableClause> joinableClauses = ImmutableList.of(
+        new JoinableClause(
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+            LookupJoinable.wrap(countryIsoCodeToNameLookup),
+            JoinType.LEFT,
+            JoinConditionAnalysis.forExpression(
+                "x == y",
+                FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+                ExprMacroTable.nil()
+            )
+        )
+    );
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        null,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.readCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            null,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of()
+    );
+  }
+
+  @Test
   public void test_makeCursors_errorOnNonKeyBasedJoin()
   {
     expectedException.expect(IllegalArgumentException.class);
@@ -1523,6 +2011,51 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new JoinableClause(
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
             new IndexedTableJoinable(countriesTable),
+            JoinType.LEFT,
+            JoinConditionAnalysis.forExpression(
+                StringUtils.format("x == \"%scountryName\"", FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX),
+                FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+                ExprMacroTable.nil()
+            )
+        )
+    );
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        null,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.readCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            null,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of()
+    );
+  }
+
+  @Test
+  public void test_makeCursors_errorOnNonKeyBasedJoinUsingLookup()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Cannot join lookup with condition referring to non-key column: x == \"c1.countryName");
+    List<JoinableClause> joinableClauses = ImmutableList.of(
+        new JoinableClause(
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
+            LookupJoinable.wrap(countryIsoCodeToNameLookup),
             JoinType.LEFT,
             JoinConditionAnalysis.forExpression(
                 StringUtils.format("x == \"%scountryName\"", FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX),
@@ -1594,6 +2127,45 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryIsoCode",
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName",
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryNumber"
+        ),
+        ImmutableList.of()
+    );
+  }
+
+  @Test
+  public void test_makeCursors_factToCountryLeft_filterExcludesAllLeftRowsUsingLookup()
+  {
+    Filter originalFilter = new SelectorFilter("page", "this matches nothing");
+    List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
+
+    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+        joinableClauses,
+        VirtualColumns.EMPTY,
+        originalFilter,
+        true,
+        true,
+        true,
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+    );
+
+    JoinTestHelper.verifyCursors(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            joinableClauses,
+            preAnalysis
+        ).makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "k",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v"
         ),
         ImmutableList.of()
     );

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
@@ -45,7 +45,6 @@ import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;

--- a/processing/src/test/java/org/apache/druid/segment/join/table/LookupJoinMatcherTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/LookupJoinMatcherTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.join.table;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.query.lookup.LookupExtractor;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.data.SingleIndexedInt;
+import org.apache.druid.segment.join.JoinConditionAnalysis;
+import org.apache.druid.segment.join.lookup.LookupJoinMatcher;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LookupJoinMatcherTest
+{
+  private final Map<String, String> lookupMap =
+      ImmutableMap.of("foo", "bar", "null", "", "empty String", "", "", "empty_string");
+  private static final String PREFIX = "j.";
+
+  @Mock
+  private LookupExtractor extractor;
+
+  @Mock
+  private ColumnSelectorFactory leftSelectorFactory;
+
+  @Mock
+  private DimensionSelector dimensionSelector;
+
+  private LookupJoinMatcher target;
+
+  @Before
+  public void setUp()
+  {
+    Mockito.doReturn(true).when(extractor).canIterate();
+    Mockito.doReturn(lookupMap.entrySet()).when(extractor).iterable();
+  }
+
+  @Test
+  public void testCreateConditionAlwaysFalse()
+  {
+    JoinConditionAnalysis condition = JoinConditionAnalysis.forExpression("0", PREFIX, ExprMacroTable.nil());
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, false);
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, false);
+  }
+
+  @Test
+  public void testCreateConditionAlwaysTrue()
+  {
+    JoinConditionAnalysis condition = JoinConditionAnalysis.forExpression("1", PREFIX, ExprMacroTable.nil());
+    Mockito.doReturn(true).when(extractor).canIterate();
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, false);
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, true);
+  }
+
+  @Test
+  public void testMatchConditionAlwaysTrue()
+  {
+    JoinConditionAnalysis condition = JoinConditionAnalysis.forExpression("1", PREFIX, ExprMacroTable.nil());
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, true);
+    // Test match first
+    target.matchCondition();
+    Assert.assertTrue(target.hasMatch());
+    verifyMatch("foo", "bar");
+    // Test match second
+    target.nextMatch();
+    Assert.assertTrue(target.hasMatch());
+    verifyMatch("null", "");
+    // Test match third
+    target.nextMatch();
+    Assert.assertTrue(target.hasMatch());
+    verifyMatch("empty String", "");
+    // Test match forth
+    target.nextMatch();
+    Assert.assertTrue(target.hasMatch());
+    verifyMatch("", "empty_string");
+    // Test no more
+    target.nextMatch();
+    Assert.assertFalse(target.hasMatch());
+  }
+
+  @Test
+  public void testMatchConditionAlwaysFalse()
+  {
+    JoinConditionAnalysis condition = JoinConditionAnalysis.forExpression("0", PREFIX, ExprMacroTable.nil());
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, true);
+    // Test match first
+    target.matchCondition();
+    Assert.assertFalse(target.hasMatch());
+    verifyMatch(null, null);
+  }
+
+  @Test
+  public void testMatchConditionSometimesTrueSometimesFalse()
+  {
+    final int index = 1;
+    SingleIndexedInt row = new SingleIndexedInt();
+    row.setValue(index);
+    Mockito.doReturn(dimensionSelector).when(leftSelectorFactory).makeDimensionSelector(ArgumentMatchers.any(DimensionSpec.class));
+    Mockito.doReturn(row).when(dimensionSelector).getRow();
+    Mockito.doReturn("foo").when(dimensionSelector).lookupName(index);
+    Mockito.doReturn("bar").when(extractor).apply("foo");
+
+    JoinConditionAnalysis condition = JoinConditionAnalysis.forExpression(
+        StringUtils.format("\"%sk\" == foo", PREFIX),
+        PREFIX,
+        ExprMacroTable.nil()
+    );
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, true);
+    // Test match
+    target.matchCondition();
+    Assert.assertTrue(target.hasMatch());
+    verifyMatch("foo", "bar");
+    // Test no more
+    target.nextMatch();
+    Assert.assertFalse(target.hasMatch());
+  }
+
+  private void verifyMatch(String expectedKey, String expectedValue)
+  {
+    DimensionSelector selector = target.getColumnSelectorFactory()
+                                             .makeDimensionSelector(DefaultDimensionSpec.of("k"));
+    Assert.assertEquals(-1, selector.getValueCardinality());
+    Assert.assertEquals(expectedKey, selector.lookupName(0));
+    Assert.assertEquals(expectedKey, selector.lookupName(0));
+    Assert.assertNull(selector.idLookup());
+
+    selector = target.getColumnSelectorFactory()
+                                             .makeDimensionSelector(DefaultDimensionSpec.of("v"));
+    Assert.assertEquals(-1, selector.getValueCardinality());
+    Assert.assertEquals(expectedValue, selector.lookupName(0));
+    Assert.assertEquals(expectedValue, selector.lookupName(0));
+    Assert.assertNull(selector.idLookup());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/join/table/LookupJoinMatcherTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/LookupJoinMatcherTest.java
@@ -67,20 +67,24 @@ public class LookupJoinMatcherTest
   }
 
   @Test
-  public void testCreateConditionAlwaysFalse()
+  public void testCreateConditionAlwaysFalseShouldReturnSuccessfullyAndNotThrowException()
   {
     JoinConditionAnalysis condition = JoinConditionAnalysis.forExpression("0", PREFIX, ExprMacroTable.nil());
     target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, false);
-    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, false);
+    Assert.assertNotNull(target);
+    target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, true);
+    Assert.assertNotNull(target);
   }
 
   @Test
-  public void testCreateConditionAlwaysTrue()
+  public void testCreateConditionAlwaysTrueShouldReturnSuccessfullyAndNotThrowException()
   {
     JoinConditionAnalysis condition = JoinConditionAnalysis.forExpression("1", PREFIX, ExprMacroTable.nil());
     Mockito.doReturn(true).when(extractor).canIterate();
     target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, false);
+    Assert.assertNotNull(target);
     target = LookupJoinMatcher.create(extractor, leftSelectorFactory, condition, true);
+    Assert.assertNotNull(target);
   }
 
   @Test


### PR DESCRIPTION
Add equivalent test coverage for all RHS join impls

### Description

This PR adds unit tests to make sure that we have equal coverage for all RHS join impls. 
We currently have 2 implementations of "joins", join against a lookup and join against an indexed table. We already have equal coverage tests for LookupJoinable and IndexedTableJoinable via LookupJoinableTest and IndexedTableJoinableTest (added from PR https://github.com/apache/druid/pull/9760). This PR adds the remaining missing tests for LookupJoinMatcher and IndexedTableJoinMatcher (so that we have equal coverage for LookupJoinMatcher and IndexedTableJoinMatcher too).    

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.