### PR TITLE
low hanging fruit - presize hash map for DruidSegmentReader

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentReader.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentReader.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.input;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntity.CleanableFile;
 import org.apache.druid.data.input.InputRow;
@@ -49,6 +48,7 @@ import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.realtime.firehose.WindowedStorageAdapter;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 
 import java.io.File;
@@ -245,7 +245,8 @@ public class DruidSegmentReader extends IntermediateRowParsingReader<Map<String,
       if (!hasNext()) {
         throw new NoSuchElementException();
       }
-      final Map<String, Object> theEvent = Maps.newLinkedHashMap();
+      final Map<String, Object> theEvent =
+          CollectionUtils.newLinkedHashMapWithExpectedSize(dimSelectors.size() + metSelectors.size() + 1);
 
       for (Entry<String, DimensionSelector> dimSelector : dimSelectors.entrySet()) {
         final String dim = dimSelector.getKey();


### PR DESCRIPTION
I don't have an after flame graph, but here is the before:

<img width="1638" alt="Screen Shot 2020-05-06 at 3 00 24 PM" src="https://user-images.githubusercontent.com/1577461/81259389-b3cf9100-8fec-11ea-8e8c-75a64078035c.png">

where we are spending time resizing the `HashMap` that we don't need to be when we know the approximate size up front.