### PR TITLE
Replace varchar primary key with auto-increment integer primary key

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -228,10 +228,12 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  sequence_prev_id VARCHAR(255) NOT NULL,\n"
                 + "  sequence_name_prev_id_sha1 VARCHAR(255) NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
-                + "  PRIMARY KEY (id),\n"
+                + "  autoid %5$s NOT NULL,\n"
+                + "  UNIQUE (id),\n"
+                + "  PRIMARY KEY (autoid),\n"
                 + "  UNIQUE (sequence_name_prev_id_sha1)\n"
                 + ")",
-                tableName, getPayloadType(), getQuoteString(), getCollation()
+                tableName, getPayloadType(), getQuoteString(), getCollation(), getSerialType()
             ),
             StringUtils.format(
                 "CREATE INDEX idx_%1$s_datasource_end ON %1$s(dataSource, %2$send%2$s)",
@@ -257,9 +259,11 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  created_date VARCHAR(255) NOT NULL,\n"
                 + "  commit_metadata_payload %2$s NOT NULL,\n"
                 + "  commit_metadata_sha1 VARCHAR(255) NOT NULL,\n"
-                + "  PRIMARY KEY (dataSource)\n"
+                + "  autoid %4$s NOT NULL,\n"
+                + "  UNIQUE (dataSource),\n"
+                + "  PRIMARY KEY (autoid)\n"
                 + ")",
-                tableName, getPayloadType(), getCollation()
+                tableName, getPayloadType(), getCollation(), getSerialType()
             )
         )
     );
@@ -281,9 +285,11 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  version VARCHAR(255) NOT NULL,\n"
                 + "  used BOOLEAN NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
-                + "  PRIMARY KEY (id)\n"
+                + "  autoid %5$s NOT NULL,\n"
+                + "  UNIQUE (id),\n"
+                + "  PRIMARY KEY (autoid)\n"
                 + ")",
-                tableName, getPayloadType(), getQuoteString(), getCollation()
+                tableName, getPayloadType(), getQuoteString(), getCollation(), getSerialType()
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_used ON %1$s(used)", tableName),
             StringUtils.format(
@@ -306,9 +312,11 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  dataSource VARCHAR(255) %3$s NOT NULL,\n"
                 + "  version VARCHAR(255) NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
-                + "  PRIMARY KEY (id)\n"
+                + "  autoid %4$s NOT NULL,\n"
+                + "  UNIQUE (id),\n"
+                + "  PRIMARY KEY (autoid)\n"
                 + ")",
-                tableName, getPayloadType(), getCollation()
+                tableName, getPayloadType(), getCollation(), getSerialType()
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_datasource ON %1$s(dataSource)", tableName)
         )
@@ -324,9 +332,11 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 "CREATE TABLE %1$s (\n"
                 + "  name VARCHAR(255) NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
-                + "  PRIMARY KEY(name)\n"
+                + "  autoid %3$s NOT NULL,\n"
+                + "  UNIQUE (name),\n"
+                + "  PRIMARY KEY (autoid)\n"
                 + ")",
-                tableName, getPayloadType()
+                tableName, getPayloadType(), getSerialType()
             )
         )
     );
@@ -345,9 +355,11 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  payload %2$s NOT NULL,\n"
                 + "  status_payload %2$s NOT NULL,\n"
                 + "  active BOOLEAN NOT NULL DEFAULT FALSE,\n"
-                + "  PRIMARY KEY (id)\n"
+                + "  autoid %4$s NOT NULL,\n"
+                + "  UNIQUE (id),\n"
+                + "  PRIMARY KEY (autoid)\n"
                 + ")",
-                tableName, getPayloadType(), getCollation()
+                tableName, getPayloadType(), getCollation(), getSerialType()
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_active_created_date ON %1$s(active, created_date)", tableName)
         )


### PR DESCRIPTION

### Description
This PR propose a schema changing for metadata tables to replace the varchar primary key with an auto-increment integer primary key. 

This changing seems dogmatic and old-fashioned at first. But it really matters if you have been complained by the internal DBA team for the heavy load caused by druid metadata db.

As we know that the auto-increment integer primary key usually has better performance than UUID primary key, especially if the table contains a large number of rows, eg: druid_segments and druid_pendingSegments.


This PR has:
- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `SQLMetadataConnector`
