### PR TITLE
Fix potential resource leak in ParquetReader

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/InputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/InputFormat.java
@@ -32,7 +32,6 @@ import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.guice.annotations.UnstableApi;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * InputFormat abstracts the file format of input data.
@@ -64,5 +63,5 @@ public interface InputFormat
       InputRowSchema inputRowSchema,
       InputEntity source,
       File temporaryDirectory
-  ) throws IOException;
+  );
 }

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.conf.Configuration;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.IOException;
 import java.util.Objects;
 
 public class ParquetInputFormat extends NestedInputFormat
@@ -69,7 +68,7 @@ public class ParquetInputFormat extends NestedInputFormat
       InputRowSchema inputRowSchema,
       InputEntity source,
       File temporaryDirectory
-  ) throws IOException
+  )
   {
     return new ParquetReader(conf, inputRowSchema, source, temporaryDirectory, getFlattenSpec(), binaryAsString);
   }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetReaderTest.java
@@ -39,7 +39,7 @@ class BaseParquetReaderTest
 {
   ObjectWriter DEFAULT_JSON_WRITER = new ObjectMapper().writerWithDefaultPrettyPrinter();
 
-  InputEntityReader createReader(String parquetFile, InputRowSchema schema, JSONPathSpec flattenSpec) throws IOException
+  InputEntityReader createReader(String parquetFile, InputRowSchema schema, JSONPathSpec flattenSpec)
   {
     return createReader(parquetFile, schema, flattenSpec, false);
   }
@@ -49,7 +49,7 @@ class BaseParquetReaderTest
       InputRowSchema schema,
       JSONPathSpec flattenSpec,
       boolean binaryAsString
-  ) throws IOException
+  )
   {
     FileEntity entity = new FileEntity(new File(parquetFile));
     ParquetInputFormat parquet = new ParquetInputFormat(flattenSpec, binaryAsString, new Configuration());

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.parquet;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.FileEntity;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Objects;
+
+public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
+{
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testFetchOnReadCleanupAfterExhaustingIterator() throws IOException
+  {
+    InputRowSchema schema = new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(
+            DimensionsSpec.getDefaultSchemas(ImmutableList.of("page", "language", "user", "unpatrolled"))
+        ),
+        Collections.emptyList()
+    );
+    FetchingFileEntity entity = new FetchingFileEntity(new File("example/wiki/wiki.parquet"));
+    ParquetInputFormat parquet = new ParquetInputFormat(JSONPathSpec.DEFAULT, false, new Configuration());
+    File tempDir = temporaryFolder.newFolder();
+    InputEntityReader reader = parquet.createReader(schema, entity, tempDir);
+    Assert.assertEquals(0, Objects.requireNonNull(tempDir.list()).length);
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      Assert.assertTrue(Objects.requireNonNull(tempDir.list()).length > 0);
+      while (iterator.hasNext()) {
+        iterator.next();
+      }
+    }
+    Assert.assertEquals(0, Objects.requireNonNull(tempDir.list()).length);
+  }
+
+  private static class FetchingFileEntity extends FileEntity
+  {
+    private FetchingFileEntity(File file)
+    {
+      super(file);
+    }
+
+    @Override
+    public CleanableFile fetch(File temporaryDirectory, byte[] fetchBuffer)
+    {
+      // Copied from InputEntity
+      try {
+        final File tempFile = File.createTempFile("druid-input-entity", ".tmp", temporaryDirectory);
+        try (InputStream is = open()) {
+          FileUtils.copyLarge(
+              is,
+              tempFile,
+              fetchBuffer,
+              getRetryCondition(),
+              DEFAULT_MAX_NUM_FETCH_TRIES,
+              StringUtils.format("Failed to fetch into [%s]", tempFile.getAbsolutePath())
+          );
+        }
+
+        return new CleanableFile()
+        {
+          @Override
+          public File file()
+          {
+            return tempFile;
+          }
+
+          @Override
+          public void close()
+          {
+            if (!tempFile.delete()) {
+              LOG.warn("Failed to remove file[%s]", tempFile.getAbsolutePath());
+            }
+          }
+        };
+      }
+      catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SettableByteEntityReader.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SettableByteEntityReader.java
@@ -60,7 +60,7 @@ class SettableByteEntityReader implements InputEntityReader
     this.indexingTmpDir = indexingTmpDir;
   }
 
-  void setEntity(ByteEntity entity) throws IOException
+  void setEntity(ByteEntity entity)
   {
     this.delegate = new TransformingInputEntityReader(
         // Yes, we are creating a new reader for every stream chunk.


### PR DESCRIPTION
### Description

`ParquetReader` fetches the input file and creates a reader in its constructor. These are registered on a `Closer` which is closed when the `CloseableIterator` returned from `intermediateRowIterator` is exhausted. This can lead to potential resource leaks if the task is canceled without calling `intermediateRowIterator`. I think the fetched file will be still deleted when the task is canceled since it is created in the task temporary working directory. The reader will also be closed when the peon is shut down on middleManager. So, probably the resource leak will exist only with Indexer. However, it would be nice to clean up all resources properly when it should be rather than depending on other clean up mechanism. 

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.