### PR TITLE
Update password-provider.md

### DIFF
--- a/docs/operations/password-provider.md
+++ b/docs/operations/password-provider.md
@@ -33,7 +33,7 @@ Environment variable password provider provides password by looking at specified
 e.g
 
 ```json
-{ "type": "environment", "variable": "METADATA_STORAGE_PASSWORD" }
+druid.metadata.storage.connector.password={ "type": "environment", "variable": "METADATA_STORAGE_PASSWORD" }
 ```
 
 The values are described below.
@@ -50,5 +50,5 @@ Please have a look at "Adding a new Password Provider implementation" on this [p
 To use this implementation, simply set the relevant password runtime property to something similar as was done for Environment variable password provider like -
 
 ```json
-{ "type": "<registered_password_provider_name>", "<jackson_property>": "<value>", ... }
+druid.metadata.storage.connector.password={ "type": "<registered_password_provider_name>", "<jackson_property>": "<value>", ... }
 ```


### PR DESCRIPTION

Fixes #9465


### Description

Provide a complete usage example of Password provider in runtime.properties file, in order to avoid misinterpretation like in 
#9465

<hr>

This PR has:

- [ x] added documentation for new or modified features or behaviors.

<hr>
