### PR TITLE
fix license registry for com.nimbusds lang-tag

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -710,7 +710,7 @@ name: com.nimbusds lang-tag
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 1.4.4
+version: 1.5
 libraries:
   - com.nimbusds: lang-tag
 


### PR DESCRIPTION
CI license check is failing:

```
Error: found 1 missing licenses. These licenses are reported, but missing in the registry
druid_module: druid-pac4j, groupId: com.nimbusds, artifactId: lang-tag, version: 1.5, license: Apache License version 2.0
```