### PR TITLE
add some details to the build doc

### DIFF
--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -43,7 +43,7 @@ Use of other databases such as Postgres or Derby are entirely reasonable, but do
 This also assumes you have [ZooKeeper](http://zookeeper.apache.org/releases.html) running locally, which usually just involves downloading the latst distribution of ZooKeeper, doing some minor configuration in ZooKeeper's `conf/` directory (most defaults are fine), then running `./bin/zkServer.sh start` in the ZooKeeper directory. 
 
 ## Initial Build
-Before running the apps, you should do a `mvn clean install -DskipTests` in the Druid source in order to make sure directories are populated correctly.
+Before running the apps, you should do a `mvn clean install -Pdist -DskipTests` in the Druid source in order to make sure directories are populated correctly.
 
 ## XML App Def
 You can configure application definitions in XML for import into IntelliJ. Below are a few examples. These should be placed in an XML file in `.idea/runConfigurations` in the Druid source code.

--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -42,8 +42,17 @@ Use of other databases such as Postgres or Derby are entirely reasonable, but do
 ## ZooKeeper
 This also assumes you have [ZooKeeper](http://zookeeper.apache.org/releases.html) running locally, which usually just involves downloading the latst distribution of ZooKeeper, doing some minor configuration in ZooKeeper's `conf/` directory (most defaults are fine), then running `./bin/zkServer.sh start` in the ZooKeeper directory. 
 
+On macOS, you can also achieve this through the following commands
+
+1. `brew install zookeeper`
+2. `brew services start zookeeper`
+
 ## Initial Build
-Before running the apps, you should do a `mvn clean install -Pdist -DskipTests` in the Druid source in order to make sure directories are populated correctly.
+Before running or debugging the apps, you should do a `mvn clean install -Pdist -DskipTests` in the Druid source in order to make sure directories are populated correctly.
+
+`-Pdist` is required because it puts all core extensions under `distribution\target\extensions` directory, where `runConfigurations` below could load extensions from.
+
+You may also add `-Ddruid.console.skip=true` to the command if you're focusing on backend servers instead of frontend project. This option saves great building time.
 
 ## XML App Def
 You can configure application definitions in XML for import into IntelliJ. Below are a few examples. These should be placed in an XML file in `.idea/runConfigurations` in the Druid source code.
@@ -89,3 +98,8 @@ You can configure application definitions in XML for import into IntelliJ. Below
   </configuration>
 </component>
 ```
+## property files
+
+You can also provide a property file for running or debugging the application through intellij. 
+
+For example, put a file named as `common.properties` under `.idea/conf` directory, then add `-Ddruid.properties.file=$PROJECT_DIR$/.idea/conf/common.properties` to `VM_PARAMETERS` in the App Def file.

--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -34,6 +34,8 @@ For building the latest code in master, follow the instructions [here](https://g
   like [Amazon Corretto](https://aws.amazon.com/corretto/) or [Azul Zulu](https://www.azul.com/downloads/zulu/).
 - [Maven version 3.x](http://maven.apache.org/download.cgi)
 
+##### Other Dependencies
+- for distribution build, Python and yaml module are required
 
 
 ##### Downloading the source:
@@ -60,6 +62,7 @@ In addition to the basic stages, you may also want to add the following profiles
 - **-Papache-release** - Apache release profile: Generates GPG signature and checksums, and builds the source distribution tarball as `distribution/target/apache-druid-x.x.x-src.tar.gz`
 - **-Prat** - Apache Rat profile: Runs the Apache Rat license audit tool
 - **-DskipTests** - Skips unit tests (which reduces build time)
+- **-Ddruid.console.skip=true** - Skip frontend project
 
 Putting these together, if you wish to build the source and binary distributions with signatures and checksums, audit licenses, and skip the unit tests, you would run:
 

--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -62,7 +62,7 @@ In addition to the basic stages, you may also want to add the following profiles
 - **-Papache-release** - Apache release profile: Generates GPG signature and checksums, and builds the source distribution tarball as `distribution/target/apache-druid-x.x.x-src.tar.gz`
 - **-Prat** - Apache Rat profile: Runs the Apache Rat license audit tool
 - **-DskipTests** - Skips unit tests (which reduces build time)
-- **-Ddruid.console.skip=true** - Skip frontend project
+- **-Ddruid.console.skip=true** - Skip front end project
 
 Putting these together, if you wish to build the source and binary distributions with signatures and checksums, audit licenses, and skip the unit tests, you would run:
 

--- a/website/.spelling
+++ b/website/.spelling
@@ -451,6 +451,8 @@ v9
 DskipTests
 Papache-release
 Pdist
+Ddruid.console.skip
+yaml
  - ../docs/development/extensions-contrib/ambari-metrics-emitter.md
 ambari-metrics
 metricName
@@ -1750,5 +1752,3 @@ CVE-2019-17571
 CVE-2019-12399
 CVE-2018-17196
 bin.tar.gz
-Ddruid.console.skip
-yaml

--- a/website/.spelling
+++ b/website/.spelling
@@ -1750,3 +1750,5 @@ CVE-2019-17571
 CVE-2019-12399
 CVE-2018-17196
 bin.tar.gz
+Ddruid.console.skip
+yaml


### PR DESCRIPTION
### Description

it's not easy to build the source and start debugging the code for people who are new to this project. following the original documents, it still takes me several hours to set up intellj and succeed debugging it. 

if the document could be a little bit clear, it would save people a lot of time. so I put some details  to the doc that I wish would know before i started to build the source. 

