### PR TITLE
Fix web console query view crashing on simple query

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4707,7 +4707,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Imply Data
-version: 0.5.1
+version: 0.6.1
 
 ---
 

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -4243,9 +4243,9 @@
       }
     },
     "druid-query-toolkit": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.5.1.tgz",
-      "integrity": "sha512-oI1YddnzIbkcelI93qaRtonu3PLGw65fDqLLK6e35gD4Ef/Yf8bOZvFK9wDYNAXcA6SDy7UDarfWsgD2dDWsjg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.6.1.tgz",
+      "integrity": "sha512-ykrWD9AbDQEvE55x8ST1kyiiGHSN8zhp/Lqe7z43/l7XG9QD7AQwfBzOn+HATXFynrOQN/3z3Cis70EzdDjc1g==",
       "requires": {
         "tslib": "^1.10.0"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -68,7 +68,7 @@
     "d3-axis": "^1.0.12",
     "d3-scale": "^3.2.0",
     "d3-selection": "^1.4.0",
-    "druid-query-toolkit": "^0.5.1",
+    "druid-query-toolkit": "^0.6.1",
     "file-saver": "^2.0.2",
     "has-own-prop": "^2.0.0",
     "hjson": "^3.2.1",

--- a/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
+++ b/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
@@ -81,3 +81,85 @@ exports[`sql view matches snapshot 1`] = `
   </t>
 </div>
 `;
+
+exports[`sql view matches snapshot with query 1`] = `
+<div
+  className="query-view app-view"
+>
+  <ColumnTree
+    columnMetadataLoading={true}
+    defaultSchema="druid"
+    getParsedQuery={[Function]}
+    onQueryStringChange={[Function]}
+  />
+  <t
+    customClassName=""
+    onDragEnd={null}
+    onDragStart={null}
+    onSecondaryPaneSizeChange={[Function]}
+    percentage={true}
+    primaryIndex={0}
+    primaryMinSize={30}
+    secondaryInitialSize={60}
+    secondaryMinSize={30}
+    vertical={true}
+  >
+    <div
+      className="control-pane"
+    >
+      <QueryInput
+        currentSchema="druid"
+        onQueryStringChange={[Function]}
+        queryString="SELECT +3"
+        runeMode={false}
+      />
+      <div
+        className="control-bar"
+      >
+        <HotkeysTarget(RunButton)
+          loading={false}
+          onEditContext={[Function]}
+          onExplain={[Function]}
+          onHistory={[Function]}
+          onPrettier={[Function]}
+          onQueryContextChange={[Function]}
+          onRun={[Function]}
+          queryContext={Object {}}
+          runeMode={false}
+        />
+        <Blueprint3.Tooltip
+          content="Automatically run queries when modified via helper action menus."
+          hoverCloseDelay={0}
+          hoverOpenDelay={800}
+          transitionDuration={100}
+        >
+          <Blueprint3.Switch
+            checked={true}
+            className="auto-run"
+            label="Auto run"
+            onChange={[Function]}
+          />
+        </Blueprint3.Tooltip>
+        <Blueprint3.Tooltip
+          content="Automatically wrap the query with a limit to protect against queries with very large result sets."
+          hoverCloseDelay={0}
+          hoverOpenDelay={800}
+          transitionDuration={100}
+        >
+          <Blueprint3.Switch
+            checked={true}
+            className="smart-query-limit"
+            label="Smart query limit"
+            onChange={[Function]}
+          />
+        </Blueprint3.Tooltip>
+      </div>
+    </div>
+    <Memo(QueryOutput)
+      loading={false}
+      onQueryChange={[Function]}
+      runeMode={false}
+    />
+  </t>
+</div>
+`;

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
@@ -17,21 +17,19 @@
  */
 
 import { render } from '@testing-library/react';
-import { sqlParserFactory } from 'druid-query-toolkit';
+import { parseSqlQuery } from 'druid-query-toolkit';
 import React from 'react';
 
 import { NumberMenuItems } from './number-menu-items';
 
 describe('number menu', () => {
-  const parser = sqlParserFactory(['COUNT']);
-
   it('matches snapshot when menu is opened for column not inside group by', () => {
     const numberMenu = (
       <NumberMenuItems
         schema="schema"
         table="table"
         columnName={'added'}
-        parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        parsedQuery={parseSqlQuery(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );
@@ -46,7 +44,7 @@ describe('number menu', () => {
         schema="schema"
         table="table"
         columnName={'added'}
-        parsedQuery={parser(`SELECT added, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        parsedQuery={parseSqlQuery(`SELECT added, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
@@ -17,21 +17,19 @@
  */
 
 import { render } from '@testing-library/react';
-import { sqlParserFactory } from 'druid-query-toolkit';
+import { parseSqlQuery } from 'druid-query-toolkit';
 import React from 'react';
 
 import { StringMenuItems } from './string-menu-items';
 
 describe('string menu', () => {
-  const parser = sqlParserFactory(['COUNT']);
-
   it('matches snapshot when menu is opened for column not inside group by', () => {
     const stringMenu = (
       <StringMenuItems
         table={'table'}
         schema={'schema'}
         columnName={'cityName'}
-        parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        parsedQuery={parseSqlQuery(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );
@@ -46,7 +44,7 @@ describe('string menu', () => {
         table={'table'}
         schema={'schema'}
         columnName={'channel'}
-        parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        parsedQuery={parseSqlQuery(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
@@ -17,21 +17,19 @@
  */
 
 import { render } from '@testing-library/react';
-import { sqlParserFactory } from 'druid-query-toolkit';
+import { parseSqlQuery } from 'druid-query-toolkit';
 import React from 'react';
 
 import { TimeMenuItems } from './time-menu-items';
 
 describe('time menu', () => {
-  const parser = sqlParserFactory(['COUNT']);
-
   it('matches snapshot when menu is opened for column not inside group by', () => {
     const timeMenu = (
       <TimeMenuItems
         table={'table'}
         schema={'schema'}
         columnName={'__time'}
-        parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        parsedQuery={parseSqlQuery(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );
@@ -46,7 +44,7 @@ describe('time menu', () => {
         table={'table'}
         schema={'schema'}
         columnName={'__time'}
-        parsedQuery={parser(`SELECT __time, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        parsedQuery={parseSqlQuery(`SELECT __time, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );

--- a/web-console/src/views/query-view/column-tree/column-tree.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree.spec.tsx
@@ -17,7 +17,7 @@
  */
 
 import { render } from '@testing-library/react';
-import { sqlParserFactory } from 'druid-query-toolkit';
+import { parseSqlQuery } from 'druid-query-toolkit';
 import React from 'react';
 
 import { ColumnMetadata } from '../../../utils/column-metadata';
@@ -25,13 +25,11 @@ import { ColumnMetadata } from '../../../utils/column-metadata';
 import { ColumnTree } from './column-tree';
 
 describe('column tree', () => {
-  const parser = sqlParserFactory(['COUNT']);
-
   it('matches snapshot', () => {
     const columnTree = (
       <ColumnTree
         getParsedQuery={() => {
-          return parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`);
+          return parseSqlQuery(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`);
         }}
         defaultSchema="druid"
         defaultTable="wikipedia"

--- a/web-console/src/views/query-view/query-output/query-output.spec.tsx
+++ b/web-console/src/views/query-view/query-output/query-output.spec.tsx
@@ -17,18 +17,14 @@
  */
 
 import { render } from '@testing-library/react';
-import { sqlParserFactory } from 'druid-query-toolkit';
+import { parseSqlQuery } from 'druid-query-toolkit';
 import React from 'react';
-
-import { SQL_FUNCTIONS } from '../../../../lib/sql-docs';
 
 import { QueryOutput } from './query-output';
 
 describe('query output', () => {
   it('matches snapshot', () => {
-    const parser = sqlParserFactory(SQL_FUNCTIONS.map(sqlFunction => sqlFunction.name));
-
-    const parsedQuery = parser(`SELECT
+    const parsedQuery = parseSqlQuery(`SELECT
   "language",
   COUNT(*) AS "Count", COUNT(DISTINCT "language") AS "dist_language", COUNT(*) FILTER (WHERE "language"= 'xxx') AS "language_filtered_count"
 FROM "github"

--- a/web-console/src/views/query-view/query-view.spec.tsx
+++ b/web-console/src/views/query-view/query-view.spec.tsx
@@ -27,6 +27,11 @@ describe('sql view', () => {
     expect(sqlView).toMatchSnapshot();
   });
 
+  it('matches snapshot with query', () => {
+    const sqlView = shallow(<QueryView initQuery={'SELECT +3'} />);
+    expect(sqlView).toMatchSnapshot();
+  });
+
   it('trimSemicolon', () => {
     expect(QueryView.trimSemicolon('SELECT * FROM tbl;')).toEqual('SELECT * FROM tbl');
     expect(QueryView.trimSemicolon('SELECT * FROM tbl;   ')).toEqual('SELECT * FROM tbl   ');

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -23,8 +23,8 @@ import {
   HeaderRows,
   isFirstRowHeader,
   normalizeQueryResult,
+  parseSqlQuery,
   shouldIncludeTimestamp,
-  sqlParserFactory,
   SqlQuery,
 } from 'druid-query-toolkit';
 import Hjson from 'hjson';
@@ -32,7 +32,6 @@ import memoizeOne from 'memoize-one';
 import React from 'react';
 import SplitterLayout from 'react-splitter-layout';
 
-import { SQL_FUNCTIONS } from '../../../lib/sql-docs';
 import { QueryPlanDialog } from '../../dialogs';
 import { EditContextDialog } from '../../dialogs/edit-context-dialog/edit-context-dialog';
 import { QueryHistoryDialog } from '../../dialogs/query-history-dialog/query-history-dialog';
@@ -63,13 +62,9 @@ import { RunButton } from './run-button/run-button';
 
 import './query-view.scss';
 
-const parserRaw = sqlParserFactory(SQL_FUNCTIONS.map(sqlFunction => sqlFunction.name));
-
 const parser = memoizeOne((sql: string): SqlQuery | undefined => {
   try {
-    const parsed = parserRaw(sql);
-    if (!(parsed instanceof SqlQuery)) return;
-    return parsed;
+    return parseSqlQuery(sql);
   } catch {
     return;
   }


### PR DESCRIPTION
Fixes an issue that if you enter the query `SELECT +3` into the query view the console crashes into an unrecoverable state. (Hilariously a refresh would not help as it the query is saved).

Note if you try it, you can recover by opening the JS console and entering `localStorage.clear()`

There are two issues here:

1. The parser does not parse `SELECT +3` correctly
2. The console has a missing check where an invalid output from the parser is not caught and gets way too far in the logic.