### PR TITLE
Remove warn log message when metricSpec is explicitly set to empty

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -113,8 +113,8 @@ public class DataSchema
           throw new IAE("duplicate aggregators found with name [%s].", factory.getName());
         }
       }
-    } else if (this.granularitySpec.isRollup()) {
-      log.warn("No metricsSpec has been specified. Are you sure this is what you want?");
+    } else if (aggregators == null && this.granularitySpec.isRollup()) {
+      log.warn("Rollup is enabled but no metricsSpec has been specified. Are you sure this is what you want?");
     }
   }
 


### PR DESCRIPTION
Remove warn log message when metricSpec is explicitly set to empty

### Description

Saw the warning messages, `org.apache.druid.segment.indexing.DataSchema - No metricsSpec has been specified. Are you sure this is what you want?` in coordinator logs even when metricSpec is present but empty in the schema. It is annoying and fills up the logs. If metricSpec is present but is explicitly set to empty, then we do not need to show this warn log message. (After all the user did include and explicitly set metricSpec to empty in the ingestionSpec so they probably know what they are doing).

Also, improve log message to make it clearer. 

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
