### PR TITLE
Fix Hadoop IT Legacy test query json was not parameterized

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/hadoop/ITHadoopIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/hadoop/ITHadoopIndexTest.java
@@ -57,7 +57,7 @@ public class ITHadoopIndexTest extends AbstractITBatchIndexTest
 
   private static final String BATCH_TASK = "/hadoop/batch_hadoop_indexer.json";
   private static final String BATCH_QUERIES_RESOURCE = "/hadoop/batch_hadoop_queries.json";
-  private static final String BATCH_DATASOURCE = "batchHadoop";
+  private static final String BATCH_DATASOURCE = "batchLegacyHadoop";
 
   private static final String INDEX_TASK = "/hadoop/wikipedia_hadoop_index_task.json";
   private static final String INDEX_QUERIES_RESOURCE = "/indexer/wikipedia_index_queries.json";
@@ -85,8 +85,9 @@ public class ITHadoopIndexTest extends AbstractITBatchIndexTest
   @Test
   public void testLegacyITHadoopIndexTest() throws Exception
   {
+    String indexDatasource = BATCH_DATASOURCE + "_" + UUID.randomUUID();
     try (
-        final Closeable ignored0 = unloader(BATCH_DATASOURCE + config.getExtraDatasourceNameSuffix());
+        final Closeable ignored0 = unloader(indexDatasource + config.getExtraDatasourceNameSuffix());
     ) {
       final Function<String, String> specPathsTransform = spec -> {
         try {
@@ -105,7 +106,7 @@ public class ITHadoopIndexTest extends AbstractITBatchIndexTest
       };
 
       doIndexTest(
-          BATCH_DATASOURCE,
+          indexDatasource,
           BATCH_TASK,
           specPathsTransform,
           BATCH_QUERIES_RESOURCE,

--- a/integration-tests/src/test/resources/hadoop/batch_hadoop_queries.json
+++ b/integration-tests/src/test/resources/hadoop/batch_hadoop_queries.json
@@ -3,7 +3,7 @@
     "description": "segmentMetadata_query",
     "query": {
       "queryType": "segmentMetadata",
-      "dataSource": "batchHadoop",
+      "dataSource": "%%DATASOURCE%%",
       "merge": "true",
       "intervals": "2014-10/2014-12"
     },
@@ -73,7 +73,7 @@
     "description": "time_boundary_query",
     "query": {
       "queryType": "timeBoundary",
-      "dataSource": "batchHadoop"
+      "dataSource": "%%DATASOURCE%%"
     },
     "expectedResults": [
       {
@@ -90,7 +90,7 @@
     "query": {
       "queryType": "groupBy",
       "dataSource": {
-        "name": "batchHadoop",
+        "name": "%%DATASOURCE%%",
         "type": "table"
       },
       "dimensions": [],


### PR DESCRIPTION
Fix Hadoop IT Legacy test query json was not parameterized

### Description
Hadoop Integration test (like every other integration tests) can be run with -Dextra.datasource.name.suffix= to set the suffix to the dataSource name in the integration tests. In ITHadoopIndexTest#testLegacyITHadoopIndexTest, we set the suffix to the dataSource name when we ingest but do not set the suffix to the datasource name when we do verification query test. Basically, the datasource field in the query file was not parameterized 

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
