### PR TITLE
Suppress CVEs for openstack-keystone

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -53,6 +53,9 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.jclouds\.api/openstack\-keystone@.*$</packageUrl>
     <cve>CVE-2015-7546</cve>
+    <cve>CVE-2020-12689</cve>
+    <cve>CVE-2020-12690</cve>
+    <cve>CVE-2020-12691</cve>
   </suppress>
 
   <!-- FIXME: These are suppressed so that CI can enforce that no new vulnerable dependencies are added. -->


### PR DESCRIPTION
### Description

CVE-2020-12689, CVE-2020-12691, and CVE-2020-12690 can be ignored for openstack-keystone as they are for the python SDK and druid uses the java SDK.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.