### PR TITLE
fix bug:MaterializedView gropuby query return arry result by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,8 @@ jobs:
           project_files="$(echo "${all_files}" | grep "${regex}" || [[ $? == 1 ]])";
           fi
         - for f in ${project_files}; do echo $f; done  # for debugging
-        # Check diff code coverage for the maven projects being tested (retry install in case of network error)
+        # Check diff code coverage for the maven projects being tested (retry install in case of network error).
+        # Currently, the function coverage check is not reliable, so it is disabled.
         - >
           if [ -n "${project_files}" ]; then
           travis_retry npm install @connectis/diff-test-coverage@1.5.3
@@ -176,7 +177,7 @@ jobs:
           --type jacoco
           --line-coverage 65
           --branch-coverage 65
-          --function-coverage 80
+          --function-coverage 0
           --
           || { printf "\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\n" && false; }
           fi

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -71,7 +71,7 @@ There are four JVM parameters that we set on all of our processes:
 
 1.  `-Duser.timezone=UTC` This sets the default timezone of the JVM to UTC. We always set this and do not test with other default timezones, so local timezones might work, but they also might uncover weird and interesting bugs. To issue queries in a non-UTC timezone, see [query granularities](../querying/granularities.html#period-granularities)
 2.  `-Dfile.encoding=UTF-8` This is similar to timezone, we test assuming UTF-8. Local encodings might work, but they also might result in weird and interesting bugs.
-3.  `-Djava.io.tmpdir=<a path>` Various parts of the system that interact with the file system do it via temporary files, and these files can get somewhat large. Many production systems are set up to have small (but fast) `/tmp` directories, which can be problematic with Druid so we recommend pointing the JVM’s tmp directory to something with a little more meat.
+3.  `-Djava.io.tmpdir=<a path>` Various parts of the system that interact with the file system do it via temporary files, and these files can get somewhat large. Many production systems are set up to have small (but fast) `/tmp` directories, which can be problematic with Druid so we recommend pointing the JVM’s tmp directory to something with a little more meat. This directory should not be volatile tmpfs. This directory should also have good read and write speed and hence NFS mount should strongly be avoided.
 4.  `-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager` This allows log4j2 to handle logs for non-log4j2 components (like jetty) which use standard java logging.
 
 ### Extensions

--- a/docs/operations/basic-cluster-tuning.md
+++ b/docs/operations/basic-cluster-tuning.md
@@ -389,7 +389,7 @@ Enabling process termination on out-of-memory errors is useful as well, since th
 ```
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
--Djava.io.tmpdir=<something other than /tmp which might be mounted to volatile tmpfs file system>
+-Djava.io.tmpdir=<should not be volatile tmpfs and also has good read and write speed. Strongly recommended to avoid using NFS mount>
 -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 -Dorg.jboss.logging.provider=slf4j
 -Dnet.spy.log.LoggerImpl=net.spy.memcached.compat.log.SLF4JLogger

--- a/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChest.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.materializedview;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -94,6 +95,13 @@ public class MaterializedViewQueryQueryToolChest extends QueryToolChest
   {
     Query realQuery = getRealQuery(query);
     return warehouse.getToolChest(realQuery).makePostComputeManipulatorFn(realQuery, fn);
+  }
+
+  @Override
+  public ObjectMapper decorateObjectMapper(final ObjectMapper objectMapper, final Query query)
+  {
+    Query realQuery = getRealQuery(query);
+    return warehouse.getToolChest(realQuery).decorateObjectMapper(objectMapper, realQuery);
   }
 
   @Override

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
@@ -219,4 +219,30 @@ public class MaterializedViewQueryQueryToolChestTest
         objectMapper.writeValueAsString(results)
     );
   }
+
+  @Test
+  public void testGetRealQuery()
+  {
+    GroupByQuery realQuery = GroupByQuery.builder()
+        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setDimensions(new DefaultDimensionSpec("quality", "alias"))
+        .setAggregatorSpecs(
+            QueryRunnerTestHelper.ROWS_COUNT,
+            new LongSumAggregatorFactory("idx", "index")
+        )
+        .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
+        .setContext(ImmutableMap.of(GroupByQueryConfig.CTX_KEY_ARRAY_RESULT_ROWS, false))
+        .build();
+    MaterializedViewQuery materializedViewQuery = new MaterializedViewQuery(realQuery, null);
+
+    MaterializedViewQueryQueryToolChest materializedViewQueryQueryToolChest =
+        new MaterializedViewQueryQueryToolChest(new MapQueryToolChestWarehouse(
+            ImmutableMap.<Class<? extends Query>, QueryToolChest>builder()
+                .put(GroupByQuery.class, new GroupByQueryQueryToolChest(null))
+                .build()
+        ));
+
+    Assert.assertEquals(realQuery, materializedViewQueryQueryToolChest.getRealQuery(materializedViewQuery));
+  }
 }

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
@@ -245,4 +245,5 @@ public class MaterializedViewQueryQueryToolChestTest
 
     Assert.assertEquals(realQuery, materializedViewQueryQueryToolChest.getRealQuery(materializedViewQuery));
   }
+  
 }

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
@@ -19,8 +19,12 @@
 
 package org.apache.druid.query.materializedview;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.MapBasedRow;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.MapQueryToolChestWarehouse;
@@ -29,17 +33,30 @@ import org.apache.druid.query.QueryRunnerTestHelper;
 import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.MetricManipulationFn;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.groupby.GroupByQuery;
+import org.apache.druid.query.groupby.GroupByQueryConfig;
+import org.apache.druid.query.groupby.GroupByQueryQueryToolChest;
+import org.apache.druid.query.groupby.GroupByQueryRunnerTestHelper;
+import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class MaterializedViewQueryQueryToolChestTest
 {
+  private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
+
   @Test
   public void testMakePostComputeManipulatorFn()
   {
@@ -84,5 +101,64 @@ public class MaterializedViewQueryQueryToolChestTest
     Assert.assertEquals(postResultMap.size(), 2);
     Assert.assertEquals(postResultMap.get(QueryRunnerTestHelper.ROWS_COUNT.getName()), "metricvalue1");
     Assert.assertEquals(postResultMap.get("dim1"), "dimvalue1");
+  }
+
+  @Test
+  public void testDecorateObjectMapper() throws IOException
+  {
+    GroupByQuery realQuery = GroupByQuery.builder()
+        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setDimensions(new DefaultDimensionSpec("quality", "alias"))
+        .setAggregatorSpecs(
+            QueryRunnerTestHelper.ROWS_COUNT,
+            new LongSumAggregatorFactory("idx", "index")
+        )
+        .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
+        .setContext(ImmutableMap.of(GroupByQueryConfig.CTX_KEY_ARRAY_RESULT_ROWS, false))
+        .build();
+    MaterializedViewQuery materializedViewQuery = new MaterializedViewQuery(realQuery, null);
+
+    QueryToolChest materializedViewQueryQueryToolChest =
+        new MaterializedViewQueryQueryToolChest(new MapQueryToolChestWarehouse(
+            ImmutableMap.<Class<? extends Query>, QueryToolChest>builder()
+                .put(GroupByQuery.class, new GroupByQueryQueryToolChest(null))
+                .build()
+        ));
+
+    ObjectMapper objectMapper = materializedViewQueryQueryToolChest.decorateObjectMapper(JSON_MAPPER, materializedViewQuery);
+
+    List<ResultRow> results = Arrays.asList(
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            realQuery,
+            "2011-04-01",
+            "alias",
+            "automotive",
+            "rows",
+            1L,
+            "idx",
+            135L
+
+        ),
+        GroupByQueryRunnerTestHelper.createExpectedRow(
+            realQuery,
+            "2011-04-01",
+            "alias",
+            "business",
+            "rows",
+            1L,
+            "idx",
+            118L
+        )
+    );
+    List<MapBasedRow> expectedResults = results.stream()
+        .map(resultRow -> resultRow.toMapBasedRow(realQuery))
+        .collect(Collectors.toList());
+
+    Assert.assertEquals(
+        "decorate-object-mapper",
+        JSON_MAPPER.writerFor(new TypeReference<List<MapBasedRow>>(){}).writeValueAsString(expectedResults),
+        objectMapper.writeValueAsString(results)
+    );
   }
 }

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -53,6 +53,9 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.jclouds\.api/openstack\-keystone@.*$</packageUrl>
     <cve>CVE-2015-7546</cve>
+    <cve>CVE-2020-12689</cve>
+    <cve>CVE-2020-12690</cve>
+    <cve>CVE-2020-12691</cve>
   </suppress>
 
   <!-- FIXME: These are suppressed so that CI can enforce that no new vulnerable dependencies are added. -->


### PR DESCRIPTION
This PR fixes an issure introduced by #8196.
The MaterializedView gropuby query is now return array by default,and can not control by context key "resultAsArray".