### PR TITLE
Refactor JoinFilterAnalyzer

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -49,6 +49,7 @@ import org.apache.druid.segment.filter.cnf.HiveCnfHelper;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -520,5 +521,26 @@ public class Filters
     }
 
     return new OrFilter(filterSet);
+  }
+
+  /**
+   * @param filter the filter.
+   * @return The normalized or clauses for the provided filter.
+   */
+  public static Set<Filter> toNormalizedOrClauses(Filter filter)
+  {
+    Filter normalizedFilter = Filters.toCnf(filter);
+
+    // List of candidates for pushdown
+    // CNF normalization will generate either
+    // - an AND filter with multiple subfilters
+    // - or a single non-AND subfilter which cannot be split further
+    Set<Filter> normalizedOrClauses;
+    if (normalizedFilter instanceof AndFilter) {
+      normalizedOrClauses = ((AndFilter) normalizedFilter).getFilters();
+    } else {
+      normalizedOrClauses = Collections.singleton(normalizedFilter);
+    }
+    return normalizedOrClauses;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
@@ -19,11 +19,18 @@
 
 package org.apache.druid.segment.join.filter;
 
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.join.Equality;
 import org.apache.druid.segment.join.JoinableClause;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +60,7 @@ public class JoinFilterPreAnalysis
   private final List<VirtualColumn> postJoinVirtualColumns;
   private final Map<String, Set<Expr>> equiconditions;
 
-  public JoinFilterPreAnalysis(
+  private JoinFilterPreAnalysis(
       final List<JoinableClause> joinableClauses,
       final Filter originalFilter,
       final List<VirtualColumn> postJoinVirtualColumns,
@@ -126,6 +133,109 @@ public class JoinFilterPreAnalysis
   public Map<String, Set<Expr>> getEquiconditions()
   {
     return equiconditions;
+  }
+
+  /**
+   * A Builder class to build {@link JoinFilterPreAnalysis}
+   */
+  public static class Builder
+  {
+    @Nonnull private final List<JoinableClause> joinableClauses;
+    @Nullable private final Filter originalFilter;
+    @Nullable private List<Filter> normalizedBaseTableClauses;
+    @Nullable private List<Filter> normalizedJoinTableClauses;
+    @Nullable private Map<String, List<JoinFilterColumnCorrelationAnalysis>> correlationsByFilteringColumn;
+    @Nullable private Map<String, List<JoinFilterColumnCorrelationAnalysis>> correlationsByDirectFilteringColumn;
+    private boolean enableFilterPushDown = false;
+    private boolean enableFilterRewrite = false;
+    @Nonnull private final List<VirtualColumn> postJoinVirtualColumns;
+    @Nonnull private Map<String, Set<Expr>> equiconditions = Collections.emptyMap();
+
+    public Builder(
+        @Nonnull List<JoinableClause> joinableClauses,
+        @Nullable Filter originalFilter,
+        @Nonnull List<VirtualColumn> postJoinVirtualColumns
+    )
+    {
+      this.joinableClauses = joinableClauses;
+      this.originalFilter = originalFilter;
+      this.postJoinVirtualColumns = postJoinVirtualColumns;
+    }
+
+    public Builder withNormalizedBaseTableClauses(List<Filter> normalizedBaseTableClauses)
+    {
+      this.normalizedBaseTableClauses = normalizedBaseTableClauses;
+      return this;
+    }
+
+    public Builder withNormalizedJoinTableClauses(List<Filter> normalizedJoinTableClauses)
+    {
+      this.normalizedJoinTableClauses = normalizedJoinTableClauses;
+      return this;
+    }
+
+    public Builder withCorrelationsByFilteringColumn(
+        Map<String, List<JoinFilterColumnCorrelationAnalysis>> correlationsByFilteringColumn
+    )
+    {
+      this.correlationsByFilteringColumn = correlationsByFilteringColumn;
+      return this;
+    }
+
+    public Builder withCorrelationsByDirectFilteringColumn(
+        Map<String, List<JoinFilterColumnCorrelationAnalysis>> correlationsByDirectFilteringColumn
+    )
+    {
+      this.correlationsByDirectFilteringColumn = correlationsByDirectFilteringColumn;
+      return this;
+    }
+
+    public Builder withEnableFilterPushDown(boolean enableFilterPushDown)
+    {
+      this.enableFilterPushDown = enableFilterPushDown;
+      return this;
+    }
+
+    public Builder withEnableFilterRewrite(boolean enableFilterRewrite)
+    {
+      this.enableFilterRewrite = enableFilterRewrite;
+      return this;
+    }
+
+    public Map<String, Set<Expr>> computeEquiconditionsFromJoinableClauses()
+    {
+      if (equiconditions != null) {
+        throw new RE("Equiconditions already set! Incorrect call to compute equiconditions");
+      }
+      this.equiconditions = new HashMap<>();
+      for (JoinableClause clause : joinableClauses) {
+        for (Equality equality : clause.getCondition().getEquiConditions()) {
+          Set<Expr> exprsForRhs = equiconditions.computeIfAbsent(
+              clause.getPrefix() + equality.getRightColumn(),
+              (rhs) -> new HashSet<>()
+          );
+          exprsForRhs.add(equality.getLeftExpr());
+        }
+      }
+      return equiconditions;
+    }
+
+    public JoinFilterPreAnalysis build()
+    {
+      return new JoinFilterPreAnalysis(
+          joinableClauses,
+          originalFilter,
+          postJoinVirtualColumns,
+          normalizedBaseTableClauses,
+          normalizedJoinTableClauses,
+          correlationsByFilteringColumn,
+          correlationsByDirectFilteringColumn,
+          enableFilterPushDown,
+          enableFilterRewrite,
+          equiconditions
+      );
+    }
+
   }
 }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.segment.join.filter;
 
-import org.apache.druid.java.util.common.RE;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.VirtualColumn;
@@ -204,9 +203,6 @@ public class JoinFilterPreAnalysis
 
     public Map<String, Set<Expr>> computeEquiconditionsFromJoinableClauses()
     {
-      if (equiconditions != null) {
-        throw new RE("Equiconditions already set! Incorrect call to compute equiconditions");
-      }
       this.equiconditions = new HashMap<>();
       for (JoinableClause clause : joinableClauses) {
         for (Equality equality : clause.getCondition().getEquiConditions()) {

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterCnfConversionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterCnfConversionTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.filter;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.dimension.DimensionSpec;
@@ -35,6 +36,7 @@ import org.junit.Test;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -156,6 +158,51 @@ public class FilterCnfConversionTest
   }
 
   @Test
+  public void testToNormalizedOrClausesWithMuchReducibleFilter()
+  {
+    final Filter muchReducible = FilterTestUtils.and(
+        // should be flattened
+        FilterTestUtils.and(
+            FilterTestUtils.and(
+                FilterTestUtils.and(FilterTestUtils.selector("col1", "val1"))
+            )
+        ),
+        // should be flattened
+        FilterTestUtils.and(
+            FilterTestUtils.or(
+                FilterTestUtils.and(FilterTestUtils.selector("col1", "val1"))
+            )
+        ),
+        // should be flattened
+        FilterTestUtils.or(
+            FilterTestUtils.and(
+                FilterTestUtils.or(FilterTestUtils.selector("col1", "val1"))
+            )
+        ),
+        // should eliminate duplicate filters
+        FilterTestUtils.selector("col1", "val1"),
+        FilterTestUtils.selector("col2", "val2"),
+        FilterTestUtils.and(
+            FilterTestUtils.selector("col1", "val1"),
+            FilterTestUtils.selector("col2", "val2")
+        ),
+        FilterTestUtils.and(
+            FilterTestUtils.selector("col1", "val1"),
+            FilterTestUtils.and(
+                FilterTestUtils.selector("col2", "val2"),
+                FilterTestUtils.selector("col1", "val1")
+            )
+        )
+    );
+    final Set<Filter> expected = ImmutableSet.of(
+        FilterTestUtils.selector("col1", "val1"),
+        FilterTestUtils.selector("col2", "val2")
+    );
+    final Set<Filter> normalizedOrClauses = Filters.toNormalizedOrClauses(muchReducible);
+    Assert.assertEquals(expected, normalizedOrClauses);
+  }
+
+  @Test
   public void testToCnfWithComplexFilterIncludingNotAndOr()
   {
     final Filter filter = FilterTestUtils.and(
@@ -260,6 +307,110 @@ public class FilterCnfConversionTest
   }
 
   @Test
+  public void testToNormalizedOrClausesWithComplexFilterIncludingNotAndOr()
+  {
+    final Filter filter = FilterTestUtils.and(
+        FilterTestUtils.or(
+            FilterTestUtils.and(
+                FilterTestUtils.selector("col1", "val1"),
+                FilterTestUtils.selector("col2", "val2")
+            ),
+            FilterTestUtils.not(
+                FilterTestUtils.and(
+                    FilterTestUtils.selector("col4", "val4"),
+                    FilterTestUtils.selector("col5", "val5")
+                )
+            )
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.not(
+                FilterTestUtils.or(
+                    FilterTestUtils.selector("col2", "val2"),
+                    FilterTestUtils.selector("col4", "val4"),
+                    FilterTestUtils.selector("col5", "val5")
+                )
+            ),
+            FilterTestUtils.and(
+                FilterTestUtils.selector("col1", "val1"),
+                FilterTestUtils.selector("col3", "val3")
+            )
+        ),
+        FilterTestUtils.and(
+            FilterTestUtils.or(
+                FilterTestUtils.selector("col1", "val1"),
+                FilterTestUtils.selector("col2", "val22"), // selecting different value
+                FilterTestUtils.selector("col3", "val3")
+            ),
+            FilterTestUtils.not(
+                FilterTestUtils.selector("col1", "val11")
+            )
+        ),
+        FilterTestUtils.and(
+            FilterTestUtils.or(
+                FilterTestUtils.selector("col1", "val1"),
+                FilterTestUtils.selector("col2", "val22"),
+                FilterTestUtils.selector("col3", "val3")
+            ),
+            FilterTestUtils.not(
+                FilterTestUtils.selector("col1", "val11") // selecting different value
+            )
+        )
+    );
+    final Set<Filter> expected = ImmutableSet.of(
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col1", "val1"),
+            FilterTestUtils.selector("col2", "val22"),
+            FilterTestUtils.selector("col3", "val3")
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col1", "val1"),
+            FilterTestUtils.not(FilterTestUtils.selector("col2", "val2"))
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.not(FilterTestUtils.selector("col2", "val2")),
+            FilterTestUtils.selector("col3", "val3")
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col1", "val1"),
+            FilterTestUtils.not(FilterTestUtils.selector("col4", "val4"))
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col3", "val3"),
+            FilterTestUtils.not(FilterTestUtils.selector("col4", "val4"))
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col1", "val1"),
+            FilterTestUtils.not(FilterTestUtils.selector("col5", "val5"))
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col3", "val3"),
+            FilterTestUtils.not(FilterTestUtils.selector("col5", "val5"))
+        ),
+        FilterTestUtils.not(FilterTestUtils.selector("col1", "val11")),
+        // The below OR filter could be eliminated because this filter also has
+        // (col1 = val1 || ~(col4 = val4)) && (col1 = val1 || ~(col5 = val5)).
+        // The reduction process would be
+        // (col1 = val1 || ~(col4 = val4)) && (col1 = val1 || ~(col5 = val5)) && (col1 = val1 || ~(col4 = val4) || ~(col5 = val5))
+        // => (col1 = val1 && ~(col4 = val4) || ~(col5 = val5)) && (col1 = val1 || ~(col4 = val4) || ~(col5 = val5))
+        // => (col1 = val1 && ~(col4 = val4) || ~(col5 = val5))
+        // => (col1 = val1 || ~(col4 = val4)) && (col1 = val1 || ~(col5 = val5)).
+        // However, we don't have this reduction now, so we have a filter in a suboptimized CNF.
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col1", "val1"),
+            FilterTestUtils.not(FilterTestUtils.selector("col4", "val4")),
+            FilterTestUtils.not(FilterTestUtils.selector("col5", "val5"))
+        ),
+        FilterTestUtils.or(
+            FilterTestUtils.selector("col2", "val2"),
+            FilterTestUtils.not(FilterTestUtils.selector("col4", "val4")),
+            FilterTestUtils.not(FilterTestUtils.selector("col5", "val5"))
+        )
+    );
+    final Set<Filter> normalizedOrClauses = Filters.toNormalizedOrClauses(filter);
+    Assert.assertEquals(expected, normalizedOrClauses);
+  }
+
+  @Test
   public void testToCnfCollapsibleBigFilter()
   {
     Set<Filter> ands = new HashSet<>();
@@ -353,6 +504,18 @@ public class FilterCnfConversionTest
     );
 
     assertFilter(filter, expectedCnf, Filters.toCnf(filter));
+  }
+
+  @Test
+  public void testToNormalizedOrClausesNonAndFilterShouldReturnSingleton()
+  {
+    Filter filter = FilterTestUtils.or(
+        FilterTestUtils.selector("col1", "val1"),
+        FilterTestUtils.selector("col2", "val2")
+    );
+    Set<Filter> expected = Collections.singleton(filter);
+    Set<Filter> normalizedOrClauses = Filters.toNormalizedOrClauses(filter);
+    Assert.assertEquals(expected, normalizedOrClauses);
   }
 
   @Test


### PR DESCRIPTION
This patch attempts to make it easier to follow the join filter analysis code
with the hope of making it easier to add rewrite optimizations in the future.

To keep the patch small and easy to review, this is the first of at least 2
patches that are planned.

This patch adds a builder to the Pre-Analysis, so that it is easier to
instantiate the preAnalysis. It also moves some of the filter normalization
code out to Fitlers with associated tests.