### PR TITLE
Disable function code coverage check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,8 @@ jobs:
           project_files="$(echo "${all_files}" | grep "${regex}" || [[ $? == 1 ]])";
           fi
         - for f in ${project_files}; do echo $f; done  # for debugging
-        # Check diff code coverage for the maven projects being tested (retry install in case of network error)
+        # Check diff code coverage for the maven projects being tested (retry install in case of network error).
+        # Currently, the function coverage check is not reliable, so it is disabled.
         - >
           if [ -n "${project_files}" ]; then
           travis_retry npm install @connectis/diff-test-coverage@1.5.3
@@ -176,7 +177,7 @@ jobs:
           --type jacoco
           --line-coverage 65
           --branch-coverage 65
-          --function-coverage 80
+          --function-coverage 0
           --
           || { printf "\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\n" && false; }
           fi


### PR DESCRIPTION
### Description

As observed in https://github.com/apache/druid/pull/9905 and https://github.com/apache/druid/pull/9915, the function code coverage check flags false positive issues, so it should be disabled for now.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been manually tested: https://github.com/ccaominh/druid/pull/2 and https://github.com/ccaominh/druid/pull/3