### PR TITLE
Prevent JOIN reducing to a JOIN with constant in the ON condition

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
@@ -123,7 +123,11 @@ public class Rules
           ProjectTableScanRule.INTERPRETER
       );
 
-  // Rules from RelOptUtil's registerReductionRules.
+  // Rules from RelOptUtil's registerReductionRules, minus:
+  //
+  // 1) ReduceExpressionsRule.JOIN_INSTANCE
+  //    Removed by https://github.com/apache/druid/pull/9941 due to issue in https://github.com/apache/druid/issues/9942
+  //    TODO: Re-enable when https://github.com/apache/druid/issues/9942 is fixed
   private static final List<RelOptRule> REDUCTION_RULES =
       ImmutableList.of(
           ReduceExpressionsRule.PROJECT_INSTANCE,
@@ -165,6 +169,9 @@ public class Rules
   // 2) SemiJoinRule.PROJECT and SemiJoinRule.JOIN (we don't need to detect semi-joins, because they are handled
   //    fine as-is by DruidJoinRule).
   // 3) JoinCommuteRule (we don't support reordering joins yet).
+  // 4) FilterJoinRule.FILTER_ON_JOIN and FilterJoinRule.JOIN
+  //    Removed by https://github.com/apache/druid/pull/9773 due to issue in https://github.com/apache/druid/issues/9843
+  //    TODO: Re-enable when https://github.com/apache/druid/issues/9843 is fixed
   private static final List<RelOptRule> ABSTRACT_RELATIONAL_RULES =
       ImmutableList.of(
           AbstractConverter.ExpandConversionRule.INSTANCE,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
@@ -130,7 +130,6 @@ public class Rules
           ReduceExpressionsRule.FILTER_INSTANCE,
           ReduceExpressionsRule.CALC_INSTANCE,
           ReduceExpressionsRule.WINDOW_INSTANCE,
-          ReduceExpressionsRule.JOIN_INSTANCE,
           ValuesReduceRule.FILTER_INSTANCE,
           ValuesReduceRule.PROJECT_FILTER_INSTANCE,
           ValuesReduceRule.PROJECT_INSTANCE,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -14048,6 +14048,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   {
     testQuery(
         "SELECT dim1 FROM foo WHERE dim1 IN (SELECT dim1 FROM foo WHERE dim1 = '10.1')\n",
+        queryContext,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(
@@ -14062,7 +14063,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                         )
                                         .setGranularity(Granularities.ALL)
                                         .setDimensions(dimensions(new DefaultDimensionSpec("dim1", "d0")))
-                                        .setContext(QUERY_CONTEXT_DEFAULT)
+                                        .setContext(queryContext)
                                         .build()
                         ),
                         "j0.",
@@ -14073,7 +14074,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .intervals(querySegmentSpec(Filtration.eternity()))
                 .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
                 .columns("v0")
-                .context(QUERY_CONTEXT_DEFAULT)
+                .context(queryContext)
                 .build()
         ),
         ImmutableList.of(
@@ -14092,6 +14093,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         + "  SELECT dim1, \"__time\", m1 from foo WHERE \"dim1\" = '10.1' AND \"__time\" >= '1999'\n"
         + ")\n"
         + "SELECT t1.dim1, t1.\"__time\" from abc as t1 LEFT JOIN abc as t2 on t1.dim1 = t2.dim1 WHERE t1.dim1 = '10.1'\n",
+        queryContext,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(
@@ -14111,7 +14113,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
                                 .columns(ImmutableList.of("__time", "v0"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         new QueryDataSource(
@@ -14129,7 +14131,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
                                 .columns(ImmutableList.of("v0"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         "j0.",
@@ -14141,7 +14143,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
                 .columns("__time", "_v0")
                 .filters(new SelectorDimFilter("v0", "10.1", null))
-                .context(QUERY_CONTEXT_DEFAULT)
+                .context(queryContext)
                 .build()
         ),
         ImmutableList.of(
@@ -14160,6 +14162,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         + "  SELECT dim1, \"__time\", m1 from foo WHERE \"dim1\" = '10.1'\n"
         + ")\n"
         + "SELECT t1.dim1, t1.\"__time\" from abc as t1 LEFT JOIN abc as t2 on t1.dim1 = t2.dim1 WHERE t1.dim1 = '10.1'\n",
+        queryContext,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(
@@ -14172,7 +14175,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
                                 .columns(ImmutableList.of("__time", "v0"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         new QueryDataSource(
@@ -14182,7 +14185,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .filters(new SelectorDimFilter("dim1", "10.1", null))
                                 .columns(ImmutableList.of("dim1"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         "j0.",
@@ -14194,7 +14197,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
                 .columns("__time", "_v0")
                 .filters(new SelectorDimFilter("v0", "10.1", null))
-                .context(QUERY_CONTEXT_DEFAULT)
+                .context(queryContext)
                 .build()
         ),
         ImmutableList.of(
@@ -14213,6 +14216,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         + "  SELECT dim1, \"__time\", m1 from foo WHERE \"dim1\" = '10.1'\n"
         + ")\n"
         + "SELECT t1.dim1, t1.\"__time\" from abc as t1 LEFT JOIN abc as t2 on t1.dim1 = t2.dim1\n",
+        queryContext,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(
@@ -14225,7 +14229,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
                                 .columns(ImmutableList.of("__time", "v0"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         new QueryDataSource(
@@ -14235,7 +14239,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .filters(new SelectorDimFilter("dim1", "10.1", null))
                                 .columns(ImmutableList.of("dim1"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         "j0.",
@@ -14246,7 +14250,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .intervals(querySegmentSpec(Filtration.eternity()))
                 .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
                 .columns("__time", "_v0")
-                .context(QUERY_CONTEXT_DEFAULT)
+                .context(queryContext)
                 .build()
         ),
         ImmutableList.of(
@@ -14265,6 +14269,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         + "  SELECT dim1, \"__time\", m1 from foo WHERE \"dim1\" = '10.1'\n"
         + ")\n"
         + "SELECT t1.dim1, t1.\"__time\" from abc as t1 INNER JOIN abc as t2 on t1.dim1 = t2.dim1 WHERE t1.dim1 = '10.1'\n",
+        queryContext,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(
@@ -14277,7 +14282,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
                                 .columns(ImmutableList.of("__time", "v0"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         new QueryDataSource(
@@ -14287,7 +14292,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .filters(new SelectorDimFilter("dim1", "10.1", null))
                                 .columns(ImmutableList.of("dim1"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         "j0.",
@@ -14299,7 +14304,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
                 .columns("__time", "_v0")
                 .filters(new NotDimFilter(new SelectorDimFilter("v0", null, null)))
-                .context(QUERY_CONTEXT_DEFAULT)
+                .context(queryContext)
                 .build()
         ),
         ImmutableList.of(
@@ -14318,6 +14323,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         + "  SELECT dim1, \"__time\", m1 from foo WHERE \"dim1\" = '10.1'\n"
         + ")\n"
         + "SELECT t1.dim1, t1.\"__time\" from abc as t1 INNER JOIN abc as t2 on t1.dim1 = t2.dim1\n",
+        queryContext,
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(
@@ -14330,7 +14336,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
                                 .columns(ImmutableList.of("__time", "v0"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         new QueryDataSource(
@@ -14340,7 +14346,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .filters(new SelectorDimFilter("dim1", "10.1", null))
                                 .columns(ImmutableList.of("dim1"))
                                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(QUERY_CONTEXT_DEFAULT)
+                                .context(queryContext)
                                 .build()
                         ),
                         "j0.",
@@ -14351,7 +14357,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .intervals(querySegmentSpec(Filtration.eternity()))
                 .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
                 .columns("__time", "_v0")
-                .context(QUERY_CONTEXT_DEFAULT)
+                .context(queryContext)
                 .build()
         ),
         ImmutableList.of(
@@ -14373,6 +14379,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
 
     testQuery(
         query,
+        queryContext,
         ImmutableList.of(),
         ImmutableList.of()
     );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -9088,7 +9088,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                         .build()
                         ),
                         "j0.",
-                        "0",
+                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
                         JoinType.INNER
                     )
                 )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql.calcite;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.druid.common.config.NullHandling;
@@ -14194,6 +14195,22 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"10.1", 946771200000L}
         )
+    );
+  }
+
+  // This query is expected to fail as we do not support join with constant in the on condition
+  // (see issue https://github.com/apache/druid/issues/9942 for more information)
+  @Test(expected = RelOptPlanner.CannotPlanException.class)
+  public void testJoinOnConstantShouldFail() throws Exception
+  {
+    cannotVectorize();
+
+    final String query = "SELECT t1.dim1 from foo as t1 LEFT JOIN foo as t2 on t1.dim1 = '10.1'";
+
+    testQuery(
+        query,
+        ImmutableList.of(),
+        ImmutableList.of()
     );
   }
 


### PR DESCRIPTION
Prevent Join reducing to a Join with constant in the condition

### Description

We have already documented that JOIN do not support joining on constant (for example `SELECT t1.cityName from wikipedia as t1 LEFT join wikipedia as t2 on t1.cityName = 'Buenos Aires'`). However, some valid JOIN SQL gets optimize by Calcite into a JOIN with constant in the ON condition. For example, `with abc as ( SELECT cityName, "__time", sum_added from wikipedia WHERE "cityName" = 'Buenos Aires' ) SELECT t1.cityName, t1."__time" from abc as t1 LEFT join abc as t2 on t1.cityName = t2.cityName WHERE t1.cityName = 'Buenos Aires'` gets reduce to a JOIN with the condition `=($0, 'Buenos Aires')`. This then fails to plan as we do not support JOIN with constant in the ON condition. The above SQL was optimized into JOIN with constant in the ON condition due to the `ReduceExpressionsRule.JOIN_INSTANCE`. This PR disable the `ReduceExpressionsRule.JOIN_INSTANCE` rule. This will prevent valid join query that we supports (such as `with abc as ( SELECT cityName, "__time", sum_added from wikipedia WHERE "cityName" = 'Buenos Aires' ) SELECT t1.cityName, t1."__time" from abc as t1 LEFT join abc as t2 on t1.cityName = t2.cityName WHERE t1.cityName = 'Buenos Aires'`) from transforming into a dead end that we cannot plan (join on constant). We are taking this approach as we do not see a strong demand for join on constant and we have already mention that we do not support join on constant. 

Please see issue https://github.com/apache/druid/issues/9942 for follow up work on supporting JOIN with constant in the ON condition. Once the follow up work is done, the `ReduceExpressionsRule.JOIN_INSTANCE` can be added back. The tests added in CalciteQueryTest here will also make sure there is no regression introduce by the follow up work.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

