### PR TITLE
fix unsafe concurrent access in StreamAppenderatorDriver

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorDriver.java
@@ -136,13 +136,7 @@ public class BatchAppenderatorDriver extends BaseAppenderatorDriver
       long pushAndClearTimeoutMs
   ) throws InterruptedException, ExecutionException, TimeoutException
   {
-    final Set<SegmentIdWithShardSpec> requestedSegmentIdsForSequences;
-    synchronized (segments) {
-      requestedSegmentIdsForSequences = getAppendingSegments(sequenceNames)
-          .map(SegmentWithState::getSegmentIdentifier)
-          .collect(Collectors.toSet());
-    }
-
+    final Set<SegmentIdWithShardSpec> requestedSegmentIdsForSequences = getAppendingSegments(sequenceNames);
 
     final ListenableFuture<SegmentsAndCommitMetadata> future = ListenableFutures.transformAsync(
         pushInBackground(null, requestedSegmentIdsForSequences, false),

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorDriver.java
@@ -136,9 +136,12 @@ public class BatchAppenderatorDriver extends BaseAppenderatorDriver
       long pushAndClearTimeoutMs
   ) throws InterruptedException, ExecutionException, TimeoutException
   {
-    final Set<SegmentIdWithShardSpec> requestedSegmentIdsForSequences = getAppendingSegments(sequenceNames)
-        .map(SegmentWithState::getSegmentIdentifier)
-        .collect(Collectors.toSet());
+    final Set<SegmentIdWithShardSpec> requestedSegmentIdsForSequences;
+    synchronized (segments) {
+      requestedSegmentIdsForSequences = getAppendingSegments(sequenceNames)
+          .map(SegmentWithState::getSegmentIdentifier)
+          .collect(Collectors.toSet());
+    }
 
 
     final ListenableFuture<SegmentsAndCommitMetadata> future = ListenableFutures.transformAsync(

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
@@ -271,12 +271,7 @@ public class StreamAppenderatorDriver extends BaseAppenderatorDriver
       final Collection<String> sequenceNames
   )
   {
-    final List<SegmentIdWithShardSpec> theSegments;
-    synchronized (segments) {
-      theSegments = getSegmentWithStates(sequenceNames)
-          .map(SegmentWithState::getSegmentIdentifier)
-          .collect(Collectors.toList());
-    }
+    final List<SegmentIdWithShardSpec> theSegments = getSegmentIdsWithShardSpecs(sequenceNames);
 
     final ListenableFuture<SegmentsAndCommitMetadata> publishFuture = ListenableFutures.transformAsync(
         // useUniquePath=true prevents inconsistencies in segment data when task failures or replicas leads to a second

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
@@ -271,9 +271,12 @@ public class StreamAppenderatorDriver extends BaseAppenderatorDriver
       final Collection<String> sequenceNames
   )
   {
-    final List<SegmentIdWithShardSpec> theSegments = getSegmentWithStates(sequenceNames)
-        .map(SegmentWithState::getSegmentIdentifier)
-        .collect(Collectors.toList());
+    final List<SegmentIdWithShardSpec> theSegments;
+    synchronized (segments) {
+      theSegments = getSegmentWithStates(sequenceNames)
+          .map(SegmentWithState::getSegmentIdentifier)
+          .collect(Collectors.toList());
+    }
 
     final ListenableFuture<SegmentsAndCommitMetadata> publishFuture = ListenableFutures.transformAsync(
         // useUniquePath=true prevents inconsistencies in segment data when task failures or replicas leads to a second


### PR DESCRIPTION
during segment publishing we do streaming operations on a collection not
safe for concurrent modification. To guarantee correct results we must
also guard any operations on the stream itself.

This may explain the issue seen in https://github.com/apache/druid/issues/9845