### PR TITLE
add SegmentizerFactory unfactorize method with default do nothing implementation

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/loading/SegmentizerFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/SegmentizerFactory.java
@@ -32,4 +32,9 @@ import java.io.File;
 public interface SegmentizerFactory
 {
   Segment factorize(DataSegment segment, File parentDir, boolean lazy) throws SegmentLoadingException;
+
+  default void unfactorize(DataSegment segment, File parentDir)
+  {
+    // do nothing by default
+  }
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -158,6 +158,7 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
     }
   }
 
+  @VisibleForTesting
   protected SegmentizerFactory loadSegmentizerFactory(File segmentFiles) throws SegmentLoadingException
   {
     File factoryJson = new File(segmentFiles, "factory.json");


### PR DESCRIPTION
### Description
This PR adds an optional method to the `SegmentizerFactory` interface that allows a custom segment unloading logic to occur when a segment is dropped from `SegmentLoaderLocalCacheManager`. There is a default do nothing implementation so this change shouldn't be very disruptive, but we do need to consider that cleanup will now try to read the `factory.json` file again to call this method before the files are deleted, so there is some small cost to this change.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `SegmentizerFactory`
 * `SegmentLoaderLocalCacheManager`
