### PR TITLE
Fix NPE in KinesisRecordSupplier when closing on supervisor

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -560,16 +560,18 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
 
     assign(ImmutableSet.of());
 
-    scheduledExec.shutdown();
+    if (scheduledExec != null) {
+      scheduledExec.shutdown();
 
-    try {
-      if (!scheduledExec.awaitTermination(EXCEPTION_RETRY_DELAY_MS, TimeUnit.MILLISECONDS)) {
-        scheduledExec.shutdownNow();
+      try {
+        if (!scheduledExec.awaitTermination(EXCEPTION_RETRY_DELAY_MS, TimeUnit.MILLISECONDS)) {
+          scheduledExec.shutdownNow();
+        }
       }
-    }
-    catch (InterruptedException e) {
-      log.warn(e, "InterruptedException while shutting down");
-      throw new RuntimeException(e);
+      catch (InterruptedException e) {
+        log.warn(e, "InterruptedException while shutting down");
+        throw new RuntimeException(e);
+      }
     }
 
     this.closed = true;


### PR DESCRIPTION
Fix NPE of the form 

```
java.lang.NullPointerException: null
	at org.apache.druid.indexing.kinesis.KinesisRecordSupplier.close(KinesisRecordSupplier.java:563) ~[?:?]
...```
