### PR TITLE
API to verify a datasource has the latest ingested data

### DIFF
--- a/docs/ingestion/faq.md
+++ b/docs/ingestion/faq.md
@@ -66,13 +66,14 @@ Other common reasons that hand-off fails are as follows:
 
 Make sure to include the `druid-hdfs-storage` and all the hadoop configuration, dependencies (that can be obtained by running command `hadoop classpath` on a machine where hadoop has been setup) in the classpath. And, provide necessary HDFS settings as described in [deep storage](../dependencies/deep-storage.md) .
 
-## How do I know when I can make query to Druid after submitting ingestion task?
+## How do I know when I can make query to Druid after submitting batch ingestion task?
 
 You can verify if segments created by a recent ingestion task are loaded onto historicals and available for querying using the following workflow.
 1. Submit your ingestion task.
 2. Repeatedly poll the [Overlord's tasks API](../operations/api-reference.md#tasks) ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
 3. Poll the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
-`forceMetadataRefresh=true` and `interval=<INTERVAL_OF_INGESTED_DATA>` once.
+`forceMetadataRefresh=true` and `interval=<INTERVAL_OF_INGESTED_DATA>` once. 
+(Note: `forceMetadataRefresh=true` refreshes Coordinator's metadata cache of all datasources. This can be a heavy operation in terms of the load on the metadata store but is necessary to make sure that we verify all the latest segments' load status)
 If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
 4. Repeatedly poll the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
 `forceMetadataRefresh=false` and `interval=<INTERVAL_OF_INGESTED_DATA>`. 

--- a/docs/ingestion/faq.md
+++ b/docs/ingestion/faq.md
@@ -78,7 +78,7 @@ If there are segments not yet loaded, continue to step 4, otherwise you can now 
 4. Repeatedly poll the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
 `forceMetadataRefresh=false` and `interval=<INTERVAL_OF_INGESTED_DATA>`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data. 
-Note that this workflow only guarantees that the segments are avaiable at the time of the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) call. Segments can still become missing because of historical process failures or any other reasons afterward.
+Note that this workflow only guarantees that the segments are available at the time of the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) call. Segments can still become missing because of historical process failures or any other reasons afterward.
 
 ## I don't see my Druid segments on my Historical processes
 

--- a/docs/ingestion/faq.md
+++ b/docs/ingestion/faq.md
@@ -70,11 +70,11 @@ Make sure to include the `druid-hdfs-storage` and all the hadoop configuration, 
 
 You can verify if segments created by a recent ingestion task are loaded onto historicals and available for querying using the following workflow.
 1. Submit your ingestion task.
-2. Repeatedly poll the [Overlord's task API](../operations/api-reference.html#tasks) ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
-3. Poll the [datasource loadstatus API](../operations/api-reference.html#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
+2. Repeatedly poll the [Overlord's task API](../operations/api-reference.md#tasks) ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
+3. Poll the [datasource loadstatus API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
 `forceMetadataRefresh=true` and `interval=<INTERVAL_OF_INGESTED_DATA>` once.
 If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
-4. Repeatedly poll the [datasource loadstatus API](../operations/api-reference.html#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
+4. Repeatedly poll the [datasource loadstatus API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
 `forceMetadataRefresh=false` and `interval=<INTERVAL_OF_INGESTED_DATA>`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data. 
 

--- a/docs/ingestion/faq.md
+++ b/docs/ingestion/faq.md
@@ -78,6 +78,7 @@ If there are segments not yet loaded, continue to step 4, otherwise you can now 
 4. Repeatedly poll the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
 `forceMetadataRefresh=false` and `interval=<INTERVAL_OF_INGESTED_DATA>`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data. 
+Note that this workflow only guarantees that the segments are avaiable at the time of the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) call. Segments can still become missing because of historical process failures or any other reasons afterward.
 
 ## I don't see my Druid segments on my Historical processes
 

--- a/docs/ingestion/faq.md
+++ b/docs/ingestion/faq.md
@@ -70,11 +70,11 @@ Make sure to include the `druid-hdfs-storage` and all the hadoop configuration, 
 
 You can verify if segments created by a recent ingestion task are loaded onto historicals and available for querying using the following workflow.
 1. Submit your ingestion task.
-2. Repeatedly poll the [Overlord's task API](../operations/api-reference.md#tasks) ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
-3. Poll the [datasource loadstatus API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
+2. Repeatedly poll the [Overlord's tasks API](../operations/api-reference.md#tasks) ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
+3. Poll the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
 `forceMetadataRefresh=true` and `interval=<INTERVAL_OF_INGESTED_DATA>` once.
 If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
-4. Repeatedly poll the [datasource loadstatus API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
+4. Repeatedly poll the [Segment Loading by Datasource API](../operations/api-reference.md#segment-loading-by-datasource) (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with 
 `forceMetadataRefresh=false` and `interval=<INTERVAL_OF_INGESTED_DATA>`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data. 
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -118,7 +118,7 @@ Returns the serialized JSON of segments to load and drop for each Historical pro
 #### Segment Loading by Datasource
 
 Note that all _interval_ query parameters are ISO 8601 strings (e.g., 2016-06-27/2016-06-28).
-Also note that these APIs only guarantees that the segments are avaiable at the time of the call. 
+Also note that these APIs only guarantees that the segments are available at the time of the call. 
 Segments can still become missing because of historical process failures or any other reasons afterward.
 
 ##### GET

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -96,11 +96,11 @@ Returns the percentage of segments actually loaded in the cluster versus segment
 
  * `/druid/coordinator/v1/loadstatus?simple`
 
-Returns the number of segments left to load until segments that should be loaded in the cluster are available for queries. This does not include replication.
+Returns the number of segments left to load until segments that should be loaded in the cluster are available for queries. This does not include replica of segments.
 
 * `/druid/coordinator/v1/loadstatus?full`
 
-Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available. This includes replication.
+Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available. This include replica of segments.
 
 * `/druid/coordinator/v1/loadqueue`
 
@@ -115,15 +115,15 @@ Returns the number of segments to load and drop, as well as the total segment lo
 Returns the serialized JSON of segments to load and drop for each Historical process.
 
 
-#### Segment Loading for Datasource
+#### Segment Loading by Datasource
 
-These APIs can be used to verify if segments created by recent ingestion task are loaded onto historicals and available for query.
+You can verify if segments created by a recent ingestion task are loaded onto historicals and available for querying using the following APIs.
 An example workflow for this is:
-1. Submit your ingestion task
-2. Repeatedly poll Overlord's task API ( `/druid/indexer/v1/task/{taskId}/status`) until task is completed and succeeded.
-3. Poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once. 
+1. Submit your ingestion task.
+2. Repeatedly poll the Overlord's task API ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
+3. Poll the datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once.
 If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
-4. Repeatedly poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
+4. Repeatedly poll the datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data.
 
 ##### GET
@@ -131,23 +131,21 @@ Continue polling until all segments are loaded. Once all segments are loaded you
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the percentage of segments actually loaded in the cluster versus segments that should be loaded in the cluster for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). Setting `forceMetadataRefresh=true`
-will force the coordinator to poll latest segment metadata from the metadata store. `forceMetadataRefresh` will be set to true if not given.
-If no used segments found for the given inputs, this API returns 100% as the value.
+over the given interval (or last 2 weeks if interval is not given). Setting `forceMetadataRefresh` to true (the default)
+will force the coordinator to poll latest segment metadata from the metadata store. If all segments have been loaded or 
+no used segments are found for the given inputs, this API returns 100% as the value.
 
  * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?simple&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load until segments that should be loaded in the cluster are available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This does not include replication. Setting `forceMetadataRefresh=true` 
-will force the coordinator to poll latest segment metadata from the metadata store. `forceMetadataRefresh` will be set to true if not given.
-If no used segments found for the given inputs, this API returns 0 as the value.
+over the given interval (or last 2 weeks if interval is not given). This does not include replica of segments. Setting `forceMetadataRefresh` to true (the default)
+will force the coordinator to poll latest segment metadata from the metadata store. If no used segments found for the given inputs, this API returns 0 as the value.
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?full&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This includes replication. Setting `forceMetadataRefresh=true`
-will force the coordinator to poll latest segment metadata from the metadata store. `forceMetadataRefresh` will be set to true if not given.
-If no used segments found for the given inputs, this API returns empty map.
+over the given interval (or last 2 weeks if interval is not given). This include replica of segments. Setting `forceMetadataRefresh` to true (the default)
+will force the coordinator to poll latest segment metadata from the metadata store. If no used segments found for the given inputs, this API returns empty map.
 
 #### Metadata store information
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -96,11 +96,11 @@ Returns the percentage of segments actually loaded in the cluster versus segment
 
  * `/druid/coordinator/v1/loadstatus?simple`
 
-Returns the number of segments left to load until segments that should be loaded in the cluster are available for queries. This does not include replica of segments.
+Returns the number of segments left to load until segments that should be loaded in the cluster are available for queries. This does not include segment replication counts.
 
 * `/druid/coordinator/v1/loadstatus?full`
 
-Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available. This include replica of segments.
+Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available. This includes segment replication counts.
 
 * `/druid/coordinator/v1/loadqueue`
 
@@ -117,15 +117,6 @@ Returns the serialized JSON of segments to load and drop for each Historical pro
 
 #### Segment Loading by Datasource
 
-You can verify if segments created by a recent ingestion task are loaded onto historicals and available for querying using the following APIs.
-An example workflow for this is:
-1. Submit your ingestion task.
-2. Repeatedly poll the Overlord's task API ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
-3. Poll the below `datasource loadstatus` API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once.
-If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
-4. Repeatedly poll the below `datasource loadstatus` API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
-Continue polling until all segments are loaded. Once all segments are loaded you can now query the data.
-
 ##### GET
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?forceMetadataRefresh={boolean}&interval={myInterval}`
@@ -139,7 +130,7 @@ If no used segments are found for the given inputs, this API returns `204 No Con
  * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?simple&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load until segments that should be loaded in the cluster are available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This does not include replica of segments. `forceMetadataRefresh` is required to be set. 
+over the given interval (or last 2 weeks if interval is not given). This does not include segment replication counts. `forceMetadataRefresh` is required to be set. 
 Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
 Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
 If no used segments are found for the given inputs, this API returns `204 No Content` 
@@ -147,7 +138,7 @@ If no used segments are found for the given inputs, this API returns `204 No Con
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?full&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This include replica of segments. `forceMetadataRefresh` is required to be set. 
+over the given interval (or last 2 weeks if interval is not given). This includes segment replication counts. `forceMetadataRefresh` is required to be set. 
 Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
 Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
 If no used segments are found for the given inputs, this API returns `204 No Content`

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -120,10 +120,10 @@ Returns the serialized JSON of segments to load and drop for each Historical pro
 These APIs can be used to verify if segments created by recent ingestion task are loaded onto historicals and available for query.
 An example workflow for this is:
 1. Submit your ingestion task
-2. Repeatedly poll Overlod's task API ( `/druid/indexer/v1/task/{taskId}/status`) until task is completed and succeeded.
-3. Poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with forceMetadataRefresh=true once. 
+2. Repeatedly poll Overlord's task API ( `/druid/indexer/v1/task/{taskId}/status`) until task is completed and succeeded.
+3. Poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once. 
 If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
-4. Repeatedly poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with forceMetadataRefresh=false. 
+4. Repeatedly poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data.
 
 ##### GET
@@ -131,22 +131,22 @@ Continue polling until all segments are loaded. Once all segments are loaded you
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the percentage of segments actually loaded in the cluster versus segments that should be loaded in the cluster for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). Setting forceMetadataRefresh to true
-will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+over the given interval (or last 2 weeks if interval is not given). Setting `forceMetadataRefresh=true`
+will force the coordinator to poll latest segment metadata from the metadata store. `forceMetadataRefresh` will be set to true if not given.
 If no used segments found for the given inputs, this API returns 100% as the value.
 
  * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?simple&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load until segments that should be loaded in the cluster are available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This does not include replication. Setting forceMetadataRefresh to true 
-will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+over the given interval (or last 2 weeks if interval is not given). This does not include replication. Setting `forceMetadataRefresh=true` 
+will force the coordinator to poll latest segment metadata from the metadata store. `forceMetadataRefresh` will be set to true if not given.
 If no used segments found for the given inputs, this API returns 0 as the value.
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?full&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This includes replication. Setting forceMetadataRefresh to true
-will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+over the given interval (or last 2 weeks if interval is not given). This includes replication. Setting `forceMetadataRefresh=true`
+will force the coordinator to poll latest segment metadata from the metadata store. `forceMetadataRefresh` will be set to true if not given.
 If no used segments found for the given inputs, this API returns empty map.
 
 #### Metadata store information

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -121,31 +121,36 @@ You can verify if segments created by a recent ingestion task are loaded onto hi
 An example workflow for this is:
 1. Submit your ingestion task.
 2. Repeatedly poll the Overlord's task API ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
-3. Poll the datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once.
+3. Poll the below datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once.
 If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
-4. Repeatedly poll the datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
+4. Repeatedly poll the below datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data.
 
 ##### GET
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?forceMetadataRefresh={boolean}&interval={myInterval}`
 
-Returns the percentage of segments actually loaded in the cluster versus segments that should be loaded in the cluster for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). Setting `forceMetadataRefresh` to true (the default)
-will force the coordinator to poll latest segment metadata from the metadata store. If all segments have been loaded or 
-no used segments are found for the given inputs, this API returns 100% as the value.
+Returns the percentage of segments actually loaded in the cluster versus segments that should be loaded in the cluster for the given 
+datasource over the given interval (or last 2 weeks if interval is not given). `forceMetadataRefresh` is required to be set. 
+Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
+Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
+If no used segments are found for the given inputs, this API returns `204 No Content`
 
  * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?simple&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load until segments that should be loaded in the cluster are available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This does not include replica of segments. Setting `forceMetadataRefresh` to true (the default)
-will force the coordinator to poll latest segment metadata from the metadata store. If no used segments found for the given inputs, this API returns 0 as the value.
+over the given interval (or last 2 weeks if interval is not given). This does not include replica of segments. `forceMetadataRefresh` is required to be set. 
+Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
+Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
+If no used segments are found for the given inputs, this API returns `204 No Content` 
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?full&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available for the given datasource 
-over the given interval (or last 2 weeks if interval is not given). This include replica of segments. Setting `forceMetadataRefresh` to true (the default)
-will force the coordinator to poll latest segment metadata from the metadata store. If no used segments found for the given inputs, this API returns empty map.
+over the given interval (or last 2 weeks if interval is not given). This include replica of segments. `forceMetadataRefresh` is required to be set. 
+Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
+Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
+If no used segments are found for the given inputs, this API returns `204 No Content`
 
 #### Metadata store information
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -121,9 +121,9 @@ You can verify if segments created by a recent ingestion task are loaded onto hi
 An example workflow for this is:
 1. Submit your ingestion task.
 2. Repeatedly poll the Overlord's task API ( `/druid/indexer/v1/task/{taskId}/status`) until your task is shown to be successfully completed.
-3. Poll the below datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once.
+3. Poll the below `datasource loadstatus` API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=true` once.
 If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
-4. Repeatedly poll the below datasource loadstatus API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
+4. Repeatedly poll the below `datasource loadstatus` API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with `forceMetadataRefresh=false`. 
 Continue polling until all segments are loaded. Once all segments are loaded you can now query the data.
 
 ##### GET

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -117,13 +117,17 @@ Returns the serialized JSON of segments to load and drop for each Historical pro
 
 #### Segment Loading by Datasource
 
+Note that all _interval_ query parameters are ISO 8601 strings (e.g., 2016-06-27/2016-06-28).
+
 ##### GET
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the percentage of segments actually loaded in the cluster versus segments that should be loaded in the cluster for the given 
 datasource over the given interval (or last 2 weeks if interval is not given). `forceMetadataRefresh` is required to be set. 
-Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
+Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store 
+(Note: `forceMetadataRefresh=true` refreshes Coordinator's metadata cache of all datasources. This can be a heavy operation in terms 
+of the load on the metadata store but can be necessary to make sure that we verify all the latest segments' load status)
 Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
 If no used segments are found for the given inputs, this API returns `204 No Content`
 
@@ -131,7 +135,9 @@ If no used segments are found for the given inputs, this API returns `204 No Con
 
 Returns the number of segments left to load until segments that should be loaded in the cluster are available for the given datasource 
 over the given interval (or last 2 weeks if interval is not given). This does not include segment replication counts. `forceMetadataRefresh` is required to be set. 
-Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
+Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store 
+(Note: `forceMetadataRefresh=true` refreshes Coordinator's metadata cache of all datasources. This can be a heavy operation in terms 
+of the load on the metadata store but can be necessary to make sure that we verify all the latest segments' load status)
 Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
 If no used segments are found for the given inputs, this API returns `204 No Content` 
 
@@ -139,7 +145,9 @@ If no used segments are found for the given inputs, this API returns `204 No Con
 
 Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available for the given datasource 
 over the given interval (or last 2 weeks if interval is not given). This includes segment replication counts. `forceMetadataRefresh` is required to be set. 
-Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store. 
+Setting `forceMetadataRefresh` to true will force the coordinator to poll latest segment metadata from the metadata store 
+(Note: `forceMetadataRefresh=true` refreshes Coordinator's metadata cache of all datasources. This can be a heavy operation in terms 
+of the load on the metadata store but can be necessary to make sure that we verify all the latest segments' load status)
 Setting `forceMetadataRefresh` to false will use the metadata cached on the coordinator from the last force/periodic refresh. 
 If no used segments are found for the given inputs, this API returns `204 No Content`
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -118,6 +118,8 @@ Returns the serialized JSON of segments to load and drop for each Historical pro
 #### Segment Loading by Datasource
 
 Note that all _interval_ query parameters are ISO 8601 strings (e.g., 2016-06-27/2016-06-28).
+Also note that these APIs only guarantees that the segments are avaiable at the time of the call. 
+Segments can still become missing because of historical process failures or any other reasons afterward.
 
 ##### GET
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -114,6 +114,41 @@ Returns the number of segments to load and drop, as well as the total segment lo
 
 Returns the serialized JSON of segments to load and drop for each Historical process.
 
+
+#### Segment Loading for Datasource
+
+Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` instead of a `/`
+(e.g., 2016-06-27_2016-06-28).
+
+These APIs can be used to verify if segments created by recent ingestion task are loaded onto historicals and available for query.
+An example workflow for this is:
+1. Submit your ingestion task
+2. Repeatedly poll Overlod's task API ( `/druid/indexer/v1/task/{taskId}/status`) until task is completed and succeeded.
+3. Poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with forceMetadataRefresh=true once. 
+If there are segments not yet loaded, continue to step 4, otherwise you can now query the data.
+4. Repeatedly poll Segment Loading for Datasource API (`/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus`) with forceMetadataRefresh=false. 
+Continue polling until all segments are loaded. Once all segments are loaded you can now query the data.
+
+##### GET
+
+* `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?forceMetadataRefresh={boolean}&interval={myInterval}`
+
+Returns the percentage of segments actually loaded in the cluster versus segments that should be loaded in the cluster for the given datasource 
+over the given interval (or last 2 weeks if interval is not given). Setting forceMetadataRefresh to true
+will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+
+ * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?simple&forceMetadataRefresh={boolean}&interval={myInterval}`
+
+Returns the number of segments left to load until segments that should be loaded in the cluster are available for the given datasource 
+over the given interval (or last 2 weeks if interval is not given). This does not include replication. Setting forceMetadataRefresh to true 
+will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+
+* `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?full&forceMetadataRefresh={boolean}&interval={myInterval}`
+
+Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available for the given datasource 
+over the given interval (or last 2 weeks if interval is not given). This includes replication. Setting forceMetadataRefresh to true
+will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+
 #### Metadata store information
 
 ##### GET

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -117,9 +117,6 @@ Returns the serialized JSON of segments to load and drop for each Historical pro
 
 #### Segment Loading for Datasource
 
-Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` instead of a `/`
-(e.g., 2016-06-27_2016-06-28).
-
 These APIs can be used to verify if segments created by recent ingestion task are loaded onto historicals and available for query.
 An example workflow for this is:
 1. Submit your ingestion task
@@ -136,18 +133,21 @@ Continue polling until all segments are loaded. Once all segments are loaded you
 Returns the percentage of segments actually loaded in the cluster versus segments that should be loaded in the cluster for the given datasource 
 over the given interval (or last 2 weeks if interval is not given). Setting forceMetadataRefresh to true
 will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+If no used segments found for the given inputs, this API returns 100% as the value.
 
  * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?simple&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load until segments that should be loaded in the cluster are available for the given datasource 
 over the given interval (or last 2 weeks if interval is not given). This does not include replication. Setting forceMetadataRefresh to true 
 will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+If no used segments found for the given inputs, this API returns 0 as the value.
 
 * `/druid/coordinator/v1/datasources/{dataSourceName}/loadstatus?full&forceMetadataRefresh={boolean}&interval={myInterval}`
 
 Returns the number of segments left to load in each tier until segments that should be loaded in the cluster are all available for the given datasource 
 over the given interval (or last 2 weeks if interval is not given). This includes replication. Setting forceMetadataRefresh to true
 will force the coordinator to poll latest segment metadata from the metadatastore. forceMetadataRefresh will be set to true if not given.
+If no used segments found for the given inputs, this API returns empty map.
 
 #### Metadata store information
 

--- a/server/src/main/java/org/apache/druid/client/CoordinatorServerView.java
+++ b/server/src/main/java/org/apache/druid/client/CoordinatorServerView.java
@@ -200,6 +200,10 @@ public class CoordinatorServerView implements InventoryView
     }
   }
 
+  public Map<SegmentId, SegmentLoadInfo> getSegmentLoadInfos()
+  {
+    return segmentLoadInfos;
+  }
 
   @Override
   public DruidServer getInventoryValue(String serverKey)

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -122,9 +122,11 @@ public interface SegmentsMetadataManager
    * If {@param requiresLatest} is false then segment information from stale snapshot of up to the last periodic poll
    * period {@link SqlSegmentsMetadataManager#periodicPollDelay} will be used.
    */
-  Optional<Iterable<DataSegment>> iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(String datasource,
-                                                                                             Interval interval,
-                                                                                             boolean requiresLatest);
+  Optional<Iterable<DataSegment>> iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(
+      String datasource,
+      Interval interval,
+      boolean requiresLatest
+  );
 
   /**
    * Retrieves all data source names for which there are segment in the database, regardless of whether those segments

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -114,6 +114,18 @@ public interface SegmentsMetadataManager
   Iterable<DataSegment> iterateAllUsedSegments();
 
   /**
+   * Returns an iterable to go over all used and non-overshadowed segments of given data sources over given interval.
+   * The order in which segments are iterated is unspecified.
+   * If {@param requiresLatest} is true then a force metadatastore poll will be triggered. This can cause a longer
+   * response time but will ensure that the latest segment information (at the time this method is called) is returned.
+   * If {@param requiresLatest} is false then segment information from stale snapshot of up to the last periodic poll
+   * period {@link SqlSegmentsMetadataManager#periodicPollDelay} will be used.
+   */
+  Iterable<DataSegment> iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(String datasource,
+                                                                                   Interval interval,
+                                                                                   boolean requiresLatest);
+
+  /**
    * Retrieves all data source names for which there are segment in the database, regardless of whether those segments
    * are used or not. If there are no segments in the database, returns an empty set.
    *

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -116,7 +116,9 @@ public interface SegmentsMetadataManager
 
   /**
    * Returns an iterable to go over all used and non-overshadowed segments of given data sources over given interval.
-   * The order in which segments are iterated is unspecified.
+   * The order in which segments are iterated is unspecified. Note: the iteration may not be as trivially cheap as,
+   * for example, iteration over an ArrayList. Try (to some reasonable extent) to organize the code so that it
+   * iterates the returned iterable only once rather than several times.
    * If {@param requiresLatest} is true then a force metadatastore poll will be triggered. This can cause a longer
    * response time but will ensure that the latest segment information (at the time this method is called) is returned.
    * If {@param requiresLatest} is false then segment information from stale snapshot of up to the last periodic poll

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -20,6 +20,7 @@
 package org.apache.druid.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.timeline.DataSegment;
@@ -121,9 +122,9 @@ public interface SegmentsMetadataManager
    * If {@param requiresLatest} is false then segment information from stale snapshot of up to the last periodic poll
    * period {@link SqlSegmentsMetadataManager#periodicPollDelay} will be used.
    */
-  Iterable<DataSegment> iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(String datasource,
-                                                                                   Interval interval,
-                                                                                   boolean requiresLatest);
+  Optional<Iterable<DataSegment>> iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(String datasource,
+                                                                                             Interval interval,
+                                                                                             boolean requiresLatest);
 
   /**
    * Retrieves all data source names for which there are segment in the database, regardless of whether those segments

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -20,6 +20,7 @@
 package org.apache.druid.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
@@ -936,9 +937,9 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public Iterable<DataSegment> iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(String datasource,
-                                                                                          Interval interval,
-                                                                                          boolean requiresLatest)
+  public Optional<Iterable<DataSegment>> iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(String datasource,
+                                                                                                    Interval interval,
+                                                                                                    boolean requiresLatest)
   {
     if (requiresLatest) {
       forceOrWaitOngoingDatabasePoll();
@@ -947,7 +948,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     }
     VersionedIntervalTimeline<String, DataSegment> usedSegmentsTimeline
         = dataSourcesSnapshot.getUsedSegmentsTimelinesPerDataSource().get(datasource);
-    return usedSegmentsTimeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE);
+    return Optional.of(usedSegmentsTimeline)
+                   .transform(timeline -> timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE));
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -82,8 +82,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static java.lang.Thread.sleep;
-
 /**
  *
  */
@@ -327,7 +325,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
                            - ((OnDemandDatabasePoll) latestDatabasePoll).nanosElapsedFromInitiation();
           TimeUnit.NANOSECONDS.sleep(sleepNano);
         }
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         log.debug(e, "Exception found while waiting for next periodic poll");
       }
 
@@ -484,9 +483,10 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
             return;
           }
         }
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         // Latest poll was unsuccessful, try to do a new poll
-        log.debug(e,"Latest poll was unsuccessful. Starting a new poll...");
+        log.debug(e, "Latest poll was unsuccessful. Starting a new poll...");
       }
       // Force a database poll
       OnDemandDatabasePoll onDemandDatabasePoll = new OnDemandDatabasePoll();

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -948,7 +948,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     }
     VersionedIntervalTimeline<String, DataSegment> usedSegmentsTimeline
         = dataSourcesSnapshot.getUsedSegmentsTimelinesPerDataSource().get(datasource);
-    return Optional.of(usedSegmentsTimeline)
+    return Optional.fromNullable(usedSegmentsTimeline)
                    .transform(timeline -> timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE));
   }
 

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -432,7 +432,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
    * made not longer than {@link #periodicPollDelay} from current time.
    * This method does wait untill completion for if the latest {@link DatabasePoll} is a
    * {@link PeriodicDatabasePoll} that has not completed it's first poll, or an {@link OnDemandDatabasePoll} that is
-   * alrady in the process of polling the database.
+   * already in the process of polling the database.
    * This means that any method using this check can read from snapshot that is
    * up to {@link SqlSegmentsMetadataManager#periodicPollDelay} old.
    */

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -20,6 +20,7 @@
 package org.apache.druid.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
@@ -97,7 +98,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
   {}
 
   /** Represents periodic {@link #poll}s happening from {@link #exec}. */
-  private static class PeriodicDatabasePoll implements DatabasePoll
+  @VisibleForTesting
+  static class PeriodicDatabasePoll implements DatabasePoll
   {
     /**
      * This future allows to wait until {@link #dataSourcesSnapshot} is initialized in the first {@link #poll()}
@@ -113,7 +115,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
    * Represents on-demand {@link #poll} initiated at periods of time when SqlSegmentsMetadataManager doesn't poll the database
    * periodically.
    */
-  private static class OnDemandDatabasePoll implements DatabasePoll
+  @VisibleForTesting
+  static class OnDemandDatabasePoll implements DatabasePoll
   {
     final long initiationTimeNanos = System.nanoTime();
     final CompletableFuture<Void> pollCompletionFuture = new CompletableFuture<>();
@@ -433,7 +436,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
    * This means that any method using this check can read from snapshot that is
    * up to {@link SqlSegmentsMetadataManager#periodicPollDelay} old.
    */
-  private boolean useLatestSnapshotIfWithinDelay()
+  @VisibleForTesting
+  boolean useLatestSnapshotIfWithinDelay()
   {
     DatabasePoll latestDatabasePoll = this.latestDatabasePoll;
     if (latestDatabasePoll instanceof PeriodicDatabasePoll) {
@@ -462,7 +466,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
    * This means that any method using this check can be sure that the latest poll for the snapshot was completed after
    * this method was called.
    */
-  public void forceOrWaitOngoingDatabasePoll()
+  @VisibleForTesting
+  void forceOrWaitOngoingDatabasePoll()
   {
     long checkStartTime = System.currentTimeMillis();
     ReentrantReadWriteLock.WriteLock lock = startStopPollLock.writeLock();
@@ -928,6 +933,19 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     useLatestIfWithinDelayOrPerformNewDatabasePoll();
     return dataSourcesSnapshot;
   }
+
+  @VisibleForTesting
+  DataSourcesSnapshot getDataSourcesSnapshot()
+  {
+    return dataSourcesSnapshot;
+  }
+
+  @VisibleForTesting
+  DatabasePoll getLatestDatabasePoll()
+  {
+    return latestDatabasePoll;
+  }
+
 
   @Override
   public Iterable<DataSegment> iterateAllUsedSegments()

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -257,13 +257,19 @@ public class DruidCoordinator
    */
   public Map<String, Object2LongMap<String>> computeUnderReplicationCountsPerDataSourcePerTier()
   {
+    final Iterable<DataSegment> dataSegments = segmentsMetadataManager.iterateAllUsedSegments();
+    return computeUnderReplicationCountsPerDataSourcePerTierForSegments(dataSegments);
+  }
+
+  public Map<String, Object2LongMap<String>> computeUnderReplicationCountsPerDataSourcePerTierForSegments(
+      Iterable<DataSegment> dataSegments
+  )
+  {
     final Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTier = new HashMap<>();
 
     if (segmentReplicantLookup == null) {
       return underReplicationCountsPerDataSourcePerTier;
     }
-
-    final Iterable<DataSegment> dataSegments = segmentsMetadataManager.iterateAllUsedSegments();
 
     final DateTime now = DateTimes.nowUtc();
 
@@ -320,7 +326,7 @@ public class DruidCoordinator
 
     for (ImmutableDruidDataSource dataSource : dataSources) {
       final Set<DataSegment> segments = Sets.newHashSet(dataSource.getSegments());
-      final int numUsedSegments = segments.size();
+      final int numPublishedSegments = segments.size();
 
       // remove loaded segments
       for (DruidServer druidServer : serverInventoryView.getInventory()) {
@@ -333,10 +339,10 @@ public class DruidCoordinator
           }
         }
       }
-      final int numUnloadedSegments = segments.size();
+      final int numUnavailableSegments = segments.size();
       loadStatus.put(
           dataSource.getName(),
-          100 * ((double) (numUsedSegments - numUnloadedSegments) / (double) numUsedSegments)
+          100 * ((double) (numPublishedSegments - numUnavailableSegments) / (double) numPublishedSegments)
       );
     }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -261,6 +261,9 @@ public class DruidCoordinator
     return computeUnderReplicationCountsPerDataSourcePerTierForSegments(dataSegments);
   }
 
+  /**
+   * @return tier -> { dataSource -> underReplicationCount } map
+   */
   public Map<String, Object2LongMap<String>> computeUnderReplicationCountsPerDataSourcePerTierForSegments(
       Iterable<DataSegment> dataSegments
   )

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -414,7 +414,7 @@ public class DataSourcesResource
       long currentTimeInMs = System.currentTimeMillis();
       theInterval = Intervals.utc(currentTimeInMs - defaultIntervalOffset, currentTimeInMs);
     } else {
-      theInterval = Intervals.of(interval);
+      theInterval = Intervals.of(interval.replace('_', '/'));
     }
 
     boolean requiresMetadataStorePoll = forceMetadataRefresh == null ? true : forceMetadataRefresh;
@@ -494,6 +494,14 @@ public class DataSourcesResource
         if (!segmentLoadInfos.containsKey(segment.getId())) {
           numUnloadedSegments++;
         }
+      }
+      if (numUsedSegments == 0) {
+        return Response.ok(
+            ImmutableMap.of(
+                dataSourceName,
+                100
+            )
+        ).build();
       }
       return Response.ok(
           ImmutableMap.of(

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -24,14 +24,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
-import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Table;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
-import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.druid.client.CoordinatorServerView;
@@ -56,7 +53,6 @@ import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordinator.DruidCoordinator;
-import org.apache.druid.server.coordinator.SegmentReplicantLookup;
 import org.apache.druid.server.coordinator.rules.LoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.http.security.DatasourceResourceFilter;
@@ -477,7 +473,8 @@ public class DataSourcesResource
     }
   }
 
-  private SegmentsLoadStatistics computeSegmentLoadStatistics(Iterable<DataSegment> segments) {
+  private SegmentsLoadStatistics computeSegmentLoadStatistics(Iterable<DataSegment> segments)
+  {
     Map<SegmentId, SegmentLoadInfo> segmentLoadInfos = serverInventoryView.getSegmentLoadInfos();
     int numPublishedSegments = 0;
     int numUnavailableSegments = 0;

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
-import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.druid.client.CoordinatorServerView;
 import org.apache.druid.client.DruidDataSource;
@@ -435,7 +434,7 @@ public class DataSourcesResource
       return logAndCreateDataSourceNotFoundResponse(dataSourceName);
     }
 
-    if (IterableUtils.size(segments.get()) == 0) {
+    if (Iterables.size(segments.get()) == 0) {
       return Response
           .status(Response.Status.NO_CONTENT)
           .entity("No used segment found for the given datasource and interval")

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
-import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import org.apache.commons.lang.StringUtils;
 import org.apache.druid.client.CoordinatorServerView;
 import org.apache.druid.client.DruidDataSource;
@@ -408,7 +407,7 @@ public class DataSourcesResource
     }
     // Force poll
     Interval theInterval = interval == null ? Intervals.ETERNITY : Intervals.of(interval);
-    boolean requiresMetadataStorePoll = firstCheck == null ? true :firstCheck;
+    boolean requiresMetadataStorePoll = firstCheck == null ? true : firstCheck;
 
     Optional<Iterable<DataSegment>> segments = segmentsMetadataManager.iterateAllUsedNonOvershadowedSegmentsForDatasourceInterval(
         dataSourceName,

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -402,7 +402,7 @@ public class DataSourcesResource
       @QueryParam("firstCheck") @Nullable final Boolean firstCheck
   )
   {
-    if (serverInventoryView == null || serverInventoryView.getSegmentLoadInfos() != null) {
+    if (serverInventoryView == null || serverInventoryView.getSegmentLoadInfos() == null) {
       return Response.ok(ImmutableMap.of("loaded", false)).build();
     }
     // Force poll

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -99,6 +99,7 @@ import java.util.stream.Collectors;
 public class DataSourcesResource
 {
   private static final Logger log = new Logger(DataSourcesResource.class);
+  private static final long DEFAULT_LOADSTATUS_INTERVAL_OFFSET = 14 * 24 * 60 * 60 * 1000;
 
   private final CoordinatorServerView serverInventoryView;
   private final SegmentsMetadataManager segmentsMetadataManager;
@@ -417,9 +418,8 @@ public class DataSourcesResource
     }
     final Interval theInterval;
     if (interval == null) {
-      long defaultIntervalOffset = 14 * 24 * 60 * 60 * 1000;
       long currentTimeInMs = System.currentTimeMillis();
-      theInterval = Intervals.utc(currentTimeInMs - defaultIntervalOffset, currentTimeInMs);
+      theInterval = Intervals.utc(currentTimeInMs - DEFAULT_LOADSTATUS_INTERVAL_OFFSET, currentTimeInMs);
     } else {
       theInterval = Intervals.of(interval.replace('_', '/'));
     }

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -177,7 +177,7 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server, request);
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, null, AuthTestUtils.TEST_AUTHORIZER_MAPPER);
+        new DataSourcesResource(inventoryView, null, null, null, AuthTestUtils.TEST_AUTHORIZER_MAPPER, null);
     Response response = dataSourcesResource.getQueryableDataSources("full", null, request);
     Set<ImmutableDruidDataSource> result = (Set<ImmutableDruidDataSource>) response.getEntity();
     Assert.assertEquals(200, response.getStatus());
@@ -251,7 +251,7 @@ public class DataSourcesResourceTest
       }
     };
 
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, null, null, null, authMapper);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, null, null, null, authMapper, null);
     Response response = dataSourcesResource.getQueryableDataSources("full", null, request);
     Set<ImmutableDruidDataSource> result = (Set<ImmutableDruidDataSource>) response.getEntity();
 
@@ -290,7 +290,7 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server, request);
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, null, AuthTestUtils.TEST_AUTHORIZER_MAPPER);
+        new DataSourcesResource(inventoryView, null, null, null, AuthTestUtils.TEST_AUTHORIZER_MAPPER, null);
     Response response = dataSourcesResource.getQueryableDataSources(null, "simple", request);
     Assert.assertEquals(200, response.getStatus());
     List<Map<String, Object>> results = (List<Map<String, Object>>) response.getEntity();
@@ -314,7 +314,7 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server);
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, null, null);
+        new DataSourcesResource(inventoryView, null, null, null, null, null);
     Response response = dataSourcesResource.getDataSource("datasource1", "full");
     ImmutableDruidDataSource result = (ImmutableDruidDataSource) response.getEntity();
     Assert.assertEquals(200, response.getStatus());
@@ -330,7 +330,7 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server);
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, null, null);
+        new DataSourcesResource(inventoryView, null, null, null, null, null);
     Assert.assertEquals(204, dataSourcesResource.getDataSource("none", null).getStatus());
     EasyMock.verify(inventoryView, server);
   }
@@ -348,7 +348,7 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server);
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, null, null);
+        new DataSourcesResource(inventoryView, null, null, null, null, null);
     Response response = dataSourcesResource.getDataSource("datasource1", null);
     Assert.assertEquals(200, response.getStatus());
     Map<String, Map<String, Object>> result = (Map<String, Map<String, Object>>) response.getEntity();
@@ -381,7 +381,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(inventoryView.getInventory()).andReturn(ImmutableList.of(server, server2, server3)).atLeastOnce();
 
     EasyMock.replay(inventoryView, server, server2, server3);
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, null, null, null, null);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, null, null, null, null, null);
     Response response = dataSourcesResource.getDataSource("datasource1", null);
     Assert.assertEquals(200, response.getStatus());
     Map<String, Map<String, Object>> result = (Map<String, Map<String, Object>>) response.getEntity();
@@ -419,7 +419,7 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView);
 
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, null, null, null, null);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, null, null, null, null, null);
     Response response = dataSourcesResource.getDataSource("datasource1", null);
     Assert.assertEquals(200, response.getStatus());
     Map<String, Map<String, Object>> result1 = (Map<String, Map<String, Object>>) response.getEntity();
@@ -464,7 +464,7 @@ public class DataSourcesResourceTest
     expectedIntervals.add(Intervals.of("2010-01-22T00:00:00.000Z/2010-01-23T00:00:00.000Z"));
     expectedIntervals.add(Intervals.of("2010-01-01T00:00:00.000Z/2010-01-02T00:00:00.000Z"));
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, null, null);
+        new DataSourcesResource(inventoryView, null, null, null, null, null);
 
     Response response = dataSourcesResource.getIntervalsWithServedSegmentsOrAllServedSegmentsPerIntervals(
         "invalidDataSource",
@@ -524,7 +524,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(inventoryView);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, null, null);
+        new DataSourcesResource(inventoryView, null, null, null, null, null);
     Response response = dataSourcesResource.getServedSegmentsInInterval(
         "invalidDataSource",
         "2010-01-01/P1D",
@@ -594,7 +594,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(indexingServiceClient, server);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, indexingServiceClient, null);
+        new DataSourcesResource(inventoryView, null, null, indexingServiceClient, null, null);
     Response response = dataSourcesResource.killUnusedSegmentsInInterval("datasource1", interval);
 
     Assert.assertEquals(200, response.getStatus());
@@ -608,7 +608,7 @@ public class DataSourcesResourceTest
     IndexingServiceClient indexingServiceClient = EasyMock.createStrictMock(IndexingServiceClient.class);
     EasyMock.replay(indexingServiceClient, server);
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, null, indexingServiceClient, null);
+        new DataSourcesResource(inventoryView, null, null, indexingServiceClient, null, null);
     try {
       Response response =
           dataSourcesResource.markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval("datasource", "true", "???");
@@ -631,7 +631,7 @@ public class DataSourcesResourceTest
     Rule loadRule = new IntervalLoadRule(Intervals.of("2013-01-02T00:00:00Z/2013-01-03T00:00:00Z"), null);
     Rule dropRule = new IntervalDropRule(Intervals.of("2013-01-01T00:00:00Z/2013-01-02T00:00:00Z"));
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, null, databaseRuleManager, null, null);
+        new DataSourcesResource(inventoryView, null, databaseRuleManager, null, null, null);
 
     // test dropped
     EasyMock.expect(databaseRuleManager.getRulesWithDefault("dataSource1"))
@@ -700,7 +700,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(segmentsMetadataManager.markSegmentAsUsed(segment.getId().toString())).andReturn(true).once();
     EasyMock.replay(segmentsMetadataManager);
 
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(null, segmentsMetadataManager, null, null, null);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(null, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markSegmentAsUsed(segment.getDataSource(), segment.getId().toString());
     Assert.assertEquals(200, response.getStatus());
@@ -714,7 +714,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(segmentsMetadataManager.markSegmentAsUsed(segment.getId().toString())).andReturn(false).once();
     EasyMock.replay(segmentsMetadataManager);
 
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(null, segmentsMetadataManager, null, null, null);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(null, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markSegmentAsUsed(segment.getDataSource(), segment.getId().toString());
     Assert.assertEquals(200, response.getStatus());
@@ -735,7 +735,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -758,7 +758,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -781,7 +781,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -804,7 +804,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -822,7 +822,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -836,7 +836,7 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsInvalidPayloadNoArguments()
   {
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -849,7 +849,7 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsInvalidPayloadBothArguments()
   {
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -862,7 +862,7 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsInvalidPayloadEmptyArray()
   {
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
@@ -875,7 +875,7 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsNoPayload()
   {
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments("datasource1", null);
     Assert.assertEquals(400, response.getStatus());
@@ -1027,7 +1027,7 @@ public class DataSourcesResourceTest
         new DataSourcesResource.MarkDataSourceSegmentsPayload(null, segmentIds);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(ImmutableMap.of("numChangedSegments", 1), response.getEntity());
@@ -1050,7 +1050,7 @@ public class DataSourcesResourceTest
         new DataSourcesResource.MarkDataSourceSegmentsPayload(null, segmentIds);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(ImmutableMap.of("numChangedSegments", 0), response.getEntity());
@@ -1075,7 +1075,7 @@ public class DataSourcesResourceTest
         new DataSourcesResource.MarkDataSourceSegmentsPayload(null, segmentIds);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload);
     Assert.assertEquals(500, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1097,7 +1097,7 @@ public class DataSourcesResourceTest
         new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(ImmutableMap.of("numChangedSegments", 1), response.getEntity());
@@ -1120,7 +1120,7 @@ public class DataSourcesResourceTest
         new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(ImmutableMap.of("numChangedSegments", 0), response.getEntity());
@@ -1144,7 +1144,7 @@ public class DataSourcesResourceTest
         new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null);
 
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload);
     Assert.assertEquals(500, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1155,7 +1155,7 @@ public class DataSourcesResourceTest
   public void testMarkSegmentsAsUnusedNullPayload()
   {
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", null);
     Assert.assertEquals(400, response.getStatus());
@@ -1170,7 +1170,7 @@ public class DataSourcesResourceTest
   public void testMarkSegmentsAsUnusedInvalidPayload()
   {
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
         new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null);
@@ -1184,7 +1184,7 @@ public class DataSourcesResourceTest
   public void testMarkSegmentsAsUnusedInvalidPayloadBothArguments()
   {
     DataSourcesResource dataSourcesResource =
-        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
         new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-01/P1D"), ImmutableSet.of());
@@ -1247,7 +1247,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(inventoryView.getSegmentLoadInfos()).andReturn(completedLoadInfoMap).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.getDatasourceLoadstatus("datasource1", null, null, null, null);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1263,7 +1263,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(inventoryView.getSegmentLoadInfos()).andReturn(halfLoadedInfoMap).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
-    dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+    dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     response = dataSourcesResource.getDatasourceLoadstatus("datasource1", null, null, null, null);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1326,7 +1326,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(inventoryView.getSegmentLoadInfos()).andReturn(completedLoadInfoMap).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     Response response = dataSourcesResource.getDatasourceLoadstatus("datasource1", null, null, "simple", null);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1342,7 +1342,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(inventoryView.getSegmentLoadInfos()).andReturn(halfLoadedInfoMap).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
-    dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null);
+    dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, null, null, null, null);
     response = dataSourcesResource.getDatasourceLoadstatus("datasource1", null, null, "simple", null);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1415,7 +1415,7 @@ public class DataSourcesResourceTest
             .once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, databaseRuleManager);
 
-    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, databaseRuleManager, null, null);
+    DataSourcesResource dataSourcesResource = new DataSourcesResource(inventoryView, segmentsMetadataManager, databaseRuleManager, null, null, null);
     Response response = dataSourcesResource.getDatasourceLoadstatus("datasource1", null, null, null, "full");
     Assert.assertEquals(200, response.getStatus());
     Assert.assertNotNull(response.getEntity());


### PR DESCRIPTION
API to verify a datasource has the latest ingested data

### Description

This PR address https://github.com/apache/druid/issues/5721 / https://github.com/apache/druid/issues/10005

The existing loadstatus API on the Coordinator reads segments from SqlSegmentsMetadataManager of the Coordinator which caches segments in memory and periodically updates them. Hence, there can be a race condition as this API implementation compares segments metadata from the mentioned cache with published segments in historicals. Particularly, when there is a new ingestion after the initial load of the datasource, the cache still only contains the metadata of old segments. The API would compares list of old segments with what is published by historical and returns that everything is available when the new segments are not actually available yet. 

This new API will fix this problem. The new API will be able to do the following:
- new api takes in datasource. This will returns false if any used segment (of the past 2 weeks) of the given datasource are not available to be query (i.e. not loaded onto historical yet). Return true otherwise. The interval of 2 weeks above is not finalized yet. We can decide later what is a good default number

- (same) new api takes in datasource and a time interval (start + end): This will returns false if any used segment (between the given start and given end time) of the given datasource are not available to be query (i.e. not loaded onto historical yet). Return true otherwise.

Note that the above are both the same API. The time interval is an optional parameter. The time interval referred above is the timestamp of the data in the segment (nothing to do with when the segment is ingested). This can be the same time interval as the time interval the user want to query data from. Basically if the user wants to query from x to y then they can call this new api with the datasource and time interval x to y. This will ensure that all segments of the datasource for the timestamp from x to y is ready to be query (loaded onto historical).

Important differencees between this API from the existing coordinator loadstatus API:
- Takes datasource (required) to be able to check faster (iterate smaller number of segments)
- Takes interval (optional) to be able to check faster (iterate smaller number of segments)
- **IMPORATANT**. Takes boolean firstCheck. If this is true, this will force poll the metadata source to get latest published segment information.

The workflow will be :

1) submit ingestion task

2) poll task api until task succeeded

3) poll the new api with datasource, interval, and firstCheck=true once. If false, go to step 4, otherwise the data is available and user can query.

4) poll the new api with datasource, interval, and firstCheck=false until return true. After true, data is available and user can query.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
