### PR TITLE
Add the ability to run sql tests from a config file

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/TestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestHelper.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -39,6 +40,7 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.DataSegment.PruneSpecsHolder;
 import org.junit.Assert;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashMap;
@@ -71,9 +73,9 @@ public class TestHelper
     return new IndexIO(JSON_MAPPER, columnConfig);
   }
 
-  public static ObjectMapper makeJsonMapper()
+  public static ObjectMapper makeJsonMapper(@Nullable JsonFactory factory)
   {
-    final ObjectMapper mapper = new DefaultObjectMapper();
+    final ObjectMapper mapper = new DefaultObjectMapper(factory);
     mapper.setInjectableValues(
         new InjectableValues.Std()
             .addValue(ExprMacroTable.class.getName(), TestExprMacroTable.INSTANCE)
@@ -81,6 +83,11 @@ public class TestHelper
             .addValue(PruneSpecsHolder.class, PruneSpecsHolder.DEFAULT)
     );
     return mapper;
+  }
+
+  public static ObjectMapper makeJsonMapper()
+  {
+    return makeJsonMapper(null);
   }
 
   public static ObjectMapper makeSmileMapper()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTestData.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTestData.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.query.Query;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A data class that holds data for {@link CalciteQueryTest}
+ */
+public class CalciteQueryTestData
+{
+  /**
+   * A comment that describes what the test is doing
+   */
+  @Nonnull
+  public final String testName;
+
+  /**
+   * The SQL query under test.
+   */
+  @Nonnull
+  public final String sql;
+
+  /**
+   * The native query that this should transform to. If the SQL query generates many native queries, provide them
+   * as a list. To generate the native query use `EXPLAIN PLAN FOR` for the same query in a druid cluster. If the Druid
+   * cluster produces output that does not look like a native query, you can still see the native query by enabling
+   * request logging on the broker. https://druid.apache.org/docs/latest/configuration/index.html#request-logging
+   *
+   * Set to null if the test does not need to test the shape of the native query.
+   */
+  @Nullable
+  public final List<Query> expectedQueries;
+
+  /**
+   * The expected output of the query.
+   *
+   * Set to an empty list if the expected result is empty.
+   */
+  @Nonnull
+  public final List<Object[]> expectedResults;
+
+  /**
+   * A link to the apache issue if it is expected that this query will not succeed.
+   */
+  @Nullable
+  public final String apacheIssue;
+
+  /**
+   * The expected exception class to be thrown. Null if no exception is expected.
+   */
+  @Nullable
+  public final Class expectedException;
+
+  /**
+   * Whether the query can be vectorized. By default, this is false (ie. it is assumed that the query
+   * can be vectorized).
+   */
+  public final boolean cannotVectorize;
+
+  @JsonCreator
+  public CalciteQueryTestData(
+      @JsonProperty("testName") @Nonnull String testName,
+      @JsonProperty("sql") @Nonnull String sql,
+      @JsonProperty("expectedQueries") @Nullable List<Query> expectedQueries,
+      @JsonProperty("expectedResults") @Nonnull List<Object[]> expectedResults,
+      @JsonProperty("apacheIssue") @Nullable String apacheIssue,
+      @JsonProperty("expectedException") @Nullable Class expectedException,
+      @JsonProperty("cannotVectorize") @Nullable Boolean cannotVectorize
+  )
+  {
+    this.testName = testName;
+    this.sql = sql;
+    this.expectedQueries = expectedQueries;
+    this.expectedResults = expectedResults;
+    this.apacheIssue = apacheIssue;
+    this.expectedException = expectedException;
+    this.cannotVectorize = cannotVectorize == null ? false : cannotVectorize;
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder resultBuilder = new StringBuilder("test - ").append(testName);
+    if (expectedException != null) {
+      resultBuilder.append(" withExpectedException=").append(expectedException.getName());
+    }
+    if (apacheIssue != null) {
+      resultBuilder.append(" withKnownIssue=").append(apacheIssue);
+    }
+    return resultBuilder.toString();
+  }
+}

--- a/sql/src/test/resources/calcite/tests/calciteQueryTests.yaml
+++ b/sql/src/test/resources/calcite/tests/calciteQueryTests.yaml
@@ -1,0 +1,46 @@
+# List of tests to be run.
+# Please add tests in the appropriate test block for easier maintainability.
+# Start block with a comment explaining what the block is for so similar tests can be placed alongside.
+# End each block with a delimiting comment
+
+# Select constant expressions ##############
+- "testName": "SelectConstantExpression"
+  "sql": "SELECT REGEXP_EXTRACT('foo', '^(.)')"
+  "expectedQueries": []
+  "expectedResults":
+    - ["f"]
+
+- "testName": "SelectConstantExpressionFromTable"
+  "sql": "SELECT 1 + 1, dim1 FROM foo LIMIT 1"
+  "expectedQueries":
+    - {
+        "queryType":"scan",
+        "dataSource":{
+          "type":"table","name":"foo"
+        },
+        "intervals":{
+          "type":"intervals",
+          "intervals":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"]
+        },
+        "virtualColumns":[
+          {
+            "type":"expression",
+            "name":"v0",
+            "expression":"2",
+            "outputType":"LONG"
+          }
+        ],
+        "resultFormat":"compactedList",
+        "batchSize":20480,
+        "limit":1,
+        "order":"none",
+        "filter":null,
+        "columns":["dim1","v0"],
+        "legacy":false,
+        "descending":false,
+        "granularity":{"type":"all"}
+    }
+  "expectedResults":
+      - [2, ""]
+
+############################################


### PR DESCRIPTION
This PR aims to make it easier for non Druid devs to add sql tests to Druid.

If anyone in the community has particular query shapes they expect to see
working in Druid, they can add the queries to the provided config.
This will ensure the queries work as expected with each Druid release.

Sample ingestion specs are provided in the test/resources folder so that tests
are easier to build by testing against a local cluster.

yaml is chosen as the data format for the tests as it allows devs to place
comments within the configuration which helps with maintainability of the
tests.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.