### PR TITLE
More lenient code coverage check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -175,9 +175,13 @@ jobs:
           | node_modules/.bin/diff-test-coverage
           --coverage "**/target/site/jacoco/jacoco.xml"
           --type jacoco
-          --line-coverage 65
-          --branch-coverage 65
+          --line-coverage 50 
+          --branch-coverage 50
           --function-coverage 0
+          --log-template "coverage-lines-complete"
+          --log-template "coverage-files-complete"
+          --log-template "totals-complete"
+          --log-template "errors"
           --
           || { printf "\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\n" && false; }
           fi


### PR DESCRIPTION
### Description

Since there is not currently a good way to have fine-grain code coverage check exclusions, lower the coverage thresholds to make the check more lenient for now.

Also, display the code coverage report in the Travis CI logs to make it easier to understand how to improve coverage:

```
Diff coverage results:

  F = Function coverage
  L = Line coverage
  B = Branch coverage

------------------------------------------------------------------------------
org/apache/druid/cli/validate/DruidJsonValidator.java
------------------------------------------------------------------------------
254                       }
255                   );
256                 }
257               
258                 @Override
259                 public String toString()
260                 {
261 F | L             return "DruidJsonValidator{" +
262                          "logWriter=" + logWriter +
263                          ", jsonFile='" + jsonFile + '\'' +
264                          ", type='" + type + '\'' +
265                          ", resource='" + resource + '\'' +
266                          ", toLogger=" + toLogger +
267                          '}';
268                 }
------------------------------------------------------------------------------

Diff coverage statistics:
------------------------------------------------------------------------------
|     lines      |    branches    |   functions    |   path
------------------------------------------------------------------------------
|   0% (0/1)     | 100% (0/0)     |   0% (0/1)     | org/apache/druid/cli/validate/DruidJsonValidator.java
------------------------------------------------------------------------------
Total diff coverage:
 - lines: 0% (0/1)
 - branches: 100% (0/0)
 - functions: 0% (0/1)

ERROR: Insufficient line coverage of 0% (0/1). Required 50%.
```

<hr>

This PR has:
- [x] been self-reviewed.
