### PR TITLE
Fix join filter rewrites with nested queries

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
@@ -49,6 +49,7 @@ import org.apache.druid.segment.join.JoinTestHelper;
 import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.segment.join.JoinableClause;
 import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
@@ -139,10 +140,13 @@ public class JoinAndLookupBenchmark
         )
     );
     JoinFilterPreAnalysisGroup preAnalysisGroupLookupStringKey = new JoinFilterPreAnalysisGroup(
-        false,
-        false,
-        false,
-        0
+        new JoinFilterRewriteConfig(
+            false,
+            false,
+            false,
+            0,
+            false
+        )
     );
 
     hashJoinLookupStringKeySegment = new HashJoinSegment(
@@ -165,10 +169,13 @@ public class JoinAndLookupBenchmark
     );
 
     JoinFilterPreAnalysisGroup preAnalysisGroupLookupLongKey = new JoinFilterPreAnalysisGroup(
-        false,
-        false,
-        false,
-        0
+        new JoinFilterRewriteConfig(
+            false,
+            false,
+            false,
+            0,
+            false
+        )
     );
     hashJoinLookupLongKeySegment = new HashJoinSegment(
         baseSegment,
@@ -190,10 +197,13 @@ public class JoinAndLookupBenchmark
     );
 
     JoinFilterPreAnalysisGroup preAnalysisGroupIndexedStringKey = new JoinFilterPreAnalysisGroup(
-        false,
-        false,
-        false,
-        0
+        new JoinFilterRewriteConfig(
+            false,
+            false,
+            false,
+            0,
+            false
+        )
     );
     hashJoinIndexedTableStringKeySegment = new HashJoinSegment(
         baseSegment,
@@ -214,10 +224,13 @@ public class JoinAndLookupBenchmark
         )
     );
     JoinFilterPreAnalysisGroup preAnalysisGroupIndexedLongKey = new JoinFilterPreAnalysisGroup(
-        false,
-        false,
-        false,
-        0
+        new JoinFilterRewriteConfig(
+            false,
+            false,
+            false,
+            0,
+            false
+        )
     );
     hashJoinIndexedTableLongKeySegment = new HashJoinSegment(
         baseSegment,

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
@@ -48,9 +48,7 @@ import org.apache.druid.segment.join.JoinConditionAnalysis;
 import org.apache.druid.segment.join.JoinTestHelper;
 import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.segment.join.JoinableClause;
-import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
-import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
-import org.apache.druid.segment.join.filter.JoinableClauses;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
@@ -140,19 +138,17 @@ public class JoinAndLookupBenchmark
             )
         )
     );
-    JoinFilterPreAnalysis preAnalysisLookupStringKey = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClausesLookupStringKey),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup preAnalysisGroupLookupStringKey = new JoinFilterPreAnalysisGroup(
         false,
         false,
         false,
         0
     );
+
     hashJoinLookupStringKeySegment = new HashJoinSegment(
         baseSegment,
         joinableClausesLookupStringKey,
-        preAnalysisLookupStringKey
+        preAnalysisGroupLookupStringKey
     );
 
     List<JoinableClause> joinableClausesLookupLongKey = ImmutableList.of(
@@ -167,10 +163,8 @@ public class JoinAndLookupBenchmark
             )
         )
     );
-    JoinFilterPreAnalysis preAnalysisLookupLongKey = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClausesLookupLongKey),
-        VirtualColumns.EMPTY,
-        null,
+
+    JoinFilterPreAnalysisGroup preAnalysisGroupLookupLongKey = new JoinFilterPreAnalysisGroup(
         false,
         false,
         false,
@@ -179,7 +173,7 @@ public class JoinAndLookupBenchmark
     hashJoinLookupLongKeySegment = new HashJoinSegment(
         baseSegment,
         joinableClausesLookupLongKey,
-        preAnalysisLookupLongKey
+        preAnalysisGroupLookupLongKey
     );
 
     List<JoinableClause> joinableClausesIndexedTableStringKey = ImmutableList.of(
@@ -194,10 +188,8 @@ public class JoinAndLookupBenchmark
             )
         )
     );
-    JoinFilterPreAnalysis preAnalysisIndexedTableStringKey = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClausesIndexedTableStringKey),
-        VirtualColumns.EMPTY,
-        null,
+
+    JoinFilterPreAnalysisGroup preAnalysisGroupIndexedStringKey = new JoinFilterPreAnalysisGroup(
         false,
         false,
         false,
@@ -206,7 +198,7 @@ public class JoinAndLookupBenchmark
     hashJoinIndexedTableStringKeySegment = new HashJoinSegment(
         baseSegment,
         joinableClausesIndexedTableStringKey,
-        preAnalysisIndexedTableStringKey
+        preAnalysisGroupIndexedStringKey
     );
 
     List<JoinableClause> joinableClausesIndexedTableLonggKey = ImmutableList.of(
@@ -221,10 +213,7 @@ public class JoinAndLookupBenchmark
             )
         )
     );
-    JoinFilterPreAnalysis preAnalysisIndexedTableLongKey = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClausesIndexedTableLonggKey),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup preAnalysisGroupIndexedLongKey = new JoinFilterPreAnalysisGroup(
         false,
         false,
         false,
@@ -233,7 +222,7 @@ public class JoinAndLookupBenchmark
     hashJoinIndexedTableLongKeySegment = new HashJoinSegment(
         baseSegment,
         joinableClausesIndexedTableLonggKey,
-        preAnalysisIndexedTableLongKey
+        preAnalysisGroupIndexedLongKey
     );
 
     final Map<String, String> countryCodeToNameMap = JoinTestHelper.createCountryIsoCodeToNameLookup().getMap();

--- a/processing/src/main/java/org/apache/druid/query/Query.java
+++ b/processing/src/main/java/org/apache/druid/query/Query.java
@@ -37,7 +37,6 @@ import org.apache.druid.query.timeboundary.TimeBoundaryQuery;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.topn.TopNQuery;
 import org.apache.druid.segment.Segment;
-import org.apache.druid.segment.VirtualColumns;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
@@ -169,10 +168,5 @@ public interface Query<T>
   default Query<T> withLane(String lane)
   {
     return withOverriddenContext(ImmutableMap.of(QueryContexts.LANE_KEY, lane));
-  }
-
-  default VirtualColumns getVirtualColumns()
-  {
-    return VirtualColumns.EMPTY;
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/Query.java
+++ b/processing/src/main/java/org/apache/druid/query/Query.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.timeboundary.TimeBoundaryQuery;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.topn.TopNQuery;
 import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.VirtualColumns;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
@@ -168,5 +169,10 @@ public interface Query<T>
   default Query<T> withLane(String lane)
   {
     return withOverriddenContext(ImmutableMap.of(QueryContexts.LANE_KEY, lane));
+  }
+
+  default VirtualColumns getVirtualColumns()
+  {
+    return VirtualColumns.EMPTY;
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -52,6 +52,7 @@ public class QueryContexts
   public static final String JOIN_FILTER_REWRITE_ENABLE_KEY = "enableJoinFilterRewrite";
   public static final String JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY = "enableJoinFilterRewriteValueColumnFilters";
   public static final String JOIN_FILTER_REWRITE_MAX_SIZE_KEY = "joinFilterRewriteMaxSize";
+  public static final String JOIN_FILTER_REWRITE_USE_OLD_REWRITE_MODE = "joinFilterRewriteUseOldRewriteMode";
   public static final String USE_FILTER_CNF_KEY = "useFilterCNF";
 
   public static final boolean DEFAULT_BY_SEGMENT = false;
@@ -68,6 +69,7 @@ public class QueryContexts
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_REWRITE = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS = false;
+  public static final boolean DEFAULT_JOIN_FILTER_REWRITE_USE_OLD_REWRITE_MODE = false;
   public static final long DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE = 10000;
   public static final boolean DEFAULT_USE_FILTER_CNF = false;
 
@@ -264,6 +266,26 @@ public class QueryContexts
     return parseBoolean(query, JOIN_FILTER_REWRITE_ENABLE_KEY, DEFAULT_ENABLE_JOIN_FILTER_REWRITE);
   }
 
+  /**
+   * This is an undocumented option provided as a transition tool:
+   *
+   * The join filter rewrites originally performed the pre-analysis phase prior to any per-segment processing,
+   * analyzing only the filter in the top-level of the query.
+   *
+   * This did not work for nested queries (see https://github.com/apache/druid/pull/9978), so the rewrite pre-analysis
+   * was moved into the cursor creation of the {@link org.apache.druid.segment.join.HashJoinSegmentStorageAdapter}.
+   * This design requires synchronization across multiple segment processing threads; the old rewrite mode
+   * is kept temporarily available in case issues arise with the new mode, and the user does not run queries with the
+   * affected nested shape.
+   */
+  public static <T> boolean getUseJoinFilterRewriteOldRewriteMode(Query<T> query)
+  {
+    return parseBoolean(
+        query,
+        JOIN_FILTER_REWRITE_USE_OLD_REWRITE_MODE,
+        DEFAULT_JOIN_FILTER_REWRITE_USE_OLD_REWRITE_MODE
+    );
+  }
 
   public static <T> Query<T> withMaxScatterGatherBytes(Query<T> query, long maxScatterGatherBytesLimit)
   {

--- a/processing/src/main/java/org/apache/druid/query/filter/AndDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/AndDimFilter.java
@@ -20,12 +20,14 @@
 package org.apache.druid.query.filter;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.filter.AndFilter;
 import org.apache.druid.segment.filter.Filters;
 
@@ -42,6 +44,9 @@ public class AndDimFilter implements DimFilter
   private static final Joiner AND_JOINER = Joiner.on(" && ");
 
   private final List<DimFilter> fields;
+
+  @JsonIgnore
+  private Integer fieldsHashCode;
 
   @JsonCreator
   public AndDimFilter(
@@ -67,7 +72,7 @@ public class AndDimFilter implements DimFilter
   @Override
   public byte[] getCacheKey()
   {
-    return DimFilterUtils.computeCacheKey(DimFilterUtils.AND_CACHE_ID, fields);
+    return new CacheKeyBuilder(DimFilterUtils.AND_CACHE_ID).appendInt(hashCode()).build();
   }
 
   @Override
@@ -142,7 +147,10 @@ public class AndDimFilter implements DimFilter
   @Override
   public int hashCode()
   {
-    return fields != null ? fields.hashCode() : 0;
+    if (fieldsHashCode == null) {
+      fieldsHashCode = fields != null ? fields.hashCode() : 0;
+    }
+    return fieldsHashCode;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/DimFilterUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/DimFilterUtils.java
@@ -23,7 +23,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.RangeSet;
 import org.apache.druid.timeline.partition.ShardSpec;
 
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -56,29 +55,6 @@ public class DimFilterUtils
   public static final byte BLOOM_DIM_FILTER_CACHE_ID = 0x10;
 
   public static final byte STRING_SEPARATOR = (byte) 0xFF;
-
-  static byte[] computeCacheKey(byte cacheIdKey, List<DimFilter> filters)
-  {
-    if (filters.size() == 1) {
-      return filters.get(0).getCacheKey();
-    }
-
-    byte[][] cacheKeys = new byte[filters.size()][];
-    int totalSize = 0;
-    int index = 0;
-    for (DimFilter field : filters) {
-      cacheKeys[index] = field.getCacheKey();
-      totalSize += cacheKeys[index].length;
-      ++index;
-    }
-
-    ByteBuffer retVal = ByteBuffer.allocate(1 + totalSize);
-    retVal.put(cacheIdKey);
-    for (byte[] cacheKey : cacheKeys) {
-      retVal.put(cacheKey);
-    }
-    return retVal.array();
-  }
 
   /**
    * Filter the given iterable of objects by removing any object whose ShardSpec, obtained from the converter function,

--- a/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
@@ -168,21 +168,6 @@ public class InDimFilter implements DimFilter
     return cacheKey;
   }
 
-  private static HashCode computeValuesHashCode(Set<String> values)
-  {
-    final List<String> sortedValues = new ArrayList<>(values);
-    sortedValues.sort(Comparator.nullsFirst(Ordering.natural()));
-    final Hasher hasher = Hashing.sha256().newHasher();
-    for (String v : sortedValues) {
-      if (v == null) {
-        hasher.putInt(0);
-      } else {
-        hasher.putString(v, StandardCharsets.UTF_8);
-      }
-    }
-    return hasher.hash();
-  }
-
   @Override
   public DimFilter optimize()
   {
@@ -316,7 +301,22 @@ public class InDimFilter implements DimFilter
     if (valuesHashCode == null) {
       valuesHashCode = computeValuesHashCode(values);
     }
-    return Objects.hash(values, dimension, extractionFn, filterTuning);
+    return Objects.hash(valuesHashCode, dimension, extractionFn, filterTuning);
+  }
+
+  public static HashCode computeValuesHashCode(Set<String> values)
+  {
+    final List<String> sortedValues = new ArrayList<>(values);
+    sortedValues.sort(Comparator.nullsFirst(Ordering.natural()));
+    final Hasher hasher = Hashing.sha256().newHasher();
+    for (String v : sortedValues) {
+      if (v == null) {
+        hasher.putInt(0);
+      } else {
+        hasher.putString(v, StandardCharsets.UTF_8);
+      }
+    }
+    return hasher.hash();
   }
 
   private DruidLongPredicate createLongPredicate()

--- a/processing/src/main/java/org/apache/druid/query/filter/OrDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/OrDimFilter.java
@@ -20,12 +20,14 @@
 package org.apache.druid.query.filter;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.filter.OrFilter;
 
@@ -43,6 +45,9 @@ public class OrDimFilter implements DimFilter
   private static final Joiner OR_JOINER = Joiner.on(" || ");
 
   private final List<DimFilter> fields;
+
+  @JsonIgnore
+  private Integer fieldsHashCode;
 
   @JsonCreator
   public OrDimFilter(@JsonProperty("fields") List<DimFilter> fields)
@@ -75,7 +80,7 @@ public class OrDimFilter implements DimFilter
   @Override
   public byte[] getCacheKey()
   {
-    return DimFilterUtils.computeCacheKey(DimFilterUtils.OR_CACHE_ID, fields);
+    return new CacheKeyBuilder(DimFilterUtils.OR_CACHE_ID).appendInt(hashCode()).build();
   }
 
   @Override
@@ -148,7 +153,10 @@ public class OrDimFilter implements DimFilter
   @Override
   public int hashCode()
   {
-    return fields != null ? fields.hashCode() : 0;
+    if (fieldsHashCode == null) {
+      fieldsHashCode = fields != null ? fields.hashCode() : 0;
+    }
+    return fieldsHashCode;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -249,7 +249,6 @@ public class GroupByQuery extends BaseQuery<ResultRow>
     return subtotalsSpec;
   }
 
-  @Override
   @JsonProperty
   public VirtualColumns getVirtualColumns()
   {

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -250,6 +250,7 @@ public class GroupByQuery extends BaseQuery<ResultRow>
   }
 
   @JsonProperty
+  @Override
   public VirtualColumns getVirtualColumns()
   {
     return virtualColumns;

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
@@ -183,7 +183,6 @@ public class ScanQuery extends BaseQuery<ScanResultValue>
     return maxSegmentPartitionsOrderedInMemory;
   }
 
-  @Override
   @JsonProperty
   public VirtualColumns getVirtualColumns()
   {

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
@@ -184,6 +184,7 @@ public class ScanQuery extends BaseQuery<ScanResultValue>
   }
 
   @JsonProperty
+  @Override
   public VirtualColumns getVirtualColumns()
   {
     return virtualColumns;

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
@@ -103,7 +103,6 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     return Query.TIMESERIES;
   }
 
-  @Override
   @JsonProperty
   public VirtualColumns getVirtualColumns()
   {

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
@@ -104,6 +104,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
   }
 
   @JsonProperty
+  @Override
   public VirtualColumns getVirtualColumns()
   {
     return virtualColumns;

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
@@ -113,7 +113,6 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     return TOPN;
   }
 
-  @Override
   @JsonProperty
   public VirtualColumns getVirtualColumns()
   {

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
@@ -114,6 +114,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
   }
 
   @JsonProperty
+  @Override
   public VirtualColumns getVirtualColumns()
   {
     return virtualColumns;

--- a/processing/src/main/java/org/apache/druid/segment/filter/AndFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/AndFilter.java
@@ -39,6 +39,7 @@ import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -47,6 +48,7 @@ import java.util.Set;
 
 /**
  */
+@Immutable
 public class AndFilter implements BooleanFilter
 {
   private static final Joiner AND_JOINER = Joiner.on(" && ");
@@ -259,7 +261,7 @@ public class AndFilter implements BooleanFilter
       return false;
     }
     AndFilter andFilter = (AndFilter) o;
-    return Objects.equals(getFilters(), andFilter.getFilters());
+    return Objects.equals(hashCode(), andFilter.hashCode());
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/filter/AndFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/AndFilter.java
@@ -53,6 +53,8 @@ public class AndFilter implements BooleanFilter
 
   private final Set<Filter> filters;
 
+  private Integer filtersHashCode;
+
   @VisibleForTesting
   public AndFilter(List<Filter> filters)
   {
@@ -263,6 +265,10 @@ public class AndFilter implements BooleanFilter
   @Override
   public int hashCode()
   {
-    return Objects.hash(getFilters());
+    if (filtersHashCode == null) {
+      filtersHashCode = Objects.hash(getFilters());
+    }
+
+    return filtersHashCode;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/filter/AndFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/AndFilter.java
@@ -22,6 +22,8 @@ package org.apache.druid.segment.filter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
@@ -55,7 +57,7 @@ public class AndFilter implements BooleanFilter
 
   private final Set<Filter> filters;
 
-  private Integer filtersHashCode;
+  private final Supplier<Integer> filtersHashCode;
 
   @VisibleForTesting
   public AndFilter(List<Filter> filters)
@@ -67,6 +69,7 @@ public class AndFilter implements BooleanFilter
   {
     Preconditions.checkArgument(filters.size() > 0, "Can't construct empty AndFilter");
     this.filters = filters;
+    this.filtersHashCode = Suppliers.memoize(() -> Objects.hash(getFilters()));
   }
 
   public static <T> ImmutableBitmap getBitmapIndex(
@@ -267,10 +270,6 @@ public class AndFilter implements BooleanFilter
   @Override
   public int hashCode()
   {
-    if (filtersHashCode == null) {
-      filtersHashCode = Objects.hash(getFilters());
-    }
-
-    return filtersHashCode;
+    return filtersHashCode.get();
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/filter/InFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/InFilter.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.filter.DruidLongPredicate;
 import org.apache.druid.query.filter.DruidPredicateFactory;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.FilterTuning;
+import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.ValueMatcher;
 import org.apache.druid.query.filter.vector.VectorValueMatcher;
 import org.apache.druid.query.filter.vector.VectorValueMatcherColumnProcessorFactory;
@@ -73,7 +74,7 @@ public class InFilter implements Filter
   private final Supplier<DruidLongPredicate> longPredicateSupplier;
   private final Supplier<DruidFloatPredicate> floatPredicateSupplier;
   private final Supplier<DruidDoublePredicate> doublePredicateSupplier;
-  private final HashCode valuesHashCode;
+  private HashCode valuesHashCode;
 
   public InFilter(
       String dimension,
@@ -235,8 +236,7 @@ public class InFilter implements Filter
         values,
         longPredicateSupplier,
         floatPredicateSupplier,
-        doublePredicateSupplier,
-        valuesHashCode
+        doublePredicateSupplier
     );
   }
 
@@ -259,6 +259,9 @@ public class InFilter implements Filter
   @Override
   public int hashCode()
   {
+    if (valuesHashCode == null) {
+      valuesHashCode = InDimFilter.computeValuesHashCode(values);
+    }
     return Objects.hash(dimension, valuesHashCode, extractionFn, filterTuning);
   }
 
@@ -270,15 +273,13 @@ public class InFilter implements Filter
     private final Supplier<DruidLongPredicate> longPredicateSupplier;
     private final Supplier<DruidFloatPredicate> floatPredicateSupplier;
     private final Supplier<DruidDoublePredicate> doublePredicateSupplier;
-    private final HashCode valuesHashCode;
 
     InFilterDruidPredicateFactory(
         ExtractionFn extractionFn,
         Set<String> values,
         Supplier<DruidLongPredicate> longPredicateSupplier,
         Supplier<DruidFloatPredicate> floatPredicateSupplier,
-        Supplier<DruidDoublePredicate> doublePredicateSupplier,
-        HashCode valuesHashCode
+        Supplier<DruidDoublePredicate> doublePredicateSupplier
     )
     {
       this.extractionFn = extractionFn;
@@ -286,7 +287,6 @@ public class InFilter implements Filter
       this.longPredicateSupplier = longPredicateSupplier;
       this.floatPredicateSupplier = floatPredicateSupplier;
       this.doublePredicateSupplier = doublePredicateSupplier;
-      this.valuesHashCode = valuesHashCode;
     }
 
     @Override
@@ -345,7 +345,7 @@ public class InFilter implements Filter
     @Override
     public int hashCode()
     {
-      return Objects.hash(extractionFn, valuesHashCode);
+      return Objects.hash(extractionFn, values);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/filter/InFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/InFilter.java
@@ -23,7 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.hash.HashCode;
+import com.google.errorprone.annotations.Immutable;
 import it.unimi.dsi.fastutil.ints.IntIterable;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
@@ -65,6 +65,7 @@ import java.util.Set;
  * In default null handling mode, this filter is equivalent to {@code (dimension IN [values])} or
  * {@code (dimension IN [non-null values, ''])} when {@link #values} contains nulls.
  */
+@Immutable
 public class InFilter implements Filter
 {
   private final String dimension;
@@ -74,7 +75,7 @@ public class InFilter implements Filter
   private final Supplier<DruidLongPredicate> longPredicateSupplier;
   private final Supplier<DruidFloatPredicate> floatPredicateSupplier;
   private final Supplier<DruidDoublePredicate> doublePredicateSupplier;
-  private HashCode valuesHashCode;
+  private Integer valuesHashCode;
 
   public InFilter(
       String dimension,
@@ -84,7 +85,7 @@ public class InFilter implements Filter
       Supplier<DruidDoublePredicate> doublePredicateSupplier,
       ExtractionFn extractionFn,
       FilterTuning filterTuning,
-      HashCode valuesHashCode
+      Integer valuesHashCode
   )
   {
     this.dimension = dimension;
@@ -250,8 +251,13 @@ public class InFilter implements Filter
       return false;
     }
     InFilter inFilter = (InFilter) o;
+
+    // make sure the hashCode is initialized for both filters
+    hashCode();
+    inFilter.hashCode();
+
     return Objects.equals(dimension, inFilter.dimension) &&
-           Objects.equals(values, inFilter.values) &&
+           Objects.equals(valuesHashCode, inFilter.valuesHashCode) &&
            Objects.equals(extractionFn, inFilter.extractionFn) &&
            Objects.equals(filterTuning, inFilter.filterTuning);
   }

--- a/processing/src/main/java/org/apache/druid/segment/filter/InFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/InFilter.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashCode;
 import it.unimi.dsi.fastutil.ints.IntIterable;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
@@ -72,6 +73,7 @@ public class InFilter implements Filter
   private final Supplier<DruidLongPredicate> longPredicateSupplier;
   private final Supplier<DruidFloatPredicate> floatPredicateSupplier;
   private final Supplier<DruidDoublePredicate> doublePredicateSupplier;
+  private final HashCode valuesHashCode;
 
   public InFilter(
       String dimension,
@@ -80,7 +82,8 @@ public class InFilter implements Filter
       Supplier<DruidFloatPredicate> floatPredicateSupplier,
       Supplier<DruidDoublePredicate> doublePredicateSupplier,
       ExtractionFn extractionFn,
-      FilterTuning filterTuning
+      FilterTuning filterTuning,
+      HashCode valuesHashCode
   )
   {
     this.dimension = dimension;
@@ -90,6 +93,7 @@ public class InFilter implements Filter
     this.longPredicateSupplier = longPredicateSupplier;
     this.floatPredicateSupplier = floatPredicateSupplier;
     this.doublePredicateSupplier = doublePredicateSupplier;
+    this.valuesHashCode = valuesHashCode;
   }
 
   @Override
@@ -201,7 +205,8 @@ public class InFilter implements Filter
         floatPredicateSupplier,
         doublePredicateSupplier,
         extractionFn,
-        filterTuning
+        filterTuning,
+        valuesHashCode
     );
   }
 
@@ -225,7 +230,14 @@ public class InFilter implements Filter
 
   private DruidPredicateFactory getPredicateFactory()
   {
-    return new InFilterDruidPredicateFactory(extractionFn, values, longPredicateSupplier, floatPredicateSupplier, doublePredicateSupplier);
+    return new InFilterDruidPredicateFactory(
+        extractionFn,
+        values,
+        longPredicateSupplier,
+        floatPredicateSupplier,
+        doublePredicateSupplier,
+        valuesHashCode
+    );
   }
 
   @Override
@@ -247,7 +259,7 @@ public class InFilter implements Filter
   @Override
   public int hashCode()
   {
-    return Objects.hash(dimension, values, extractionFn, filterTuning);
+    return Objects.hash(dimension, valuesHashCode, extractionFn, filterTuning);
   }
 
   @VisibleForTesting
@@ -258,13 +270,15 @@ public class InFilter implements Filter
     private final Supplier<DruidLongPredicate> longPredicateSupplier;
     private final Supplier<DruidFloatPredicate> floatPredicateSupplier;
     private final Supplier<DruidDoublePredicate> doublePredicateSupplier;
+    private final HashCode valuesHashCode;
 
     InFilterDruidPredicateFactory(
         ExtractionFn extractionFn,
         Set<String> values,
         Supplier<DruidLongPredicate> longPredicateSupplier,
         Supplier<DruidFloatPredicate> floatPredicateSupplier,
-        Supplier<DruidDoublePredicate> doublePredicateSupplier
+        Supplier<DruidDoublePredicate> doublePredicateSupplier,
+        HashCode valuesHashCode
     )
     {
       this.extractionFn = extractionFn;
@@ -272,6 +286,7 @@ public class InFilter implements Filter
       this.longPredicateSupplier = longPredicateSupplier;
       this.floatPredicateSupplier = floatPredicateSupplier;
       this.doublePredicateSupplier = doublePredicateSupplier;
+      this.valuesHashCode = valuesHashCode;
     }
 
     @Override
@@ -330,7 +345,7 @@ public class InFilter implements Filter
     @Override
     public int hashCode()
     {
-      return Objects.hash(extractionFn, values);
+      return Objects.hash(extractionFn, valuesHashCode);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
@@ -53,6 +53,8 @@ public class OrFilter implements BooleanFilter
 
   private final Set<Filter> filters;
 
+  private Integer filtersHashCode;
+
   @VisibleForTesting
   public OrFilter(List<Filter> filters)
   {
@@ -248,6 +250,10 @@ public class OrFilter implements BooleanFilter
   @Override
   public int hashCode()
   {
-    return Objects.hash(getFilters());
+    if (filtersHashCode == null) {
+      filtersHashCode = Objects.hash(getFilters());
+    }
+
+    return filtersHashCode;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
@@ -39,6 +39,7 @@ import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -47,6 +48,7 @@ import java.util.Set;
 
 /**
  */
+@Immutable
 public class OrFilter implements BooleanFilter
 {
   private static final Joiner OR_JOINER = Joiner.on(" || ");
@@ -244,7 +246,7 @@ public class OrFilter implements BooleanFilter
       return false;
     }
     OrFilter orFilter = (OrFilter) o;
-    return Objects.equals(getFilters(), orFilter.getFilters());
+    return Objects.equals(hashCode(), orFilter.hashCode());
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
@@ -22,6 +22,8 @@ package org.apache.druid.segment.filter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.java.util.common.StringUtils;
@@ -55,7 +57,7 @@ public class OrFilter implements BooleanFilter
 
   private final Set<Filter> filters;
 
-  private Integer filtersHashCode;
+  private final Supplier<Integer> filtersHashCode;
 
   @VisibleForTesting
   public OrFilter(List<Filter> filters)
@@ -68,6 +70,7 @@ public class OrFilter implements BooleanFilter
     Preconditions.checkArgument(filters.size() > 0, "Can't construct empty OrFilter (the universe does not exist)");
 
     this.filters = filters;
+    this.filtersHashCode = Suppliers.memoize(() -> Objects.hash(getFilters()));
   }
 
   @Override
@@ -252,10 +255,6 @@ public class OrFilter implements BooleanFilter
   @Override
   public int hashCode()
   {
-    if (filtersHashCode == null) {
-      filtersHashCode = Objects.hash(getFilters());
-    }
-
-    return filtersHashCode;
+    return filtersHashCode.get();
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
@@ -47,7 +47,8 @@ public class HashJoinSegment extends AbstractSegment
    * @param baseSegment           The left-hand side base segment
    * @param clauses               The right-hand side clauses. The caller is responsible for ensuring that there are no
    *                              duplicate prefixes or prefixes that shadow each other across the clauses
-   * @param joinFilterPreAnalysisGroup Pre-analysis computed by {@link org.apache.druid.segment.join.filter.JoinFilterAnalyzer#computeJoinFilterPreAnalysis}
+   * @param joinFilterPreAnalysisGroup Pre-analysis group that holds all of the JoinFilterPreAnalysis results within
+   *                                   the scope of a query
    */
   public HashJoinSegment(
       Segment baseSegment,

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
@@ -24,7 +24,7 @@ import org.apache.druid.segment.AbstractSegment;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.StorageAdapter;
-import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.Interval;
 
@@ -41,23 +41,23 @@ public class HashJoinSegment extends AbstractSegment
 {
   private final Segment baseSegment;
   private final List<JoinableClause> clauses;
-  private final JoinFilterPreAnalysis joinFilterPreAnalysis;
+  private final JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup;
 
   /**
    * @param baseSegment           The left-hand side base segment
    * @param clauses               The right-hand side clauses. The caller is responsible for ensuring that there are no
    *                              duplicate prefixes or prefixes that shadow each other across the clauses
-   * @param joinFilterPreAnalysis Pre-analysis computed by {@link org.apache.druid.segment.join.filter.JoinFilterAnalyzer#computeJoinFilterPreAnalysis}
+   * @param joinFilterPreAnalysisGroup Pre-analysis computed by {@link org.apache.druid.segment.join.filter.JoinFilterAnalyzer#computeJoinFilterPreAnalysis}
    */
   public HashJoinSegment(
       Segment baseSegment,
       List<JoinableClause> clauses,
-      JoinFilterPreAnalysis joinFilterPreAnalysis
+      JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup
   )
   {
     this.baseSegment = baseSegment;
     this.clauses = clauses;
-    this.joinFilterPreAnalysis = joinFilterPreAnalysis;
+    this.joinFilterPreAnalysisGroup = joinFilterPreAnalysisGroup;
 
     // Verify 'clauses' is nonempty (otherwise it's a waste to create this object, and the caller should know)
     if (clauses.isEmpty()) {
@@ -90,7 +90,7 @@ public class HashJoinSegment extends AbstractSegment
   @Override
   public StorageAdapter asStorageAdapter()
   {
-    return new HashJoinSegmentStorageAdapter(baseSegment.asStorageAdapter(), clauses, joinFilterPreAnalysis);
+    return new HashJoinSegmentStorageAdapter(baseSegment.asStorageAdapter(), clauses, joinFilterPreAnalysisGroup);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -21,7 +21,6 @@ package org.apache.druid.segment.join;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
@@ -38,6 +37,8 @@ import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterSplit;
+import org.apache.druid.segment.join.filter.JoinableClauses;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -47,7 +48,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -55,22 +55,22 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
 {
   private final StorageAdapter baseAdapter;
   private final List<JoinableClause> clauses;
-  private final JoinFilterPreAnalysis joinFilterPreAnalysis;
+  private final JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup;
 
   /**
    * @param baseAdapter          A StorageAdapter for the left-hand side base segment
    * @param clauses              The right-hand side clauses. The caller is responsible for ensuring that there are no
-   *                             duplicate prefixes or prefixes that shadow each other across the clauses
+   * @param joinFilterPreAnalysisGroup
    */
   HashJoinSegmentStorageAdapter(
       StorageAdapter baseAdapter,
       List<JoinableClause> clauses,
-      final JoinFilterPreAnalysis joinFilterPreAnalysis
+      final JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup
   )
   {
     this.baseAdapter = baseAdapter;
     this.clauses = clauses;
-    this.joinFilterPreAnalysis = joinFilterPreAnalysis;
+    this.joinFilterPreAnalysisGroup = joinFilterPreAnalysisGroup;
   }
 
   @Override
@@ -209,13 +209,36 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
       @Nullable final QueryMetrics<?> queryMetrics
   )
   {
-    if (!Objects.equals(joinFilterPreAnalysis.getOriginalFilter(), filter)) {
-      throw new ISE(
-          "Filter provided to cursor [%s] does not match join pre-analysis filter [%s]",
+    JoinFilterPreAnalysis jfpa;
+    if (filter == null) {
+      jfpa = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+          joinFilterPreAnalysisGroup,
+          JoinableClauses.fromList(clauses),
+          virtualColumns,
+          null,
+          joinFilterPreAnalysisGroup.isEnableFilterPushDown(),
+          joinFilterPreAnalysisGroup.isEnableFilterRewrite(),
+          joinFilterPreAnalysisGroup.isEnableRewriteValueColumnFilters(),
+          joinFilterPreAnalysisGroup.getFilterRewriteMaxSize()
+      );
+    } else {
+      jfpa = joinFilterPreAnalysisGroup.getAnalyses().computeIfAbsent(
           filter,
-          joinFilterPreAnalysis.getOriginalFilter()
+          (theFilter) -> {
+            return JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
+                joinFilterPreAnalysisGroup,
+                JoinableClauses.fromList(clauses),
+                virtualColumns,
+                theFilter,
+                joinFilterPreAnalysisGroup.isEnableFilterPushDown(),
+                joinFilterPreAnalysisGroup.isEnableFilterRewrite(),
+                joinFilterPreAnalysisGroup.isEnableRewriteValueColumnFilters(),
+                joinFilterPreAnalysisGroup.getFilterRewriteMaxSize()
+            );
+          }
       );
     }
+
     final List<VirtualColumn> preJoinVirtualColumns = new ArrayList<>();
     final List<VirtualColumn> postJoinVirtualColumns = new ArrayList<>();
 
@@ -225,7 +248,7 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
         postJoinVirtualColumns
     );
 
-    JoinFilterSplit joinFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    JoinFilterSplit joinFilterSplit = JoinFilterAnalyzer.splitFilter(jfpa);
     preJoinVirtualColumns.addAll(joinFilterSplit.getPushDownVirtualColumns());
 
     // Soon, we will need a way to push filters past a join when possible. This could potentially be done right here

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -37,7 +37,6 @@ import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterSplit;
-import org.apache.druid.segment.join.filter.JoinableClauses;
 import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -210,32 +209,13 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
   )
   {
     JoinFilterPreAnalysis jfpa;
-    if (filter == null) {
-      jfpa = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-          joinFilterPreAnalysisGroup,
-          JoinableClauses.fromList(clauses),
-          virtualColumns,
-          null,
-          joinFilterPreAnalysisGroup.isEnableFilterPushDown(),
-          joinFilterPreAnalysisGroup.isEnableFilterRewrite(),
-          joinFilterPreAnalysisGroup.isEnableRewriteValueColumnFilters(),
-          joinFilterPreAnalysisGroup.getFilterRewriteMaxSize()
-      );
+    if (joinFilterPreAnalysisGroup.getJoinFilterRewriteConfig().isOldRewriteMode()) {
+      jfpa = joinFilterPreAnalysisGroup.getPreAnalysisForOldRewriteMode();
     } else {
-      jfpa = joinFilterPreAnalysisGroup.getAnalyses().computeIfAbsent(
+      jfpa = joinFilterPreAnalysisGroup.computeJoinFilterPreAnalysisIfAbsent(
           filter,
-          (theFilter) -> {
-            return JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-                joinFilterPreAnalysisGroup,
-                JoinableClauses.fromList(clauses),
-                virtualColumns,
-                theFilter,
-                joinFilterPreAnalysisGroup.isEnableFilterPushDown(),
-                joinFilterPreAnalysisGroup.isEnableFilterRewrite(),
-                joinFilterPreAnalysisGroup.isEnableRewriteValueColumnFilters(),
-                joinFilterPreAnalysisGroup.getFilterRewriteMaxSize()
-            );
-          }
+          clauses,
+          virtualColumns
       );
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -60,8 +60,8 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
   /**
    * @param baseAdapter          A StorageAdapter for the left-hand side base segment
    * @param clauses              The right-hand side clauses. The caller is responsible for ensuring that there are no
-   * @param joinFilterPreAnalysisGroup
-   */
+   * @param joinFilterPreAnalysisGroup Pre-analysis group that holds all of the JoinFilterPreAnalysis results within
+   *                                   the scope of a query   */
   HashJoinSegmentStorageAdapter(
       StorageAdapter baseAdapter,
       List<JoinableClause> clauses,

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
@@ -70,22 +70,19 @@ public class Joinables
   /**
    * Creates a Function that maps base segments to {@link HashJoinSegment} if needed (i.e. if the number of join
    * clauses is > 0). If mapping is not needed, this method will return {@link Function#identity()}.
-   *
    * @param clauses              pre-joinable clauses
    * @param joinableFactory      factory for joinables
    * @param cpuTimeAccumulator   an accumulator that we will add CPU nanos to; this is part of the function to encourage
-   *                             callers to remember to track metrics on CPU time required for creation of Joinables
+ *                             callers to remember to track metrics on CPU time required for creation of Joinables
    * @param enableFilterPushDown whether to enable filter push down optimizations to the base segment. In production
-   *                             this should generally be {@code QueryContexts.getEnableJoinFilterPushDown(query)}.
+*                             this should generally be {@code QueryContexts.getEnableJoinFilterPushDown(query)}.
    * @param enableFilterRewrite whether to enable filter rewrite optimizations for RHS columns. In production
-   *                             this should generally be {@code QueryContexts.getEnableJoinFilterRewrite(query)}.
+*                             this should generally be {@code QueryContexts.getEnableJoinFilterRewrite(query)}.
    * @param enableRewriteValueColumnFilters whether to enable filter rewrite optimizations for RHS columns that are not
-   *                                        key columns. In production this should generally
-   *                                        be {@code QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(query)}.
+*                                        key columns. In production this should generally
+*                                        be {@code QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(query)}.
    * @param filterRewriteMaxSize the max allowed size of correlated value sets for RHS rewrites. In production
-   *                             this should generally be {@code QueryContexts.getJoinFilterRewriteMaxSize(query)}.
-   * @param originalFilter The original filter from the query.
-   * @param virtualColumns The virtual columns from the query.
+*                             this should generally be {@code QueryContexts.getJoinFilterRewriteMaxSize(query)}.
    */
   public static Function<Segment, Segment> createSegmentMapFn(
       final List<PreJoinableClause> clauses,
@@ -94,9 +91,7 @@ public class Joinables
       final boolean enableFilterPushDown,
       final boolean enableFilterRewrite,
       final boolean enableRewriteValueColumnFilters,
-      final long filterRewriteMaxSize,
-      final Filter originalFilter,
-      final VirtualColumns virtualColumns
+      final long filterRewriteMaxSize
   )
   {
     // compute column correlations here and RHS correlated values

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
@@ -20,10 +20,8 @@
 package org.apache.druid.segment.join;
 
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.planning.PreJoinableClause;
 import org.apache.druid.segment.Segment;
-import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.join.filter.JoinableClauses;
 import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinables.java
@@ -25,9 +25,8 @@ import org.apache.druid.query.planning.PreJoinableClause;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnHolder;
-import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
-import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinableClauses;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.utils.JvmUtils;
 
 import javax.annotation.Nullable;
@@ -108,16 +107,14 @@ public class Joinables
             return Function.identity();
           } else {
             final JoinableClauses joinableClauses = JoinableClauses.createClauses(clauses, joinableFactory);
-            JoinFilterPreAnalysis jfpa = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-                joinableClauses,
-                virtualColumns,
-                originalFilter,
+            final JoinFilterPreAnalysisGroup jfpag = new JoinFilterPreAnalysisGroup(
                 enableFilterPushDown,
                 enableFilterRewrite,
                 enableRewriteValueColumnFilters,
                 filterRewriteMaxSize
             );
-            return baseSegment -> new HashJoinSegment(baseSegment, joinableClauses.getJoinableClauses(), jfpa);
+
+            return baseSegment -> new HashJoinSegment(baseSegment, joinableClauses.getJoinableClauses(), jfpag);
           }
         }
     );

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
@@ -32,7 +32,7 @@ import org.apache.druid.segment.filter.FalseFilter;
 import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.filter.OrFilter;
 import org.apache.druid.segment.filter.SelectorFilter;
-import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 
 import java.util.ArrayList;
@@ -83,29 +83,17 @@ public class JoinFilterAnalyzer
    * 
    * See {@link JoinFilterPreAnalysis} for details on the result of this pre-analysis step.
    *
-   * @param joinFilterPreAnalysisGroup      The query-scoped pre analysis group, used to hold pre-analysis results
-   *                                        on a per-filter basis
    * @param joinableClauses                 The joinable clauses from the query
    * @param virtualColumns                  The virtual columns from the query
    * @param originalFilter                  The original filter from the query
-   * @param enableFilterPushDown            Whether to enable filter push down
-   * @param enableFilterRewrite             Whether to enable rewrites of filters involving RHS columns
-   * @param enableRewriteValueColumnFilters Whether to enable rewrites of filters invovling RHS non-key columns
-   * @param filterRewriteMaxSize            The maximum size of the correlated value set for rewritten filters.
-   *                                        If the correlated value set size exceeds this, the filter will not be
-   *                                        rewritten and pushed down.
-   *
+   * @param joinFilterRewriteConfig         Configuration options for the join rewrites
    * @return A JoinFilterPreAnalysis containing information determined in this pre-analysis step.
    */
   public static JoinFilterPreAnalysis computeJoinFilterPreAnalysis(
-      JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup,
       JoinableClauses joinableClauses,
       VirtualColumns virtualColumns,
       Filter originalFilter,
-      boolean enableFilterPushDown,
-      boolean enableFilterRewrite,
-      boolean enableRewriteValueColumnFilters,
-      long filterRewriteMaxSize
+      JoinFilterRewriteConfig joinFilterRewriteConfig
   )
   {
     final List<VirtualColumn> preJoinVirtualColumns = new ArrayList<>();
@@ -113,8 +101,8 @@ public class JoinFilterAnalyzer
 
     joinableClauses.splitVirtualColumns(virtualColumns, preJoinVirtualColumns, postJoinVirtualColumns);
     JoinFilterPreAnalysis.Builder preAnalysisBuilder =
-        new JoinFilterPreAnalysis.Builder(joinFilterPreAnalysisGroup, joinableClauses, originalFilter, postJoinVirtualColumns);
-    if (originalFilter == null || !enableFilterPushDown) {
+        new JoinFilterPreAnalysis.Builder(joinFilterRewriteConfig, joinableClauses, originalFilter, postJoinVirtualColumns);
+    if (originalFilter == null || !joinFilterRewriteConfig.isEnableFilterPushDown()) {
       return preAnalysisBuilder.build();
     }
 
@@ -137,7 +125,7 @@ public class JoinFilterAnalyzer
     preAnalysisBuilder
         .withNormalizedBaseTableClauses(normalizedBaseTableClauses)
         .withNormalizedJoinTableClauses(normalizedJoinTableClauses);
-    if (!enableFilterRewrite) {
+    if (!joinFilterRewriteConfig.isEnableFilterRewrite()) {
       return preAnalysisBuilder.build();
     }
 
@@ -148,8 +136,8 @@ public class JoinFilterAnalyzer
         normalizedJoinTableClauses,
         equiconditions,
         joinableClauses,
-        enableRewriteValueColumnFilters,
-        filterRewriteMaxSize
+        joinFilterRewriteConfig.isEnableRewriteValueColumnFilters(),
+        joinFilterRewriteConfig.getFilterRewriteMaxSize()
     );
 
     return preAnalysisBuilder.withCorrelations(correlations)

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
@@ -32,6 +32,7 @@ import org.apache.druid.segment.filter.FalseFilter;
 import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.filter.OrFilter;
 import org.apache.druid.segment.filter.SelectorFilter;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 
 import java.util.ArrayList;
@@ -95,6 +96,7 @@ public class JoinFilterAnalyzer
    * @return A JoinFilterPreAnalysis containing information determined in this pre-analysis step.
    */
   public static JoinFilterPreAnalysis computeJoinFilterPreAnalysis(
+      JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup,
       JoinableClauses joinableClauses,
       VirtualColumns virtualColumns,
       Filter originalFilter,
@@ -109,9 +111,7 @@ public class JoinFilterAnalyzer
 
     joinableClauses.splitVirtualColumns(virtualColumns, preJoinVirtualColumns, postJoinVirtualColumns);
     JoinFilterPreAnalysis.Builder preAnalysisBuilder =
-        new JoinFilterPreAnalysis.Builder(joinableClauses, originalFilter, postJoinVirtualColumns)
-            .withEnableFilterPushDown(enableFilterPushDown)
-            .withEnableFilterRewrite(enableFilterRewrite);
+        new JoinFilterPreAnalysis.Builder(joinFilterPreAnalysisGroup, joinableClauses, originalFilter, postJoinVirtualColumns);
     if (originalFilter == null || !enableFilterPushDown) {
       return preAnalysisBuilder.build();
     }

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
@@ -83,6 +83,8 @@ public class JoinFilterAnalyzer
    * 
    * See {@link JoinFilterPreAnalysis} for details on the result of this pre-analysis step.
    *
+   * @param joinFilterPreAnalysisGroup      The query-scoped pre analysis group, used to hold pre-analysis results
+   *                                        on a per-filter basis
    * @param joinableClauses                 The joinable clauses from the query
    * @param virtualColumns                  The virtual columns from the query
    * @param originalFilter                  The original filter from the query

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
@@ -39,11 +39,11 @@ import java.util.Set;
  * A JoinFilterPreAnalysis contains filter push down/rewrite information that does not have per-segment dependencies.
  * This includes:
  * - The query's JoinableClauses list
- * - The query's original filter (if any)
+ * - The original filter that an analysis was performed ons
  * - A list of filter clauses from the original filter's CNF representation that only reference the base table
  * - A list of filter clauses from the original filter's CNF representation that reference RHS join tables
  * - A list of virtual columns that can only be computed post-join
- * - Control flag booleans for whether filter push down and RHS rewrites are enabled.
+ * - The JoinFilterPreAnalysisGroup that this pre-analysis is associated with.
  */
 public class JoinFilterPreAnalysis
 {
@@ -120,16 +120,6 @@ public class JoinFilterPreAnalysis
   public boolean isEnableFilterRewrite()
   {
     return myGroup.isEnableFilterRewrite();
-  }
-
-  public boolean isEnableRewriteValueColumnFilters()
-  {
-    return myGroup.isEnableRewriteValueColumnFilters();
-  }
-
-  public long getFilterRewriteMaxSize()
-  {
-    return myGroup.getFilterRewriteMaxSize();
   }
 
   public Equiconditions getEquiconditions()

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterPreAnalysis.java
@@ -24,7 +24,7 @@ import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.join.Equality;
 import org.apache.druid.segment.join.JoinableClause;
-import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,7 +43,7 @@ import java.util.Set;
  * - A list of filter clauses from the original filter's CNF representation that only reference the base table
  * - A list of filter clauses from the original filter's CNF representation that reference RHS join tables
  * - A list of virtual columns that can only be computed post-join
- * - The JoinFilterPreAnalysisGroup that this pre-analysis is associated with.
+ * - The JoinFilterRewriteConfig that this pre-analysis is associated with.
  */
 public class JoinFilterPreAnalysis
 {
@@ -52,9 +52,9 @@ public class JoinFilterPreAnalysis
   private final List<Filter> normalizedBaseTableClauses;
   private final List<Filter> normalizedJoinTableClauses;
   private final JoinFilterCorrelations correlations;
-  private final JoinFilterPreAnalysisGroup myGroup;
   private final List<VirtualColumn> postJoinVirtualColumns;
   private final Equiconditions equiconditions;
+  private final JoinFilterRewriteConfig rewriteConfig;
 
   private JoinFilterPreAnalysis(
       final JoinableClauses joinableClauses,
@@ -63,8 +63,8 @@ public class JoinFilterPreAnalysis
       final List<Filter> normalizedBaseTableClauses,
       final List<Filter> normalizedJoinTableClauses,
       JoinFilterCorrelations correlations,
-      final JoinFilterPreAnalysisGroup myGroup,
-      final Equiconditions equiconditions
+      final Equiconditions equiconditions,
+      final JoinFilterRewriteConfig rewriteConfig
   )
   {
     this.joinableClauses = joinableClauses;
@@ -73,7 +73,7 @@ public class JoinFilterPreAnalysis
     this.normalizedBaseTableClauses = normalizedBaseTableClauses;
     this.normalizedJoinTableClauses = normalizedJoinTableClauses;
     this.correlations = correlations;
-    this.myGroup = myGroup;
+    this.rewriteConfig = rewriteConfig;
     this.equiconditions = equiconditions;
   }
 
@@ -114,12 +114,12 @@ public class JoinFilterPreAnalysis
 
   public boolean isEnableFilterPushDown()
   {
-    return myGroup.isEnableFilterPushDown();
+    return rewriteConfig.isEnableFilterPushDown();
   }
 
   public boolean isEnableFilterRewrite()
   {
-    return myGroup.isEnableFilterRewrite();
+    return rewriteConfig.isEnableFilterRewrite();
   }
 
   public Equiconditions getEquiconditions()
@@ -132,7 +132,7 @@ public class JoinFilterPreAnalysis
    */
   public static class Builder
   {
-    @Nonnull private final JoinFilterPreAnalysisGroup group;
+    @Nonnull private final JoinFilterRewriteConfig rewriteConfig;
     @Nonnull private final JoinableClauses joinableClauses;
     @Nullable private final Filter originalFilter;
     @Nullable private List<Filter> normalizedBaseTableClauses;
@@ -142,13 +142,13 @@ public class JoinFilterPreAnalysis
     @Nonnull private Equiconditions equiconditions = new Equiconditions(Collections.emptyMap());
 
     public Builder(
-        @Nonnull JoinFilterPreAnalysisGroup group,
+        @Nonnull JoinFilterRewriteConfig rewriteConfig,
         @Nonnull JoinableClauses joinableClauses,
         @Nullable Filter originalFilter,
         @Nonnull List<VirtualColumn> postJoinVirtualColumns
     )
     {
-      this.group = group;
+      this.rewriteConfig = rewriteConfig;
       this.joinableClauses = joinableClauses;
       this.originalFilter = originalFilter;
       this.postJoinVirtualColumns = postJoinVirtualColumns;
@@ -199,8 +199,8 @@ public class JoinFilterPreAnalysis
           normalizedBaseTableClauses,
           normalizedJoinTableClauses,
           correlations,
-          group,
-          equiconditions
+          equiconditions,
+          rewriteConfig
       );
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
@@ -24,6 +24,15 @@ import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * A JoinFilterPreAnalysisGroup holds all of the JoinFilterPreAnalysis objects for a given query and
+ * also stores the per-query parameters that control the filter rewrite operations (from the query context).
+ *
+ * The analyses map is keyed by Filter: each Filter in the map belongs to separate level of query
+ * (e.g. outer query, subquery level 1, etc.)
+ *
+ * A concurrent hash map is used since the per-level Filter processing occurs across multiple threads.
+ */
 public class JoinFilterPreAnalysisGroup
 {
   private final boolean enableFilterPushDown;

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
@@ -77,15 +77,6 @@ public class JoinFilterPreAnalysisGroup
       VirtualColumns virtualColumns
   )
   {
-    // Some filters have potentially expensive hash codes that are lazily computed and cached.
-    // We call hashCode() here in a synchronized block before we attempt to use the Filter in the analyses map,
-    // to ensure that the hashCode is only computed once per Filter since the Filter interface is not thread-safe.
-    synchronized (analyses) {
-      if (filter != null) {
-        filter.hashCode();
-      }
-    }
-
     JoinFilterPreAnalysisGroupKey key = new JoinFilterPreAnalysisGroupKey(filter, clauses, virtualColumns);
     return analyses.computeIfAbsent(
         key,

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.join.filter.rewrite;
+
+import org.apache.druid.query.filter.Filter;
+import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class JoinFilterPreAnalysisGroup
+{
+  private final boolean enableFilterPushDown;
+  private final boolean enableFilterRewrite;
+  private final boolean enableRewriteValueColumnFilters;
+  private final long filterRewriteMaxSize;
+  private final ConcurrentHashMap<Filter, JoinFilterPreAnalysis> analyses;
+
+  public JoinFilterPreAnalysisGroup(
+      boolean enableFilterPushDown,
+      boolean enableFilterRewrite,
+      boolean enableRewriteValueColumnFilters,
+      long filterRewriteMaxSize
+  )
+  {
+    this.enableFilterPushDown = enableFilterPushDown;
+    this.enableFilterRewrite = enableFilterRewrite;
+    this.enableRewriteValueColumnFilters = enableRewriteValueColumnFilters;
+    this.filterRewriteMaxSize = filterRewriteMaxSize;
+    this.analyses = new ConcurrentHashMap<>();
+  }
+
+  public boolean isEnableFilterPushDown()
+  {
+    return enableFilterPushDown;
+  }
+
+  public boolean isEnableFilterRewrite()
+  {
+    return enableFilterRewrite;
+  }
+
+  public boolean isEnableRewriteValueColumnFilters()
+  {
+    return enableRewriteValueColumnFilters;
+  }
+
+  public long getFilterRewriteMaxSize()
+  {
+    return filterRewriteMaxSize;
+  }
+
+  public ConcurrentHashMap<Filter, JoinFilterPreAnalysis> getAnalyses()
+  {
+    return analyses;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
@@ -87,7 +87,6 @@ public class JoinFilterPreAnalysisGroup
     }
 
     JoinFilterPreAnalysisGroupKey key = new JoinFilterPreAnalysisGroupKey(filter, clauses, virtualColumns);
-
     return analyses.computeIfAbsent(
         key,
         (groupKey) -> {

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterPreAnalysisGroup.java
@@ -146,21 +146,6 @@ public class JoinFilterPreAnalysisGroup
       this.virtualColumns = virtualColumns;
     }
 
-    public Filter getFilter()
-    {
-      return filter;
-    }
-
-    public List<JoinableClause> getClauses()
-    {
-      return clauses;
-    }
-
-    public VirtualColumns getVirtualColumns()
-    {
-      return virtualColumns;
-    }
-
     @Override
     public boolean equals(Object o)
     {

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterRewriteConfig.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterRewriteConfig.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.join.filter.rewrite;
+
+/**
+ * A config class that holds properties that control how join filter rewrites behave.
+ */
+public class JoinFilterRewriteConfig
+{
+  /**
+   * Whether to enable filter push down optimizations to the base segment.
+   * In production this should generally be {@code QueryContexts.getEnableJoinFilterPushDown(query)}.
+   */
+  private final boolean enableFilterPushDown;
+
+  /**
+   * Whether to enable filter rewrite optimizations for RHS columns.
+   * In production this should generally be {@code QueryContexts.getEnableJoinFilterRewrite(query)}.
+   */
+  private final boolean enableFilterRewrite;
+
+  /**
+   * Whether to enable filter rewrite optimizations for RHS columns that are not key columns.
+   * In production this should generally be {@code QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(query)}.
+   */
+  private final boolean enableRewriteValueColumnFilters;
+
+  /**
+   * The max allowed size of correlated value sets for RHS rewrites. In production
+   * This should generally be {@code QueryContexts.getJoinFilterRewriteMaxSize(query)}.
+   */
+  private final long filterRewriteMaxSize;
+
+  /**
+   * This is an undocumented option provided as a transition tool:
+   *
+   * The join filter rewrites originally performed the pre-analysis phase prior to any per-segment processing,
+   * analyzing only the filter in the top-level of the query.
+   *
+   * This did not work for nested queries (see https://github.com/apache/druid/pull/9978), so the rewrite pre-analysis
+   * was moved into the cursor creation of the {@link org.apache.druid.segment.join.HashJoinSegmentStorageAdapter}.
+   * This design requires synchronization across multiple segment processing threads; the old rewrite mode
+   * is kept temporarily available in case issues arise with the new mode, and the user does not run queries with the
+   * affected nested shape.
+   */
+  private final boolean oldRewriteMode;
+
+
+  public JoinFilterRewriteConfig(
+      boolean enableFilterPushDown,
+      boolean enableFilterRewrite,
+      boolean enableRewriteValueColumnFilters,
+      long filterRewriteMaxSize,
+      boolean oldRewriteMode
+  )
+  {
+    this.enableFilterPushDown = enableFilterPushDown;
+    this.enableFilterRewrite = enableFilterRewrite;
+    this.enableRewriteValueColumnFilters = enableRewriteValueColumnFilters;
+    this.filterRewriteMaxSize = filterRewriteMaxSize;
+    this.oldRewriteMode = oldRewriteMode;
+  }
+
+  public boolean isEnableFilterPushDown()
+  {
+    return enableFilterPushDown;
+  }
+
+  public boolean isEnableFilterRewrite()
+  {
+    return enableFilterRewrite;
+  }
+
+  public boolean isEnableRewriteValueColumnFilters()
+  {
+    return enableRewriteValueColumnFilters;
+  }
+
+  public long getFilterRewriteMaxSize()
+  {
+    return filterRewriteMaxSize;
+  }
+
+  public boolean isOldRewriteMode()
+  {
+    return oldRewriteMode;
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.extraction.RegexDimExtractionFn;
@@ -144,4 +145,15 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final InDimFilter filter = new InDimFilter("dim", Collections.singleton("v1"), null);
     Assert.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize());
   }
+
+  @Test
+  public void test_equals()
+  {
+    EqualsVerifier.forClass(InDimFilter.class)
+                  .usingGetClass()
+                  .withNonnullFields("dimension", "values")
+                  .withIgnoredFields("values", "cacheKey", "longPredicateSupplier", "floatPredicateSupplier", "doublePredicateSupplier")
+                  .verify();
+  }
+
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -20,6 +20,8 @@
 package org.apache.druid.query.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -151,9 +153,9 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     EqualsVerifier.forClass(InDimFilter.class)
                   .usingGetClass()
-                  .withNonnullFields("dimension", "values")
+                  .withNonnullFields("dimension", "values", "valuesHashCode")
                   .withIgnoredFields("values", "cacheKey", "longPredicateSupplier", "floatPredicateSupplier", "doublePredicateSupplier")
+                  .withPrefabValues(Supplier.class, Suppliers.ofInstance(1), Suppliers.ofInstance(2))
                   .verify();
   }
-
 }

--- a/processing/src/test/java/org/apache/druid/segment/filter/AndFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/AndFilterTest.java
@@ -180,6 +180,10 @@ public class AndFilterTest extends BaseFilterTest
   @Test
   public void test_equals()
   {
-    EqualsVerifier.forClass(AndFilter.class).usingGetClass().withNonnullFields("filters").verify();
+    EqualsVerifier.forClass(AndFilter.class)
+                  .usingGetClass()
+                  .withNonnullFields("filters")
+                  .withIgnoredFields("filters")
+                  .verify();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/filter/AndFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/AndFilterTest.java
@@ -20,6 +20,8 @@
 package org.apache.druid.segment.filter;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -182,8 +184,13 @@ public class AndFilterTest extends BaseFilterTest
   {
     EqualsVerifier.forClass(AndFilter.class)
                   .usingGetClass()
-                  .withNonnullFields("filters")
+                  .withNonnullFields("filters", "filtersHashCode")
                   .withIgnoredFields("filters")
+                  .withPrefabValues(
+                      Supplier.class,
+                      Suppliers.ofInstance(1),
+                      Suppliers.ofInstance(2)
+                  )
                   .verify();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
@@ -384,7 +384,7 @@ public class InFilterTest extends BaseFilterTest
     EqualsVerifier.forClass(InFilter.class)
                   .usingGetClass()
                   .withNonnullFields("dimension", "values")
-                  .withIgnoredFields("longPredicateSupplier", "floatPredicateSupplier", "doublePredicateSupplier")
+                  .withIgnoredFields("values", "longPredicateSupplier", "floatPredicateSupplier", "doublePredicateSupplier")
                   .verify();
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
@@ -20,6 +20,8 @@
 package org.apache.druid.segment.filter;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -383,8 +385,9 @@ public class InFilterTest extends BaseFilterTest
   {
     EqualsVerifier.forClass(InFilter.class)
                   .usingGetClass()
-                  .withNonnullFields("dimension", "values")
+                  .withNonnullFields("dimension", "values", "valuesHashCode")
                   .withIgnoredFields("values", "longPredicateSupplier", "floatPredicateSupplier", "doublePredicateSupplier")
+                  .withPrefabValues(Supplier.class, Suppliers.ofInstance(1), Suppliers.ofInstance(2))
                   .verify();
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
@@ -19,14 +19,26 @@
 
 package org.apache.druid.segment.filter;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Test;
 
-public class OrFilterTest
+public class OrFilterTest extends InitializedNullHandlingTest
 {
   @Test
   public void test_equals()
   {
-    EqualsVerifier.forClass(OrFilter.class).usingGetClass().withNonnullFields("filters").verify();
+    EqualsVerifier.forClass(OrFilter.class)
+                  .usingGetClass()
+                  .withNonnullFields("filters", "filtersHashCode")
+                  .withIgnoredFields("filters")
+                  .withPrefabValues(
+                      Supplier.class,
+                      Suppliers.ofInstance(1),
+                      Suppliers.ofInstance(2)
+                      )
+                  .verify();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.lookup.LookupExtractor;
 import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
@@ -44,6 +45,14 @@ import java.io.IOException;
 
 public class BaseHashJoinSegmentStorageAdapterTest
 {
+  public static JoinFilterRewriteConfig DEFAULT_JOIN_FILTER_REWRITE_CONFIG = new JoinFilterRewriteConfig(
+      true,
+      true,
+      true,
+      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
+      false
+  );
+
   public static final String FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX = "c1.";
   public static final String FACT_TO_COUNTRY_ON_NUMBER_PREFIX = "c2.";
   public static final String FACT_TO_REGION_PREFIX = "r1.";
@@ -184,12 +193,7 @@ public class BaseHashJoinSegmentStorageAdapterTest
 
   protected HashJoinSegmentStorageAdapter makeFactToCountrySegment()
   {
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     return new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -214,6 +218,13 @@ public class BaseHashJoinSegmentStorageAdapterTest
     Assert.assertEquals(
         expectedVirtualColumn.getParsedExpression().get().toString(),
         actualVirtualColumn.getParsedExpression().get().toString()
+    );
+  }
+
+  protected static JoinFilterPreAnalysisGroup makeDefaultConfigPreAnalysisGroup()
+  {
+    return new JoinFilterPreAnalysisGroup(
+        DEFAULT_JOIN_FILTER_REWRITE_CONFIG
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
@@ -26,10 +26,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.lookup.LookupExtractor;
 import org.apache.druid.segment.QueryableIndexSegment;
-import org.apache.druid.segment.VirtualColumns;
-import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
-import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
-import org.apache.druid.segment.join.filter.JoinableClauses;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
@@ -187,10 +184,7 @@ public class BaseHashJoinSegmentStorageAdapterTest
 
   protected HashJoinSegmentStorageAdapter makeFactToCountrySegment()
   {
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT))),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -200,7 +194,7 @@ public class BaseHashJoinSegmentStorageAdapterTest
     return new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT)),
-        preAnalysis
+        joinFilterPreAnalysisGroup
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -2067,7 +2067,6 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     );
   }
 
-  /*
   @Test
   public void test_makeCursors_originalFilterDoesNotMatchPreAnalysis_shouldThrowISE()
   {
@@ -2081,24 +2080,27 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     );
     Filter filter = new SelectorFilter("page", "this matches nothing");
 
+    new HashJoinSegmentStorageAdapter(
+        factSegment.asStorageAdapter(),
+        joinableClauses,
+        joinFilterPreAnalysisGroup
+    ).makeCursors(
+        filter,
+        Intervals.ETERNITY,
+        VirtualColumns.EMPTY,
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    /*
     try {
-      new HashJoinSegmentStorageAdapter(
-          factSegment.asStorageAdapter(),
-          joinableClauses,
-          joinFilterPreAnalysisGroup
-      ).makeCursors(
-          filter,
-          Intervals.ETERNITY,
-          VirtualColumns.EMPTY,
-          Granularities.ALL,
-          false,
-          null
-      );
+
       Assert.fail();
     }
     catch (ISE e) {
       Assert.assertTrue(e.getMessage().startsWith("Filter provided to cursor ["));
     }
+    */
   }
-  */
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -37,9 +36,7 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.filter.SelectorFilter;
-import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
-import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
-import org.apache.druid.segment.join.filter.JoinableClauses;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
@@ -302,10 +299,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -316,7 +310,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -371,10 +365,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -385,7 +376,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -438,10 +429,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_makeCursors_factToCountryInner()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.INNER));
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -452,7 +440,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -500,10 +488,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_makeCursors_factToCountryInnerUsingLookup()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.INNER));
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -514,7 +499,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -564,10 +549,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     // is interpreted as 0 (a.k.a. Australia).
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnNumber(JoinType.INNER));
     Filter filter = new SelectorDimFilter("channel", "#en.wikipedia", null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -578,7 +560,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -634,10 +616,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     // is interpreted as 0 (a.k.a. Australia).
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingNumberLookup(JoinType.INNER));
     Filter filter = new SelectorDimFilter("channel", "#en.wikipedia", null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -648,7 +627,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -700,10 +679,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -714,7 +690,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -741,10 +717,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -755,7 +728,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -781,10 +754,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.RIGHT));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -795,7 +765,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -824,10 +794,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.RIGHT));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -838,7 +805,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -866,10 +833,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.FULL));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -880,7 +844,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -909,10 +873,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.FULL));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -923,7 +884,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -956,10 +917,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         null
     ).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -970,7 +928,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1003,10 +961,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         null
     ).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1017,7 +972,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1050,10 +1005,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new SelectorDimFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryNumber", "10", null)
     ).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1064,7 +1016,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1097,10 +1049,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new SelectorDimFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "Norway", null)
     ).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1111,7 +1060,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1157,10 +1106,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         ExprMacroTable.nil()
     ).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1171,7 +1117,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1239,10 +1185,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         ExprMacroTable.nil()
     ).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1253,7 +1196,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1304,10 +1247,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1318,7 +1258,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -1383,10 +1323,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     );
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1396,7 +1333,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1450,10 +1387,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1464,7 +1398,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1501,10 +1435,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1515,7 +1446,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1569,10 +1500,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1583,7 +1511,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1629,10 +1557,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        virtualColumns,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1643,7 +1568,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -1695,10 +1620,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        virtualColumns,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1709,7 +1631,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -1753,10 +1675,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1767,7 +1686,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -1810,10 +1729,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1824,7 +1740,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -1870,10 +1786,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Filter filter = new SelectorDimFilter("regionIsoCode", "VA", null).toFilter();
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        filter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1884,7 +1797,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             filter,
             Intervals.ETERNITY,
@@ -1930,10 +1843,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1944,7 +1854,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -1976,10 +1886,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -1990,7 +1897,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -2022,10 +1929,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -2036,7 +1940,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -2067,10 +1971,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -2081,7 +1982,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             null,
             Intervals.ETERNITY,
@@ -2100,10 +2001,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     Filter originalFilter = new SelectorFilter("page", "this matches nothing");
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        originalFilter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -2114,7 +2012,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             originalFilter,
             Intervals.ETERNITY,
@@ -2139,10 +2037,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     Filter originalFilter = new SelectorFilter("page", "this matches nothing");
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        originalFilter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -2153,7 +2048,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
             joinableClauses,
-            preAnalysis
+            joinFilterPreAnalysisGroup
         ).makeCursors(
             originalFilter,
             Intervals.ETERNITY,
@@ -2172,15 +2067,13 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     );
   }
 
+  /*
   @Test
   public void test_makeCursors_originalFilterDoesNotMatchPreAnalysis_shouldThrowISE()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
 
-    JoinFilterPreAnalysis preAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -2192,7 +2085,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
       new HashJoinSegmentStorageAdapter(
           factSegment.asStorageAdapter(),
           joinableClauses,
-          preAnalysis
+          joinFilterPreAnalysisGroup
       ).makeCursors(
           filter,
           Intervals.ETERNITY,
@@ -2207,4 +2100,5 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
       Assert.assertTrue(e.getMessage().startsWith("Filter provided to cursor ["));
     }
   }
+  */
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -27,7 +27,6 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.math.expr.ExprMacroTable;
-import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.filter.ExpressionDimFilter;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.OrDimFilter;
@@ -299,12 +298,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -365,12 +359,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -429,12 +418,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_makeCursors_factToCountryInner()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.INNER));
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -488,12 +472,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   public void test_makeCursors_factToCountryInnerUsingLookup()
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.INNER));
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -549,12 +528,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     // is interpreted as 0 (a.k.a. Australia).
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnNumber(JoinType.INNER));
     Filter filter = new SelectorDimFilter("channel", "#en.wikipedia", null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -616,12 +590,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     // is interpreted as 0 (a.k.a. Australia).
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingNumberLookup(JoinType.INNER));
     Filter filter = new SelectorDimFilter("channel", "#en.wikipedia", null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -679,12 +648,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -717,12 +681,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -754,12 +713,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.RIGHT));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -794,12 +748,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.RIGHT));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -833,12 +782,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.FULL));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -873,12 +817,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.FULL));
     Filter filter = new SelectorDimFilter("channel", null, null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -917,12 +856,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         null
     ).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -961,12 +895,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         null
     ).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1005,12 +934,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new SelectorDimFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryNumber", "10", null)
     ).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1049,12 +973,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         new SelectorDimFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "Norway", null)
     ).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1106,12 +1025,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         ExprMacroTable.nil()
     ).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1184,13 +1098,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         StringUtils.format("\"%sk\" == countryIsoCode", FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX),
         ExprMacroTable.nil()
     ).toFilter();
-
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1246,13 +1154,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         factToRegion(JoinType.LEFT),
         regionToCountry(JoinType.LEFT)
     );
-
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1323,12 +1225,8 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     );
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
+
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
@@ -1387,12 +1285,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1435,12 +1328,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1500,12 +1388,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Filter filter = new SelectorDimFilter("channel", "#de.wikipedia", null).toFilter();
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1557,12 +1440,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1620,12 +1498,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1675,12 +1548,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1729,12 +1597,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1785,13 +1648,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     );
 
     Filter filter = new SelectorDimFilter("regionIsoCode", "VA", null).toFilter();
-
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1843,12 +1700,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.readCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1886,12 +1738,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.readCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1929,12 +1776,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.readCursors(
         new HashJoinSegmentStorageAdapter(
@@ -1971,12 +1813,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.readCursors(
         new HashJoinSegmentStorageAdapter(
@@ -2001,12 +1838,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     Filter originalFilter = new SelectorFilter("page", "this matches nothing");
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -2037,12 +1869,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     Filter originalFilter = new SelectorFilter("page", "this matches nothing");
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.LEFT));
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
@@ -2072,12 +1899,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   {
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
     Filter filter = new SelectorFilter("page", "this matches nothing");
 
     new HashJoinSegmentStorageAdapter(
@@ -2092,15 +1914,6 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         false,
         null
     );
-
-    /*
-    try {
-
-      Assert.fail();
-    }
-    catch (ISE e) {
-      Assert.assertTrue(e.getMessage().startsWith("Filter provided to cursor ["));
-    }
-    */
   }
+
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.timeline.SegmentId;
 import org.hamcrest.CoreMatchers;
@@ -41,6 +42,14 @@ import java.util.List;
 
 public class HashJoinSegmentTest
 {
+  private JoinFilterRewriteConfig DEFAULT_JOIN_FILTER_REWRITE_CONFIG = new JoinFilterRewriteConfig(
+      true,
+      true,
+      true,
+      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
+      false
+  );
+
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -80,10 +89,7 @@ public class HashJoinSegmentTest
     );
 
     JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+        DEFAULT_JOIN_FILTER_REWRITE_CONFIG
     );
 
     hashJoinSegment = new HashJoinSegment(
@@ -102,10 +108,7 @@ public class HashJoinSegmentTest
     List<JoinableClause> joinableClauses = ImmutableList.of();
 
     JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+        DEFAULT_JOIN_FILTER_REWRITE_CONFIG
     );
 
     final HashJoinSegment ignored = new HashJoinSegment(

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
@@ -24,10 +24,7 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.segment.QueryableIndexSegment;
-import org.apache.druid.segment.VirtualColumns;
-import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
-import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
-import org.apache.druid.segment.join.filter.JoinableClauses;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.timeline.SegmentId;
 import org.hamcrest.CoreMatchers;
@@ -82,10 +79,7 @@ public class HashJoinSegmentTest
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -95,7 +89,7 @@ public class HashJoinSegmentTest
     hashJoinSegment = new HashJoinSegment(
         baseSegment,
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
   }
 
@@ -107,10 +101,7 @@ public class HashJoinSegmentTest
 
     List<JoinableClause> joinableClauses = ImmutableList.of();
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        null,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         true,
         true,
@@ -120,7 +111,7 @@ public class HashJoinSegmentTest
     final HashJoinSegment ignored = new HashJoinSegment(
         baseSegment,
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
@@ -47,6 +47,7 @@ import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterSplit;
 import org.apache.druid.segment.join.filter.JoinableClauses;
 import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
@@ -67,7 +68,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -112,7 +113,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         null,
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -141,7 +146,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionExprToCountry
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -173,7 +178,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter("rtc.countryName", "United States"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -193,7 +202,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -234,7 +243,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter("rtc.countryName", "United States"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -256,7 +269,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -301,7 +314,12 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -323,7 +341,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
@@ -360,7 +378,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -379,7 +401,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -435,7 +457,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         null,
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        virtualColumns
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -461,7 +487,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         factToRegion(JoinType.LEFT)
     ));
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -492,7 +518,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter("v0", "VIRGINIA"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses.getJoinableClauses(),
+        virtualColumns
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -562,7 +592,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -653,7 +683,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -686,7 +720,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -723,7 +757,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter("rtc.countryName", "States United"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
 
     ExpressionVirtualColumn expectedVirtualColumn = new ExpressionVirtualColumn(
@@ -774,7 +812,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("Cannot build hash-join matcher on non-equi-join condition: \"r1.regionIsoCode\" == regionIsoCode && reverse(\"r1.countryIsoCode\") == countryIsoCode");
@@ -823,7 +861,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -891,7 +929,12 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -922,7 +965,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -968,7 +1011,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             expectedVirtualColumn
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        filter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(
         expectedFilterSplit.getBaseTableFilter(),
@@ -1009,7 +1056,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1055,7 +1102,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             expectedVirtualColumn
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        filter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(
         expectedFilterSplit.getBaseTableFilter(),
@@ -1080,7 +1131,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "Germany")
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
@@ -1119,7 +1170,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "Germany"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1134,7 +1189,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "Germany")
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1173,7 +1228,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "Germany"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1188,7 +1247,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", null)
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1226,7 +1285,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1241,7 +1304,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "NO MATCH")
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1280,7 +1343,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1295,7 +1362,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1332,7 +1399,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1347,7 +1418,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", "Australia")
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1393,7 +1464,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", "Australia"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1408,7 +1483,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", "Australia")
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1453,7 +1528,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", "Australia"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1468,7 +1547,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", null)
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1505,7 +1584,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1520,7 +1603,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", null)
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1556,7 +1639,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1571,7 +1658,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.FULL));
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1611,7 +1698,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "El Salvador"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        filter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1626,7 +1717,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.FULL));
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1665,7 +1756,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "El Salvador"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        filter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1680,7 +1775,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", null)
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1718,7 +1813,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1733,7 +1832,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
         )
     );
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
@@ -1769,7 +1868,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1796,7 +1899,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     Filter originalFilter = new SelectorFilter("r1.regionName", "Fourems Province");
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1832,7 +1935,12 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter("r1.regionName", "Fourems Province"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1864,7 +1972,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1900,7 +2008,12 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         originalFilter,
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1934,7 +2047,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -1975,7 +2088,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         null,
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -1990,10 +2107,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     Filter originalFilter = new SelectorFilter("page", "Peremptory norm");
 
     JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        false,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+        new JoinFilterRewriteConfig(
+            false,
+            true,
+            true,
+            QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
+            false
+        )
     );
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
@@ -2026,7 +2146,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         new SelectorFilter("page", "Peremptory norm"),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses.getJoinableClauses(),
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -2061,10 +2185,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
     JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
-        true,
-        false,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+        new JoinFilterRewriteConfig(
+            true,
+            false,
+            true,
+            QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
+            false
+        )
     );
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -2124,7 +2251,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses.getJoinableClauses(),
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -2234,7 +2365,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
@@ -2366,7 +2497,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         expectedVirtualColumns
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -2386,7 +2521,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = makeDefaultConfigPreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
@@ -2432,7 +2567,86 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         originalFilter,
         ImmutableSet.of()
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalysis(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+  }
+
+
+  @Test
+  public void test_filterPushDown_factToRegionExprToCountryLeftFilterOnCountryNameWithOldRewriteMode()
+  {
+    Filter originalFilter = new SelectorFilter("rtc.countryName", "United States");
+    JoinableClause regionExprToCountry = new JoinableClause(
+        REGION_TO_COUNTRY_PREFIX,
+        new IndexedTableJoinable(countriesTable),
+        JoinType.LEFT,
+        JoinConditionAnalysis.forExpression(
+            StringUtils.format(
+                "reverse(\"%scountryIsoCode\") == \"%scountryIsoCode\"",
+                FACT_TO_REGION_PREFIX,
+                REGION_TO_COUNTRY_PREFIX
+            ),
+            REGION_TO_COUNTRY_PREFIX,
+            ExprMacroTable.nil()
+        )
+    );
+    List<JoinableClause> joinableClauses = ImmutableList.of(
+        factToRegion(JoinType.LEFT),
+        regionExprToCountry
+    );
+
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
+        new JoinFilterRewriteConfig(
+            true,
+            true,
+            true,
+            QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
+            true
+        )
+    );
+
+    joinFilterPreAnalysisGroup.performAnalysisForOldRewriteMode(
+        originalFilter,
+        joinableClauses,
+        VirtualColumns.EMPTY
+    );
+
+    HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
+        factSegment.asStorageAdapter(),
+        joinableClauses,
+        joinFilterPreAnalysisGroup
+    );
+
+    JoinTestHelper.verifyCursors(
+        adapter.makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            FACT_TO_REGION_PREFIX + "regionName",
+            REGION_TO_COUNTRY_PREFIX + "countryName"
+        ),
+        ImmutableList.of(
+            new Object[]{"Cream Soda", "Ainigriv", "United States"}
+        )
+    );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new SelectorFilter("rtc.countryName", "United States"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getPreAnalysisForOldRewriteMode();
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
@@ -2444,16 +2658,5 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
                   .usingGetClass()
                   .withNonnullFields("baseTableFilter", "pushDownVirtualColumns")
                   .verify();
-  }
-
-  private static JoinFilterPreAnalysisGroup simplePreAnalysisGroup()
-  {
-    return new JoinFilterPreAnalysisGroup(
-      true,
-      true,
-      true,
-      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-  );
-
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
@@ -46,6 +46,7 @@ import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterSplit;
 import org.apache.druid.segment.join.filter.JoinableClauses;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterPreAnalysisGroup;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
@@ -66,24 +67,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new SelectorFilter("channel", "#en.wikipedia"),
-        null,
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -116,6 +106,15 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"History of Fourems", "Fourems Province", "Fourems"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new SelectorFilter("channel", "#en.wikipedia"),
+        null,
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -142,24 +141,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionExprToCountry
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new SelectorFilter("rtc.countryName", "United States"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -179,6 +167,15 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Cream Soda", "Ainigriv", "United States"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new SelectorFilter("rtc.countryName", "United States"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -196,29 +193,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#en.wikipedia"),
-                new InDimFilter("countryIsoCode", ImmutableSet.of("US"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter("rtc.countryName", "United States"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -242,6 +223,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Old Anatolian Turkish", "Virginia", "United States"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#en.wikipedia"),
+                new InDimFilter("countryIsoCode", ImmutableSet.of("US"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter("rtc.countryName", "United States"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -261,32 +256,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("countryIsoCode", null),
-                new SelectorFilter("countryNumber", null),
-                new SelectorFilter("rtc.countryName", null),
-                new SelectorFilter("r1.regionName", null)
-            )
-        ),
-        ImmutableSet.of()
-    );
-
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -312,8 +288,24 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ) :
         ImmutableList.of() // when not running in SQL compatible mode, countryNumber does not have nulls
     );
-  }
 
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("countryIsoCode", null),
+                new SelectorFilter("countryNumber", null),
+                new SelectorFilter("rtc.countryName", null),
+                new SelectorFilter("r1.regionName", null)
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+  }
+  
   @Test
   public void test_filterPushDown_factToRegionToCountryLeftFilterOnInvalidColumns()
   {
@@ -331,30 +323,14 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new SelectorFilter("baseTableInvalidColumn", "abcd"),
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("baseTableInvalidColumn2", null),
-                new SelectorFilter("rtc.invalidColumn", "abcd"),
-                new SelectorFilter("r1.invalidColumn", "abcd")
-            )
-        ),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -372,6 +348,21 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new SelectorFilter("baseTableInvalidColumn", "abcd"),
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("baseTableInvalidColumn2", null),
+                new SelectorFilter("rtc.invalidColumn", "abcd"),
+                new SelectorFilter("r1.invalidColumn", "abcd")
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -388,15 +379,12 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
 
     VirtualColumns virtualColumns = VirtualColumns.create(
@@ -409,14 +397,6 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             )
         )
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new SelectorFilter("v1", "virtual-column-#en.wikipedia"),
-        null,
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -449,6 +429,15 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"History of Fourems", "Fourems Province", "Fourems"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new SelectorFilter("v1", "virtual-column-#en.wikipedia"),
+        null,
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -472,29 +461,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         factToRegion(JoinType.LEFT)
     ));
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        joinableClauses,
-        virtualColumns,
-        originalFilter,
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses.getJoinableClauses(),
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new SelectorFilter("v0", "VIRGINIA"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -513,8 +486,16 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Old Anatolian Turkish", "VIRGINIA"}
         )
     );
-  }
 
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new SelectorFilter("v0", "VIRGINIA"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+  }
 
   @Test
   public void test_filterPushDown_factToRegionToCountryLeftFilterNormalizedAlreadyPushDownVariety()
@@ -581,14 +562,31 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
+    );
+
+    JoinTestHelper.verifyCursors(
+        adapter.makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            FACT_TO_REGION_PREFIX + "regionName",
+            REGION_TO_COUNTRY_PREFIX + "countryName"
+        ),
+        ImmutableList.of(
+            new Object[]{"Les Argonautes", "Quebec", "Canada"}
+        )
     );
 
     JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
@@ -655,27 +653,9 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
-
-    JoinTestHelper.verifyCursors(
-        adapter.makeCursors(
-            originalFilter,
-            Intervals.ETERNITY,
-            VirtualColumns.EMPTY,
-            Granularities.ALL,
-            false,
-            null
-        ),
-        ImmutableList.of(
-            "page",
-            FACT_TO_REGION_PREFIX + "regionName",
-            REGION_TO_COUNTRY_PREFIX + "countryName"
-        ),
-        ImmutableList.of(
-            new Object[]{"Les Argonautes", "Quebec", "Canada"}
-        )
-    );
   }
 
   @Test
@@ -705,46 +685,14 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter("rtc.countryName", "States United")
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#en.wikipedia"),
-                new InDimFilter("JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0", ImmutableSet.of("SU"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter("rtc.countryName", "States United"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-
-    ExpressionVirtualColumn expectedVirtualColumn = new ExpressionVirtualColumn(
-        "JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0",
-        "reverse(countryIsoCode)",
-        ValueType.STRING,
-        ExprMacroTable.nil()
-    );
-    Assert.assertEquals(
-        expectedFilterSplit.getBaseTableFilter(),
-        actualFilterSplit.getBaseTableFilter()
-    );
-    Assert.assertEquals(
-        expectedFilterSplit.getJoinTableFilter(),
-        actualFilterSplit.getJoinTableFilter()
-    );
-    ExpressionVirtualColumn actualVirtualColumn = (ExpressionVirtualColumn) actualFilterSplit.getPushDownVirtualColumns()
-                                                                                             .iterator().next();
-    compareExpressionVirtualColumns(expectedVirtualColumn, actualVirtualColumn);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -764,6 +712,37 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Old Anatolian Turkish", "Ainigriv", "States United"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#en.wikipedia"),
+                new InDimFilter("JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0", ImmutableSet.of("SU"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter("rtc.countryName", "States United"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+
+    ExpressionVirtualColumn expectedVirtualColumn = new ExpressionVirtualColumn(
+        "JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0",
+        "reverse(countryIsoCode)",
+        ValueType.STRING,
+        ExprMacroTable.nil()
+    );
+    Assert.assertEquals(
+        expectedFilterSplit.getBaseTableFilter(),
+        actualFilterSplit.getBaseTableFilter()
+    );
+    Assert.assertEquals(
+        expectedFilterSplit.getJoinTableFilter(),
+        actualFilterSplit.getJoinTableFilter()
+    );
+    ExpressionVirtualColumn actualVirtualColumn = (ExpressionVirtualColumn) actualFilterSplit.getPushDownVirtualColumns()
+                                                                                             .iterator().next();
+    compareExpressionVirtualColumns(expectedVirtualColumn, actualVirtualColumn);
   }
 
   @Test
@@ -795,17 +774,15 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("Cannot build hash-join matcher on non-equi-join condition: \"r1.regionIsoCode\" == regionIsoCode && reverse(\"r1.countryIsoCode\") == countryIsoCode");
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -846,14 +823,32 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
+    );
+
+    JoinTestHelper.verifyCursors(
+        adapter.makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            FACT_TO_REGION_PREFIX + "regionName",
+            REGION_TO_COUNTRY_PREFIX + "countryName"
+        ),
+        ImmutableList.of(
+            new Object[]{"유희왕 GX", "Seoul", "Republic of Korea"},
+            new Object[]{"Old Anatolian Turkish", "Virginia", "United States"}
+        )
     );
 
     JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
@@ -896,28 +891,9 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
-
-    JoinTestHelper.verifyCursors(
-        adapter.makeCursors(
-            originalFilter,
-            Intervals.ETERNITY,
-            VirtualColumns.EMPTY,
-            Granularities.ALL,
-            false,
-            null
-        ),
-        ImmutableList.of(
-            "page",
-            FACT_TO_REGION_PREFIX + "regionName",
-            REGION_TO_COUNTRY_PREFIX + "countryName"
-        ),
-        ImmutableList.of(
-            new Object[]{"유희왕 GX", "Seoul", "Republic of Korea"},
-            new Object[]{"Old Anatolian Turkish", "Virginia", "United States"}
-        )
-    );
   }
 
   @Test
@@ -946,47 +922,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        filter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    ExpressionVirtualColumn expectedVirtualColumn = new ExpressionVirtualColumn(
-        "JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0",
-        "concat(countryIsoCode, regionIsoCode)",
-        ValueType.STRING,
-        ExprMacroTable.nil()
-    );
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#en.wikipedia"),
-                new InDimFilter("JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0", ImmutableSet.of("USCA"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter("c1.countryName", "Usca"),
-        ImmutableSet.of(
-            expectedVirtualColumn
-        )
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(
-        expectedFilterSplit.getBaseTableFilter(),
-        actualFilterSplit.getBaseTableFilter()
-    );
-    Assert.assertEquals(
-        expectedFilterSplit.getJoinTableFilter(),
-        actualFilterSplit.getJoinTableFilter()
-    );
-    ExpressionVirtualColumn actualVirtualColumn = (ExpressionVirtualColumn) actualFilterSplit.getPushDownVirtualColumns()
-                                                                                             .iterator().next();
-    compareExpressionVirtualColumns(expectedVirtualColumn, actualVirtualColumn);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1007,6 +949,38 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Carlo Curti", "Usca"}
         )
     );
+
+    ExpressionVirtualColumn expectedVirtualColumn = new ExpressionVirtualColumn(
+        "JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0",
+        "concat(countryIsoCode, regionIsoCode)",
+        ValueType.STRING,
+        ExprMacroTable.nil()
+    );
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#en.wikipedia"),
+                new InDimFilter("JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0", ImmutableSet.of("USCA"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter("c1.countryName", "Usca"),
+        ImmutableSet.of(
+            expectedVirtualColumn
+        )
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(
+        expectedFilterSplit.getBaseTableFilter(),
+        actualFilterSplit.getBaseTableFilter()
+    );
+    Assert.assertEquals(
+        expectedFilterSplit.getJoinTableFilter(),
+        actualFilterSplit.getJoinTableFilter()
+    );
+    ExpressionVirtualColumn actualVirtualColumn = (ExpressionVirtualColumn) actualFilterSplit.getPushDownVirtualColumns()
+                                                                                             .iterator().next();
+    compareExpressionVirtualColumns(expectedVirtualColumn, actualVirtualColumn);
   }
 
   @Test
@@ -1035,47 +1009,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        filter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    ExpressionVirtualColumn expectedVirtualColumn = new ExpressionVirtualColumn(
-        "JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0",
-        "concat(countryIsoCode, regionIsoCode)",
-        ValueType.STRING,
-        ExprMacroTable.nil()
-    );
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#en.wikipedia"),
-                new InDimFilter("JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0", ImmutableSet.of("USCA"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter("c1.v", "Usca"),
-        ImmutableSet.of(
-            expectedVirtualColumn
-        )
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(
-        expectedFilterSplit.getBaseTableFilter(),
-        actualFilterSplit.getBaseTableFilter()
-    );
-    Assert.assertEquals(
-        expectedFilterSplit.getJoinTableFilter(),
-        actualFilterSplit.getJoinTableFilter()
-    );
-    ExpressionVirtualColumn actualVirtualColumn = (ExpressionVirtualColumn) actualFilterSplit.getPushDownVirtualColumns()
-                                                                                             .iterator().next();
-    compareExpressionVirtualColumns(expectedVirtualColumn, actualVirtualColumn);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1096,6 +1036,38 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Carlo Curti", "Usca"}
         )
     );
+
+    ExpressionVirtualColumn expectedVirtualColumn = new ExpressionVirtualColumn(
+        "JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0",
+        "concat(countryIsoCode, regionIsoCode)",
+        ValueType.STRING,
+        ExprMacroTable.nil()
+    );
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#en.wikipedia"),
+                new InDimFilter("JOIN-FILTER-PUSHDOWN-VIRTUAL-COLUMN-0", ImmutableSet.of("USCA"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter("c1.v", "Usca"),
+        ImmutableSet.of(
+            expectedVirtualColumn
+        )
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(
+        expectedFilterSplit.getBaseTableFilter(),
+        actualFilterSplit.getBaseTableFilter()
+    );
+    Assert.assertEquals(
+        expectedFilterSplit.getJoinTableFilter(),
+        actualFilterSplit.getJoinTableFilter()
+    );
+    ExpressionVirtualColumn actualVirtualColumn = (ExpressionVirtualColumn) actualFilterSplit.getPushDownVirtualColumns()
+                                                                                             .iterator().next();
+    compareExpressionVirtualColumns(expectedVirtualColumn, actualVirtualColumn);
   }
 
   @Test
@@ -1108,28 +1080,12 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "Germany")
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#de.wikipedia"),
-                new InDimFilter("countryIsoCode", ImmutableSet.of("DE"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "Germany"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1152,6 +1108,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Diskussion:Sebastian Schulz", "DE", 3L, "DE", "Germany", 3L}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#de.wikipedia"),
+                new InDimFilter("countryIsoCode", ImmutableSet.of("DE"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "Germany"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1164,28 +1134,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "Germany")
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#de.wikipedia"),
-                new InDimFilter("countryIsoCode", ImmutableSet.of("DE"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "Germany"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1207,6 +1162,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Diskussion:Sebastian Schulz", "DE", 3L, "DE", "Germany"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#de.wikipedia"),
+                new InDimFilter("countryIsoCode", ImmutableSet.of("DE"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "Germany"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1219,14 +1188,32 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", null)
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
+    );
+
+    JoinTestHelper.verifyCursors(
+        adapter.makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            "countryIsoCode",
+            "countryNumber",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryIsoCode",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName",
+            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryNumber"
+        ),
+        ImmutableList.of()
     );
 
     JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
@@ -1239,28 +1226,9 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
-
-    JoinTestHelper.verifyCursors(
-        adapter.makeCursors(
-            originalFilter,
-            Intervals.ETERNITY,
-            VirtualColumns.EMPTY,
-            Granularities.ALL,
-            false,
-            null
-        ),
-        ImmutableList.of(
-            "page",
-            "countryIsoCode",
-            "countryNumber",
-            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryIsoCode",
-            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName",
-            FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryNumber"
-        ),
-        ImmutableList.of()
-    );
   }
 
   @Test
@@ -1273,28 +1241,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "NO MATCH")
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        FalseFilter.instance(),
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", null),
-                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "NO MATCH")
-            )
-        ),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1315,6 +1268,21 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
+
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        FalseFilter.instance(),
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", null),
+                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "NO MATCH")
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1327,28 +1295,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", null),
-                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
-            )
-        ),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1368,6 +1321,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", null),
+                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1380,28 +1347,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", "Australia")
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#en.wikipedia"),
-                new InDimFilter("countryNumber", ImmutableSet.of("0"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", "Australia"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     // In non-SQL-compatible mode, we get an extra row, since the 'null' countryNumber for "Talk:Oswald Tilghman"
     // is interpreted as 0 (a.k.a. Australia).
@@ -1430,6 +1382,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Peremptory norm", "AU", "AU", "Australia", 0L}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#en.wikipedia"),
+                new InDimFilter("countryNumber", ImmutableSet.of("0"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", "Australia"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1442,28 +1408,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", "Australia")
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#en.wikipedia"),
-                new InDimFilter("countryNumber", ImmutableSet.of("0"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", "Australia"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     // In non-SQL-compatible mode, we get an extra row, since the 'null' countryNumber for "Talk:Oswald Tilghman"
     // is interpreted as 0 (a.k.a. Australia).
@@ -1491,6 +1442,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Peremptory norm", "AU", "0", "Australia"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#en.wikipedia"),
+                new InDimFilter("countryNumber", ImmutableSet.of("0"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", "Australia"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1503,28 +1468,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", null)
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", null),
-                new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", null)
-            )
-        ),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1544,6 +1494,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", null),
+                new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "countryName", null)
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1556,28 +1520,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", null)
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", null),
-                new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", null)
-            )
-        ),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1596,6 +1545,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", null),
+                new SelectorFilter(FACT_TO_COUNTRY_ON_NUMBER_PREFIX + "v", null)
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1608,28 +1571,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.FULL));
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        filter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#es.wikipedia"),
-                new InDimFilter("countryIsoCode", ImmutableSet.of("SV"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "El Salvador"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1652,6 +1600,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Wendigo", "SV", 12L, "SV", "El Salvador", 12L}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#es.wikipedia"),
+                new InDimFilter("countryIsoCode", ImmutableSet.of("SV"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", "El Salvador"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1664,28 +1626,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryNameUsingIsoCodeLookup(JoinType.FULL));
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        filter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", "#es.wikipedia"),
-                new InDimFilter("countryIsoCode", ImmutableSet.of("SV"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "El Salvador"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1707,6 +1654,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Wendigo", "SV", 12L, "SV", "El Salvador"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", "#es.wikipedia"),
+                new InDimFilter("countryIsoCode", ImmutableSet.of("SV"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", "El Salvador"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(filter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1719,28 +1680,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", null)
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", null),
-                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", null)
-            )
-        ),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1761,6 +1707,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", null),
+                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName", null)
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1773,28 +1733,12 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new AndFilter(
-            ImmutableList.of(
-                new SelectorFilter("channel", null),
-                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
-            )
-        ),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1814,6 +1758,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new AndFilter(
+            ImmutableList.of(
+                new SelectorFilter("channel", null),
+                new SelectorFilter(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "v", null)
+            )
+        ),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1838,29 +1796,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     );
     Filter originalFilter = new SelectorFilter("r1.regionName", "Fourems Province");
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
 
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new AndFilter(
-            ImmutableList.of(
-                new InDimFilter("countryIsoCode", ImmutableSet.of("MMMM"), null, null).toFilter(),
-                new InDimFilter("regionIsoCode", ImmutableSet.of("MMMM"), null, null).toFilter()
-            )
-        ),
-        new SelectorFilter("r1.regionName", "Fourems Province"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1879,6 +1821,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"History of Fourems", "Fourems Province"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new AndFilter(
+            ImmutableList.of(
+                new InDimFilter("countryIsoCode", ImmutableSet.of("MMMM"), null, null).toFilter(),
+                new InDimFilter("regionIsoCode", ImmutableSet.of("MMMM"), null, null).toFilter()
+            )
+        ),
+        new SelectorFilter("r1.regionName", "Fourems Province"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1908,28 +1864,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new OrFilter(
-            ImmutableList.of(
-                new InDimFilter("regionIsoCode", ImmutableSet.of("MMMM"), null, null).toFilter(),
-                new SelectorFilter("regionIsoCode", "AAAA")
-            )
-        ),
-        originalFilter,
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -1948,6 +1889,20 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"History of Fourems", "Fourems Province"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new OrFilter(
+            ImmutableList.of(
+                new InDimFilter("regionIsoCode", ImmutableSet.of("MMMM"), null, null).toFilter(),
+                new SelectorFilter("regionIsoCode", "AAAA")
+            )
+        ),
+        originalFilter,
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
 
@@ -1979,28 +1934,13 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         )
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        new OrFilter(
-            ImmutableList.of(
-                new SelectorFilter("user", "Fourems Province"),
-                new SelectorFilter("regionIsoCode", "AAAA")
-            )
-        ),
-        null,
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     // This query doesn't execute because regionName is not a key column, but we can still check the
     // filter rewrites.
@@ -2024,8 +1964,21 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableList.of()
     );
-  }
 
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        new OrFilter(
+            ImmutableList.of(
+                new SelectorFilter("user", "Fourems Province"),
+                new SelectorFilter("regionIsoCode", "AAAA")
+            )
+        ),
+        null,
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+  }
 
   @Test
   public void test_filterPushDown_factToRegionToCountryLeftFilterOnPageDisablePushDown()
@@ -2036,28 +1989,18 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     ));
     Filter originalFilter = new SelectorFilter("page", "Peremptory norm");
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        joinableClauses,
-        VirtualColumns.EMPTY,
-        originalFilter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         false,
         true,
         true,
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
     );
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses.getJoinableClauses(),
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
-
-    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
-        null,
-        new SelectorFilter("page", "Peremptory norm"),
-        ImmutableSet.of()
-    );
-    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
 
     JoinTestHelper.verifyCursors(
         adapter.makeCursors(
@@ -2077,6 +2020,15 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             new Object[]{"Peremptory norm", "New South Wales", "Australia"}
         )
     );
+
+    JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
+        null,
+        new SelectorFilter("page", "Peremptory norm"),
+        ImmutableSet.of()
+    );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
+    JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
+    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -2108,10 +2060,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
             ))
         )
     );
-    JoinFilterPreAnalysis joinFilterPreAnalysis = JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        joinableClauses,
-        VirtualColumns.EMPTY,
-        originalFilter,
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = new JoinFilterPreAnalysisGroup(
         true,
         false,
         true,
@@ -2120,7 +2069,30 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses.getJoinableClauses(),
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
+    );
+
+    JoinTestHelper.verifyCursors(
+        adapter.makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            FACT_TO_REGION_PREFIX + "regionName",
+            REGION_TO_COUNTRY_PREFIX + "countryName"
+        ),
+        ImmutableList.of(
+            new Object[]{"President of India", "California", "United States"},
+            new Object[]{"Otjiwarongo Airport", "California", "United States"},
+            new Object[]{"DirecTV", "North Carolina", "United States"},
+            new Object[]{"Carlo Curti", "California", "United States"},
+            new Object[]{"Old Anatolian Turkish", "Virginia", "United States"}
+        )
     );
 
     JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
@@ -2152,31 +2124,9 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         ImmutableSet.of()
     );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
-
-    JoinTestHelper.verifyCursors(
-        adapter.makeCursors(
-            originalFilter,
-            Intervals.ETERNITY,
-            VirtualColumns.EMPTY,
-            Granularities.ALL,
-            false,
-            null
-        ),
-        ImmutableList.of(
-            "page",
-            FACT_TO_REGION_PREFIX + "regionName",
-            REGION_TO_COUNTRY_PREFIX + "countryName"
-        ),
-        ImmutableList.of(
-            new Object[]{"President of India", "California", "United States"},
-            new Object[]{"Otjiwarongo Airport", "California", "United States"},
-            new Object[]{"DirecTV", "North Carolina", "United States"},
-            new Object[]{"Carlo Curti", "California", "United States"},
-            new Object[]{"Old Anatolian Turkish", "Virginia", "United States"}
-        )
-    );
   }
 
   @Test
@@ -2284,15 +2234,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
-
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
     );
 
     String rewrittenCountryIsoCodeColumnName = hasLhsExpressionInJoinCondition
@@ -2323,6 +2269,25 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
     } else {
       expectedVirtualColumns = ImmutableSet.of();
     }
+
+    JoinTestHelper.verifyCursors(
+        adapter.makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            FACT_TO_REGION_PREFIX + "regionName",
+            REGION_TO_COUNTRY_PREFIX + "countryName"
+        ),
+        ImmutableList.of(
+            new Object[]{"Didier Leclair", "Ontario", "Canada"}
+        )
+    );
 
     JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
         new AndFilter(
@@ -2401,27 +2366,9 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         ),
         expectedVirtualColumns
     );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
-
-    JoinTestHelper.verifyCursors(
-        adapter.makeCursors(
-            originalFilter,
-            Intervals.ETERNITY,
-            VirtualColumns.EMPTY,
-            Granularities.ALL,
-            false,
-            null
-        ),
-        ImmutableList.of(
-            "page",
-            FACT_TO_REGION_PREFIX + "regionName",
-            REGION_TO_COUNTRY_PREFIX + "countryName"
-        ),
-        ImmutableList.of(
-            new Object[]{"Didier Leclair", "Ontario", "Canada"}
-        )
-    );
   }
 
   @Test
@@ -2439,14 +2386,30 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         regionToCountry(JoinType.LEFT)
     );
 
-    JoinFilterPreAnalysis joinFilterPreAnalysis = simplePreAnalysis(
-        joinableClauses,
-        originalFilter
-    );
+    JoinFilterPreAnalysisGroup joinFilterPreAnalysisGroup = simplePreAnalysisGroup();
+
     HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
         factSegment.asStorageAdapter(),
         joinableClauses,
-        joinFilterPreAnalysis
+        joinFilterPreAnalysisGroup
+    );
+
+    JoinTestHelper.verifyCursors(
+        adapter.makeCursors(
+            originalFilter,
+            Intervals.ETERNITY,
+            VirtualColumns.EMPTY,
+            Granularities.ALL,
+            false,
+            null
+        ),
+        ImmutableList.of(
+            "page",
+            FACT_TO_REGION_PREFIX + "regionName",
+            REGION_TO_COUNTRY_PREFIX + "countryName"
+        ),
+        ImmutableList.of(
+        )
     );
 
     JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
@@ -2469,26 +2432,9 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
         originalFilter,
         ImmutableSet.of()
     );
+    JoinFilterPreAnalysis joinFilterPreAnalysis = joinFilterPreAnalysisGroup.getAnalyses().get(originalFilter);
     JoinFilterSplit actualFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
     Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
-
-    JoinTestHelper.verifyCursors(
-        adapter.makeCursors(
-            originalFilter,
-            Intervals.ETERNITY,
-            VirtualColumns.EMPTY,
-            Granularities.ALL,
-            false,
-            null
-        ),
-        ImmutableList.of(
-            "page",
-            FACT_TO_REGION_PREFIX + "regionName",
-            REGION_TO_COUNTRY_PREFIX + "countryName"
-        ),
-        ImmutableList.of(
-        )
-    );
   }
 
   @Test
@@ -2500,19 +2446,14 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
                   .verify();
   }
 
-  private static JoinFilterPreAnalysis simplePreAnalysis(
-      List<JoinableClause> joinableClauses,
-      Filter originalFilter
-  )
+  private static JoinFilterPreAnalysisGroup simplePreAnalysisGroup()
   {
-    return JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
-        JoinableClauses.fromList(joinableClauses),
-        VirtualColumns.EMPTY,
-        originalFilter,
-        true,
-        true,
-        true,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-    );
+    return new JoinFilterPreAnalysisGroup(
+      true,
+      true,
+      true,
+      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+  );
+
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
@@ -28,7 +28,6 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.query.planning.PreJoinableClause;
 import org.apache.druid.segment.Segment;
-import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.junit.Assert;
@@ -102,9 +101,7 @@ public class JoinablesTest
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN,
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE,
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
-        null,
-        VirtualColumns.EMPTY
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
     );
 
     Assert.assertSame(Function.identity(), segmentMapFn);
@@ -131,9 +128,7 @@ public class JoinablesTest
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN,
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE,
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
-        null,
-        VirtualColumns.EMPTY
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
     );
   }
 
@@ -168,9 +163,7 @@ public class JoinablesTest
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN,
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE,
         QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
-        null,
-        VirtualColumns.EMPTY
+        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
     );
 
     Assert.assertNotSame(Function.identity(), segmentMapFn);

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinablesTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.query.planning.PreJoinableClause;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -43,6 +44,14 @@ import java.util.function.Function;
 
 public class JoinablesTest
 {
+  private static final JoinFilterRewriteConfig DEFAULT_JOIN_FILTER_REWRITE_CONFIG = new JoinFilterRewriteConfig(
+      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN,
+      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE,
+      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS,
+      QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE,
+      QueryContexts.DEFAULT_JOIN_FILTER_REWRITE_USE_OLD_REWRITE_MODE
+  );
+
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
@@ -98,10 +107,9 @@ public class JoinablesTest
         ImmutableList.of(),
         NoopJoinableFactory.INSTANCE,
         new AtomicLong(),
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+        DEFAULT_JOIN_FILTER_REWRITE_CONFIG,
+        null,
+        null
     );
 
     Assert.assertSame(Function.identity(), segmentMapFn);
@@ -125,10 +133,9 @@ public class JoinablesTest
         ImmutableList.of(clause),
         NoopJoinableFactory.INSTANCE,
         new AtomicLong(),
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+        DEFAULT_JOIN_FILTER_REWRITE_CONFIG,
+        null,
+        null
     );
   }
 
@@ -160,10 +167,9 @@ public class JoinablesTest
           }
         },
         new AtomicLong(),
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS,
-        QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
+        DEFAULT_JOIN_FILTER_REWRITE_CONFIG,
+        null,
+        null
     );
 
     Assert.assertNotSame(Function.identity(), segmentMapFn);

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
@@ -178,9 +178,7 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
         QueryContexts.getEnableJoinFilterPushDown(query),
         QueryContexts.getEnableJoinFilterRewrite(query),
         QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(query),
-        QueryContexts.getJoinFilterRewriteMaxSize(query),
-        query.getFilter() == null ? null : query.getFilter().toFilter(),
-        query.getVirtualColumns()
+        QueryContexts.getJoinFilterRewriteMaxSize(query)
     );
 
     Iterable<QueryRunner<T>> perSegmentRunners = Iterables.transform(

--- a/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
@@ -39,6 +39,7 @@ import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentWrangler;
 import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.join.Joinables;
+import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.joda.time.Interval;
 
 import java.util.HashSet;
@@ -93,14 +94,20 @@ public class LocalQuerySegmentWalker implements QuerySegmentWalker
     final Query<T> prioritizedAndLaned = prioritizeAndLaneQuery(query, segments);
 
     final AtomicLong cpuAccumulator = new AtomicLong(0L);
+    final JoinFilterRewriteConfig joinFilterRewriteConfig = new JoinFilterRewriteConfig(
+        QueryContexts.getEnableJoinFilterPushDown(prioritizedAndLaned),
+        QueryContexts.getEnableJoinFilterRewrite(prioritizedAndLaned),
+        QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(prioritizedAndLaned),
+        QueryContexts.getJoinFilterRewriteMaxSize(prioritizedAndLaned),
+        QueryContexts.getUseJoinFilterRewriteOldRewriteMode(prioritizedAndLaned)
+    );
     final Function<Segment, Segment> segmentMapFn = Joinables.createSegmentMapFn(
         analysis.getPreJoinableClauses(),
         joinableFactory,
         cpuAccumulator,
-        QueryContexts.getEnableJoinFilterPushDown(prioritizedAndLaned),
-        QueryContexts.getEnableJoinFilterRewrite(prioritizedAndLaned),
-        QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(prioritizedAndLaned),
-        QueryContexts.getJoinFilterRewriteMaxSize(prioritizedAndLaned)
+        joinFilterRewriteConfig,
+        prioritizedAndLaned.getFilter() == null ? null : prioritizedAndLaned.getFilter().toFilter(),
+        prioritizedAndLaned.getVirtualColumns()
     );
 
     final QueryRunnerFactory<T, Query<T>> queryRunnerFactory = conglomerate.findFactory(prioritizedAndLaned);

--- a/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
@@ -100,9 +100,7 @@ public class LocalQuerySegmentWalker implements QuerySegmentWalker
         QueryContexts.getEnableJoinFilterPushDown(prioritizedAndLaned),
         QueryContexts.getEnableJoinFilterRewrite(prioritizedAndLaned),
         QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(prioritizedAndLaned),
-        QueryContexts.getJoinFilterRewriteMaxSize(prioritizedAndLaned),
-        prioritizedAndLaned.getFilter() == null ? null : prioritizedAndLaned.getFilter().toFilter(),
-        prioritizedAndLaned.getVirtualColumns()
+        QueryContexts.getJoinFilterRewriteMaxSize(prioritizedAndLaned)
     );
 
     final QueryRunnerFactory<T, Query<T>> queryRunnerFactory = conglomerate.findFactory(prioritizedAndLaned);

--- a/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
@@ -201,9 +201,7 @@ public class ServerManager implements QuerySegmentWalker
         QueryContexts.getEnableJoinFilterPushDown(query),
         QueryContexts.getEnableJoinFilterRewrite(query),
         QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(query),
-        QueryContexts.getJoinFilterRewriteMaxSize(query),
-        query.getFilter() == null ? null : query.getFilter().toFilter(),
-        query.getVirtualColumns()
+        QueryContexts.getJoinFilterRewriteMaxSize(query)
     );
 
     FunctionalIterable<QueryRunner<T>> queryRunners = FunctionalIterable

--- a/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
+++ b/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
@@ -146,9 +146,7 @@ public class TestClusterQuerySegmentWalker implements QuerySegmentWalker
         QueryContexts.getEnableJoinFilterPushDown(query),
         QueryContexts.getEnableJoinFilterRewrite(query),
         QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(query),
-        QueryContexts.getJoinFilterRewriteMaxSize(query),
-        query.getFilter() == null ? null : query.getFilter().toFilter(),
-        query.getVirtualColumns()
+        QueryContexts.getJoinFilterRewriteMaxSize(query)
     );
 
     final QueryRunner<T> baseRunner = new FinalizeResultsQueryRunner<>(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -11483,7 +11483,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
 
   @Test
   @Parameters(source = QueryContextForJoinProvider.class)
-  public void testNestedGroupByOnInlineDataSourceWithFilterIsNotSupported(Map<String, Object> queryContext) throws Exception
+  public void testNestedGroupByOnInlineDataSourceWithFilter(Map<String, Object> queryContext) throws Exception
   {
     // Cannot vectorize due to virtual columns.
     cannotVectorize();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -31,7 +31,6 @@ import org.apache.druid.annotations.UsedByJUnitParamsRunner;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.StringUtils;
@@ -11486,79 +11485,75 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Parameters(source = QueryContextForJoinProvider.class)
   public void testNestedGroupByOnInlineDataSourceWithFilterIsNotSupported(Map<String, Object> queryContext) throws Exception
   {
-    try {
-      testQuery(
-          "with abc as"
-          + "("
-          + "  SELECT dim1, m2 from druid.foo where \"__time\" >= '2001-01-02'"
-          + ")"
-          + ", def as"
-          + "("
-          + "  SELECT t1.dim1, SUM(t2.m2) as \"metricSum\" "
-          + "  from abc as t1 inner join abc as t2 on t1.dim1 = t2.dim1"
-          + "  where t1.dim1='def'"
-          + "  group by 1"
-          + ")"
-          + "SELECT count(*) from def",
-          queryContext,
-          ImmutableList.of(
-              GroupByQuery
-                  .builder()
-                  .setDataSource(
-                      GroupByQuery
-                          .builder()
-                          .setDataSource(
-                              join(
-                                  new QueryDataSource(
-                                      newScanQueryBuilder()
-                                          .dataSource(CalciteTests.DATASOURCE1)
-                                          .intervals(querySegmentSpec(Intervals.of("2001-01-02T00:00:00.000Z/146140482-04-24T15:36:27.903Z")))
-                                          .columns("dim1", "m2")
-                                          .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                          .context(queryContext)
-                                          .build()
-                                  ),
-                                  new QueryDataSource(
-                                      newScanQueryBuilder()
-                                          .dataSource(CalciteTests.DATASOURCE1)
-                                          .intervals(querySegmentSpec(Intervals.of("2001-01-02T00:00:00.000Z/146140482-04-24T15:36:27.903Z")))
-                                          .columns("dim1", "m2")
-                                          .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                          .context(queryContext)
-                                          .build()
-                                  ),
-                                  "j0",
-                                  equalsCondition(
-                                      DruidExpression.fromColumn("dim1"),
-                                      DruidExpression.fromColumn("j0.dim1")
-                                  ),
-                                  JoinType.INNER
-                              )
-                          )
-                          .setGranularity(Granularities.ALL)
-                          .setInterval(querySegmentSpec(Filtration.eternity()))
-                          .build()
-                  )
-                  .setGranularity(Granularities.ALL)
-                  .setInterval(querySegmentSpec(Filtration.eternity()))
-                  .build()
-          ),
-          ImmutableList.of(new Object[] {1})
-      );
-      Assert.fail("Expected an ISE to be thrown");
-    }
-    catch (RuntimeException e) {
-      Throwable cause = e.getCause();
-      boolean foundISE = false;
-      while (cause != null) {
-        if (cause instanceof ISE) {
-          foundISE = true;
-          break;
-        }
-        cause = cause.getCause();
-      }
-      Assert.assertTrue(foundISE);
-    }
+    // Cannot vectorize due to virtual columns.
+    cannotVectorize();
+
+    testQuery(
+        "with abc as"
+        + "("
+        + "  SELECT dim1, m2 from druid.foo where \"__time\" >= '2001-01-02'"
+        + ")"
+        + ", def as"
+        + "("
+        + "  SELECT t1.dim1, SUM(t2.m2) as \"metricSum\" "
+        + "  from abc as t1 inner join abc as t2 on t1.dim1 = t2.dim1"
+        + "  where t1.dim1='def'"
+        + "  group by 1"
+        + ")"
+        + "SELECT count(*) from def",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery
+                .builder()
+                .setDataSource(
+                    GroupByQuery
+                        .builder()
+                        .setDataSource(
+                            join(
+                                new QueryDataSource(
+                                    newScanQueryBuilder()
+                                        .dataSource(CalciteTests.DATASOURCE1)
+                                        .intervals(querySegmentSpec(Intervals.of("2001-01-02T00:00:00.000Z/146140482-04-24T15:36:27.903Z")))
+                                        .columns("dim1")
+                                        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                        .context(queryContext)
+                                        .build()
+                                ),
+                                new QueryDataSource(
+                                    newScanQueryBuilder()
+                                        .dataSource(CalciteTests.DATASOURCE1)
+                                        .intervals(querySegmentSpec(Intervals.of("2001-01-02T00:00:00.000Z/146140482-04-24T15:36:27.903Z")))
+                                        .columns("dim1", "m2")
+                                        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                        .context(queryContext)
+                                        .build()
+                                ),
+                                "j0.",
+                                equalsCondition(
+                                    DruidExpression.fromColumn("dim1"),
+                                    DruidExpression.fromColumn("j0.dim1")
+                                ),
+                                JoinType.INNER
+                            )
+                        )
+                        .setGranularity(Granularities.ALL)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setDimFilter(selector("dim1", "def", null))
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0")
+                            )
+                        )
+                        .setVirtualColumns(expressionVirtualColumn("v0", "'def'", ValueType.STRING))
+                        .build()
+                )
+                .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
+                .setGranularity(Granularities.ALL)
+                .setInterval(querySegmentSpec(Filtration.eternity()))
+                .build()
+        ),
+        ImmutableList.of(new Object[] {1L})
+    );
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/9792 by moving the join filter pre-analysis into the `makeCursors` method of `HashJoinSegmentStorageAdapter`. This is done by introducing a new `JoinFilterPreAnalysisGroup` class, which holds a concurrent hash map of Filter -> JoinFilterPreAnalysis, used to avoid redundant computation of the JoinFilterPreAnalysis

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
