### PR TITLE
Fix groupBy with literal in subquery grouping

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
@@ -179,11 +179,10 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
   );
 
   /**
-   * Generally speaking this is the exact same thing as makePreComputeManipulatorFn.  It is leveraged in
-   * order to compute PostAggregators on results after they have been completely merged together, which
-   * should actually be done in the mergeResults() call instead of here.
-   * <p>
-   * This should never actually be overridden and it should be removed as quickly as possible.
+   * Generally speaking this is the exact same thing as makePreComputeManipulatorFn.  It is leveraged in order to
+   * compute PostAggregators on results after they have been completely merged together. To minimize walks of segments,
+   * it is recommended to use mergeResults() call instead of this method if possible. However, this may not always be
+   * possible as we don’t always want to run PostAggregators and other stuff that happens there when you mergeResults.
    *
    * @param query The Query that is currently being processed
    * @param fn    The function that should be applied to all metrics in the results

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -317,7 +317,6 @@ public class DruidQuery
 
     final Subtotals subtotals = computeSubtotals(
         partialQuery,
-        plannerContext,
         rowSignature
     );
 
@@ -430,7 +429,6 @@ public class DruidQuery
    */
   private static Subtotals computeSubtotals(
       final PartialDruidQuery partialQuery,
-      final PlannerContext plannerContext,
       final RowSignature rowSignature
   )
   {
@@ -439,21 +437,7 @@ public class DruidQuery
     // dimBitMapping maps from input field position to group set position (dimension number).
     final int[] dimBitMapping;
     if (partialQuery.getSelectProject() != null) {
-      int fieldCount = 0;
-      for (final RexNode rexNode : partialQuery.getSelectProject().getChildExps()) {
-        final DruidExpression expression = Expressions.toDruidExpression(
-            plannerContext,
-            rowSignature,
-            rexNode
-        );
-
-        if (expression == null) {
-          throw new CannotBuildQueryException(partialQuery.getSelectProject(), rexNode);
-        } else {
-          fieldCount++;
-        }
-      }
-      dimBitMapping = new int[fieldCount];
+      dimBitMapping = new int[partialQuery.getSelectProject().getRowType().getFieldCount()];
     } else {
       dimBitMapping = new int[rowSignature.size()];
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -424,6 +424,8 @@ public class DruidQuery
 
   /**
    * Builds a {@link Subtotals} object based on {@link Aggregate#getGroupSets()}.
+   *
+   * @throws CannotBuildQueryException if subtotals cannot be computed
    */
   private static Subtotals computeSubtotals(
       final PartialDruidQuery partialQuery,
@@ -432,10 +434,15 @@ public class DruidQuery
   {
     final Aggregate aggregate = partialQuery.getAggregate();
 
+
     // dimBitMapping maps from input field position to group set position (dimension number).
     final int[] dimBitMapping = new int[rowSignature.size()];
     int i = 0;
     for (int dimBit : aggregate.getGroupSet()) {
+      // subtotals cannot be computed since grouping field is not contained in rowSignature
+      if (dimBit >= rowSignature.size()) {
+        throw new CannotBuildQueryException(aggregate);
+      }
       dimBitMapping[dimBit] = i++;
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -424,8 +424,6 @@ public class DruidQuery
 
   /**
    * Builds a {@link Subtotals} object based on {@link Aggregate#getGroupSets()}.
-   *
-   * @throws CannotBuildQueryException if subtotals cannot be computed
    */
   private static Subtotals computeSubtotals(
       final PartialDruidQuery partialQuery,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -191,7 +191,7 @@ public class DruidQuery
           computeGrouping(
               partialQuery,
               plannerContext,
-              computeOutputRowSignature(sourceRowSignature, selectProjection, null, null),
+              computeOutputRowSignature(sourceRowSignature, null, null, null),
               virtualColumnRegistry,
               rexBuilder,
               finalizeAggregations
@@ -434,15 +434,16 @@ public class DruidQuery
   {
     final Aggregate aggregate = partialQuery.getAggregate();
 
-
     // dimBitMapping maps from input field position to group set position (dimension number).
-    final int[] dimBitMapping = new int[rowSignature.size()];
+    final int[] dimBitMapping;
+    if (partialQuery.getSelectProject() != null) {
+      dimBitMapping = new int[partialQuery.getSelectProject().getRowType().getFieldCount()];
+    } else {
+      dimBitMapping = new int[rowSignature.size()];
+    }
+
     int i = 0;
     for (int dimBit : aggregate.getGroupSet()) {
-      // subtotals cannot be computed since grouping field is not contained in rowSignature
-      if (dimBit >= rowSignature.size()) {
-        throw new CannotBuildQueryException(aggregate);
-      }
       dimBitMapping[dimBit] = i++;
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -317,6 +317,7 @@ public class DruidQuery
 
     final Subtotals subtotals = computeSubtotals(
         partialQuery,
+        plannerContext,
         rowSignature
     );
 
@@ -429,6 +430,7 @@ public class DruidQuery
    */
   private static Subtotals computeSubtotals(
       final PartialDruidQuery partialQuery,
+      final PlannerContext plannerContext,
       final RowSignature rowSignature
   )
   {
@@ -437,7 +439,21 @@ public class DruidQuery
     // dimBitMapping maps from input field position to group set position (dimension number).
     final int[] dimBitMapping;
     if (partialQuery.getSelectProject() != null) {
-      dimBitMapping = new int[partialQuery.getSelectProject().getRowType().getFieldCount()];
+      int fieldCount = 0;
+      for (final RexNode rexNode : partialQuery.getSelectProject().getChildExps()) {
+        final DruidExpression expression = Expressions.toDruidExpression(
+            plannerContext,
+            rowSignature,
+            rexNode
+        );
+
+        if (expression == null) {
+          throw new CannotBuildQueryException(partialQuery.getSelectProject(), rexNode);
+        } else {
+          fieldCount++;
+        }
+      }
+      dimBitMapping = new int[fieldCount];
     } else {
       dimBitMapping = new int[rowSignature.size()];
     }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -70,7 +70,6 @@ import org.apache.druid.query.aggregation.last.FloatLastAggregatorFactory;
 import org.apache.druid.query.aggregation.last.LongLastAggregatorFactory;
 import org.apache.druid.query.aggregation.last.StringLastAggregatorFactory;
 import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
-import org.apache.druid.query.aggregation.post.ExpressionPostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.apache.druid.query.aggregation.post.FinalizingFieldAccessPostAggregator;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -13450,26 +13450,25 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                         .setInterval(querySegmentSpec(Filtration.eternity()))
                                         .setGranularity(Granularities.ALL)
                                         .setDimensions(new DefaultDimensionSpec("dim4", "_d0", ValueType.STRING))
-                                        .setPostAggregatorSpecs(
-                                            ImmutableList.of(
-                                                expressionPostAgg(
-                                                    "p0",
-                                                    "\'dummy\'"
-                                                ),
-                                                expressionPostAgg(
-                                                    "p1",
-                                                    "case_searched((\"_d0\" == 'b'),\"_d0\",null)"
-                                                )
-                                            )
-                                        )
                                         .setContext(QUERY_CONTEXT_DEFAULT)
                                         .build()
                         )
-                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setVirtualColumns(
+                            expressionVirtualColumn(
+                                "v0",
+                                "\'dummy\'",
+                                ValueType.STRING
+                            ),
+                            expressionVirtualColumn(
+                                "v1",
+                                "case_searched((\"_d0\" == 'b'),\"_d0\",null)",
+                                ValueType.STRING
+                            )
+                        )                        .setInterval(querySegmentSpec(Filtration.eternity()))
                         .setDimensions(
                             dimensions(
-                                new DefaultDimensionSpec("p0", "d0", ValueType.STRING),
-                                new DefaultDimensionSpec("p1", "d1", ValueType.STRING)
+                                new DefaultDimensionSpec("v0", "d0", ValueType.STRING),
+                                new DefaultDimensionSpec("v1", "d1", ValueType.STRING)
                             )
                         )
                         .setGranularity(Granularities.ALL)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -13464,7 +13464,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 "case_searched((\"_d0\" == 'b'),\"_d0\",null)",
                                 ValueType.STRING
                             )
-                        )                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        )
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
                         .setDimensions(
                             dimensions(
                                 new DefaultDimensionSpec("v0", "d0", ValueType.STRING),
@@ -13475,13 +13476,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        NullHandling.replaceWithDefault() ?
         ImmutableList.of(
-            new Object[]{"dummy", ""},
-            new Object[]{"dummy", "b"}
-        ) :
-        ImmutableList.of(
-            new Object[]{"dummy", null},
+            new Object[]{"dummy", NULL_STRING},
             new Object[]{"dummy", "b"}
         )
     );


### PR DESCRIPTION
Fix groupBy with literal in subquery grouping

### Description

I believe this is a regression/bug caused by https://github.com/apache/druid/pull/9122
When we have a query such as:
```
SELECT 
	t1, t2
FROM
	( SELECT
		'm' as t1,
		CASE
	  	WHEN 
	  		cityName = 'Egypt'
	  	THEN cityName
      	ELSE NULL
    END AS t2
	  FROM
		wikipedia
	  GROUP BY
		cityName
	)
GROUP BY
	t1,t2
```
Calcite will creates a Rel `2020-06-04T08:59:34,977 TRACE [sql[0840a1a8-ff59-4986-ad69-be2ce27a5e68]] org.apache.calcite.plan.RelOptPlanner - Register rel#5424:DruidQueryRel.NONE.[](query={"queryType":"groupBy","dataSource":{"type":"table","name":"wikipedia"},"intervals":{"type":"intervals","intervals":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"]},"virtualColumns":[],"filter":null,"granularity":{"type":"all"},"dimensions":[{"type":"default","dimension":"cityName","outputName":"d0","outputType":"STRING"}],"aggregations":[],"postAggregations":[],"having":null,"limitSpec":{"type":"NoopLimitSpec"},"context":{"populateCache":false,"sqlQueryId":"0840a1a8-ff59-4986-ad69-be2ce27a5e68","useCache":false},"descending":false},signature={d0:STRING}) in rel#5415:Subset#2.NONE.[]` for part of the subquery. This Rel signature is only a single field. The other field which is a literal is not part of the groupBy and is part of the projection on top of this. 

Now the problem is when we try to build new Rel, in computeSubtotals with the above Rel as the sourceRel and a partialQuery with aggregate looking like `aggregate=rel#5418:LogicalAggregate.NONE.[](input=RelSubset#5417,group={0, 1}), havingFilter=null, aggregateProject=null, sort=null, sortProject=null}`. This aggregate has two bits in the groupSet. This fails without taking into account the projection mentioned above. Hence, we should skip and not build this new Rel and handle this case with CannotBuildQueryException so that we can move on to other Rels.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

