### PR TITLE
Update RoaringBitmap to 0.9.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2016,7 +2016,7 @@ name: RoaringBitmap
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 0.8.11
+version: 0.9.0
 libraries:
   - org.roaringbitmap: RoaringBitmap
   - org.roaringbitmap: shims

--- a/pom.xml
+++ b/pom.xml
@@ -918,7 +918,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>0.8.11</version>
+                <version>0.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Fixes #9920. Some improvements were made to the `FastAggregation` class. 

Actually, won't fix the issue, just saw druid uses the iterator overload which hasn't been modified.

https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/collections/bitmap/RoaringBitmapFactory.java#L160