### PR TITLE
Fix failed tests in TimestampParserTest when timezone is not UTC

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -394,6 +394,8 @@
           <argLine>
             @{jacocoArgLine}
             -Djava.library.path=${project.build.directory}/hyperic-sigar-${sigar.base.version}/sigar-bin/lib/
+            -Duser.language=en
+            -Duser.country=US
           </argLine>
         </configuration>
       </plugin>


### PR DESCRIPTION
### Description

Fix timezone problem in TimestampParserTest when running unit tests locally if locale is not Locale.US. Following is the error message:

`java.lang.IllegalArgumentException: Invalid format: "Sat Jan 22 05 13:00:00 GMT-0600 CST`

<hr>

This PR has:
- [x] been self-reviewed.

<hr>
