### PR TITLE
Simplify CompressedVSizeColumnarIntsSupplierTest

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
@@ -56,13 +56,8 @@ public class CompressedVSizeColumnarIntsSupplierTest extends CompressionStrategy
   @Parameterized.Parameters(name = "{index}: compression={0}, byteOrder={1}")
   public static Iterable<Object[]> compressionStrategies()
   {
-    final Iterable<CompressionStrategy> compressionStrategies = Iterables.transform(
-        CompressionStrategyTest.compressionStrategies(),
-        (Object[] input) -> (CompressionStrategy) input[0]
-    );
-
     Set<List<Object>> combinations = Sets.cartesianProduct(
-        Sets.newHashSet(compressionStrategies),
+        Sets.newHashSet(CompressionStrategy.noNoneValues()),
         Sets.newHashSet(ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN)
     );
 


### PR DESCRIPTION


### Description

Improve readability of the test by simplifying its parameters generator.

The parameters generator uses `CompressionStrategy.noNoneValues()` instead of `CompressionStrategyTest.compressionStrategies()` which wrapped each `CompressionStrategy` in a single element array.

<hr>

This PR has:
- [x] been self-reviewed.

<hr>

##### Key changed/added classes in this PR
 * `CompressedVSizeColumnarIntsSupplierTest`
