### PR TITLE
Remove colocated datasources from web console for broadcast indexed tables

### DIFF
--- a/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
+++ b/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
@@ -214,6 +214,186 @@ exports[`rule editor matches snapshot no tier in rule 1`] = `
 </div>
 `;
 
+exports[`rule editor matches snapshot with broadcast rule 1`] = `
+<div
+  class="rule-editor"
+>
+  <div
+    class="title"
+  >
+    <button
+      class="bp3-button bp3-minimal left"
+      type="button"
+    >
+      <span
+        class="bp3-button-text"
+      >
+        broadcastByInterval(2010-01-01/2015-01-01)
+      </span>
+      <span
+        class="bp3-icon bp3-icon-caret-down"
+        icon="caret-down"
+      >
+        <svg
+          data-icon="caret-down"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            caret-down
+          </desc>
+          <path
+            d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </button>
+    <div
+      class="spacer"
+    />
+    <button
+      class="bp3-button bp3-minimal"
+      type="button"
+    >
+      <span
+        class="bp3-icon bp3-icon-trash"
+        icon="trash"
+      >
+        <svg
+          data-icon="trash"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            trash
+          </desc>
+          <path
+            d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+  <div
+    class="bp3-collapse"
+    style="height: auto; overflow-y: visible; transition: none;"
+  >
+    <div
+      aria-hidden="false"
+      class="bp3-collapse-body"
+      style="transform: translateY(0); transition: none;"
+    >
+      <div
+        class="bp3-card bp3-elevation-0"
+      >
+        <div
+          class="bp3-form-group"
+        >
+          <div
+            class="bp3-form-content"
+          >
+            <div
+              class="bp3-control-group"
+            >
+              <div
+                class="bp3-html-select"
+              >
+                <select>
+                  <option
+                    value="loadForever"
+                  >
+                    loadForever
+                  </option>
+                  <option
+                    value="loadByInterval"
+                  >
+                    loadByInterval
+                  </option>
+                  <option
+                    value="loadByPeriod"
+                  >
+                    loadByPeriod
+                  </option>
+                  <option
+                    value="dropForever"
+                  >
+                    dropForever
+                  </option>
+                  <option
+                    value="dropByInterval"
+                  >
+                    dropByInterval
+                  </option>
+                  <option
+                    value="dropByPeriod"
+                  >
+                    dropByPeriod
+                  </option>
+                  <option
+                    value="dropBeforeByPeriod"
+                  >
+                    dropBeforeByPeriod
+                  </option>
+                  <option
+                    value="broadcastForever"
+                  >
+                    broadcastForever
+                  </option>
+                  <option
+                    value="broadcastByInterval"
+                  >
+                    broadcastByInterval
+                  </option>
+                  <option
+                    value="broadcastByPeriod"
+                  >
+                    broadcastByPeriod
+                  </option>
+                </select>
+                <span
+                  class="bp3-icon bp3-icon-double-caret-vertical"
+                  icon="double-caret-vertical"
+                >
+                  <svg
+                    data-icon="double-caret-vertical"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <desc>
+                      double-caret-vertical
+                    </desc>
+                    <path
+                      d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="bp3-input-group"
+              >
+                <input
+                  class="bp3-input"
+                  placeholder="2010-01-01/2020-01-01"
+                  style="padding-right: 10px;"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`rule editor matches snapshot with existing tier and non existing tier in rule 1`] = `
 <div
   class="rule-editor"

--- a/web-console/src/components/rule-editor/rule-editor.spec.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.spec.tsx
@@ -96,4 +96,22 @@ describe('rule editor', () => {
     const { container } = render(ruleEditor);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('matches snapshot with broadcast rule', () => {
+    const ruleEditor = (
+      <RuleEditor
+        rule={{
+          type: 'broadcastByInterval',
+          period: '2010-01-01/2015-01-01',
+        }}
+        tiers={[]}
+        onChange={() => {}}
+        onDelete={() => {}}
+        moveUp={null}
+        moveDown={null}
+      />
+    );
+    const { container } = render(ruleEditor);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -26,7 +26,6 @@ import {
   InputGroup,
   NumericInput,
   Switch,
-  TagInput,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import React, { useState } from 'react';
@@ -207,15 +206,6 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
             <FormGroup>
               {renderTiers()}
               {renderTierAdder()}
-            </FormGroup>
-          )}
-          {RuleUtil.hasColocatedDataSources(rule) && (
-            <FormGroup label="Colocated datasources">
-              <TagInput
-                values={rule.colocatedDataSources || []}
-                onChange={(v: any) => onChange(RuleUtil.changeColocatedDataSources(rule, v))}
-                fill
-              />
             </FormGroup>
           )}
         </Card>

--- a/web-console/src/utils/load-rule.ts
+++ b/web-console/src/utils/load-rule.ts
@@ -36,7 +36,6 @@ export interface Rule {
   period?: string;
   includeFuture?: boolean;
   tieredReplicants?: Record<string, number>;
-  colocatedDataSources?: string[];
 }
 
 export class RuleUtil {
@@ -83,8 +82,6 @@ export class RuleUtil {
       delete newRule.tieredReplicants;
     }
 
-    if (!RuleUtil.hasColocatedDataSources(newRule)) delete newRule.colocatedDataSources;
-
     return newRule;
   }
 
@@ -123,13 +120,5 @@ export class RuleUtil {
   static addTieredReplicant(rule: Rule, tier: string, replication: number): Rule {
     const newTieredReplicants = deepSet(rule.tieredReplicants || {}, tier, replication);
     return deepSet(rule, 'tieredReplicants', newTieredReplicants);
-  }
-
-  static hasColocatedDataSources(rule: Rule): boolean {
-    return rule.type.startsWith('broadcast');
-  }
-
-  static changeColocatedDataSources(rule: Rule, colocatedDataSources: string[]): Rule {
-    return deepSet(rule, 'colocatedDataSources', colocatedDataSources);
   }
 }


### PR DESCRIPTION
Remove colocated datasources from web console for broadcast indexed tables

### Description
This PR removes the colocated datasources option from the web console in the broadcast rules UI. This is a followup/related to https://github.com/apache/druid/issues/9953

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
