### PR TITLE
Fix broadcast rule drop and docs

### DIFF
--- a/docs/operations/rule-configuration.md
+++ b/docs/operations/rule-configuration.md
@@ -170,8 +170,9 @@ The interval of a segment will be compared against the specified period. The per
 
 ## Broadcast Rules
 
-Broadcast rules indicate how segments of different datasources should be co-located in Historical processes.
-Once a broadcast rule is configured for a datasource, all segments of the datasource are broadcasted to the servers holding _any segments_ of the co-located datasources.
+Broadcast rules indicate that segments of a data source should be loaded by all servers of a cluster of the following types: historicals, brokers, tasks, and indexers.
+
+Note that the broadcast segments are only directly queryable through the historicals, but they are currently loaded on other server types to support join queries.
 
 ### Forever Broadcast Rule
 
@@ -179,13 +180,13 @@ Forever broadcast rules are of the form:
 
 ```json
 {
-  "type" : "broadcastForever",
-  "colocatedDataSources" : [ "target_source1", "target_source2" ]
+  "type" : "broadcastForever"
 }
 ```
 
 * `type` - this should always be "broadcastForever"
-* `colocatedDataSources` - A JSON List containing datasource names to be co-located. `null` and empty list means broadcasting to every process in the cluster.
+
+This rule applies to all segments of a datasource, covering all intervals.
 
 ### Interval Broadcast Rule
 
@@ -194,13 +195,11 @@ Interval broadcast rules are of the form:
 ```json
 {
   "type" : "broadcastByInterval",
-  "colocatedDataSources" : [ "target_source1", "target_source2" ],
   "interval" : "2012-01-01/2013-01-01"
 }
 ```
 
 * `type` - this should always be "broadcastByInterval"
-* `colocatedDataSources` - A JSON List containing datasource names to be co-located. `null` and empty list means broadcasting to every process in the cluster.
 * `interval` - A JSON Object representing ISO-8601 Periods. Only the segments of the interval will be broadcasted.
 
 ### Period Broadcast Rule
@@ -210,21 +209,16 @@ Period broadcast rules are of the form:
 ```json
 {
   "type" : "broadcastByPeriod",
-  "colocatedDataSources" : [ "target_source1", "target_source2" ],
   "period" : "P1M",
   "includeFuture" : true
 }
 ```
 
 * `type` - this should always be "broadcastByPeriod"
-* `colocatedDataSources` - A JSON List containing datasource names to be co-located. `null` and empty list means broadcasting to every process in the cluster.
 * `period` - A JSON Object representing ISO-8601 Periods
 * `includeFuture` - A JSON Boolean indicating whether the load period should include the future. This property is optional, Default is true.
 
 The interval of a segment will be compared against the specified period. The period is from some time in the past to the future or to the current time, which depends on `includeFuture` is true or false. The rule matches if the period *overlaps* the interval.
-
-> broadcast rules don't guarantee that segments of the datasources are always co-located because segments for the colocated datasources are not loaded together atomically.
-> If you want to always co-locate the segments of some datasources together, it is recommended to leave colocatedDataSources empty.
 
 ## Permanently deleting data
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegments.java
@@ -66,9 +66,8 @@ public class MarkAsUnusedOvershadowedSegments implements CoordinatorDuty
       addSegmentsFromServer(serverHolder, timelines);
     }
 
-    for (ServerHolder serverHolder : cluster.getRealtimes()) {
-      addSegmentsFromServer(serverHolder, timelines);
-    }
+    // Note that we do not include segments from ingestion services such as tasks or indexers,
+    // to prevent unpublished segments from prematurely overshadowing segments.
 
     // Mark all segments as unused in db that are overshadowed by served segments
     for (DataSegment dataSegment : params.getUsedSegments()) {

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
@@ -76,8 +76,7 @@ public class MarkAsUnusedOvershadowedSegmentsTest
   @Parameters(
       {
           "historical",
-          "broker",
-          "indexer-executor"
+          "broker"
       }
   )
   public void testRun(String serverTypeString)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
@@ -21,6 +21,8 @@ package org.apache.druid.server.coordinator.duty;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.common.DateTimes;
@@ -39,9 +41,11 @@ import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 
+@RunWith(JUnitParamsRunner.class)
 public class MarkAsUnusedOvershadowedSegmentsTest
 {
   MarkAsUnusedOvershadowedSegments markAsUnusedOvershadowedSegments;
@@ -69,8 +73,17 @@ public class MarkAsUnusedOvershadowedSegmentsTest
                                                            .build();
 
   @Test
-  public void testRun()
+  @Parameters(
+      {
+          "historical",
+          "broker",
+          "indexer-executor"
+      }
+  )
+  public void testRun(String serverTypeString)
   {
+    ServerType serverType = ServerType.fromString(serverTypeString);
+
     markAsUnusedOvershadowedSegments =
         new MarkAsUnusedOvershadowedSegments(coordinator);
     usedSegments = ImmutableList.of(segmentV1, segmentV0, segmentV2);
@@ -95,7 +108,7 @@ public class MarkAsUnusedOvershadowedSegmentsTest
             .andReturn("")
             .anyTimes();
     EasyMock.expect(druidServer.getType())
-            .andReturn(ServerType.HISTORICAL)
+            .andReturn(serverType)
             .anyTimes();
 
     EasyMock.expect(druidServer.getDataSources())

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
@@ -225,11 +225,6 @@ public class UnloadUnusedSegmentsTest
     CoordinatorStats stats = params.getCoordinatorStats();
     Assert.assertEquals(3, stats.getTieredStat("unneededCount", DruidServer.DEFAULT_TIER));
     Assert.assertEquals(1, stats.getTieredStat("unneededCount", "tier2"));
-    Assert.assertEquals(historicalPeon.getSegmentsToDrop(), Collections.singleton(segment1));
-    Assert.assertEquals(historicalTier2Peon.getSegmentsToDrop(), Collections.singleton(segment1));
-    Assert.assertEquals(brokerPeon.getSegmentsToDrop(), Collections.singleton(segment1));
-    Assert.assertEquals(indexerPeon.getSegmentsToDrop(), Collections.singleton(segment1));
-
   }
 
   private static void mockDruidServer(

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.client.ImmutableDruidDataSource;
+import org.apache.druid.client.ImmutableDruidServer;
+import org.apache.druid.client.ImmutableDruidServerTests;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.CoordinatorRuntimeParamsTestHelpers;
+import org.apache.druid.server.coordinator.CoordinatorStats;
+import org.apache.druid.server.coordinator.DruidClusterBuilder;
+import org.apache.druid.server.coordinator.DruidCoordinator;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.LoadQueuePeonTester;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NoneShardSpec;
+import org.easymock.EasyMock;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+public class UnloadUnusedSegmentsTest
+{
+  private DruidCoordinator coordinator;
+  private ImmutableDruidServer historicalServer;
+  private ImmutableDruidServer historicalServerTier2;
+  private ImmutableDruidServer brokerServer;
+  private ImmutableDruidServer indexerServer;
+  private LoadQueuePeonTester historicalPeon;
+  private LoadQueuePeonTester historicalTier2Peon;
+  private LoadQueuePeonTester brokerPeon;
+  private LoadQueuePeonTester indexerPeon;
+  private DataSegment segment1;
+  private DataSegment segment2;
+  private List<DataSegment> segments;
+  private ImmutableDruidDataSource dataSource1;
+  private ImmutableDruidDataSource dataSource2;
+  private List<ImmutableDruidDataSource> dataSources;
+
+  @Before
+  public void setUp()
+  {
+    coordinator = EasyMock.createMock(DruidCoordinator.class);
+    historicalServer = EasyMock.createMock(ImmutableDruidServer.class);
+    historicalServerTier2 = EasyMock.createMock(ImmutableDruidServer.class);
+    brokerServer = EasyMock.createMock(ImmutableDruidServer.class);
+    indexerServer = EasyMock.createMock(ImmutableDruidServer.class);
+    segment1 = EasyMock.createMock(DataSegment.class);
+    segment2 = EasyMock.createMock(DataSegment.class);
+
+    DateTime start1 = DateTimes.of("2012-01-01");
+    DateTime start2 = DateTimes.of("2012-02-01");
+    DateTime version = DateTimes.of("2012-03-01");
+    segment1 = new DataSegment(
+        "datasource1",
+        new Interval(start1, start1.plusHours(1)),
+        version.toString(),
+        new HashMap<>(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        NoneShardSpec.instance(),
+        0,
+        11L
+    );
+    segment2 = new DataSegment(
+        "datasource2",
+        new Interval(start2, start2.plusHours(1)),
+        version.toString(),
+        new HashMap<>(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        NoneShardSpec.instance(),
+        0,
+        7L
+    );
+
+    segments = new ArrayList<>();
+    segments.add(segment1);
+    segments.add(segment2);
+
+    historicalPeon = new LoadQueuePeonTester();
+    historicalTier2Peon = new LoadQueuePeonTester();
+    brokerPeon = new LoadQueuePeonTester();
+    indexerPeon = new LoadQueuePeonTester();
+
+    dataSource1 = new ImmutableDruidDataSource(
+        "dataSource1",
+        Collections.emptyMap(),
+        Collections.singleton(segment1)
+    );
+
+    dataSource2 = new ImmutableDruidDataSource(
+        "dataSource1",
+        Collections.emptyMap(),
+        Collections.singleton(segment2)
+    );
+
+    dataSources = ImmutableList.of(dataSource1, dataSource2);
+  }
+
+  @After
+  public void tearDown()
+  {
+    EasyMock.verify(coordinator);
+    EasyMock.verify(historicalServer);
+    EasyMock.verify(historicalServerTier2);
+    EasyMock.verify(brokerServer);
+    EasyMock.verify(indexerServer);
+  }
+
+  @Test
+  public void test_unloadUnusedSegmentsFromAllServers()
+  {
+    mockDruidServer(
+        historicalServer,
+        ServerType.HISTORICAL,
+        "historical",
+        DruidServer.DEFAULT_TIER,
+        30L,
+        100L,
+        segments,
+        dataSources
+    );
+    mockDruidServer(
+        historicalServerTier2,
+        ServerType.HISTORICAL,
+        "historicalTier2",
+        "tier2",
+        30L,
+        100L,
+        segments,
+        dataSources
+    );
+    mockDruidServer(
+        brokerServer,
+        ServerType.BROKER,
+        "broker",
+        DruidServer.DEFAULT_TIER,
+        30L,
+        100L,
+        segments,
+        dataSources
+    );
+    mockDruidServer(
+        indexerServer,
+        ServerType.INDEXER_EXECUTOR,
+        "indexer",
+        DruidServer.DEFAULT_TIER,
+        30L,
+        100L,
+        segments,
+        dataSources
+    );
+
+    // Mock stuff that the coordinator needs
+    mockCoordinator(coordinator);
+
+    // We keep datasource2, drop datasource1 from all servers
+    Set<DataSegment> usedSegments = Collections.singleton(segment2);
+
+    DruidCoordinatorRuntimeParams params = CoordinatorRuntimeParamsTestHelpers
+        .newBuilder()
+        .withDruidCluster(
+            DruidClusterBuilder
+                .newBuilder()
+                .addTier(
+                    DruidServer.DEFAULT_TIER,
+                    new ServerHolder(historicalServer, historicalPeon, false)
+                )
+                .addTier(
+                    "tier2",
+                    new ServerHolder(historicalServerTier2, historicalTier2Peon, false)
+                )
+                .withBrokers(
+                    new ServerHolder(brokerServer, brokerPeon, false)
+                )
+                .withRealtimes(
+                    new ServerHolder(indexerServer, indexerPeon, false)
+                )
+                .build()
+        )
+        .withLoadManagementPeons(
+            ImmutableMap.of(
+                "historical", historicalPeon,
+                "historicalTier2", historicalTier2Peon,
+                "broker", brokerPeon,
+                "indexer", indexerPeon
+            )
+        )
+        .withUsedSegmentsInTest(usedSegments)
+        .build();
+
+    params = new UnloadUnusedSegments().run(params);
+    CoordinatorStats stats = params.getCoordinatorStats();
+    Assert.assertEquals(3, stats.getTieredStat("unneededCount", DruidServer.DEFAULT_TIER));
+    Assert.assertEquals(1, stats.getTieredStat("unneededCount", "tier2"));
+    Assert.assertEquals(historicalPeon.getSegmentsToDrop(), Collections.singleton(segment1));
+    Assert.assertEquals(historicalTier2Peon.getSegmentsToDrop(), Collections.singleton(segment1));
+    Assert.assertEquals(brokerPeon.getSegmentsToDrop(), Collections.singleton(segment1));
+    Assert.assertEquals(indexerPeon.getSegmentsToDrop(), Collections.singleton(segment1));
+
+  }
+
+  private static void mockDruidServer(
+      ImmutableDruidServer druidServer,
+      ServerType serverType,
+      String name,
+      String tier,
+      long currentSize,
+      long maxSize,
+      List<DataSegment> segments,
+      List<ImmutableDruidDataSource> dataSources
+  )
+  {
+    EasyMock.expect(druidServer.getName()).andReturn(name).anyTimes();
+    EasyMock.expect(druidServer.getTier()).andReturn(tier).anyTimes();
+    EasyMock.expect(druidServer.getCurrSize()).andReturn(currentSize).anyTimes();
+    EasyMock.expect(druidServer.getMaxSize()).andReturn(maxSize).anyTimes();
+    ImmutableDruidServerTests.expectSegments(druidServer, segments);
+    EasyMock.expect(druidServer.getHost()).andReturn(name).anyTimes();
+    EasyMock.expect(druidServer.getType()).andReturn(serverType).anyTimes();
+    EasyMock.expect(druidServer.getDataSources()).andReturn(dataSources).anyTimes();
+    if (!segments.isEmpty()) {
+      segments.forEach(
+          s -> EasyMock.expect(druidServer.getSegment(s.getId())).andReturn(s).anyTimes()
+      );
+    }
+    EasyMock.expect(druidServer.getSegment(EasyMock.anyObject())).andReturn(null).anyTimes();
+    EasyMock.replay(druidServer);
+  }
+
+  private static void mockCoordinator(DruidCoordinator coordinator)
+  {
+    coordinator.moveSegment(
+        EasyMock.anyObject(),
+        EasyMock.anyObject(),
+        EasyMock.anyObject(),
+        EasyMock.anyObject(),
+        EasyMock.anyObject()
+    );
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(coordinator);
+  }
+}


### PR DESCRIPTION
This fixes missing functionality with broadcast segments on non-historical servers, where `UnloadUnusedSegments` in the coordinator was not accounting for such servers, causing unused segments to not be dropped.

This PR also updates the docs to account for the removed colocated datasources functionality, removed in https://github.com/apache/druid/pull/9971

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.