### PR TITLE
fix balancer + broadcast segments npe

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -226,7 +226,8 @@ public class DruidCoordinatorRuntimeParams
         coordinatorCompactionConfig,
         stats,
         balancerReferenceTimestamp,
-        balancerStrategy
+        balancerStrategy,
+        broadcastDatasources
     );
   }
 
@@ -246,7 +247,8 @@ public class DruidCoordinatorRuntimeParams
         coordinatorCompactionConfig,
         stats,
         balancerReferenceTimestamp,
-        balancerStrategy
+        balancerStrategy,
+        broadcastDatasources
     );
   }
 
@@ -300,7 +302,8 @@ public class DruidCoordinatorRuntimeParams
         CoordinatorCompactionConfig coordinatorCompactionConfig,
         CoordinatorStats stats,
         DateTime balancerReferenceTimestamp,
-        BalancerStrategy balancerStrategy
+        BalancerStrategy balancerStrategy,
+        Set<String> broadcastDatasources
     )
     {
       this.startTimeNanos = startTimeNanos;
@@ -317,6 +320,7 @@ public class DruidCoordinatorRuntimeParams
       this.stats = stats;
       this.balancerReferenceTimestamp = balancerReferenceTimestamp;
       this.balancerStrategy = balancerStrategy;
+      this.broadcastDatasources = broadcastDatasources;
     }
 
     public DruidCoordinatorRuntimeParams build()


### PR DESCRIPTION
### Description

This PR fixes an NPE which occurs during the balancer phase after #9971 due to a missing parameter to pass on the broadcast datasources set in the coordinator parameter builder class.

```
2020-06-11T13:34:21,945 ERROR [Coordinator-Exec--0] org.apache.druid.server.coordinator.DruidCoordinator - Caught exception, ignoring so that schedule keeps going.: {class=org.apache.druid.server.coordinator.DruidCoordinator, exceptionType=class java.lang.NullPointerException, exceptionMessage=null}
java.lang.NullPointerException: null
	at org.apache.druid.server.coordinator.ReservoirSegmentSampler.getRandomBalancerSegmentHolder(ReservoirSegmentSampler.java:47) ~[classes/:?]
	at org.apache.druid.server.coordinator.CostBalancerStrategy.pickSegmentToMove(CostBalancerStrategy.java:220) ~[classes/:?]
	at org.apache.druid.server.coordinator.duty.BalanceSegments.balanceServers(BalanceSegments.java:190) ~[classes/:?]
	at org.apache.druid.server.coordinator.duty.BalanceSegments.balanceTier(BalanceSegments.java:158) ~[classes/:?]
	at org.apache.druid.server.coordinator.duty.BalanceSegments.lambda$run$0(BalanceSegments.java:81) ~[classes/:?]
	at java.util.HashMap.forEach(HashMap.java:1289) ~[?:1.8.0_242]
	at org.apache.druid.server.coordinator.duty.BalanceSegments.run(BalanceSegments.java:80) ~[classes/:?]
```

