### PR TITLE
Remove duplicate parameters from test

### DIFF
--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleSerdeTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleSerdeTest.java
@@ -44,13 +44,7 @@ public class BroadcastDistributionRuleSerdeTest
   {
     return Lists.newArrayList(
         new Object[]{new ForeverBroadcastDistributionRule()},
-        new Object[]{new ForeverBroadcastDistributionRule()},
-        new Object[]{new ForeverBroadcastDistributionRule()},
         new Object[]{new IntervalBroadcastDistributionRule(Intervals.of("0/1000"))},
-        new Object[]{new IntervalBroadcastDistributionRule(Intervals.of("0/1000"))},
-        new Object[]{new IntervalBroadcastDistributionRule(Intervals.of("0/1000"))},
-        new Object[]{new PeriodBroadcastDistributionRule(new Period(1000), null)},
-        new Object[]{new PeriodBroadcastDistributionRule(new Period(1000), null)},
         new Object[]{new PeriodBroadcastDistributionRule(new Period(1000), null)}
     );
   }


### PR DESCRIPTION
### Description

Commit 771870ae2d312d643e6d98f3d0af8a9618af9681 removed constructor
arguments from the rules. Therefore multiple parameters of the test are
now equal and can be removed.

<hr>

This PR has:
- [x] been self-reviewed.

<hr>

##### Key changed/added classes in this PR
 * `BroadcastDistributionRuleSerdeTest`
