### PR TITLE
Don't extend CompressionStrategyTest

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplierTest.java
@@ -29,6 +29,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -42,11 +45,21 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
+@RunWith(Parameterized.class)
+public class CompressedColumnarIntsSupplierTest
 {
+
+  @Parameters(name = "{0}")
+  public static Object[] compressionStrategies()
+  {
+    return CompressionStrategy.noNoneValues();
+  }
+
+  private final CompressionStrategy compressionStrategy;
+
   public CompressedColumnarIntsSupplierTest(CompressionStrategy compressionStrategy)
   {
-    super(compressionStrategy);
+    this.compressionStrategy = compressionStrategy;
   }
 
   private Closer closer;

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(Parameterized.class)
-public class CompressedVSizeColumnarIntsSupplierTest extends CompressionStrategyTest
+public class CompressedVSizeColumnarIntsSupplierTest
 {
   @Parameterized.Parameters(name = "{index}: compression={0}, byteOrder={1}")
   public static Iterable<Object[]> compressionStrategies()
@@ -71,7 +71,7 @@ public class CompressedVSizeColumnarIntsSupplierTest extends CompressionStrategy
 
   public CompressedVSizeColumnarIntsSupplierTest(CompressionStrategy compressionStrategy, ByteOrder byteOrder)
   {
-    super(compressionStrategy);
+    this.compressionStrategy = compressionStrategy;
     this.byteOrder = byteOrder;
   }
 
@@ -79,6 +79,7 @@ public class CompressedVSizeColumnarIntsSupplierTest extends CompressionStrategy
   private ColumnarInts columnarInts;
   private CompressedVSizeColumnarIntsSupplier supplier;
   private int[] vals;
+  private final CompressionStrategy compressionStrategy;
   private final ByteOrder byteOrder;
 
 

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressionStrategyTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressionStrategyTest.java
@@ -62,7 +62,7 @@ public class CompressionStrategyTest
     );
   }
 
-  protected final CompressionStrategy compressionStrategy;
+  private final CompressionStrategy compressionStrategy;
 
   public CompressionStrategyTest(CompressionStrategy compressionStrategy)
   {


### PR DESCRIPTION
### Description

Avoid unnecessary coupling of test classes. Having independent classes
makes it easier to understand and modify them.

The two classes that extended CompressionStrategyTest didn't have a lot
in common with it. All of them are parameterized tests where the
parameter is a CompressionStrategy. Therefore they used the parent class
to store the value of the strategy. CompressedColumnarIntsSupplierTest
also used the @Parameters method of its parent. That's pretty much
everything that these classes had in common.

<hr>

This PR has:
- [x] been self-reviewed.

<hr>

##### Key changed/added classes in this PR
 * `CompressionStrategyTest`
 * `CompressedColumnarIntsSupplierTest`
 * `CompressedVSizeColumnarIntsSupplierTest`
