### PR TITLE
make phaser of ReferenceCountingCloseableObject protected 

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/ReferenceCountingCloseableObject.java
+++ b/processing/src/main/java/org/apache/druid/segment/ReferenceCountingCloseableObject.java
@@ -41,7 +41,7 @@ public abstract class ReferenceCountingCloseableObject<BaseObject extends Closea
   private static final Logger log = new Logger(ReferenceCountingCloseableObject.class);
 
   private final AtomicBoolean closed = new AtomicBoolean(false);
-  private final Phaser referents = new Phaser(1)
+  protected final Phaser referents = new Phaser(1)
   {
     @Override
     protected boolean onAdvance(int phase, int registeredParties)


### PR DESCRIPTION
…instead of private so subclasses can do stuff with it. Follow up to #9982, which made `ReferenceCountingCloseableObject` base class that `ReferenceCountingSegment` uses.