### PR TITLE
Remove changes from #9114

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -353,7 +353,6 @@ The following monitors are available:
 |`org.apache.druid.segment.realtime.RealtimeMetricsMonitor`|Reports statistics on Realtime processes.|
 |`org.apache.druid.server.metrics.EventReceiverFirehoseMonitor`|Reports how many events have been queued in the EventReceiverFirehose.|
 |`org.apache.druid.server.metrics.QueryCountStatsMonitor`|Reports how many queries have been successful/failed/interrupted.|
-|`org.apache.druid.server.metrics.TaskCountStatsMonitor`|Reports how many tasks are success/failed/running/pending/waiting.|
 |`org.apache.druid.server.emitter.HttpEmittingMonitor`|Reports internal metrics of `http` or `parametrized` emitter (see below). Must not be used with another emitter type. See the description of the metrics here: https://github.com/apache/druid/pull/4973.|
 |`org.apache.druid.server.metrics.TaskCountStatsMonitor`|Reports how many ingestion tasks are currently running/pending/waiting and also the number of successful/failed tasks per emission period.|
 


### PR DESCRIPTION
#9114 added docs for TaskCountStatsMonitor
#9447 also added docs for this monitor.

This PR backs out the changes in #9114 since #9447 was merged in to the repository first
