### PR TITLE
SketchAggregator.updateUnion should handle null inside List update object

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregator.java
@@ -122,7 +122,9 @@ public class SketchAggregator implements Aggregator
       union.update((long[]) update);
     } else if (update instanceof List) {
       for (Object entry : (List) update) {
-        union.update(entry.toString());
+        if (entry != null) {
+          union.update(entry.toString());
+        }
       }
     } else {
       throw new ISE("Illegal type received while theta sketch merging [%s]", update.getClass());

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
@@ -35,8 +35,10 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
+import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.aggregation.TestObjectColumnSelector;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
@@ -491,6 +493,25 @@ public class SketchAggregationTest
         SketchHolder.class
     );
     Assert.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
+  }
+
+  @Test
+  public void testUpdateUnionWithNullInList()
+  {
+    List<String> value = new ArrayList<>();
+    value.add("foo");
+    value.add(null);
+    value.add("bar");
+    List[] columnValues = new List[]{value};
+    final TestObjectColumnSelector selector = new TestObjectColumnSelector(columnValues);
+    final Aggregator agg = new SketchAggregator(selector, 4096);
+    agg.aggregate();
+    Assert.assertFalse(agg.isNull());
+    Assert.assertNotNull(agg.get());
+    Assert.assertTrue(agg.get() instanceof SketchHolder);
+    Assert.assertEquals(2, ((SketchHolder) agg.get()).getEstimate(), 0);
+    Assert.assertNotNull(((SketchHolder) agg.get()).getSketch());
+    Assert.assertEquals(2, ((SketchHolder) agg.get()).getSketch().getEstimate(), 0);
   }
 
   private void assertPostAggregatorSerde(PostAggregator agg) throws Exception


### PR DESCRIPTION
SketchAggregator.updateUnion should handle null inside List update object

### Description

SketchAggregator.updateUnion already skip when the update object is null however it should also handle null inside List update object by skipping those null values.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
