### PR TITLE
The ole pooled algorithm switcheroo

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/topn/AggregateTopNMetricFirstAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/AggregateTopNMetricFirstAlgorithm.java
@@ -36,6 +36,13 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
+ * This {@link TopNAlgorithm} is tailored to processing aggregates on high cardility columns which are likely to have
+ * larger result sets. Internally it uses a 2 phase approach to compute the top-n result using the
+ * {@link PooledTopNAlgorithm} for each phase. The first phase is to process the segment with only the order-by
+ * aggregator to compute which values constitute the top 'n' results. With this information, a actual result set
+ * is computed by a second run of the {@link PooledTopNAlgorithm}, this time with all aggregators, but only considering
+ * the values from the 'n' results to avoid performing any aggregations that would have been thrown away for results
+ * that didn't make the top-n.
  */
 public class AggregateTopNMetricFirstAlgorithm implements TopNAlgorithm<int[], TopNParams>
 {

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -121,7 +121,7 @@ public class TopNQueryEngine
 
     final TopNAlgorithm<?, ?> topNAlgorithm;
     if (canUsePooledAlgorithm(selector, query, columnCapabilities)) {
-      // pool based algorithm selection
+      // pool based algorithm selection, if we can
       if (selector.isAggregateAllMetrics()) {
         // if sorted by dimension we should aggregate all metrics in a single pass, use the regular pooled algorithm for
         // this
@@ -135,7 +135,7 @@ public class TopNQueryEngine
         topNAlgorithm = new PooledTopNAlgorithm(adapter, query, bufferPool);
       }
     } else {
-      // heap based algorithm selection, if we have to
+      // heap based algorithm selection, if we must
       if (selector.isHasExtractionFn() && dimension.equals(ColumnHolder.TIME_COLUMN_NAME)) {
         // TimeExtractionTopNAlgorithm can work on any single-value dimension of type long.
         // We might be able to use this for any long column with an extraction function, that is


### PR DESCRIPTION
### Description
Inspired by https://github.com/apache/druid/pull/10053#discussion_r442988947

Also added javadoc for `PooledTopNAlgorithm`, `AggregateTopNMetricFirstAlgorithm`, and some other stuff.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `TopNQueryEngine`
