### PR TITLE
retry 500 and 503 errors against kinesis

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -110,7 +110,8 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
   {
     final boolean isIOException = ex.getCause() instanceof IOException;
     final boolean isTimeout = "RequestTimeout".equals(ex.getErrorCode());
-    return isIOException || isTimeout;
+    final boolean isInternalError = ex.getStatusCode() == 500 || ex.getStatusCode() == 503;
+    return isIOException || isTimeout || isInternalError;
   }
 
   /**

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -810,6 +810,10 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
                 );
                 return true;
               }
+              if (throwable instanceof AmazonServiceException) {
+                AmazonServiceException ase = (AmazonServiceException) throwable;
+                return isServiceExceptionRecoverable(ase);
+              }
               return false;
             },
             GET_SEQUENCE_NUMBER_RETRY_COUNT

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
@@ -352,11 +352,17 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     getException.setServiceName("AmazonKinesis");
     EasyMock.expect(getRecordsResult0.getRecords()).andThrow(getException).once();
     EasyMock.expect(getRecordsResult0.getRecords()).andReturn(SHARD0_RECORDS).once();
+    AmazonServiceException getException2 = new AmazonServiceException("InternalFailure");
+    getException2.setErrorCode("InternalFailure");
+    getException2.setStatusCode(503);
+    getException2.setServiceName("AmazonKinesis");
+    EasyMock.expect(getRecordsResult1.getRecords()).andThrow(getException2).once();
     EasyMock.expect(getRecordsResult1.getRecords()).andReturn(SHARD1_RECORDS).once();
     EasyMock.expect(getRecordsResult0.getNextShardIterator()).andReturn(null).anyTimes();
     EasyMock.expect(getRecordsResult1.getNextShardIterator()).andReturn(null).anyTimes();
     EasyMock.expect(getRecordsResult0.getMillisBehindLatest()).andReturn(SHARD0_LAG_MILLIS).once();
     EasyMock.expect(getRecordsResult0.getMillisBehindLatest()).andReturn(SHARD0_LAG_MILLIS).once();
+    EasyMock.expect(getRecordsResult1.getMillisBehindLatest()).andReturn(SHARD1_LAG_MILLIS).once();
     EasyMock.expect(getRecordsResult1.getMillisBehindLatest()).andReturn(SHARD1_LAG_MILLIS).once();
 
     replayAll();
@@ -385,7 +391,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     recordSupplier.seekToEarliest(partitions);
     recordSupplier.start();
 
-    while (recordSupplier.bufferSize() < 12) {
+    while (recordSupplier.bufferSize() < 14) {
       Thread.sleep(100);
     }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes part of https://support.imply.io/hc/en-us/requests/5701

### Description

We ran into an issue whereby a 500 when getting records from kinesis would cause the thread to stop until the end of `taskDuration`. This would cause our ingestion to fall behind. We filed a support ticket with AWS regarding the 500s and were basically told that those should be retried by the client and they should be expected in the normal operation of Kinesis. The same advice is echoed at https://aws.amazon.com/premiumsupport/knowledge-center/kinesis-data-stream-500-error/

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

The only change here is errors with status codes 500 and 503 are now considered retryable.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->