### PR TITLE
More prominent instructions on code coverage failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ jobs:
           --log-template "totals-complete"
           --log-template "errors"
           --
-          || { printf "\n\n****FAILED****\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\nFor more instructions on how to run code coverage locally, follow instructions here - https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md#running-code-coverage-locally\n\n" && false; }
+          || { printf "\n\n****FAILED****\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\nFor more details on how to run code coverage locally, follow instructions here - https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md#running-code-coverage-locally\n\n" && false; }
           fi
       after_success:
         # retry in case of network error

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ jobs:
           --log-template "totals-complete"
           --log-template "errors"
           --
-          || { printf "\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\n" && false; }
+          || { printf "\n\n****FAILED****\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\nFor more instructions on how to run code coverage locally, follow instructions here - https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md#running-code-coverage-locally\n\n" && false; }
           fi
       after_success:
         # retry in case of network error


### PR DESCRIPTION
This change aims to make the instructions for what to do on a code coverage failure more prominent by linking to the docs in the repo. It also increases spacing between other log lines to make it more obvious that this is the relevant part of the logs.

The log lines are prefaced with `FAILED` as this is what someone might search for when looking through the logs of a travis job to see why it failed.