### PR TITLE
Fix HyperUniquesAggregatorFactory.estimateCardinality null handling to respect output type

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -59,7 +59,7 @@ public class QueryContexts
   public static final boolean DEFAULT_USE_CACHE = true;
   public static final boolean DEFAULT_POPULATE_RESULTLEVEL_CACHE = true;
   public static final boolean DEFAULT_USE_RESULTLEVEL_CACHE = true;
-  public static final Vectorize DEFAULT_VECTORIZE = Vectorize.FALSE;
+  public static final Vectorize DEFAULT_VECTORIZE = Vectorize.TRUE;
   public static final int DEFAULT_PRIORITY = 0;
   public static final int DEFAULT_UNCOVERED_INTERVALS_LIMIT = 0;
   public static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -59,7 +59,7 @@ public class QueryContexts
   public static final boolean DEFAULT_USE_CACHE = true;
   public static final boolean DEFAULT_POPULATE_RESULTLEVEL_CACHE = true;
   public static final boolean DEFAULT_USE_RESULTLEVEL_CACHE = true;
-  public static final Vectorize DEFAULT_VECTORIZE = Vectorize.TRUE;
+  public static final Vectorize DEFAULT_VECTORIZE = Vectorize.FALSE;
   public static final int DEFAULT_PRIORITY = 0;
   public static final int DEFAULT_UNCOVERED_INTERVALS_LIMIT = 0;
   public static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -58,22 +58,13 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
 {
   public static Object estimateCardinality(@Nullable Object object, boolean round)
   {
-    if (object == null) {
-      if (round) {
-        return 0L;
-      } else {
-        return 0d;
-
-      }
-    }
-
     final HyperLogLogCollector collector = (HyperLogLogCollector) object;
 
-    // Avoid ternary, it causes estimateCardinalityRound to be cast to double.
+    // Avoid ternary for round check as it causes estimateCardinalityRound to be cast to double.
     if (round) {
-      return collector.estimateCardinalityRound();
+      return collector == null ? 0L : collector.estimateCardinalityRound();
     } else {
-      return collector.estimateCardinality();
+      return collector == null ? 0d : collector.estimateCardinality();
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -59,7 +59,12 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
   public static Object estimateCardinality(@Nullable Object object, boolean round)
   {
     if (object == null) {
-      return 0;
+      if (round) {
+        return 0L;
+      } else {
+        return 0d;
+
+      }
     }
 
     final HyperLogLogCollector collector = (HyperLogLogCollector) object;

--- a/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
@@ -241,7 +241,7 @@ public class SchemaEvolutionTest
 
     // index1 has no "uniques" column
     Assert.assertEquals(
-        timeseriesResult(ImmutableMap.of("uniques", 0)),
+        timeseriesResult(ImmutableMap.of("uniques", 0d)),
         runQuery(query, factory, ImmutableList.of(index1))
     );
 

--- a/processing/src/test/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactoryTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.Random;
 
@@ -171,6 +172,30 @@ public class HyperUniquesAggregatorFactoryTest
           orderedByComparator
       );
     }
+  }
+
+  @Test
+  public void testEstimateCardinalityForZeroCardinality()
+  {
+    HyperLogLogCollector emptyHyperLogLogCollector = HyperUniquesBufferAggregator.doGet(
+        ByteBuffer.allocate(HyperLogLogCollector.getLatestNumBytesForDenseStorage()),
+        0
+    );
+
+    Assert.assertEquals(0L, HyperUniquesAggregatorFactory.estimateCardinality(null, true));
+    Assert.assertEquals(0d, HyperUniquesAggregatorFactory.estimateCardinality(null, false));
+
+    Assert.assertEquals(0L, HyperUniquesAggregatorFactory.estimateCardinality(emptyHyperLogLogCollector, true));
+    Assert.assertEquals(0d, HyperUniquesAggregatorFactory.estimateCardinality(emptyHyperLogLogCollector, false));
+
+    Assert.assertEquals(
+        HyperUniquesAggregatorFactory.estimateCardinality(emptyHyperLogLogCollector, true).getClass(),
+        HyperUniquesAggregatorFactory.estimateCardinality(null, true).getClass()
+    );
+    Assert.assertEquals(
+        HyperUniquesAggregatorFactory.estimateCardinality(emptyHyperLogLogCollector, false).getClass(),
+        HyperUniquesAggregatorFactory.estimateCardinality(null, false).getClass()
+    );
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -2568,7 +2568,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
           );
           Assert.assertEquals(
               0.0D,
-              NullHandling.sqlCompatible() ? (Double) result[4] : (Integer) result[4],
+              (Double) result[4],
               0.02
           );
           Assert.assertEquals(
@@ -2581,7 +2581,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
               result[3]
           );
           Assert.assertEquals(
-              (Integer) result[4],
+              (Double) result[4],
               0.0,
               0.02
           );

--- a/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerTest.java
@@ -647,15 +647,15 @@ public class TopNQueryRunnerTest extends InitializedNullHandlingTest
                 Arrays.<Map<String, Object>>asList(
                     ImmutableMap.<String, Object>builder()
                         .put("market", "spot")
-                        .put("uniques", 0)
+                        .put("uniques", 0d)
                         .build(),
                     ImmutableMap.<String, Object>builder()
                         .put("market", "total_market")
-                        .put("uniques", 0)
+                        .put("uniques", 0d)
                         .build(),
                     ImmutableMap.<String, Object>builder()
                         .put("market", "upfront")
-                        .put("uniques", 0)
+                        .put("uniques", 0d)
                         .build()
                 )
             )


### PR DESCRIPTION
Make return type consistent for HyperUniquesAggregator and HyperUniquesVectorAggregator when no value found

### Description

This bug was discovered by turning on vectorization. In HyperUniquesAggregator, when a column is empty, `collector` will be null and the get() method will returns null. In HyperUniquesVectorAggregator, when a column is empty, get() method will still returns a HyperLogLogCollector (from the call to `HyperUniquesBufferAggregator.doGet(buf, position);`). In HyperUniquesAggregatorFactory#estimateCardinality (called by HyperUniquesAggregatorFactory#finalizeComputation) we return integer 0 if input is null, while we return long/double value. otherwise. Hence, for the above mentioned case, the non-vectorize returns integer 0 while the vectorize returns long/double 0. The test failed since we are expecting integer 0. 
This PR, make sure that for the case when the input to HyperUniquesAggregatorFactory#estimateCardinality is null, we still return 0 with the same value type as when it is not null.  

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
