### PR TITLE
update avatica to handle additional character sets over jdbc

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1295,7 +1295,7 @@ name: Apache Calcite Avatica
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.15.0
+version: 1.17.0
 libraries:
   - org.apache.calcite.avatica: avatica-core
   - org.apache.calcite.avatica: avatica-metrics
@@ -1303,13 +1303,13 @@ libraries:
 notices:
   - avatica-core: |
       Apache Calcite Avatica
-      Copyright 2012-2018 The Apache Software Foundation
+      Copyright 2012-2020 The Apache Software Foundation
   - avatica-metrics: |
       Apache Calcite Avatica Metrics
-      Copyright 2012-2018 The Apache Software Foundation
+      Copyright 2012-2020 The Apache Software Foundation
   - avatica-server: |
       Apache Calcite Avatica Server
-      Copyright 2012-2018 The Apache Software Foundation
+      Copyright 2012-2020 The Apache Software Foundation
 ---
 
 name: Apache Curator

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <apache.kafka.version>2.5.0</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
-        <avatica.version>1.15.0</avatica.version>
+        <avatica.version>1.17.0</avatica.version>
         <avro.version>1.9.2</avro.version>
         <calcite.version>1.21.0</calcite.version>
         <datasketches.version>1.3.0-incubating</datasketches.version>

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -992,6 +992,36 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
   }
 
   @Test
+  public void testExtendedCharacters() throws Exception
+  {
+    final ResultSet resultSet = client.createStatement().executeQuery(
+        "SELECT COUNT(*) AS cnt FROM druid.lotsocolumns WHERE dimMultivalEnumerated = 'ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ'"
+    );
+    final List<Map<String, Object>> rows = getRows(resultSet);
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("cnt", 1L)
+        ),
+        rows
+    );
+
+
+    PreparedStatement statement = client.prepareStatement(
+        "SELECT COUNT(*) AS cnt FROM druid.lotsocolumns WHERE dimMultivalEnumerated = ?"
+    );
+    statement.setString(1, "ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ");
+    final ResultSet resultSet2 = statement.executeQuery();
+    final List<Map<String, Object>> rows2 = getRows(resultSet2);
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("cnt", 1L)
+        ),
+        rows
+    );
+    Assert.assertEquals(rows, rows2);
+  }
+
+  @Test
   public void testEscapingForGetColumns() throws Exception
   {
     final DatabaseMetaData metaData = client.getMetaData();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -1331,7 +1331,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 1576306800000L,
                 1L,
                 "8",
-                "[\"Baz\",\"World\",\"World\",\"World\"]",
+                "[\"Baz\",\"World\",\"ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ\"]",
                 useDefault ? "[\"\",\"Corundum\",\"Xylophone\"]" : "[null,\"Corundum\",\"Xylophone\"]",
                 useDefault ? "" : null,
                 "8",

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -1261,7 +1261,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 1576306800000L,
                 1L,
                 "8",
-                "[\"Baz\",\"World\",\"World\",\"World\"]",
+                "[\"Baz\",\"World\",\"ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ\"]",
                 useDefault ? "[\"\",\"Corundum\",\"Xylophone\"]" : "[null,\"Corundum\",\"Xylophone\"]",
                 useDefault ? "" : null,
                 "8",

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -608,7 +608,7 @@ public class CalciteTests
               .put("metFloatNormal", 4999.0)
               .put("dimZipf", "9")
               .put("dimUniform", "50515")
-              .put("dimMultivalEnumerated", Arrays.asList("Baz", "World", "World", "World"))
+              .put("dimMultivalEnumerated", Arrays.asList("Baz", "World", "ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ"))
               .put("metLongSequential", 8)
               .put("dimHyperUnique", "8")
               .put("dimSequential", "8")

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -243,6 +243,23 @@ public class SqlResourceTest extends CalciteTestBase
     checkSqlRequestLog(true);
   }
 
+
+  @Test
+  public void testCountStarExtendedCharacters() throws Exception
+  {
+    final List<Map<String, Object>> rows = doPost(
+        new SqlQuery("SELECT COUNT(*) AS cnt FROM druid.lotsocolumns WHERE dimMultivalEnumerated = 'ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ'", null, false, null, null)
+    ).rhs;
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("cnt", 1)
+        ),
+        rows
+    );
+    checkSqlRequestLog(true);
+  }
+
   @Test
   public void testTimestampsInResponse() throws Exception
   {


### PR DESCRIPTION
Fixes #10064.

### Description
The test added to `DruidAvaticaHandlerTest` fails prior to bumping Avatica dependency version, where

```
SELECT COUNT(*) AS cnt FROM druid.lotsocolumns WHERE dimMultivalEnumerated = 'ㅑ ㅓ ㅕ ㅗ ㅛ ㅜ ㅠ ㅡ ㅣ'
```

would plan into 
```
{
  "queryType" : "timeseries",
  "dataSource" : {
    "type" : "table",
    "name" : "lotsocolumns"
  },
  "intervals" : {
    "type" : "intervals",
    "intervals" : [ "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z" ]
  },
  "descending" : false,
  "virtualColumns" : [ ],
  "filter" : {
    "type" : "selector",
    "dimension" : "dimMultivalEnumerated",
    "value" : "? ? ? ? ? ? ? ? ?",
    "extractionFn" : null
  },
  "granularity" : {
    "type" : "all"
  },
  "aggregations" : [ {
    "type" : "count",
    "name" : "a0"
  } ],
  "postAggregations" : [ ],
  "limit" : 2147483647,
  "context" : {
    "skipEmptyBuckets" : true,
    "sqlQueryId" : "bdd1bd09-1452-4802-8a92-a20ef765bca9"
  }
}
```

The test added to `SqlResourceTest` was just for fun, and passed prior to updating Avatica.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

