### PR TITLE
fix dropwizard emitter jvm bufferpoolName metric

### DIFF
--- a/docs/design/extensions-contrib/dropwizard.md
+++ b/docs/design/extensions-contrib/dropwizard.md
@@ -465,19 +465,19 @@ Latest default metrics mapping can be found [here] (https://github.com/apache/dr
   },
   "jvm/bufferpool/counter": {
     "dimensions": [
-      "bufferPoolName"
+      "bufferpoolName"
     ],
     "type": "gauge"
   },
   "jvm/bufferpool/used": {
     "dimensions": [
-      "bufferPoolName"
+      "bufferpoolName"
     ],
     "type": "gauge"
   },
   "jvm/bufferpool/capacity": {
     "dimensions": [
-      "bufferPoolName"
+      "bufferpoolName"
     ],
     "type": "gauge"
   },

--- a/docs/design/extensions-contrib/dropwizard.md
+++ b/docs/design/extensions-contrib/dropwizard.md
@@ -507,20 +507,23 @@ Latest default metrics mapping can be found [here] (https://github.com/apache/dr
   },
   "jvm/gc/counter": {
     "dimensions": [
-      "gcName"
+      "gcName",
+      "gcGen"
     ],
     "type": "counter"
   },
   "jvm/gc/cpu": {
     "dimensions": [
-      "gcName"
+      "gcName",
+      "gcGen"
     ],
     "type": "timer",
     "timeUnit": "NANOSECONDS"
   },
   "ingest/events/buffered": {
     "dimensions": [
-      "serviceName, bufferCapacity"
+      "serviceName",
+      "bufferCapacity"
     ],
     "type": "gauge"
   },

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -242,9 +242,9 @@ These metrics are only available if the JVMMonitor module is included.
 |`jvm/pool/init`|Initial pool.|poolKind, poolName.|Varies.|
 |`jvm/pool/max`|Max pool.|poolKind, poolName.|Varies.|
 |`jvm/pool/used`|Pool used.|poolKind, poolName.|< max pool|
-|`jvm/bufferpool/count`|Bufferpool count.|bufferPoolName.|Varies.|
-|`jvm/bufferpool/used`|Bufferpool used.|bufferPoolName.|close to capacity|
-|`jvm/bufferpool/capacity`|Bufferpool capacity.|bufferPoolName.|Varies.|
+|`jvm/bufferpool/count`|Bufferpool count.|bufferpoolName.|Varies.|
+|`jvm/bufferpool/used`|Bufferpool used.|bufferpoolName.|close to capacity|
+|`jvm/bufferpool/capacity`|Bufferpool capacity.|bufferpoolName.|Varies.|
 |`jvm/mem/init`|Initial memory.|memKind.|Varies.|
 |`jvm/mem/max`|Max memory.|memKind.|Varies.|
 |`jvm/mem/used`|Used memory.|memKind.|< max memory|

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/WhiteListBasedDruidToTimelineEventConverterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/WhiteListBasedDruidToTimelineEventConverterTest.java
@@ -183,7 +183,7 @@ public class WhiteListBasedDruidToTimelineEventConverterTest
             defaultNamespace + ".data-source.ingest/persists/count"
         },
         new Object[]{
-            new ServiceMetricEvent.Builder().setDimension("bufferPoolName", "BufferPool")
+            new ServiceMetricEvent.Builder().setDimension("bufferpoolName", "BufferPool")
                                             .setDimension("type", "groupBy")
                                             .setDimension("some_random_dim1", "random_dim_value1")
                                             .build(createdTime, "jvm/bufferpool/capacity", 10)

--- a/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
@@ -370,19 +370,19 @@
   },
   "jvm/bufferpool/counter": {
     "dimensions": [
-      "bufferPoolName"
+      "bufferpoolName"
     ],
     "type": "gauge"
   },
   "jvm/bufferpool/used": {
     "dimensions": [
-      "bufferPoolName"
+      "bufferpoolName"
     ],
     "type": "gauge"
   },
   "jvm/bufferpool/capacity": {
     "dimensions": [
-      "bufferPoolName"
+      "bufferpoolName"
     ],
     "type": "gauge"
   },

--- a/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
@@ -412,20 +412,23 @@
   },
   "jvm/gc/counter": {
     "dimensions": [
-      "gcName"
+      "gcName",
+      "gcGen"
     ],
     "type": "counter"
   },
   "jvm/gc/cpu": {
     "dimensions": [
-      "gcName"
+      "gcName",
+      "gcGen"
     ],
     "type": "timer",
     "timeUnit": "NANOSECONDS"
   },
   "ingest/events/buffered": {
     "dimensions": [
-      "serviceName, bufferCapacity"
+      "serviceName",
+      "bufferCapacity"
     ],
     "type": "gauge"
   },

--- a/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/WhiteListBasedConverterTest.java
+++ b/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/WhiteListBasedConverterTest.java
@@ -189,7 +189,7 @@ public class WhiteListBasedConverterTest
             defaultNamespace + ".ingest/persists/count"
         },
         new Object[]{
-            new ServiceMetricEvent.Builder().setDimension("bufferPoolName", "BufferPool")
+            new ServiceMetricEvent.Builder().setDimension("bufferpoolName", "BufferPool")
                                             .setDimension("type", "groupBy")
                                             .setDimension("some_random_dim1", "random_dim_value1")
                                             .build(createdTime, "jvm/bufferpool/capacity", 10)

--- a/website/.spelling
+++ b/website/.spelling
@@ -1161,7 +1161,7 @@ Sys
 SysMonitor
 TaskCountStatsMonitor
 bufferCapacity
-bufferPoolName
+bufferpoolName
 cms
 cpuName
 cpuTime


### PR DESCRIPTION
Related to #10071, fixed a few other places using `bufferPoolName` instead of `bufferpoolName`