### PR TITLE
ensure ParallelMergeCombiningSequence closes its closeables

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
@@ -22,10 +22,12 @@ package org.apache.druid.java.util.common.guava;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import org.apache.druid.java.util.common.RE;
+import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.JvmUtils;
 
 import javax.annotation.Nullable;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -300,6 +302,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
     @Override
     protected void compute()
     {
+      List<BatchedResultsCursor<T>> sequenceCursors = new ArrayList<>(sequences.size());
       try {
         final int parallelTaskCount = computeNumTasks();
 
@@ -315,7 +318,6 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
 
           QueuePusher<ResultBatch<T>> resultsPusher = new QueuePusher<>(out, hasTimeout, timeoutAt);
 
-          List<BatchedResultsCursor<T>> sequenceCursors = new ArrayList<>(sequences.size());
           for (Sequence<T> s : sequences) {
             sequenceCursors.add(new YielderBatchedResultsCursor<>(new SequenceBatcher<>(s, batchSize), orderingFn));
           }
@@ -341,6 +343,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
         }
       }
       catch (Exception ex) {
+        closeAllCursors(sequenceCursors);
         cancellationGizmo.cancel(ex);
         out.offer(ResultBatch.TERMINAL);
       }
@@ -624,6 +627,8 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
           // if we got the cancellation signal, go ahead and write terminal value into output queue to help gracefully
           // allow downstream stuff to stop
           LOG.debug("cancelled after %s tasks", metricsAccumulator.getTaskCount());
+          // make sure to close underlying cursors
+          closeAllCursors(pQueue);
           outputQueue.offer(ResultBatch.TERMINAL);
         } else {
           // if priority queue is empty, push the final accumulated value into the output batch and push it out
@@ -636,6 +641,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
         }
       }
       catch (Exception ex) {
+        closeAllCursors(pQueue);
         cancellationGizmo.cancel(ex);
         outputQueue.offer(ResultBatch.TERMINAL);
       }
@@ -695,13 +701,15 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
     @Override
     protected void compute()
     {
+      PriorityQueue<BatchedResultsCursor<T>> cursors = new PriorityQueue<>(partition.size());
       try {
-        PriorityQueue<BatchedResultsCursor<T>> cursors = new PriorityQueue<>(partition.size());
         for (BatchedResultsCursor<T> cursor : partition) {
           // this is blocking
           cursor.initialize();
           if (!cursor.isDone()) {
             cursors.offer(cursor);
+          } else {
+            cursor.close();
           }
         }
 
@@ -723,6 +731,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
         }
       }
       catch (Exception ex) {
+        closeAllCursors(partition);
         cancellationGizmo.cancel(ex);
         outputQueue.offer(ResultBatch.TERMINAL);
       }
@@ -844,23 +853,34 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
      */
     static <E> Yielder<ResultBatch<E>> fromSequence(Sequence<E> sequence, int batchSize)
     {
-      return sequence.toYielder(
-          new ResultBatch<>(batchSize),
-          new YieldingAccumulator<ResultBatch<E>, E>()
-          {
-            int count = 0;
-            @Override
-            public ResultBatch<E> accumulate(ResultBatch<E> accumulated, E in)
+      Yielder<ResultBatch<E>> theYielder = null;
+      try {
+        theYielder = sequence.toYielder(
+            new ResultBatch<>(batchSize),
+            new YieldingAccumulator<ResultBatch<E>, E>()
             {
-              accumulated.add(in);
-              count++;
-              if (count % batchSize == 0) {
-                yield();
+              int count = 0;
+
+              @Override
+              public ResultBatch<E> accumulate(ResultBatch<E> accumulated, E in)
+              {
+                accumulated.add(in);
+                count++;
+                if (count % batchSize == 0) {
+                  yield();
+                }
+                return accumulated;
               }
-              return accumulated;
             }
-          }
-      );
+        );
+        return theYielder;
+      }
+      catch (Exception ex) {
+        if (theYielder != null) {
+          CloseQuietly.close(theYielder);
+        }
+        throw ex;
+      }
     }
   }
 
@@ -913,7 +933,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
    * from these cursors, and combine results with the same ordering using the combining function.
    */
   abstract static class BatchedResultsCursor<E>
-      implements ForkJoinPool.ManagedBlocker, Comparable<BatchedResultsCursor<E>>
+      implements ForkJoinPool.ManagedBlocker, Comparable<BatchedResultsCursor<E>>, Closeable
   {
     final Ordering<E> ordering;
     volatile ResultBatch<E> resultBatch;
@@ -939,6 +959,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
       }
     }
 
+    @Override
     public void close()
     {
       // nothing to close for blocking queue, but yielders will need to clean up or they will leak resources
@@ -1036,11 +1057,13 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
     @Override
     public void close()
     {
-      try {
-        yielder.close();
-      }
-      catch (IOException e) {
-        throw new RuntimeException("Failed to close yielder", e);
+      if (yielder != null) {
+        try {
+          yielder.close();
+        }
+        catch (IOException e) {
+          throw new RuntimeException("Failed to close yielder", e);
+        }
       }
     }
   }
@@ -1349,5 +1372,25 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
     {
       return totalCpuTimeNanos;
     }
+  }
+
+  private static <T> void closeAllCursors(final PriorityQueue<BatchedResultsCursor<T>> pQueue)
+  {
+    Closer closer = Closer.create();
+    while (!pQueue.isEmpty()) {
+      final BatchedResultsCursor<T> yielder = pQueue.poll();
+      if (yielder != null) {
+        // Note: yielder can be null if our comparator threw an exception during queue.add.
+        closer.register(yielder);
+      }
+    }
+    CloseQuietly.close(closer);
+  }
+
+  private static <T> void closeAllCursors(final List<BatchedResultsCursor<T>> list)
+  {
+    Closer closer = Closer.create();
+    closer.registerAll(list);
+    CloseQuietly.close(closer);
   }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
@@ -853,34 +853,24 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
      */
     static <E> Yielder<ResultBatch<E>> fromSequence(Sequence<E> sequence, int batchSize)
     {
-      Yielder<ResultBatch<E>> theYielder = null;
-      try {
-        theYielder = sequence.toYielder(
-            new ResultBatch<>(batchSize),
-            new YieldingAccumulator<ResultBatch<E>, E>()
-            {
-              int count = 0;
+      return sequence.toYielder(
+          new ResultBatch<>(batchSize),
+          new YieldingAccumulator<ResultBatch<E>, E>()
+          {
+            int count = 0;
 
-              @Override
-              public ResultBatch<E> accumulate(ResultBatch<E> accumulated, E in)
-              {
-                accumulated.add(in);
-                count++;
-                if (count % batchSize == 0) {
-                  yield();
-                }
-                return accumulated;
+            @Override
+            public ResultBatch<E> accumulate(ResultBatch<E> accumulated, E in)
+            {
+              accumulated.add(in);
+              count++;
+              if (count % batchSize == 0) {
+                yield();
               }
+              return accumulated;
             }
-        );
-        return theYielder;
-      }
-      catch (Exception ex) {
-        if (theYielder != null) {
-          CloseQuietly.close(theYielder);
-        }
-        throw ex;
-      }
+          }
+      );
     }
   }
 

--- a/core/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
@@ -343,9 +343,9 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
           spawnParallelTasks(parallelTaskCount);
         }
       }
-      catch (Exception ex) {
+      catch (Throwable t) {
         closeAllCursors(sequenceCursors);
-        cancellationGizmo.cancel(ex);
+        cancellationGizmo.cancel(t);
         out.offer(ResultBatch.TERMINAL);
       }
     }
@@ -641,9 +641,9 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
           LOG.debug("merge combine complete after %s tasks", metricsAccumulator.getTaskCount());
         }
       }
-      catch (Exception ex) {
+      catch (Throwable t) {
         closeAllCursors(pQueue);
-        cancellationGizmo.cancel(ex);
+        cancellationGizmo.cancel(t);
         outputQueue.offer(ResultBatch.TERMINAL);
       }
     }
@@ -731,9 +731,9 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
           outputQueue.offer(ResultBatch.TERMINAL);
         }
       }
-      catch (Exception ex) {
+      catch (Throwable t) {
         closeAllCursors(partition);
-        cancellationGizmo.cancel(ex);
+        cancellationGizmo.cancel(t);
         outputQueue.offer(ResultBatch.TERMINAL);
       }
     }
@@ -1144,21 +1144,21 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
    */
   static class CancellationGizmo
   {
-    private final AtomicReference<Exception> exception = new AtomicReference<>(null);
+    private final AtomicReference<Throwable> throwable = new AtomicReference<>(null);
 
-    void cancel(Exception ex)
+    void cancel(Throwable t)
     {
-      exception.compareAndSet(null, ex);
+      throwable.compareAndSet(null, t);
     }
 
     boolean isCancelled()
     {
-      return exception.get() != null;
+      return throwable.get() != null;
     }
 
     RuntimeException getRuntimeException()
     {
-      Exception ex = exception.get();
+      Throwable ex = throwable.get();
       if (ex instanceof RuntimeException) {
         return (RuntimeException) ex;
       }


### PR DESCRIPTION

### Description
#9934 but for `ParallelMergeCombiningSequence`. Also spotted a place where we weren't closing a non-exploding `BatchedResultCursor` so fixes more leaks than I was anticipating :metal:.

I might be abusing `ExplodingSequence` added in #9934 in my added tests... but I needed an interface for checking if my Sequence yielders were cleaning up after themselves, so.. it served my purposes.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `ParallelMergeCombiningSequence`
