### PR TITLE
Move shardSpec tests to core

### DIFF
--- a/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
@@ -43,6 +43,7 @@ import java.util.stream.IntStream;
 public class HashBasedNumberedShardSpecTest
 {
   private final ObjectMapper objectMapper = ShardSpecTestUtils.initObjectMapper();
+
   @Test
   public void testEquals()
   {

--- a/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.timeline.partition;
 
-import com.fasterxml.jackson.databind.InjectableValues.Std;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;

--- a/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.timeline.partition;
 
+import com.fasterxml.jackson.databind.InjectableValues.Std;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;

--- a/core/src/test/java/org/apache/druid/timeline/partition/NumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/NumberedShardSpecTest.java
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-package org.apache.druid.server.shard;
+package org.apache.druid.timeline.partition;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -26,17 +27,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.server.ServerTestHelper;
 import org.apache.druid.timeline.Overshadowable;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
-import org.apache.druid.timeline.partition.HashBasedNumberedPartialShardSpec;
-import org.apache.druid.timeline.partition.NumberedOverwritePartialShardSpec;
-import org.apache.druid.timeline.partition.NumberedPartialShardSpec;
-import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.apache.druid.timeline.partition.PartitionChunk;
-import org.apache.druid.timeline.partition.ShardSpec;
-import org.apache.druid.timeline.partition.SingleDimensionPartialShardSpec;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,8 +51,9 @@ public class NumberedShardSpecTest
   @Test
   public void testSerdeRoundTrip() throws Exception
   {
-    final ShardSpec spec = ServerTestHelper.MAPPER.readValue(
-        ServerTestHelper.MAPPER.writeValueAsBytes(new NumberedShardSpec(1, 2)),
+    final ObjectMapper objectMapper = ShardSpecTestUtils.initObjectMapper();
+    final ShardSpec spec = objectMapper.readValue(
+        objectMapper.writeValueAsBytes(new NumberedShardSpec(1, 2)),
         ShardSpec.class
     );
     Assert.assertEquals(1, spec.getPartitionNum());
@@ -69,7 +63,8 @@ public class NumberedShardSpecTest
   @Test
   public void testSerdeBackwardsCompat() throws Exception
   {
-    final ShardSpec spec = ServerTestHelper.MAPPER.readValue(
+    final ObjectMapper objectMapper = ShardSpecTestUtils.initObjectMapper();
+    final ShardSpec spec = objectMapper.readValue(
         "{\"type\": \"numbered\", \"partitions\": 2, \"partitionNum\": 1}",
         ShardSpec.class
     );

--- a/core/src/test/java/org/apache/druid/timeline/partition/ShardSpecTestUtils.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/ShardSpecTestUtils.java
@@ -20,6 +20,7 @@
 package org.apache.druid.timeline.partition;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues.Std;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -30,6 +31,7 @@ public class ShardSpecTestUtils
   {
     // Copied configurations from org.apache.druid.jackson.DefaultObjectMapper
     final ObjectMapper mapper = new ObjectMapper();
+    mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(MapperFeature.AUTO_DETECT_GETTERS, false);
     // See https://github.com/FasterXML/jackson-databind/issues/170

--- a/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionShardSpecTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.druid.server.shard;
+package org.apache.druid.timeline.partition;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -30,12 +30,6 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.timeline.partition.HashBasedNumberedPartialShardSpec;
-import org.apache.druid.timeline.partition.NumberedOverwritePartialShardSpec;
-import org.apache.druid.timeline.partition.NumberedPartialShardSpec;
-import org.apache.druid.timeline.partition.ShardSpec;
-import org.apache.druid.timeline.partition.SingleDimensionPartialShardSpec;
-import org.apache.druid.timeline.partition.SingleDimensionShardSpec;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
### Description

Follow-up for https://github.com/apache/druid/pull/10033#issuecomment-649750336.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.