### PR TITLE
add bitwise and, or, negate expressions

### DIFF
--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -18,7 +18,7 @@ grammar Expr;
 expr : NULL                                                         # null
      | ('-'|'!'|'~') expr                                           # unaryOpExpr
      |<assoc=right> expr '^' expr                                   # powOpExpr
-     | expr ('&'|'|'|' xor ') expr                                  # bitwiseOpExpr
+     | expr ('&'|'|'|) expr                                         # bitwiseOpExpr
      | expr ('*'|'/'|'%') expr                                      # mulDivModuloExpr
      | expr ('+'|'-') expr                                          # addSubExpr
      | expr ('<'|'<='|'>'|'>='|'=='|'!=') expr                      # logicalOpExpr
@@ -80,4 +80,3 @@ OR : '||' ;
 BITAND : '&' ;
 BITOR : '|' ;
 BITNEG : '~' ;
-BITXOR : ' xor ' ;

--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -16,8 +16,9 @@
 grammar Expr;
 
 expr : NULL                                                         # null
-     | ('-'|'!') expr                                               # unaryOpExpr
+     | ('-'|'!'|'~') expr                                           # unaryOpExpr
      |<assoc=right> expr '^' expr                                   # powOpExpr
+     | expr ('&'|'|'|' xor ') expr                                  # bitwiseOpExpr
      | expr ('*'|'/'|'%') expr                                      # mulDivModuloExpr
      | expr ('+'|'-') expr                                          # addSubExpr
      | expr ('<'|'<='|'>'|'>='|'=='|'!=') expr                      # logicalOpExpr
@@ -76,3 +77,7 @@ EQ : '==' ;
 NEQ : '!=' ;
 AND : '&&' ;
 OR : '||' ;
+BITAND : '&' ;
+BITOR : '|' ;
+BITNEG : '~' ;
+BITXOR : ' xor ' ;

--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -18,7 +18,7 @@ grammar Expr;
 expr : NULL                                                         # null
      | ('-'|'!'|'~') expr                                           # unaryOpExpr
      |<assoc=right> expr '^' expr                                   # powOpExpr
-     | expr ('&'|'|'|) expr                                         # bitwiseOpExpr
+     | expr ('&'|'|') expr                                         # bitwiseOpExpr
      | expr ('*'|'/'|'%') expr                                      # mulDivModuloExpr
      | expr ('+'|'-') expr                                          # addSubExpr
      | expr ('<'|'<='|'>'|'>='|'=='|'!=') expr                      # logicalOpExpr

--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -26,10 +26,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.math.LongMath;
 import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.druid.annotations.SubclassesMustOverrideEqualsAndHashCode;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -1459,7 +1459,7 @@ class UnaryBitwiseNegateExpr extends UnaryExpr
   public ExprEval eval(ObjectBinding bindings)
   {
     ExprEval ret = expr.eval(bindings);
-    if (NullHandling.sqlCompatible() && (ret.value() == null)) {
+    if ((NullHandling.sqlCompatible() && (ret.value() == null)) || ret.isNumericNull()) {
       return ExprEval.of(null);
     }
     return ExprEval.of(~ret.asLong());
@@ -2038,8 +2038,8 @@ class BinBitwiseAndExpr extends BinaryEvalOpExprBase
   @Override
   protected ExprEval evalString(@Nullable String left, @Nullable String right)
   {
-    Long l1 = Longs.tryParse(left);
-    Long l2 = Longs.tryParse(right);
+    Long l1 = GuavaUtils.tryParseLong(left);
+    Long l2 = GuavaUtils.tryParseLong(right);
     if (l1 == null || l2 == null) {
       return ExprEval.of(null);
     }
@@ -2075,8 +2075,8 @@ class BinBitwiseOrExpr extends BinaryEvalOpExprBase
   @Override
   protected ExprEval evalString(@Nullable String left, @Nullable String right)
   {
-    Long l1 = Longs.tryParse(left);
-    Long l2 = Longs.tryParse(right);
+    Long l1 = GuavaUtils.tryParseLong(left);
+    Long l2 = GuavaUtils.tryParseLong(right);
     if (l1 == null || l2 == null) {
       return ExprEval.of(null);
     }

--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.math.LongMath;
 import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.druid.annotations.SubclassesMustOverrideEqualsAndHashCode;
 import org.apache.druid.common.config.NullHandling;
@@ -1461,10 +1462,7 @@ class UnaryBitwiseNegateExpr extends UnaryExpr
     if (NullHandling.sqlCompatible() && (ret.value() == null)) {
       return ExprEval.of(null);
     }
-    if (ret.type().equals(ExprType.LONG)) {
-      return ExprEval.of(~ret.asLong());
-    }
-    throw new IllegalArgumentException("unsupported type " + ret.type());
+    return ExprEval.of(~ret.asLong());
   }
 
   @Override
@@ -2036,6 +2034,17 @@ class BinBitwiseAndExpr extends BinaryEvalOpExprBase
   {
     throw new IllegalArgumentException("unsupported type " + ExprType.DOUBLE);
   }
+
+  @Override
+  protected ExprEval evalString(@Nullable String left, @Nullable String right)
+  {
+    Long l1 = Longs.tryParse(left);
+    Long l2 = Longs.tryParse(right);
+    if (l1 == null || l2 == null) {
+      return ExprEval.of(null);
+    }
+    return ExprEval.of(l1 & l2);
+  }
 }
 
 class BinBitwiseOrExpr extends BinaryEvalOpExprBase
@@ -2062,30 +2071,15 @@ class BinBitwiseOrExpr extends BinaryEvalOpExprBase
   {
     throw new IllegalArgumentException("unsupported type " + ExprType.DOUBLE);
   }
-}
-
-class BinBitwiseXorExpr extends BinaryEvalOpExprBase
-{
-  BinBitwiseXorExpr(String op, Expr left, Expr right)
-  {
-    super(op, left, right);
-  }
 
   @Override
-  protected BinaryOpExprBase copy(Expr left, Expr right)
+  protected ExprEval evalString(@Nullable String left, @Nullable String right)
   {
-    return new BinBitwiseXorExpr(op, left, right);
-  }
-
-  @Override
-  protected final long evalLong(long left, long right)
-  {
-    return left ^ right;
-  }
-
-  @Override
-  protected final double evalDouble(double left, double right)
-  {
-    throw new IllegalArgumentException("unsupported type " + ExprType.DOUBLE);
+    Long l1 = Longs.tryParse(left);
+    Long l2 = Longs.tryParse(right);
+    if (l1 == null || l2 == null) {
+      return ExprEval.of(null);
+    }
+    return ExprEval.of(l1 | l2);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -1441,6 +1441,45 @@ class UnaryNotExpr extends UnaryExpr
   }
 }
 
+class UnaryBitwiseNegateExpr extends UnaryExpr
+{
+  UnaryBitwiseNegateExpr(Expr expr)
+  {
+    super(expr);
+  }
+
+  @Override
+  UnaryExpr copy(Expr expr)
+  {
+    return new UnaryBitwiseNegateExpr(expr);
+  }
+
+  @Override
+  public ExprEval eval(ObjectBinding bindings)
+  {
+    ExprEval ret = expr.eval(bindings);
+    if (NullHandling.sqlCompatible() && (ret.value() == null)) {
+      return ExprEval.of(null);
+    }
+    if (ret.type().equals(ExprType.LONG)) {
+      return ExprEval.of(~ret.asLong());
+    }
+    throw new IllegalArgumentException("unsupported type " + ret.type());
+  }
+
+  @Override
+  public String stringify()
+  {
+    return StringUtils.format("~%s", expr.stringify());
+  }
+
+  @Override
+  public String toString()
+  {
+    return StringUtils.format("~%s", expr);
+  }
+}
+
 /**
  * Base type for all binary operators, this {@link Expr} has two children {@link Expr} for the left and right side
  * operands.
@@ -1971,6 +2010,82 @@ class BinOrExpr extends BinaryOpExprBase
     ExprEval leftVal = left.eval(bindings);
     return leftVal.asBoolean() ? leftVal : right.eval(bindings);
   }
-
 }
 
+class BinBitwiseAndExpr extends BinaryEvalOpExprBase
+{
+  BinBitwiseAndExpr(String op, Expr left, Expr right)
+  {
+    super(op, left, right);
+  }
+
+  @Override
+  protected BinaryOpExprBase copy(Expr left, Expr right)
+  {
+    return new BinBitwiseAndExpr(op, left, right);
+  }
+
+  @Override
+  protected final long evalLong(long left, long right)
+  {
+    return left & right;
+  }
+
+  @Override
+  protected final double evalDouble(double left, double right)
+  {
+    throw new IllegalArgumentException("unsupported type " + ExprType.DOUBLE);
+  }
+}
+
+class BinBitwiseOrExpr extends BinaryEvalOpExprBase
+{
+  BinBitwiseOrExpr(String op, Expr left, Expr right)
+  {
+    super(op, left, right);
+  }
+
+  @Override
+  protected BinaryOpExprBase copy(Expr left, Expr right)
+  {
+    return new BinBitwiseOrExpr(op, left, right);
+  }
+
+  @Override
+  protected final long evalLong(long left, long right)
+  {
+    return left | right;
+  }
+
+  @Override
+  protected final double evalDouble(double left, double right)
+  {
+    throw new IllegalArgumentException("unsupported type " + ExprType.DOUBLE);
+  }
+}
+
+class BinBitwiseXorExpr extends BinaryEvalOpExprBase
+{
+  BinBitwiseXorExpr(String op, Expr left, Expr right)
+  {
+    super(op, left, right);
+  }
+
+  @Override
+  protected BinaryOpExprBase copy(Expr left, Expr right)
+  {
+    return new BinBitwiseXorExpr(op, left, right);
+  }
+
+  @Override
+  protected final long evalLong(long left, long right)
+  {
+    return left ^ right;
+  }
+
+  @Override
+  protected final double evalDouble(double left, double right)
+  {
+    throw new IllegalArgumentException("unsupported type " + ExprType.DOUBLE);
+  }
+}

--- a/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
@@ -329,16 +329,6 @@ public class ExprListenerImpl extends ExprBaseListener
             )
         );
         break;
-      case ExprParser.BITXOR:
-        nodes.put(
-            ctx,
-            new BinBitwiseXorExpr(
-                ctx.getChild(1).getText().trim(),
-                (Expr) nodes.get(ctx.getChild(0)),
-                (Expr) nodes.get(ctx.getChild(2))
-            )
-        );
-        break;
       default:
         throw new RE("Unrecognized bitwise operator %s", ctx.getChild(1).getText());
     }

--- a/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprListenerImpl.java
@@ -78,6 +78,9 @@ public class ExprListenerImpl extends ExprBaseListener
       case ExprParser.NOT:
         nodes.put(ctx, new UnaryNotExpr((Expr) nodes.get(ctx.getChild(1))));
         break;
+      case ExprParser.BITNEG:
+        nodes.put(ctx, new UnaryBitwiseNegateExpr((Expr) nodes.get(ctx.getChild(1))));
+        break;
       default:
         throw new RE("Unrecognized unary operator %s", ctx.getChild(0).getText());
     }
@@ -298,6 +301,46 @@ public class ExprListenerImpl extends ExprBaseListener
         break;
       default:
         throw new RE("Unrecognized binary operator %s", ctx.getChild(1).getText());
+    }
+  }
+
+  @Override
+  public void exitBitwiseOpExpr(ExprParser.BitwiseOpExprContext ctx)
+  {
+    int opCode = ((TerminalNode) ctx.getChild(1)).getSymbol().getType();
+    switch (opCode) {
+      case ExprParser.BITAND:
+        nodes.put(
+            ctx,
+            new BinBitwiseAndExpr(
+                ctx.getChild(1).getText(),
+                (Expr) nodes.get(ctx.getChild(0)),
+                (Expr) nodes.get(ctx.getChild(2))
+            )
+        );
+        break;
+      case ExprParser.BITOR:
+        nodes.put(
+            ctx,
+            new BinBitwiseOrExpr(
+                ctx.getChild(1).getText(),
+                (Expr) nodes.get(ctx.getChild(0)),
+                (Expr) nodes.get(ctx.getChild(2))
+            )
+        );
+        break;
+      case ExprParser.BITXOR:
+        nodes.put(
+            ctx,
+            new BinBitwiseXorExpr(
+                ctx.getChild(1).getText().trim(),
+                (Expr) nodes.get(ctx.getChild(0)),
+                (Expr) nodes.get(ctx.getChild(2))
+            )
+        );
+        break;
+      default:
+        throw new RE("Unrecognized bitwise operator %s", ctx.getChild(1).getText());
     }
   }
 

--- a/core/src/test/java/org/apache/druid/math/expr/ExprTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ExprTest.java
@@ -103,6 +103,14 @@ public class ExprTest
   }
 
   @Test
+  public void testEqualsContractForBitwiseExpr()
+  {
+    EqualsVerifier.forClass(BinBitwiseAndExpr.class).usingGetClass().verify();
+    EqualsVerifier.forClass(BinBitwiseOrExpr.class).usingGetClass().verify();
+    EqualsVerifier.forClass(UnaryBitwiseNegateExpr.class).usingGetClass().verify();
+  }
+
+  @Test
   public void testEqualsContractForFunctionExpr()
   {
     EqualsVerifier.forClass(FunctionExpr.class).usingGetClass().withIgnoredFields("function").verify();

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -496,7 +496,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   {
     // Same types
     assertExpr("least(y, 0)", 0L);
-    assertExpr("least(34.0, z, 5.0, 767.0", 3.1);
+    assertExpr("least(34.0, z, 5.0, 767.0)", 3.1);
     assertExpr("least('B', x, 'A')", "A");
 
     // Different types

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -468,7 +468,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   {
     // Same types
     assertExpr("greatest(y, 0)", 2L);
-    assertExpr("greatest(34.0, z, 5.0, 767.0", 767.0);
+    assertExpr("greatest(34.0, z, 5.0, 767.0)", 767.0);
     assertExpr("greatest('B', x, 'A')", "foo");
 
     // Different types

--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -181,7 +181,26 @@ public class ParserTest extends InitializedNullHandlingTest
     validateFlatten("3 | 1", "(| 3 1)", "3");
     validateFlatten("2 | 1", "(| 2 1)", "3");
     validateFlatten("(~1) & 7", "(& ~1 7)", "6");
-    validateFlatten("8 xor 1", "(xor 8 1)", "9");
+
+    validateFlatten("'2' & '1'", "(& 2 1)", "0");
+    validateFlatten("'3' | '1'", "(| 3 1)", "3");
+    validateFlatten("(~'1') & 7", "(& ~1 7)", "6");
+  }
+
+  @Test
+  public void testBitwiseDoubleAndExplosion()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("DOUBLE");
+    validateFlatten("3.0 & 1", "(& 3.0 1)", "1");
+  }
+
+  @Test
+  public void testBitwiseDoubleOrExplosion()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("DOUBLE");
+    validateFlatten("3.0 | 1", "(| 3.0 1)", "1");
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -185,6 +186,12 @@ public class ParserTest extends InitializedNullHandlingTest
     validateFlatten("'2' & '1'", "(& 2 1)", "0");
     validateFlatten("'3' | '1'", "(| 3 1)", "3");
     validateFlatten("(~'1') & 7", "(& ~1 7)", "6");
+
+    validateFlatten("'notanumber' & '1'", "(& notanumber 1)", null);
+    validateFlatten("'3' | 'notanumber'", "(| 3 notanumber)", null);
+    validateFlatten("~'notanumber'", "~notanumber", null);
+    validateFlatten("(~'notanumber') & '7'", "(& ~notanumber 7)", null);
+    validateFlatten("(~'notanumber') | '7'", "(| ~notanumber 7)", null);
   }
 
   @Test
@@ -574,7 +581,7 @@ public class ParserTest extends InitializedNullHandlingTest
   }
 
 
-  private void validateFlatten(String expression, String withoutFlatten, String withFlatten)
+  private void validateFlatten(String expression, String withoutFlatten, @Nullable String withFlatten)
   {
     Expr notFlat = Parser.parse(expression, ExprMacroTable.nil(), false);
     Expr flat = Parser.parse(expression, ExprMacroTable.nil(), true);

--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -173,6 +173,18 @@ public class ParserTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testBitwiseOps()
+  {
+    validateFlatten("3 & 1", "(& 3 1)", "1");
+    validateFlatten("3 & 1", "(& 3 1)", "1");
+    validateFlatten("2 & 1", "(& 2 1)", "0");
+    validateFlatten("3 | 1", "(| 3 1)", "3");
+    validateFlatten("2 | 1", "(| 2 1)", "3");
+    validateFlatten("(~1) & 7", "(& ~1 7)", "6");
+    validateFlatten("8 xor 1", "(xor 8 1)", "9");
+  }
+
+  @Test
   public void testIdentifiers()
   {
     validateParser("foo", "foo", ImmutableList.of("foo"), ImmutableSet.of());

--- a/docs/misc/math-expr.md
+++ b/docs/misc/math-expr.md
@@ -37,7 +37,7 @@ This expression language supports the following operators (listed in decreasing 
 |---------|-----------|
 |!, -, ^|Unary NOT, Minus, and bitwise Negate|
 |^|Binary power op|
-|&, &#124;, xor|Bitwise AND, OR, XOR|
+|&, &#124;|Binary bitwise AND, OR|
 |*, /, %|Binary multiplicative|
 |+, -|Binary additive|
 |<, <=, >, >=, ==, !=|Binary Comparison|

--- a/docs/misc/math-expr.md
+++ b/docs/misc/math-expr.md
@@ -35,12 +35,14 @@ This expression language supports the following operators (listed in decreasing 
 
 |Operators|Description|
 |---------|-----------|
-|!, -|Unary NOT and Minus|
+|!, -, ^|Unary NOT, Minus, and bitwise Negate|
 |^|Binary power op|
+|&, &#124;, xor|Bitwise AND, OR, XOR|
 |*, /, %|Binary multiplicative|
 |+, -|Binary additive|
 |<, <=, >, >=, ==, !=|Binary Comparison|
 |&&, &#124;&#124;|Binary Logical AND, OR|
+
 
 Long, double, and string data types are supported. If a number contains a dot, it is interpreted as a double, otherwise it is interpreted as a long. That means, always add a '.' to your number if you want it interpreted as a double value. String literals should be quoted by single quotation marks.
 

--- a/website/.spelling
+++ b/website/.spelling
@@ -196,6 +196,7 @@ backfills
 backpressure
 base64
 big-endian
+bitwise
 blobstore
 boolean
 breakpoint


### PR DESCRIPTION
### Description

This PR adds bitwise operators `&`, `|`, `~` to Druid native JSON query expressions. 

`^` was already taken for power unfortunately, though I would be in favor of reworking it to a function so we can use `^` for xor and find an alternatively way to express the power operation.

SQL support appears to be not possible until https://issues.apache.org/jira/browse/CALCITE-3732 settles, so unfortunately only native JSON queries are supported at this time.

Related to #8560.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * expression grammar file
 * `Expr`
 * `ExprListenerImpl`
