### PR TITLE
Add groupBy limitSpec to queryCache key

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -524,6 +524,7 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<ResultRow, GroupB
             .appendCacheables(query.getAggregatorSpecs())
             .appendCacheables(query.getDimensions())
             .appendCacheable(query.getVirtualColumns())
+            .appendCacheable(query.getLimitSpec())
             .build();
       }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -517,15 +517,17 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<ResultRow, GroupB
       @Override
       public byte[] computeCacheKey(GroupByQuery query)
       {
-        return new CacheKeyBuilder(GROUPBY_QUERY)
+        CacheKeyBuilder builder = new CacheKeyBuilder(GROUPBY_QUERY)
             .appendByte(CACHE_STRATEGY_VERSION)
             .appendCacheable(query.getGranularity())
             .appendCacheable(query.getDimFilter())
             .appendCacheables(query.getAggregatorSpecs())
             .appendCacheables(query.getDimensions())
-            .appendCacheable(query.getVirtualColumns())
-            .appendCacheable(query.getLimitSpec())
-            .build();
+            .appendCacheable(query.getVirtualColumns());
+        if (query.isApplyLimitPushDown()) {
+          builder.appendCacheable(query.getLimitSpec());
+        }
+        return builder.build();
       }
 
       @Override


### PR DESCRIPTION
### Description

This PR Fixes a bug with groupBy query cache key. The current cache key for groupby queries does not contain limitSpec info. So when a user queries with a given limit lets say 10 and then increase the limit to 100, he would still get the cached results with older limit. 

Note: This only shows up if you have enabled caching for groupby queries, which is enabled by default from 0.13 release. 

This PR has:
- [*] been self-reviewed.
- [*] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [*] been tested in a test Druid cluster.
