### PR TITLE
Correct the position of the double quotation in distinctcount.md file

### DIFF
--- a/docs/development/extensions-contrib/distinctcount.md
+++ b/docs/development/extensions-contrib/distinctcount.md
@@ -83,7 +83,7 @@ Example:
 {
   "queryType": "groupBy",
   "dataSource": "sample_datasource",
-  "dimensions": "[sample_dim]",
+  "dimensions": ["sample_dim"],
   "granularity": "all",
   "aggregations": [
     {


### PR DESCRIPTION
```
"dimensions": "[sample_dim]"
```
should be
```
"dimensions": ["sample_dim"]
```

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `distinctcount.md`
