### PR TITLE
Closing yielder from ParallelMergeCombiningSequence should trigger cancellation

### DIFF
--- a/core/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -556,7 +556,10 @@ public class ParallelMergeCombiningSequenceTest
       Assert.assertEquals(2, reportMetrics.getParallelism());
       Assert.assertEquals(6, reportMetrics.getInputSequences());
       // 49166 is total set of results if yielder were fully processed, expect somewhere more than 0 but less than that
-      // this isn't super indicative of anything really, since closing the yielder would have killed
+      // this isn't super indicative of anything really, since closing the yielder would have triggered the baggage
+      // to run, which runs this metrics reporter function, while the actual processing could still be occuring on the
+      // pool in the background and the yielder still operates as intended if cancellation isn't in fact happening.
+      // other tests ensure that this is true though (yielder.next throwing an exception for example)
       Assert.assertTrue(49166 > reportMetrics.getInputRows());
       Assert.assertTrue(0 < reportMetrics.getInputRows());
     });

--- a/core/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -699,7 +699,8 @@ public class ParallelMergeCombiningSequenceTest
       parallelMergeCombineYielder.next(parallelMergeCombineYielder.get());
       // this should explode so the contradictory next statement should not be reached
       Assert.assertTrue(false);
-    } catch (RuntimeException rex) {
+    }
+    catch (RuntimeException rex) {
       Assert.assertEquals(expectedExceptionMsg, rex.getMessage());
     }
 

--- a/core/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -540,6 +540,29 @@ public class ParallelMergeCombiningSequenceTest
     assertException(input, 8, 64, 1000, 500);
   }
 
+  @Test
+  public void testGracefulCloseOfYielderCancelsPool() throws Exception
+  {
+
+    List<Sequence<IntPair>> input = new ArrayList<>();
+    input.add(nonBlockingSequence(10_000));
+    input.add(nonBlockingSequence(9_001));
+    input.add(nonBlockingSequence(7_777));
+    input.add(nonBlockingSequence(8_500));
+    input.add(nonBlockingSequence(5_000));
+    input.add(nonBlockingSequence(8_888));
+
+    assertResultWithEarlyClose(input, 128, 1024, 256, reportMetrics -> {
+      Assert.assertEquals(2, reportMetrics.getParallelism());
+      Assert.assertEquals(6, reportMetrics.getInputSequences());
+      // 49166 is total set of results if yielder were fully processed, expect somewhere more than 0 but less than that
+      // this isn't super indicative of anything really, since closing the yielder would have killed
+      Assert.assertTrue(49166 > reportMetrics.getInputRows());
+      Assert.assertTrue(0 < reportMetrics.getInputRows());
+    });
+  }
+
+
   private void assertResult(List<Sequence<IntPair>> sequences) throws InterruptedException, IOException
   {
     assertResult(
@@ -611,6 +634,86 @@ public class ParallelMergeCombiningSequenceTest
     Assert.assertEquals(0, pool.getRunningThreadCount());
     combiningYielder.close();
     parallelMergeCombineYielder.close();
+    // cancellation trigger should not be set if sequence was fully yielded and close is called
+    // (though shouldn't actually matter even if it was...)
+    Assert.assertFalse(parallelMergeCombineSequence.getCancellationGizmo().isCancelled());
+  }
+
+  private void assertResultWithEarlyClose(
+      List<Sequence<IntPair>> sequences,
+      int batchSize,
+      int yieldAfter,
+      int closeYielderAfter,
+      Consumer<ParallelMergeCombiningSequence.MergeCombineMetrics> reporter
+  )
+      throws InterruptedException, IOException
+  {
+    final CombiningSequence<IntPair> combiningSequence = CombiningSequence.create(
+        new MergeSequence<>(INT_PAIR_ORDERING, Sequences.simple(sequences)),
+        INT_PAIR_ORDERING,
+        INT_PAIR_MERGE_FN
+    );
+
+    final ParallelMergeCombiningSequence<IntPair> parallelMergeCombineSequence = new ParallelMergeCombiningSequence<>(
+        pool,
+        sequences,
+        INT_PAIR_ORDERING,
+        INT_PAIR_MERGE_FN,
+        true,
+        5000,
+        0,
+        TEST_POOL_SIZE,
+        yieldAfter,
+        batchSize,
+        ParallelMergeCombiningSequence.DEFAULT_TASK_TARGET_RUN_TIME_MILLIS,
+        reporter
+    );
+
+    Yielder<IntPair> combiningYielder = Yielders.each(combiningSequence);
+    Yielder<IntPair> parallelMergeCombineYielder = Yielders.each(parallelMergeCombineSequence);
+
+    IntPair prev = null;
+
+    int yields = 0;
+    while (!combiningYielder.isDone() && !parallelMergeCombineYielder.isDone()) {
+      if (yields >= closeYielderAfter) {
+        parallelMergeCombineYielder.close();
+        combiningYielder.close();
+        break;
+      } else {
+        yields++;
+        Assert.assertEquals(combiningYielder.get(), parallelMergeCombineYielder.get());
+        Assert.assertNotEquals(parallelMergeCombineYielder.get(), prev);
+        prev = parallelMergeCombineYielder.get();
+        combiningYielder = combiningYielder.next(combiningYielder.get());
+        parallelMergeCombineYielder = parallelMergeCombineYielder.next(parallelMergeCombineYielder.get());
+      }
+    }
+    // trying to next the yielder creates sadness for you
+    final String expectedExceptionMsg = "Already closed";
+    try {
+      Assert.assertEquals(combiningYielder.get(), parallelMergeCombineYielder.get());
+      parallelMergeCombineYielder.next(parallelMergeCombineYielder.get());
+      // this should explode so the contradictory next statement should not be reached
+      Assert.assertTrue(false);
+    } catch (RuntimeException rex) {
+      Assert.assertEquals(expectedExceptionMsg, rex.getMessage());
+    }
+
+    // cancellation gizmo of sequence should be cancelled, and also should contain our expected message
+    Assert.assertTrue(parallelMergeCombineSequence.getCancellationGizmo().isCancelled());
+    Assert.assertEquals(
+        expectedExceptionMsg,
+        parallelMergeCombineSequence.getCancellationGizmo().getRuntimeException().getMessage()
+    );
+
+    while (pool.getRunningThreadCount() > 0) {
+      Thread.sleep(100);
+    }
+    Assert.assertEquals(0, pool.getRunningThreadCount());
+
+    Assert.assertFalse(combiningYielder.isDone());
+    Assert.assertFalse(parallelMergeCombineYielder.isDone());
   }
 
   private void assertException(List<Sequence<IntPair>> sequences) throws Exception


### PR DESCRIPTION
### Description
This PR fixes an issue with/modifies the behavior of closing a `Yielder` created from a `ParallelMergeCombiningSequence` to trigger a cancellation to immediately halt any additional processing on the broker's merging `ForkJoinPool`. I'm unsure if this causes any issues in practice, but could be an issue if closing a yielder early. Closing the yielder and stopping processing would potentially cause running pool tasks associated with the query to managed block until the offer/poll timeouts on the blocking queue, at which point they would fully die.

Amusingly, prior to the change in this PR, you could continue to use the "closed" yielder to get the complete set of results assuming no exceptions occur inside of the parallel merge processing itself, however the sequence 'baggage' that reports the parallel merge pool metrics would have been triggered early, reporting incorrect metric values.

The added test ensures that cancellation happens upon close of the `Yielder`, which is valid behavior within the contract of the `Yielder` interface which allows for close to put the entire chain into an undefined state.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `ParallelMergeCombiningSequence`
