### PR TITLE
Fix Stack overflow with infinite loop in ReduceExpressionsRule of HepProgram

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
@@ -26,10 +26,13 @@ import org.apache.calcite.plan.RelOptMaterialization;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.plan.volcano.AbstractConverter;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
+import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.rules.AggregateCaseToFilterRule;
 import org.apache.calcite.rel.rules.AggregateExpandDistinctAggregatesRule;
 import org.apache.calcite.rel.rules.AggregateJoinTransposeRule;
@@ -84,6 +87,13 @@ public class Rules
 {
   public static final int DRUID_CONVENTION_RULES = 0;
   public static final int BINDABLE_CONVENTION_RULES = 1;
+
+  // Due to Calcite bug (CALCITE-3845), ReduceExpressionsRule can considered expression which is the same as the
+  // previous input expression as reduced. Basically, the expression is actually not reduced but is still considered as
+  // reduced. Hence, this resulted in an infinite loop of Calcite trying to reducing the same expression over and over.
+  // Calcite 1.23.0 fixes this issue by not consider expression as reduced if this case happens. However, while
+  // we are still using Calcite 1.21.0, a workaround is to limit the number of pattern matches to avoid infinite loop.
+  private static final int HEP_DEFAULT_MATCH_LIMIT = 1200;
 
   // Rules from RelOptUtil's registerBaseRules, minus:
   //
@@ -191,18 +201,33 @@ public class Rules
 
   public static List<Program> programs(final PlannerContext plannerContext, final QueryMaker queryMaker)
   {
+
+
     // Program that pre-processes the tree before letting the full-on VolcanoPlanner loose.
     final Program preProgram =
         Programs.sequence(
             Programs.subQuery(DefaultRelMetadataProvider.INSTANCE),
             DecorrelateAndTrimFieldsProgram.INSTANCE,
-            Programs.hep(REDUCTION_RULES, true, DefaultRelMetadataProvider.INSTANCE)
+            buildHepProgram(REDUCTION_RULES, true, DefaultRelMetadataProvider.INSTANCE, HEP_DEFAULT_MATCH_LIMIT)
         );
 
     return ImmutableList.of(
         Programs.sequence(preProgram, Programs.ofRules(druidConventionRuleSet(plannerContext, queryMaker))),
         Programs.sequence(preProgram, Programs.ofRules(bindableConventionRuleSet(plannerContext)))
     );
+  }
+
+  private static Program buildHepProgram(Iterable<? extends RelOptRule> rules,
+                                         boolean noDag,
+                                         RelMetadataProvider metadataProvider,
+                                         int matchLimit)
+  {
+    final HepProgramBuilder builder = HepProgram.builder();
+    builder.addMatchLimit(matchLimit);
+    for (RelOptRule rule : rules) {
+      builder.addRuleInstance(rule);
+    }
+    return Programs.of(builder.build(), noDag, metadataProvider);
   }
 
   private static List<RelOptRule> druidConventionRuleSet(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
@@ -93,7 +93,10 @@ public class Rules
   // reduced. Hence, this resulted in an infinite loop of Calcite trying to reducing the same expression over and over.
   // Calcite 1.23.0 fixes this issue by not consider expression as reduced if this case happens. However, while
   // we are still using Calcite 1.21.0, a workaround is to limit the number of pattern matches to avoid infinite loop.
-  private static final int HEP_DEFAULT_MATCH_LIMIT = 1200;
+  private static final String HEP_DEFAULT_MATCH_LIMIT_CONFIG_STRING = "druid.sql.planner.hepMatchLimit";
+  private static final int HEP_DEFAULT_MATCH_LIMIT = Integer.valueOf(
+      System.getProperty(HEP_DEFAULT_MATCH_LIMIT_CONFIG_STRING, "1200")
+  );
 
   // Rules from RelOptUtil's registerBaseRules, minus:
   //

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -140,6 +140,19 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testExpressionContainingNull() throws Exception
+  {
+    List<String> expectedResult = new ArrayList<>();
+    expectedResult.add("Hello");
+    expectedResult.add(null);
+    testQuery(
+        "SELECT ARRAY ['Hello', NULL]",
+        ImmutableList.of(),
+        ImmutableList.of(new Object[]{expectedResult})
+    );
+  }
+
+  @Test
   public void testSelectNonNumericNumberLiterals() throws Exception
   {
     // Tests to convert NaN, positive infinity and negative infinity as literals.


### PR DESCRIPTION
Fix Stack overflow with infinite loop in ReduceExpressionsRule of HepProgram

### Description

This fix https://github.com/apache/druid/issues/9906

Due to Calcite bug (CALCITE-3845), ReduceExpressionsRule can considered expression which is the same as the previous input expression as reduced. Basically, the expression is actually not reduced but is still considered as reduced. Hence, this resulted in an infinite loop of Calcite trying to reducing the same expression over and over in ReduceExpressionsRule. Calcite 1.23.0 fixes this issue by not consider expression as reduced if this case happens. However, while we are still using Calcite 1.21.0, a workaround is to limit the number of pattern matches to avoid infinite loop in ReduceExpressionsRule of the HepProgram. One example of this case is the query `SELECT ARRAY ['Hello', NULL]`

The matchLimit value of 1200 is chosen with the suggestion by a Calcite committer, Chunwei Lei. (See: https://lists.apache.org/x/thread.html/rea7691aec3947a49faaa29cdfba4ef5d0a5e1da2c3b7546ae8dea3c8@%3Cdev.calcite.apache.org%3E)

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
