### PR TITLE
Fix CachingClusteredClient when querying specific segments

### DIFF
--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -2999,51 +2999,6 @@ public class CachingClusteredClientTest
     Assert.assertNotEquals(etag1, etag2);
   }
 
-  @Test
-  public void testGetQueryRunnerForSegments()
-  {
-    final Interval interval1 = Intervals.of("2011-01-06/2011-01-07");
-    final Interval interval2 = Intervals.of("2011-01-07/2011-01-08");
-
-    final DruidServer lastServer = servers[random.nextInt(servers.length)];
-    ServerSelector selector1 = makeMockSingleDimensionSelector(lastServer, "dim1", null, "b", 0);
-    ServerSelector selector2 = makeMockSingleDimensionSelector(lastServer, "dim1", "e", "f", 1);
-    ServerSelector selector3 = makeMockSingleDimensionSelector(lastServer, "dim1", "hi", "zzz", 2);
-    ServerSelector selector4 = makeMockSingleDimensionSelector(lastServer, "dim2", "a", "e", 0);
-    ServerSelector selector5 = makeMockSingleDimensionSelector(lastServer, "dim2", null, null, 1);
-
-    timeline.add(interval1, "v", new NumberedPartitionChunk<>(0, 3, selector1));
-    timeline.add(interval1, "v", new NumberedPartitionChunk<>(1, 3, selector2));
-    timeline.add(interval1, "v", new NumberedPartitionChunk<>(2, 3, selector3));
-    timeline.add(interval2, "v", new NumberedPartitionChunk<>(0, 2, selector4));
-    timeline.add(interval2, "v", new NumberedPartitionChunk<>(1, 2, selector5));
-
-    final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
-                                        .dataSource(DATA_SOURCE)
-                                        .intervals("2011-01-05/2011-01-10")
-                                        .filters(DIM_FILTER)
-                                        .granularity(GRANULARITY)
-                                        .aggregators(AGGS)
-                                        .postAggregators(POST_AGGS)
-                                        .context(CONTEXT)
-                                        .randomQueryId()
-                                        .build();
-
-    final QueryRunner<Result<TimeseriesResultValue>> runner = new FinalizeResultsQueryRunner(
-        client.getQueryRunnerForSegments(
-            query,
-            ImmutableList.of(new SegmentDescriptor(interval1, "v", 0), new SegmentDescriptor(interval2, "v", 0))
-        ),
-        new TimeseriesQueryQueryToolChest()
-    );
-
-    final Sequence<Result<TimeseriesResultValue>> sequence = runner.run(
-        QueryPlus.wrap(query),
-        initializeResponseContext()
-    );
-    System.out.println(sequence.toList());
-  }
-
   @SuppressWarnings("unchecked")
   private QueryRunner getDefaultQueryRunner()
   {

--- a/server/src/test/java/org/apache/druid/client/TestHttpClient.java
+++ b/server/src/test/java/org/apache/druid/client/TestHttpClient.java
@@ -171,7 +171,7 @@ public class TestHttpClient implements HttpClient
     private QueryRunner getQueryRunner()
     {
       if (isSegmentDropped) {
-        return new ReportTimelineMissingSegmentQueryRunner(
+        return new ReportTimelineMissingSegmentQueryRunner<>(
             new SegmentDescriptor(segment.getInterval(), segment.getVersion(), segment.getId().getPartitionNum())
         );
       } else {

--- a/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
@@ -337,7 +337,7 @@ public class RetryQueryRunnerTest
                  .context(
                      ImmutableMap.of(
                          DirectDruidClient.QUERY_FAIL_TIME,
-                         System.currentTimeMillis() + 1000000
+                         System.currentTimeMillis() + 10000
                      )
                  )
                  .build()

--- a/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.client.CachingClusteredClient;
@@ -35,7 +36,9 @@ import org.apache.druid.client.cache.MapCache;
 import org.apache.druid.guice.http.DruidHttpClientConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.NonnullPair;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.io.Closer;
@@ -74,7 +77,7 @@ public class RetryQueryRunnerTest
 {
   private static final Closer CLOSER = Closer.create();
   private static final String DATASOURCE = "datasource";
-  private static final GeneratorSchemaInfo SCHEMA_INFO = GeneratorBasicSchemas.SCHEMA_MAP.get("basic");
+  private static final GeneratorSchemaInfo BASE_SCHEMA_INFO = GeneratorBasicSchemas.SCHEMA_MAP.get("basic");
   private static final boolean USE_PARALLEL_MERGE_POOL_CONFIGURED = false;
 
   @Rule
@@ -148,7 +151,7 @@ public class RetryQueryRunnerTest
   public void testNoRetry()
   {
     prepareCluster(10);
-    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(SCHEMA_INFO.getDataInterval());
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
         newRetryQueryRunnerConfig(1, false),
         query,
@@ -165,7 +168,7 @@ public class RetryQueryRunnerTest
   public void testRetryForMovedSegment()
   {
     prepareCluster(10);
-    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(SCHEMA_INFO.getDataInterval());
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
         newRetryQueryRunnerConfig(1, true),
         query,
@@ -189,7 +192,7 @@ public class RetryQueryRunnerTest
   public void testRetryUntilWeGetFullResult()
   {
     prepareCluster(10);
-    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(SCHEMA_INFO.getDataInterval());
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
         newRetryQueryRunnerConfig(100, false), // retry up to 100
         query,
@@ -209,7 +212,7 @@ public class RetryQueryRunnerTest
   public void testFailWithPartialResultsAfterRetry()
   {
     prepareCluster(10);
-    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(SCHEMA_INFO.getDataInterval());
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
         newRetryQueryRunnerConfig(1, false),
         query,
@@ -229,12 +232,26 @@ public class RetryQueryRunnerTest
 
   private void prepareCluster(int numServers)
   {
+    Preconditions.checkArgument(numServers < 25, "Cannot be larger than 24");
     for (int i = 0; i < numServers; i++) {
-      final DataSegment segment = newSegment(SCHEMA_INFO.getDataInterval(), i);
+      final int partitionId = i % 2;
+      final int intervalIndex = i / 2;
+      final Interval interval = Intervals.of("2000-01-01T%02d/PT1H", intervalIndex);
+      final DataSegment segment = newSegment(interval, partitionId, 2);
       addServer(
           SimpleServerView.createServer(i + 1),
           segment,
-          segmentGenerator.generate(segment, SCHEMA_INFO, Granularities.NONE, 10)
+          segmentGenerator.generate(
+              segment,
+              new GeneratorSchemaInfo(
+                  BASE_SCHEMA_INFO.getColumnSchemas(),
+                  BASE_SCHEMA_INFO.getAggs(),
+                  interval,
+                  BASE_SCHEMA_INFO.isWithRollup()
+              ),
+              Granularities.NONE,
+              10
+          )
       );
     }
   }
@@ -315,12 +332,12 @@ public class RetryQueryRunnerTest
     return Druids.newTimeseriesQueryBuilder()
                  .dataSource(DATASOURCE)
                  .intervals(ImmutableList.of(interval))
-                 .granularity(Granularities.DAY)
+                 .granularity(Granularities.HOUR)
                  .aggregators(new CountAggregatorFactory("rows"))
                  .context(
                      ImmutableMap.of(
                          DirectDruidClient.QUERY_FAIL_TIME,
-                         System.currentTimeMillis() + 10000
+                         System.currentTimeMillis() + 1000000
                      )
                  )
                  .build()
@@ -338,20 +355,26 @@ public class RetryQueryRunnerTest
   {
     return IntStream
         .range(0, expectedNumResultRows)
-        .mapToObj(i -> new Result<>(DateTimes.of("2000-01-01"), new TimeseriesResultValue(ImmutableMap.of("rows", 10))))
+        .mapToObj(
+            i -> new Result<>(
+                DateTimes.of(StringUtils.format("2000-01-01T%02d", i / 2)),
+                new TimeseriesResultValue(ImmutableMap.of("rows", 10))
+            )
+        )
         .collect(Collectors.toList());
   }
 
   private static DataSegment newSegment(
       Interval interval,
-      int partitionId
+      int partitionId,
+      int numCorePartitions
   )
   {
     return DataSegment.builder()
                       .dataSource(DATASOURCE)
                       .interval(interval)
                       .version("1")
-                      .shardSpec(new NumberedShardSpec(partitionId, 0))
+                      .shardSpec(new NumberedShardSpec(partitionId, numCorePartitions))
                       .size(10)
                       .build();
   }


### PR DESCRIPTION
### Description

`CachingClusteredClient.getQueryRunnerForSegments()` can be called when `RetryQueryRunner` retries the query for missing segments. Since it is possible to query only a subset of core partition set per time chunk, `CachingClusteredClient` should use `TimelineLookup.lookupWithIncompletePartitions()` instead. The query can return incomplete result otherwise. Maybe later, it is possible to refactor `CachingClusteredClient.getQueryRunnerForSegments()` to use the given segments as they are instead of creating a timeline with them.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.