### PR TITLE
mask secrets in MM task command log

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -28,6 +28,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
@@ -58,6 +59,7 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.log.StartupLoggingConfig;
 import org.apache.druid.server.metrics.MonitorsConfig;
 import org.apache.druid.tasklogs.TaskLogPusher;
 import org.apache.druid.tasklogs.TaskLogStreamer;
@@ -95,6 +97,7 @@ public class ForkingTaskRunner
   private final DruidNode node;
   private final ListeningExecutorService exec;
   private final PortFinder portFinder;
+  private final StartupLoggingConfig startupLoggingConfig;
 
   private volatile boolean stopping = false;
 
@@ -106,7 +109,8 @@ public class ForkingTaskRunner
       Properties props,
       TaskLogPusher taskLogPusher,
       ObjectMapper jsonMapper,
-      @Self DruidNode node
+      @Self DruidNode node,
+      StartupLoggingConfig startupLoggingConfig
   )
   {
     super(jsonMapper, taskConfig);
@@ -115,6 +119,7 @@ public class ForkingTaskRunner
     this.taskLogPusher = taskLogPusher;
     this.node = node;
     this.portFinder = new PortFinder(config.getStartPort(), config.getEndPort(), config.getPorts());
+    this.startupLoggingConfig = startupLoggingConfig;
     this.exec = MoreExecutors.listeningDecorator(
         Execs.multiThreaded(workerConfig.getCapacity(), "forking-task-runner-%d")
     );
@@ -338,7 +343,19 @@ public class ForkingTaskRunner
                           jsonMapper.writeValue(taskFile, task);
                         }
 
-                        LOGGER.info("Running command: %s", Joiner.on(" ").join(command));
+                        final Set<String> maskedProperties = Sets.newHashSet(startupLoggingConfig.getMaskProperties());
+                        final Iterator<String> printableCommandIterator = command.stream().map(element -> {
+                          for (String masked : maskedProperties) {
+                            if (element.contains(masked)) {
+                              String[] splits = element.split("=", 2);
+                              if (splits.length == 2) {
+                                return StringUtils.format("%s=%s", splits[0], "<masked>");
+                              }
+                            }
+                          }
+                          return element;
+                        }).iterator();
+                        LOGGER.info("Running command: %s", Joiner.on(" ").join(printableCommandIterator));
                         taskWorkItem.processHolder = new ProcessHolder(
                           new ProcessBuilder(ImmutableList.copyOf(command)).redirectErrorStream(true).start(),
                           logFile,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -637,13 +637,13 @@ public class ForkingTaskRunner
     final Set<String> maskedPropertiesSet = Sets.newHashSet(maskedProperties);
     final Iterator<String> maskedIterator = command.stream().map(element -> {
       String[] splits = element.split("=", 2);
-        if (splits.length == 2) {
-          for (String masked : maskedPropertiesSet) {
-            if (splits[0].contains(masked)) {
-              return StringUtils.format("%s=%s", splits[0], "<masked>");
-            }
+      if (splits.length == 2) {
+        for (String masked : maskedPropertiesSet) {
+          if (splits[0].contains(masked)) {
+            return StringUtils.format("%s=%s", splits[0], "<masked>");
           }
         }
+      }
       return element;
     }).iterator();
     return Joiner.on(" ").join(maskedIterator);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerFactory.java
@@ -26,6 +26,7 @@ import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.overlord.config.ForkingTaskRunnerConfig;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.log.StartupLoggingConfig;
 import org.apache.druid.tasklogs.TaskLogPusher;
 
 import java.util.Properties;
@@ -41,6 +42,7 @@ public class ForkingTaskRunnerFactory implements TaskRunnerFactory<ForkingTaskRu
   private final ObjectMapper jsonMapper;
   private final TaskLogPusher persistentTaskLogs;
   private final DruidNode node;
+  private final StartupLoggingConfig startupLoggingConfig;
 
   @Inject
   public ForkingTaskRunnerFactory(
@@ -50,7 +52,8 @@ public class ForkingTaskRunnerFactory implements TaskRunnerFactory<ForkingTaskRu
       final Properties props,
       final ObjectMapper jsonMapper,
       final TaskLogPusher persistentTaskLogs,
-      @Self DruidNode node
+      @Self DruidNode node,
+      final StartupLoggingConfig startupLoggingConfig
   )
   {
     this.config = config;
@@ -60,11 +63,12 @@ public class ForkingTaskRunnerFactory implements TaskRunnerFactory<ForkingTaskRu
     this.jsonMapper = jsonMapper;
     this.persistentTaskLogs = persistentTaskLogs;
     this.node = node;
+    this.startupLoggingConfig = startupLoggingConfig;
   }
 
   @Override
   public ForkingTaskRunner build()
   {
-    return new ForkingTaskRunner(config, taskConfig, workerConfig, props, persistentTaskLogs, jsonMapper, node);
+    return new ForkingTaskRunner(config, taskConfig, workerConfig, props, persistentTaskLogs, jsonMapper, node, startupLoggingConfig);
   }
 }


### PR DESCRIPTION
### Description

MM logs the java task command and does not mask the secrets so this PR fixes that and respects the masked properties config.

<hr>

This PR has:
- [x] been self-reviewed.
 
<hr>

##### Key changed/added classes in this PR
 * `ForkingTaskRunner`
