### PR TITLE
allow retention rules to be imported from other data sources

### DIFF
--- a/docs/operations/rule-configuration.md
+++ b/docs/operations/rule-configuration.md
@@ -220,6 +220,19 @@ Period broadcast rules are of the form:
 
 The interval of a segment will be compared against the specified period. The period is from some time in the past to the future or to the current time, which depends on `includeFuture` is true or false. The rule matches if the period *overlaps* the interval.
 
+### Import Rule
+
+Import rules are of the form:
+
+```json
+    {
+      "importedRuleset": "stuff_other_source",
+      "type": "importRules"
+    }
+```
+* `type` - this should always be "importRules"
+* `importedRuleset` - A datasource from which to include rules. Changes to rules on the imported datasource will be reflected dynamically. 
+
 ## Permanently deleting data
 
 Druid can fully drop data from the cluster, wipe the metadata store entry, and remove the data from deep storage for any
@@ -232,3 +245,4 @@ Data that has been dropped from a Druid cluster cannot be reloaded using only ru
 you must first set your retention period (i.e. changing the retention period from 1 month to 2 months), and then mark as
 used all segments belonging to the datasource in the Druid Coordinator console, or through the Druid Coordinator
 endpoints.
+

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ImportRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ImportRule.java
@@ -19,32 +19,59 @@
 
 package org.apache.druid.server.coordinator.rules;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.server.coordinator.CoordinatorStats;
+import org.apache.druid.server.coordinator.DruidCoordinator;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
+import java.util.Objects;
+
 /**
  */
-public class ForeverDropRule extends DropRule
+public class ImportRule implements Rule
 {
+
+  private final String importedRuleset;
+
+  @JsonCreator
+  public ImportRule(@JsonProperty("importedRuleset") String importedRuleset)
+  {
+    this.importedRuleset = importedRuleset;
+  }
+
   @Override
   @JsonProperty
   public String getType()
   {
-    return "dropForever";
+    return "importRules";
+  }
+
+  @JsonProperty
+  public String getImportedRuleset()
+  {
+    return importedRuleset;
   }
 
   @Override
   public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
   {
-    return true;
+    return false;
   }
 
   @Override
   public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
   {
-    return true;
+    return false;
+  }
+
+  @Override
+  public CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment)
+  {
+    return new CoordinatorStats();
   }
   
   @Override
@@ -53,12 +80,23 @@ public class ForeverDropRule extends DropRule
     if (this == o) {
       return true;
     }
-    return o != null && getClass() == o.getClass();
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ImportRule that = (ImportRule) o;
+    return Objects.equals(importedRuleset, that.importedRuleset);
   }
   
   @Override
-  public int hashCode()
+  public int hashCode() 
   {
-    return ForeverDropRule.class.hashCode();
+    return Objects.hash(importedRuleset);
   }
+
+  @Override
+  public boolean canLoadSegments()
+  {
+    return false;
+  }
+
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
@@ -26,14 +26,14 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 
+import java.util.Objects;
+
 public class PeriodDropBeforeRule extends DropRule
 {
   private final Period period;
 
   @JsonCreator
-  public PeriodDropBeforeRule(
-      @JsonProperty("period") Period period
-  )
+  public PeriodDropBeforeRule(@JsonProperty("period") Period period)
   {
     this.period = period;
   }
@@ -62,5 +62,30 @@ public class PeriodDropBeforeRule extends DropRule
   {
     final DateTime periodAgo = referenceTimestamp.minus(period);
     return theInterval.getEndMillis() <= periodAgo.getMillis();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PeriodDropBeforeRule that = (PeriodDropBeforeRule) o;
+
+    if (period != null ? !period.equals(that.period) : that.period != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(period);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
@@ -26,6 +26,8 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 
+import java.util.Objects;
+
 /**
  */
 public class PeriodDropRule extends DropRule
@@ -80,4 +82,30 @@ public class PeriodDropRule extends DropRule
       return currInterval.contains(theInterval);
     }
   }
+  
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PeriodDropRule that = (PeriodDropRule) o;
+
+    if (period != null ? !period.equals(that.period) : that.period != null) {
+      return false;
+    }
+
+    return includeFuture == that.includeFuture;
+  }
+  
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(period, includeFuture);
+  }
 }
+

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -30,6 +30,7 @@ import org.joda.time.Interval;
 import org.joda.time.Period;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  */
@@ -98,5 +99,30 @@ public class PeriodLoadRule extends LoadRule
   public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
   {
     return Rules.eligibleForLoad(period, interval, referenceTimestamp, includeFuture);
+  }
+  
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PeriodLoadRule that = (PeriodLoadRule) o;
+
+    if (period != null ? !period.equals(that.period) : that.period != null) {
+      return false;
+    }
+
+    return includeFuture == that.includeFuture && Objects.equals(tieredReplicants, that.tieredReplicants);
+  }
+  
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(period, includeFuture, tieredReplicants);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -44,6 +44,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = "dropBeforeByPeriod", value = PeriodDropBeforeRule.class),
     @JsonSubTypes.Type(name = "dropByInterval", value = IntervalDropRule.class),
     @JsonSubTypes.Type(name = "dropForever", value = ForeverDropRule.class),
+    @JsonSubTypes.Type(name = "importRules", value = ImportRule.class),
     @JsonSubTypes.Type(name = ForeverBroadcastDistributionRule.TYPE, value = ForeverBroadcastDistributionRule.class),
     @JsonSubTypes.Type(name = IntervalBroadcastDistributionRule.TYPE, value = IntervalBroadcastDistributionRule.class),
     @JsonSubTypes.Type(name = PeriodBroadcastDistributionRule.TYPE, value = PeriodBroadcastDistributionRule.class)

--- a/server/src/main/java/org/apache/druid/server/http/RulesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/RulesResource.java
@@ -45,7 +45,11 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  */
@@ -70,8 +74,16 @@ public class RulesResource
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(StateResourceFilter.class)
-  public Response getRules()
+  public Response getRules(@QueryParam("full") final String full)
   {
+    if (full != null) {
+      Map<String, List<Rule>> expandedRules = new HashMap<String, List<Rule>>();
+      Set<String> allRulesets = databaseRuleManager.getAllRules().keySet();
+      for (String ds : allRulesets) {
+        expandedRules.put(ds, databaseRuleManager.getRulesWithDefault(ds));
+      }
+      return Response.ok(expandedRules).build();
+    }
     return Response.ok(databaseRuleManager.getAllRules()).build();
   }
 

--- a/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
+++ b/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
@@ -43,7 +43,6 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Duration;
 
 import javax.annotation.concurrent.GuardedBy;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +134,7 @@ public class CoordinatorRuleManager
   {
     try {
       StringFullResponseHolder response = druidLeaderClient.go(
-          druidLeaderClient.makeRequest(HttpMethod.GET, RulesResource.RULES_ENDPOINT)
+          druidLeaderClient.makeRequest(HttpMethod.GET, RulesResource.RULES_ENDPOINT + "?full")
       );
 
       if (!response.getStatus().equals(HttpResponseStatus.OK)) {
@@ -158,17 +157,10 @@ public class CoordinatorRuleManager
 
   public List<Rule> getRulesWithDefault(final String dataSource)
   {
-    List<Rule> rulesWithDefault = new ArrayList<>();
-    Map<String, List<Rule>> theRules = rules.get();
-    List<Rule> dataSourceRules = theRules.get(dataSource);
-    if (dataSourceRules != null) {
-      rulesWithDefault.addAll(dataSourceRules);
+    if (!rules.get().containsKey(dataSource)) {
+      return rules.get().get(config.get().getDefaultRule());
     }
-    List<Rule> defaultRules = theRules.get(config.get().getDefaultRule());
-    if (defaultRules != null) {
-      rulesWithDefault.addAll(defaultRules);
-    }
-    return rulesWithDefault;
+    return rules.get().get(dataSource);
   }
 
   /**

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverDropRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverDropRuleTest.java
@@ -19,46 +19,16 @@
 
 package org.apache.druid.server.coordinator.rules;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 
 /**
  */
-public class ForeverDropRule extends DropRule
+public class ForeverDropRuleTest
 {
-  @Override
-  @JsonProperty
-  public String getType()
+  @Test
+  public void testEquals()
   {
-    return "dropForever";
-  }
-
-  @Override
-  public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-
-  @Override
-  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-  
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    return o != null && getClass() == o.getClass();
-  }
-  
-  @Override
-  public int hashCode()
-  {
-    return ForeverDropRule.class.hashCode();
+    EqualsVerifier.forClass(ForeverDropRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
@@ -87,5 +88,21 @@ public class ForeverLoadRuleTest
 
     ObjectMapper jsonMapper = new DefaultObjectMapper();
     Rule reread = jsonMapper.readValue(jsonMapper.writeValueAsString(rule), Rule.class);
+  }
+  
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(ForeverLoadRule.class)
+      .usingGetClass()
+      .withIgnoredFields("targetReplicants", "currentReplicants", "strategyCache")
+      .verify();
+  }
+  
+  @Test
+  public void testDefaultReplicants()
+  {
+    ForeverLoadRule rule = new ForeverLoadRule(null);
+    Assert.assertEquals(rule.getNumReplicants(DruidServer.DEFAULT_TIER), DruidServer.DEFAULT_NUM_REPLICANTS);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ImportRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ImportRuleTest.java
@@ -19,46 +19,15 @@
 
 package org.apache.druid.server.coordinator.rules;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 
-/**
- */
-public class ForeverDropRule extends DropRule
+public class ImportRuleTest
 {
-  @Override
-  @JsonProperty
-  public String getType()
+  @Test
+  public void testEquals()
   {
-    return "dropForever";
+    EqualsVerifier.forClass(ImportRule.class).usingGetClass().verify();
   }
 
-  @Override
-  public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-
-  @Override
-  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-  
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    return o != null && getClass() == o.getClass();
-  }
-  
-  @Override
-  public int hashCode()
-  {
-    return ForeverDropRule.class.hashCode();
-  }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalDropRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalDropRuleTest.java
@@ -19,46 +19,14 @@
 
 package org.apache.druid.server.coordinator.rules;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 
-/**
- */
-public class ForeverDropRule extends DropRule
+public class IntervalDropRuleTest
 {
-  @Override
-  @JsonProperty
-  public String getType()
+  @Test
+  public void testEquals()
   {
-    return "dropForever";
-  }
-
-  @Override
-  public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-
-  @Override
-  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-  
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    return o != null && getClass() == o.getClass();
-  }
-  
-  @Override
-  public int hashCode()
-  {
-    return ForeverDropRule.class.hashCode();
+    EqualsVerifier.forClass(IntervalDropRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
@@ -80,5 +81,13 @@ public class IntervalLoadRuleTest
     IntervalLoadRule inputIntervalLoadRule = jsonMapper.readValue(inputJson, IntervalLoadRule.class);
     IntervalLoadRule expectedIntervalLoadRule = jsonMapper.readValue(expectedJson, IntervalLoadRule.class);
     Assert.assertEquals(expectedIntervalLoadRule, inputIntervalLoadRule);
+  }
+  
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(IntervalLoadRule.class)
+                  .usingGetClass()
+                  .withIgnoredFields("targetReplicants", "currentReplicants", "strategyCache").verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRuleTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.timeline.DataSegment;
@@ -84,5 +85,11 @@ public class PeriodDropBeforeRuleTest
             now
         )
     );
+  }
+  
+  @Test
+  public void testEquals() 
+  {
+    EqualsVerifier.forClass(PeriodDropBeforeRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropRuleTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.coordinator.rules;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
@@ -132,5 +133,11 @@ public class PeriodDropRuleTest
             now
         )
     );
+  }
+  
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(PeriodDropRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
@@ -57,6 +58,15 @@ public class PeriodLoadRuleTest
     Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("2012-01-01/2012-12-31")).build(), now));
     Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("1000-01-01/2012-12-31")).build(), now));
     Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("0500-01-01/2100-12-31")).build(), now));
+  }
+  
+  @Test
+  public void testEquals() 
+  {
+    EqualsVerifier.forClass(PeriodLoadRule.class)
+            .usingGetClass()
+            .withIgnoredFields("targetReplicants", "currentReplicants", "strategyCache")
+            .verify();
   }
 
   @Test
@@ -185,5 +195,12 @@ public class PeriodLoadRuleTest
     Assert.assertEquals(expectedPeriodLoadRule.getTieredReplicants(), inputPeriodLoadRule.getTieredReplicants());
     Assert.assertEquals(expectedPeriodLoadRule.getPeriod(), inputPeriodLoadRule.getPeriod());
     Assert.assertEquals(expectedPeriodLoadRule.isIncludeFuture(), inputPeriodLoadRule.isIncludeFuture());
+  }
+  
+  @Test
+  public void testDefaultReplicants()
+  {
+    PeriodLoadRule rule = new PeriodLoadRule(new Period("P1D"), null, null);
+    Assert.assertEquals(rule.getNumReplicants(DruidServer.DEFAULT_TIER), DruidServer.DEFAULT_NUM_REPLICANTS);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/router/CoordinatorRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/router/CoordinatorRuleManagerTest.java
@@ -119,13 +119,14 @@ public class CoordinatorRuleManagerTest
   {
     final Map<String, List<Rule>> rules = ImmutableMap.of(
         DATASOURCE1,
-        ImmutableList.of(new ForeverLoadRule(null)),
+        ImmutableList.of(new ForeverLoadRule(null), new ForeverLoadRule(ImmutableMap.of("__default", 2))),
         DATASOURCE2,
-        ImmutableList.of(new ForeverLoadRule(null), new IntervalDropRule(Intervals.of("2020-01-01/2020-01-02"))),
+        ImmutableList.of(new ForeverLoadRule(null), new IntervalDropRule(Intervals.of("2020-01-01/2020-01-02")), new ForeverLoadRule(ImmutableMap.of("__default", 2))),
         "datasource3",
         ImmutableList.of(
             new PeriodLoadRule(new Period("P1M"), true, null),
-            new ForeverDropRule()
+            new ForeverDropRule(),
+            new ForeverLoadRule(ImmutableMap.of("__default", 2))
         ),
         TieredBrokerConfig.DEFAULT_RULE_NAME,
         ImmutableList.of(new ForeverLoadRule(ImmutableMap.of("__default", 2)))

--- a/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
+++ b/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
@@ -139,6 +139,11 @@ exports[`rule editor matches snapshot no tier in rule 1`] = `
                   >
                     broadcastByPeriod
                   </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
+                  </option>
                 </select>
                 <span
                   class="bp3-icon bp3-icon-double-caret-vertical"
@@ -353,6 +358,11 @@ exports[`rule editor matches snapshot with broadcast rule 1`] = `
                   >
                     broadcastByPeriod
                   </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
+                  </option>
                 </select>
                 <span
                   class="bp3-icon bp3-icon-double-caret-vertical"
@@ -532,6 +542,11 @@ exports[`rule editor matches snapshot with existing tier and non existing tier i
                     value="broadcastByPeriod"
                   >
                     broadcastByPeriod
+                  </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
                   </option>
                 </select>
                 <span
@@ -1076,6 +1091,11 @@ exports[`rule editor matches snapshot with existing tier in rule 1`] = `
                   >
                     broadcastByPeriod
                   </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
+                  </option>
                 </select>
                 <span
                   class="bp3-icon bp3-icon-double-caret-vertical"
@@ -1461,6 +1481,11 @@ exports[`rule editor matches snapshot with non existing tier in rule 1`] = `
                     value="broadcastByPeriod"
                   >
                     broadcastByPeriod
+                  </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
                   </option>
                 </select>
                 <span

--- a/web-console/src/components/rule-editor/rule-editor.spec.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.spec.tsx
@@ -27,6 +27,7 @@ describe('rule editor', () => {
       <RuleEditor
         rule={{ type: 'loadForever' }}
         tiers={['test', 'test', 'test']}
+        allRules={{ _default: [{ type: 'loadForever' }] }}
         onChange={() => {}}
         onDelete={() => {}}
         moveUp={null}
@@ -46,6 +47,7 @@ describe('rule editor', () => {
           tieredReplicants: { nonexist: 2 },
         }}
         tiers={['test1', 'test2', 'test3']}
+        allRules={{ _default: [{ type: 'loadForever' }] }}
         onChange={() => {}}
         onDelete={() => {}}
         moveUp={null}
@@ -65,6 +67,7 @@ describe('rule editor', () => {
           tieredReplicants: { test1: 2 },
         }}
         tiers={['test1', 'test2', 'test3']}
+        allRules={{ _default: [{ type: 'loadForever' }] }}
         onChange={() => {}}
         onDelete={() => {}}
         moveUp={null}
@@ -87,6 +90,7 @@ describe('rule editor', () => {
           },
         }}
         tiers={['test1', 'test2', 'test3']}
+        allRules={{ _default: [{ type: 'loadForever' }] }}
         onChange={() => {}}
         onDelete={() => {}}
         moveUp={null}
@@ -105,6 +109,7 @@ describe('rule editor', () => {
           period: '2010-01-01/2015-01-01',
         }}
         tiers={[]}
+        allRules={{ _default: [{ type: 'loadForever' }] }}
         onChange={() => {}}
         onDelete={() => {}}
         moveUp={null}

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -37,6 +37,7 @@ import './rule-editor.scss';
 export interface RuleEditorProps {
   rule: Rule;
   tiers: any[];
+  allRules: any;
   onChange: (newRule: Rule) => void;
   onDelete: () => void;
   moveUp: (() => void) | null;
@@ -44,7 +45,7 @@ export interface RuleEditorProps {
 }
 
 export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps) {
-  const { rule, onChange, tiers, onDelete, moveUp, moveDown } = props;
+  const { rule, onChange, tiers, allRules, onDelete, moveUp, moveDown } = props;
   const [isOpen, setIsOpen] = useState(true);
   if (!rule) return null;
 
@@ -69,6 +70,16 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
     }
 
     onChange(RuleUtil.addTieredReplicant(rule, newTierName, 1));
+  }
+
+  function ImportedRules(props: any) {
+    return (
+      <ul>
+        {allRules[props.selectedRule].map((r: any) => {
+          return <li key={RuleUtil.ruleToString(r)}>{RuleUtil.ruleToString(r)}</li>;
+        })}
+      </ul>
+    );
   }
 
   function renderTiers() {
@@ -172,6 +183,22 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
                   );
                 })}
               </HTMLSelect>
+              {RuleUtil.hasImport(rule) && (
+                <HTMLSelect
+                  value={rule.importedRuleset}
+                  onChange={(e: any) =>
+                    onChange(RuleUtil.changeImport(rule, e.target.value as any))
+                  }
+                >
+                  {Object.keys(allRules).map((type: any) => {
+                    return (
+                      <option key={type} value={type}>
+                        {type}
+                      </option>
+                    );
+                  })}
+                </HTMLSelect>
+              )}
               {RuleUtil.hasPeriod(rule) && (
                 <InputGroup
                   value={rule.period || ''}
@@ -208,6 +235,7 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
               {renderTierAdder()}
             </FormGroup>
           )}
+          {RuleUtil.hasImport(rule) && <ImportedRules selectedRule={rule.importedRuleset} />}
         </Card>
       </Collapse>
     </div>

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
@@ -27,6 +27,7 @@ describe('retention dialog', () => {
       <RetentionDialog
         datasource={'test'}
         rules={[null]}
+        allRules={null}
         tiers={['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']}
         onEditDefaults={() => {}}
         onCancel={() => {}}

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
@@ -41,6 +41,7 @@ export function reorderArray<T>(items: T[], oldIndex: number, newIndex: number):
 export interface RetentionDialogProps {
   datasource: string;
   rules: any[];
+  allRules: any;
   tiers: string[];
   onEditDefaults: () => void;
   onCancel: () => void;
@@ -126,13 +127,14 @@ export class RetentionDialog extends React.PureComponent<
   }
 
   renderRule = (rule: any, index: number) => {
-    const { tiers } = this.props;
+    const { tiers, allRules } = this.props;
     const { currentRules } = this.state;
 
     return (
       <RuleEditor
         rule={rule}
         tiers={tiers}
+        allRules={allRules}
         key={index}
         onChange={r => this.changeRule(r, index)}
         onDelete={() => this.onDeleteRule(index)}

--- a/web-console/src/utils/load-rule.ts
+++ b/web-console/src/utils/load-rule.ts
@@ -28,12 +28,14 @@ export type RuleType =
   | 'dropBeforeByPeriod'
   | 'broadcastForever'
   | 'broadcastByInterval'
-  | 'broadcastByPeriod';
+  | 'broadcastByPeriod'
+  | 'importRules';
 
 export interface Rule {
   type: RuleType;
   interval?: string;
   period?: string;
+  importedRuleset?: string;
   includeFuture?: boolean;
   tieredReplicants?: Record<string, number>;
 }
@@ -50,6 +52,7 @@ export class RuleUtil {
     'broadcastForever',
     'broadcastByInterval',
     'broadcastByPeriod',
+    'importRules',
   ];
 
   static ruleToString(rule: Rule): string {
@@ -57,6 +60,7 @@ export class RuleUtil {
       rule.type,
       rule.period ? `(${rule.period}${rule.includeFuture ? `+future` : ''})` : '',
       rule.interval ? `(${rule.interval})` : '',
+      rule.importedRuleset ? `(${rule.importedRuleset})` : '',
     ].join('');
   }
 
@@ -68,6 +72,12 @@ export class RuleUtil {
     } else {
       delete newRule.period;
       delete newRule.includeFuture;
+    }
+
+    if (RuleUtil.hasImport(newRule)) {
+      if (!newRule.importedRuleset) newRule.importedRuleset = '_default';
+    } else {
+      delete newRule.importedRuleset;
     }
 
     if (RuleUtil.hasInterval(newRule)) {
@@ -85,12 +95,20 @@ export class RuleUtil {
     return newRule;
   }
 
+  static hasImport(rule: Rule): boolean {
+    return rule.type.startsWith('import');
+  }
+
   static hasPeriod(rule: Rule): boolean {
     return rule.type.endsWith('ByPeriod');
   }
 
   static changePeriod(rule: Rule, period: string): Rule {
     return deepSet(rule, 'period', period);
+  }
+
+  static changeImport(rule: Rule, importedRuleset: string): Rule {
+    return deepSet(rule, 'importedRuleset', importedRuleset);
   }
 
   static hasIncludeFuture(rule: Rule): boolean {

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -146,6 +146,7 @@ export interface DatasourcesViewState {
   datasources: Datasource[] | null;
   tiers: string[];
   defaultRules: any[];
+  allRules: any;
   datasourcesError?: string;
   datasourceFilter: Filter[];
 
@@ -203,7 +204,7 @@ GROUP BY 1`;
 
   private datasourceQueryManager: QueryManager<
     Capabilities,
-    { tiers: string[]; defaultRules: any[]; datasources: Datasource[] }
+    { tiers: string[]; defaultRules: any[]; datasources: Datasource[]; allRules: any }
   >;
 
   constructor(props: DatasourcesViewProps, context: any) {
@@ -219,6 +220,7 @@ GROUP BY 1`;
       datasources: null,
       tiers: [],
       defaultRules: [],
+      allRules: {},
       datasourceFilter,
 
       showUnused: false,
@@ -274,6 +276,7 @@ GROUP BY 1`;
             datasources,
             tiers: [],
             defaultRules: [],
+            allRules: {},
           };
         }
 
@@ -313,6 +316,7 @@ GROUP BY 1`;
           datasources: allDatasources,
           tiers,
           defaultRules: rules['_default'],
+          allRules: rules,
         };
       },
       onStateChange: ({ result, loading, error }) => {
@@ -321,6 +325,7 @@ GROUP BY 1`;
           datasources: result ? result.datasources : null,
           tiers: result ? result.tiers : [],
           defaultRules: result ? result.defaultRules : [],
+          allRules: result ? result.allRules : {},
           datasourcesError: error || undefined,
         });
       },
@@ -700,7 +705,7 @@ GROUP BY 1`;
   }
 
   renderRetentionDialog() {
-    const { retentionDialogOpenOn, tiers } = this.state;
+    const { retentionDialogOpenOn, tiers, allRules } = this.state;
     if (!retentionDialogOpenOn) return null;
 
     return (
@@ -708,6 +713,7 @@ GROUP BY 1`;
         datasource={retentionDialogOpenOn.datasource}
         rules={retentionDialogOpenOn.rules}
         tiers={tiers}
+        allRules={allRules}
         onEditDefaults={this.editDefaultRules}
         onCancel={() => this.setState({ retentionDialogOpenOn: undefined })}
         onSave={this.saveRules}

--- a/website/.spelling
+++ b/website/.spelling
@@ -260,6 +260,7 @@ http
 https
 idempotency
 i.e.
+importRules
 influxdb
 ingestionSpec
 injective


### PR DESCRIPTION
Discussion of the general problem of Increase reusability of retention rule configurations is here [Issue #10237 ](https://github.com/apache/druid/issues/10237)
This pull request implements a new rule type that imports rules from any other rule set, including rules from other data sources. 


![sizecheck](https://user-images.githubusercontent.com/8482587/86393561-3ed6ab80-bc6b-11ea-8521-663126be0475.gif)

### Description

This branch adds a new ImportRule type that specifies an imported rule set. Whenever rules are used, they are expanded to include the default rules for the cluster. This changes the getRulesWithDefault to also expand any import rules found at the time they are retrieved. This is functionally equivalent to the original list as the rules are replaced before evaluation. Rules are also used in CoordinatorRuleManager in the router, where getRulesWithDefault was implemented again. Here, that implementation is left at one place, in SQLRuleManager and a new method is added to RulesResource to allow CoordinatorRuleManager to retrieve the expanded list of rules without knowing how it was generated. 

In the implementation, the function of getRulesWithDefault has diverged a little bit from the name, maybe a name like getExpandedRules would be better. Also, the implementation for ImportRule is specifically in SQLMetadataRuleManager maybe it should be interface methods or in a utility class for use by other implementations in the future. 

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `SQLMetadataRuleManager`
 * `ImportRule`
 * `CoordinatorRuleManager`
 * `RulesResource`
