### PR TITLE
Fix null handling in AvgSqlAggregator

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
@@ -20,20 +20,37 @@
 package org.apache.druid.sql.calcite.aggregation.builtin;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
+import org.apache.druid.sql.calcite.aggregation.Aggregations;
+import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
 
-public class AvgSqlAggregator extends SimpleSqlAggregator
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class AvgSqlAggregator implements SqlAggregator
 {
   @Override
   public SqlAggFunction calciteFunction()
@@ -41,15 +58,46 @@ public class AvgSqlAggregator extends SimpleSqlAggregator
     return SqlStdOperatorTable.AVG;
   }
 
+  @Nullable
   @Override
-  Aggregation getAggregation(
-      final String name,
-      final AggregateCall aggregateCall,
-      final ExprMacroTable macroTable,
-      final String fieldName,
-      final String expression
+  public Aggregation toDruidAggregation(
+          final PlannerContext plannerContext,
+          final RowSignature rowSignature,
+          final VirtualColumnRegistry virtualColumnRegistry,
+          final RexBuilder rexBuilder,
+          final String name,
+          final AggregateCall aggregateCall,
+          final Project project,
+          final List<Aggregation> existingAggregations,
+          final boolean finalizeAggregations
   )
   {
+
+    final List<DruidExpression> arguments = Aggregations.getArgumentsForSimpleAggregator(
+            plannerContext,
+            rowSignature,
+            aggregateCall,
+            project
+    );
+
+    if (arguments == null) {
+      return null;
+    }
+
+    final String fieldName;
+    final String expression;
+    final DruidExpression arg = Iterables.getOnlyElement(arguments);
+
+    if (arg.isDirectColumnAccess()) {
+      fieldName = arg.getDirectColumn();
+      expression = null;
+    } else {
+      fieldName = null;
+      expression = arg.getExpression();
+    }
+
+    final ExprMacroTable macroTable = plannerContext.getExprMacroTable();
+
     final ValueType sumType;
     // Use 64-bit sum regardless of the type of the AVG aggregator.
     if (SqlTypeName.INT_TYPES.contains(aggregateCall.getType().getSqlTypeName())) {
@@ -61,25 +109,48 @@ public class AvgSqlAggregator extends SimpleSqlAggregator
     final String sumName = Calcites.makePrefixedName(name, "sum");
     final String countName = Calcites.makePrefixedName(name, "count");
     final AggregatorFactory sum = SumSqlAggregator.createSumAggregatorFactory(
-        sumType,
-        sumName,
-        fieldName,
-        expression,
-        macroTable
+            sumType,
+            sumName,
+            fieldName,
+            expression,
+            macroTable
     );
 
-    final AggregatorFactory count = new CountAggregatorFactory(countName);
+    final AggregatorFactory count;
+
+    final RexNode rexNode = Expressions.fromFieldAccess(
+            rowSignature,
+            project,
+            Iterables.getOnlyElement(aggregateCall.getArgList())
+    );
+
+    if (rexNode.getType().isNullable()) {
+      final DimFilter nonNullFilter = Expressions.toFilter(
+              plannerContext,
+              rowSignature,
+              virtualColumnRegistry,
+              rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, ImmutableList.of(rexNode))
+      );
+
+      if (nonNullFilter == null) {
+        // Don't expect this to happen.
+        throw new ISE("Could not create not-null filter for rexNode[%s]", rexNode);
+      }
+      count = new FilteredAggregatorFactory(new CountAggregatorFactory(countName), nonNullFilter);
+    } else {
+      count = new CountAggregatorFactory(countName);
+    }
 
     return Aggregation.create(
-        ImmutableList.of(sum, count),
-        new ArithmeticPostAggregator(
-            name,
-            "quotient",
-            ImmutableList.of(
-                new FieldAccessPostAggregator(null, sumName),
-                new FieldAccessPostAggregator(null, countName)
+            ImmutableList.of(sum, count),
+            new ArithmeticPostAggregator(
+                    name,
+                    "quotient",
+                    ImmutableList.of(
+                            new FieldAccessPostAggregator(null, sumName),
+                            new FieldAccessPostAggregator(null, countName)
+                    )
             )
-        )
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
@@ -28,8 +28,8 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.segment.column.RowSignature;
@@ -62,7 +62,8 @@ public class CountSqlAggregator implements SqlAggregator
           final RexBuilder rexBuilder,
           final AggregateCall aggregateCall,
           final Project project
-  ) {
+  )
+  {
     final RexNode rexNode = Expressions.fromFieldAccess(
             rowSignature,
             project,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
@@ -81,6 +81,7 @@ public class CountSqlAggregator implements SqlAggregator
         // Don't expect this to happen.
         throw new ISE("Could not create not-null filter for rexNode[%s]", rexNode);
       }
+
       return new FilteredAggregatorFactory(new CountAggregatorFactory(countName), nonNullFilter);
     } else {
       return new CountAggregatorFactory(countName);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
@@ -29,6 +29,8 @@ import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -50,6 +52,39 @@ public class CountSqlAggregator implements SqlAggregator
   public SqlAggFunction calciteFunction()
   {
     return SqlStdOperatorTable.COUNT;
+  }
+
+  static AggregatorFactory createCountAggregatorFactory(
+          final String countName,
+          final PlannerContext plannerContext,
+          final RowSignature rowSignature,
+          final VirtualColumnRegistry virtualColumnRegistry,
+          final RexBuilder rexBuilder,
+          final AggregateCall aggregateCall,
+          final Project project
+  ) {
+    final RexNode rexNode = Expressions.fromFieldAccess(
+            rowSignature,
+            project,
+            Iterables.getOnlyElement(aggregateCall.getArgList())
+    );
+
+    if (rexNode.getType().isNullable()) {
+      final DimFilter nonNullFilter = Expressions.toFilter(
+              plannerContext,
+              rowSignature,
+              virtualColumnRegistry,
+              rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, ImmutableList.of(rexNode))
+      );
+
+      if (nonNullFilter == null) {
+        // Don't expect this to happen.
+        throw new ISE("Could not create not-null filter for rexNode[%s]", rexNode);
+      }
+      return new FilteredAggregatorFactory(new CountAggregatorFactory(countName), nonNullFilter);
+    } else {
+      return new CountAggregatorFactory(countName);
+    }
   }
 
   @Nullable
@@ -96,32 +131,16 @@ public class CountSqlAggregator implements SqlAggregator
       }
     } else {
       // Not COUNT(*), not distinct
-
       // COUNT(x) should count all non-null values of x.
-      final RexNode rexNode = Expressions.fromFieldAccess(
-          rowSignature,
-          project,
-          Iterables.getOnlyElement(aggregateCall.getArgList())
-      );
-
-      if (rexNode.getType().isNullable()) {
-        final DimFilter nonNullFilter = Expressions.toFilter(
+      return Aggregation.create(createCountAggregatorFactory(
+            name,
             plannerContext,
             rowSignature,
             virtualColumnRegistry,
-            rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, ImmutableList.of(rexNode))
-        );
-
-        if (nonNullFilter == null) {
-          // Don't expect this to happen.
-          throw new ISE("Could not create not-null filter for rexNode[%s]", rexNode);
-        }
-
-        return Aggregation.create(new CountAggregatorFactory(name))
-                          .filter(rowSignature, virtualColumnRegistry, nonNullFilter);
-      } else {
-        return Aggregation.create(new CountAggregatorFactory(name));
-      }
+            rexBuilder,
+            aggregateCall,
+            project
+      ));
     }
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -4341,7 +4341,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                               new CountAggregatorFactory("a6"),
                               not(selector("dim2", null, null))
                           ),
-                          new DoubleSumAggregatorFactory("a7:sum","d1"),
+                          new DoubleSumAggregatorFactory("a7:sum", "d1"),
                           new CountAggregatorFactory("a7:count")
                       )
                       : aggregators(
@@ -4404,10 +4404,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ),
         NullHandling.replaceWithDefault() ?
         ImmutableList.of(
-            new Object[]{6L, 6L, 5L, 1L, 6L, 8L, 3L, 6L, ((1+1.7)/6)}
+            new Object[]{6L, 6L, 5L, 1L, 6L, 8L, 3L, 6L, ((1 + 1.7) / 6)}
         ) :
         ImmutableList.of(
-            new Object[]{6L, 6L, 6L, 1L, 6L, 8L, 4L, 3L, ((1+1.7)/3)}
+            new Object[]{6L, 6L, 6L, 1L, 6L, 8L, 4L, 3L, ((1 + 1.7) / 3)}
         )
     );
   }
@@ -6422,17 +6422,28 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setInterval(querySegmentSpec(Filtration.eternity()))
                         .setGranularity(Granularities.ALL)
-                        .setAggregatorSpecs(aggregators(
-                            new LongMaxAggregatorFactory("_a0", "a0"),
-                            new LongMinAggregatorFactory("_a1", "a0"),
-                            new LongSumAggregatorFactory("_a2:sum", "a0"),
-                            new FilteredAggregatorFactory(
-                                new CountAggregatorFactory("_a2:count"),
-                                not(selector("a0", null, null))
-                            ),
-                            new LongMaxAggregatorFactory("_a3", "d0"),
-                            new CountAggregatorFactory("_a4")
-                        ))
+                        .setAggregatorSpecs(
+                            useDefault
+                            ? aggregators(
+                              new LongMaxAggregatorFactory("_a0", "a0"),
+                              new LongMinAggregatorFactory("_a1", "a0"),
+                              new LongSumAggregatorFactory("_a2:sum", "a0"),
+                              new CountAggregatorFactory("_a2:count"),
+                              new LongMaxAggregatorFactory("_a3", "d0"),
+                              new CountAggregatorFactory("_a4")
+                            )
+                            : aggregators(
+                                new LongMaxAggregatorFactory("_a0", "a0"),
+                                new LongMinAggregatorFactory("_a1", "a0"),
+                                new LongSumAggregatorFactory("_a2:sum", "a0"),
+                                new FilteredAggregatorFactory(
+                                    new CountAggregatorFactory("_a2:count"),
+                                    not(selector("a0", null, null))
+                                ),
+                                new LongMaxAggregatorFactory("_a3", "d0"),
+                                new CountAggregatorFactory("_a4")
+                            )
+                        )
                         .setPostAggregatorSpecs(
                             ImmutableList.of(
                                 new ArithmeticPostAggregator(
@@ -6510,13 +6521,20 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setInterval(querySegmentSpec(Filtration.eternity()))
                         .setGranularity(Granularities.ALL)
-                        .setAggregatorSpecs(aggregators(
-                            new LongSumAggregatorFactory("_a0:sum", "a0"),
-                            new FilteredAggregatorFactory(
-                                new CountAggregatorFactory("_a0:count"),
-                                not(selector("a0", null, null))
+                        .setAggregatorSpecs(
+                            useDefault
+                            ? aggregators(
+                              new LongSumAggregatorFactory("_a0:sum", "a0"),
+                              new CountAggregatorFactory("_a0:count")
                             )
-                        ))
+                            : aggregators(
+                                new LongSumAggregatorFactory("_a0:sum", "a0"),
+                                new FilteredAggregatorFactory(
+                                    new CountAggregatorFactory("_a0:count"),
+                                    not(selector("a0", null, null))
+                                )
+                            )
+                        )
                         .setPostAggregatorSpecs(
                             ImmutableList.of(
                                 new ArithmeticPostAggregator(
@@ -11749,13 +11767,22 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .dimension(new DefaultDimensionSpec("m1", "d0", ValueType.FLOAT))
                 .filters("dim2", "a")
                 .aggregators(
-                    new DoubleSumAggregatorFactory("a0:sum", "m2"),
-                    new FilteredAggregatorFactory(
-                        new CountAggregatorFactory("a0:count"),
-                        not(selector("m2", null, null))
-                    ),
-                    new DoubleSumAggregatorFactory("a1", "m1"),
-                    new DoubleSumAggregatorFactory("a2", "m2")
+                    useDefault
+                    ? aggregators(
+                      new DoubleSumAggregatorFactory("a0:sum", "m2"),
+                      new CountAggregatorFactory("a0:count"),
+                      new DoubleSumAggregatorFactory("a1", "m1"),
+                      new DoubleSumAggregatorFactory("a2", "m2")
+                    )
+                    : aggregators(
+                      new DoubleSumAggregatorFactory("a0:sum", "m2"),
+                      new FilteredAggregatorFactory(
+                          new CountAggregatorFactory("a0:count"),
+                          not(selector("m2", null, null))
+                      ),
+                      new DoubleSumAggregatorFactory("a1", "m1"),
+                      new DoubleSumAggregatorFactory("a2", "m2")
+                    )
                 )
                 .postAggregators(
                     new ArithmeticPostAggregator(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6426,7 +6426,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             new LongMaxAggregatorFactory("_a0", "a0"),
                             new LongMinAggregatorFactory("_a1", "a0"),
                             new LongSumAggregatorFactory("_a2:sum", "a0"),
-                            new CountAggregatorFactory("_a2:count"),
+                            new FilteredAggregatorFactory(
+                                new CountAggregatorFactory("_a2:count"),
+                                not(selector("a0", null, null))
+                            ),
                             new LongMaxAggregatorFactory("_a3", "d0"),
                             new CountAggregatorFactory("_a4")
                         ))
@@ -6509,7 +6512,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setGranularity(Granularities.ALL)
                         .setAggregatorSpecs(aggregators(
                             new LongSumAggregatorFactory("_a0:sum", "a0"),
-                            new CountAggregatorFactory("_a0:count")
+                            new FilteredAggregatorFactory(
+                                new CountAggregatorFactory("_a0:count"),
+                                not(selector("a0", null, null))
+                            )
                         ))
                         .setPostAggregatorSpecs(
                             ImmutableList.of(
@@ -11744,7 +11750,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .filters("dim2", "a")
                 .aggregators(
                     new DoubleSumAggregatorFactory("a0:sum", "m2"),
-                    new CountAggregatorFactory("a0:count"),
+                    new FilteredAggregatorFactory(
+                        new CountAggregatorFactory("a0:count"),
+                        not(selector("m2", null, null))
+                    ),
                     new DoubleSumAggregatorFactory("a1", "m1"),
                     new DoubleSumAggregatorFactory("a2", "m2")
                 )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -4317,11 +4317,11 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     cannotVectorize();
 
     testQuery(
-        "SELECT COUNT(*), COUNT(cnt), COUNT(dim1), AVG(cnt), SUM(cnt), SUM(cnt) + MIN(cnt) + MAX(cnt), COUNT(dim2) FROM druid.foo",
+        "SELECT COUNT(*), COUNT(cnt), COUNT(dim1), AVG(cnt), SUM(cnt), SUM(cnt) + MIN(cnt) + MAX(cnt), COUNT(dim2), COUNT(d1), AVG(d1) FROM druid.numfoo",
         ImmutableList.of(
 
             Druids.newTimeseriesQueryBuilder()
-                  .dataSource(CalciteTests.DATASOURCE1)
+                  .dataSource(CalciteTests.DATASOURCE3)
                   .intervals(querySegmentSpec(Filtration.eternity()))
                   .granularity(Granularities.ALL)
                   .aggregators(
@@ -4340,7 +4340,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                           new FilteredAggregatorFactory(
                               new CountAggregatorFactory("a6"),
                               not(selector("dim2", null, null))
-                          )
+                          ),
+                          new DoubleSumAggregatorFactory("a7:sum","d1"),
+                          new CountAggregatorFactory("a7:count")
                       )
                       : aggregators(
                           new CountAggregatorFactory("a0"),
@@ -4353,13 +4355,25 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                               not(selector("dim1", null, null))
                           ),
                           new LongSumAggregatorFactory("a3:sum", "cnt"),
-                          new CountAggregatorFactory("a3:count"),
+                          new FilteredAggregatorFactory(
+                              new CountAggregatorFactory("a3:count"),
+                              not(selector("cnt", null, null))
+                          ),
                           new LongSumAggregatorFactory("a4", "cnt"),
                           new LongMinAggregatorFactory("a5", "cnt"),
                           new LongMaxAggregatorFactory("a6", "cnt"),
                           new FilteredAggregatorFactory(
                               new CountAggregatorFactory("a7"),
                               not(selector("dim2", null, null))
+                          ),
+                          new FilteredAggregatorFactory(
+                              new CountAggregatorFactory("a8"),
+                              not(selector("d1", null, null))
+                          ),
+                          new DoubleSumAggregatorFactory("a9:sum", "d1"),
+                          new FilteredAggregatorFactory(
+                              new CountAggregatorFactory("a9:count"),
+                              not(selector("d1", null, null))
                           )
                       )
                   )
@@ -4372,6 +4386,14 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                               new FieldAccessPostAggregator(null, useDefault ? "a2:count" : "a3:count")
                           )
                       ),
+                      new ArithmeticPostAggregator(
+                          useDefault ? "a7" : "a9",
+                          "quotient",
+                          ImmutableList.of(
+                              new FieldAccessPostAggregator(null, useDefault ? "a7:sum" : "a9:sum"),
+                              new FieldAccessPostAggregator(null, useDefault ? "a7:count" : "a9:count")
+                          )
+                      ),
                       expressionPostAgg(
                           "p0",
                           useDefault ? "((\"a3\" + \"a4\") + \"a5\")" : "((\"a4\" + \"a5\") + \"a6\")"
@@ -4382,10 +4404,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ),
         NullHandling.replaceWithDefault() ?
         ImmutableList.of(
-            new Object[]{6L, 6L, 5L, 1L, 6L, 8L, 3L}
+            new Object[]{6L, 6L, 5L, 1L, 6L, 8L, 3L, 6L, ((1+1.7)/6)}
         ) :
         ImmutableList.of(
-            new Object[]{6L, 6L, 6L, 1L, 6L, 8L, 4L}
+            new Object[]{6L, 6L, 6L, 1L, 6L, 8L, 4L, 3L, ((1+1.7)/3)}
         )
     );
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
