### PR TITLE
ui - change search filter to includes

### DIFF
--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -50,7 +50,7 @@ describe('general', () => {
           id: 'datasource',
           value: `hello`,
         }),
-      ).toMatchInlineSnapshot(`"LOWER(\\"datasource\\") LIKE LOWER('hello%')"`);
+      ).toMatchInlineSnapshot(`"LOWER(\\"datasource\\") LIKE LOWER('%hello%')"`);
 
       expect(
         sqlQueryCustomTableFilter({

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -89,7 +89,7 @@ export function makeBooleanFilter(): FilterRender {
 
 interface NeedleAndMode {
   needle: string;
-  mode: 'exact' | 'prefix';
+  mode: 'exact' | 'includes';
 }
 
 function getNeedleAndMode(input: string): NeedleAndMode {
@@ -101,7 +101,7 @@ function getNeedleAndMode(input: string): NeedleAndMode {
   }
   return {
     needle: input.startsWith(`"`) ? input.substring(1) : input,
-    mode: 'prefix',
+    mode: 'includes',
   };
 }
 
@@ -113,7 +113,7 @@ export function booleanCustomTableFilter(filter: Filter, value: any): boolean {
   if (needleAndMode.mode === 'exact') {
     return needle === haystack;
   }
-  return haystack.startsWith(needle);
+  return haystack.includes(needle);
 }
 
 export function sqlQueryCustomTableFilter(filter: Filter): string {
@@ -123,7 +123,7 @@ export function sqlQueryCustomTableFilter(filter: Filter): string {
   if (needleAndMode.mode === 'exact') {
     return `${columnName} = '${needle}'`;
   } else {
-    return `LOWER(${columnName}) LIKE LOWER('${needle}%')`;
+    return `LOWER(${columnName}) LIKE LOWER('%${needle}%')`;
   }
 }
 


### PR DESCRIPTION
### Description

Throughout the web console, search is based on prefix. When there are a lot of servers in a cluster, particularly with long DNS names, it can be difficult to narrow down jobs and servers. The proposal is to change from prefix based to includes based search at the UI layer. 

<hr>

This PR has:
- [X] been self-reviewed.
- [X] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `general.tsx`
