### PR TITLE
AbstractOptimizableDimFilter should be public

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/AbstractOptimizableDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/AbstractOptimizableDimFilter.java
@@ -27,7 +27,7 @@ import com.google.common.base.Suppliers;
  * Base class for DimFilters that support optimization. This abstract class provides a default implementation of
  * toOptimizedFilter that relies on the existing optimize() and toFilter() methods. It uses a memoized supplier.
  */
-abstract class AbstractOptimizableDimFilter implements DimFilter
+public abstract class AbstractOptimizableDimFilter implements DimFilter
 {
   private final Supplier<Filter> cachedOptimizedFilter = Suppliers.memoize(
       () -> optimize().toFilter()


### PR DESCRIPTION
After #10056

```
...
2020-07-06T19:15:12,028 INFO [main] org.apache.druid.initialization.Initialization - Loading extension [druid-lookups-cached-global], jars: druid-lookups-cached-global-0.19.0-SNAPSHOT.jar, mapdb-1.0.8.jar, postgresql-42.2.14.jar
2020-07-06T19:15:12,033 INFO [main] org.apache.druid.initialization.Initialization - Loading extension [druid-s3-extensions], jars: druid-s3-extensions-0.19.0-SNAPSHOT.jar
Exception in thread "main" java.lang.IllegalAccessError: class org.apache.druid.query.filter.BloomDimFilter cannot access its superclass org.apache.druid.query.filter.AbstractOptimizableDimFilter
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
...
```

For a test to catch this, it would need to use a separate class loader. Currently even the integration tests probably would not have caught this because most extensions are placed in the lib directory instead loaded as an extension from the extensions path.