### PR TITLE
Add availability and consistency docs.

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -226,7 +226,7 @@ publish in an all-or-nothing manner:
 - Supervised "seekable-stream" ingestion methods like [Kafka](../development/extensions-core/kafka-ingestion.md) and
 [Kinesis](../development/extensions-core/kinesis-ingestion.md). With these methods, Druid commits stream offsets to its
 [metadata store](#metadata-storage) alongside segment metadata, in the same transaction. Note that ingestion of data
-that has not yet been published can be rolled back if ingestion tasks fail. In this case, partially-ingested data
+that has not yet been published can be rolled back if ingestion tasks fail. In this case, partially-ingested data is
 discarded, and Druid will resume ingestion from the last committed set of stream offsets. This ensures exactly-once
 publishing behavior.
 - [Hadoop-based batch ingestion](../ingestion/hadoop.html). Each task publishes all segment metadata in a single

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -213,6 +213,75 @@ this will generally start off `true` and then become `false` as the segment is p
 published segments. Generally this is a transient state, and segments in this state will soon have their `used` flag
 automatically set to false.
 
+### Availability and consistency
+
+Druid has an architectural separation between ingestion and querying, as described above in
+[Indexing and handoff](#indexing-and-handoff). This means that when understanding Druid's availability and
+consistency properties, we must look at each function separately.
+
+On the **ingestion side**, Druid's primary [ingestion methods](../ingestion/index.md#ingestion-methods) are all
+pull-based and offer transactional guarantees. This means that you are guaranteed that ingestion using these will
+publish in an all-or-nothing manner:
+
+- Supervised "seekable-stream" ingestion methods like [Kafka](../development/extensions-core/kafka-ingestion.md) and
+[Kinesis](../development/extensions-core/kinesis-ingestion.md). With these methods, Druid commits stream offsets to its
+[metadata store](#metadata-storage) alongside segment metadata, in the same transaction. Note that ingestion of data
+that has not yet been published can be rolled back if ingestion tasks fail. In this case, partially-ingested data
+discarded, and Druid will resume ingestion from the last committed set of stream offsets. This ensures exactly-once
+publishing behavior.
+- [Hadoop-based batch ingestion](../ingestion/hadoop.html). Each task publishes all segment metadata in a single
+transaction.
+- [Native batch ingestion](../ingestion/native-batch.html). In parallel mode, the supervisor task publishes all segment
+metadata in a single transaction after the subtasks are finished. In simple (single-task) mode, the single task
+publishes all segment metadata in a single transaction after it is complete.
+
+[Tranquility](../ingestion/tranquility.md), a streaming ingestion method that is no longer recommended, does not perform
+transactional loading.
+
+Additionally, some ingestion methods offer an _idempotency_ guarantee. This means that repeated executions of the same
+ingestion will not cause duplicate data to be ingested:
+
+- Supervised "seekable-stream" ingestion methods like [Kafka](../development/extensions-core/kafka-ingestion.md) and
+[Kinesis](../development/extensions-core/kinesis-ingestion.md) are idempotent due to the fact that stream offsets and
+segment metadata are stored together and updated in lock-step.
+- [Hadoop-based batch ingestion](../ingestion/hadoop.html) is idempotent unless one of your input sources
+is the same Druid datasource that you are ingesting into. In this case, running the same task twice is non-idempotent,
+because you are adding to existing data instead of overwriting it.
+- [Native batch ingestion](../ingestion/native-batch.html) is idempotent unless
+[`appendToExisting`](../ingestion/native-batch.html) is true, or one of your input sources is the same Druid datasource
+that you are ingesting into. In either of these two cases, running the same task twice is non-idempotent, because you
+are adding to existing data instead of overwriting it.
+
+On the **query side**, the Druid Broker is responsible for ensuring that a consistent set of segments is involved in a
+given query. It selects the appropriate set of segments to use when the query starts based on what is currently
+available. This is supported by _atomic replacement_, a feature that ensures that from a user's perspective, queries
+flip instantaneously from an older set of data to a newer set of data, with no consistency or performance impact.
+This is used for Hadoop-based batch ingestion, native batch ingestion when `appendToExisting` is false, and compaction.
+
+Note that atomic replacement happens for each time chunk individually. If a batch ingestion task or compaction
+involves multiple time chunks, then each time chunk will undergo atomic replacement soon after the task finishes, but
+the replacements will not all happen simultaneously.
+
+Typically, atomic replacement in Druid is based on a _core set_ concept that works in conjunction with segment versions.
+When a time chunk is overwritten, a new core set of segments is created with a higher version number. The core set
+must _all_ be available before the Broker will use them instead of the older set. There can also only be one core set
+per version per time chunk. Druid will also only use a single version at a time per time chunk. Together, these
+properties provide Druid's atomic replacement guarantees.
+
+Druid also supports an experimental _segment locking_ mode that is activated by setting
+[`forceTimeChunkLock`](../ingestion/tasks.md#context) to false in the context of an ingestion task. In this case, Druid
+creates an _atomic update group_ using the existing version for the time chunk, instead of creating a new core set
+with a new version number. There can be multiple atomic update groups with the same version number per time chunk. Each
+one replaces a specific set of earlier segments in the same time chunk and with the same version number. Druid will
+query the latest one that is fully available. This is a more powerful version of the core set concept, because it
+enables atomically replacing a subset of data for a time chunk, as well as doing atomic replacement and appending
+simultaneously.
+
+If segments become unavailable due to multiple Historicals going offline simultaneously (beyond your replication
+factor), then Druid queries will include only the segments that are still available. In the background, Druid will
+reload these unavailable segments on other Historicals as quickly as possible, at which point they will be included in
+queries again.
+
 ## Query processing
 
 Queries first enter the [Broker](../design/broker.md), where the Broker will identify which segments have data that may pertain to that query.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -51,10 +51,6 @@ import java.util.stream.Collectors;
 /**
  * Insert segments into metadata storage. The segment versions must all be less than or equal to a lock held by
  * your task for the segment intervals.
- * <p/>
- * Word of warning: Very large "segments" sets can cause oversized audit log entries, which is bad because it means
- * that the task cannot actually complete. Callers should avoid this by avoiding inserting too many segments in the
- * same action.
  */
 public class SegmentTransactionalInsertAction implements TaskAction<SegmentPublishResult>
 {


### PR DESCRIPTION
Describes transactional ingestion and atomic replacement. Also, this patch
deletes some bad advice from the javadocs for SegmentTransactionalInsertAction.