### PR TITLE
Fix flaky tests in DruidCoordinatorTest

### DIFF
--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -674,17 +674,16 @@ public class DruidCoordinatorTest extends CuratorTestBase
     pathChildrenCache.getListenable().addListener(
         (CuratorFramework client, PathChildrenCacheEvent event) -> {
           if (CuratorUtils.isChildAdded(event)) {
-              DataSegment segment = findSegmentRelatedToCuratorEvent(segments, event);
-              if (segment != null) {
-                if (countDownLatch.getCount() > 0) {
-                  server.addDataSegment(segment);
-                  curator.delete().guaranteed().forPath(event.getData().getPath());
-                  countDownLatch.countDown();
-                } else {
-                  Assert.fail("The segment path " + event.getData().getPath()
-                              + " is assigned to the server more times than expected. Expected only " + latchCount);
-                }
+            DataSegment segment = findSegmentRelatedToCuratorEvent(segments, event);
+            if (segment != null && server.getSegment(segment.getId()) == null) {
+              if (countDownLatch.getCount() > 0) {
+                server.addDataSegment(segment);
+                curator.delete().guaranteed().forPath(event.getData().getPath());
+                countDownLatch.countDown();
+              } else {
+                Assert.fail("The segment path " + event.getData().getPath() + " is not expected");
               }
+            }
           }
         }
     );

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -681,7 +681,8 @@ public class DruidCoordinatorTest extends CuratorTestBase
                   curator.delete().guaranteed().forPath(event.getData().getPath());
                   countDownLatch.countDown();
                 } else {
-                  Assert.fail("The segment is assigned to the server more times than expected");
+                  Assert.fail("The segment path " + event.getData().getPath()
+                              + " is assigned to the server more times than expected. Expected only " + latchCount);
                 }
               }
           }


### PR DESCRIPTION
Fix flaky tests in DruidCoordinatorTest

### Description

The following tests in DruidCoordinatorTest are flaky:
- testComputeUnderReplicationCountsPerDataSourcePerTierForSegmentsWithBroadcastRule
- testCoordinatorTieredRun

This is because of incorrect logic when using the countDownLatch to check if all the segments from curator events is added. We should only countdown the countDownLatch if the received curator event isChildAdded AND we are able to find the segment related to the curator event from the expected list of segments. 

I have ran the job with the above flaky tests 44 times and all of them pass. See: https://travis-ci.com/github/maytasm/druid/builds/174877686

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

