### PR TITLE
cleanSpec retains task context

### DIFF
--- a/web-console/src/utils/__snapshots__/ingestion-spec.spec.ts.snap
+++ b/web-console/src/utils/__snapshots__/ingestion-spec.spec.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`ingestion-spec upgrades 1`] = `
 Object {
+  "context": Object {
+    "forceTimeChunkLock": true,
+  },
   "spec": Object {
     "dataSchema": Object {
       "dataSource": "wikipedia",

--- a/web-console/src/utils/ingestion-spec.spec.ts
+++ b/web-console/src/utils/ingestion-spec.spec.ts
@@ -89,6 +89,9 @@ describe('ingestion-spec', () => {
         ],
       },
     },
+    context: {
+      forceTimeChunkLock: true,
+    },
   };
 
   it('upgrades', () => {
@@ -112,11 +115,17 @@ describe('ingestion-spec', () => {
         spec: {
           dataSchema: {},
         },
+        context: {
+          forceTimeChunkLock: true,
+        },
       } as any),
     ).toEqual({
       type: 'index_parallel',
       spec: {
         dataSchema: {},
+      },
+      context: {
+        forceTimeChunkLock: true,
       },
     });
   });

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -39,9 +39,14 @@ export const EMPTY_ARRAY: any[] = [];
 
 const CURRENT_YEAR = new Date().getUTCFullYear();
 
+export interface TaskContext {
+  [key: string]: any;
+}
+
 export interface IngestionSpec {
   type: IngestionType;
   spec: IngestionSpecInner;
+  context?: TaskContext;
 }
 
 export interface IngestionSpecInner {
@@ -296,13 +301,14 @@ export function normalizeSpec(spec: Partial<IngestionSpec>): IngestionSpec {
 }
 
 /**
- * Make sure that any extra junk in the spec other than 'type' and 'spec' is removed
+ * Make sure that any extra junk in the spec other than 'type', 'spec', and 'context' is removed
  * @param spec
  */
 export function cleanSpec(spec: IngestionSpec): IngestionSpec {
   return {
     type: spec.type,
     spec: spec.spec,
+    context: spec.context,
   };
 }
 


### PR DESCRIPTION
This PR intends to keep the context property in `IngestionSpec`.

When editing and submitting the configuration of an existing task supervisor through the console page, user may lose their explicitly setting properties in the context.

This PR has:
- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `ingestion-spec.tsx`
