### PR TITLE
Update ambari-metrics-common to version 2.6.1.0.0 

### DIFF
--- a/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-common</artifactId>
-      <version>2.4.1.0.22</version>
+      <version>2.6.1.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.jackson</groupId>
@@ -159,12 +159,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>hortonworks</id>
-      <name>hortonworks</name>
-      <url>https://repo.hortonworks.com/content/repositories/releases</url>
-    </repository>
-  </repositories>
 </project>

--- a/extensions-contrib/ambari-metrics-emitter/src/main/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitter.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/main/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitter.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.metrics2.sink.timeline.AbstractTimelineMetricsSink;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -141,15 +143,46 @@ public class AmbariMetricsEmitter extends AbstractTimelineMetricsSink implements
   }
 
   @Override
-  protected String getCollectorUri()
+  protected String getCollectorUri(String host)
   {
-    return collectorURI;
+    return constructTimelineMetricUri(getCollectorProtocol(), host, getCollectorPort());
+  }
+
+  @Override
+  protected String getCollectorProtocol()
+  {
+    return config.getProtocol();
+  }
+
+  @Override
+  protected String getCollectorPort()
+  {
+    return String.valueOf(config.getPort());
   }
 
   @Override
   protected int getTimeoutSeconds()
   {
     return (int) (DEFAULT_FLUSH_TIMEOUT_MILLIS / 1000);
+  }
+
+  @Override
+  protected String getZookeeperQuorum()
+  {
+    //Ignoring Zk Fallback.
+    return null;
+  }
+
+  @Override
+  protected Collection<String> getConfiguredCollectorHosts()
+  {
+    return Collections.singleton(config.getHostname());
+  }
+
+  @Override
+  protected String getHostname()
+  {
+    return config.getHostname();
   }
 
   private class ConsumerRunnable implements Runnable

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.ambari.metrics;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class AmbariMetricsEmitterTest
+{
+  private final ObjectMapper mapper = new DefaultObjectMapper();
+
+  @Before
+  public void setUp()
+  {
+    mapper.setInjectableValues(new InjectableValues.Std().addValue(
+        ObjectMapper.class,
+        new DefaultObjectMapper()
+    ));
+  }
+
+  @Test
+  public void testSerDeAmbariMetricsEmitterConfig() throws IOException
+  {
+    AmbariMetricsEmitterConfig config = new AmbariMetricsEmitterConfig(
+        "hostname",
+        8080,
+        "http",
+        "truststore.path",
+        "truststore.type",
+        "truststore.password",
+        1000,
+        1000L,
+        100,
+        new SendAllTimelineEventConverter("prefix", "druid"),
+        Collections.emptyList(),
+        500L,
+        400L
+    );
+    AmbariMetricsEmitter emitter = new AmbariMetricsEmitter(config, Collections.emptyList());
+    Assert.assertEquals("8080", emitter.getCollectorPort());
+    Assert.assertEquals("http", emitter.getCollectorProtocol());
+    Assert.assertEquals("http://myHost:8080/ws/v1/timeline/metrics", emitter.getCollectorUri("myHost"));
+    Assert.assertEquals("hostname", emitter.getHostname());
+    Assert.assertNull(emitter.getZookeeperQuorum());
+    Assert.assertEquals(Collections.singleton("hostname"), emitter.getConfiguredCollectorHosts());
+  }
+}

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
@@ -43,7 +43,7 @@ public class AmbariMetricsEmitterTest
   }
 
   @Test
-  public void testSerDeAmbariMetricsEmitterConfig() throws IOException
+  public void testSerDeAmbariMetricsEmitterConfig()
   {
     AmbariMetricsEmitterConfig config = new AmbariMetricsEmitterConfig(
         "hostname",

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
@@ -26,7 +26,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 
 public class AmbariMetricsEmitterTest


### PR DESCRIPTION
prev version is available in only hortonworks repo. 
This PR upgrades to ambari-metrics-common 2.6.1.0.0 and also remove dependency on hortonworks repo 