### PR TITLE
Fix JettyTest.testNumConnectionsMetricHttp flaky test

### DIFF
--- a/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
@@ -511,13 +511,13 @@ public class JettyTest extends BaseJettyTest
   {
     // it can take a bit to close the connection, so maybe sleep for a while and hope it closes
     final int sleepTimeMills = 10;
-    final int totalSleeps = 10_000 / sleepTimeMills;
+    final int totalSleeps = 15_000 / sleepTimeMills;
     int count = 0;
     while (jsm.getActiveConnections() > 0 && count++ < totalSleeps) {
       Thread.sleep(sleepTimeMills);
     }
     if (jsm.getActiveConnections() > 0) {
-      throw new RuntimeException("Connections greater than 0");
+      throw new RuntimeException("Connections greater than 0. activeConnections=" + jsm.getActiveConnections() + " port=" + port);
     }
   }
 }


### PR DESCRIPTION
Fix JettyTest.testNumConnectionsMetricHttp flaky test

### Description

The unit test, JettyTest.testNumConnectionsMetricHttp, has been observed to be flaky. Such as in https://github.com/apache/druid/pull/10027#issuecomment-648684719 and in https://github.com/apache/druid/pull/9661#issuecomment-611875446

The test waits for number of active connection on the Jetty JettyServerModule to be 0 before running tests. For some unknown reason the active connection is > 0 and even after sleeping/retry is still > 0. This causes the test to fail.

However, this test is very rarely flaky. I have try to run the test job containing the flaky test in equivalent Travis environment over 100 times and could not get it to fail (See: https://travis-ci.com/github/maytasm/druid/builds/175034012).

The test is already doing the following:
- Using random port between each retry.
- Retry check of active connection every 10 ms over 10000 ms total.
 
Since the test rarely fails, this PR aims to achieve the following:
- Increase return check of active connection to every 10 ms over 15000 ms total. Hopefully, this will further reduce the probability of the test failing.
- Improve error message when test fails to indicate the number of active connection and the port that was used. 

Note: an alternative is to start the test at the number of open connections instead of 0, and just test for 1 above that and make sure it goes back down to where it started or below. However, as we are not sure how unexpected connections are from, there may as well be connections opening or closing while the test is running (between recording initialize connection number and verifying final connection number).


This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
