### PR TITLE
Fix broken sampler for re-indexing

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -262,12 +262,8 @@ export function isTask(spec: IngestionSpec) {
   );
 }
 
-export function isDruidSourceFromInputSource(inputSource: InputSource): boolean {
-  return deepGet(inputSource, 'type') === 'druid';
-}
-
 export function isDruidSource(spec: IngestionSpec): boolean {
-  return isDruidSourceFromInputSource(deepGet(spec, 'spec.ioConfig.inputSource'));
+  return deepGet(spec, 'spec.ioConfig.inputSource.type') === 'druid';
 }
 
 /**

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -262,8 +262,12 @@ export function isTask(spec: IngestionSpec) {
   );
 }
 
+export function isDruidSourceFromInputSource(inputSource: InputSource): boolean {
+  return deepGet(inputSource, 'type') === 'druid';
+}
+
 export function isDruidSource(spec: IngestionSpec): boolean {
-  return deepGet(spec, 'spec.ioConfig.inputSource.type') === 'druid';
+  return isDruidSourceFromInputSource(deepGet(spec, 'spec.ioConfig.inputSource'));
 }
 
 /**

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -30,6 +30,7 @@ import {
   IoConfig,
   isColumnTimestampSpec,
   isDruidSource,
+  isDruidSourceFromInputSource,
   MetricSpec,
   TimestampSpec,
   Transform,
@@ -202,7 +203,10 @@ function makeSamplerIoConfig(
     ioConfig = deepSet(ioConfig, 'useEarliestSequenceNumber', sampleStrategy === 'start');
   }
   // In order to prevent potential data loss null columns should be kept by the sampler and shown in the ingestion flow
-  ioConfig = deepSet(ioConfig, 'inputFormat.keepNullColumns', true);
+  const reingestMode = isDruidSourceFromInputSource(deepGet(ioConfig, 'inputSource'));
+  if (!reingestMode) {
+    ioConfig = deepSet(ioConfig, 'inputFormat.keepNullColumns', true);
+  }
   return ioConfig;
 }
 

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -30,7 +30,6 @@ import {
   IoConfig,
   isColumnTimestampSpec,
   isDruidSource,
-  isDruidSourceFromInputSource,
   MetricSpec,
   TimestampSpec,
   Transform,
@@ -109,7 +108,9 @@ export function applyCache(sampleSpec: SampleSpec, cacheRows: CacheRows) {
   if (!cacheRows) return sampleSpec;
 
   // In order to prevent potential data loss null columns should be kept by the sampler and shown in the ingestion flow
-  sampleSpec = deepSet(sampleSpec, 'spec.ioConfig.inputFormat.keepNullColumns', true);
+  if (deepGet(sampleSpec, 'spec.ioConfig.inputFormat')) {
+    sampleSpec = deepSet(sampleSpec, 'spec.ioConfig.inputFormat.keepNullColumns', true);
+  }
 
   // If this is already an inline spec there is nothing to do
   if (deepGet(sampleSpec, 'spec.ioConfig.inputSource.type') === 'inline') return sampleSpec;
@@ -203,8 +204,7 @@ function makeSamplerIoConfig(
     ioConfig = deepSet(ioConfig, 'useEarliestSequenceNumber', sampleStrategy === 'start');
   }
   // In order to prevent potential data loss null columns should be kept by the sampler and shown in the ingestion flow
-  const reingestMode = isDruidSourceFromInputSource(deepGet(ioConfig, 'inputSource'));
-  if (!reingestMode) {
+  if (ioConfig.inputFormat) {
     ioConfig = deepSet(ioConfig, 'inputFormat.keepNullColumns', true);
   }
   return ioConfig;


### PR DESCRIPTION
Fixes  #10197 

### Description

When re-indexing a Druid datasource, the web-console would generate an invalid inputFormat 
since the type is not specified. The DruidInputSource does not need an InputFormat, so this change
skips adding an inputFormat to the provided spec.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.