### PR TITLE
Fix timeseries query constructor when postAggregator has an expression reading timestamp result column

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -629,9 +629,7 @@ Druid SQL uses four different native query types.
 period)`, have no other grouping expressions, no HAVING or LIMIT clauses, no nesting, and either no ORDER BY, or an
 ORDER BY that orders by same expression as present in GROUP BY. It also uses Timeseries for "grand total" queries that
 have aggregation functions but no GROUP BY. This query type takes advantage of the fact that Druid segments are sorted
-by time. The SQL planner can inject `timestampResultField` in the query context when there is a grouping key. This
-context value is used in several places to reference the "timestamp" field after the aggregation such as when Druid converts
-the output format for SQL queries or computes post aggregations.
+by time.
 
 - [TopN](topnquery.html) is used by default for queries that group by a single expression, do have ORDER BY and LIMIT
 clauses, do not have HAVING clauses, and are not nested. However, the TopN query type will deliver approximate ranking

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -629,7 +629,9 @@ Druid SQL uses four different native query types.
 period)`, have no other grouping expressions, no HAVING or LIMIT clauses, no nesting, and either no ORDER BY, or an
 ORDER BY that orders by same expression as present in GROUP BY. It also uses Timeseries for "grand total" queries that
 have aggregation functions but no GROUP BY. This query type takes advantage of the fact that Druid segments are sorted
-by time.
+by time. The SQL planner can inject `timestampResultField` in the query context when there is a grouping key. This
+context value is used in several places to reference the "timestamp" field after the aggregation such as when Druid converts
+the output format for SQL queries or computes post aggregations.
 
 - [TopN](topnquery.html) is used by default for queries that group by a single expression, do have ORDER BY and LIMIT
 clauses, do not have HAVING clauses, and are not nested. However, the TopN query type will deliver approximate ranking

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
@@ -78,11 +78,14 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
   {
     super(dataSource, querySegmentSpec, descending, context, granularity);
 
+    // The below should be executed after context is initialized.
+    final String timestampField = getTimestampResultField();
+
     this.virtualColumns = VirtualColumns.nullToEmpty(virtualColumns);
     this.dimFilter = dimFilter;
     this.aggregatorSpecs = aggregatorSpecs == null ? ImmutableList.of() : aggregatorSpecs;
     this.postAggregatorSpecs = Queries.prepareAggregations(
-        ImmutableList.of(),
+        ImmutableList.of(timestampField),
         this.aggregatorSpecs,
         postAggregatorSpecs == null ? ImmutableList.of() : postAggregatorSpecs
     );

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
@@ -85,7 +85,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     this.dimFilter = dimFilter;
     this.aggregatorSpecs = aggregatorSpecs == null ? ImmutableList.of() : aggregatorSpecs;
     this.postAggregatorSpecs = Queries.prepareAggregations(
-        ImmutableList.of(timestampField),
+        timestampField == null ? ImmutableList.of() : ImmutableList.of(timestampField),
         this.aggregatorSpecs,
         postAggregatorSpecs == null ? ImmutableList.of() : postAggregatorSpecs
     );

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -402,7 +402,6 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
   @Override
   public RowSignature resultArraySignature(TimeseriesQuery query)
   {
-
     RowSignature.Builder rowSignatureBuilder = RowSignature.builder();
     rowSignatureBuilder.addTimeColumn();
     if (StringUtils.isNotEmpty(query.getTimestampResultField())) {
@@ -450,6 +449,14 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       final TimeseriesResultValue holder = result.getValue();
       final Map<String, Object> values = new HashMap<>(holder.getBaseObject());
       if (calculatePostAggs) {
+        // If "timestampResultField" is set, we must include a copy of the timestamp in the result.
+        // This is used by the SQL layer when it generates a Timeseries query for a group-by-time-floor SQL query.
+        // The SQL layer expects the result of the time-floor to have a specific name that is not going to be "__time".
+        // This should be done before computing post aggregators since they can reference "timestampResultField".
+        if (StringUtils.isNotEmpty(query.getTimestampResultField()) && result.getTimestamp() != null) {
+          final DateTime timestamp = result.getTimestamp();
+          values.put(query.getTimestampResultField(), timestamp.getMillis());
+        }
         if (!query.getPostAggregatorSpecs().isEmpty()) {
           // put non finalized aggregators for calculating dependent post Aggregators
           for (AggregatorFactory agg : query.getAggregatorSpecs()) {
@@ -458,13 +465,6 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
           for (PostAggregator postAgg : query.getPostAggregatorSpecs()) {
             values.put(postAgg.getName(), postAgg.compute(values));
           }
-        }
-        // If "timestampResultField" is set, we must include a copy of the timestamp in the result.
-        // This is used by the SQL layer when it generates a Timeseries query for a group-by-time-floor SQL query.
-        // The SQL layer expects the result of the time-floor to have a specific name that is not going to be "__time".
-        if (StringUtils.isNotEmpty(query.getTimestampResultField()) && result.getTimestamp() != null) {
-          final DateTime timestamp = result.getTimestamp();
-          values.put(query.getTimestampResultField(), timestamp.getMillis());
         }
       }
       for (AggregatorFactory agg : query.getAggregatorSpecs()) {

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.granularity.PeriodGranularity;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.io.Closer;
@@ -40,9 +41,15 @@ import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.DoubleMaxAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleMinAggregatorFactory;
 import org.apache.druid.query.context.ResponseContext;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryRunnerTest;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
+import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.joda.time.DateTime;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -52,10 +59,11 @@ import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
- *
+ * This class is for testing both timeseries and groupBy queries with the same set of queries.
  */
 @RunWith(Parameterized.class)
 public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
@@ -99,15 +107,36 @@ public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
               toolChest
           );
 
+          final String timeDimension = tsQuery.getTimestampResultField();
+          final List<VirtualColumn> virtualColumns = new ArrayList<>(
+              Arrays.asList(tsQuery.getVirtualColumns().getVirtualColumns())
+          );
+          if (timeDimension != null) {
+            final PeriodGranularity granularity = (PeriodGranularity) tsQuery.getGranularity();
+            virtualColumns.add(
+                new ExpressionVirtualColumn(
+                    "v0",
+                    StringUtils.format("timestamp_floor(__time, '%s')", granularity.getPeriod()),
+                    ValueType.LONG,
+                    TestExprMacroTable.INSTANCE
+                )
+            );
+          }
+
           GroupByQuery newQuery = GroupByQuery
               .builder()
               .setDataSource(tsQuery.getDataSource())
               .setQuerySegmentSpec(tsQuery.getQuerySegmentSpec())
               .setGranularity(tsQuery.getGranularity())
               .setDimFilter(tsQuery.getDimensionsFilter())
+              .setDimensions(
+                  timeDimension == null
+                  ? ImmutableList.of()
+                  : ImmutableList.of(new DefaultDimensionSpec("v0", timeDimension, ValueType.LONG))
+              )
               .setAggregatorSpecs(tsQuery.getAggregatorSpecs())
               .setPostAggregatorSpecs(tsQuery.getPostAggregatorSpecs())
-              .setVirtualColumns(tsQuery.getVirtualColumns())
+              .setVirtualColumns(VirtualColumns.create(virtualColumns))
               .setContext(tsQuery.getContext())
               .build();
 
@@ -239,14 +268,28 @@ public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
   @Override
   public void testTimeseriesWithTimestampResultFieldContextForArrayResponse()
   {
-    // Skip this test because the timeseries test expects an extra column to be created (map from the timestamp_floor
-    // of the timestamp dimension) but group by doesn't do this.
+    // Cannot vectorize with an expression virtual column
+    if (!vectorize) {
+      super.testTimeseriesWithTimestampResultFieldContextForArrayResponse();
+    }
   }
 
   @Override
   public void testTimeseriesWithTimestampResultFieldContextForMapResponse()
   {
-    // Skip this test because the timeseries test expects an extra column to be created (map from the timestamp_floor
-    // of the timestamp dimension) but group by doesn't do this.
+    // Cannot vectorize with an expression virtual column
+    if (!vectorize) {
+      super.testTimeseriesWithTimestampResultFieldContextForMapResponse();
+    }
+  }
+
+  @Override
+  @Test
+  public void testTimeseriesWithPostAggregatorReferencingTimestampResultField()
+  {
+    // Cannot vectorize with an expression virtual column
+    if (!vectorize) {
+      super.testTimeseriesWithPostAggregatorReferencingTimestampResultField();
+    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -1620,7 +1620,6 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                                   .intervals(QueryRunnerTestHelper.FIRST_TO_THIRD)
                                   .aggregators(aggregatorFactoryList)
                                   .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
-                                  .context(ImmutableMap.of("skipEmptyBuckets", "true"))
                                   .descending(descending)
                                   .context(makeContext(ImmutableMap.of("skipEmptyBuckets", "true")))
                                   .build();
@@ -2490,9 +2489,14 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                                   )
                                   .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
                                   .descending(descending)
-                                  .context(ImmutableMap.of(
-                                      TimeseriesQuery.CTX_TIMESTAMP_RESULT_FIELD, TIMESTAMP_RESULT_FIELD_NAME
-                                  ))
+                                  .context(
+                                      makeContext(
+                                          ImmutableMap.of(
+                                              TimeseriesQuery.CTX_TIMESTAMP_RESULT_FIELD, TIMESTAMP_RESULT_FIELD_NAME,
+                                              "skipEmptyBuckets", true
+                                          )
+                                      )
+                                  )
                                   .build();
 
     Assert.assertEquals(TIMESTAMP_RESULT_FIELD_NAME, query.getTimestampResultField());
@@ -2519,6 +2523,9 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
     final String[] expectedIndex = descending ?
                                    QueryRunnerTestHelper.EXPECTED_FULL_ON_INDEX_VALUES_DESC :
                                    QueryRunnerTestHelper.EXPECTED_FULL_ON_INDEX_VALUES;
+    final String[] expectedIndexToUse = Arrays.stream(expectedIndex)
+                                              .filter(eachIndex -> !"0.0".equals(eachIndex))
+                                              .toArray(String[]::new);
 
     final Long expectedLast = descending ?
                                   QueryRunnerTestHelper.EARLIEST.getMillis() :
@@ -2546,7 +2553,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
 
       if (QueryRunnerTestHelper.SKIPPED_DAY.getMillis() != current) {
         Assert.assertEquals(
-            Doubles.tryParse(expectedIndex[count]).doubleValue(),
+            Doubles.tryParse(expectedIndexToUse[count]).doubleValue(),
             (Double) result[3],
             (Double) result[3] * 1e-6
         );
@@ -2556,7 +2563,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
             0.02
         );
         Assert.assertEquals(
-            new Double(expectedIndex[count]) + 13L + 1L,
+            new Double(expectedIndexToUse[count]) + 13L + 1L,
             (Double) result[5],
             (Double) result[5] * 1e-6
         );
@@ -2573,7 +2580,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
               0.02
           );
           Assert.assertEquals(
-              new Double(expectedIndex[count]) + 1L,
+              new Double(expectedIndexToUse[count]) + 1L,
               (Double) result[5],
               (Double) result[5] * 1e-6
           );
@@ -2613,9 +2620,14 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                                   )
                                   .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
                                   .descending(descending)
-                                  .context(ImmutableMap.of(
-                                      TimeseriesQuery.CTX_TIMESTAMP_RESULT_FIELD, TIMESTAMP_RESULT_FIELD_NAME
-                                  ))
+                                  .context(
+                                      makeContext(
+                                          ImmutableMap.of(
+                                              TimeseriesQuery.CTX_TIMESTAMP_RESULT_FIELD, TIMESTAMP_RESULT_FIELD_NAME,
+                                              "skipEmptyBuckets", true
+                                          )
+                                      )
+                                  )
                                   .build();
 
     Assert.assertEquals(TIMESTAMP_RESULT_FIELD_NAME, query.getTimestampResultField());
@@ -2625,6 +2637,9 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
     final String[] expectedIndex = descending ?
                                    QueryRunnerTestHelper.EXPECTED_FULL_ON_INDEX_VALUES_DESC :
                                    QueryRunnerTestHelper.EXPECTED_FULL_ON_INDEX_VALUES;
+    final String[] expectedIndexToUse = Arrays.stream(expectedIndex)
+                                              .filter(eachIndex -> !"0.0".equals(eachIndex))
+                                              .toArray(String[]::new);
 
     final DateTime expectedLast = descending ?
                                   QueryRunnerTestHelper.EARLIEST :
@@ -2656,13 +2671,13 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
       if (!QueryRunnerTestHelper.SKIPPED_DAY.equals(current)) {
         Assert.assertEquals(
             result.toString(),
-            Doubles.tryParse(expectedIndex[count]).doubleValue(),
+            Doubles.tryParse(expectedIndexToUse[count]).doubleValue(),
             value.getDoubleMetric("index").doubleValue(),
             value.getDoubleMetric("index").doubleValue() * 1e-6
         );
         Assert.assertEquals(
             result.toString(),
-            new Double(expectedIndex[count]) +
+            new Double(expectedIndexToUse[count]) +
             13L + 1L,
             value.getDoubleMetric("addRowsIndexConstant"),
             value.getDoubleMetric("addRowsIndexConstant") * 1e-6
@@ -2682,7 +2697,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
           );
           Assert.assertEquals(
               result.toString(),
-              new Double(expectedIndex[count]) + 1L,
+              new Double(expectedIndexToUse[count]) + 1L,
               value.getDoubleMetric("addRowsIndexConstant"),
               value.getDoubleMetric("addRowsIndexConstant") * 1e-6
           );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -204,6 +204,52 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testQueryOnTimeseries() throws Exception
+  {
+    cannotVectorize();
+
+    testQuery(
+        "SELECT TIME_FORMAT(\"date\", 'yyyy-MM'), SUM(x)\n"
+        + "FROM (\n"
+        + "    SELECT\n"
+        + "        FLOOR(__time to hour) as \"date\",\n"
+        + "        COUNT(*) as x\n"
+        + "    FROM foo\n"
+        + "    GROUP BY 1\n"
+        + ")\n"
+        + "GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(CalciteTests.DATASOURCE1)
+                                  .intervals(querySegmentSpec(Filtration.eternity()))
+                                  .granularity(Granularities.HOUR)
+                                  .aggregators(aggregators(new CountAggregatorFactory("a0")))
+                                  .context(getTimeseriesContextWithFloorTime(TIMESERIES_CONTEXT_DEFAULT, "d0"))
+                                  .build()
+                        )
+                        .setInterval(querySegmentSpec(Intervals.ETERNITY))
+                        .setVirtualColumns(
+                            expressionVirtualColumn(
+                                "v0",
+                                "timestamp_format(\"d0\",'yyyy-MM','UTC')",
+                                ValueType.STRING
+                            )
+                        )
+                        .setGranularity(Granularities.ALL)
+                        .addDimension(new DefaultDimensionSpec("v0", "_d0"))
+                        .addAggregator(new LongSumAggregatorFactory("_a0", "a0"))
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"2000-01", 3L},
+            new Object[]{"2001-01", 3L}
+        )
+    );
+  }
+
+  @Test
   public void testJoinOuterGroupByAndSubqueryHasLimit() throws Exception
   {
     // Cannot vectorize JOIN operator.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -204,7 +204,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testQueryOnTimeseries() throws Exception
+  public void testGroupByWithPostAggregatorReferencingTimeFloorColumnOnTimeseries() throws Exception
   {
     cannotVectorize();
 


### PR DESCRIPTION
### Description

The timestamp result column should be passed to `Queries.prepareAggregation()` for timeseries queries, otherwise the query can fail at the sanity check with the below error if there are some post aggregators which read the timestamp result column. 

```
Caused by: java.lang.IllegalArgumentException: Missing fields [[d0]] for postAggregator [p0]
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:148)
	at org.apache.druid.query.Queries.prepareAggregations(Queries.java:117)
	at org.apache.druid.query.timeseries.TimeseriesQuery.<init>(TimeseriesQuery.java:84)
	at org.apache.druid.sql.calcite.rel.DruidQuery.toTimeseriesQuery(DruidQuery.java:808)
	at org.apache.druid.sql.calcite.rel.DruidQuery.computeQuery(DruidQuery.java:703)
	at org.apache.druid.sql.calcite.rel.DruidQuery.<init>(DruidQuery.java:140)
	at org.apache.druid.sql.calcite.rel.DruidQuery.fromPartialQuery(DruidQuery.java:218)
	at org.apache.druid.sql.calcite.rel.PartialDruidQuery.build(PartialDruidQuery.java:307)
	at org.apache.druid.sql.calcite.rel.DruidQueryRel.toDruidQuery(DruidQueryRel.java:86)
	at org.apache.druid.sql.calcite.rel.DruidQueryRel.toDruidQueryForExplaining(DruidQueryRel.java:98)
	at org.apache.druid.sql.calcite.rel.DruidRel.isValidDruidQuery(DruidRel.java:55)
	at org.apache.druid.sql.calcite.rule.DruidRules$DruidQueryRule.onMatch(DruidRules.java:133)
	at org.apache.calcite.plan.volcano.VolcanoRuleCall.onMatch(VolcanoRuleCall.java:208)
	... 45 more
```

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.