### PR TITLE
Add vectorization support for the longMin aggregator.

### DIFF
--- a/docs/querying/query-context.md
+++ b/docs/querying/query-context.md
@@ -86,7 +86,7 @@ requirements:
 - All query-level filters must either be able to run on bitmap indexes or must offer vectorized row-matchers. These
 include "selector", "bound", "in", "like", "regex", "search", "and", "or", and "not".
 - All filters in filtered aggregators must offer vectorized row-matchers.
-- All aggregators must offer vectorized implementations. These include "count", "doubleSum", "floatSum", "longSum",
+- All aggregators must offer vectorized implementations. These include "count", "doubleSum", "floatSum", "longSum", "longMin",
 "hyperUnique", and "filtered".
 - No virtual columns.
 - For GroupBy: All dimension specs must be "default" (no extraction functions or filtered dimension specs).

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * AggregatorFactory is a strategy (in the terms of Design Patterns) that represents column aggregation, e. g. min,
+ * AggregatorFactory is a strategy (in the terms of Design Patterns) that represents column aggregation, e.g. min,
  * max, sum of metric columns, or cardinality of dimension columns (see {@link
  * org.apache.druid.query.aggregation.cardinality.CardinalityAggregatorFactory}).
  * Implementations of {@link AggregatorFactory} which need to Support Nullable Aggregations are encouraged
@@ -46,7 +46,7 @@ import java.util.Map;
  * for them e.g. doubleSum aggregator tries to parse the string value as double and assumes it to be zero if parsing
  * fails.
  * If it is a multi value column then each individual value should be taken into account for aggregation e.g. if a row
- * had value ["1","1","1"] , doubleSum aggregation would take each of them and sum them to 3.
+ * had value ["1","1","1"], doubleSum aggregation would take each of them and sum them to 3.
  */
 @ExtensionPoint
 public abstract class AggregatorFactory implements Cacheable

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMinVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMinVectorAggregator.java
@@ -43,13 +43,13 @@ public class LongMinVectorAggregator implements VectorAggregator
   public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
   {
     final long[] vector = selector.getLongVector();
-    long min = Long.MAX_VALUE;
+
+    long min = buf.getLong(position);
     for (int i = startRow; i < endRow; i++) {
       min = Math.min(min, vector[i]);
     }
 
     buf.putLong(position, min);
-
   }
 
   @Override
@@ -62,6 +62,7 @@ public class LongMinVectorAggregator implements VectorAggregator
   )
   {
     final long[] vector = selector.getLongVector();
+
     for (int i = 0; i < numRows; i++) {
       final int position = positions[i] + positionOffset;
       buf.putLong(position, Math.min(buf.getLong(position), vector[rows != null ? rows[i] : i]));

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMinVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMinVectorAggregator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation;
+
+import org.apache.druid.segment.vector.VectorValueSelector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+public class LongMinVectorAggregator implements VectorAggregator
+{
+    private final VectorValueSelector selector;
+
+    public LongMinVectorAggregator(final VectorValueSelector selector)
+    {
+        this.selector = selector;
+    }
+
+    @Override
+    public void init(final ByteBuffer buf, final int position)
+    {
+        buf.putLong(position, Long.MAX_VALUE);
+    }
+
+    @Override
+    public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
+    {
+        final long[] vector = selector.getLongVector();
+        long min = Long.MAX_VALUE;
+        for (int i = startRow; i < endRow; i++) {
+            min = Math.min(min, vector[i]);
+        }
+        buf.putLong(position, min);
+    }
+
+    @Override
+    public void aggregate(
+            final ByteBuffer buf,
+            final int numRows,
+            final int[] positions,
+            @Nullable final int[] rows,
+            final int positionOffset
+    )
+    {
+        final long[] vector = selector.getLongVector();
+        for (int i = 0; i < numRows; i++) {
+            final int position = positions[i] + positionOffset;
+            buf.putLong(position, Math.min(buf.getLong(position), vector[rows != null ? rows[i] : i]));
+        }
+    }
+
+    @Override
+    public Object get(final ByteBuffer buf, final int position)
+    {
+        return buf.getLong(position);
+    }
+
+    @Override
+    public void close()
+    {
+        // Nothing to close.
+    }
+}

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMinVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMinVectorAggregator.java
@@ -26,55 +26,57 @@ import java.nio.ByteBuffer;
 
 public class LongMinVectorAggregator implements VectorAggregator
 {
-    private final VectorValueSelector selector;
+  private final VectorValueSelector selector;
 
-    public LongMinVectorAggregator(final VectorValueSelector selector)
-    {
-        this.selector = selector;
+  public LongMinVectorAggregator(final VectorValueSelector selector)
+  {
+    this.selector = selector;
+  }
+
+  @Override
+  public void init(final ByteBuffer buf, final int position)
+  {
+    buf.putLong(position, Long.MAX_VALUE);
+  }
+
+  @Override
+  public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
+  {
+    final long[] vector = selector.getLongVector();
+    long min = Long.MAX_VALUE;
+    for (int i = startRow; i < endRow; i++) {
+      min = Math.min(min, vector[i]);
     }
 
-    @Override
-    public void init(final ByteBuffer buf, final int position)
-    {
-        buf.putLong(position, Long.MAX_VALUE);
-    }
+    buf.putLong(position, min);
 
-    @Override
-    public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
-    {
-        final long[] vector = selector.getLongVector();
-        long min = Long.MAX_VALUE;
-        for (int i = startRow; i < endRow; i++) {
-            min = Math.min(min, vector[i]);
-        }
-        buf.putLong(position, min);
-    }
+  }
 
-    @Override
-    public void aggregate(
-            final ByteBuffer buf,
-            final int numRows,
-            final int[] positions,
-            @Nullable final int[] rows,
-            final int positionOffset
-    )
-    {
-        final long[] vector = selector.getLongVector();
-        for (int i = 0; i < numRows; i++) {
-            final int position = positions[i] + positionOffset;
-            buf.putLong(position, Math.min(buf.getLong(position), vector[rows != null ? rows[i] : i]));
-        }
+  @Override
+  public void aggregate(
+      final ByteBuffer buf,
+      final int numRows,
+      final int[] positions,
+      @Nullable final int[] rows,
+      final int positionOffset
+  )
+  {
+    final long[] vector = selector.getLongVector();
+    for (int i = 0; i < numRows; i++) {
+      final int position = positions[i] + positionOffset;
+      buf.putLong(position, Math.min(buf.getLong(position), vector[rows != null ? rows[i] : i]));
     }
+  }
 
-    @Override
-    public Object get(final ByteBuffer buf, final int position)
-    {
-        return buf.getLong(position);
-    }
+  @Override
+  public Object get(final ByteBuffer buf, final int position)
+  {
+    return buf.getLong(position);
+  }
 
-    @Override
-    public void close()
-    {
-        // Nothing to close.
-    }
+  @Override
+  public void close()
+  {
+    // Nothing to close.
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryRunnerTestHelper.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.FloatSumAggregatorFactory;
 import org.apache.druid.query.aggregation.JavaScriptAggregatorFactory;
+import org.apache.druid.query.aggregation.LongMinAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.cardinality.CardinalityAggregatorFactory;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniqueFinalizingPostAggregator;
@@ -113,6 +114,7 @@ public class QueryRunnerTestHelper
   public static final String INDEX_METRIC = "index";
   public static final String UNIQUE_METRIC = "uniques";
   public static final String ADD_ROWS_INDEX_CONSTANT_METRIC = "addRowsIndexConstant";
+  public static final String LONG_MIN_INDEX_METRIC = "longMinIndex";
   public static String dependentPostAggMetric = "dependentPostAgg";
   public static final CountAggregatorFactory ROWS_COUNT = new CountAggregatorFactory("rows");
   public static final LongSumAggregatorFactory INDEX_LONG_SUM = new LongSumAggregatorFactory("index", INDEX_METRIC);
@@ -121,6 +123,7 @@ public class QueryRunnerTestHelper
       "index",
       INDEX_METRIC
   );
+  public static final LongMinAggregatorFactory INDEX_LONG_MIN = new LongMinAggregatorFactory(LONG_MIN_INDEX_METRIC, INDEX_METRIC);
   public static final String JS_COMBINE_A_PLUS_B = "function combine(a, b) { return a + b; }";
   public static final String JS_RESET_0 = "function reset() { return 0; }";
   public static final JavaScriptAggregatorFactory JS_INDEX_SUM_IF_PLACEMENTISH_A = new JavaScriptAggregatorFactory(

--- a/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
@@ -382,11 +382,11 @@ public class SchemaEvolutionTest
             "b",
             NullHandling.defaultDoubleValue(),
             "c",
-            NullHandling.defaultLongValue(),
+            0L,
             "d",
             NullHandling.defaultFloatValue(),
             "e",
-            Long.MAX_VALUE
+            NullHandling.sqlCompatible() ? null : Long.MAX_VALUE
         )),
         runQuery(query, factory, ImmutableList.of(index4))
     );

--- a/processing/src/test/java/org/apache/druid/query/aggregation/LongMinAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/LongMinAggregationTest.java
@@ -22,6 +22,10 @@ package org.apache.druid.query.aggregation;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
+import org.apache.druid.segment.vector.VectorValueSelector;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,15 +38,21 @@ import java.nio.ByteBuffer;
 public class LongMinAggregationTest
 {
   private LongMinAggregatorFactory longMinAggFactory;
+  private LongMinAggregatorFactory longMinVectorAggFactory;
   private ColumnSelectorFactory colSelectorFactory;
+  private VectorColumnSelectorFactory vectorColumnSelectorFactory;
   private TestLongColumnSelector selector;
 
-  private long[] values = {-9223372036854775802L, -9223372036854775803L, -9223372036854775806L, -9223372036854775805L};
+  private final long[] values = {-9223372036854775802L, -9223372036854775803L, -9223372036854775806L, -9223372036854775805L};
+  private final long[] longValues1 = {5L, 2L, 4L, 100L, 1L, 5L, -2L, -3L, 0L, 55L};
 
   public LongMinAggregationTest() throws Exception
   {
     String aggSpecJson = "{\"type\": \"longMin\", \"name\": \"billy\", \"fieldName\": \"nilly\"}";
     longMinAggFactory = TestHelper.makeJsonMapper().readValue(aggSpecJson, LongMinAggregatorFactory.class);
+
+    String vectorAggSpecJson = "{\"type\": \"longMin\", \"name\": \"lng\", \"fieldName\": \"lngFld\"}";
+    longMinVectorAggFactory = TestHelper.makeJsonMapper().readValue(vectorAggSpecJson, LongMinAggregatorFactory.class);
   }
 
   @Before
@@ -54,6 +64,17 @@ public class LongMinAggregationTest
     EasyMock.expect(colSelectorFactory.makeColumnValueSelector("nilly")).andReturn(selector);
     EasyMock.expect(colSelectorFactory.getColumnCapabilities("nilly")).andReturn(null);
     EasyMock.replay(colSelectorFactory);
+
+    VectorValueSelector vectorValueSelector = EasyMock.createMock(VectorValueSelector.class);
+    EasyMock.expect(vectorValueSelector.getLongVector()).andReturn(longValues1).anyTimes();
+    EasyMock.expect(vectorValueSelector.getNullVector()).andReturn(null).anyTimes();
+    EasyMock.replay(vectorValueSelector);
+
+    vectorColumnSelectorFactory = EasyMock.createMock(VectorColumnSelectorFactory.class);
+    EasyMock.expect(vectorColumnSelectorFactory.getColumnCapabilities("lngFld"))
+            .andReturn(new ColumnCapabilitiesImpl().setType(ValueType.LONG).setDictionaryEncoded(true)).anyTimes();
+    EasyMock.expect(vectorColumnSelectorFactory.makeValueSelector("lngFld")).andReturn(vectorValueSelector).anyTimes();
+    EasyMock.replay(vectorColumnSelectorFactory);
   }
 
   @Test
@@ -88,6 +109,33 @@ public class LongMinAggregationTest
     Assert.assertEquals(values[2], agg.getLong(buffer, 0));
     Assert.assertEquals((float) values[2], agg.getFloat(buffer, 0), 0.0001);
   }
+
+  @Test
+  public void testLongMinVectorAggregator()
+  {
+    // Some sanity.
+    Assert.assertTrue(longMinVectorAggFactory.canVectorize(vectorColumnSelectorFactory));
+    VectorValueSelector vectorValueSelector = longMinVectorAggFactory.vectorSelector(vectorColumnSelectorFactory);
+    Assert.assertEquals(longValues1, vectorValueSelector.getLongVector());
+
+    VectorAggregator vectorAggregator = longMinVectorAggFactory.factorizeVector(vectorColumnSelectorFactory);
+
+    final ByteBuffer buf = ByteBuffer.allocate(longMinAggFactory.getMaxIntermediateSizeWithNulls() * 2);
+    vectorAggregator.init(buf, 0);
+
+    vectorAggregator.aggregate(buf, 0, 0, 3);
+    Assert.assertEquals(longValues1[1], (long) vectorAggregator.get(buf, 0));
+
+    vectorAggregator.aggregate(buf, 1, 0, 3);
+    Assert.assertEquals(longValues1[1], (long) vectorAggregator.get(buf, 1));
+
+    vectorAggregator.aggregate(buf, 2, 3, 7);
+    Assert.assertEquals(longValues1[6], (long) vectorAggregator.get(buf, 2));
+
+    vectorAggregator.aggregate(buf, 0, 0, 10);
+    Assert.assertEquals(longValues1[7], (long) vectorAggregator.get(buf, 0));
+  }
+
 
   @Test
   public void testCombine()

--- a/processing/src/test/java/org/apache/druid/query/aggregation/LongMinAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/LongMinAggregationTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.TestHelper;
 import org.easymock.EasyMock;
@@ -47,6 +48,7 @@ public class LongMinAggregationTest
   @Before
   public void setup()
   {
+    NullHandling.initializeForTests();
     selector = new TestLongColumnSelector(values);
     colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(colSelectorFactory.makeColumnValueSelector("nilly")).andReturn(selector);

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -4128,7 +4128,7 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setInterval("2011-01-25/2011-01-28")
         .setDimensions(new DefaultDimensionSpec("quality", "alias"))
-        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, new DoubleSumAggregatorFactory("index", "index"))
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, new DoubleSumAggregatorFactory("index", "index"), QueryRunnerTestHelper.INDEX_LONG_MIN)
         .setGranularity(Granularities.ALL)
         .setHavingSpec(new GreaterThanHavingSpec("index", 310L))
         .setLimitSpec(
@@ -4141,11 +4141,11 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
     GroupByQuery fullQuery = builder.build();
 
     List<ResultRow> expectedResults = Arrays.asList(
-        makeRow(fullQuery, "2011-01-25", "alias", "business", "rows", 3L, "index", 312.38165283203125),
-        makeRow(fullQuery, "2011-01-25", "alias", "news", "rows", 3L, "index", 312.7834167480469),
-        makeRow(fullQuery, "2011-01-25", "alias", "technology", "rows", 3L, "index", 324.6412353515625),
-        makeRow(fullQuery, "2011-01-25", "alias", "travel", "rows", 3L, "index", 393.36322021484375),
-        makeRow(fullQuery, "2011-01-25", "alias", "health", "rows", 3L, "index", 511.2996826171875)
+        makeRow(fullQuery, "2011-01-25", "alias", "business", "rows", 3L, "index", 312.38165283203125, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 101L),
+        makeRow(fullQuery, "2011-01-25", "alias", "news", "rows", 3L, "index", 312.7834167480469, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 102L),
+        makeRow(fullQuery, "2011-01-25", "alias", "technology", "rows", 3L, "index", 324.6412353515625, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 102L),
+        makeRow(fullQuery, "2011-01-25", "alias", "travel", "rows", 3L, "index", 393.36322021484375, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 122L),
+        makeRow(fullQuery, "2011-01-25", "alias", "health", "rows", 3L, "index", 511.2996826171875, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 159L)
     );
 
     Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, fullQuery);
@@ -4266,16 +4266,16 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setInterval("2011-04-02/2011-04-04")
         .setDimensions(new DefaultDimensionSpec("quality", "alias"))
-        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, new LongSumAggregatorFactory("idx", "index"))
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, new LongSumAggregatorFactory("idx", "index"), QueryRunnerTestHelper.INDEX_LONG_MIN)
         .setGranularity(new PeriodGranularity(new Period("P1M"), null, null))
         .setHavingSpec(havingSpec);
 
     final GroupByQuery fullQuery = builder.build();
 
     List<ResultRow> expectedResults = Arrays.asList(
-        makeRow(fullQuery, "2011-04-01", "alias", "business", "rows", 2L, "idx", 217L),
-        makeRow(fullQuery, "2011-04-01", "alias", "mezzanine", "rows", 6L, "idx", 4420L),
-        makeRow(fullQuery, "2011-04-01", "alias", "premium", "rows", 6L, "idx", 4416L)
+        makeRow(fullQuery, "2011-04-01", "alias", "business", "rows", 2L, "idx", 217L, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 105L),
+        makeRow(fullQuery, "2011-04-01", "alias", "mezzanine", "rows", 6L, "idx", 4420L, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 107L),
+        makeRow(fullQuery, "2011-04-01", "alias", "premium", "rows", 6L, "idx", 4416L, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 122L)
     );
 
     TestHelper.assertExpectedObjects(

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -625,7 +625,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                     QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT_METRIC,
                     NullHandling.sqlCompatible() ? null : 1.0,
                     QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC,
-                    Long.MAX_VALUE
+                    NullHandling.sqlCompatible() ? null : Long.MAX_VALUE
                 )
             )
         )

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -370,6 +370,34 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testFullOnTimeseriesLongMin()
+  {
+    TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                  .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+                                  .granularity(Granularities.ALL)
+                                  .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+                                  .aggregators(
+                                      QueryRunnerTestHelper.INDEX_LONG_MIN
+                                  )
+                                  .descending(descending)
+                                  .context(makeContext())
+                                  .build();
+
+    DateTime expectedEarliest = DateTimes.of("2011-01-12");
+    DateTime expectedLast = DateTimes.of("2011-04-15");
+
+    Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query)).toList();
+    Result<TimeseriesResultValue> result = results.iterator().next();
+    Assert.assertEquals(expectedEarliest, result.getTimestamp());
+    Assert.assertFalse(
+        StringUtils.format("Timestamp[%s] > expectedLast[%s]", result.getTimestamp(), expectedLast),
+        result.getTimestamp().isAfter(expectedLast)
+    );
+
+    Assert.assertEquals(59L, (long) result.getValue().getLongMetric(QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC));
+  }
+
+  @Test
   public void testFullOnTimeseriesWithFilter()
   {
 
@@ -438,7 +466,8 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                                               "idx",
                                               "index"
                                           ),
-                                          QueryRunnerTestHelper.QUALITY_UNIQUES
+                                          QueryRunnerTestHelper.QUALITY_UNIQUES,
+                                          QueryRunnerTestHelper.INDEX_LONG_MIN
                                       )
                                   )
                                   .descending(descending)
@@ -449,19 +478,18 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
         new Result<>(
             DateTimes.of("2011-04-01"),
             new TimeseriesResultValue(
-                ImmutableMap.of("rows", 13L, "idx", 6619L, "uniques", QueryRunnerTestHelper.UNIQUES_9)
+                ImmutableMap.of("rows", 13L, "idx", 6619L, "uniques", QueryRunnerTestHelper.UNIQUES_9, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 78L)
             )
         ),
         new Result<>(
             DateTimes.of("2011-04-02"),
             new TimeseriesResultValue(
-                ImmutableMap.of("rows", 13L, "idx", 5827L, "uniques", QueryRunnerTestHelper.UNIQUES_9)
+                ImmutableMap.of("rows", 13L, "idx", 5827L, "uniques", QueryRunnerTestHelper.UNIQUES_9, QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 97L)
             )
         )
     );
 
     Iterable<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query)).toList();
-
     assertExpectedResults(expectedResults, results);
   }
 
@@ -476,7 +504,8 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                                       Arrays.asList(
                                           QueryRunnerTestHelper.ROWS_COUNT,
                                           QueryRunnerTestHelper.INDEX_LONG_SUM,
-                                          QueryRunnerTestHelper.QUALITY_UNIQUES
+                                          QueryRunnerTestHelper.QUALITY_UNIQUES,
+                                          QueryRunnerTestHelper.INDEX_LONG_MIN
                                       )
                                   )
                                   .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
@@ -498,7 +527,9 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                     "uniques",
                     QueryRunnerTestHelper.UNIQUES_9,
                     QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT_METRIC,
-                    6633.0
+                    6633.0,
+                    QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC,
+                    78L
                 )
             )
         )
@@ -516,7 +547,9 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                     "uniques",
                     QueryRunnerTestHelper.UNIQUES_9,
                     QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT_METRIC,
-                    5841.0
+                    5841.0,
+                    QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC,
+                    97L
                 )
             )
         )
@@ -538,7 +571,9 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                     "uniques",
                     QueryRunnerTestHelper.UNIQUES_9,
                     QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT_METRIC,
-                    12473.0
+                    12473.0,
+                    QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC,
+                    78L
                 )
             )
         )
@@ -568,7 +603,8 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                                   .aggregators(
                                       Arrays.asList(
                                           QueryRunnerTestHelper.ROWS_COUNT,
-                                          QueryRunnerTestHelper.INDEX_LONG_SUM
+                                          QueryRunnerTestHelper.INDEX_LONG_SUM,
+                                          QueryRunnerTestHelper.INDEX_LONG_MIN
                                       )
                                   )
                                   .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
@@ -587,7 +623,9 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                     "index",
                     NullHandling.defaultLongValue(),
                     QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT_METRIC,
-                    NullHandling.sqlCompatible() ? null : 1.0
+                    NullHandling.sqlCompatible() ? null : 1.0,
+                    QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC,
+                    Long.MAX_VALUE
                 )
             )
         )
@@ -1140,7 +1178,8 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                                   .aggregators(
                                       QueryRunnerTestHelper.ROWS_COUNT,
                                       QueryRunnerTestHelper.INDEX_LONG_SUM,
-                                      QueryRunnerTestHelper.QUALITY_UNIQUES
+                                      QueryRunnerTestHelper.QUALITY_UNIQUES,
+                                      QueryRunnerTestHelper.INDEX_LONG_MIN
                                   )
                                   .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
                                   .descending(descending)
@@ -1155,7 +1194,8 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                     "rows", 9L,
                     "index", 1102L,
                     "addRowsIndexConstant", 1112.0,
-                    "uniques", QueryRunnerTestHelper.UNIQUES_9
+                    "uniques", QueryRunnerTestHelper.UNIQUES_9,
+                    QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 78L
                 )
             )
         ),
@@ -1166,7 +1206,8 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
                     "rows", 9L,
                     "index", 1120L,
                     "addRowsIndexConstant", 1130.0,
-                    "uniques", QueryRunnerTestHelper.UNIQUES_9
+                    "uniques", QueryRunnerTestHelper.UNIQUES_9,
+                    QueryRunnerTestHelper.LONG_MIN_INDEX_METRIC, 97L
                 )
             )
         )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -4752,6 +4752,30 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testSimpleLongAggregations() throws Exception
+  {
+    testQuery(
+        "SELECT  MIN(l1), MIN(cnt) FROM druid.numfoo",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .granularity(Granularities.ALL)
+                .aggregators(aggregators(
+                                new LongMinAggregatorFactory("a0", "l1"),
+                                new LongMinAggregatorFactory("a1", "cnt")
+                            ))
+                .context(TIMESERIES_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{0L, 1L}
+        )
+    );
+  }
+
+
+  @Test
   public void testSimpleAggregations() throws Exception
   {
     // Cannot vectorize due to "longMax" aggregator.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -4336,7 +4336,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   public void testGroupByWithGroupByEmpty() throws Exception
   {
     testQuery(
-        "SELECT COUNT(*), SUM(cnt) FROM druid.foo GROUP BY ()",
+        "SELECT COUNT(*), SUM(cnt), MIN(cnt) FROM druid.foo GROUP BY ()",
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4344,12 +4344,13 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .granularity(Granularities.ALL)
                   .aggregators(aggregators(
                       new CountAggregatorFactory("a0"),
-                      new LongSumAggregatorFactory("a1", "cnt")
+                      new LongSumAggregatorFactory("a1", "cnt"),
+                      new LongMinAggregatorFactory("a2", "cnt")
                   ))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
                   .build()
         ),
-        ImmutableList.of(new Object[]{6L, 6L})
+        ImmutableList.of(new Object[]{6L, 6L, 1L})
     );
   }
 


### PR DESCRIPTION
This patch adds vectorization support for the `longMin` aggregator to speed up queries that use the `MIN` aggregator.

Summary of changes:
- Added a new class `LongMinVectorAggregator` that implements the `VectorAggregator` interface.
- Modified some existing test cases to include this vectorized in `SchemaEvolutionTest`.
- Added a new simple test case to each `CalciteQueryTest` and `TimeseriesQueryRunnerTest`. Modified some test cases in `TimeseriesQueryRunnerTest` and `GroupByQueryRunnerTest`, `SchemaEvolutionTest` to demonstrate that vectorization _does_ work for the `longMin` aggregator.
- Enabled null handling in the `LongMinAggregatorTest` to test both null-compatibility and non null-compatibility code paths.
- Query context documentation update.
- Miscellaneous minor tweaks to java doc comments.

Once this is reviewed, I am hoping to also do the other min and max aggregators for float/double/long types, so we can trim down the list of aggregators that do not support vectorization :). Also, please suggest if I could add more tests or modify existing ones to ensure more code coverage, so the new code paths are exercised. Thanks!

/cc: @gianm @jihoonson 