### PR TITLE
Allow STS regional endpoints

### DIFF
--- a/docs/development/extensions-core/kinesis-ingestion.md
+++ b/docs/development/extensions-core/kinesis-ingestion.md
@@ -139,6 +139,7 @@ A sample supervisor spec is shown below:
 |`recordsPerFetch`|Integer|The number of records to request per GetRecords call to Kinesis. See 'Determining Fetch Settings' below.|no (default == 2000)|
 |`fetchDelayMillis`|Integer|Time in milliseconds to wait between subsequent GetRecords calls to Kinesis. See 'Determining Fetch Settings' below.|no (default == 1000)|
 |`awsAssumedRoleArn`|String|The AWS assumed role to use for additional permissions.|no|
+|`awsStsEndpoint`|String|The STS endpoint to use to assume a role. Using a regional STS endpoint is recommended by AWS.|no (default === sts.amazonaws.com)|
 |`awsExternalId`|String|The AWS external id to use for additional permissions.|no|
 |`deaggregate`|Boolean|Whether to use the de-aggregate function of the KCL. See below for details.|no|
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
@@ -109,6 +109,7 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String>
             ioConfig.getEndpoint(),
             awsCredentialsConfig,
             ioConfig.getAwsAssumedRoleArn(),
+            ioConfig.getAwsStsEndpoint(),
             ioConfig.getAwsExternalId()
         ),
         ioConfig.getRecordsPerFetch(),

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskIOConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskIOConfig.java
@@ -41,6 +41,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
   private final Integer fetchDelayMillis;
 
   private final String awsAssumedRoleArn;
+  private final String awsStsEndpoint;
   private final String awsExternalId;
   private final boolean deaggregate;
 
@@ -69,6 +70,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
       @JsonProperty("recordsPerFetch") Integer recordsPerFetch,
       @JsonProperty("fetchDelayMillis") Integer fetchDelayMillis,
       @JsonProperty("awsAssumedRoleArn") String awsAssumedRoleArn,
+      @JsonProperty("awsStsEndpoint") String awsStsEndpoint,
       @JsonProperty("awsExternalId") String awsExternalId,
       @JsonProperty("deaggregate") boolean deaggregate
   )
@@ -95,6 +97,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
     this.recordsPerFetch = recordsPerFetch != null ? recordsPerFetch : DEFAULT_RECORDS_PER_FETCH;
     this.fetchDelayMillis = fetchDelayMillis != null ? fetchDelayMillis : DEFAULT_FETCH_DELAY_MILLIS;
     this.awsAssumedRoleArn = awsAssumedRoleArn;
+    this.awsStsEndpoint = awsStsEndpoint;
     this.awsExternalId = awsExternalId;
     this.deaggregate = deaggregate;
   }
@@ -112,6 +115,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
       Integer recordsPerFetch,
       Integer fetchDelayMillis,
       String awsAssumedRoleArn,
+      String awsStsEndpoint,
       String awsExternalId,
       boolean deaggregate
   )
@@ -132,6 +136,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
         recordsPerFetch,
         fetchDelayMillis,
         awsAssumedRoleArn,
+        awsStsEndpoint,
         awsExternalId,
         deaggregate
     );
@@ -146,7 +151,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
     if (newStartSequenceNumbers == null) {
       Preconditions.checkNotNull(
           oldStartSequenceNumbers,
-          "Either startSequenceNumbers or startPartitions shoulnd't be null"
+          "Either startSequenceNumbers or startPartitions shouldn't be null"
       );
 
       return new SeekableStreamStartSequenceNumbers<>(
@@ -221,6 +226,12 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
   }
 
   @JsonProperty
+  public String getAwsStsEndpoint()
+  {
+    return awsStsEndpoint;
+  }
+
+  @JsonProperty
   public String getAwsExternalId()
   {
     return awsExternalId;
@@ -246,6 +257,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
            ", recordsPerFetch=" + recordsPerFetch +
            ", fetchDelayMillis=" + fetchDelayMillis +
            ", awsAssumedRoleArn='" + awsAssumedRoleArn + '\'' +
+           ", awsStsEndpoint='" + awsStsEndpoint + '\'' +
            ", awsExternalId='" + awsExternalId + '\'' +
            ", deaggregate=" + deaggregate +
            '}';

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpec.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpec.java
@@ -61,6 +61,7 @@ public class KinesisSamplerSpec extends SeekableStreamSamplerSpec
             ioConfig.getEndpoint(),
             awsCredentialsConfig,
             ioConfig.getAwsAssumedRoleArn(),
+            ioConfig.getAwsStsEndpoint(),
             ioConfig.getAwsExternalId()
         ),
         ioConfig.getRecordsPerFetch(),

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -144,6 +144,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String>
         ioConfig.getRecordsPerFetch(),
         ioConfig.getFetchDelayMillis(),
         ioConfig.getAwsAssumedRoleArn(),
+        ioConfig.getAwsStsEndpoint(),
         ioConfig.getAwsExternalId(),
         ioConfig.isDeaggregate()
     );
@@ -196,6 +197,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String>
             ioConfig.getEndpoint(),
             awsCredentialsConfig,
             ioConfig.getAwsAssumedRoleArn(),
+            ioConfig.getAwsStsEndpoint(),
             ioConfig.getAwsExternalId()
         ),
         ioConfig.getRecordsPerFetch(),

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfig.java
@@ -47,6 +47,7 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
   private final Integer fetchDelayMillis;
 
   private final String awsAssumedRoleArn;
+  private final String awsStsEndpoint;
   private final String awsExternalId;
   private final boolean deaggregate;
 
@@ -69,6 +70,7 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
       @JsonProperty("recordsPerFetch") Integer recordsPerFetch,
       @JsonProperty("fetchDelayMillis") Integer fetchDelayMillis,
       @JsonProperty("awsAssumedRoleArn") String awsAssumedRoleArn,
+      @JsonProperty("awsStsEndpoint") String awsStsEndpoint,
       @JsonProperty("awsExternalId") String awsExternalId,
       @JsonProperty("deaggregate") boolean deaggregate
   )
@@ -97,6 +99,7 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
                             ? fetchDelayMillis
                             : KinesisIndexTaskIOConfig.DEFAULT_FETCH_DELAY_MILLIS;
     this.awsAssumedRoleArn = awsAssumedRoleArn;
+    this.awsStsEndpoint = awsStsEndpoint;
     this.awsExternalId = awsExternalId;
     this.deaggregate = deaggregate;
   }
@@ -123,6 +126,12 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
   public String getAwsAssumedRoleArn()
   {
     return awsAssumedRoleArn;
+  }
+
+  @JsonProperty
+  public String getAwsStsEndpoint()
+  {
+    return awsStsEndpoint;
   }
 
   @JsonProperty
@@ -156,6 +165,7 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
            ", recordsPerFetch=" + recordsPerFetch +
            ", fetchDelayMillis=" + fetchDelayMillis +
            ", awsAssumedRoleArn='" + awsAssumedRoleArn + '\'' +
+           ", awsStsEndpoint='" + awsStsEndpoint + '\'' +
            ", awsExternalId='" + awsExternalId + '\'' +
            ", deaggregate=" + deaggregate +
            '}';

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIOConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIOConfigTest.java
@@ -97,6 +97,7 @@ public class KinesisIOConfigTest
     Assert.assertEquals(config.getFetchDelayMillis(), 0);
     Assert.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
     Assert.assertNull(config.getAwsAssumedRoleArn());
+    Assert.assertNull(config.getAwsStsEndpoint());
     Assert.assertNull(config.getAwsExternalId());
     Assert.assertFalse(config.isDeaggregate());
   }
@@ -117,6 +118,7 @@ public class KinesisIOConfigTest
                      + "  \"recordsPerFetch\": 1000,\n"
                      + "  \"fetchDelayMillis\": 1000,\n"
                      + "  \"awsAssumedRoleArn\": \"role\",\n"
+                     + "  \"awsStsEndpoint\": \"sts.us-west-2.amazonaws.com\",\n"
                      + "  \"awsExternalId\": \"awsexternalid\",\n"
                      + "  \"deaggregate\": true\n"
                      + "}";
@@ -152,6 +154,7 @@ public class KinesisIOConfigTest
     Assert.assertEquals(1000, config.getRecordsPerFetch());
     Assert.assertEquals(1000, config.getFetchDelayMillis());
     Assert.assertEquals("role", config.getAwsAssumedRoleArn());
+    Assert.assertEquals("sts.us-west-2.amazonaws.com", config.getAwsStsEndpoint());
     Assert.assertEquals("awsexternalid", config.getAwsExternalId());
     Assert.assertTrue(config.isDeaggregate());
   }
@@ -274,6 +277,7 @@ public class KinesisIOConfigTest
         1000,
         2000,
         "awsAssumedRoleArn",
+        "awsStsEndpoint",
         "awsExternalId",
         true
     );

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfigTest.java
@@ -73,6 +73,7 @@ public class KinesisSupervisorIOConfigTest
     Assert.assertEquals((Integer) 4000, config.getRecordsPerFetch());
     Assert.assertEquals((Integer) 0, config.getFetchDelayMillis());
     Assert.assertNull(config.getAwsAssumedRoleArn());
+    Assert.assertNull(config.getAwsStsEndpoint());
     Assert.assertNull(config.getAwsExternalId());
     Assert.assertFalse(config.isDeaggregate());
   }
@@ -97,6 +98,7 @@ public class KinesisSupervisorIOConfigTest
                      + "  \"recordsPerFetch\": 4000,\n"
                      + "  \"fetchDelayMillis\": 1000,\n"
                      + "  \"awsAssumedRoleArn\": \"role\",\n"
+                     + "  \"awsStsEndpoint\": \"sts.us-west-2.amazonaws.com\",\n"
                      + "  \"awsExternalId\": \"awsexternalid\",\n"
                      + "  \"deaggregate\": true\n"
                      + "}";
@@ -120,6 +122,7 @@ public class KinesisSupervisorIOConfigTest
     Assert.assertEquals((Integer) 4000, config.getRecordsPerFetch());
     Assert.assertEquals((Integer) 1000, config.getFetchDelayMillis());
     Assert.assertEquals("role", config.getAwsAssumedRoleArn());
+    Assert.assertEquals("sts.us-west-2.amazonaws.com", config.getAwsStsEndpoint());
     Assert.assertEquals("awsexternalid", config.getAwsExternalId());
     Assert.assertTrue(config.isDeaggregate());
   }

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1568,6 +1568,43 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           info: <>The AWS assumed role to use for additional permissions.</>,
         },
         {
+          name: 'awsStsEndpoint',
+          type: 'string',
+          defaultValue: null,
+          suggestions: [
+            'sts.us-east-2.amazonaws.com',
+            'sts.us-east-1.amazonaws.com',
+            'sts.us-west-1.amazonaws.com',
+            'sts.us-west-2.amazonaws.com',
+            'sts.af-south-1.amazonaws.com',
+            'sts.ap-east-1.amazonaws.com',
+            'sts.ap-south-1.amazonaws.com',
+            'sts.ap-northeast-2.amazonaws.com',
+            'sts.ap-southeast-1.amazonaws.com',
+            'sts.ap-southeast-2.amazonaws.com',
+            'sts.ap-northeast-1.amazonaws.com	',
+            'sts.ca-central-1.amazonaws.com',
+            'sts.eu-central-1.amazonaws.com',
+            'sts.eu-west-1.amazonaws.com',
+            'sts.eu-west-2.amazonaws.com',
+            'sts.eu-south-1.amazonaws.com',
+            'sts.eu-west-3.amazonaws.com',
+            'sts.eu-north-1.amazonaws.com',
+            'sts.me-south-1.amazonaws.com',
+            'sts.sa-east-1.amazonaws.com',
+          ],
+          info: (
+            <>
+              The Amazon STS regional endpoint to use when assuming the awsAssumedRoleArn. You can
+              find a list of endpoints{' '}
+              <ExternalLink href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_region-endpoints">
+                here
+              </ExternalLink>
+              .
+            </>
+          ),
+        },
+        {
           name: 'awsExternalId',
           label: 'AWS external ID',
           type: 'string',


### PR DESCRIPTION
### Description

This change allows Druid users to configure a regional endpoint for STS in their Kinesis ingest specs. Configuring a regional endpoint rather than using the default global endpoint is [recommended by AWS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html). This is also an internal requirement for running our Druid cluster.

I added an optional `awsStsEndpoint` configuration value to the `KinesisIndexTaskIOConfig` class. When this value is present, the `AWSSecurityTokenServiceClientBuilder` has endpoint configuration applied.

I picked the name `awsStsEndpoint` to align with the existing configuration values `awsAssumedRoleArn` and `awsExternalId`.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `KinesisIndexTaskIOConfig`
