### PR TITLE
Web console: Improve retention rules dialog in all sorts of ways

### DIFF
--- a/web-console/src/components/rule-editor/rule-editor.scss
+++ b/web-console/src/components/rule-editor/rule-editor.scss
@@ -21,8 +21,6 @@
     text-align: right;
   }
 
-  margin-bottom: 20px;
-
   .title {
     display: flex;
 

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -31,8 +31,11 @@ import { IconNames } from '@blueprintjs/icons';
 import React, { useState } from 'react';
 
 import { Rule, RuleUtil } from '../../utils/load-rule';
+import { SuggestibleInput } from '../suggestible-input/suggestible-input';
 
 import './rule-editor.scss';
+
+const PERIOD_SUGGESTIONS: string[] = ['P1D', 'P7D', 'P1M', 'P1Y', 'P1000Y'];
 
 export interface RuleEditorProps {
   rule: Rule;
@@ -46,7 +49,6 @@ export interface RuleEditorProps {
 export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps) {
   const { rule, onChange, tiers, onDelete, moveUp, moveDown } = props;
   const [isOpen, setIsOpen] = useState(true);
-  if (!rule) return null;
 
   function removeTier(key: string) {
     const newTierReplicants = Object.assign({}, rule.tieredReplicants);
@@ -173,12 +175,16 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
                 })}
               </HTMLSelect>
               {RuleUtil.hasPeriod(rule) && (
-                <InputGroup
+                <SuggestibleInput
                   value={rule.period || ''}
-                  onChange={(e: any) =>
-                    onChange(RuleUtil.changePeriod(rule, e.target.value as any))
-                  }
-                  placeholder="P1D"
+                  onValueChange={period => {
+                    if (typeof period === 'undefined') return;
+                    // Ensure the period is upper case and does not contain anytihng but the allowed chars
+                    period = period.toUpperCase().replace(/[^PYMDTHS0-9]/g, '');
+                    onChange(RuleUtil.changePeriod(rule, period));
+                  }}
+                  placeholder={PERIOD_SUGGESTIONS[0]}
+                  suggestions={PERIOD_SUGGESTIONS}
                 />
               )}
               {RuleUtil.hasIncludeFuture(rule) && (

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`retention dialog matches snapshot 1`] = `
           <h4
             class="bp3-heading"
           >
-            Edit retention rules: test
+            Edit retention rules: test-datasource
           </h4>
           <button
             aria-label="Close"
@@ -404,44 +404,14 @@ exports[`retention dialog matches snapshot 1`] = `
                                   _default_tier
                                 </option>
                                 <option
-                                  value="a"
+                                  value="tier1"
                                 >
-                                  a
+                                  tier1
                                 </option>
                                 <option
-                                  value="b"
+                                  value="tier2"
                                 >
-                                  b
-                                </option>
-                                <option
-                                  value="c"
-                                >
-                                  c
-                                </option>
-                                <option
-                                  value="d"
-                                >
-                                  d
-                                </option>
-                                <option
-                                  value="e"
-                                >
-                                  e
-                                </option>
-                                <option
-                                  value="f"
-                                >
-                                  f
-                                </option>
-                                <option
-                                  value="g"
-                                >
-                                  g
-                                </option>
-                                <option
-                                  value="h"
-                                >
-                                  h
+                                  tier2
                                 </option>
                               </select>
                               <span

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -71,41 +71,528 @@ exports[`retention dialog matches snapshot 1`] = `
           >
             <div
               class="bp3-form-content"
-            />
+            >
+              <div
+                class="rule-editor"
+              >
+                <div
+                  class="title"
+                >
+                  <button
+                    class="bp3-button bp3-minimal left"
+                    type="button"
+                  >
+                    <span
+                      class="bp3-button-text"
+                    >
+                      loadByPeriod(P1000Y+future)
+                    </span>
+                    <span
+                      class="bp3-icon bp3-icon-caret-down"
+                      icon="caret-down"
+                    >
+                      <svg
+                        data-icon="caret-down"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                      >
+                        <desc>
+                          caret-down
+                        </desc>
+                        <path
+                          d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                  <div
+                    class="spacer"
+                  />
+                  <button
+                    class="bp3-button bp3-minimal"
+                    type="button"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-trash"
+                      icon="trash"
+                    >
+                      <svg
+                        data-icon="trash"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                      >
+                        <desc>
+                          trash
+                        </desc>
+                        <path
+                          d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="bp3-collapse"
+                  style="height: auto; overflow-y: visible; transition: none;"
+                >
+                  <div
+                    aria-hidden="false"
+                    class="bp3-collapse-body"
+                    style="transform: translateY(0); transition: none;"
+                  >
+                    <div
+                      class="bp3-card bp3-elevation-0"
+                    >
+                      <div
+                        class="bp3-form-group"
+                      >
+                        <div
+                          class="bp3-form-content"
+                        >
+                          <div
+                            class="bp3-control-group"
+                          >
+                            <div
+                              class="bp3-html-select"
+                            >
+                              <select>
+                                <option
+                                  value="loadForever"
+                                >
+                                  loadForever
+                                </option>
+                                <option
+                                  value="loadByInterval"
+                                >
+                                  loadByInterval
+                                </option>
+                                <option
+                                  value="loadByPeriod"
+                                >
+                                  loadByPeriod
+                                </option>
+                                <option
+                                  value="dropForever"
+                                >
+                                  dropForever
+                                </option>
+                                <option
+                                  value="dropByInterval"
+                                >
+                                  dropByInterval
+                                </option>
+                                <option
+                                  value="dropByPeriod"
+                                >
+                                  dropByPeriod
+                                </option>
+                                <option
+                                  value="dropBeforeByPeriod"
+                                >
+                                  dropBeforeByPeriod
+                                </option>
+                                <option
+                                  value="broadcastForever"
+                                >
+                                  broadcastForever
+                                </option>
+                                <option
+                                  value="broadcastByInterval"
+                                >
+                                  broadcastByInterval
+                                </option>
+                                <option
+                                  value="broadcastByPeriod"
+                                >
+                                  broadcastByPeriod
+                                </option>
+                              </select>
+                              <span
+                                class="bp3-icon bp3-icon-double-caret-vertical"
+                                icon="double-caret-vertical"
+                              >
+                                <svg
+                                  data-icon="double-caret-vertical"
+                                  height="16"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                >
+                                  <desc>
+                                    double-caret-vertical
+                                  </desc>
+                                  <path
+                                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                            </div>
+                            <div
+                              class="bp3-input-group suggestible-input"
+                            >
+                              <input
+                                class="bp3-input"
+                                placeholder="P1D"
+                                style="padding-right: 0px;"
+                                suggestions="P1D,P7D,P1M,P1Y,P1000Y"
+                                type="text"
+                                value="P1000Y"
+                              />
+                              <span
+                                class="bp3-input-action"
+                              >
+                                <span
+                                  class="bp3-popover-wrapper"
+                                >
+                                  <span
+                                    class="bp3-popover-target"
+                                  >
+                                    <button
+                                      class="bp3-button bp3-minimal"
+                                      type="button"
+                                    >
+                                      <span
+                                        class="bp3-icon bp3-icon-caret-down"
+                                        icon="caret-down"
+                                      >
+                                        <svg
+                                          data-icon="caret-down"
+                                          height="16"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                        >
+                                          <desc>
+                                            caret-down
+                                          </desc>
+                                          <path
+                                            d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </button>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                            <label
+                              class="bp3-control bp3-switch include-future"
+                            >
+                              <input
+                                checked=""
+                                type="checkbox"
+                              />
+                              <span
+                                class="bp3-control-indicator"
+                              />
+                              Include future
+                            </label>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="bp3-form-group"
+                      >
+                        <div
+                          class="bp3-form-content"
+                        >
+                          <div
+                            class="bp3-control-group"
+                          >
+                            <button
+                              class="bp3-button bp3-minimal"
+                              style="pointer-events: none;"
+                              type="button"
+                            >
+                              <span
+                                class="bp3-button-text"
+                              >
+                                Replicants:
+                              </span>
+                            </button>
+                            <div
+                              class="bp3-control-group bp3-numeric-input"
+                            >
+                              <div
+                                class="bp3-input-group"
+                              >
+                                <input
+                                  autocomplete="off"
+                                  class="bp3-input"
+                                  max="256"
+                                  min="1"
+                                  style="padding-right: 10px;"
+                                  type="text"
+                                  value="2"
+                                />
+                              </div>
+                              <div
+                                class="bp3-button-group bp3-vertical bp3-fixed"
+                              >
+                                <button
+                                  class="bp3-button"
+                                  type="button"
+                                >
+                                  <span
+                                    class="bp3-icon bp3-icon-chevron-up"
+                                    icon="chevron-up"
+                                  >
+                                    <svg
+                                      data-icon="chevron-up"
+                                      height="16"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                    >
+                                      <desc>
+                                        chevron-up
+                                      </desc>
+                                      <path
+                                        d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 001.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71z"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                                <button
+                                  class="bp3-button"
+                                  type="button"
+                                >
+                                  <span
+                                    class="bp3-icon bp3-icon-chevron-down"
+                                    icon="chevron-down"
+                                  >
+                                    <svg
+                                      data-icon="chevron-down"
+                                      height="16"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                    >
+                                      <desc>
+                                        chevron-down
+                                      </desc>
+                                      <path
+                                        d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                            <button
+                              class="bp3-button bp3-minimal"
+                              style="pointer-events: none;"
+                              type="button"
+                            >
+                              <span
+                                class="bp3-button-text"
+                              >
+                                Tier:
+                              </span>
+                            </button>
+                            <div
+                              class="bp3-html-select bp3-fill"
+                            >
+                              <select>
+                                <option
+                                  value="_default_tier"
+                                >
+                                  _default_tier
+                                </option>
+                                <option
+                                  value="a"
+                                >
+                                  a
+                                </option>
+                                <option
+                                  value="b"
+                                >
+                                  b
+                                </option>
+                                <option
+                                  value="c"
+                                >
+                                  c
+                                </option>
+                                <option
+                                  value="d"
+                                >
+                                  d
+                                </option>
+                                <option
+                                  value="e"
+                                >
+                                  e
+                                </option>
+                                <option
+                                  value="f"
+                                >
+                                  f
+                                </option>
+                                <option
+                                  value="g"
+                                >
+                                  g
+                                </option>
+                                <option
+                                  value="h"
+                                >
+                                  h
+                                </option>
+                              </select>
+                              <span
+                                class="bp3-icon bp3-icon-double-caret-vertical"
+                                icon="double-caret-vertical"
+                              >
+                                <svg
+                                  data-icon="double-caret-vertical"
+                                  height="16"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                >
+                                  <desc>
+                                    double-caret-vertical
+                                  </desc>
+                                  <path
+                                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                            </div>
+                            <button
+                              class="bp3-button bp3-disabled"
+                              disabled=""
+                              tabindex="-1"
+                              type="button"
+                            >
+                              <span
+                                class="bp3-icon bp3-icon-trash"
+                                icon="trash"
+                              >
+                                <svg
+                                  data-icon="trash"
+                                  height="16"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                >
+                                  <desc>
+                                    trash
+                                  </desc>
+                                  <path
+                                    d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </span>
+                            </button>
+                          </div>
+                          <div
+                            class="bp3-form-group right"
+                          >
+                            <div
+                              class="bp3-form-content"
+                            >
+                              <button
+                                class="bp3-button bp3-minimal"
+                                type="button"
+                              >
+                                <span
+                                  class="bp3-icon bp3-icon-plus"
+                                  icon="plus"
+                                >
+                                  <svg
+                                    data-icon="plus"
+                                    height="16"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                  >
+                                    <desc>
+                                      plus
+                                    </desc>
+                                    <path
+                                      d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                                      fill-rule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="bp3-button-text"
+                                >
+                                  Add a tier
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <button
+                  class="bp3-button"
+                  type="button"
+                >
+                  <span
+                    class="bp3-icon bp3-icon-plus"
+                    icon="plus"
+                  >
+                    <svg
+                      data-icon="plus"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <desc>
+                        plus
+                      </desc>
+                      <path
+                        d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="bp3-button-text"
+                  >
+                    New rule
+                  </span>
+                </button>
+              </div>
+            </div>
           </div>
           <div
-            class="bp3-form-group right"
+            class="bp3-divider"
+          />
+          <div
+            class="bp3-form-group"
           >
             <div
               class="bp3-form-content"
             >
+              <p>
+                Cluster defaults (
+                <a>
+                  edit
+                </a>
+                ):
+              </p>
               <button
-                class="bp3-button"
+                class="bp3-button bp3-disabled"
+                disabled=""
+                tabindex="-1"
                 type="button"
               >
                 <span
-                  class="bp3-icon bp3-icon-plus"
-                  icon="plus"
-                >
-                  <svg
-                    data-icon="plus"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      plus
-                    </desc>
-                    <path
-                      d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-                <span
                   class="bp3-button-text"
                 >
-                  New rule
+                  loadForever
                 </span>
               </button>
             </div>

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.scss
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.scss
@@ -22,16 +22,13 @@
     width: 750px;
   }
 
-  .dialog-body {
-    overflow: scroll;
-    max-height: 70vh;
-
-    .form-group {
-      margin: 0 0 5px;
+  .bp3-dialog-body {
+    .rule-editor {
+      margin-bottom: 15px;
     }
 
-    .small {
-      width: 0px;
+    .no-rules-message {
+      font-style: italic;
     }
 
     .comment {

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
@@ -25,7 +25,7 @@ describe('retention dialog', () => {
   it('matches snapshot', () => {
     const retentionDialog = (
       <RetentionDialog
-        datasource={'test'}
+        datasource={'test-datasource'}
         rules={[
           {
             period: 'P1000Y',
@@ -35,7 +35,7 @@ describe('retention dialog', () => {
           },
         ]}
         defaultRules={[{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }]}
-        tiers={['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']}
+        tiers={['tier1', 'tier2']}
         onEditDefaults={() => {}}
         onCancel={() => {}}
         onSave={() => {}}

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
@@ -26,7 +26,15 @@ describe('retention dialog', () => {
     const retentionDialog = (
       <RetentionDialog
         datasource={'test'}
-        rules={[null]}
+        rules={[
+          {
+            period: 'P1000Y',
+            includeFuture: true,
+            tieredReplicants: { _default_tier: 2 },
+            type: 'loadByPeriod',
+          },
+        ]}
+        defaultRules={[{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }]}
         tiers={['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']}
         onEditDefaults={() => {}}
         onCancel={() => {}}

--- a/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
+++ b/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
@@ -21,6 +21,15 @@ exports[`data source view matches snapshot 1`] = `
         shouldDismissPopover={true}
         text="View SQL query for table"
       />
+      <Blueprint3.MenuItem
+        disabled={false}
+        icon="edit"
+        multiline={false}
+        onClick={[Function]}
+        popoverProps={Object {}}
+        shouldDismissPopover={true}
+        text="Edit default retention rules"
+      />
     </Memo(MoreButton)>
     <Blueprint3.Switch
       checked={false}

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -53,7 +53,7 @@ import {
 } from '../../utils';
 import { BasicAction } from '../../utils/basic-action';
 import { Capabilities, CapabilitiesMode } from '../../utils/capabilities';
-import { RuleUtil } from '../../utils/load-rule';
+import { Rule, RuleUtil } from '../../utils/load-rule';
 import { LocalStorageBackedArray } from '../../utils/local-storage-backed-array';
 import { deepGet } from '../../utils/object-change';
 
@@ -107,7 +107,7 @@ function formatLoadDrop(segmentsToLoad: number, segmentsToDrop: number): string 
 
 interface Datasource {
   datasource: string;
-  rules: any[];
+  rules: Rule[];
   [key: string]: any;
 }
 
@@ -125,7 +125,7 @@ interface DatasourceQueryResultRow {
 
 interface RetentionDialogOpenOn {
   datasource: string;
-  rules: any[];
+  rules: Rule[];
 }
 
 interface CompactionDialogOpenOn {
@@ -145,7 +145,7 @@ export interface DatasourcesViewState {
   datasourcesLoading: boolean;
   datasources: Datasource[] | null;
   tiers: string[];
-  defaultRules: any[];
+  defaultRules: Rule[];
   datasourcesError?: string;
   datasourceFilter: Filter[];
 
@@ -497,6 +497,11 @@ GROUP BY 1`;
             onClick={() => goToQuery(DatasourcesView.DATASOURCE_SQL)}
           />
         )}
+        <MenuItem
+          icon={IconNames.EDIT}
+          text="Edit default retention rules"
+          onClick={this.editDefaultRules}
+        />
       </MoreButton>
     );
   }
@@ -700,13 +705,14 @@ GROUP BY 1`;
   }
 
   renderRetentionDialog() {
-    const { retentionDialogOpenOn, tiers } = this.state;
+    const { retentionDialogOpenOn, tiers, defaultRules } = this.state;
     if (!retentionDialogOpenOn) return null;
 
     return (
       <RetentionDialog
         datasource={retentionDialogOpenOn.datasource}
         rules={retentionDialogOpenOn.rules}
+        defaultRules={defaultRules}
         tiers={tiers}
         onEditDefaults={this.editDefaultRules}
         onCancel={() => this.setState({ retentionDialogOpenOn: undefined })}


### PR DESCRIPTION
This PR materializes a lot of informal feedback that I heard about the rule editor UI

![image](https://user-images.githubusercontent.com/177816/88987124-cd9a1080-d289-11ea-82ea-56b0b4e44d57.png)

Specifically:

- Add suggestions to period dropdown
- Add basic validation to period dropdown
- Show the cluster default rules for context
- Add `...` item to edit the default retention
- Improve types but replacing `any`s with proper types
- Expanded testing
- Remove dead classes, tidy CSS

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths
- [x] been tested in a test Druid cluster.

