### PR TITLE
Adding bitwise expressions

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Function.java
@@ -461,6 +461,96 @@ public interface Function
     }
   }
 
+  class BitwiseAnd extends BivariateMathFunction
+  {
+    @Override
+    public String name()
+    {
+      return "bitwiseAnd";
+    }
+
+    @Override
+    protected ExprEval eval(long x, long y)
+    {
+      return ExprEval.of(x & y);
+    }
+  }
+
+  class BitwiseComplement extends UnivariateMathFunction
+  {
+    @Override
+    public String name()
+    {
+      return "bitwiseComplement";
+    }
+
+    @Override
+    protected ExprEval eval(long param)
+    {
+      return ExprEval.of(~param);
+    }
+  }
+
+  class BitwiseOr extends BivariateMathFunction
+  {
+    @Override
+    public String name()
+    {
+      return "bitwiseOr";
+    }
+
+    @Override
+    protected ExprEval eval(long x, long y)
+    {
+      return ExprEval.of(x | y);
+    }
+  }
+
+  class BitwiseShiftLeft extends BivariateMathFunction
+  {
+    @Override
+    public String name()
+    {
+      return "bitwiseShiftLeft";
+    }
+
+    @Override
+    protected ExprEval eval(long x, long y)
+    {
+      return ExprEval.of(x << y);
+    }
+  }
+
+  class BitwiseShiftRight extends BivariateMathFunction
+  {
+    @Override
+    public String name()
+    {
+      return "bitwiseShiftRight";
+    }
+
+    @Override
+    protected ExprEval eval(long x, long y)
+    {
+      return ExprEval.of(x >> y);
+    }
+  }
+
+  class BitwiseXor extends BivariateMathFunction
+  {
+    @Override
+    public String name()
+    {
+      return "bitwiseXor";
+    }
+
+    @Override
+    protected ExprEval eval(long x, long y)
+    {
+      return ExprEval.of(x ^ y);
+    }
+  }
+
   class Cbrt extends UnivariateMathFunction
   {
     @Override

--- a/docs/misc/math-expr.md
+++ b/docs/misc/math-expr.md
@@ -117,6 +117,12 @@ See javadoc of java.lang.Math for detailed explanation for each function.
 |acos|acos(x) would return the arc cosine of x|
 |asin|asin(x) would return the arc sine of x|
 |atan|atan(x) would return the arc tangent of x|
+|bitwiseAnd|bitwiseAnd(x,y) would return the result of x & y|
+|bitwiseComplement|bitwiseComplement(x) would return the result of ~x|
+|bitwiseOr|bitwiseOr(x,y) would return the result of x [PIPE] y |
+|bitwiseShiftLeft|bitwiseShiftLeft(x,y) would return the result of x << y|
+|bitwiseShiftRight|bitwiseShiftRight(x,y) would return the result of x >> y|
+|bitwiseXor|bitwiseXor(x,y) would return the result of x ^ y|
 |atan2|atan2(y, x) would return the angle theta from the conversion of rectangular coordinates (x, y) to polar * coordinates (r, theta)|
 |cbrt|cbrt(x) would return the cube root of x|
 |ceil|ceil(x) would return the smallest (closest to negative infinity) double value that is greater than or equal to x and is equal to a mathematical integer|


### PR DESCRIPTION
Related to #8560 

This feature adds several bitwise expressions to be used on ingestion.

**Use Case**

Say you're doing CDC and your source table has a column of binary flags. For OLAP queries, it's extremely useful to have these flags extracted out into their own dimensions which can be done now on ingestion via the new expressions.

Example:

- You might have a column in your source DB called `flags` that represents a series of binary flags. Bit 1 might mean an order was placed on mobile, bit 2 might mean it was purchased on web, bit 4 might mean it was the users first purchase.
- Instead of ingesting the raw integer value of the `flags` column, you can break these columns out into something like `mobile_ind`, `web_ind`, `first_purchase_ind` where your expression can be `bitwiseAnd(flags, 1)`, `bitwiseAnd(flags, 2)`, `bitwiseAnd(flags, 4)`.

Druid SQL currently does not support bitwise operations (#8560) which makes these even more valuable IMO.

**Tested on a local cluster**

Ingestion spec:

```
{
  "type": "index_parallel",
  "spec": {
    "ioConfig": {
      "type": "index_parallel",
      "inputSource": {
        "type": "inline",
        "data": "\"x\",\"y\"\n4,2\n8,4\n16,8\n3,2\n5,2"
      },
      "inputFormat": {
        "type": "csv",
        "findColumnsFromHeader": true
      }
    },
    "tuningConfig": {
      "type": "index_parallel",
      "partitionsSpec": {
        "type": "dynamic"
      }
    },
    "dataSchema": {
      "dataSource": "bitwise_test",
      "granularitySpec": {
        "type": "uniform",
        "queryGranularity": "NONE",
        "rollup": false,
        "segmentGranularity": "YEAR"
      },
      "timestampSpec": {
        "column": "!!!_no_such_column_!!!",
        "missingValue": "2010-01-01T00:00:00Z"
      },
      "transformSpec": {
        "transforms": [
          {
            "type": "expression",
            "name": "zBitwiseAnd",
            "expression": "bitwiseAnd(CAST(x, 'LONG'), CAST(y, 'LONG'))"
          },
          {
            "type": "expression",
            "name": "zBitwiseOr",
            "expression": "bitwiseOr(CAST(x, 'LONG'), CAST(y, 'LONG'))"
          },
          {
            "type": "expression",
            "name": "zBitwiseComplement",
            "expression": "bitwiseComplement(CAST(x, 'LONG'))"
          },
          {
            "type": "expression",
            "expression": "bitwiseShiftLeft(CAST(x, 'LONG'), CAST(y, 'LONG'))",
            "name": "zBitwiseShiftLeft"
          },
          {
            "type": "expression",
            "name": "zBitwiseShiftRight",
            "expression": "bitwiseShiftRight(CAST(x, 'LONG'), CAST(y, 'LONG'))"
          },
          {
            "type": "expression",
            "name": "zBitwiseXor",
            "expression": "bitwiseXor(CAST(x, 'LONG'), CAST(y, 'LONG'))"
          }
        ]
      },
      "dimensionsSpec": {
        "dimensions": [
          {
            "type": "long",
            "name": "x"
          },
          {
            "type": "long",
            "name": "y"
          },
          {
            "type": "long",
            "name": "zBitwiseAnd"
          },
          {
            "type": "long",
            "name": "zBitwiseComplement"
          },
          {
            "type": "long",
            "name": "zBitwiseOr"
          },
          {
            "type": "long",
            "name": "zBitwiseShiftLeft"
          },
          {
            "type": "long",
            "name": "zBitwiseShiftRight"
          },
          {
            "type": "long",
            "name": "zBitwiseXor"
          }
        ]
      }
    }
  }
}
```

![Screenshot from 2020-08-01 18-27-54](https://user-images.githubusercontent.com/3860450/89112251-f8bd6500-d42d-11ea-8aff-33f761a34f61.png)


<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->