### PR TITLE
Fix Avro support in Web Console

### DIFF
--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -29,4 +29,23 @@ two Avro Parsers for stream ingestion and Hadoop batch ingestion.
 See [Avro Hadoop Parser](../../ingestion/data-formats.md#avro-hadoop-parser) and [Avro Stream Parser](../../ingestion/data-formats.md#avro-stream-parser)
 for more details about how to use these in an ingestion spec.
 
+Additionally, it provides an InputFormat for reading Avro OCF files when using
+[native batch indexing](../../ingestion/native-batch.md), see [Avro OCF](../../ingestion/data-formats.md#avro-ocf)
+for details on how to ingest OCF files.
+
 Make sure to [include](../../development/extensions.md#loading-extensions) `druid-avro-extensions` as an extension.
+
+### Avro Types
+
+Druid supports most Avro types natively, there are however some exceptions which are detailed here.
+
+`union` types which aren't of the form `[null, otherType]` aren't supported at this time.
+
+`bytes` and `fixed` Avro types will be returned by default as base64 encoded strings unless the `binaryAsString` option is enabled on the Avro parser.
+This setting will decode these types as UTF-8 strings.
+
+`enum` types will be returned as `string` of the enum symbol.
+
+`record` and `map` types representing nested data can be ingested using [flattenSpec](../../ingestion/data-formats.md#flattenspec) on the parser.
+
+Druid doesn't currently support Avro logical types, they will be ignored and fields will be handled according to the underlying primitive type.

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -227,6 +227,8 @@ The Parquet `inputFormat` has the following components:
 
 > You need to include the [`druid-avro-extensions`](../development/extensions-core/avro.md) as an extension to use the Avro OCF input format.
 
+> See the [Avro Types](../development/extensions-core/avro.md#avro-types) section for how Avro types are handled in Druid
+
 The `inputFormat` to load data of Avro OCF format. An example is:
 ```json
 "ioConfig": {
@@ -342,6 +344,8 @@ Each line can be further parsed using [`parseSpec`](#parsespec).
 ### Avro Hadoop Parser
 
 > You need to include the [`druid-avro-extensions`](../development/extensions-core/avro.md) as an extension to use the Avro Hadoop Parser.
+
+> See the [Avro Types](../development/extensions-core/avro.md#avro-types) section for how Avro types are handled in Druid
 
 This parser is for [Hadoop batch ingestion](./hadoop.md).
 The `inputFormat` of `inputSpec` in `ioConfig` must be set to `"org.apache.druid.data.input.avro.AvroValueInputFormat"`.
@@ -864,6 +868,8 @@ an explicitly defined [format](http://www.joda.org/joda-time/apidocs/org/joda/ti
 ### Avro Stream Parser
 
 > You need to include the [`druid-avro-extensions`](../development/extensions-core/avro.md) as an extension to use the Avro Stream Parser.
+
+> See the [Avro Types](../development/extensions-core/avro.md#avro-types) section for how Avro types are handled in Druid
 
 This parser is for [stream ingestion](./index.md#streaming) and reads Avro data from a stream directly.
 

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -80,7 +80,8 @@ public class AvroFlattenerMakerTest
         flattener.getRootField(record, "someNull")
     );
     Assert.assertEquals(
-        record.getSomeFixed(),
+        // Casted to an array by transformValue
+        record.getSomeFixed().bytes(),
         flattener.getRootField(record, "someFixed")
     );
     Assert.assertEquals(
@@ -89,7 +90,8 @@ public class AvroFlattenerMakerTest
         flattener.getRootField(record, "someBytes")
     );
     Assert.assertEquals(
-        record.getSomeEnum(),
+        // Casted to a string by transformValue
+        record.getSomeEnum().toString(),
         flattener.getRootField(record, "someEnum")
     );
     Assert.assertEquals(
@@ -165,7 +167,8 @@ public class AvroFlattenerMakerTest
         flattener.makeJsonPathExtractor("$.someNull").apply(record)
     );
     Assert.assertEquals(
-        record.getSomeFixed(),
+        // Casted to an array by transformValue
+        record.getSomeFixed().bytes(),
         flattener.makeJsonPathExtractor("$.someFixed").apply(record)
     );
     Assert.assertEquals(
@@ -174,7 +177,8 @@ public class AvroFlattenerMakerTest
         flattener.makeJsonPathExtractor("$.someBytes").apply(record)
     );
     Assert.assertEquals(
-        record.getSomeEnum(),
+        // Casted to a string by transformValue
+        record.getSomeEnum().toString(),
         flattener.makeJsonPathExtractor("$.someEnum").apply(record)
     );
     Assert.assertEquals(

--- a/web-console/src/utils/ingestion-spec.spec.ts
+++ b/web-console/src/utils/ingestion-spec.spec.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { cleanSpec, downgradeSpec, upgradeSpec } from './ingestion-spec';
+import { cleanSpec, downgradeSpec, guessInputFormat, upgradeSpec } from './ingestion-spec';
 
 describe('ingestion-spec', () => {
   const oldSpec = {
@@ -118,6 +118,37 @@ describe('ingestion-spec', () => {
       spec: {
         dataSchema: {},
       },
+    });
+  });
+
+  describe('guessInputFormat', () => {
+    it('works for parquet', () => {
+      expect(guessInputFormat(['PAR1lol']).type).toEqual('parquet');
+    });
+
+    it('works for orc', () => {
+      expect(guessInputFormat(['ORClol']).type).toEqual('orc');
+    });
+
+    it('works for AVRO', () => {
+      expect(guessInputFormat(['Obj\x01lol']).type).toEqual('avro_ocf');
+      expect(guessInputFormat(['Obj1lol']).type).toEqual('regex');
+    });
+
+    it('works for JSON', () => {
+      expect(guessInputFormat(['{"a":1}']).type).toEqual('json');
+    });
+
+    it('works for TSV', () => {
+      expect(guessInputFormat(['A\tB\tX\tY']).type).toEqual('tsv');
+    });
+
+    it('works for CSV', () => {
+      expect(guessInputFormat(['A,B,X,Y']).type).toEqual('csv');
+    });
+
+    it('works for regex', () => {
+      expect(guessInputFormat(['A|B|X|Y']).type).toEqual('regex');
     });
   });
 });

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -2672,7 +2672,7 @@ function guessInputFormat(sampleData: string[]): InputFormat {
       return inputFormatFromType('orc');
     }
     // Avro OCF 4 byte magic header: https://avro.apache.org/docs/current/spec.html#Object+Container+Files
-    if (sampleDatum.startsWith('Obj1')) {
+    if (sampleDatum.startsWith('Obj')) {
       return inputFormatFromType('avro_ocf');
     }
 

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -2672,7 +2672,7 @@ function guessInputFormat(sampleData: string[]): InputFormat {
       return inputFormatFromType('orc');
     }
     // Avro OCF 4 byte magic header: https://avro.apache.org/docs/current/spec.html#Object+Container+Files
-    if (sampleDatum.startsWith('Obj')) {
+    if (sampleDatum.startsWith('Obj') && sampleDatum.charCodeAt(3) === 1) {
       return inputFormatFromType('avro_ocf');
     }
 

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -2656,7 +2656,7 @@ export function fillInputFormat(spec: IngestionSpec, sampleData: string[]): Inge
   return deepSet(spec, 'spec.ioConfig.inputFormat', guessInputFormat(sampleData));
 }
 
-function guessInputFormat(sampleData: string[]): InputFormat {
+export function guessInputFormat(sampleData: string[]): InputFormat {
   let sampleDatum = sampleData[0];
   if (sampleDatum) {
     sampleDatum = String(sampleDatum); // Really ensure it is a string

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -1235,9 +1235,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 fillDataSourceNameIfNeeded(
                   fillInputFormat(
                     spec,
-                    filterMap(inputQueryState.data.data, l =>
-                      l.parsed ? l.parsed.raw : undefined,
-                    ),
+                    filterMap(inputQueryState.data.data, l => (l.input ? l.input.raw : undefined)),
                   ),
                 ),
               );

--- a/website/.spelling
+++ b/website/.spelling
@@ -613,6 +613,7 @@ Avro-1124
 SchemaRepo
 avro
 avroBytesDecoder
+flattenSpec
 jq
 org.apache.druid.extensions
 schemaRepository


### PR DESCRIPTION
Fixes #10229 

### Description

This PR includes 2 sets of fixes to make working with Avro OCF files in the Web Console work seamlessly.

The first is fixing the format detection by first changing the detection logic to run against the "raw" input rows and also patching the Avro OCF check to only check for the ASCII `Obj` prefix.

The second corrects some more fundamental issues that wouldn't have been noticed without the web UI as manual ingestion specs that don't use the sampler API or rely on root field enumeration wouldn't have run into.
First of which is that Enum and Fixed types were not properly supported in the `AvroFlattenerMaker`, they wouldn't be listed as root fields and were not properly converted into primitive types.
Additionally the `AvroFlattenerMaker` didn't override the `ObjectFlatteners#finalizeConversionForMap` method so raw Avro types leaked into the `SamplerResponse`. The raw Avro types aren't configured to be mapped correctly so were causing errors when serialising `SamplerResponse` whilst using the Web UI. This is what led to the discovery of Enum and Fixed not being supported correctly.

A follow up to this PR will likely include tests for `AvroOCFReader#sample` in a similar vein to what exists for `ParquetReader`.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `AvroFlattenerMaker`
