### PR TITLE
Add maxNumFiles to splitHintSpec

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/MaxSizeSplitHintSpec.java
+++ b/core/src/main/java/org/apache/druid/data/input/MaxSizeSplitHintSpec.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -43,20 +44,45 @@ public class MaxSizeSplitHintSpec implements SplitHintSpec
   public static final String TYPE = "maxSize";
 
   @VisibleForTesting
-  static final long DEFAULT_MAX_SPLIT_SIZE = 512 * 1024 * 1024;
+  static final HumanReadableBytes DEFAULT_MAX_SPLIT_SIZE = new HumanReadableBytes("512MiB");
 
-  private final long maxSplitSize;
+  /**
+   * There are two known issues when a split contains a large list of files.
+   *
+   * - 'jute.maxbuffer' in ZooKeeper. This system property controls the max size of ZNode. As its default is 500KB,
+   *   task allocation can fail if the serialized ingestion spec is larger than this limit.
+   * - 'max_allowed_packet' in MySQL. This is the max size of a communication packet sent to a MySQL server.
+   *   The default is either 64MB or 4MB depending on MySQL version. Updating metadata store can fail if the serialized
+   *   ingestion spec is larger than this limit.
+   *
+   * The default is consertively determined under an assumption that each file path is up to 100 bytes long.
+   */
+  @VisibleForTesting
+  static final int DEFAULT_MAX_NUM_FILES = 5000;
+
+  private final HumanReadableBytes maxSplitSize;
+  private final int maxNumFiles;
 
   @JsonCreator
-  public MaxSizeSplitHintSpec(@JsonProperty("maxSplitSize") @Nullable Long maxSplitSize)
+  public MaxSizeSplitHintSpec(
+      @JsonProperty("maxSplitSize") @Nullable HumanReadableBytes maxSplitSize,
+      @JsonProperty("maxNumFiles") @Nullable Integer maxNumFiles
+  )
   {
     this.maxSplitSize = maxSplitSize == null ? DEFAULT_MAX_SPLIT_SIZE : maxSplitSize;
+    this.maxNumFiles = maxNumFiles == null ? DEFAULT_MAX_NUM_FILES : maxNumFiles;
   }
 
   @JsonProperty
-  public long getMaxSplitSize()
+  public HumanReadableBytes getMaxSplitSize()
   {
     return maxSplitSize;
+  }
+
+  @JsonProperty
+  public int getMaxNumFiles()
+  {
+    return maxNumFiles;
   }
 
   @Override
@@ -68,6 +94,7 @@ public class MaxSizeSplitHintSpec implements SplitHintSpec
     );
     return new Iterator<List<T>>()
     {
+      private final long maxSplitSizeBytes = maxSplitSize.getBytes();
       private T peeking;
 
       @Override
@@ -84,12 +111,13 @@ public class MaxSizeSplitHintSpec implements SplitHintSpec
         }
         final List<T> current = new ArrayList<>();
         long splitSize = 0;
-        while (splitSize < maxSplitSize && (peeking != null || nonEmptyFileOnlyIterator.hasNext())) {
+        while (splitSize < maxSplitSizeBytes && (peeking != null || nonEmptyFileOnlyIterator.hasNext())) {
           if (peeking == null) {
             peeking = nonEmptyFileOnlyIterator.next();
           }
           final long size = inputAttributeExtractor.apply(peeking).getSize();
-          if (current.isEmpty() || splitSize + size < maxSplitSize) {
+          if (current.isEmpty() // each split should have at least one file even if the file is larger than maxSplitSize
+              || (splitSize + size < maxSplitSizeBytes && current.size() < maxNumFiles)) {
             current.add(peeking);
             splitSize += size;
             peeking = null;
@@ -113,12 +141,13 @@ public class MaxSizeSplitHintSpec implements SplitHintSpec
       return false;
     }
     MaxSizeSplitHintSpec that = (MaxSizeSplitHintSpec) o;
-    return maxSplitSize == that.maxSplitSize;
+    return maxNumFiles == that.maxNumFiles &&
+           Objects.equals(maxSplitSize, that.maxSplitSize);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(maxSplitSize);
+    return Objects.hash(maxSplitSize, maxNumFiles);
   }
 }

--- a/core/src/main/java/org/apache/druid/data/input/impl/SplittableInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/SplittableInputSource.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
  */
 public interface SplittableInputSource<T> extends InputSource
 {
-  SplitHintSpec DEFAULT_SPLIT_HINT_SPEC = new MaxSizeSplitHintSpec(null);
+  SplitHintSpec DEFAULT_SPLIT_HINT_SPEC = new MaxSizeSplitHintSpec(null, null);
 
   @JsonIgnore
   @Override

--- a/core/src/test/java/org/apache/druid/data/input/impl/LocalInputSourceTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/LocalInputSourceTest.java
@@ -25,6 +25,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.utils.Streams;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -69,11 +70,11 @@ public class LocalInputSourceTest
   public void testCreateSplitsRespectingSplitHintSpec()
   {
     final long fileSize = 15;
-    final long maxSplitSize = 50;
+    final HumanReadableBytes maxSplitSize = new HumanReadableBytes(50L);
     final Set<File> files = mockFiles(10, fileSize);
     final LocalInputSource inputSource = new LocalInputSource(null, null, files);
     final List<InputSplit<List<File>>> splits = inputSource
-        .createSplits(new NoopInputFormat(), new MaxSizeSplitHintSpec(maxSplitSize))
+        .createSplits(new NoopInputFormat(), new MaxSizeSplitHintSpec(maxSplitSize, null))
         .collect(Collectors.toList());
     Assert.assertEquals(4, splits.size());
     Assert.assertEquals(3, splits.get(0).get().size());
@@ -86,12 +87,12 @@ public class LocalInputSourceTest
   public void testEstimateNumSplitsRespectingSplitHintSpec()
   {
     final long fileSize = 13;
-    final long maxSplitSize = 40;
+    final HumanReadableBytes maxSplitSize = new HumanReadableBytes(40L);
     final Set<File> files = mockFiles(10, fileSize);
     final LocalInputSource inputSource = new LocalInputSource(null, null, files);
     Assert.assertEquals(
         4,
-        inputSource.estimateNumSplits(new NoopInputFormat(), new MaxSizeSplitHintSpec(maxSplitSize))
+        inputSource.estimateNumSplits(new NoopInputFormat(), new MaxSizeSplitHintSpec(maxSplitSize, null))
     );
   }
 

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -233,6 +233,7 @@ The size-based split hint spec is respected by all splittable input sources exce
 |--------|-----------|-------|---------|
 |type|This should always be `maxSize`.|none|yes|
 |maxSplitSize|Maximum number of bytes of input files to process in a single task. If a single file is larger than this number, it will be processed by itself in a single task (Files are never split across tasks yet).|500MB|no|
+|maxNumFiles|Maximum number of input files to process in a single task. This limit is to avoid task failures when the ingestion spec is too long. There are two known limits on the max size of serialized ingestion spec, i.e., the max ZNode size in ZooKeeper (`jute.maxbuffer`) and the max packet size in MySQL (`max_allowed_packet`). These can make ingestion tasks fail if the serialized ingestion spec size hits one of them.|5000|no|
 
 #### Segments Split Hint Spec
 

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -232,7 +232,7 @@ The size-based split hint spec is respected by all splittable input sources exce
 |property|description|default|required?|
 |--------|-----------|-------|---------|
 |type|This should always be `maxSize`.|none|yes|
-|maxSplitSize|Maximum number of bytes of input files to process in a single task. If a single file is larger than this number, it will be processed by itself in a single task (Files are never split across tasks yet).|500MB|no|
+|maxSplitSize|Maximum number of bytes of input files to process in a single task. If a single file is larger than this number, it will be processed by itself in a single task (Files are never split across tasks yet). [Human-readable format](../configuration/human-readable-byte.md) is supported.|500MiB|no|
 |maxNumFiles|Maximum number of input files to process in a single task. This limit is to avoid task failures when the ingestion spec is too long. There are two known limits on the max size of serialized ingestion spec, i.e., the max ZNode size in ZooKeeper (`jute.maxbuffer`) and the max packet size in MySQL (`max_allowed_packet`). These can make ingestion tasks fail if the serialized ingestion spec size hits one of them.|5000|no|
 
 #### Segments Split Hint Spec


### PR DESCRIPTION
### Description

This PR adds `maxNumFiles` to `maxSize` splitHintSpec which is a new limit on the max number of files in a split. Also, the human readable format is now supported for `maxSplitSize`.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.