### PR TITLE
fix bug with expressions on sparse string realtime columns without explicit null valued rows

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
@@ -59,7 +59,7 @@ public class StringDimensionIndexerBenchmark
   @Setup
   public void setup()
   {
-    indexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true);
+    indexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false);
 
     for (int i = 0; i < cardinality; i++) {
       indexer.processRowValsToUnsortedEncodedKeyComponent("abcd-" + i, true);

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -47,7 +47,7 @@ import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.BaseProgressIndicator;
 import org.apache.druid.segment.ProgressIndicator;
 import org.apache.druid.segment.QueryableIndex;
-import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.indexing.TuningConfigs;
@@ -289,7 +289,7 @@ public class IndexGeneratorJob implements Jobby
       AggregatorFactory[] aggs,
       HadoopDruidIndexerConfig config,
       Iterable<String> oldDimOrder,
-      Map<String, ColumnCapabilitiesImpl> oldCapabilities
+      Map<String, ColumnCapabilities> oldCapabilities
   )
   {
     final HadoopTuningConfig tuningConfig = config.getSchema().getTuningConfig();

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -340,7 +340,7 @@ public class GroupByQueryEngineV2
 
               // Now check column capabilities.
               final ColumnCapabilities columnCapabilities = capabilitiesFunction.apply(dimension.getDimension());
-              return (columnCapabilities != null && !columnCapabilities.hasMultipleValues().isMaybeTrue()) ||
+              return (columnCapabilities != null && columnCapabilities.hasMultipleValues().isFalse()) ||
                      (missingMeansNonExistent && columnCapabilities == null);
             });
   }

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -227,7 +227,7 @@ public class SegmentAnalyzer
         min = NullHandling.nullToEmptyIfNeeded(bitmapIndex.getValue(0));
         max = NullHandling.nullToEmptyIfNeeded(bitmapIndex.getValue(cardinality - 1));
       }
-    } else if (capabilities.isDictionaryEncoded()) {
+    } else if (capabilities.isDictionaryEncoded().isTrue()) {
       // fallback if no bitmap index
       DictionaryEncodedColumn<String> theColumn = (DictionaryEncodedColumn<String>) columnHolder.getColumn();
       cardinality = theColumn.getCardinality();

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -194,7 +194,7 @@ public class TopNQueryEngine
     }
     if (capabilities != null && capabilities.getType() == ValueType.STRING) {
       // string columns must use the on heap algorithm unless they have the following capabilites
-      return capabilities.isDictionaryEncoded() && capabilities.areDictionaryValuesUnique().isTrue();
+      return capabilities.isDictionaryEncoded().isTrue() && capabilities.areDictionaryValuesUnique().isTrue();
     } else {
       // non-strings are not eligible to use the pooled algorithm, and should use a heap algorithm
       return false;

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -73,7 +73,7 @@ public final class DimensionHandlerUtils
   )
   {
     if (capabilities == null) {
-      return new StringDimensionHandler(dimensionName, multiValueHandling, true);
+      return new StringDimensionHandler(dimensionName, multiValueHandling, true, false);
     }
 
     multiValueHandling = multiValueHandling == null ? MultiValueHandling.ofDefault() : multiValueHandling;
@@ -82,7 +82,7 @@ public final class DimensionHandlerUtils
       if (!capabilities.isDictionaryEncoded()) {
         throw new IAE("String column must have dictionary encoding.");
       }
-      return new StringDimensionHandler(dimensionName, multiValueHandling, capabilities.hasBitmapIndexes());
+      return new StringDimensionHandler(dimensionName, multiValueHandling, capabilities.hasBitmapIndexes(), capabilities.hasSpatialIndexes());
     }
 
     if (capabilities.getType() == ValueType.LONG) {
@@ -98,7 +98,7 @@ public final class DimensionHandlerUtils
     }
 
     // Return a StringDimensionHandler by default (null columns will be treated as String typed)
-    return new StringDimensionHandler(dimensionName, multiValueHandling, true);
+    return new StringDimensionHandler(dimensionName, multiValueHandling, true, false);
   }
 
   public static List<ValueType> getValueTypesFromDimensionSpecs(List<DimensionSpec> dimSpecs)

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -79,7 +79,7 @@ public final class DimensionHandlerUtils
     multiValueHandling = multiValueHandling == null ? MultiValueHandling.ofDefault() : multiValueHandling;
 
     if (capabilities.getType() == ValueType.STRING) {
-      if (!capabilities.isDictionaryEncoded()) {
+      if (!capabilities.isDictionaryEncoded().isMaybeTrue()) {
         throw new IAE("String column must have dictionary encoding.");
       }
       return new StringDimensionHandler(dimensionName, multiValueHandling, capabilities.hasBitmapIndexes(), capabilities.hasSpatialIndexes());
@@ -226,11 +226,11 @@ public final class DimensionHandlerUtils
       capabilities = ColumnCapabilitiesImpl.copyOf(capabilities)
                                            .setType(ValueType.STRING)
                                            .setDictionaryValuesUnique(
-                                               capabilities.isDictionaryEncoded() &&
+                                               capabilities.isDictionaryEncoded().isTrue() &&
                                                fn.getExtractionType() == ExtractionFn.ExtractionType.ONE_TO_ONE
                                            )
                                            .setDictionaryValuesSorted(
-                                               capabilities.isDictionaryEncoded() && fn.preservesOrdering()
+                                               capabilities.isDictionaryEncoded().isTrue() && fn.preservesOrdering()
                                            );
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -79,7 +79,7 @@ public final class DimensionHandlerUtils
     multiValueHandling = multiValueHandling == null ? MultiValueHandling.ofDefault() : multiValueHandling;
 
     if (capabilities.getType() == ValueType.STRING) {
-      if (capabilities.isDictionaryEncoded().isFalse()) {
+      if (!capabilities.isDictionaryEncoded().isTrue()) {
         throw new IAE("String column must have dictionary encoding.");
       }
       return new StringDimensionHandler(dimensionName, multiValueHandling, capabilities.hasBitmapIndexes(), capabilities.hasSpatialIndexes());

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -79,7 +79,7 @@ public final class DimensionHandlerUtils
     multiValueHandling = multiValueHandling == null ? MultiValueHandling.ofDefault() : multiValueHandling;
 
     if (capabilities.getType() == ValueType.STRING) {
-      if (!capabilities.isDictionaryEncoded().isMaybeTrue()) {
+      if (capabilities.isDictionaryEncoded().isFalse()) {
         throw new IAE("String column must have dictionary encoding.");
       }
       return new StringDimensionHandler(dimensionName, multiValueHandling, capabilities.hasBitmapIndexes(), capabilities.hasSpatialIndexes());

--- a/processing/src/main/java/org/apache/druid/segment/DimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionIndexer.java
@@ -22,7 +22,7 @@ package org.apache.druid.segment;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.MutableBitmap;
 import org.apache.druid.query.dimension.DimensionSpec;
-import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexRowHolder;
@@ -237,7 +237,7 @@ public interface DimensionIndexer
       IncrementalIndex.DimensionDesc desc
   );
 
-  ColumnCapabilitiesImpl getColumnCapabilities();
+  ColumnCapabilities getColumnCapabilities();
   /**
    * Compares the row values for this DimensionIndexer's dimension from a Row key.
    *

--- a/processing/src/main/java/org/apache/druid/segment/DimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionIndexer.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.MutableBitmap;
 import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexRowHolder;
@@ -236,6 +237,7 @@ public interface DimensionIndexer
       IncrementalIndex.DimensionDesc desc
   );
 
+  ColumnCapabilitiesImpl getColumnCapabilities();
   /**
    * Compares the row values for this DimensionIndexer's dimension from a Row key.
    *

--- a/processing/src/main/java/org/apache/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/DoubleDimensionIndexer.java
@@ -25,6 +25,8 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexRowHolder;
@@ -37,6 +39,9 @@ import java.util.Objects;
 public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, Double>
 {
   public static final Comparator<Double> DOUBLE_COMPARATOR = Comparators.naturalNullsFirst();
+
+  private final ColumnCapabilitiesImpl capabilities =
+      ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ValueType.DOUBLE);
 
   @Override
   public Double processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
@@ -87,6 +92,12 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
   public int getCardinality()
   {
     return DimensionDictionarySelector.CARDINALITY_UNKNOWN;
+  }
+
+  @Override
+  public ColumnCapabilitiesImpl getColumnCapabilities()
+  {
+    return capabilities;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/DoubleDimensionIndexer.java
@@ -25,6 +25,7 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.CloseableIndexed;
@@ -95,7 +96,7 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
   }
 
   @Override
-  public ColumnCapabilitiesImpl getColumnCapabilities()
+  public ColumnCapabilities getColumnCapabilities()
   {
     return capabilities;
   }

--- a/processing/src/main/java/org/apache/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/FloatDimensionIndexer.java
@@ -25,6 +25,8 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexRowHolder;
@@ -37,6 +39,9 @@ import java.util.Objects;
 public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Float>
 {
   public static final Comparator<Float> FLOAT_COMPARATOR = Comparators.naturalNullsFirst();
+
+  private final ColumnCapabilitiesImpl capabilities =
+      ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ValueType.FLOAT);
 
   @Override
   public Float processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
@@ -88,6 +93,12 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
   public int getCardinality()
   {
     return DimensionDictionarySelector.CARDINALITY_UNKNOWN;
+  }
+
+  @Override
+  public ColumnCapabilitiesImpl getColumnCapabilities()
+  {
+    return capabilities;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/FloatDimensionIndexer.java
@@ -25,6 +25,7 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.CloseableIndexed;
@@ -96,7 +97,7 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
   }
 
   @Override
-  public ColumnCapabilitiesImpl getColumnCapabilities()
+  public ColumnCapabilities getColumnCapabilities()
   {
     return capabilities;
   }

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -89,7 +89,7 @@ public class IndexMergerV9 implements IndexMerger
   private static final Logger log = new Logger(IndexMergerV9.class);
 
   // merge logic for the state capabilities will be in after incremental index is persisted
-  private static final ColumnCapabilities.CoercionLogic DIMENSION_CAPABILITY_MERGE_LOGIC =
+  public static final ColumnCapabilities.CoercionLogic DIMENSION_CAPABILITY_MERGE_LOGIC =
       new ColumnCapabilities.CoercionLogic()
       {
         @Override
@@ -108,6 +108,34 @@ public class IndexMergerV9 implements IndexMerger
         public boolean dictionaryValuesUnique()
         {
           return true;
+        }
+
+        @Override
+        public boolean multipleValues()
+        {
+          return false;
+        }
+      };
+
+  public static final ColumnCapabilities.CoercionLogic METRIC_CAPABILITY_MERGE_LOGIC =
+      new ColumnCapabilities.CoercionLogic()
+      {
+        @Override
+        public boolean dictionaryEncoded()
+        {
+          return false;
+        }
+
+        @Override
+        public boolean dictionaryValuesSorted()
+        {
+          return false;
+        }
+
+        @Override
+        public boolean dictionaryValuesUnique()
+        {
+          return false;
         }
 
         @Override
@@ -759,7 +787,7 @@ public class IndexMergerV9 implements IndexMerger
       for (String metric : adapter.getMetricNames()) {
         ColumnCapabilities capabilities = adapter.getCapabilities(metric);
         capabilitiesMap.compute(metric, (m, existingCapabilities) ->
-            ColumnCapabilitiesImpl.merge(capabilities, existingCapabilities, ColumnCapabilitiesImpl.ALL_FALSE)
+            ColumnCapabilitiesImpl.merge(capabilities, existingCapabilities, METRIC_CAPABILITY_MERGE_LOGIC)
         );
         metricsValueTypes.put(metric, capabilities.getType());
         metricTypeNames.put(metric, adapter.getMetricType(metric));

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -1068,7 +1068,10 @@ public class IndexMergerV9 implements IndexMerger
   {
     Map<String, DimensionHandler> handlers = new LinkedHashMap<>();
     for (int i = 0; i < mergedDimensions.size(); i++) {
-      ColumnCapabilities capabilities = dimCapabilities.get(i);
+      ColumnCapabilities capabilities = ColumnCapabilitiesImpl.snapshot(
+          dimCapabilities.get(i),
+          DIMENSION_CAPABILITY_MERGE_LOGIC
+      );
       String dimName = mergedDimensions.get(i);
       DimensionHandler handler = DimensionHandlerUtils.getHandlerFromCapabilities(dimName, capabilities, null);
       handlers.put(dimName, handler);

--- a/processing/src/main/java/org/apache/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/LongDimensionIndexer.java
@@ -25,6 +25,8 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexRowHolder;
@@ -37,6 +39,10 @@ import java.util.Objects;
 public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
 {
   public static final Comparator LONG_COMPARATOR = Comparators.<Long>naturalNullsFirst();
+
+  private final ColumnCapabilitiesImpl capabilities =
+      ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ValueType.LONG);
+
 
   @Override
   public Long processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
@@ -88,6 +94,12 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
   public int getCardinality()
   {
     return DimensionDictionarySelector.CARDINALITY_UNKNOWN;
+  }
+
+  @Override
+  public ColumnCapabilitiesImpl getColumnCapabilities()
+  {
+    return capabilities;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/LongDimensionIndexer.java
@@ -25,6 +25,7 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.CloseableIndexed;
@@ -97,7 +98,7 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
   }
 
   @Override
-  public ColumnCapabilitiesImpl getColumnCapabilities()
+  public ColumnCapabilities getColumnCapabilities()
   {
     return capabilities;
   }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
@@ -98,12 +98,14 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
   private final String dimensionName;
   private final MultiValueHandling multiValueHandling;
   private final boolean hasBitmapIndexes;
+  private final boolean hasSpatialIndexes;
 
-  public StringDimensionHandler(String dimensionName, MultiValueHandling multiValueHandling, boolean hasBitmapIndexes)
+  public StringDimensionHandler(String dimensionName, MultiValueHandling multiValueHandling, boolean hasBitmapIndexes, boolean hasSpatialIndexes)
   {
     this.dimensionName = dimensionName;
     this.multiValueHandling = multiValueHandling;
     this.hasBitmapIndexes = hasBitmapIndexes;
+    this.hasSpatialIndexes = hasSpatialIndexes;
   }
 
   @Override
@@ -139,7 +141,7 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
   @Override
   public DimensionIndexer<Integer, int[], String> makeIndexer()
   {
-    return new StringDimensionIndexer(multiValueHandling, hasBitmapIndexes);
+    return new StringDimensionIndexer(multiValueHandling, hasBitmapIndexes, hasSpatialIndexes);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -472,12 +472,12 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
   @Override
   public ColumnCapabilitiesImpl getColumnCapabilities()
   {
-    ColumnCapabilitiesImpl capabilites =  new ColumnCapabilitiesImpl().setType(ValueType.STRING)
-                                                                      .setHasBitmapIndexes(hasBitmapIndexes)
-                                                                      .setHasSpatialIndexes(false)
-                                                                      .setDictionaryEncoded(dictionaryEncodesAllValues())
-                                                                      .setDictionaryValuesUnique(true)
-                                                                      .setDictionaryValuesSorted(false);
+    ColumnCapabilitiesImpl capabilites = new ColumnCapabilitiesImpl().setType(ValueType.STRING)
+                                                                     .setHasBitmapIndexes(hasBitmapIndexes)
+                                                                     .setHasSpatialIndexes(false)
+                                                                     .setDictionaryEncoded(dictionaryEncodesAllValues())
+                                                                     .setDictionaryValuesUnique(true)
+                                                                     .setDictionaryValuesSorted(false);
     // strings are only single valued, until they are not...
     // only explicitly set multiple values if they are certain, otherwise this indexer might process a multi-valued
     // row in the future in the period between obtaining capabilities and actually processing the rows with a selector

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -235,17 +235,19 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
   private final DimensionDictionary dimLookup;
   private final MultiValueHandling multiValueHandling;
   private final boolean hasBitmapIndexes;
+  private final boolean hasSpatialIndexes;
   private volatile boolean hasMultipleValues = false;
   private volatile boolean isSparse = false;
 
   @Nullable
   private SortedDimensionDictionary sortedLookup;
 
-  public StringDimensionIndexer(MultiValueHandling multiValueHandling, boolean hasBitmapIndexes)
+  public StringDimensionIndexer(MultiValueHandling multiValueHandling, boolean hasBitmapIndexes, boolean hasSpatialIndexes)
   {
     this.dimLookup = new DimensionDictionary();
     this.multiValueHandling = multiValueHandling == null ? MultiValueHandling.ofDefault() : multiValueHandling;
     this.hasBitmapIndexes = hasBitmapIndexes;
+    this.hasSpatialIndexes = hasSpatialIndexes;
   }
 
   @Override
@@ -474,7 +476,7 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
   {
     ColumnCapabilitiesImpl capabilites = new ColumnCapabilitiesImpl().setType(ValueType.STRING)
                                                                      .setHasBitmapIndexes(hasBitmapIndexes)
-                                                                     .setHasSpatialIndexes(false)
+                                                                     .setHasSpatialIndexes(hasSpatialIndexes)
                                                                      .setDictionaryEncoded(dictionaryEncodesAllValues())
                                                                      .setDictionaryValuesUnique(true)
                                                                      .setDictionaryValuesSorted(false);

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -405,6 +405,9 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
    */
   public boolean dictionaryEncodesAllValues()
   {
+    // name lookup is possible in advance if we process a value for every row (setSparseIndexed was not called on this
+    // column) or we've encountered an actual null value and it is present in our dictionary. otherwise the dictionary
+    // will be missing null values
     return !isSparse || dimLookup.idForNull != ABSENT_VALUE_ID;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -477,15 +477,20 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
     ColumnCapabilitiesImpl capabilites = new ColumnCapabilitiesImpl().setType(ValueType.STRING)
                                                                      .setHasBitmapIndexes(hasBitmapIndexes)
                                                                      .setHasSpatialIndexes(hasSpatialIndexes)
-                                                                     .setDictionaryEncoded(dictionaryEncodesAllValues())
                                                                      .setDictionaryValuesUnique(true)
                                                                      .setDictionaryValuesSorted(false);
+
     // strings are only single valued, until they are not...
     // only explicitly set multiple values if they are certain, otherwise this indexer might process a multi-valued
     // row in the future in the period between obtaining capabilities and actually processing the rows with a selector
     // leaving as unknown allows the caller to decide
     if (hasMultipleValues) {
       capabilites.setHasMultipleValues(true);
+    }
+    // likewise only set dictionaryEncoded if explicitly if true
+    final boolean allValuesEncoded = dictionaryEncodesAllValues();
+    if (allValuesEncoded) {
+      capabilites.setDictionaryEncoded(true);
     }
     return capabilites;
   }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -74,7 +74,7 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
     private String minValue = null;
     @Nullable
     private String maxValue = null;
-    private int idForNull = ABSENT_VALUE_ID;
+    private volatile int idForNull = ABSENT_VALUE_ID;
 
     private final Object2IntMap<String> valueToId = new Object2IntOpenHashMap<>();
 
@@ -400,6 +400,14 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
     return dimLookup.size();
   }
 
+  /**
+   * returns true if all values are encoded in {@link #dimLookup}
+   */
+  public boolean dictionaryEncodesAllValues()
+  {
+    return !isSparse || dimLookup.idForNull != ABSENT_VALUE_ID;
+  }
+
   @Override
   public int compareUnsortedEncodedKeyComponents(int[] lhs, int[] rhs)
   {
@@ -630,9 +638,7 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
       @Override
       public boolean nameLookupPossibleInAdvance()
       {
-        // name lookup is possible in advance if we got a value for every row (setSparseIndexed was not called on this
-        // column) or we've encountered an actual null value and it is present in our dictionary
-        return !isSparse || dimLookup.idForNull != ABSENT_VALUE_ID;
+        return dictionaryEncodesAllValues();
       }
 
       @Nullable

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilities.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilities.java
@@ -30,13 +30,12 @@ import javax.annotation.Nullable;
 public interface ColumnCapabilities
 {
   ValueType getType();
-  boolean isDictionaryEncoded();
+  Capable isDictionaryEncoded();
   Capable areDictionaryValuesSorted();
   Capable areDictionaryValuesUnique();
-  boolean isRunLengthEncoded();
+  Capable hasMultipleValues();
   boolean hasBitmapIndexes();
   boolean hasSpatialIndexes();
-  Capable hasMultipleValues();
   boolean isFilterable();
 
   enum Capable
@@ -103,6 +102,48 @@ public interface ColumnCapabilities
     public String toString()
     {
       return StringUtils.toLowerCase(super.toString());
+    }
+  }
+
+  interface CoercionLogic
+  {
+    boolean dictionaryEncoded();
+    boolean dictionaryValuesSorted();
+    boolean dictionaryValuesUnique();
+    boolean multipleValues();
+  }
+
+  class AllCoercionLogic implements CoercionLogic
+  {
+    private final boolean coerceTo;
+
+    public AllCoercionLogic(boolean coerceTo)
+    {
+      this.coerceTo = coerceTo;
+    }
+
+    @Override
+    public boolean dictionaryEncoded()
+    {
+      return coerceTo;
+    }
+
+    @Override
+    public boolean dictionaryValuesSorted()
+    {
+      return coerceTo;
+    }
+
+    @Override
+    public boolean dictionaryValuesUnique()
+    {
+      return coerceTo;
+    }
+
+    @Override
+    public boolean multipleValues()
+    {
+      return coerceTo;
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilities.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilities.java
@@ -54,6 +54,11 @@ public interface ColumnCapabilities
       return isTrue() || isUnknown();
     }
 
+    public boolean isFalse()
+    {
+      return this == FALSE;
+    }
+
     public boolean isUnknown()
     {
       return this == UNKNOWN;
@@ -111,39 +116,5 @@ public interface ColumnCapabilities
     boolean dictionaryValuesSorted();
     boolean dictionaryValuesUnique();
     boolean multipleValues();
-  }
-
-  class AllCoercionLogic implements CoercionLogic
-  {
-    private final boolean coerceTo;
-
-    public AllCoercionLogic(boolean coerceTo)
-    {
-      this.coerceTo = coerceTo;
-    }
-
-    @Override
-    public boolean dictionaryEncoded()
-    {
-      return coerceTo;
-    }
-
-    @Override
-    public boolean dictionaryValuesSorted()
-    {
-      return coerceTo;
-    }
-
-    @Override
-    public boolean dictionaryValuesUnique()
-    {
-      return coerceTo;
-    }
-
-    @Override
-    public boolean multipleValues()
-    {
-      return coerceTo;
-    }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilities.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilities.java
@@ -26,16 +26,59 @@ import org.apache.druid.java.util.common.StringUtils;
 import javax.annotation.Nullable;
 
 /**
+ * This interface is used to expose information about columns that is interesting to know for all matters dealing with
+ * reading from columns, including query planning and optimization, creating readers to merge segments at ingestion
+ * time, and probably nearly anything else you can imagine.
  */
 public interface ColumnCapabilities
 {
+  /**
+   * Column type, good to know so caller can know what to expect and which optimal selector to use
+   */
   ValueType getType();
+
+  /**
+   * Is the column dictionary encoded? If so, a DimensionDictionarySelector may be used instead of using a value
+   * selector, allowing algorithms to operate on primitive integer dictionary ids rather than the looked up dictionary
+   * values
+   */
   Capable isDictionaryEncoded();
+
+  /**
+   * If the column is dictionary encoded, are those values sorted? Useful to know for optimizations that can defer
+   * looking up values and allowing sorting with the dictionary ids directly
+   */
   Capable areDictionaryValuesSorted();
+
+  /**
+   * If the column is dictionary encoded, is there a 1:1 mapping of dictionary ids to values? If this is true, it
+   * unlocks optimizations such as allowing for things like grouping directly on dictionary ids and deferred value
+   * lookup
+   */
   Capable areDictionaryValuesUnique();
+
+  /**
+   * String columns are sneaky, and might have multiple values, this is to allow callers to know and appropriately
+   * prepare themselves
+   */
   Capable hasMultipleValues();
+
+  /**
+   * Does the column have an inverted index bitmap for each value? If so, these may be employed to 'pre-filter' the
+   * column by examining if the values match the filter and intersecting the bitmaps, to avoid having to scan and
+   * evaluate if every row matches the filter
+   */
   boolean hasBitmapIndexes();
+
+  /**
+   * Does the column have spatial indexes available to allow use with spatial filtering?
+   */
   boolean hasSpatialIndexes();
+
+  /**
+   * All Druid primitive columns support filtering, maybe with or without indexes, but by default complex columns
+   * do not support direct filtering, unless provided by through a custom implementation.
+   */
   boolean isFilterable();
 
   enum Capable
@@ -110,11 +153,35 @@ public interface ColumnCapabilities
     }
   }
 
+  /**
+   * This interface define the shape of a mechnism to allow for bespoke coercion of {@link Capable#UNKNOWN} into
+   * {@link Capable#TRUE} or {@link Capable#FALSE} for each {@link Capable} of a {@link ColumnCapabilities}, as is
+   * appropriate for the situation of the caller.
+   */
   interface CoercionLogic
   {
+    /**
+     * If {@link ColumnCapabilities#isDictionaryEncoded()} is {@link Capable#UNKNOWN}, define if it should be treated
+     * as true or false.
+     */
     boolean dictionaryEncoded();
+
+    /**
+     * If {@link ColumnCapabilities#areDictionaryValuesSorted()} ()} is {@link Capable#UNKNOWN}, define if it should be treated
+     * as true or false.
+     */
     boolean dictionaryValuesSorted();
+
+    /**
+     * If {@link ColumnCapabilities#areDictionaryValuesUnique()} ()} is {@link Capable#UNKNOWN}, define if it should be treated
+     * as true or false.
+     */
     boolean dictionaryValuesUnique();
+
+    /**
+     * If {@link ColumnCapabilities#hasMultipleValues()} is {@link Capable#UNKNOWN}, define if it should be treated
+     * as true or false.
+     */
     boolean multipleValues();
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilitiesImpl.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilitiesImpl.java
@@ -32,8 +32,6 @@ import javax.annotation.Nullable;
  */
 public class ColumnCapabilitiesImpl implements ColumnCapabilities
 {
-  public static final CoercionLogic ALL_FALSE = new AllCoercionLogic(false);
-
   public static ColumnCapabilitiesImpl copyOf(@Nullable final ColumnCapabilities other)
   {
     final ColumnCapabilitiesImpl capabilities = new ColumnCapabilitiesImpl();

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilitiesImpl.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilitiesImpl.java
@@ -32,7 +32,6 @@ import javax.annotation.Nullable;
  */
 public class ColumnCapabilitiesImpl implements ColumnCapabilities
 {
-  public static final CoercionLogic ALL_TRUE = new AllCoercionLogic(true);
   public static final CoercionLogic ALL_FALSE = new AllCoercionLogic(false);
 
   public static ColumnCapabilitiesImpl copyOf(@Nullable final ColumnCapabilities other)

--- a/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
@@ -115,7 +115,7 @@ public class ExpressionFilter implements Filter
       // multiple values. The lack of multiple values is important because expression filters treat multi-value
       // arrays as nulls, which doesn't permit index based filtering.
       final String column = Iterables.getOnlyElement(requiredBindings.get());
-      return selector.getBitmapIndex(column) != null && !selector.hasMultipleValues(column).isMaybeTrue();
+      return selector.getBitmapIndex(column) != null && selector.hasMultipleValues(column).isFalse();
     } else {
       // Multi-column expression.
       return false;

--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -414,7 +414,7 @@ public class Filters
     if (filter.supportsBitmapIndex(indexSelector)) {
       final ColumnHolder columnHolder = columnSelector.getColumnHolder(dimension);
       if (columnHolder != null) {
-        return !columnHolder.getCapabilities().hasMultipleValues().isMaybeTrue();
+        return columnHolder.getCapabilities().hasMultipleValues().isFalse();
       }
     }
     return false;

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -954,6 +954,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
       for (String dim : oldDimensionOrder) {
         if (dimensionDescs.get(dim) == null) {
           ColumnCapabilitiesImpl capabilities = oldColumnCapabilities.get(dim);
+          capabilities.setDictionaryEncoded(capabilities.getType().equals(ValueType.STRING));
           DimensionHandler handler = DimensionHandlerUtils.getHandlerFromCapabilities(dim, capabilities, null);
           addNewDimension(dim, handler);
         }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -59,6 +59,7 @@ import org.apache.druid.segment.DimensionIndexer;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.DoubleColumnSelector;
 import org.apache.druid.segment.FloatColumnSelector;
+import org.apache.druid.segment.IndexMergerV9;
 import org.apache.druid.segment.LongColumnSelector;
 import org.apache.druid.segment.Metadata;
 import org.apache.druid.segment.NilColumnValueSelector;
@@ -953,8 +954,10 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
       }
       for (String dim : oldDimensionOrder) {
         if (dimensionDescs.get(dim) == null) {
-          ColumnCapabilitiesImpl capabilities = oldColumnCapabilities.get(dim);
-          capabilities.setDictionaryEncoded(capabilities.getType().equals(ValueType.STRING));
+          ColumnCapabilitiesImpl capabilities = ColumnCapabilitiesImpl.snapshot(
+              oldColumnCapabilities.get(dim),
+              IndexMergerV9.DIMENSION_CAPABILITY_MERGE_LOGIC
+          );
           DimensionHandler handler = DimensionHandlerUtils.getHandlerFromCapabilities(dim, capabilities, null);
           addNewDimension(dim, handler);
         }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -945,7 +945,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
    */
   public void loadDimensionIterable(
       Iterable<String> oldDimensionOrder,
-      Map<String, ColumnCapabilitiesImpl> oldColumnCapabilities
+      Map<String, ColumnCapabilities> oldColumnCapabilities
   )
   {
     synchronized (dimensionDescs) {

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -250,7 +250,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
   private final Map<String, DimensionDesc> dimensionDescs;
   private final List<DimensionDesc> dimensionDescsList;
   // dimension capabilities are provided by the indexers
-  private final Map<String, ColumnCapabilitiesImpl> timeAndMetricsColumnCapabilities;
+  private final Map<String, ColumnCapabilities> timeAndMetricsColumnCapabilities;
   private final AtomicInteger numEntries = new AtomicInteger();
   private final AtomicLong bytesInMemory = new AtomicLong();
 
@@ -588,10 +588,10 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     return row;
   }
 
-  public Map<String, ColumnCapabilitiesImpl> getColumnCapabilities()
+  public Map<String, ColumnCapabilities> getColumnCapabilities()
   {
-    ImmutableMap.Builder<String, ColumnCapabilitiesImpl> builder =
-        ImmutableMap.<String, ColumnCapabilitiesImpl>builder().putAll(timeAndMetricsColumnCapabilities);
+    ImmutableMap.Builder<String, ColumnCapabilities> builder =
+        ImmutableMap.<String, ColumnCapabilities>builder().putAll(timeAndMetricsColumnCapabilities);
 
     dimensionDescs.forEach((dimension, desc) -> builder.put(dimension, desc.getCapabilities()));
     return builder.build();
@@ -1099,7 +1099,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
       return name;
     }
 
-    public ColumnCapabilitiesImpl getCapabilities()
+    public ColumnCapabilities getCapabilities()
     {
       return indexer.getColumnCapabilities();
     }
@@ -1120,7 +1120,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     private final int index;
     private final String name;
     private final String type;
-    private final ColumnCapabilitiesImpl capabilities;
+    private final ColumnCapabilities capabilities;
 
     public MetricDesc(int index, AggregatorFactory factory)
     {
@@ -1159,7 +1159,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
       return type;
     }
 
-    public ColumnCapabilitiesImpl getCapabilities()
+    public ColumnCapabilities getCapabilities()
     {
       return capabilities;
     }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -154,7 +154,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
     // to the StringDimensionIndexer so the selector built on top of it can produce values from the snapshot state of
     // multi-valuedness at cursor creation time, instead of the latest state, and getSnapshotColumnCapabilities could
     // be removed.
-    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), true);
+    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), ColumnCapabilitiesImpl.ALL_TRUE);
   }
 
   /**
@@ -165,7 +165,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
    */
   public ColumnCapabilities getSnapshotColumnCapabilities(String column)
   {
-    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column));
+    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), ColumnCapabilitiesImpl.ALL_FALSE);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -52,6 +52,62 @@ import java.util.Iterator;
  */
 public class IncrementalIndexStorageAdapter implements StorageAdapter
 {
+  private static final ColumnCapabilities.CoercionLogic STORAGE_ADAPTER_CAPABILITIES_COERCE_LOGIC =
+      new ColumnCapabilities.CoercionLogic()
+      {
+        @Override
+        public boolean dictionaryEncoded()
+        {
+          return false;
+        }
+
+        @Override
+        public boolean dictionaryValuesSorted()
+        {
+          return false;
+        }
+
+        @Override
+        public boolean dictionaryValuesUnique()
+        {
+          return true;
+        }
+
+        @Override
+        public boolean multipleValues()
+        {
+          return true;
+        }
+      };
+
+  private static final ColumnCapabilities.CoercionLogic SNAPSHOT_STORAGE_ADAPTER_CAPABILITIES_COERCE_LOGIC =
+      new ColumnCapabilities.CoercionLogic()
+      {
+        @Override
+        public boolean dictionaryEncoded()
+        {
+          return true;
+        }
+
+        @Override
+        public boolean dictionaryValuesSorted()
+        {
+          return true;
+        }
+
+        @Override
+        public boolean dictionaryValuesUnique()
+        {
+          return true;
+        }
+
+        @Override
+        public boolean multipleValues()
+        {
+          return false;
+        }
+      };
+
   final IncrementalIndex<?> index;
 
   public IncrementalIndexStorageAdapter(IncrementalIndex<?> index)
@@ -154,7 +210,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
     // to the StringDimensionIndexer so the selector built on top of it can produce values from the snapshot state of
     // multi-valuedness at cursor creation time, instead of the latest state, and getSnapshotColumnCapabilities could
     // be removed.
-    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), ColumnCapabilitiesImpl.ALL_TRUE);
+    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), STORAGE_ADAPTER_CAPABILITIES_COERCE_LOGIC);
   }
 
   /**
@@ -165,7 +221,10 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
    */
   public ColumnCapabilities getSnapshotColumnCapabilities(String column)
   {
-    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), ColumnCapabilitiesImpl.ALL_FALSE);
+    return ColumnCapabilitiesImpl.snapshot(
+        index.getCapabilities(column),
+        SNAPSHOT_STORAGE_ADAPTER_CAPABILITIES_COERCE_LOGIC
+    );
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -35,12 +35,10 @@ import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.DimensionIndexer;
 import org.apache.druid.segment.Metadata;
 import org.apache.druid.segment.StorageAdapter;
-import org.apache.druid.segment.StringDimensionIndexer;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
-import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.filter.BooleanValueMatcher;
@@ -156,14 +154,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
     // to the StringDimensionIndexer so the selector built on top of it can produce values from the snapshot state of
     // multi-valuedness at cursor creation time, instead of the latest state, and getSnapshotColumnCapabilities could
     // be removed.
-    ColumnCapabilitiesImpl snapshot = ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), true);
-    if (snapshot != null && snapshot.isDictionaryEncoded() && snapshot.getType().equals(ValueType.STRING)) {
-      // only consider the column dictionary encoded if all dictionary entries have a value
-      snapshot.setDictionaryEncoded(
-          ((StringDimensionIndexer) index.getDimension(column).getIndexer()).dictionaryEncodesAllValues()
-      );
-    }
-    return snapshot;
+    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), true);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -35,10 +35,12 @@ import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.DimensionIndexer;
 import org.apache.druid.segment.Metadata;
 import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.StringDimensionIndexer;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.filter.BooleanValueMatcher;
@@ -154,7 +156,14 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
     // to the StringDimensionIndexer so the selector built on top of it can produce values from the snapshot state of
     // multi-valuedness at cursor creation time, instead of the latest state, and getSnapshotColumnCapabilities could
     // be removed.
-    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), true);
+    ColumnCapabilitiesImpl snapshot = ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), true);
+    if (snapshot != null && snapshot.isDictionaryEncoded() && snapshot.getType().equals(ValueType.STRING)) {
+      // only consider the column dictionary encoded if all dictionary entries have a value
+      snapshot.setDictionaryEncoded(
+          ((StringDimensionIndexer) index.getDimension(column).getIndexer()).dictionaryEncodesAllValues()
+      );
+    }
+    return snapshot;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactory.java
@@ -83,7 +83,7 @@ public class QueryableIndexVectorColumnSelectorFactory implements VectorColumnSe
         spec -> {
           final ColumnHolder holder = index.getColumnHolder(spec.getDimension());
           if (holder == null
-              || !holder.getCapabilities().isDictionaryEncoded()
+              || !holder.getCapabilities().isDictionaryEncoded().isTrue()
               || holder.getCapabilities().getType() != ValueType.STRING
               || !holder.getCapabilities().hasMultipleValues().isMaybeTrue()) {
             throw new ISE(
@@ -119,7 +119,7 @@ public class QueryableIndexVectorColumnSelectorFactory implements VectorColumnSe
         spec -> {
           final ColumnHolder holder = index.getColumnHolder(spec.getDimension());
           if (holder == null
-              || !holder.getCapabilities().isDictionaryEncoded()
+              || !holder.getCapabilities().isDictionaryEncoded().isTrue()
               || holder.getCapabilities().getType() != ValueType.STRING) {
             // Asking for a single-value dimension selector on a non-string column gets you a bunch of nulls.
             return NilVectorSelector.create(offset);

--- a/processing/src/main/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactory.java
@@ -83,9 +83,9 @@ public class QueryableIndexVectorColumnSelectorFactory implements VectorColumnSe
         spec -> {
           final ColumnHolder holder = index.getColumnHolder(spec.getDimension());
           if (holder == null
-              || !holder.getCapabilities().isDictionaryEncoded().isTrue()
+              || holder.getCapabilities().isDictionaryEncoded().isFalse()
               || holder.getCapabilities().getType() != ValueType.STRING
-              || !holder.getCapabilities().hasMultipleValues().isMaybeTrue()) {
+              || holder.getCapabilities().hasMultipleValues().isFalse()) {
             throw new ISE(
                 "Column[%s] is not a multi-value string column, do not ask for a multi-value selector",
                 spec.getDimension()

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -153,7 +153,7 @@ public class ExpressionSelectors
         );
       } else if (capabilities != null
                  && capabilities.getType() == ValueType.STRING
-                 && capabilities.isDictionaryEncoded()
+                 && capabilities.isDictionaryEncoded().isTrue()
                  && !capabilities.hasMultipleValues().isMaybeTrue()
                  && exprDetails.getArrayBindings().isEmpty()) {
         // Optimization for expressions that hit one scalar string column and nothing else.
@@ -225,7 +225,7 @@ public class ExpressionSelectors
       // not treating it as an array and not wanting to output an array
       if (capabilities != null
           && capabilities.getType() == ValueType.STRING
-          && capabilities.isDictionaryEncoded()
+          && capabilities.isDictionaryEncoded().isTrue()
           && !capabilities.hasMultipleValues().isUnknown()
           && !exprDetails.hasInputArrays()
           && !exprDetails.isOutputArray()

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -154,7 +154,7 @@ public class ExpressionSelectors
       } else if (capabilities != null
                  && capabilities.getType() == ValueType.STRING
                  && capabilities.isDictionaryEncoded().isTrue()
-                 && !capabilities.hasMultipleValues().isMaybeTrue()
+                 && capabilities.hasMultipleValues().isFalse()
                  && exprDetails.getArrayBindings().isEmpty()) {
         // Optimization for expressions that hit one scalar string column and nothing else.
         return new SingleStringInputCachingExpressionColumnValueSelector(

--- a/processing/src/test/java/org/apache/druid/query/lookup/LookupSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/query/lookup/LookupSegmentTest.java
@@ -138,7 +138,7 @@ public class LookupSegmentTest
     // reporting complete single-valued capabilities. It would be good to change this in the future, so query engines
     // running on top of lookups can take advantage of singly-valued optimizations.
     Assert.assertTrue(capabilities.hasMultipleValues().isUnknown());
-    Assert.assertFalse(capabilities.isDictionaryEncoded());
+    Assert.assertFalse(capabilities.isDictionaryEncoded().isTrue());
   }
 
   @Test
@@ -151,7 +151,7 @@ public class LookupSegmentTest
     // running on top of lookups can take advantage of singly-valued optimizations.
     Assert.assertEquals(ValueType.STRING, capabilities.getType());
     Assert.assertTrue(capabilities.hasMultipleValues().isUnknown());
-    Assert.assertFalse(capabilities.isDictionaryEncoded());
+    Assert.assertFalse(capabilities.isDictionaryEncoded().isTrue());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -45,7 +45,6 @@ import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
-import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
 import org.apache.druid.segment.column.StringDictionaryEncodedColumn;
@@ -2010,32 +2009,6 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
     Assert.assertEquals(-1, dictIdSeeker.seek(3));
     Assert.assertEquals(2, dictIdSeeker.seek(4));
     Assert.assertEquals(-1, dictIdSeeker.seek(5));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testCloser() throws Exception
-  {
-    final long timestamp = System.currentTimeMillis();
-    IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);
-    IncrementalIndexTest.populateIndex(timestamp, toPersist);
-    ColumnCapabilitiesImpl capabilities = (ColumnCapabilitiesImpl) toPersist.getCapabilities("dim1");
-    capabilities.setHasSpatialIndexes(true);
-
-    final File tempDir = temporaryFolder.newFolder();
-    final File v8TmpDir = new File(tempDir, "v8-tmp");
-    final File v9TmpDir = new File(tempDir, "v9-tmp");
-
-    try {
-      indexMerger.persist(toPersist, tempDir, indexSpec, null);
-    }
-    finally {
-      if (v8TmpDir.exists()) {
-        Assert.fail("v8-tmp dir not clean.");
-      }
-      if (v9TmpDir.exists()) {
-        Assert.fail("v9-tmp dir not clean.");
-      }
-    }
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
@@ -159,7 +159,9 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
     // at index merge or query time we 'complete' the capabilities to take a snapshot of the current state,
     // coercing any 'UNKNOWN' values to false
     Assert.assertFalse(
-        ColumnCapabilitiesImpl.snapshot(caps, ColumnCapabilitiesImpl.ALL_FALSE).hasMultipleValues().isMaybeTrue()
+        ColumnCapabilitiesImpl.snapshot(caps, IndexMergerV9.DIMENSION_CAPABILITY_MERGE_LOGIC)
+                              .hasMultipleValues()
+                              .isMaybeTrue()
     );
     Assert.assertFalse(caps.hasSpatialIndexes());
 
@@ -201,7 +203,6 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
     assertNonStringColumnCapabilities(INC_INDEX.getCapabilities("m4"), ValueType.COMPLEX);
     assertNonStringColumnCapabilities(MMAP_INDEX.getColumnHolder("m4").getCapabilities(), ValueType.COMPLEX);
   }
-
 
   private void assertNonStringColumnCapabilities(ColumnCapabilities caps, ValueType valueType)
   {

--- a/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
@@ -150,20 +150,23 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
     ColumnCapabilities caps = INC_INDEX.getCapabilities("d1");
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded());
+    Assert.assertTrue(caps.isDictionaryEncoded().isMaybeTrue());
+    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
     // multi-value is unknown unless explicitly set to 'true'
     Assert.assertTrue(caps.hasMultipleValues().isUnknown());
     // at index merge or query time we 'complete' the capabilities to take a snapshot of the current state,
     // coercing any 'UNKNOWN' values to false
-    Assert.assertFalse(ColumnCapabilitiesImpl.snapshot(caps).hasMultipleValues().isMaybeTrue());
+    Assert.assertFalse(
+        ColumnCapabilitiesImpl.snapshot(caps, ColumnCapabilitiesImpl.ALL_FALSE).hasMultipleValues().isMaybeTrue()
+    );
     Assert.assertFalse(caps.hasSpatialIndexes());
 
     caps = MMAP_INDEX.getColumnHolder("d1").getCapabilities();
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded());
+    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
     Assert.assertTrue(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
@@ -176,7 +179,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
     ColumnCapabilities caps = INC_INDEX.getCapabilities("d2");
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded());
+    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertTrue(caps.hasMultipleValues().isTrue());
@@ -185,7 +188,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
     caps = MMAP_INDEX.getColumnHolder("d2").getCapabilities();
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded());
+    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
     Assert.assertTrue(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertTrue(caps.hasMultipleValues().isTrue());
@@ -204,7 +207,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   {
     Assert.assertEquals(valueType, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());

--- a/processing/src/test/java/org/apache/druid/segment/RowBasedColumnSelectorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/RowBasedColumnSelectorFactoryTest.java
@@ -51,7 +51,7 @@ public class RowBasedColumnSelectorFactoryTest
         RowBasedColumnSelectorFactory.getColumnCapabilities(ROW_SIGNATURE, ColumnHolder.TIME_COLUMN_NAME);
     Assert.assertEquals(ValueType.LONG, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
@@ -65,7 +65,7 @@ public class RowBasedColumnSelectorFactoryTest
         RowBasedColumnSelectorFactory.getColumnCapabilities(ROW_SIGNATURE, STRING_COLUMN_NAME);
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertTrue(caps.hasMultipleValues().isUnknown());
@@ -79,7 +79,7 @@ public class RowBasedColumnSelectorFactoryTest
         RowBasedColumnSelectorFactory.getColumnCapabilities(ROW_SIGNATURE, LONG_COLUMN_NAME);
     Assert.assertEquals(ValueType.LONG, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
@@ -93,7 +93,7 @@ public class RowBasedColumnSelectorFactoryTest
         RowBasedColumnSelectorFactory.getColumnCapabilities(ROW_SIGNATURE, FLOAT_COLUMN_NAME);
     Assert.assertEquals(ValueType.FLOAT, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
@@ -107,7 +107,7 @@ public class RowBasedColumnSelectorFactoryTest
         RowBasedColumnSelectorFactory.getColumnCapabilities(ROW_SIGNATURE, DOUBLE_COLUMN_NAME);
     Assert.assertEquals(ValueType.DOUBLE, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
@@ -121,7 +121,7 @@ public class RowBasedColumnSelectorFactoryTest
         RowBasedColumnSelectorFactory.getColumnCapabilities(ROW_SIGNATURE, COMPLEX_COLUMN_NAME);
     Assert.assertEquals(ValueType.COMPLEX, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertTrue(caps.hasMultipleValues().isUnknown());

--- a/processing/src/test/java/org/apache/druid/segment/column/ColumnCapabilitiesImplTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/column/ColumnCapabilitiesImplTest.java
@@ -44,8 +44,7 @@ public class ColumnCapabilitiesImplTest
     ColumnCapabilities cc = mapper.readValue(json, ColumnCapabilitiesImpl.class);
 
     Assert.assertEquals(ValueType.COMPLEX, cc.getType());
-    Assert.assertTrue(cc.isDictionaryEncoded());
-    Assert.assertFalse(cc.isRunLengthEncoded());
+    Assert.assertTrue(cc.isDictionaryEncoded().isTrue());
     Assert.assertTrue(cc.hasSpatialIndexes());
     Assert.assertTrue(cc.hasMultipleValues().isTrue());
     Assert.assertTrue(cc.hasBitmapIndexes());
@@ -69,8 +68,7 @@ public class ColumnCapabilitiesImplTest
     ColumnCapabilities cc = mapper.readValue(json, ColumnCapabilitiesImpl.class);
 
     Assert.assertEquals(ValueType.COMPLEX, cc.getType());
-    Assert.assertTrue(cc.isDictionaryEncoded());
-    Assert.assertTrue(cc.isRunLengthEncoded());
+    Assert.assertTrue(cc.isDictionaryEncoded().isTrue());
     Assert.assertTrue(cc.hasSpatialIndexes());
     Assert.assertTrue(cc.hasMultipleValues().isTrue());
     Assert.assertTrue(cc.hasBitmapIndexes());

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -200,7 +200,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     Assert.assertEquals(ValueType.STRING, capabilities.getType());
     Assert.assertTrue(capabilities.hasBitmapIndexes());
-    Assert.assertTrue(capabilities.isDictionaryEncoded());
+    Assert.assertTrue(capabilities.isDictionaryEncoded().isTrue());
     Assert.assertTrue(capabilities.areDictionaryValuesSorted().isTrue());
     Assert.assertTrue(capabilities.areDictionaryValuesUnique().isTrue());
   }
@@ -216,7 +216,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     Assert.assertFalse(capabilities.hasBitmapIndexes());
     Assert.assertFalse(capabilities.areDictionaryValuesUnique().isTrue());
     Assert.assertFalse(capabilities.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(capabilities.isDictionaryEncoded());
+    Assert.assertTrue(capabilities.isDictionaryEncoded().isTrue());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
@@ -137,7 +137,7 @@ public class IndexedTableJoinableTest
   {
     final ColumnCapabilities capabilities = target.getColumnCapabilities("str");
     Assert.assertEquals(ValueType.STRING, capabilities.getType());
-    Assert.assertTrue(capabilities.isDictionaryEncoded());
+    Assert.assertTrue(capabilities.isDictionaryEncoded().isTrue());
     Assert.assertFalse(capabilities.hasBitmapIndexes());
     Assert.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
     Assert.assertFalse(capabilities.hasSpatialIndexes());
@@ -148,7 +148,7 @@ public class IndexedTableJoinableTest
   {
     final ColumnCapabilities capabilities = target.getColumnCapabilities("long");
     Assert.assertEquals(ValueType.LONG, capabilities.getType());
-    Assert.assertFalse(capabilities.isDictionaryEncoded());
+    Assert.assertFalse(capabilities.isDictionaryEncoded().isTrue());
     Assert.assertFalse(capabilities.hasBitmapIndexes());
     Assert.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
     Assert.assertFalse(capabilities.hasSpatialIndexes());

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -261,7 +261,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         Granularities.NONE,
         VirtualColumns.EMPTY,
         DimensionsSpec.EMPTY,
-        new AggregatorFactory[]{ new CountAggregatorFactory("count")},
+        new AggregatorFactory[]{new CountAggregatorFactory("count")},
         true
     );
 
@@ -303,7 +303,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
           null
       );
       int rowCount = 0;
-      while(!cursor.isDone()) {
+      while (!cursor.isDone()) {
         Object x = xExprSelector.getObject();
         Object y = yExprSelector.getObject();
         List<String> expectedFoo = Collections.singletonList("foofoo");

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -21,20 +21,40 @@ package org.apache.druid.segment.virtual;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.SettableSupplier;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.Parser;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import org.apache.druid.segment.BaseSingleValueDimensionSelector;
 import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.TestObjectColumnSelector;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.incremental.IncrementalIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexSchema;
+import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
+import org.apache.druid.segment.incremental.IndexSizeExceededException;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class ExpressionColumnValueSelectorTest
+public class ExpressionSelectorsTest extends InitializedNullHandlingTest
 {
   @Test
   public void testSupplierFromDimensionSelector()
@@ -229,6 +249,78 @@ public class ExpressionColumnValueSelectorTest
         withNulls,
         ExpressionSelectors.coerceEvalToSelectorObject(ExprEval.ofStringArray(new String[]{"a", null, "c"}))
     );
+  }
+
+  @Test
+  public void testIncrementIndexStringSelector() throws IndexSizeExceededException
+  {
+    IncrementalIndexSchema schema = new IncrementalIndexSchema(
+        0,
+        new TimestampSpec("time", "millis", DateTimes.nowUtc()),
+        Granularities.NONE,
+        VirtualColumns.EMPTY,
+        DimensionsSpec.EMPTY,
+        new AggregatorFactory[]{ new CountAggregatorFactory("count")},
+        true
+    );
+
+    IncrementalIndex index = new IncrementalIndex.Builder().setMaxRowCount(100).setIndexSchema(schema).buildOnheap();
+    index.add(
+        new MapBasedInputRow(
+            DateTimes.nowUtc().getMillis(),
+            ImmutableList.of("x"),
+            ImmutableMap.of("x", "foo")
+        )
+    );
+    index.add(
+        new MapBasedInputRow(
+            DateTimes.nowUtc().plusMillis(1000).getMillis(),
+            ImmutableList.of("y"),
+            ImmutableMap.of("y", "foo")
+        )
+    );
+
+    IncrementalIndexStorageAdapter adapter = new IncrementalIndexStorageAdapter(index);
+
+    Sequence<Cursor> cursors = adapter.makeCursors(
+        null,
+        Intervals.ETERNITY,
+        VirtualColumns.EMPTY,
+        Granularities.ALL,
+        false,
+        null
+    );
+    int rowsProcessed = cursors.map(cursor -> {
+      DimensionSelector xExprSelector = ExpressionSelectors.makeDimensionSelector(
+          cursor.getColumnSelectorFactory(),
+          Parser.parse("concat(x, 'foo')", ExprMacroTable.nil()),
+          null
+      );
+      DimensionSelector yExprSelector = ExpressionSelectors.makeDimensionSelector(
+          cursor.getColumnSelectorFactory(),
+          Parser.parse("concat(y, 'foo')", ExprMacroTable.nil()),
+          null
+      );
+      int rowCount = 0;
+      while(!cursor.isDone()) {
+        Object x = xExprSelector.getObject();
+        Object y = yExprSelector.getObject();
+        List<String> expectedFoo = ImmutableList.of("foofoo");
+        List<String> expectedNull = NullHandling.replaceWithDefault() ? ImmutableList.of("foo") : null;
+        if (rowCount == 0) {
+          Assert.assertEquals(expectedFoo, x);
+          Assert.assertEquals(expectedNull, y);
+        } else {
+          Assert.assertEquals(expectedNull, x);
+          Assert.assertEquals(expectedFoo, y);
+        }
+        rowCount++;
+        cursor.advance();
+      }
+      return rowCount;
+    }).accumulate(0, (in, acc) -> in + acc);
+
+    Assert.assertEquals(2, rowsProcessed);
   }
 
   private static DimensionSelector dimensionSelectorFromSupplier(

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -255,6 +255,12 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void testIncrementIndexStringSelector() throws IndexSizeExceededException
   {
+    // This test covers a regression caused by ColumnCapabilites.isDictionaryEncoded not matching the value of
+    // DimensionSelector.nameLookupPossibleInAdvance in the indexers of an IncrementalIndex, which resulted in an
+    // exception trying to make an optimized string expression selector that was not appropriate to use for the
+    // underlying dimension selector.
+    // This occurred during schemaless ingestion with spare dimension values and no explicit null rows, so the
+    // conditions are replicated by this test.
     IncrementalIndexSchema schema = new IncrementalIndexSchema(
         0,
         new TimestampSpec("time", "millis", DateTimes.nowUtc()),

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -52,6 +52,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ExpressionSelectorsTest extends InitializedNullHandlingTest
@@ -305,8 +306,10 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
       while(!cursor.isDone()) {
         Object x = xExprSelector.getObject();
         Object y = yExprSelector.getObject();
-        List<String> expectedFoo = ImmutableList.of("foofoo");
-        List<String> expectedNull = NullHandling.replaceWithDefault() ? ImmutableList.of("foo") : null;
+        List<String> expectedFoo = Collections.singletonList("foofoo");
+        List<String> expectedNull = NullHandling.replaceWithDefault()
+                                    ? Collections.singletonList("foo")
+                                    : Collections.singletonList(null);
         if (rowCount == 0) {
           Assert.assertEquals(expectedFoo, x);
           Assert.assertEquals(expectedNull, y);

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -260,7 +260,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     // exception trying to make an optimized string expression selector that was not appropriate to use for the
     // underlying dimension selector.
     // This occurred during schemaless ingestion with spare dimension values and no explicit null rows, so the
-    // conditions are replicated by this test.
+    // conditions are replicated by this test. See https://github.com/apache/druid/pull/10248 for details
     IncrementalIndexSchema schema = new IncrementalIndexSchema(
         0,
         new TimestampSpec("time", "millis", DateTimes.nowUtc()),

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -810,7 +810,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     ColumnCapabilities caps = X_PLUS_Y.capabilities("expr");
     Assert.assertEquals(ValueType.FLOAT, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertTrue(caps.hasMultipleValues().isUnknown());
@@ -820,7 +820,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     caps = Z_CONCAT_X.capabilities("expr");
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded());
+    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
     Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
     Assert.assertTrue(caps.hasMultipleValues().isUnknown());

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
@@ -29,7 +29,7 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.ReferenceCountingSegment;
-import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexAddResult;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
@@ -377,7 +377,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
           FireHydrant lastHydrant = hydrants.get(numHydrants - 1);
           newCount = lastHydrant.getCount() + 1;
           if (!indexSchema.getDimensionsSpec().hasCustomDimensions()) {
-            Map<String, ColumnCapabilitiesImpl> oldCapabilities;
+            Map<String, ColumnCapabilities> oldCapabilities;
             if (lastHydrant.hasSwapped()) {
               oldCapabilities = new HashMap<>();
               ReferenceCountingSegment segment = lastHydrant.getIncrementedSegment();
@@ -385,7 +385,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
                 QueryableIndex oldIndex = segment.asQueryableIndex();
                 for (String dim : oldIndex.getAvailableDimensions()) {
                   dimOrder.add(dim);
-                  oldCapabilities.put(dim, (ColumnCapabilitiesImpl) oldIndex.getColumnHolder(dim).getCapabilities());
+                  oldCapabilities.put(dim, oldIndex.getColumnHolder(dim).getCapabilities());
                 }
               }
               finally {


### PR DESCRIPTION
### Description
This PR fixes an issue caused by #9731 when using `ExpressionVirtualColumn` with a single realtime string column input, which is sparsely populated and has not encountered explicit `null` values (to ensure that they are encoded in the dictionary). 

In the code there is a gentleman's agreement that if `ColumnCapabilities.isDictionaryEncoded` is true then `DimensionSelector.nameLookupPossibleInAdvance` is also true, and `isDictionaryEncoded` appears to be checked primarily in cases where this should also be true. The refactoring done in #9731 broke this loose contract however, since the latter method was modified to return the state of the indexer, but the former value was set as the expected final state.

To fix this, a `getColumnCapabilites` method has been added to `DimensionIndexer`, to allow the thing processing all the column values to be the single state of truth about the details of the column. It also frees `IncrementalIndex` from having to track and evolve changes to the capabilities, since it can now be handled within the indexers, though it still maintains a map of static capabilities for the time and aggregator columns.

Prior to this fix the added tests would explode with an error in the form:
```
Selector of class[org.apache.druid.segment.StringDimensionIndexer$1IndexerDimensionSelector] does not have a dictionary, cannot use it.
```
because [of this check](https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java#L52). 

While I was at it, I made `isDictionaryEncoded` be a `Capable` enum, reworked the `snapshot` method to take a new type, `CoercionLogic` which is responsible for determining how each `Capable.UNKNOWN` will be converted to true or false when calling `snapshot`. `merge` is now a static method that internally calls `snapshot` on each `ColumnCapabilities`, also using a `CoercionLogic`. 

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `IncrementalIndex`
 * `DimensionIndexer` implementations, especially `StringDimensionIndexer`
 * `ExpressionSelectors`
