### PR TITLE
Make stale bot less aggressive

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -26,6 +26,7 @@ staleLabel: stale
 pulls:
   daysUntilStale: 60
   daysUntilClose: 28
+  limitPerRun: 5
   markComment: >
     This pull request has been marked as stale due to 60 days of inactivity.
     It will be closed in 4 weeks if no further activity occurs. If you think
@@ -45,6 +46,7 @@ pulls:
 issues:
   daysUntilStale: 280
   daysUntilClose: 28
+  limitPerRun: 5
   markComment: >
     This issue has been marked as stale due to 280 days of inactivity.
     It will be closed in 4 weeks if no further activity occurs. If this issue is still


### PR DESCRIPTION
### Description

This PR adds `limitPerRun` to make the stale bot less aggressive, so that we can go through issues/prs when they are marked as stale.
