### PR TITLE
Fix javadoc mistake in DefaultLimitSpec.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -150,7 +150,7 @@ public class DefaultLimitSpec implements LimitSpec
   }
 
   /**
-   * Offset for this query; behaves like SQL "LIMIT". Will always be positive. {@link Integer#MAX_VALUE} is used in
+   * Limit for this query; behaves like SQL "LIMIT". Will always be positive. {@link Integer#MAX_VALUE} is used in
    * situations where the user wants an effectively unlimited resultset.
    */
   @JsonProperty


### PR DESCRIPTION
Javadoc for getLimit should say it's a limit, not an offset.