### PR TITLE
fix connectionId issue with JDBC prepared statement queries and router 

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.tests.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.testing.IntegrationTestingConfig;
+import org.apache.druid.testing.clients.CoordinatorResourceTestClient;
+import org.apache.druid.testing.guice.DruidTestModuleFactory;
+import org.apache.druid.testing.utils.ITRetryUtil;
+import org.apache.druid.tests.TestNGGroup;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+@Test(groups = TestNGGroup.QUERY)
+@Guice(moduleFactory = DruidTestModuleFactory.class)
+public class ITJdbcQueryTest
+{
+  private static final Logger LOG = new Logger(ITJdbcQueryTest.class);
+  private static final String WIKIPEDIA_DATA_SOURCE = "wikipedia_editstream";
+  private static final String CONNECTION_TEMPLATE = "jdbc:avatica:remote:url=%s/druid/v2/sql/avatica/";
+
+  private static final String QUERY_TEMPLATE =
+      "SELECT \"user\", SUM(\"added\"), COUNT(*)" +
+      "FROM \"wikipedia\" " +
+      "WHERE \"__time\" >= CURRENT_TIMESTAMP - INTERVAL '10' YEAR AND \"language\" = %s" +
+      "GROUP BY 1 ORDER BY 3 DESC LIMIT 10";
+  private static final String QUERY = StringUtils.format(QUERY_TEMPLATE, "'en'");
+
+  private static final String QUERY_PARAMETERIZED = StringUtils.format(QUERY_TEMPLATE, "?");
+
+  private String[] connections;
+  private Properties connectionProperties;
+
+  @Inject
+  private CoordinatorResourceTestClient coordinatorClient;
+
+  @Inject
+  private IntegrationTestingConfig config;
+
+  @BeforeMethod
+  public void before()
+  {
+    connectionProperties = new Properties();
+    connectionProperties.setProperty("user", "admin");
+    connectionProperties.setProperty("password", "priest");
+    connections = new String[]{
+        StringUtils.format(CONNECTION_TEMPLATE, config.getRouterUrl()),
+        StringUtils.format(CONNECTION_TEMPLATE, config.getBrokerUrl()),
+        StringUtils.format(CONNECTION_TEMPLATE, config.getRouterTLSUrl()),
+        StringUtils.format(CONNECTION_TEMPLATE, config.getBrokerTLSUrl())
+    };
+    // ensure that wikipedia segments are loaded completely
+    ITRetryUtil.retryUntilTrue(
+        () -> coordinatorClient.areSegmentsLoaded(WIKIPEDIA_DATA_SOURCE), "wikipedia segment load"
+    );
+  }
+
+  @Test
+  public void testJdbcMetadata()
+  {
+    for (String url : connections) {
+      try (Connection connection = DriverManager.getConnection(url, connectionProperties)) {
+        DatabaseMetaData metadata = connection.getMetaData();
+
+        List<String> catalogs = new ArrayList<>();
+        ResultSet catalogsMetadata = metadata.getCatalogs();
+        while (catalogsMetadata.next()) {
+          final String catalog = catalogsMetadata.getString(1);
+          catalogs.add(catalog);
+        }
+        LOG.info("Catalogs[%s]", catalogs);
+        Assert.assertEquals(ImmutableList.of("druid"), catalogs);
+
+        Set<String> schemas = new HashSet<>();
+        ResultSet schemasMetadata = metadata.getSchemas("druid",null);
+        while (schemasMetadata.next()) {
+          final String schema = schemasMetadata.getString(1);
+          schemas.add(schema);
+        }
+        LOG.info("Schemas[%s]", schemas);
+        Assert.assertTrue(schemas.containsAll(ImmutableList.of("INFORMATION_SCHEMA", "druid", "lookup", "sys")));
+
+        Set<String> druidTables = new HashSet<>();
+        ResultSet tablesMetadata = metadata.getTables("druid", "druid",null, null);
+        while (tablesMetadata.next()) {
+          final String table = tablesMetadata.getString(3);
+          druidTables.add(table);
+        }
+        LOG.info("Tables[druid.%s]", druidTables);
+        Assert.assertTrue(
+            druidTables.containsAll(ImmutableList.of("twitterstream", "wikipedia", "wikipedia_editstream"))
+        );
+      }
+      catch (SQLException throwables) {
+        Assert.assertFalse(true, throwables.getMessage());
+      }
+    }
+  }
+
+  @Test
+  public void testJdbcStatementQuery()
+  {
+    for (String url : connections) {
+      try (Connection connection = DriverManager.getConnection(url, connectionProperties)) {
+        try (Statement statement = connection.createStatement()) {
+          final ResultSet resultSet = statement.executeQuery(QUERY);
+          int resultRowCount = 0;
+          while (resultSet.next()) {
+            resultRowCount++;
+            LOG.info("%s,%s,%s", resultSet.getString(1), resultSet.getLong(2), resultSet.getLong(3));
+          }
+          Assert.assertEquals(10, resultRowCount);
+          resultSet.close();
+        }
+      }
+      catch (SQLException throwables) {
+        Assert.assertFalse(true, throwables.getMessage());
+      }
+    }
+  }
+
+  @Test
+  public void testJdbcPrepareStatementQuery()
+  {
+    for (String url : connections) {
+      try (Connection connection = DriverManager.getConnection(url, connectionProperties)) {
+        try (PreparedStatement statement = connection.prepareStatement(QUERY_PARAMETERIZED)) {
+          statement.setString(1, "en");
+          final ResultSet resultSet = statement.executeQuery();
+          int resultRowCount = 0;
+          while (resultSet.next()) {
+            resultRowCount++;
+            LOG.info("%s,%s,%s", resultSet.getString(1), resultSet.getLong(2), resultSet.getLong(3));
+          }
+          Assert.assertEquals(10, resultRowCount);
+          resultSet.close();
+        }
+      }
+      catch (SQLException throwables) {
+        Assert.assertFalse(true, throwables.getMessage());
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
@@ -94,7 +94,7 @@ public class ITJdbcQueryTest
             sslConfig.getTrustStorePasswordProvider().getPassword(),
             sslConfig.getKeyStorePath(),
             sslConfig.getKeyStorePasswordProvider().getPassword(),
-            sslConfig.getKeyStorePasswordProvider().getPassword()
+            sslConfig.getKeyManagerPasswordProvider().getPassword()
         ),
         StringUtils.format(
             TLS_CONNECTION_TEMPLATE,
@@ -103,7 +103,7 @@ public class ITJdbcQueryTest
             sslConfig.getTrustStorePasswordProvider().getPassword(),
             sslConfig.getKeyStorePath(),
             sslConfig.getKeyStorePasswordProvider().getPassword(),
-            sslConfig.getKeyStorePasswordProvider().getPassword()
+            sslConfig.getKeyManagerPasswordProvider().getPassword()
         )
     };
     // ensure that wikipedia segments are loaded completely

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
@@ -107,7 +107,7 @@ public class ITJdbcQueryTest
         Assert.assertEquals(ImmutableList.of("druid"), catalogs);
 
         Set<String> schemas = new HashSet<>();
-        ResultSet schemasMetadata = metadata.getSchemas("druid",null);
+        ResultSet schemasMetadata = metadata.getSchemas("druid", null);
         while (schemasMetadata.next()) {
           final String schema = schemasMetadata.getString(1);
           schemas.add(schema);
@@ -117,7 +117,7 @@ public class ITJdbcQueryTest
         Assert.assertTrue(schemas.containsAll(ImmutableList.of("INFORMATION_SCHEMA", "druid", "lookup", "sys")));
 
         Set<String> druidTables = new HashSet<>();
-        ResultSet tablesMetadata = metadata.getTables("druid", "druid",null, null);
+        ResultSet tablesMetadata = metadata.getTables("druid", "druid", null, null);
         while (tablesMetadata.next()) {
           final String table = tablesMetadata.getString(3);
           druidTables.add(table);
@@ -125,16 +125,16 @@ public class ITJdbcQueryTest
         LOG.info("'druid' schema tables %s", druidTables);
         // maybe more tables than this, but at least should have these
         Assert.assertTrue(
-            druidTables.containsAll(ImmutableList.of("twitterstream", "wikipedia", "wikipedia_editstream"))
+            druidTables.containsAll(ImmutableList.of("twitterstream", "wikipedia", WIKIPEDIA_DATA_SOURCE))
         );
 
         Set<String> wikiColumns = new HashSet<>();
-        ResultSet columnsMetadata = metadata.getColumns("druid", "druid","wikipedia_editstream", null);
+        ResultSet columnsMetadata = metadata.getColumns("druid", "druid", WIKIPEDIA_DATA_SOURCE, null);
         while (columnsMetadata.next()) {
           final String column = columnsMetadata.getString(4);
           wikiColumns.add(column);
         }
-        LOG.info("'wikipedia_editstream' columns %s", wikiColumns);
+        LOG.info("'%s' columns %s", WIKIPEDIA_DATA_SOURCE, wikiColumns);
         // a lot more columns than this, but at least should have these
         Assert.assertTrue(
             wikiColumns.containsAll(ImmutableList.of("added", "city", "delta", "language"))

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
@@ -80,9 +80,7 @@ public class ITJdbcQueryTest
     connectionProperties.setProperty("password", "priest");
     connections = new String[]{
         StringUtils.format(CONNECTION_TEMPLATE, config.getRouterUrl()),
-        StringUtils.format(CONNECTION_TEMPLATE, config.getBrokerUrl()),
-        StringUtils.format(CONNECTION_TEMPLATE, config.getRouterTLSUrl()),
-        StringUtils.format(CONNECTION_TEMPLATE, config.getBrokerTLSUrl())
+        StringUtils.format(CONNECTION_TEMPLATE, config.getBrokerUrl())
     };
     // ensure that wikipedia segments are loaded completely
     ITRetryUtil.retryUntilTrue(

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
@@ -55,7 +55,7 @@ public class ITJdbcQueryTest
   private static final String WIKIPEDIA_DATA_SOURCE = "wikipedia_editstream";
   private static final String CONNECTION_TEMPLATE = "jdbc:avatica:remote:url=%s/druid/v2/sql/avatica/";
   private static final String TLS_CONNECTION_TEMPLATE =
-      "jdbc:avatica:remote:url=%s/druid/v2/sql/avatica/;truststore=%s;truststore_password=%s";
+      "jdbc:avatica:remote:url=%s/druid/v2/sql/avatica/;truststore=%s;truststore_password=%s;keystore=%s;keystore_password=%s;key_password=%s";
 
   private static final String QUERY_TEMPLATE =
       "SELECT \"user\", SUM(\"added\"), COUNT(*)" +
@@ -91,13 +91,19 @@ public class ITJdbcQueryTest
             TLS_CONNECTION_TEMPLATE,
             config.getRouterTLSUrl(),
             sslConfig.getTrustStorePath(),
-            sslConfig.getTrustStorePasswordProvider().getPassword()
+            sslConfig.getTrustStorePasswordProvider().getPassword(),
+            sslConfig.getKeyStorePath(),
+            sslConfig.getKeyStorePasswordProvider().getPassword(),
+            sslConfig.getKeyStorePasswordProvider().getPassword()
         ),
         StringUtils.format(
             TLS_CONNECTION_TEMPLATE,
             config.getBrokerTLSUrl(),
             sslConfig.getTrustStorePath(),
-            sslConfig.getTrustStorePasswordProvider().getPassword()
+            sslConfig.getTrustStorePasswordProvider().getPassword(),
+            sslConfig.getKeyStorePath(),
+            sslConfig.getKeyStorePasswordProvider().getPassword(),
+            sslConfig.getKeyStorePasswordProvider().getPassword()
         )
     };
     // ensure that wikipedia segments are loaded completely

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
@@ -103,7 +103,7 @@ public class ITJdbcQueryTest
           final String catalog = catalogsMetadata.getString(1);
           catalogs.add(catalog);
         }
-        LOG.info("Catalogs[%s]", catalogs);
+        LOG.info("catalogs %s", catalogs);
         Assert.assertEquals(ImmutableList.of("druid"), catalogs);
 
         Set<String> schemas = new HashSet<>();
@@ -112,7 +112,8 @@ public class ITJdbcQueryTest
           final String schema = schemasMetadata.getString(1);
           schemas.add(schema);
         }
-        LOG.info("Schemas[%s]", schemas);
+        LOG.info("'druid' catalog schemas %s", schemas);
+        // maybe more schemas than this, but at least should have these
         Assert.assertTrue(schemas.containsAll(ImmutableList.of("INFORMATION_SCHEMA", "druid", "lookup", "sys")));
 
         Set<String> druidTables = new HashSet<>();
@@ -121,9 +122,22 @@ public class ITJdbcQueryTest
           final String table = tablesMetadata.getString(3);
           druidTables.add(table);
         }
-        LOG.info("Tables[druid.%s]", druidTables);
+        LOG.info("'druid' schema tables %s", druidTables);
+        // maybe more tables than this, but at least should have these
         Assert.assertTrue(
             druidTables.containsAll(ImmutableList.of("twitterstream", "wikipedia", "wikipedia_editstream"))
+        );
+
+        Set<String> wikiColumns = new HashSet<>();
+        ResultSet columnsMetadata = metadata.getColumns("druid", "druid","wikipedia_editstream", null);
+        while (columnsMetadata.next()) {
+          final String column = columnsMetadata.getString(4);
+          wikiColumns.add(column);
+        }
+        LOG.info("'wikipedia_editstream' columns %s", wikiColumns);
+        // a lot more columns than this, but at least should have these
+        Assert.assertTrue(
+            wikiColumns.containsAll(ImmutableList.of("added", "city", "delta", "language"))
         );
       }
       catch (SQLException throwables) {

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -437,6 +437,11 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.calcite.avatica</groupId>
+            <artifactId>avatica-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -78,6 +78,9 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   @Deprecated // use SmileMediaTypes.APPLICATION_JACKSON_SMILE
   private static final String APPLICATION_SMILE = "application/smile";
 
+  private static final String AVATICA_CONNECTION_ID = "connectionId";
+  private static final String AVATICA_STATEMENT_HANDLE = "statementHandle";
+
   private static final String HOST_ATTRIBUTE = "org.apache.druid.proxy.to.host";
   private static final String SCHEME_ATTRIBUTE = "org.apache.druid.proxy.to.host.scheme";
   private static final String QUERY_ATTRIBUTE = "org.apache.druid.proxy.query";
@@ -424,12 +427,22 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
 
   private static String getAvaticaConnectionId(Map<String, Object> requestMap)
   {
-    Object connectionIdObj = requestMap.get("connectionId");
+    // avatica commands always have a 'connectionId'. If commands are not part of a prepared statement, this appears at
+    // the top level of the request, but if it is part of a statement, then it will be nested in the 'statementHandle'.
+    // see https://calcite.apache.org/avatica/docs/json_reference.html#requests for more details
+    Object connectionIdObj = requestMap.get(AVATICA_CONNECTION_ID);
     if (connectionIdObj == null) {
-      throw new IAE("Received an Avatica request without a connectionId.");
+      Object statementHandle = requestMap.get(AVATICA_STATEMENT_HANDLE);
+      if (statementHandle != null && statementHandle instanceof Map) {
+        connectionIdObj = ((Map) statementHandle).get(AVATICA_CONNECTION_ID);
+      }
+    }
+
+    if (connectionIdObj == null) {
+      throw new IAE("Received an Avatica request without a %s.", AVATICA_CONNECTION_ID);
     }
     if (!(connectionIdObj instanceof String)) {
-      throw new IAE("Received an Avatica request with a non-String connectionId.");
+      throw new IAE("Received an Avatica request with a non-String %s.", AVATICA_CONNECTION_ID);
     }
 
     return (String) connectionIdObj;

--- a/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -425,7 +425,8 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     return interruptedQueryCount.get();
   }
 
-  private static String getAvaticaConnectionId(Map<String, Object> requestMap)
+  @VisibleForTesting
+  static String getAvaticaConnectionId(Map<String, Object> requestMap)
   {
     // avatica commands always have a 'connectionId'. If commands are not part of a prepared statement, this appears at
     // the top level of the request, but if it is part of a statement, then it will be nested in the 'statementHandle'.


### PR DESCRIPTION
Fixes #7931.

### Description
This PR fixes an issue when using JDBC prepared statements through a router. [Per the docs](https://calcite.apache.org/avatica/docs/json_reference.html#requests), all requests either have a top level `connectionId`, or, if part of a prepared statement, the `connectionId` might be nested in a `statementHandle`, so the router will now check for this case. There are probably more magical ways to do this, but this was the most straightforward.

Integration tests have been added to test JDBC metadata, statements, and prepared statements to make sure things work on both brokers and routers. The prepared statement query test fails prior to the changes in this patch.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
