### PR TITLE
Don't log the entire task spec

### DIFF
--- a/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
+++ b/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
@@ -19,11 +19,13 @@
 
 package org.apache.druid.common.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
+import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -74,18 +76,40 @@ public class IdUtils
     return UNDERSCORE_JOINER.join(prefix, IdUtils.getRandomId());
   }
 
-  public static String newTaskId(final String typeName, String dataSource, @Nullable Interval interval)
+  public static String newTaskId(String typeName, String dataSource, @Nullable Interval interval)
+  {
+    return newTaskId("", typeName, dataSource, interval);
+  }
+
+  public static String newTaskId(String idPrefix, String typeName, String dataSource, @Nullable Interval interval)
+  {
+    return newTaskId(idPrefix, getRandomId(), DateTimes.nowUtc(), typeName, dataSource, interval);
+  }
+
+  /**
+   * This method is only visible to outside only for testing.
+   * Use {@link #newTaskId(String, String, Interval)} or {@link #newTaskId(String, String, String, Interval)} instead.
+   */
+  @VisibleForTesting
+  static String newTaskId(
+      String idPrefix,
+      String idSuffix,
+      DateTime now,
+      String typeName,
+      String dataSource,
+      @Nullable Interval interval
+  )
   {
     final List<String> objects = new ArrayList<>();
-    final String suffix = getRandomId();
+    objects.add(idPrefix);
     objects.add(typeName);
     objects.add(dataSource);
-    objects.add(suffix);
+    objects.add(idSuffix);
     if (interval != null) {
       objects.add(interval.getStart().toString());
       objects.add(interval.getEnd().toString());
     }
-    objects.add(DateTimes.nowUtc().toString());
+    objects.add(now.toString());
 
     return String.join("_", objects);
   }

--- a/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
+++ b/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
@@ -22,8 +22,13 @@ package org.apache.druid.common.utils;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
+import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -67,5 +72,21 @@ public class IdUtils
   public static String getRandomIdWithPrefix(String prefix)
   {
     return UNDERSCORE_JOINER.join(prefix, IdUtils.getRandomId());
+  }
+
+  public static String newTaskId(final String typeName, String dataSource, @Nullable Interval interval)
+  {
+    final List<String> objects = new ArrayList<>();
+    final String suffix = getRandomId();
+    objects.add(typeName);
+    objects.add(dataSource);
+    objects.add(suffix);
+    if (interval != null) {
+      objects.add(interval.getStart().toString());
+      objects.add(interval.getEnd().toString());
+    }
+    objects.add(DateTimes.nowUtc().toString());
+
+    return String.join("_", objects);
   }
 }

--- a/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
+++ b/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
@@ -78,10 +78,10 @@ public class IdUtils
 
   public static String newTaskId(String typeName, String dataSource, @Nullable Interval interval)
   {
-    return newTaskId("", typeName, dataSource, interval);
+    return newTaskId(null, typeName, dataSource, interval);
   }
 
-  public static String newTaskId(String idPrefix, String typeName, String dataSource, @Nullable Interval interval)
+  public static String newTaskId(@Nullable String idPrefix, String typeName, String dataSource, @Nullable Interval interval)
   {
     return newTaskId(idPrefix, getRandomId(), DateTimes.nowUtc(), typeName, dataSource, interval);
   }
@@ -92,7 +92,7 @@ public class IdUtils
    */
   @VisibleForTesting
   static String newTaskId(
-      String idPrefix,
+      @Nullable String idPrefix,
       String idSuffix,
       DateTime now,
       String typeName,
@@ -101,7 +101,9 @@ public class IdUtils
   )
   {
     final List<String> objects = new ArrayList<>();
-    objects.add(idPrefix);
+    if (idPrefix != null) {
+      objects.add(idPrefix);
+    }
     objects.add(typeName);
     objects.add(dataSource);
     objects.add(idSuffix);

--- a/core/src/test/java/org/apache/druid/common/utils/IdUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/common/utils/IdUtilsTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.common.utils;
 
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -107,5 +110,51 @@ public class IdUtilsTest
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("thingToValidate cannot contain whitespace character except space.");
     IdUtils.validateId(THINGO, "form\u000cfeed?");
+  }
+
+  @Test
+  public void testNewTaskIdWithoutInterval()
+  {
+    final String id = IdUtils.newTaskId(
+        "prefix",
+        "suffix",
+        DateTimes.of("2020-01-01"),
+        "type",
+        "datasource",
+        null
+    );
+    final String expected = String.join(
+        "_",
+        "prefix",
+        "type",
+        "datasource",
+        "suffix",
+        DateTimes.of("2020-01-01").toString()
+    );
+    Assert.assertEquals(expected, id);
+  }
+
+  @Test
+  public void testNewTaskIdWithInterval()
+  {
+    final String id = IdUtils.newTaskId(
+        "prefix",
+        "suffix",
+        DateTimes.of("2020-01-01"),
+        "type",
+        "datasource",
+        Intervals.of("2020-01-01/2020-06-01")
+    );
+    final String expected = String.join(
+        "_",
+        "prefix",
+        "type",
+        "datasource",
+        "suffix",
+        DateTimes.of("2020-01-01").toString(),
+        DateTimes.of("2020-06-01").toString(),
+        DateTimes.of("2020-01-01").toString()
+    );
+    Assert.assertEquals(expected, id);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.common.task;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import org.apache.druid.common.utils.IdUtils;
@@ -41,8 +40,6 @@ import java.util.Map;
 
 public abstract class AbstractTask implements Task
 {
-  private static final Joiner ID_JOINER = Joiner.on("_");
-
   @JsonIgnore
   private final String id;
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -29,14 +29,12 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.actions.LockListAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
-import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunner;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,29 +78,18 @@ public abstract class AbstractTask implements Task
     this.context = context == null ? new HashMap<>() : new HashMap<>(context);
   }
 
-  public static String getOrMakeId(String id, final String typeName, String dataSource)
+  public static String getOrMakeId(@Nullable String id, final String typeName, String dataSource)
   {
     return getOrMakeId(id, typeName, dataSource, null);
   }
 
-  static String getOrMakeId(String id, final String typeName, String dataSource, @Nullable Interval interval)
+  static String getOrMakeId(@Nullable String id, final String typeName, String dataSource, @Nullable Interval interval)
   {
     if (id != null) {
       return id;
     }
 
-    final List<Object> objects = new ArrayList<>();
-    final String suffix = IdUtils.getRandomId();
-    objects.add(typeName);
-    objects.add(dataSource);
-    objects.add(suffix);
-    if (interval != null) {
-      objects.add(interval.getStart());
-      objects.add(interval.getEnd());
-    }
-    objects.add(DateTimes.nowUtc().toString());
-
-    return joinId(objects);
+    return IdUtils.newTaskId(typeName, dataSource, interval);
   }
 
   @JsonProperty
@@ -173,23 +160,6 @@ public abstract class AbstractTask implements Task
            ", dataSource='" + dataSource + '\'' +
            ", context=" + context +
            '}';
-  }
-
-  /**
-   * Start helper methods
-   *
-   * @param objects objects to join
-   *
-   * @return string of joined objects
-   */
-  static String joinId(List<Object> objects)
-  {
-    return ID_JOINER.join(objects);
-  }
-
-  static String joinId(Object... objects)
-  {
-    return ID_JOINER.join(objects);
   }
 
   public TaskStatus success()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -183,8 +183,8 @@ public class CompactionTask extends AbstractBatchIndexTask
 
   @JsonCreator
   public CompactionTask(
-      @JsonProperty("id") final String id,
-      @JsonProperty("resource") final TaskResource taskResource,
+      @JsonProperty("id") @Nullable final String id,
+      @JsonProperty("resource") @Nullable final TaskResource taskResource,
       @JsonProperty("dataSource") final String dataSource,
       @JsonProperty("interval") @Deprecated @Nullable final Interval interval,
       @JsonProperty("segments") @Deprecated @Nullable final List<DataSegment> segments,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -785,7 +785,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     if (published) {
       LOG.info("Published [%d] segments", newSegments.size());
     } else {
-      throw new ISE("Failed to publish segments", newSegments);
+      throw new ISE("Failed to publish segments");
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitor.java
@@ -277,13 +277,13 @@ public class TaskMonitor<T extends Task>
   {
     T task = spec.newSubTask(numAttempts);
     try {
-      indexingServiceClient.runTask(task);
+      indexingServiceClient.runTask(task.getId(), task);
     }
     catch (Exception e) {
       if (isUnknownTypeIdException(e)) {
         log.warn(e, "Got an unknown type id error. Retrying with a backward compatible type.");
         task = spec.newSubTaskWithBackwardCompatibleType(numAttempts);
-        indexingServiceClient.runTask(task);
+        indexingServiceClient.runTask(task.getId(), task);
       } else {
         throw e;
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -67,6 +67,7 @@ public class ClientCompactionTaskQuerySerdeTest
   {
     final ObjectMapper mapper = setupInjectablesInObjectMapper(new DefaultObjectMapper());
     final ClientCompactionTaskQuery query = new ClientCompactionTaskQuery(
+        null,
         "datasource",
         new ClientCompactionIOConfig(
             new ClientCompactionIntervalSpec(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -152,7 +152,7 @@ public class ClientCompactionTaskQuerySerdeTest
   public void testCompactionTaskToClientCompactionTaskQuery() throws IOException
   {
     final ObjectMapper mapper = setupInjectablesInObjectMapper(new DefaultObjectMapper());
-    final CompactionTask task = new CompactionTask.Builder(
+    final CompactionTask.Builder builder = new CompactionTask.Builder(
         "datasource",
         mapper,
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
@@ -163,44 +163,45 @@ public class ClientCompactionTaskQuerySerdeTest
         new SegmentLoaderFactory(null, mapper),
         new RetryPolicyFactory(new RetryPolicyConfig()),
         APPENDERATORS_MANAGER
-    ).inputSpec(new CompactionIntervalSpec(Intervals.of("2019/2020"), "testSha256OfSortedSegmentIds"))
-     .tuningConfig(
-         new ParallelIndexTuningConfig(
-             null,
-             null,
-             40000,
-             2000L,
-             null,
-             null,
-             new SegmentsSplitHintSpec(100000L),
-             new DynamicPartitionsSpec(100, 30000L),
-             new IndexSpec(
-                 new DefaultBitmapSerdeFactory(),
-                 CompressionStrategy.LZ4,
-                 CompressionStrategy.LZF,
-                 LongEncodingStrategy.LONGS
-             ),
-             null,
-             null,
-             null,
-             null,
-             1000L,
-             null,
-             null,
-             100,
-             null,
-             null,
-             null,
-             null,
-             null,
-             null,
-             null,
-             null,
-             null
-         )
-     )
-     .build();
-
+    );
+    final CompactionTask task = builder
+        .inputSpec(new CompactionIntervalSpec(Intervals.of("2019/2020"), "testSha256OfSortedSegmentIds"))
+        .tuningConfig(
+            new ParallelIndexTuningConfig(
+                null,
+                null,
+                40000,
+                2000L,
+                null,
+                null,
+                new SegmentsSplitHintSpec(100000L),
+                new DynamicPartitionsSpec(100, 30000L),
+                new IndexSpec(
+                    new DefaultBitmapSerdeFactory(),
+                    CompressionStrategy.LZ4,
+                    CompressionStrategy.LZF,
+                    LongEncodingStrategy.LONGS
+                ),
+                null,
+                null,
+                null,
+                null,
+                1000L,
+                null,
+                null,
+                100,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+            )
+        )
+        .build();
 
     final ClientCompactionTaskQuery expected = new ClientCompactionTaskQuery(
         task.getId(),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -67,7 +67,7 @@ public class ClientCompactionTaskQuerySerdeTest
   {
     final ObjectMapper mapper = setupInjectablesInObjectMapper(new DefaultObjectMapper());
     final ClientCompactionTaskQuery query = new ClientCompactionTaskQuery(
-        null,
+        "id",
         "datasource",
         new ClientCompactionIOConfig(
             new ClientCompactionIntervalSpec(
@@ -97,6 +97,7 @@ public class ClientCompactionTaskQuerySerdeTest
     final byte[] json = mapper.writeValueAsBytes(query);
     final CompactionTask task = (CompactionTask) mapper.readValue(json, Task.class);
 
+    Assert.assertEquals(query.getId(), task.getId());
     Assert.assertEquals(query.getDataSource(), task.getDataSource());
     Assert.assertTrue(task.getIoConfig().getInputSpec() instanceof CompactionIntervalSpec);
     Assert.assertEquals(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientKillUnusedSegmentsTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientKillUnusedSegmentsTaskQuerySerdeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.apache.druid.client.indexing.ClientKillUnusedSegmentsTaskQuery;
+import org.apache.druid.client.indexing.ClientTaskQuery;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.Intervals;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ClientKillUnusedSegmentsTaskQuerySerdeTest
+{
+  private ObjectMapper objectMapper;
+
+  @Before
+  public void setup()
+  {
+    objectMapper = new DefaultObjectMapper();
+    objectMapper.registerSubtypes(
+        new NamedType(ClientKillUnusedSegmentsTaskQuery.class, ClientKillUnusedSegmentsTaskQuery.TYPE)
+    );
+  }
+
+  @Test
+  public void testClientKillUnusedSegmentsTaskQueryToKillUnusedSegmentsTask() throws IOException
+  {
+    final ClientKillUnusedSegmentsTaskQuery taskQuery = new ClientKillUnusedSegmentsTaskQuery(
+        "killTaskId",
+        "datasource",
+        Intervals.of("2020-01-01/P1D")
+    );
+    final byte[] json = objectMapper.writeValueAsBytes(taskQuery);
+    final KillUnusedSegmentsTask fromJson = (KillUnusedSegmentsTask) objectMapper.readValue(json, Task.class);
+    Assert.assertEquals(taskQuery.getId(), fromJson.getId());
+    Assert.assertEquals(taskQuery.getDataSource(), fromJson.getDataSource());
+    Assert.assertEquals(taskQuery.getInterval(), fromJson.getInterval());
+  }
+
+  @Test
+  public void testKillUnusedSegmentsTaskToClientKillUnusedSegmentsTaskQuery() throws IOException
+  {
+    final KillUnusedSegmentsTask task = new KillUnusedSegmentsTask(
+        null,
+        "datasource",
+        Intervals.of("2020-01-01/P1D"),
+        null
+    );
+    final byte[] json = objectMapper.writeValueAsBytes(task);
+    final ClientKillUnusedSegmentsTaskQuery taskQuery = (ClientKillUnusedSegmentsTaskQuery) objectMapper.readValue(
+        json,
+        ClientTaskQuery.class
+    );
+    Assert.assertEquals(task.getId(), taskQuery.getId());
+    Assert.assertEquals(task.getDataSource(), taskQuery.getDataSource());
+    Assert.assertEquals(task.getInterval(), taskQuery.getInterval());
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.client.indexing.ClientKillUnusedSegmentsTaskQuery;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.data.input.impl.NoopInputFormat;
@@ -381,43 +380,6 @@ public class TaskSerdeTest
     Assert.assertEquals(task.getDataSource(), task2.getDataSource());
     Assert.assertTrue(task.getIngestionSchema().getIOConfig().getInputSource() instanceof LocalInputSource);
     Assert.assertTrue(task2.getIngestionSchema().getIOConfig().getInputSource() instanceof LocalInputSource);
-  }
-
-  @Test
-  public void testKillTaskSerde() throws Exception
-  {
-    final KillUnusedSegmentsTask task = new KillUnusedSegmentsTask(
-        null,
-        "foo",
-        Intervals.of("2010-01-01/P1D"),
-        null
-    );
-
-    final String json = jsonMapper.writeValueAsString(task);
-
-    Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
-    final KillUnusedSegmentsTask task2 = (KillUnusedSegmentsTask) jsonMapper.readValue(json, Task.class);
-
-    Assert.assertEquals("foo", task.getDataSource());
-    Assert.assertEquals(Intervals.of("2010-01-01/P1D"), task.getInterval());
-
-    Assert.assertEquals(task.getId(), task2.getId());
-    Assert.assertEquals(task.getGroupId(), task2.getGroupId());
-    Assert.assertEquals(task.getDataSource(), task2.getDataSource());
-    Assert.assertEquals(task.getInterval(), task2.getInterval());
-
-    final KillUnusedSegmentsTask task3 = (KillUnusedSegmentsTask) jsonMapper.readValue(
-        jsonMapper.writeValueAsString(
-            new ClientKillUnusedSegmentsTaskQuery(
-                null,
-                "foo",
-                Intervals.of("2010-01-01/P1D")
-            )
-        ), Task.class
-    );
-
-    Assert.assertEquals("foo", task3.getDataSource());
-    Assert.assertEquals(Intervals.of("2010-01-01/P1D"), task3.getInterval());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -409,6 +409,7 @@ public class TaskSerdeTest
     final KillUnusedSegmentsTask task3 = (KillUnusedSegmentsTask) jsonMapper.readValue(
         jsonMapper.writeValueAsString(
             new ClientKillUnusedSegmentsTaskQuery(
+                null,
                 "foo",
                 Intervals.of("2010-01-01/P1D")
             )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -454,7 +454,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     }
 
     @Override
-    public String runTask(Object taskObject)
+    public String runTask(String taskId, Object taskObject)
     {
       final Task task = (Task) taskObject;
       return taskRunner.run(injectIfNeeded(task));

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -83,7 +83,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
             false
         )
     );
-    getIndexingServiceClient().runTask(task);
+    getIndexingServiceClient().runTask(task.getId(), task);
     while (task.getCurrentRunner() == null) {
       Thread.sleep(100);
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -129,7 +129,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
             false
         )
     );
-    getIndexingServiceClient().runTask(task);
+    getIndexingServiceClient().runTask(task.getId(), task);
     Thread.sleep(1000);
 
     final SinglePhaseParallelIndexTaskRunner runner = (SinglePhaseParallelIndexTaskRunner) task.getCurrentRunner();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitorTest.java
@@ -245,7 +245,7 @@ public class TaskMonitorTest
   private class TestIndexingServiceClient extends NoopIndexingServiceClient
   {
     @Override
-    public String runTask(Object taskObject)
+    public String runTask(String taskId, Object taskObject)
     {
       final TestTask task = (TestTask) taskObject;
       tasks.put(task.getId(), TaskState.RUNNING);

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
@@ -21,9 +21,8 @@ package org.apache.druid.client.indexing;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.common.utils.IdUtils;
+import com.google.common.base.Preconditions;
 
-import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 
@@ -43,14 +42,14 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
 
   @JsonCreator
   public ClientCompactionTaskQuery(
-      @JsonProperty("id") @Nullable String id,
+      @JsonProperty("id") String id,
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("ioConfig") ClientCompactionIOConfig ioConfig,
       @JsonProperty("tuningConfig") ClientCompactionTaskQueryTuningConfig tuningConfig,
       @JsonProperty("context") Map<String, Object> context
   )
   {
-    this.id = id == null ? IdUtils.newTaskId(TYPE, dataSource, null) : id;
+    this.id = Preconditions.checkNotNull(id, "id");
     this.dataSource = dataSource;
     this.ioConfig = ioConfig;
     this.tuningConfig = tuningConfig;

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
@@ -57,6 +57,7 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
     this.context = context;
   }
 
+  @JsonProperty
   @Override
   public String getId()
   {

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskQuery.java
@@ -21,7 +21,9 @@ package org.apache.druid.client.indexing;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.common.utils.IdUtils;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 
@@ -31,6 +33,9 @@ import java.util.Objects;
  */
 public class ClientCompactionTaskQuery implements ClientTaskQuery
 {
+  static final String TYPE = "compact";
+
+  private final String id;
   private final String dataSource;
   private final ClientCompactionIOConfig ioConfig;
   private final ClientCompactionTaskQueryTuningConfig tuningConfig;
@@ -38,23 +43,31 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
 
   @JsonCreator
   public ClientCompactionTaskQuery(
+      @JsonProperty("id") @Nullable String id,
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("ioConfig") ClientCompactionIOConfig ioConfig,
       @JsonProperty("tuningConfig") ClientCompactionTaskQueryTuningConfig tuningConfig,
       @JsonProperty("context") Map<String, Object> context
   )
   {
+    this.id = id == null ? IdUtils.newTaskId(TYPE, dataSource, null) : id;
     this.dataSource = dataSource;
     this.ioConfig = ioConfig;
     this.tuningConfig = tuningConfig;
     this.context = context;
   }
 
+  @Override
+  public String getId()
+  {
+    return id;
+  }
+
   @JsonProperty
   @Override
   public String getType()
   {
-    return "compact";
+    return TYPE;
   }
 
   @JsonProperty
@@ -92,7 +105,8 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
       return false;
     }
     ClientCompactionTaskQuery that = (ClientCompactionTaskQuery) o;
-    return Objects.equals(dataSource, that.dataSource) &&
+    return Objects.equals(id, that.id) &&
+           Objects.equals(dataSource, that.dataSource) &&
            Objects.equals(ioConfig, that.ioConfig) &&
            Objects.equals(tuningConfig, that.tuningConfig) &&
            Objects.equals(context, that.context);
@@ -101,14 +115,15 @@ public class ClientCompactionTaskQuery implements ClientTaskQuery
   @Override
   public int hashCode()
   {
-    return Objects.hash(dataSource, ioConfig, tuningConfig, context);
+    return Objects.hash(id, dataSource, ioConfig, tuningConfig, context);
   }
 
   @Override
   public String toString()
   {
-    return "ClientCompactQuery{" +
-           "dataSource='" + dataSource + '\'' +
+    return "ClientCompactionTaskQuery{" +
+           "id='" + id + '\'' +
+           ", dataSource='" + dataSource + '\'' +
            ", ioConfig=" + ioConfig +
            ", tuningConfig=" + tuningConfig +
            ", context=" + context +

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
@@ -21,10 +21,9 @@ package org.apache.druid.client.indexing;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.common.utils.IdUtils;
+import com.google.common.base.Preconditions;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -34,7 +33,7 @@ import java.util.Objects;
  */
 public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
 {
-  static final String TYPE = "kill";
+  public static final String TYPE = "kill";
 
   private final String id;
   private final String dataSource;
@@ -42,12 +41,12 @@ public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
 
   @JsonCreator
   public ClientKillUnusedSegmentsTaskQuery(
-      @JsonProperty("id") @Nullable String id,
+      @JsonProperty("id") String id,
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("interval") Interval interval
   )
   {
-    this.id = id == null ? IdUtils.newTaskId(TYPE, dataSource, interval) : id;
+    this.id = Preconditions.checkNotNull(id, "id");
     this.dataSource = dataSource;
     this.interval = interval;
   }

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
@@ -21,7 +21,10 @@ package org.apache.druid.client.indexing;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.common.utils.IdUtils;
 import org.joda.time.Interval;
+
+import javax.annotation.Nullable;
 
 /**
  * Client representation of org.apache.druid.indexing.common.task.KillUnusedSegmentsTask. JSON searialization
@@ -30,24 +33,35 @@ import org.joda.time.Interval;
  */
 public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
 {
+  static final String TYPE = "kill";
+
+  private final String id;
   private final String dataSource;
   private final Interval interval;
 
   @JsonCreator
   public ClientKillUnusedSegmentsTaskQuery(
+      @JsonProperty("id") @Nullable String id,
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("interval") Interval interval
   )
   {
+    this.id = id == null ? IdUtils.newTaskId(TYPE, dataSource, interval) : id;
     this.dataSource = dataSource;
     this.interval = interval;
+  }
+
+  @Override
+  public String getId()
+  {
+    return id;
   }
 
   @JsonProperty
   @Override
   public String getType()
   {
-    return "kill";
+    return TYPE;
   }
 
   @JsonProperty

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
@@ -25,6 +25,7 @@ import org.apache.druid.common.utils.IdUtils;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 /**
  * Client representation of org.apache.druid.indexing.common.task.KillUnusedSegmentsTask. JSON searialization
@@ -51,6 +52,7 @@ public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
     this.interval = interval;
   }
 
+  @JsonProperty
   @Override
   public String getId()
   {
@@ -75,5 +77,26 @@ public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
   public Interval getInterval()
   {
     return interval;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ClientKillUnusedSegmentsTaskQuery that = (ClientKillUnusedSegmentsTaskQuery) o;
+    return Objects.equals(id, that.id) &&
+           Objects.equals(dataSource, that.dataSource) &&
+           Objects.equals(interval, that.interval);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(id, dataSource, interval);
   }
 }

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientTaskQuery.java
@@ -33,11 +33,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
-    @Type(name = "kill", value = ClientKillUnusedSegmentsTaskQuery.class),
-    @Type(name = "compact", value = ClientCompactionTaskQuery.class)
+    @Type(name = ClientKillUnusedSegmentsTaskQuery.TYPE, value = ClientKillUnusedSegmentsTaskQuery.class),
+    @Type(name = ClientCompactionTaskQuery.TYPE, value = ClientCompactionTaskQuery.class)
 })
 public interface ClientTaskQuery
 {
+  String getId();
+
   String getType();
 
   String getDataSource();

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
@@ -44,7 +44,7 @@ public interface IndexingServiceClient
 
   int getTotalWorkerCapacity();
 
-  String runTask(Object taskObject);
+  String runTask(String taskId, Object taskObject);
 
   String cancelTask(String taskId);
 

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
@@ -31,11 +31,27 @@ import java.util.Set;
 
 public interface IndexingServiceClient
 {
-  void killUnusedSegments(String dataSource, Interval interval);
+  default void killUnusedSegments(String dataSource, Interval interval)
+  {
+    killUnusedSegments("", dataSource, interval);
+  }
+
+  void killUnusedSegments(String idPrefix, String dataSource, Interval interval);
 
   int killPendingSegments(String dataSource, DateTime end);
 
+  default String compactSegments(
+      List<DataSegment> segments,
+      int compactionTaskPriority,
+      @Nullable ClientCompactionTaskQueryTuningConfig tuningConfig,
+      @Nullable Map<String, Object> context
+  )
+  {
+    return compactSegments("", segments, compactionTaskPriority, tuningConfig, context);
+  }
+
   String compactSegments(
+      String idPrefix,
       List<DataSegment> segments,
       int compactionTaskPriority,
       @Nullable ClientCompactionTaskQueryTuningConfig tuningConfig,

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
@@ -31,24 +31,9 @@ import java.util.Set;
 
 public interface IndexingServiceClient
 {
-  default void killUnusedSegments(String dataSource, Interval interval)
-  {
-    killUnusedSegments("", dataSource, interval);
-  }
-
   void killUnusedSegments(String idPrefix, String dataSource, Interval interval);
 
   int killPendingSegments(String dataSource, DateTime end);
-
-  default String compactSegments(
-      List<DataSegment> segments,
-      int compactionTaskPriority,
-      @Nullable ClientCompactionTaskQueryTuningConfig tuningConfig,
-      @Nullable Map<String, Object> context
-  )
-  {
-    return compactSegments("", segments, compactionTaskPriority, tuningConfig, context);
-  }
 
   String compactSegments(
       String idPrefix,

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -203,6 +203,7 @@ public class CompactSegments implements CoordinatorDuty
         final DataSourceCompactionConfig config = compactionConfigs.get(dataSourceName);
         // make tuningConfig
         final String taskId = indexingServiceClient.compactSegments(
+            "coordinator-issued",
             segmentsToCompact,
             config.getTaskPriority(),
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment()),

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
@@ -111,7 +111,7 @@ public class KillUnusedSegments implements CoordinatorDuty
         final Interval intervalToKill = findIntervalForKill(dataSource, maxSegmentsToKill);
         if (intervalToKill != null) {
           try {
-            indexingServiceClient.killUnusedSegments(dataSource, intervalToKill);
+            indexingServiceClient.killUnusedSegments("coordinator-issued", dataSource, intervalToKill);
           }
           catch (Exception ex) {
             log.error(ex, "Failed to submit kill task for dataSource [%s]", dataSource);

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -330,7 +330,7 @@ public class DataSourcesResource
     }
     final Interval theInterval = Intervals.of(interval.replace('_', '/'));
     try {
-      indexingServiceClient.killUnusedSegments(dataSourceName, theInterval);
+      indexingServiceClient.killUnusedSegments("api-issued", dataSourceName, theInterval);
       return Response.ok().build();
     }
     catch (Exception e) {

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsQueryTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsQueryTest.java
@@ -38,7 +38,7 @@ public class ClientKillUnusedSegmentsQueryTest
   @Before
   public void setUp()
   {
-    clientKillUnusedSegmentsQuery = new ClientKillUnusedSegmentsTaskQuery(DATA_SOURCE, INTERVAL);
+    clientKillUnusedSegmentsQuery = new ClientKillUnusedSegmentsTaskQuery(null, DATA_SOURCE, INTERVAL);
   }
 
   @After

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsQueryTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsQueryTest.java
@@ -19,6 +19,10 @@
 
 package org.apache.druid.client.indexing;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -26,6 +30,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
 
 public class ClientKillUnusedSegmentsQueryTest
 {
@@ -63,5 +69,29 @@ public class ClientKillUnusedSegmentsQueryTest
   public void testGetInterval()
   {
     Assert.assertEquals(INTERVAL, clientKillUnusedSegmentsQuery.getInterval());
+  }
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    final ObjectMapper objectMapper = new DefaultObjectMapper();
+    objectMapper.registerSubtypes(
+        new NamedType(ClientKillUnusedSegmentsTaskQuery.class, ClientKillUnusedSegmentsTaskQuery.TYPE)
+    );
+    final byte[] json = objectMapper.writeValueAsBytes(clientKillUnusedSegmentsQuery);
+    final ClientKillUnusedSegmentsTaskQuery fromJson = objectMapper.readValue(
+        json,
+        ClientKillUnusedSegmentsTaskQuery.class
+    );
+    Assert.assertEquals(clientKillUnusedSegmentsQuery, fromJson);
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(ClientKillUnusedSegmentsTaskQuery.class)
+                  .usingGetClass()
+                  .withNonnullFields("id", "dataSource", "interval")
+                  .verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQueryTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQueryTest.java
@@ -19,10 +19,7 @@
 
 package org.apache.druid.client.indexing;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -31,9 +28,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-
-public class ClientKillUnusedSegmentsQueryTest
+public class ClientKillUnusedSegmentsTaskQueryTest
 {
   private static final String DATA_SOURCE = "data_source";
   public static final DateTime START = DateTimes.nowUtc();
@@ -44,7 +39,7 @@ public class ClientKillUnusedSegmentsQueryTest
   @Before
   public void setUp()
   {
-    clientKillUnusedSegmentsQuery = new ClientKillUnusedSegmentsTaskQuery(null, DATA_SOURCE, INTERVAL);
+    clientKillUnusedSegmentsQuery = new ClientKillUnusedSegmentsTaskQuery("killTaskId", DATA_SOURCE, INTERVAL);
   }
 
   @After
@@ -69,21 +64,6 @@ public class ClientKillUnusedSegmentsQueryTest
   public void testGetInterval()
   {
     Assert.assertEquals(INTERVAL, clientKillUnusedSegmentsQuery.getInterval());
-  }
-
-  @Test
-  public void testSerde() throws IOException
-  {
-    final ObjectMapper objectMapper = new DefaultObjectMapper();
-    objectMapper.registerSubtypes(
-        new NamedType(ClientKillUnusedSegmentsTaskQuery.class, ClientKillUnusedSegmentsTaskQuery.TYPE)
-    );
-    final byte[] json = objectMapper.writeValueAsBytes(clientKillUnusedSegmentsQuery);
-    final ClientKillUnusedSegmentsTaskQuery fromJson = objectMapper.readValue(
-        json,
-        ClientKillUnusedSegmentsTaskQuery.class
-    );
-    Assert.assertEquals(clientKillUnusedSegmentsQuery, fromJson);
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
@@ -33,7 +33,7 @@ import java.util.Set;
 public class NoopIndexingServiceClient implements IndexingServiceClient
 {
   @Override
-  public void killUnusedSegments(String dataSource, Interval interval)
+  public void killUnusedSegments(String idPrefix, String dataSource, Interval interval)
   {
 
   }
@@ -46,6 +46,7 @@ public class NoopIndexingServiceClient implements IndexingServiceClient
 
   @Override
   public String compactSegments(
+      String idPrefix,
       List<DataSegment> segments,
       int compactionTaskPriority,
       @Nullable ClientCompactionTaskQueryTuningConfig tuningConfig,

--- a/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
@@ -62,7 +62,7 @@ public class NoopIndexingServiceClient implements IndexingServiceClient
   }
 
   @Override
-  public String runTask(Object taskObject)
+  public String runTask(String taskId, Object taskObject)
   {
     return null;
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -356,7 +356,6 @@ public class CompactSegmentsTest
     private final ObjectMapper jsonMapper;
 
     private int compactVersionSuffix = 0;
-    private int idSuffix = 0;
 
     private TestDruidLeaderClient(ObjectMapper jsonMapper)
     {
@@ -434,15 +433,15 @@ public class CompactSegmentsTest
                                                  .flatMap(holder -> Streams.sequentialStreamFrom(holder.getObject()))
                                                  .map(PartitionChunk::getObject)
                                                  .collect(Collectors.toList());
-      final String taskId = compactSegments(
+      compactSegments(
           timeline,
           segments,
           compactionTaskQuery.getTuningConfig()
       );
-      return createStringFullResponseHolder(jsonMapper.writeValueAsString(ImmutableMap.of("task", taskId)));
+      return createStringFullResponseHolder(jsonMapper.writeValueAsString(ImmutableMap.of("task", taskQuery.getId())));
     }
 
-    private String compactSegments(
+    private void compactSegments(
         VersionedIntervalTimeline<String, DataSegment> timeline,
         List<DataSegment> segments,
         ClientCompactionTaskQueryTuningConfig tuningConfig
@@ -503,8 +502,6 @@ public class CompactSegmentsTest
             compactSegment.getShardSpec().createChunk(compactSegment)
         );
       }
-
-      return "task_" + idSuffix++;
     }
   }
 

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -592,7 +592,7 @@ public class DataSourcesResourceTest
     Interval theInterval = Intervals.of(interval.replace('_', '/'));
 
     IndexingServiceClient indexingServiceClient = EasyMock.createStrictMock(IndexingServiceClient.class);
-    indexingServiceClient.killUnusedSegments("datasource1", theInterval);
+    indexingServiceClient.killUnusedSegments("api-issued", "datasource1", theInterval);
     EasyMock.expectLastCall().once();
     EasyMock.replay(indexingServiceClient, server);
 


### PR DESCRIPTION
### Description

`HttpIndexingServiceClient` prints the entire task spec when it fails to issue a task, which could be huge especially in parallel task when lots of segments are shuffled. This could end up causing OOM error in the supervisor task. This PR fixes it by logging only task ID. I also cleaned up some wrong logging in `ParallelIndexSupervisorTask`.

This PR also changes the ID pattern of compaction/kill tasks when they are submitted by the coordinator. After this PR, the ID of compaction and kill tasks will be prefixed by `coordinator-issued` if they are submitted by coordinator. `api-issued` prefix will be used when a kill task is issued by calling `DataSourcesResource.killUnusedSegmentsInInterval()`.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.