### PR TITLE
Add SQL "OFFSET" clause.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Chars;
-import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexLiteral;
@@ -368,39 +367,6 @@ public class Calcites
   public static String makePrefixedName(final String prefix, final String suffix)
   {
     return StringUtils.format("%s:%s", prefix, suffix);
-  }
-
-  public static int getInt(RexNode rex, int defaultValue)
-  {
-    return rex == null ? defaultValue : RexLiteral.intValue(rex);
-  }
-
-  public static int getOffset(Sort sort)
-  {
-    return Calcites.getInt(sort.offset, 0);
-  }
-
-  public static int getFetch(Sort sort)
-  {
-    return Calcites.getInt(sort.fetch, -1);
-  }
-
-  public static int collapseFetch(int innerFetch, int outerFetch, int outerOffset)
-  {
-    final int fetch;
-    if (innerFetch < 0 && outerFetch < 0) {
-      // Neither has a limit => no limit overall.
-      fetch = -1;
-    } else if (innerFetch < 0) {
-      // Outer limit only.
-      fetch = outerFetch;
-    } else if (outerFetch < 0) {
-      // Inner limit only.
-      fetch = Math.max(0, innerFetch - outerOffset);
-    } else {
-      fetch = Math.max(0, Math.min(innerFetch - outerOffset, outerFetch));
-    }
-    return fetch;
   }
 
   public static Class<?> sqlTypeNameJdbcToJavaClass(SqlTypeName typeName)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/OffsetLimit.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/OffsetLimit.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.planner;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.BasicSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Represents an offset and a limit.
+ */
+public class OffsetLimit
+{
+  private final long offset;
+
+  @Nullable
+  private final Long limit;
+
+  OffsetLimit(long offset, @Nullable Long limit)
+  {
+    Preconditions.checkArgument(offset >= 0, "offset >= 0");
+    Preconditions.checkArgument(limit == null || limit >= 0, "limit == null || limit >= 0");
+
+    this.offset = offset;
+    this.limit = limit;
+  }
+
+  public static OffsetLimit none()
+  {
+    return new OffsetLimit(0, null);
+  }
+
+  public static OffsetLimit fromSort(Sort sort)
+  {
+    final long offset = sort.offset == null ? 0 : (long) RexLiteral.intValue(sort.offset);
+    final Long limit = sort.fetch == null ? null : (long) RexLiteral.intValue(sort.fetch);
+    return new OffsetLimit(offset, limit);
+  }
+
+  public boolean hasOffset()
+  {
+    return offset > 0;
+  }
+
+  public long getOffset()
+  {
+    return offset;
+  }
+
+  public boolean hasLimit()
+  {
+    return limit != null;
+  }
+
+  public long getLimit()
+  {
+    Preconditions.checkState(limit != null, "limit is not present");
+    return limit;
+  }
+
+  @Nullable
+  public RexNode getOffsetAsRexNode(final RexBuilder builder)
+  {
+    if (offset == 0) {
+      return null;
+    } else {
+      return builder.makeLiteral(
+          offset,
+          new BasicSqlType(DruidTypeSystem.INSTANCE, SqlTypeName.BIGINT),
+          false
+      );
+    }
+  }
+
+  @Nullable
+  public RexNode getLimitAsRexNode(final RexBuilder builder)
+  {
+    if (limit == null) {
+      return null;
+    } else {
+      return builder.makeLiteral(
+          limit,
+          new BasicSqlType(DruidTypeSystem.INSTANCE, SqlTypeName.BIGINT),
+          false
+      );
+    }
+  }
+
+  /**
+   * Return a new instance that represents applying this one first, then the {@param next} one.
+   */
+  public OffsetLimit andThen(final OffsetLimit next)
+  {
+    final Long newLimit;
+
+    if (limit == null && next.limit == null) {
+      // Neither has a limit => no limit overall.
+      newLimit = null;
+    } else if (limit == null) {
+      // Outer limit only.
+      newLimit = next.limit;
+    } else if (next.limit == null) {
+      // Inner limit only.
+      newLimit = Math.max(0, limit - next.offset);
+    } else {
+      // Both outer and inner limit.
+      newLimit = Math.max(0, Math.min(limit - next.offset, next.limit));
+    }
+
+    return new OffsetLimit(offset + next.offset, newLimit);
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OffsetLimit that = (OffsetLimit) o;
+    return Objects.equals(offset, that.offset) &&
+           Objects.equals(limit, that.limit);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(offset, limit);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "OffsetLimit{" +
+           "offset=" + offset +
+           ", limit=" + limit +
+           '}';
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/SortCollapseRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/SortCollapseRule.java
@@ -22,7 +22,7 @@ package org.apache.druid.sql.calcite.rule;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.core.Sort;
-import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.OffsetLimit;
 
 /**
  * Collapses two adjacent Sort operations together. Useful for queries like
@@ -50,21 +50,13 @@ public class SortCollapseRule extends RelOptRule
 
     if (outerSort.collation.getFieldCollations().isEmpty()
         || outerSort.collation.getFieldCollations().equals(innerSort.collation.getFieldCollations())) {
-      final int innerOffset = Calcites.getOffset(innerSort);
-      final int innerFetch = Calcites.getFetch(innerSort);
-      final int outerOffset = Calcites.getOffset(outerSort);
-      final int outerFetch = Calcites.getFetch(outerSort);
-
-      // Add up the offsets.
-      final int offset = innerOffset + outerOffset;
-      final int fetch = Calcites.collapseFetch(innerFetch, outerFetch, outerOffset);
-
+      final OffsetLimit offsetLimit = OffsetLimit.fromSort(innerSort).andThen(OffsetLimit.fromSort(outerSort));
       final Sort combined = innerSort.copy(
           innerSort.getTraitSet(),
           innerSort.getInput(),
           innerSort.getCollation(),
-          offset == 0 ? null : call.builder().literal(offset),
-          fetch < 0 ? null : call.builder().literal(fetch)
+          offsetLimit.getOffsetAsRexNode(call.builder().getRexBuilder()),
+          offsetLimit.getLimitAsRexNode(call.builder().getRexBuilder())
       );
 
       call.transformTo(combined);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/OffsetLimitTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/OffsetLimitTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.planner;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OffsetLimitTest
+{
+  @Test
+  public void testAndThen()
+  {
+    final List<String> things = ImmutableList.of("a", "b", "c", "d", "e", "f", "g", "h");
+
+    for (int innerOffset = 0; innerOffset < 5; innerOffset++) {
+      for (int innerLimit = -1; innerLimit < 5; innerLimit++) {
+        for (int outerOffset = 0; outerOffset < 5; outerOffset++) {
+          for (int outerLimit = -1; outerLimit < 5; outerLimit++) {
+            final OffsetLimit inner = new OffsetLimit(innerOffset, innerLimit < 0 ? null : (long) innerLimit);
+            final OffsetLimit outer = new OffsetLimit(outerOffset, outerLimit < 0 ? null : (long) outerLimit);
+            final OffsetLimit combined = inner.andThen(outer);
+
+            Assert.assertEquals(
+                StringUtils.format(
+                    "innerOffset[%s], innerLimit[%s], outerOffset[%s], outerLimit[%s]",
+                    innerOffset,
+                    innerLimit,
+                    outerOffset,
+                    outerLimit
+                ),
+                things.stream()
+                      .skip(innerOffset)
+                      .limit(innerLimit < 0 ? Long.MAX_VALUE : innerLimit)
+                      .skip(outerOffset)
+                      .limit(outerLimit < 0 ? Long.MAX_VALUE : outerLimit)
+                      .collect(Collectors.toList()),
+                things.stream()
+                      .skip(combined.getOffset())
+                      .limit(combined.hasLimit() ? combined.getLimit() : Long.MAX_VALUE)
+                      .collect(Collectors.toList())
+            );
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Under the hood, this uses the new offset features from #10233 (Scan)
and #10235 (GroupBy). Since Timeseries and TopN queries do not currently
have an offset feature, SQL planning will switch from one of those to
Scan or GroupBy if users add an OFFSET.

Includes a refactoring to harmonize offset and limit planning using an
OffsetLimit wrapper class. This is useful because it ensures that the
various places that need to deal with offset and limit collapsing all
behave the same way, using its "andThen" method.