### PR TITLE
Add note about aggregations on floats

### DIFF
--- a/docs/development/extensions-core/stats.md
+++ b/docs/development/extensions-core/stats.md
@@ -44,6 +44,13 @@ This algorithm was proven to be numerically stable by J.L. Barlow in
 "Error analysis of a pairwise summation algorithm to compute sample variance"
 Numer. Math, 58 (1991) pp. 583--590
 
+> As with all [aggregators](../../querying/sql.md#aggregation-functions), the order of operations across segments is
+> non-deterministic. This means that if this aggregator is used with an input type of "float", the result of the
+> aggregation will not be precisely the same across multiple runs of the query.
+>
+> To produce consistent results, either cast the input type to a "double" or round the variance to
+> a fixed number of decimal places so that the results are stable across query runs.
+
 ### Pre-aggregating variance at ingestion time
 
 To use this feature, an "variance" aggregator must be included at indexing time.

--- a/docs/development/extensions-core/stats.md
+++ b/docs/development/extensions-core/stats.md
@@ -46,7 +46,7 @@ Numer. Math, 58 (1991) pp. 583--590
 
 > As with all [aggregators](../../querying/sql.md#aggregation-functions), the order of operations across segments is
 > non-deterministic. This means that if this aggregator operates with an input type of "float" or "double", the result
-> of the aggregation will not be precisely the same across multiple runs of the query.
+> of the aggregation may not be precisely the same across multiple runs of the query.
 >
 > To produce consistent results, round the variance to a fixed number of decimal places so that the results are 
 > precisely the same across query runs.

--- a/docs/development/extensions-core/stats.md
+++ b/docs/development/extensions-core/stats.md
@@ -45,11 +45,11 @@ This algorithm was proven to be numerically stable by J.L. Barlow in
 Numer. Math, 58 (1991) pp. 583--590
 
 > As with all [aggregators](../../querying/sql.md#aggregation-functions), the order of operations across segments is
-> non-deterministic. This means that if this aggregator is used with an input type of "float", the result of the
-> aggregation will not be precisely the same across multiple runs of the query.
+> non-deterministic. This means that if this aggregator operates with an input type of "float" or "double", the result
+> of the aggregation will not be precisely the same across multiple runs of the query.
 >
-> To produce consistent results, either cast the input type to a "double" or round the variance to
-> a fixed number of decimal places so that the results are stable across query runs.
+> To produce consistent results, round the variance to a fixed number of decimal places so that the results are 
+> precisely the same across query runs.
 
 ### Pre-aggregating variance at ingestion time
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -232,6 +232,10 @@ possible for two aggregators in the same SQL query to have different filters.
 
 Only the COUNT aggregation can accept DISTINCT.
 
+> The order of aggregation operations across segments is not deterministic. This means that non-commutative aggregation
+> functions can produce inconsistent results across the same query. Any functions that operate on an input type of "float"
+> may also see these differences in aggregation results across multiple query runs.
+
 |Function|Notes|
 |--------|-----|
 |`COUNT(*)`|Counts the number of rows.|

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -235,7 +235,7 @@ Only the COUNT aggregation can accept DISTINCT.
 > The order of aggregation operations across segments is not deterministic. This means that non-commutative aggregation
 > functions can produce inconsistent results across the same query. 
 >
-> Functions that operates on an input type of "float" or "double" may also see these differences in aggregation
+> Functions that operate on an input type of "float" or "double" may also see these differences in aggregation
 > results across multiple query runs because of this. If precisely the same value is desired across multiple query runs,
 > consider using the `ROUND` function to smooth out the inconsistencies between queries.  
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -233,8 +233,11 @@ possible for two aggregators in the same SQL query to have different filters.
 Only the COUNT aggregation can accept DISTINCT.
 
 > The order of aggregation operations across segments is not deterministic. This means that non-commutative aggregation
-> functions can produce inconsistent results across the same query. Any functions that operate on an input type of "float"
-> may also see these differences in aggregation results across multiple query runs.
+> functions can produce inconsistent results across the same query. 
+>
+> Functions that operates on an input type of "float" or "double" may also see these differences in aggregation
+> results across multiple query runs because of this. If precisely the same value is desired across multiple query runs,
+> consider using the `ROUND` function to smooth out the inconsistencies between queries.  
 
 |Function|Notes|
 |--------|-----|


### PR DESCRIPTION
Floating point math is known to be unstable. Due to the way aggregators work
across segments it's possible for the same query operating on the same data to
produce slightly different results.

The same problem exists with any aggregators that are not commutative since
the merge order across segments is not guaranteed.