### PR TITLE
Update Kafka dependencies to 2.6.0

### DIFF
--- a/docs/tutorials/tutorial-kafka.md
+++ b/docs/tutorials/tutorial-kafka.md
@@ -35,13 +35,13 @@ running on your local machine. You don't need to have loaded any data yet.
 ## Download and start Kafka
 
 [Apache Kafka](http://kafka.apache.org/) is a high throughput message bus that works well with
-Druid.  For this tutorial, we will use Kafka 2.1.0. To download Kafka, issue the following
+Druid.  For this tutorial, we will use Kafka 2.6.0. To download Kafka, issue the following
 commands in your terminal:
 
 ```bash
-curl -O https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz
-tar -xzf kafka_2.12-2.1.0.tgz
-cd kafka_2.12-2.1.0
+curl -O https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz
+tar -xzf kafka_2.13-2.6.0.tgz
+cd kafka_2.13-2.6.0
 ```
 
 Start a Kafka broker by running the following command in a new terminal:
@@ -53,7 +53,7 @@ Start a Kafka broker by running the following command in a new terminal:
 Run this command to create a Kafka topic called *wikipedia*, to which we'll send data:
 
 ```bash
-./bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic wikipedia
+./bin/kafka-topics.sh --create --topic wikipedia --bootstrap-server localhost:9092
 ```     
 
 ## Load data into Kafka

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -195,7 +195,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.12.10</version>
+      <version>2.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -150,7 +150,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.12</artifactId>
+      <artifactId>kafka_2.13</artifactId>
       <version>${apache.kafka.version}</version>
       <scope>test</scope>
     </dependency>

--- a/integration-tests/docker-base/setup.sh
+++ b/integration-tests/docker-base/setup.sh
@@ -46,11 +46,11 @@ rm /tmp/$ZK_TAR.tar.gz
 
 # Kafka
 # Match the version to the Kafka client used by KafkaSupervisor
-KAFKA_VERSION=2.5.0
-wget -q -O /tmp/kafka_2.12-$KAFKA_VERSION.tgz "https://apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.12-$KAFKA_VERSION.tgz"
-tar -xzf /tmp/kafka_2.12-$KAFKA_VERSION.tgz -C /usr/local
-ln -s /usr/local/kafka_2.12-$KAFKA_VERSION /usr/local/kafka
-rm /tmp/kafka_2.12-$KAFKA_VERSION.tgz
+KAFKA_VERSION=2.6.0
+wget -q -O /tmp/kafka_2.13-$KAFKA_VERSION.tgz "https://apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.13-$KAFKA_VERSION.tgz"
+tar -xzf /tmp/kafka_2.13-$KAFKA_VERSION.tgz -C /usr/local
+ln -s /usr/local/kafka_2.13-$KAFKA_VERSION /usr/local/kafka
+rm /tmp/kafka_2.13-$KAFKA_VERSION.tgz
 
 # Druid system user
 adduser --system --group --no-create-home druid \

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3251,7 +3251,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 2.5.0
+version: 2.6.0
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -3260,7 +3260,7 @@ libraries:
 notices:
   - kafka-clients: |
       Apache Kafka
-      Copyright 2019 The Apache Software Foundation.
+      Copyright 2020 The Apache Software Foundation.
 
       This distribution has a binary dependency on jersey, which is available under the CDDL
       License. The source code of jersey can be found at https://github.com/jersey/jersey/.
@@ -4159,9 +4159,9 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 2.5.0
+version: 2.6.0
 libraries:
-  - org.apache.kafka: kafka_2.12
+  - org.apache.kafka: kafka_2.13
   - org.apache.kafka: kafka-clients
 notices:
   - kafka-clients:

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>4.3.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
-        <apache.kafka.version>2.5.0</apache.kafka.version>
+        <apache.kafka.version>2.6.0</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
         <avatica.version>1.17.0</avatica.version>


### PR DESCRIPTION
- update Kafka dependencies to Kafka 2.6.0
- switch to Scala 2.13 build of Kafka
- update integration tests
- update Kafka tutorial