### PR TITLE
Upgrade ORC to 1.5.10 version

### DIFF
--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -238,6 +238,7 @@ def build_compatible_license_names():
     compatible_licenses['BSD licence'] = 'BSD-3-Clause License'
     compatible_licenses['BSD License'] = 'BSD-3-Clause License'
     compatible_licenses['BSD-like'] = 'BSD-3-Clause License'
+    compatible_licenses['BSD 3-clause'] = 'BSD-3-Clause License'
     compatible_licenses['The BSD 3-Clause License'] = 'BSD-3-Clause License'
     compatible_licenses['Revised BSD'] = 'BSD-3-Clause License'
     compatible_licenses['New BSD License'] = 'BSD-3-Clause License'

--- a/extensions-core/druid-bloom-filter/pom.xml
+++ b/extensions-core/druid-bloom-filter/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
-      <version>2.7.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <orc.version>1.5.6</orc.version>
+        <orc.version>1.5.10</orc.version>
     </properties>
     <dependencies>
         <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3197,7 +3197,7 @@ name: Apache Hive
 license_category: binary
 module: extensions/druid-bloom-filter
 license_name: Apache License version 2.0
-version: 2.7.0
+version: 2.7.1
 libraries:
   - org.apache.hive: hive-storage-api
 notices:
@@ -4040,7 +4040,7 @@ name: Apache ORC libraries
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 1.5.6
+version: 1.5.10
 libraries:
   - org.apache.orc: orc-mapreduce
   - org.apache.orc: orc-core
@@ -4058,6 +4058,20 @@ notices:
 
 ---
 
+name: ThreeTen
+license_category: binary
+module: extensions/druid-orc-extensions
+license_name: BSD-3-Clause License
+version: 1.5.0
+libraries:
+  - org.threeten: threeten-extra
+notices:
+  - threeten-extra: |
+      ThreeTen-Extra
+      Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
+
+---
+
 name: aircompressor
 license_category: binary
 module: extensions/druid-orc-extensions
@@ -4072,7 +4086,7 @@ name: Hive storage API
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 2.6.0
+version: 2.7.1
 libraries:
   - org.apache.hive: hive-storage-api
 notices:

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-storage-api</artifactId>
-                <version>2.6.0</version>
+                <version>2.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
### Description

Upgrades ORC version to the latest 1.5.x subminor version.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.