### PR TITLE
introduce interning of internal files names in SmooshedFileMapper

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.java.util.common.io.smoosh;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
@@ -46,6 +48,8 @@ import java.util.TreeMap;
  */
 public class SmooshedFileMapper implements Closeable
 {
+  private static final Interner<String> STRING_INTERNER = Interners.newWeakInterner();
+
   public static SmooshedFileMapper load(File baseDir) throws IOException
   {
     File metaFile = FileSmoosher.metaFile(baseDir);
@@ -81,7 +85,7 @@ public class SmooshedFileMapper implements Closeable
           throw new ISE("Wrong number of splits[%d] in line[%s]", splits.length, line);
         }
         internalFiles.put(
-            splits[0],
+            STRING_INTERNER.intern(splits[0]),
             new Metadata(Integer.parseInt(splits[1]), Integer.parseInt(splits[2]), Integer.parseInt(splits[3]))
         );
       }


### PR DESCRIPTION


### Description

This patch introduces string interning of column (..err "internal file") names in `SmooshedFileMapper` which are typically same across loaded segments of same/few DataSources. This is very similar to the interning introduced in `DataSegment` object and beneficial when large number of segments are loaded on same node and specially if those segments happen to have large number of columns.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

