### PR TITLE
Remove NUMERIC_HASHING_THRESHOLD

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ContainsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ContainsBenchmark.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import it.unimi.dsi.fastutil.longs.LongArraySet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@Fork(value = 1)
+public class ContainsBenchmark
+{
+  private static final long[] LONGS;
+  private static final long[] SORTED_LONGS;
+  private static final LongOpenHashSet LONG_HASH_SET;
+  private static final LongArraySet LONG_ARRAY_SET;
+
+  private long worstSearchValue;
+  private long worstSearchValueBin;
+
+  static {
+    LONGS = new long[16];
+    for (int i = 0; i < LONGS.length; i++) {
+      LONGS[i] = ThreadLocalRandom.current().nextInt(Short.MAX_VALUE);
+    }
+
+    LONG_HASH_SET = new LongOpenHashSet(LONGS);
+    LONG_ARRAY_SET = new LongArraySet(LONGS);
+    SORTED_LONGS = Arrays.copyOf(LONGS, LONGS.length);
+
+    Arrays.sort(SORTED_LONGS);
+
+  }
+
+  @Setup
+  public void setUp()
+  {
+    worstSearchValue = LONGS[LONGS.length - 1];
+    worstSearchValueBin = SORTED_LONGS[(SORTED_LONGS.length - 1) >>> 1];
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void linearSearch(Blackhole blackhole)
+  {
+    boolean found = LONG_ARRAY_SET.contains(worstSearchValue);
+    blackhole.consume(found);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void hashSetSearch(Blackhole blackhole)
+  {
+
+    boolean found = LONG_HASH_SET.contains(worstSearchValueBin);
+    blackhole.consume(found);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void binarySearch(Blackhole blackhole)
+  {
+    boolean found = Arrays.binarySearch(SORTED_LONGS, worstSearchValueBin) >= 0;
+    blackhole.consume(found);
+  }
+}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1901,12 +1901,6 @@ Supported query contexts:
 |`maxResults`|Can be used to lower the value of `druid.query.groupBy.maxResults` for this query.|None|
 |`useOffheap`|Set to true to store aggregations off-heap when merging results.|false|
 
-#### Filter configurations configurations
-
-|Key|Description|Default|
-|---|-----------|-------|
-|`druid.query.filter.inDimFilter.numericHashingThreshold`|The threshold at which the engine should use a `Set` to check whether the value matches the filter. If the number of values in the filter is less than the threshold, the engine will use a binary search algorithm to determine if a value matches the filter.|1|
-
 ### Router
 
 #### Router Process Configs

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1901,6 +1901,12 @@ Supported query contexts:
 |`maxResults`|Can be used to lower the value of `druid.query.groupBy.maxResults` for this query.|None|
 |`useOffheap`|Set to true to store aggregations off-heap when merging results.|false|
 
+#### Filter configurations configurations
+
+|Key|Description|Default|
+|---|-----------|-------|
+|`druid.query.filter.inDimFilter.numericHashingThreshold`|The threshold at which the engine should use a `Set` to check whether the value matches the filter. If the number of values in the filter is less than the threshold, the engine will use a binary search algorithm to determine if a value matches the filter.|1|
+
 ### Router
 
 #### Router Process Configs

--- a/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
@@ -80,7 +80,8 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
 {
   // determined through benchmark that binary search on long[] is faster than HashSet until ~16 elements
   // Hashing threshold is not applied to String for now, String still uses ImmutableSortedSet
-  public static final int NUMERIC_HASHING_THRESHOLD = 16;
+  public static final int NUMERIC_HASHING_THRESHOLD =
+      Integer.parseInt(System.getProperty("druid.query.filter.inDimFilter.numericHashingThreshold", "1"));
 
   // Values can contain `null` object
   private final Set<String> values;
@@ -109,6 +110,25 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
         values,
         extractionFn,
         filterTuning,
+        null
+    );
+  }
+
+  /**
+   *
+   * @param dimension
+   * @param values This collection instance can be reused if possible to avoid copying a big collection.
+   *               Callers should <b>not</b> modify the collection after it is passed to this constructor.
+   */
+  public InDimFilter(
+      String dimension,
+      Set<String> values
+  )
+  {
+    this(
+        dimension,
+        values,
+        null,
         null
     );
   }

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryBuilder.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryBuilder.java
@@ -236,7 +236,7 @@ public class TopNQueryBuilder
   {
     final Set<String> filterValues = Sets.newHashSet(values);
     filterValues.add(value);
-    dimFilter = new InDimFilter(dimensionName, filterValues, null, null);
+    dimFilter = new InDimFilter(dimensionName, filterValues);
     return this;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/JoinFilterAnalyzer.java
@@ -438,9 +438,7 @@ public class JoinFilterAnalyzer
         for (String correlatedBaseColumn : correlationAnalysis.getBaseColumns()) {
           Filter rewrittenFilter = new InDimFilter(
               correlatedBaseColumn,
-              newFilterValues,
-              null,
-              null
+              newFilterValues
           ).toFilter();
           newFilters.add(rewrittenFilter);
         }
@@ -461,9 +459,7 @@ public class JoinFilterAnalyzer
 
           Filter rewrittenFilter = new InDimFilter(
               pushDownVirtualColumn.getOutputName(),
-              newFilterValues,
-              null,
-              null
+              newFilterValues
           ).toFilter();
           newFilters.add(rewrittenFilter);
         }

--- a/processing/src/test/java/org/apache/druid/segment/filter/FloatAndDoubleFilteringTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FloatAndDoubleFilteringTest.java
@@ -76,6 +76,7 @@ public class FloatAndDoubleFilteringTest extends BaseFilterTest
   private static final String TIMESTAMP_COLUMN = "ts";
   private static int EXECUTOR_NUM_THREADS = 16;
   private static int EXECUTOR_NUM_TASKS = 2000;
+  private static final int NUM_FILTER_VALUES = 32;
 
   private static final InputRowParser<Map<String, Object>> PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
@@ -200,8 +201,8 @@ public class FloatAndDoubleFilteringTest extends BaseFilterTest
     );
 
     // cross the hashing threshold to test hashset implementation, filter on even values
-    List<String> infilterValues = new ArrayList<>(InDimFilter.NUMERIC_HASHING_THRESHOLD * 2);
-    for (int i = 0; i < InDimFilter.NUMERIC_HASHING_THRESHOLD * 2; i++) {
+    List<String> infilterValues = new ArrayList<>(NUM_FILTER_VALUES);
+    for (int i = 0; i < NUM_FILTER_VALUES; i++) {
       infilterValues.add(String.valueOf(i * 2));
     }
     assertFilterMatches(
@@ -377,8 +378,8 @@ public class FloatAndDoubleFilteringTest extends BaseFilterTest
     );
 
     // cross the hashing threshold to test hashset implementation, filter on even values
-    List<String> infilterValues = new ArrayList<>(InDimFilter.NUMERIC_HASHING_THRESHOLD * 2);
-    for (int i = 0; i < InDimFilter.NUMERIC_HASHING_THRESHOLD * 2; i++) {
+    List<String> infilterValues = new ArrayList<>(NUM_FILTER_VALUES);
+    for (int i = 0; i < NUM_FILTER_VALUES; i++) {
       infilterValues.add(String.valueOf(i * 2));
     }
     assertFilterMatchesMultithreaded(

--- a/processing/src/test/java/org/apache/druid/segment/filter/LongFilteringTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/LongFilteringTest.java
@@ -73,6 +73,7 @@ public class LongFilteringTest extends BaseFilterTest
   private static final String TIMESTAMP_COLUMN = "ts";
   private static int EXECUTOR_NUM_THREADS = 16;
   private static int EXECUTOR_NUM_TASKS = 2000;
+  private static final int NUM_FILTER_VALUES = 32;
 
   private static final InputRowParser<Map<String, Object>> PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
@@ -245,8 +246,8 @@ public class LongFilteringTest extends BaseFilterTest
     );
 
     // cross the hashing threshold to test hashset implementation, filter on even values
-    List<String> infilterValues = new ArrayList<>(InDimFilter.NUMERIC_HASHING_THRESHOLD * 2);
-    for (int i = 0; i < InDimFilter.NUMERIC_HASHING_THRESHOLD * 2; i++) {
+    List<String> infilterValues = new ArrayList<>(NUM_FILTER_VALUES);
+    for (int i = 0; i < NUM_FILTER_VALUES; i++) {
       infilterValues.add(String.valueOf(i * 2));
     }
     assertFilterMatches(
@@ -393,8 +394,8 @@ public class LongFilteringTest extends BaseFilterTest
     );
 
     // cross the hashing threshold to test hashset implementation, filter on even values
-    List<String> infilterValues = new ArrayList<>(InDimFilter.NUMERIC_HASHING_THRESHOLD * 2);
-    for (int i = 0; i < InDimFilter.NUMERIC_HASHING_THRESHOLD * 2; i++) {
+    List<String> infilterValues = new ArrayList<>(NUM_FILTER_VALUES);
+    for (int i = 0; i < NUM_FILTER_VALUES; i++) {
       infilterValues.add(String.valueOf(i * 2));
     }
     assertFilterMatchesMultithreaded(

--- a/processing/src/test/java/org/apache/druid/segment/filter/TimeFilteringTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/TimeFilteringTest.java
@@ -67,6 +67,7 @@ import java.util.Map;
 public class TimeFilteringTest extends BaseFilterTest
 {
   private static final String TIMESTAMP_COLUMN = "ts";
+  private static final int NUM_FILTER_VALUES = 32;
 
   private static final InputRowParser<Map<String, Object>> PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
@@ -132,8 +133,8 @@ public class TimeFilteringTest extends BaseFilterTest
     );
 
     // cross the hashing threshold to test hashset implementation, filter on even values
-    List<String> infilterValues = new ArrayList<>(InDimFilter.NUMERIC_HASHING_THRESHOLD * 2);
-    for (int i = 0; i < InDimFilter.NUMERIC_HASHING_THRESHOLD * 2; i++) {
+    List<String> infilterValues = new ArrayList<>(NUM_FILTER_VALUES);
+    for (int i = 0; i < NUM_FILTER_VALUES; i++) {
       infilterValues.add(String.valueOf(i * 2));
     }
     assertFilterMatches(


### PR DESCRIPTION
### Description

Change the default numeric hashing threshold to 1 and make it configurable.

Benchmarks attached to this PR show that binary searches are not faster
than doing a set contains check. The attached flamegraph shows the amount of
time a query spent in the binary search. Given the benchmarks, we can expect
to see roughly a 2x speed up in this part of the query which works out to
~ a 20% faster query in this instance.

<img width="1668" alt="Screen Shot 2020-08-23 at 10 38 55 PM" src="https://user-images.githubusercontent.com/44787917/91008091-72122880-e592-11ea-9b88-e9d9943201d6.png">

In this flamegraph, a query is taking ~40% of the time doing a binary search on 4 numbers. The query I used
is not very selective, so it has to do the binary search many times. 

I see a comment on `NUMERIC_HASHING_THRESHOLD` that talks about benchmarks, but I couldn't find any
in the codebase, so I wrote my own hacky ones, just to get a sense for the breaking points. The benchmarks
probably need a lot of work, and the results should be taken with a grain of salt because I ran most of them
only 10 times to calculate the average time.

I tried 3 algorithms: binary search, set contains and a linear search (using LongArraySet as a proxy)
Here's a summary of the results. The results are in ns / operation with a 20% match rate with the match being chosen at random within the list of filter values.

Algorithm | 16 | 8 | 4 | 2 |
---------- | -- |-- | -- | -- |
BinarySearch | 7.883 | 4.451 | 3.750 | 4.71  
LongOpenHashSet | 3.086 | 3.142 | 3.071 | 4.02 
LongArraySet | 9.856 | 6.077 | 4.151 | 3.28

I then ran the benchmarks to compare the worst and best case match times for 16 elements in the set. For the worst case, I picked an element at the start of the list (LongArraySet starts iterating from the end of the list) and for the best case, I picked the middle element for the binary search and the last element for the linear search.

Algorithm | Worst | Best 
---------- | -- |-- 
BinarySearch | 5.401 | 2.991 
LongArraySet | 10.985 | 2.908

These numbers seem to indicate that the performance gain of not using a set contains is minimal, even with very small sets and will depend on the number of elements in the dataset that will match the filter.

These numbers seem to indicate that the contains time is relatively consistent at ~ 3.1 ns / op whereas a binary search operation is almost 2ns per op slower.

Based on these numbers, I suspect the query above would see ~ 10% gain by switching to using the LongOpenHashSet instead of a binary search, while queries with in filters closer to 16 values would see a bigger benefit. 

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.