### PR TITLE
Handle internal kinesis sequence numbers when reporting lag

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -718,9 +718,11 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
   {
     Map<String, Long> partitionLag = Maps.newHashMapWithExpectedSize(currentOffsets.size());
     for (Map.Entry<String, String> partitionOffset : currentOffsets.entrySet()) {
-      StreamPartition<String> partition = new StreamPartition<>(stream, partitionOffset.getKey());
-      long currentLag = getPartitionTimeLag(partition, partitionOffset.getValue());
-      partitionLag.put(partitionOffset.getKey(), currentLag);
+      if (KinesisSequenceNumber.isValidAWSKinesisSequence(partitionOffset.getValue())) {
+        StreamPartition<String> partition = new StreamPartition<>(stream, partitionOffset.getKey());
+        long currentLag = getPartitionTimeLag(partition, partitionOffset.getValue());
+        partitionLag.put(partitionOffset.getKey(), currentLag);
+      }
     }
     return partitionLag;
   }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSequenceNumber.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSequenceNumber.java
@@ -52,8 +52,8 @@ public class KinesisSequenceNumber extends OrderedSequenceNumber<String>
   public static final String EXPIRED_MARKER = "EXPIRED";
 
   /**
-   * this flag is used to indicate either END_OF_SHARD_MARKER
-   * or NO_END_SEQUENCE_NUMBER so that they can be properly compared
+   * this flag is used to indicate either END_OF_SHARD_MARKER, NO_END_SEQUENCE_NUMBER
+   * or EXPIRED_MARKER so that they can be properly compared
    * with other sequence numbers
    */
   private final boolean isMaxSequenceNumber;
@@ -62,7 +62,9 @@ public class KinesisSequenceNumber extends OrderedSequenceNumber<String>
   private KinesisSequenceNumber(String sequenceNumber, boolean isExclusive)
   {
     super(sequenceNumber, isExclusive);
-    if (END_OF_SHARD_MARKER.equals(sequenceNumber) || NO_END_SEQUENCE_NUMBER.equals(sequenceNumber)) {
+    if (END_OF_SHARD_MARKER.equals(sequenceNumber)
+        || NO_END_SEQUENCE_NUMBER.equals(sequenceNumber)
+        || EXPIRED_MARKER.equals(sequenceNumber)) {
       isMaxSequenceNumber = true;
       this.intSequence = null;
     } else {
@@ -79,6 +81,19 @@ public class KinesisSequenceNumber extends OrderedSequenceNumber<String>
   public static KinesisSequenceNumber of(String sequenceNumber, boolean isExclusive)
   {
     return new KinesisSequenceNumber(sequenceNumber, isExclusive);
+  }
+
+  /**
+   * Checks whether the sequence number is recognized by kinesis client library
+   * @param sequenceNumber
+   * @return
+   */
+  public static boolean isValidAWSKinesisSequence(String sequenceNumber)
+  {
+    return !(END_OF_SHARD_MARKER.equals(sequenceNumber)
+             || NO_END_SEQUENCE_NUMBER.equals(sequenceNumber)
+             || EXPIRED_MARKER.equals(sequenceNumber)
+      );
   }
 
   @Override

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -417,19 +417,6 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String>
     );
   }
 
-  @Override
-  protected SeekableStreamDataSourceMetadata<String, String> createDataSourceMetadataWithClosedPartitions(
-      SeekableStreamDataSourceMetadata<String, String> currentMetadata, Set<String> closedPartitionIds
-  )
-  {
-    log.info("Marking closed shards in metadata: " + closedPartitionIds);
-    return createDataSourceMetadataWithClosedOrExpiredPartitions(
-        currentMetadata,
-        closedPartitionIds,
-        KinesisSequenceNumber.END_OF_SHARD_MARKER
-    );
-  }
-
   private SeekableStreamDataSourceMetadata<String, String> createDataSourceMetadataWithClosedOrExpiredPartitions(
       SeekableStreamDataSourceMetadata<String, String> currentMetadata,
       Set<String> terminatedPartitionIds,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2202,14 +2202,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     throw new UnsupportedOperationException("This supervisor type does not support partition expiration.");
   }
 
-  protected SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType> createDataSourceMetadataWithClosedPartitions(
-      SeekableStreamDataSourceMetadata<PartitionIdType, SequenceOffsetType> currentMetadata,
-      Set<PartitionIdType> closedPartitionIds
-  )
-  {
-    throw new UnsupportedOperationException("This supervisor type does not support partition closing.");
-  }
-
   /**
    * Perform a sanity check on the datasource metadata returned by
    * {@link #createDataSourceMetadataWithExpiredPartitions}.


### PR DESCRIPTION
Handles a scenario in which the result from `getHighestCurrentOffsets` has expired shards. In such a case, the sequence for a shard can be "EXPIRED". The lag reporter calls the AWS API with this offset and runs into an exception since "EXPIRED" string is not a valid sequence number. 

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>