### PR TITLE
ExpressionFilter: Use index for expressions of single multi-value columns.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
@@ -45,13 +45,13 @@ import java.util.Set;
 public class ExpressionFilter implements Filter
 {
   private final Supplier<Expr> expr;
-  private final Supplier<Set<String>> requiredBindings;
+  private final Supplier<Expr.BindingDetails> bindingDetails;
   private final FilterTuning filterTuning;
 
   public ExpressionFilter(final Supplier<Expr> expr, final FilterTuning filterTuning)
   {
     this.expr = expr;
-    this.requiredBindings = Suppliers.memoize(() -> expr.get().analyzeInputs().getRequiredBindings());
+    this.bindingDetails = Suppliers.memoize(() -> expr.get().analyzeInputs());
     this.filterTuning = filterTuning;
   }
 
@@ -107,15 +107,17 @@ public class ExpressionFilter implements Filter
   @Override
   public boolean supportsBitmapIndex(final BitmapIndexSelector selector)
   {
-    if (requiredBindings.get().isEmpty()) {
+    final Expr.BindingDetails details = this.bindingDetails.get();
+
+    if (details.getRequiredBindings().isEmpty()) {
       // Constant expression.
       return true;
-    } else if (requiredBindings.get().size() == 1) {
-      // Single-column expression. We can use bitmap indexes if this column has an index and does not have
-      // multiple values. The lack of multiple values is important because expression filters treat multi-value
-      // arrays as nulls, which doesn't permit index based filtering.
-      final String column = Iterables.getOnlyElement(requiredBindings.get());
-      return selector.getBitmapIndex(column) != null && selector.hasMultipleValues(column).isFalse();
+    } else if (details.getRequiredBindings().size() == 1) {
+      // Single-column expression. We can use bitmap indexes if this column has an index and the expression can
+      // map over the values of the index.
+      final String column = Iterables.getOnlyElement(details.getRequiredBindings());
+      return selector.getBitmapIndex(column) != null
+             && ExpressionSelectors.canMapOverDictionary(details, selector.hasMultipleValues(column));
     } else {
       // Multi-column expression.
       return false;
@@ -131,7 +133,7 @@ public class ExpressionFilter implements Filter
   @Override
   public <T> T getBitmapResult(final BitmapIndexSelector selector, final BitmapResultFactory<T> bitmapResultFactory)
   {
-    if (requiredBindings.get().isEmpty()) {
+    if (bindingDetails.get().getRequiredBindings().isEmpty()) {
       // Constant expression.
       if (expr.get().eval(ExprUtils.nilBindings()).asBoolean()) {
         return bitmapResultFactory.wrapAllTrue(Filters.allTrue(selector));
@@ -139,9 +141,11 @@ public class ExpressionFilter implements Filter
         return bitmapResultFactory.wrapAllFalse(Filters.allFalse(selector));
       }
     } else {
-      // Can assume there's only one binding and it has a bitmap index, otherwise supportsBitmapIndex would have
-      // returned false and the caller should not have called us.
-      final String column = Iterables.getOnlyElement(requiredBindings.get());
+      // Can assume there's only one binding, it has a bitmap index, and it's a single input mapping.
+      // Otherwise, supportsBitmapIndex would have returned false and the caller should not have called us.
+      assert supportsBitmapIndex(selector);
+
+      final String column = Iterables.getOnlyElement(bindingDetails.get().getRequiredBindings());
       return Filters.matchPredicate(
           column,
           selector,
@@ -175,7 +179,7 @@ public class ExpressionFilter implements Filter
   @Override
   public Set<String> getRequiredColumns()
   {
-    return requiredBindings.get();
+    return bindingDetails.get().getRequiredBindings();
   }
 
   @Override
@@ -210,7 +214,6 @@ public class ExpressionFilter implements Filter
   {
     return "ExpressionFilter{" +
            "expr=" + expr +
-           ", requiredBindings=" + requiredBindings +
            ", filterTuning=" + filterTuning +
            '}';
   }

--- a/processing/src/test/java/org/apache/druid/segment/filter/ExpressionFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/ExpressionFilterTest.java
@@ -143,6 +143,7 @@ public class ExpressionFilterTest extends BaseFilterTest
       assertFilterMatchesSkipVectorize(edf("dim3 < 2.0"), ImmutableList.of("3", "4", "6", "9"));
     }
     assertFilterMatchesSkipVectorize(edf("like(dim3, '1%')"), ImmutableList.of("1", "3", "4", "6", "9"));
+    assertFilterMatchesSkipVectorize(edf("array_contains(dim3, '1')"), ImmutableList.of("3", "4", "6"));
   }
 
   @Test
@@ -158,6 +159,16 @@ public class ExpressionFilterTest extends BaseFilterTest
     assertFilterMatchesSkipVectorize(edf("dim4 == '1'"), ImmutableList.of("0"));
     assertFilterMatchesSkipVectorize(edf("dim4 == '3'"), ImmutableList.of("3"));
     assertFilterMatchesSkipVectorize(edf("dim4 == '4'"), ImmutableList.of("4", "5"));
+    assertFilterMatchesSkipVectorize(edf("concat(dim4, dim4) == '33'"), ImmutableList.of("3"));
+    assertFilterMatchesSkipVectorize(edf("like(dim4, '4%')"), ImmutableList.of("4", "5"));
+    assertFilterMatchesSkipVectorize(edf("array_contains(dim4, '5')"), ImmutableList.of("4", "5"));
+    assertFilterMatchesSkipVectorize(edf("array_to_string(dim4, ':') == '4:5'"), ImmutableList.of("4", "5"));
+  }
+
+  @Test
+  public void testSingleAndMultiValuedStringColumn()
+  {
+    assertFilterMatchesSkipVectorize(edf("array_contains(dim4, dim3)"), ImmutableList.of("5", "9"));
   }
 
   @Test
@@ -284,7 +295,7 @@ public class ExpressionFilterTest extends BaseFilterTest
   public void testEqualsContract()
   {
     EqualsVerifier.forClass(ExpressionFilter.class)
-                  .withIgnoredFields("requiredBindings")
+                  .withIgnoredFields("bindingDetails")
                   .usingGetClass()
                   .verify();
   }


### PR DESCRIPTION
Previously, this was disallowed, because expressions treated multi-values
as nulls. But now, if there's a single multi-value column that can be
mapped over, it's okay to use the index. Expression selectors already do
this.