### PR TITLE
Allow using jsonpath predicates with AvroFlattener

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
@@ -193,6 +193,6 @@ public class GenericAvroJsonProvider implements JsonProvider
   @Override
   public Object unwrap(final Object o)
   {
-    throw new UnsupportedOperationException("Unused");
+    return o;
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -23,6 +23,8 @@ import org.apache.druid.data.input.AvroStreamInputRowParserTest;
 import org.apache.druid.data.input.SomeAvroDatum;
 import org.junit.Assert;
 import org.junit.Test;
+import java.util.Collections;
+import java.util.List;
 
 public class AvroFlattenerMakerTest
 {
@@ -194,6 +196,22 @@ public class AvroFlattenerMakerTest
     Assert.assertEquals(
         record.getSomeRecordArray(),
         flattener.makeJsonPathExtractor("$.someRecordArray").apply(record)
+    );
+
+    Assert.assertEquals(
+        record.getSomeRecordArray().get(0).getNestedString(),
+        flattener.makeJsonPathExtractor("$.someRecordArray[0].nestedString").apply(record)
+    );
+
+    Assert.assertEquals(
+        record.getSomeRecordArray(),
+        flattener.makeJsonPathExtractor("$.someRecordArray[?(@.nestedString)]").apply(record)
+    );
+
+    List<String> nestedStringArray = Collections.singletonList(record.getSomeRecordArray().get(0).getNestedString().toString());
+    Assert.assertEquals(
+        nestedStringArray,
+        flattener.makeJsonPathExtractor("$.someRecordArray[?(@.nestedString=='string in record')].nestedString").apply(record)
     );
   }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

References #5792. Not entirely relevant to error described, however, it's very closely related to being able to use jsonpath predicates

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

I'm trying to use more advanced jsonpath inline queries in while ingesting avro data. An example `flattenSpec` would be
```json
{
  "type": "path",
  "name": "attribute__test",
  "expr": "$.attributes[?(@.name == 'somekey')][0].value"
}
```
where the data looks like this (an array of avro records):

```json
{
  "attributes": [
    {
      "name": "somekey",
      "value": "test value",
    },
    {
      "name": "someotherkey",
      "value": "other value",
    }
  ]
}
```

Hoping to get the following data out in the dimension: `test value`. This would greatly improve Druid's ability to consume more intricate Avro schemas. 

The problem it seems was that when using queries the`GenericAvroJsonProvider::unwrap` method is called in Jayway, since it throws an exception the query is prevented and thus returning nothing (it silenced via `com.jayway.jsonpath.Option.SUPPRESS_EXCEPTIONS`). It doesn't seems that any wrapping occurs thus it should be safe to just return the object as is.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR

