### PR TITLE
Fix VARIANCE aggregator comparator

### DIFF
--- a/extensions-core/stats/pom.xml
+++ b/extensions-core/stats/pom.xml
@@ -137,6 +137,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/StandardDeviationPostAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/StandardDeviationPostAggregator.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
@@ -31,6 +32,7 @@ import org.apache.druid.query.aggregation.post.PostAggregatorIds;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.column.ValueType;
 
+import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
@@ -73,9 +75,11 @@ public class StandardDeviationPostAggregator implements PostAggregator
   }
 
   @Override
-  public Object compute(Map<String, Object> combinedAggregators)
+  @Nullable
+  public Double compute(Map<String, Object> combinedAggregators)
   {
-    return Math.sqrt(((VarianceAggregatorCollector) combinedAggregators.get(fieldName)).getVariance(isVariancePop));
+    Double variance = ((VarianceAggregatorCollector) combinedAggregators.get(fieldName)).getVariance(isVariancePop);
+    return variance == null ? NullHandling.defaultDoubleValue() : (Double) Math.sqrt(variance);
   }
 
   @Override

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollector.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollector.java
@@ -60,11 +60,11 @@ public class VarianceAggregatorCollector
   }
 
   public static final Comparator<VarianceAggregatorCollector> COMPARATOR = (o1, o2) -> {
-    int compare = Longs.compare(o1.count, o2.count);
+    int compare = Doubles.compare(o1.nvariance, o2.nvariance);
     if (compare == 0) {
-      compare = Doubles.compare(o1.sum, o2.sum);
+      compare = Longs.compare(o1.count, o2.count);
       if (compare == 0) {
-        compare = Doubles.compare(o1.nvariance, o2.nvariance);
+        compare = Doubles.compare(o1.sum, o2.sum);
       }
     }
     return compare;

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollector.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollector.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Longs;
+import org.apache.druid.common.config.NullHandling;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -156,11 +157,11 @@ public class VarianceAggregatorCollector
     return this;
   }
 
-  public double getVariance(boolean variancePop)
+  @Nullable
+  public Double getVariance(boolean variancePop)
   {
     if (count == 0) {
-      // in SQL standard, we should return null for zero elements. But druid there should not be such a case
-      throw new IllegalStateException("should not be empty holder");
+      return NullHandling.defaultDoubleValue();
     } else if (count == 1) {
       return 0d;
     } else {

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.AggregateCombiner;
@@ -241,8 +242,8 @@ public class VarianceAggregatorFactory extends AggregatorFactory
   public Object finalizeComputation(@Nullable Object object)
   {
     return object == null || ((VarianceAggregatorCollector) object).count == 0
-           ? null
-           : ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
+           ? NullHandling.defaultDoubleValue()
+           : (Double) ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
   }
 
   @Override

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
+ *
  */
 @JsonTypeName("variance")
 public class VarianceAggregatorFactory extends AggregatorFactory
@@ -239,7 +240,9 @@ public class VarianceAggregatorFactory extends AggregatorFactory
   @Override
   public Object finalizeComputation(@Nullable Object object)
   {
-    return object == null ? null : ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
+    return object == null || ((VarianceAggregatorCollector) object).count == 0
+           ? null
+           : ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
   }
 
   @Override

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -241,9 +241,9 @@ public class VarianceAggregatorFactory extends AggregatorFactory
   @Override
   public Object finalizeComputation(@Nullable Object object)
   {
-    return object == null || ((VarianceAggregatorCollector) object).count == 0
+    return object == null
            ? NullHandling.defaultDoubleValue()
-           : (Double) ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
+           : ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
   }
 
   @Override

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
@@ -144,6 +144,35 @@ public class VarianceAggregatorCollectorTest extends InitializedNullHandlingTest
     }
   }
 
+  @Test
+  public void testVarianceComparatorShouldCompareVarianceFirst()
+  {
+    VarianceAggregatorCollector v1 = new VarianceAggregatorCollector(4, 2d, 1.0);
+    VarianceAggregatorCollector v2 = new VarianceAggregatorCollector(3, 5d, 2.0);
+    Assert.assertTrue(VarianceAggregatorCollector.COMPARATOR.compare(v1, v2) < 0);
+    Assert.assertTrue(VarianceAggregatorCollector.COMPARATOR.compare(v2, v1) > 0);
+  }
+
+  @Test
+  public void testVarianceComparatorShouldCompareCountsIfVarianceIsEqual()
+  {
+    VarianceAggregatorCollector v1 = new VarianceAggregatorCollector(4, 2d, 1.0);
+    VarianceAggregatorCollector v2 = new VarianceAggregatorCollector(3, 5d, 1.0);
+    Assert.assertTrue(VarianceAggregatorCollector.COMPARATOR.compare(v1, v2) > 0);
+    Assert.assertTrue(VarianceAggregatorCollector.COMPARATOR.compare(v2, v1) < 0);
+  }
+
+  @Test
+  public void testVarianceComparatorShouldCompareSumIfVarianceAndCountsAreEqual()
+  {
+    VarianceAggregatorCollector v1 = new VarianceAggregatorCollector(4, 2d, 1.0);
+    VarianceAggregatorCollector v2 = new VarianceAggregatorCollector(4, 5d, 1.0);
+    Assert.assertTrue(VarianceAggregatorCollector.COMPARATOR.compare(v1, v2) < 0);
+    Assert.assertTrue(VarianceAggregatorCollector.COMPARATOR.compare(v2, v1) > 0);
+    v2.sum = v1.sum;
+    Assert.assertEquals(0, VarianceAggregatorCollector.COMPARATOR.compare(v1, v2));
+  }
+
   private static class FloatHandOver extends TestFloatColumnSelector
   {
     float v;

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactoryTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactoryTest.java
@@ -68,4 +68,19 @@ public class VarianceAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testFinalizeComputationWithZeroCountShouldReturnNull()
+  {
+    VarianceAggregatorFactory target = new VarianceAggregatorFactory("test", "test", null, null);
+    VarianceAggregatorCollector v1 = new VarianceAggregatorCollector();
+    Assert.assertNull(target.finalizeComputation(v1));
+  }
+
+  @Test
+  public void testFinalizeComputationWithNullShouldReturnNull()
+  {
+    VarianceAggregatorFactory target = new VarianceAggregatorFactory("test", "test", null, null);
+    Assert.assertNull(target.finalizeComputation(null));
+  }
 }

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactoryTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactoryTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.variance;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
@@ -28,10 +29,11 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class VarianceAggregatorFactoryTest
+public class VarianceAggregatorFactoryTest extends InitializedNullHandlingTest
 {
   @Test
   public void testResultArraySignature()
@@ -74,13 +76,13 @@ public class VarianceAggregatorFactoryTest
   {
     VarianceAggregatorFactory target = new VarianceAggregatorFactory("test", "test", null, null);
     VarianceAggregatorCollector v1 = new VarianceAggregatorCollector();
-    Assert.assertNull(target.finalizeComputation(v1));
+    Assert.assertEquals(NullHandling.defaultDoubleValue(), target.finalizeComputation(v1));
   }
 
   @Test
   public void testFinalizeComputationWithNullShouldReturnNull()
   {
     VarianceAggregatorFactory target = new VarianceAggregatorFactory("test", "test", null, null);
-    Assert.assertNull(target.finalizeComputation(null));
+    Assert.assertEquals(NullHandling.defaultDoubleValue(), target.finalizeComputation(null));
   }
 }

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.variance;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.TestFloatColumnSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
@@ -93,16 +94,10 @@ public class VarianceAggregatorTest extends InitializedNullHandlingTest
     Assert.assertEquals(sum, holder.sum, 0.0001);
     Assert.assertEquals(nvariance, holder.nvariance, 0.0001);
     if (count == 0) {
-      try {
-        holder.getVariance(false);
-        Assert.fail("Should throw ISE");
-      }
-      catch (IllegalStateException e) {
-        Assert.assertTrue(e.getMessage().contains("should not be empty holder"));
-      }
+      Assert.assertEquals(NullHandling.defaultDoubleValue(), holder.getVariance(false));
     } else {
-      Assert.assertEquals(holder.getVariance(true), variances_pop[(int) count - 1], 0.0001);
-      Assert.assertEquals(holder.getVariance(false), variances_samp[(int) count - 1], 0.0001);
+      Assert.assertEquals(variances_pop[(int) count - 1], holder.getVariance(true), 0.0001);
+      Assert.assertEquals(variances_samp[(int) count - 1], holder.getVariance(false), 0.0001);
     }
   }
 

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/sql/VarianceSqlAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/sql/VarianceSqlAggregatorTest.java
@@ -461,7 +461,7 @@ public class VarianceSqlAggregatorTest extends InitializedNullHandlingTest
         Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
     );
   }
-  
+
   @Test
   public void testStdDevWithVirtualColumns() throws Exception
   {
@@ -541,9 +541,15 @@ public class VarianceSqlAggregatorTest extends InitializedNullHandlingTest
             CalciteTestBase.DEFAULT_PARAMETERS,
             authenticationResult
         ).toList();
-    List<Object[]> expectedResults = ImmutableList.of(
+    List<Object[]> expectedResults = NullHandling.sqlCompatible()
+        ? ImmutableList.of(
+        new Object[] {"a", 0f},
+        new Object[] {null, 0f},
+        new Object[] {"", 0f},
+        new Object[] {"abc", null}
+    ) : ImmutableList.of(
         new Object[] {"a", 0.5f},
-        new Object[] {NullHandling.sqlCompatible() ? null : "", 0.0033333334f},
+        new Object[] {"", 0.0033333334f},
         new Object[] {"abc", 0f}
     );
     assertResultsEquals(expectedResults, results);


### PR DESCRIPTION
### Description

The comparator for the variance aggregator used to compare values using the
count. This is now fixed to compare values using the variance. If the variance
is equal, the count and sum are used as tie breakers.

This patch also fixes a bug where we assumed that the aggregator could not
return null because Druid did not support sql compatible mode. It appears that
this extension was written in 2016 before sql Compatible mode was introduced
~ 2018

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.