### PR TITLE
Fix result-level caching

### DIFF
--- a/server/src/main/java/org/apache/druid/query/RetryQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/RetryQueryRunner.java
@@ -99,6 +99,12 @@ public class RetryQueryRunner<T> implements QueryRunner<T>
   @Override
   public Sequence<T> run(final QueryPlus<T> queryPlus, final ResponseContext context)
   {
+    // Calling baseRunner.run() (which is SpecificQueryRunnable.run()) in the RetryingSequenceIterator
+    // could be better because we can minimize the chance that data servers report missing segments as
+    // we construct the query distribution tree when the query processing is actually started.
+    // However, we call baseRunner.run() here instead where it's executed while constructing a query plan.
+    // This is because ResultLevelCachingQueryRunner requires to compute the cache key based on
+    // the segments to query which is computed in SpecificQueryRunnable.run().
     final Sequence<T> baseSequence = baseRunner.run(queryPlus, context);
     // runnableAfterFirstAttempt is only for testing, it must be no-op for production code.
     runnableAfterFirstAttempt.run();

--- a/server/src/test/java/org/apache/druid/client/TestHttpClient.java
+++ b/server/src/test/java/org/apache/druid/client/TestHttpClient.java
@@ -154,22 +154,30 @@ public class TestHttpClient implements HttpClient
     private final QueryRunnerFactoryConglomerate conglomerate;
     private final DataSegment segment;
     private final QueryableIndex queryableIndex;
+    private final boolean throwQueryError;
 
     private boolean isSegmentDropped = false;
 
     public SimpleServerManager(
         QueryRunnerFactoryConglomerate conglomerate,
         DataSegment segment,
-        QueryableIndex queryableIndex
+        QueryableIndex queryableIndex,
+        boolean throwQueryError
     )
     {
       this.conglomerate = conglomerate;
       this.segment = segment;
       this.queryableIndex = queryableIndex;
+      this.throwQueryError = throwQueryError;
     }
 
     private QueryRunner getQueryRunner()
     {
+      if (throwQueryError) {
+        return (queryPlus, responseContext) -> {
+          throw new RuntimeException("Exception for testing");
+        };
+      }
       if (isSegmentDropped) {
         return new ReportTimelineMissingSegmentQueryRunner<>(
             new SegmentDescriptor(segment.getInterval(), segment.getVersion(), segment.getId().getPartitionNum())

--- a/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
+++ b/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
@@ -152,9 +152,22 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
 
   protected void addServer(DruidServer server, DataSegment dataSegment, QueryableIndex queryableIndex)
   {
+    addServer(server, dataSegment, queryableIndex, false);
+  }
+
+  protected void addServer(
+      DruidServer server,
+      DataSegment dataSegment,
+      QueryableIndex queryableIndex,
+      boolean throwQueryError
+  )
+  {
     servers.add(server);
     simpleServerView.addServer(server, dataSegment);
-    httpClient.addServerAndRunner(server, new SimpleServerManager(conglomerate, dataSegment, queryableIndex));
+    httpClient.addServerAndRunner(
+        server,
+        new SimpleServerManager(conglomerate, dataSegment, queryableIndex, throwQueryError)
+    );
   }
 
   protected void prepareCluster(int numServers)
@@ -168,19 +181,24 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
       addServer(
           SimpleServerView.createServer(i + 1),
           segment,
-          segmentGenerator.generate(
-              segment,
-              new GeneratorSchemaInfo(
-                  BASE_SCHEMA_INFO.getColumnSchemas(),
-                  BASE_SCHEMA_INFO.getAggs(),
-                  interval,
-                  BASE_SCHEMA_INFO.isWithRollup()
-              ),
-              Granularities.NONE,
-              10
-          )
+          generateSegment(segment)
       );
     }
+  }
+
+  protected QueryableIndex generateSegment(DataSegment segment)
+  {
+    return segmentGenerator.generate(
+        segment,
+        new GeneratorSchemaInfo(
+            BASE_SCHEMA_INFO.getColumnSchemas(),
+            BASE_SCHEMA_INFO.getAggs(),
+            segment.getInterval(),
+            BASE_SCHEMA_INFO.isWithRollup()
+        ),
+        Granularities.NONE,
+        10
+    );
   }
 
   protected static Query<Result<TimeseriesResultValue>> timeseriesQuery(Interval interval)

--- a/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
+++ b/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.client.CachingClusteredClient;
+import org.apache.druid.client.DirectDruidClient;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.client.SimpleServerView;
+import org.apache.druid.client.TestHttpClient;
+import org.apache.druid.client.TestHttpClient.SimpleServerManager;
+import org.apache.druid.client.cache.CacheConfig;
+import org.apache.druid.client.cache.CachePopulatorStats;
+import org.apache.druid.client.cache.ForegroundCachePopulator;
+import org.apache.druid.client.cache.MapCache;
+import org.apache.druid.guice.http.DruidHttpClientConfig;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.context.ConcurrentResponseContext;
+import org.apache.druid.query.context.ResponseContext;
+import org.apache.druid.query.context.ResponseContext.Key;
+import org.apache.druid.query.timeseries.TimeseriesResultValue;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.generator.GeneratorBasicSchemas;
+import org.apache.druid.segment.generator.GeneratorSchemaInfo;
+import org.apache.druid.segment.generator.SegmentGenerator;
+import org.apache.druid.server.QueryStackTests;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.joda.time.Interval;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * This class provides useful setup for testing {@link QueryRunner}s which work on top of
+ * {@link CachingClusteredClient}. In this class, each {@link DruidServer} serves one segment
+ * created using {@link SegmentGenerator}. Tests extending this class can query those segments as below:
+ *
+ * <pre>
+ * public void test()
+ * {
+ *   prepareCluster(3); // prepare a cluster of 3 servers
+ *   Query<T> query = makeQuery();
+ *   QueryRunner<T> baseRunner = cachingClusteredClient.getQueryRunnerForIntervals(query, query.getIntervals());
+ *   QueryRunner<T> queryRunner = makeQueryRunner(baseRunner);
+ *   queryRunner.run(QueryPlus.wrap(query), responseContext())
+ *   ...
+ * }
+ * </pre>
+ */
+public abstract class QueryRunnerBasedOnClusteredClientTestBase
+{
+  protected static final GeneratorSchemaInfo BASE_SCHEMA_INFO = GeneratorBasicSchemas.SCHEMA_MAP.get("basic");
+
+  private static final Closer CLOSER = Closer.create();
+  private static final String DATASOURCE = "datasource";
+  private static final boolean USE_PARALLEL_MERGE_POOL_CONFIGURED = false;
+
+  protected final ObjectMapper objectMapper = new DefaultObjectMapper();
+  protected final QueryToolChestWarehouse toolChestWarehouse;
+
+  private final QueryRunnerFactoryConglomerate conglomerate;
+
+  protected TestHttpClient httpClient;
+  protected SimpleServerView simpleServerView;
+  protected CachingClusteredClient cachingClusteredClient;
+  protected List<DruidServer> servers;
+
+  private SegmentGenerator segmentGenerator;
+
+  protected QueryRunnerBasedOnClusteredClientTestBase()
+  {
+    conglomerate = QueryStackTests.createQueryRunnerFactoryConglomerate(CLOSER, USE_PARALLEL_MERGE_POOL_CONFIGURED);
+
+    toolChestWarehouse = new QueryToolChestWarehouse()
+    {
+      @Override
+      public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(final QueryType query)
+      {
+        return conglomerate.findFactory(query).getToolchest();
+      }
+    };
+  }
+
+  @AfterClass
+  public static void tearDownAbstractClass() throws IOException
+  {
+    CLOSER.close();
+  }
+
+  @Before
+  public void setupTestBase()
+  {
+    segmentGenerator = new SegmentGenerator();
+    httpClient = new TestHttpClient(objectMapper);
+    simpleServerView = new SimpleServerView(toolChestWarehouse, objectMapper, httpClient);
+    cachingClusteredClient = new CachingClusteredClient(
+        toolChestWarehouse,
+        simpleServerView,
+        MapCache.create(0),
+        objectMapper,
+        new ForegroundCachePopulator(objectMapper, new CachePopulatorStats(), 0),
+        new CacheConfig(),
+        new DruidHttpClientConfig(),
+        QueryStackTests.getProcessingConfig(USE_PARALLEL_MERGE_POOL_CONFIGURED),
+        ForkJoinPool.commonPool(),
+        QueryStackTests.DEFAULT_NOOP_SCHEDULER
+    );
+    servers = new ArrayList<>();
+  }
+
+  @After
+  public void tearDownTestBase() throws IOException
+  {
+    segmentGenerator.close();
+  }
+
+  protected void addServer(DruidServer server, DataSegment dataSegment, QueryableIndex queryableIndex)
+  {
+    servers.add(server);
+    simpleServerView.addServer(server, dataSegment);
+    httpClient.addServerAndRunner(server, new SimpleServerManager(conglomerate, dataSegment, queryableIndex));
+  }
+
+  protected void prepareCluster(int numServers)
+  {
+    Preconditions.checkArgument(numServers < 25, "Cannot be larger than 24");
+    for (int i = 0; i < numServers; i++) {
+      final int partitionId = i % 2;
+      final int intervalIndex = i / 2;
+      final Interval interval = Intervals.of("2000-01-01T%02d/PT1H", intervalIndex);
+      final DataSegment segment = newSegment(interval, partitionId, 2);
+      addServer(
+          SimpleServerView.createServer(i + 1),
+          segment,
+          segmentGenerator.generate(
+              segment,
+              new GeneratorSchemaInfo(
+                  BASE_SCHEMA_INFO.getColumnSchemas(),
+                  BASE_SCHEMA_INFO.getAggs(),
+                  interval,
+                  BASE_SCHEMA_INFO.isWithRollup()
+              ),
+              Granularities.NONE,
+              10
+          )
+      );
+    }
+  }
+
+  protected static Query<Result<TimeseriesResultValue>> timeseriesQuery(Interval interval)
+  {
+    return Druids.newTimeseriesQueryBuilder()
+                 .dataSource(DATASOURCE)
+                 .intervals(ImmutableList.of(interval))
+                 .granularity(Granularities.HOUR)
+                 .aggregators(new CountAggregatorFactory("rows"))
+                 .context(
+                     ImmutableMap.of(
+                         DirectDruidClient.QUERY_FAIL_TIME,
+                         System.currentTimeMillis() + 10000
+                     )
+                 )
+                 .build()
+                 .withId(UUID.randomUUID().toString());
+  }
+
+  protected static List<Result<TimeseriesResultValue>> expectedTimeseriesResult(int expectedNumResultRows)
+  {
+    return IntStream
+        .range(0, expectedNumResultRows)
+        .mapToObj(
+            i -> new Result<>(
+                DateTimes.of(StringUtils.format("2000-01-01T%02d", i / 2)),
+                new TimeseriesResultValue(ImmutableMap.of("rows", 10))
+            )
+        )
+        .collect(Collectors.toList());
+  }
+
+  protected static ResponseContext responseContext()
+  {
+    final ResponseContext responseContext = ConcurrentResponseContext.createEmpty();
+    responseContext.put(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new ConcurrentHashMap<>());
+    return responseContext;
+  }
+
+  protected static DataSegment newSegment(
+      Interval interval,
+      int partitionId,
+      int numCorePartitions
+  )
+  {
+    return DataSegment.builder()
+                      .dataSource(DATASOURCE)
+                      .interval(interval)
+                      .version("1")
+                      .shardSpec(new NumberedShardSpec(partitionId, numCorePartitions))
+                      .size(10)
+                      .build();
+  }
+}

--- a/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import org.apache.druid.client.cache.Cache;
+import org.apache.druid.client.cache.CacheConfig;
+import org.apache.druid.client.cache.MapCache;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.query.timeseries.TimeseriesResultValue;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase
+{
+  private Cache cache;
+
+  @Before
+  public void setup()
+  {
+    cache = MapCache.create(1024);
+  }
+
+  @After
+  public void tearDown() throws IOException
+  {
+    cache.close();
+  }
+
+  @Test
+  public void testNotPopulateAndNotUse()
+  {
+    prepareCluster(10);
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
+        newCacheConfig(false, true),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence1 = queryRunner1.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
+        newCacheConfig(false, true),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence2 = queryRunner2.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
+    Assert.assertEquals(results1, results2);
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+  }
+
+  @Test
+  public void testPopulateAndNotUse()
+  {
+    prepareCluster(10);
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
+        newCacheConfig(true, true),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence1 = queryRunner1.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
+        newCacheConfig(true, false),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence2 = queryRunner2.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
+    Assert.assertEquals(results1, results2);
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+  }
+
+  @Test
+  public void testNotPopulateAndUse()
+  {
+    prepareCluster(10);
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
+        newCacheConfig(false, true),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence1 = queryRunner1.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
+        newCacheConfig(true, true),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence2 = queryRunner2.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
+    Assert.assertEquals(results1, results2);
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+  }
+
+  @Test
+  public void testPopulateAndUse()
+  {
+    prepareCluster(10);
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
+        newCacheConfig(true, true),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence1 = queryRunner1.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
+        newCacheConfig(true, true),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence2 = queryRunner2.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
+    Assert.assertEquals(results1, results2);
+    Assert.assertEquals(1, cache.getStats().getNumHits());
+  }
+
+  private <T> ResultLevelCachingQueryRunner<T> createQueryRunner(
+      CacheConfig cacheConfig,
+      Query<T> query
+  )
+  {
+    final QueryRunner<T> baseRunner = cachingClusteredClient.getQueryRunnerForIntervals(query, query.getIntervals());
+    return new ResultLevelCachingQueryRunner<>(
+        new RetryQueryRunner<>(
+            baseRunner,
+            cachingClusteredClient::getQueryRunnerForSegments,
+            new RetryQueryRunnerConfig(),
+            objectMapper
+        ),
+        toolChestWarehouse.getToolChest(query),
+        query,
+        objectMapper,
+        cache,
+        cacheConfig
+    );
+  }
+
+  private CacheConfig newCacheConfig(boolean populateResultLevelCache, boolean useResultLevelCache)
+  {
+    return new CacheConfig()
+    {
+      @Override
+      public boolean isPopulateResultLevelCache()
+      {
+        return populateResultLevelCache;
+      }
+
+      @Override
+      public boolean isUseResultLevelCache()
+      {
+        return useResultLevelCache;
+      }
+    };
+  }
+}

--- a/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
@@ -19,133 +19,26 @@
 
 package org.apache.druid.query;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.apache.druid.client.CachingClusteredClient;
-import org.apache.druid.client.DirectDruidClient;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.client.SimpleServerView;
-import org.apache.druid.client.TestHttpClient;
 import org.apache.druid.client.TestHttpClient.SimpleServerManager;
-import org.apache.druid.client.cache.CacheConfig;
-import org.apache.druid.client.cache.CachePopulatorStats;
-import org.apache.druid.client.cache.ForegroundCachePopulator;
-import org.apache.druid.client.cache.MapCache;
-import org.apache.druid.guice.http.DruidHttpClientConfig;
-import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.NonnullPair;
-import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
-import org.apache.druid.java.util.common.io.Closer;
-import org.apache.druid.query.aggregation.CountAggregatorFactory;
-import org.apache.druid.query.context.ConcurrentResponseContext;
-import org.apache.druid.query.context.ResponseContext;
-import org.apache.druid.query.context.ResponseContext.Key;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.SegmentMissingException;
-import org.apache.druid.segment.generator.GeneratorBasicSchemas;
-import org.apache.druid.segment.generator.GeneratorSchemaInfo;
-import org.apache.druid.segment.generator.SegmentGenerator;
-import org.apache.druid.server.QueryStackTests;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ForkJoinPool;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-public class RetryQueryRunnerTest
+public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase
 {
-  private static final Closer CLOSER = Closer.create();
-  private static final String DATASOURCE = "datasource";
-  private static final GeneratorSchemaInfo BASE_SCHEMA_INFO = GeneratorBasicSchemas.SCHEMA_MAP.get("basic");
-  private static final boolean USE_PARALLEL_MERGE_POOL_CONFIGURED = false;
-
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
-
-  private final ObjectMapper objectMapper = new DefaultObjectMapper();
-  private final QueryToolChestWarehouse toolChestWarehouse;
-  private final QueryRunnerFactoryConglomerate conglomerate;
-
-  private SegmentGenerator segmentGenerator;
-  private TestHttpClient httpClient;
-  private SimpleServerView simpleServerView;
-  private CachingClusteredClient cachingClusteredClient;
-  private List<DruidServer> servers;
-
-  public RetryQueryRunnerTest()
-  {
-    conglomerate = QueryStackTests.createQueryRunnerFactoryConglomerate(CLOSER, USE_PARALLEL_MERGE_POOL_CONFIGURED);
-
-    toolChestWarehouse = new QueryToolChestWarehouse()
-    {
-      @Override
-      public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(final QueryType query)
-      {
-        return conglomerate.findFactory(query).getToolchest();
-      }
-    };
-  }
-
-  @AfterClass
-  public static void tearDownClass() throws IOException
-  {
-    CLOSER.close();
-  }
-
-  @Before
-  public void setup()
-  {
-    segmentGenerator = new SegmentGenerator();
-    httpClient = new TestHttpClient(objectMapper);
-    simpleServerView = new SimpleServerView(toolChestWarehouse, objectMapper, httpClient);
-    cachingClusteredClient = new CachingClusteredClient(
-        toolChestWarehouse,
-        simpleServerView,
-        MapCache.create(0),
-        objectMapper,
-        new ForegroundCachePopulator(objectMapper, new CachePopulatorStats(), 0),
-        new CacheConfig(),
-        new DruidHttpClientConfig(),
-        QueryStackTests.getProcessingConfig(USE_PARALLEL_MERGE_POOL_CONFIGURED),
-        ForkJoinPool.commonPool(),
-        QueryStackTests.DEFAULT_NOOP_SCHEDULER
-    );
-    servers = new ArrayList<>();
-  }
-
-  @After
-  public void tearDown() throws IOException
-  {
-    segmentGenerator.close();
-  }
-
-  private void addServer(DruidServer server, DataSegment dataSegment, QueryableIndex queryableIndex)
-  {
-    servers.add(server);
-    simpleServerView.addServer(server, dataSegment);
-    httpClient.addServerAndRunner(server, new SimpleServerManager(conglomerate, dataSegment, queryableIndex));
-  }
 
   @Test
   public void testNoRetry()
@@ -230,32 +123,6 @@ public class RetryQueryRunnerTest
     }
   }
 
-  private void prepareCluster(int numServers)
-  {
-    Preconditions.checkArgument(numServers < 25, "Cannot be larger than 24");
-    for (int i = 0; i < numServers; i++) {
-      final int partitionId = i % 2;
-      final int intervalIndex = i / 2;
-      final Interval interval = Intervals.of("2000-01-01T%02d/PT1H", intervalIndex);
-      final DataSegment segment = newSegment(interval, partitionId, 2);
-      addServer(
-          SimpleServerView.createServer(i + 1),
-          segment,
-          segmentGenerator.generate(
-              segment,
-              new GeneratorSchemaInfo(
-                  BASE_SCHEMA_INFO.getColumnSchemas(),
-                  BASE_SCHEMA_INFO.getAggs(),
-                  interval,
-                  BASE_SCHEMA_INFO.isWithRollup()
-              ),
-              Granularities.NONE,
-              10
-          )
-      );
-    }
-  }
-
   /**
    * Drops a segment from the DruidServer. This method doesn't update the server view, but the server will stop
    * serving queries for the dropped segment.
@@ -325,57 +192,5 @@ public class RetryQueryRunnerTest
         return returnPartialResults;
       }
     };
-  }
-
-  private static Query<Result<TimeseriesResultValue>> timeseriesQuery(Interval interval)
-  {
-    return Druids.newTimeseriesQueryBuilder()
-                 .dataSource(DATASOURCE)
-                 .intervals(ImmutableList.of(interval))
-                 .granularity(Granularities.HOUR)
-                 .aggregators(new CountAggregatorFactory("rows"))
-                 .context(
-                     ImmutableMap.of(
-                         DirectDruidClient.QUERY_FAIL_TIME,
-                         System.currentTimeMillis() + 10000
-                     )
-                 )
-                 .build()
-                 .withId(UUID.randomUUID().toString());
-  }
-
-  private ResponseContext responseContext()
-  {
-    final ResponseContext responseContext = ConcurrentResponseContext.createEmpty();
-    responseContext.put(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new ConcurrentHashMap<>());
-    return responseContext;
-  }
-
-  private static List<Result<TimeseriesResultValue>> expectedTimeseriesResult(int expectedNumResultRows)
-  {
-    return IntStream
-        .range(0, expectedNumResultRows)
-        .mapToObj(
-            i -> new Result<>(
-                DateTimes.of(StringUtils.format("2000-01-01T%02d", i / 2)),
-                new TimeseriesResultValue(ImmutableMap.of("rows", 10))
-            )
-        )
-        .collect(Collectors.toList());
-  }
-
-  private static DataSegment newSegment(
-      Interval interval,
-      int partitionId,
-      int numCorePartitions
-  )
-  {
-    return DataSegment.builder()
-                      .dataSource(DATASOURCE)
-                      .interval(interval)
-                      .version("1")
-                      .shardSpec(new NumberedShardSpec(partitionId, numCorePartitions))
-                      .size(10)
-                      .build();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/10337.

### Description

This PR changes `RetryQueryRunner` to call `SpecificQueryRunnable.run()` in its `run()`, so that the segments to query can be determined early enough for `ResultLevelCachingQueryRunner`. In theory, after this change, there might be a little higher chance to see missing segments in response context, but it should be small enough to ignore because the query execution will be likely started immediately right after query distribution tree is constructed.

I believe we need integration tests for this fix, but I'm not sure how to add it without introducing a metricsMonitor for integration tests. Welcome any idea.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.