### PR TITLE
Support SearchQueryDimFilter in sql via new methods

### DIFF
--- a/docs/misc/math-expr.md
+++ b/docs/misc/math-expr.md
@@ -78,6 +78,8 @@ The following built-in functions are available.
 |parse_long|parse_long(string[, radix]) parses a string as a long with the given radix, or 10 (decimal) if a radix is not provided.|
 |regexp_extract|regexp_extract(expr, pattern[, index]) applies a regular expression pattern and extracts a capture group index, or null if there is no match. If index is unspecified or zero, returns the substring that matched the pattern. The pattern may match anywhere inside `expr`; if you want to match the entire string instead, use the `^` and `$` markers at the start and end of your pattern.|
 |regexp_like|regexp_like(expr, pattern) returns whether `expr` matches regular expression `pattern`. The pattern may match anywhere inside `expr`; if you want to match the entire string instead, use the `^` and `$` markers at the start and end of your pattern. |
+|contains_string|contains_string(expr, string) returns whether `expr` contains `string` as a substring. This method is case-sensitive.|
+|icontains_string|contains_string(expr, string) returns whether `expr` contains `string` as a substring. This method is case-insensitive.|
 |replace|replace(expr, pattern, replacement) replaces pattern with replacement|
 |substring|substring(expr, index, length) behaves like java.lang.String's substring|
 |right|right(expr, length) returns the rightmost length characters from a string|

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -397,6 +397,8 @@ String functions accept strings, and return a type appropriate to the function.
 |`POSITION(needle IN haystack [FROM fromIndex])`|Returns the index of needle within haystack, with indexes starting from 1. The search will begin at fromIndex, or 1 if fromIndex is not specified. If the needle is not found, returns 0.|
 |`REGEXP_EXTRACT(expr, pattern, [index])`|Apply regular expression `pattern` to `expr` and extract a capture group, or `NULL` if there is no match. If index is unspecified or zero, returns the first substring that matched the pattern. The pattern may match anywhere inside `expr`; if you want to match the entire string instead, use the `^` and `$` markers at the start and end of your pattern. Note: when `druid.generic.useDefaultValueForNull = true`, it is not possible to differentiate an empty-string match from a non-match (both will return `NULL`).|
 |`REGEXP_LIKE(expr, pattern)`|Returns whether `expr` matches regular expression `pattern`. The pattern may match anywhere inside `expr`; if you want to match the entire string instead, use the `^` and `$` markers at the start and end of your pattern. Similar to [`LIKE`](#comparison-operators), but uses regexps instead of LIKE patterns. Especially useful in WHERE clauses.|
+|`CONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`.|
+|`ICONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`. The match is case-insensitive.|
 |`REPLACE(expr, pattern, replacement)`|Replaces pattern with replacement in expr, and returns the result.|
 |`STRPOS(haystack, needle)`|Returns the index of needle within haystack, with indexes starting from 1. If the needle is not found, returns 0.|
 |`SUBSTRING(expr, index, [length])`|Returns a substring of expr starting at index, with a max length, both measured in UTF-16 code units.|
@@ -561,8 +563,6 @@ The [DataSketches extension](../development/extensions-core/datasketches-extensi
 |`COALESCE(value1, value2, ...)`|Returns the first value that is neither NULL nor empty string.|
 |`NVL(expr,expr-for-null)`|Returns 'expr-for-null' if 'expr' is null (or empty string for string type).|
 |`BLOOM_FILTER_TEST(<expr>, <serialized-filter>)`|Returns true if the value is contained in a Base64-serialized bloom filter. See the [Bloom filter extension](../development/extensions-core/bloom-filter.html) documentation for additional details.|
-|`CONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`.|
-|`ICONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`. The match is case-insensitive.|
 
 ## Multi-value string functions
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -561,6 +561,8 @@ The [DataSketches extension](../development/extensions-core/datasketches-extensi
 |`COALESCE(value1, value2, ...)`|Returns the first value that is neither NULL nor empty string.|
 |`NVL(expr,expr-for-null)`|Returns 'expr-for-null' if 'expr' is null (or empty string for string type).|
 |`BLOOM_FILTER_TEST(<expr>, <serialized-filter>)`|Returns true if the value is contained in a Base64-serialized bloom filter. See the [Bloom filter extension](../development/extensions-core/bloom-filter.html) documentation for additional details.|
+|`CONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`.|
+|`ICONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`. The match is case-insensitive.|
 
 ## Multi-value string functions
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -397,8 +397,8 @@ String functions accept strings, and return a type appropriate to the function.
 |`POSITION(needle IN haystack [FROM fromIndex])`|Returns the index of needle within haystack, with indexes starting from 1. The search will begin at fromIndex, or 1 if fromIndex is not specified. If the needle is not found, returns 0.|
 |`REGEXP_EXTRACT(expr, pattern, [index])`|Apply regular expression `pattern` to `expr` and extract a capture group, or `NULL` if there is no match. If index is unspecified or zero, returns the first substring that matched the pattern. The pattern may match anywhere inside `expr`; if you want to match the entire string instead, use the `^` and `$` markers at the start and end of your pattern. Note: when `druid.generic.useDefaultValueForNull = true`, it is not possible to differentiate an empty-string match from a non-match (both will return `NULL`).|
 |`REGEXP_LIKE(expr, pattern)`|Returns whether `expr` matches regular expression `pattern`. The pattern may match anywhere inside `expr`; if you want to match the entire string instead, use the `^` and `$` markers at the start and end of your pattern. Similar to [`LIKE`](#comparison-operators), but uses regexps instead of LIKE patterns. Especially useful in WHERE clauses.|
-|`CONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`.|
-|`ICONTAINS_STR(<expr>, str)`|Returns true if the `str` is a substring of `expr`. The match is case-insensitive.|
+|`CONTAINS_STRING(<expr>, str)`|Returns true if the `str` is a substring of `expr`.|
+|`ICONTAINS_STRING(<expr>, str)`|Returns true if the `str` is a substring of `expr`. The match is case-insensitive.|
 |`REPLACE(expr, pattern, replacement)`|Replaces pattern with replacement in expr, and returns the result.|
 |`STRPOS(haystack, needle)`|Returns the index of needle within haystack, with indexes starting from 1. If the needle is not found, returns 0.|
 |`SUBSTRING(expr, index, [length])`|Returns a substring of expr starting at index, with a max length, both measured in UTF-16 code units.|

--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -269,4 +269,3 @@ networks:
     ipam:
       config:
         - subnet: 172.172.172.0/24
-

--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -269,3 +269,4 @@ networks:
     ipam:
       config:
         - subnet: 172.172.172.0/24
+

--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -187,7 +187,6 @@ services:
     volumes:
       - ${HOME}/shared:/shared
       - ./service-supervisords/druid.conf:/usr/lib/druid/conf/druid.conf
-      - ../../sql/target/druid-sql-0.20.0-SNAPSHOT.jar:/usr/local/druid/lib/druid-sql-0.20.0-SNAPSHOT.jar
     env_file:
       - ./environment-configs/common
       - ./environment-configs/broker

--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -187,6 +187,7 @@ services:
     volumes:
       - ${HOME}/shared:/shared
       - ./service-supervisords/druid.conf:/usr/lib/druid/conf/druid.conf
+      - ../../sql/target/druid-sql-0.20.0-SNAPSHOT.jar:/usr/local/druid/lib/druid-sql-0.20.0-SNAPSHOT.jar
     env_file:
       - ./environment-configs/common
       - ./environment-configs/broker

--- a/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprMacroTable;
+
+import java.util.List;
+
+/**
+ * This class implements a function that checks if one string contains another string. It is required that second
+ * string be a literal. This expression is case-insensitive.
+ * signature:
+ * long contains_string(string, string)
+ * <p>
+ * Examples:
+ * - {@code contains_string("foobar", "bar") - 1 }
+ * - {@code contains_string("foobar", "car") - 0 }
+ * - {@code contains_string("foobar", "Bar") - 1 }
+ * <p>
+ * See {@link ContainsExprMacro} for the case-sensitive version.
+ */
+
+public class CaseInsensitiveContainsExprMacro implements ExprMacroTable.ExprMacro
+{
+  public static final String FN_NAME = "icontains_string";
+
+  @Override
+  public String name()
+  {
+    return FN_NAME;
+  }
+
+  @Override
+  public Expr apply(final List<Expr> args)
+  {
+    if (args.size() != 2) {
+      throw new IAE("Function[%s] must have 2 arguments", name());
+    }
+
+    final Expr arg = args.get(0);
+    final Expr searchStr = args.get(1);
+
+    if (!ExprUtils.isStringLiteral(searchStr)) {
+      throw new IAE("Function[%s] substring must be a string literal", name());
+    }
+    return new ContainsExpr(FN_NAME, arg, searchStr, false);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
@@ -58,10 +58,6 @@ public class CaseInsensitiveContainsExprMacro implements ExprMacroTable.ExprMacr
 
     final Expr arg = args.get(0);
     final Expr searchStr = args.get(1);
-
-    if (!ExprUtils.isStringLiteral(searchStr)) {
-      throw new IAE("Function[%s] substring must be a string literal", name());
-    }
     return new ContainsExpr(FN_NAME, arg, searchStr, false);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
@@ -92,7 +92,7 @@ class ContainsExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
     if (caseSensitive) {
       return s -> s.contains(searchStr);
     }
-    return s -> org.apache.commons.lang3.StringUtils.containsIgnoreCase(s, searchStr);
+    return s -> org.apache.commons.lang.StringUtils.containsIgnoreCase(s, searchStr);
   }
 
   private Expr validateSearchExpr(Expr searchExpr, String functioName)

--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.ExprType;
+
+import javax.annotation.Nonnull;
+import java.util.function.Function;
+
+/**
+ * {@link Expr} class returned by {@link ContainsExprMacro} and {@link CaseInsensitiveContainsExprMacro} for
+ * evaluating the expression.
+ */
+class ContainsExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+{
+  private final Function<String, Boolean> searchFunction;
+  private final Expr searchStrExpr;
+
+  ContainsExpr(String functioName, Expr arg, Expr searchStrExpr, boolean caseSensitive)
+  {
+    super(functioName, arg);
+    this.searchStrExpr = searchStrExpr;
+    // Creates the function eagerly to avoid branching in eval.
+    this.searchFunction = createFunction(searchStrExpr, caseSensitive);
+  }
+
+  private ContainsExpr(String functioName, Expr arg, Expr searchStrExpr, Function<String, Boolean> searchFunction)
+  {
+    super(functioName, arg);
+    this.searchFunction = searchFunction;
+    this.searchStrExpr = searchStrExpr;
+  }
+
+  @Nonnull
+  @Override
+  public ExprEval eval(final Expr.ObjectBinding bindings)
+  {
+    final String s = NullHandling.nullToEmptyIfNeeded(arg.eval(bindings).asString());
+
+    if (s == null) {
+      // same behavior as regexp_like.
+      return ExprEval.of(false, ExprType.LONG);
+    } else {
+      final boolean doesContain = searchFunction.apply(s);
+      return ExprEval.of(doesContain, ExprType.LONG);
+    }
+  }
+
+  @Override
+  public Expr visit(Expr.Shuttle shuttle)
+  {
+    Expr newArg = arg.visit(shuttle);
+    return shuttle.visit(new ContainsExpr(name, newArg, searchStrExpr, searchFunction));
+  }
+
+  @Override
+  public String stringify()
+  {
+    return StringUtils.format("%s(%s, %s)", name, arg.stringify(), searchStrExpr.stringify());
+  }
+
+  private Function<String, Boolean> createFunction(Expr searchStrExpr, boolean caseSensitive)
+  {
+    String searchStr = (String) searchStrExpr.getLiteralValue();
+    return caseSensitive ?
+           (s -> s.contains(searchStr)) :
+           (s -> org.apache.commons.lang3.StringUtils.containsIgnoreCase(s, searchStr));
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
@@ -84,11 +84,7 @@ class ContainsExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
 
   private Function<String, Boolean> createFunction(Expr searchStrExpr, boolean caseSensitive)
   {
-    String searchStr = (String) searchStrExpr.getLiteralValue();
-    if (null == searchStr) {
-      return s -> false;
-    }
-
+    String searchStr = StringUtils.nullToEmptyNonDruidDataString((String) searchStrExpr.getLiteralValue());
     if (caseSensitive) {
       return s -> s.contains(searchStr);
     }

--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprMacroTable;
+
+import java.util.List;
+
+/**
+ * This class implements a function that checks if one string contains another string. It is required that second
+ * string be a literal. This expression is case-sensitive.
+ * signature:
+ * long contains_string(string, string)
+ * <p>
+ * Examples:
+ * - {@code contains_string("foobar", "bar") - 1 }
+ * - {@code contains_string("foobar", "car") - 0 }
+ * - {@code contains_string("foobar", "Bar") - 0 }
+ * <p>
+ * See {@link CaseInsensitiveContainsExprMacro} for the case-insensitive version.
+ */
+public class ContainsExprMacro implements ExprMacroTable.ExprMacro
+{
+  public static final String FN_NAME = "contains_string";
+
+  @Override
+  public String name()
+  {
+    return FN_NAME;
+  }
+
+  @Override
+  public Expr apply(final List<Expr> args)
+  {
+    if (args.size() != 2) {
+      throw new IAE("Function[%s] must have 2 arguments", name());
+    }
+
+    final Expr arg = args.get(0);
+    final Expr searchStr = args.get(1);
+
+    if (!ExprUtils.isStringLiteral(searchStr)) {
+      throw new IAE("Function[%s] substring must be a string literal", name());
+    }
+    return new ContainsExpr(FN_NAME, arg, searchStr, true);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
@@ -57,10 +57,6 @@ public class ContainsExprMacro implements ExprMacroTable.ExprMacro
 
     final Expr arg = args.get(0);
     final Expr searchStr = args.get(1);
-
-    if (!ExprUtils.isStringLiteral(searchStr)) {
-      throw new IAE("Function[%s] substring must be a string literal", name());
-    }
     return new ContainsExpr(FN_NAME, arg, searchStr, true);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/CaseInsensitiveExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/CaseInsensitiveExprMacroTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprType;
+import org.apache.druid.math.expr.Parser;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CaseInsensitiveExprMacroTest extends MacroTestBase
+{
+  public CaseInsensitiveExprMacroTest()
+  {
+    super(new CaseInsensitiveContainsExprMacro());
+  }
+
+  @Test
+  public void testErrorZeroArguments()
+  {
+    expectException(IllegalArgumentException.class, "Function[icontains_string] must have 2 arguments");
+    eval("icontains_string()", Parser.withMap(ImmutableMap.of()));
+  }
+
+  @Test
+  public void testErrorThreeArguments()
+  {
+    expectException(IllegalArgumentException.class, "Function[icontains_string] must have 2 arguments");
+    eval("icontains_string('a', 'b', 'c')", Parser.withMap(ImmutableMap.of()));
+  }
+
+  @Test
+  public void testMatchSearchLowerCase()
+  {
+    final ExprEval<?> result = eval("icontains_string(a, 'OBA')", Parser.withMap(ImmutableMap.of("a", "foobar")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testMatchSearchUpperCase()
+  {
+    final ExprEval<?> result = eval("icontains_string(a, 'oba')", Parser.withMap(ImmutableMap.of("a", "FOOBAR")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNoMatch()
+  {
+    final ExprEval<?> result = eval("icontains_string(a, 'bar')", Parser.withMap(ImmutableMap.of("a", "foo")));
+    Assert.assertEquals(
+        ExprEval.of(false, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNullSearch()
+  {
+    if (NullHandling.sqlCompatible()) {
+      expectException(IllegalArgumentException.class, "Function[icontains_string] substring must be a string literal");
+    }
+
+    final ExprEval<?> result = eval("icontains_string(a, null)", Parser.withMap(ImmutableMap.of("a", "foo")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testEmptyStringSearch()
+  {
+    final ExprEval<?> result = eval("icontains_string(a, '')", Parser.withMap(ImmutableMap.of("a", "foo")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNullSearchOnEmptyString()
+  {
+    if (NullHandling.sqlCompatible()) {
+      expectException(IllegalArgumentException.class, "Function[icontains_string] substring must be a string literal");
+    }
+
+    final ExprEval<?> result = eval("icontains_string(a, null)", Parser.withMap(ImmutableMap.of("a", "")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testEmptyStringSearchOnEmptyString()
+  {
+    final ExprEval<?> result = eval("icontains_string(a, '')", Parser.withMap(ImmutableMap.of("a", "")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNullSearchOnNull()
+  {
+    if (NullHandling.sqlCompatible()) {
+      expectException(IllegalArgumentException.class, "Function[icontains_string] substring must be a string literal");
+    }
+
+    final ExprEval<?> result = eval(
+        "icontains_string(a, null)",
+        Parser.withSuppliers(ImmutableMap.of("a", () -> null))
+    );
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testEmptyStringSearchOnNull()
+  {
+    final ExprEval<?> result = eval("icontains_string(a, '')", Parser.withSuppliers(ImmutableMap.of("a", () -> null)));
+    Assert.assertEquals(
+        ExprEval.of(!NullHandling.sqlCompatible(), ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+}

--- a/processing/src/test/java/org/apache/druid/query/expression/ContainsExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/ContainsExprMacroTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprType;
+import org.apache.druid.math.expr.Parser;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ContainsExprMacroTest extends MacroTestBase
+{
+  public ContainsExprMacroTest()
+  {
+    super(new ContainsExprMacro());
+  }
+
+  @Test
+  public void testErrorZeroArguments()
+  {
+    expectException(IllegalArgumentException.class, "Function[contains_string] must have 2 arguments");
+    eval("contains_string()", Parser.withMap(ImmutableMap.of()));
+  }
+
+  @Test
+  public void testErrorThreeArguments()
+  {
+    expectException(IllegalArgumentException.class, "Function[contains_string] must have 2 arguments");
+    eval("contains_string('a', 'b', 'c')", Parser.withMap(ImmutableMap.of()));
+  }
+
+  @Test
+  public void testMatch()
+  {
+    final ExprEval<?> result = eval("contains_string(a, 'oba')", Parser.withMap(ImmutableMap.of("a", "foobar")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNoMatch()
+  {
+    final ExprEval<?> result = eval("contains_string(a, 'bar')", Parser.withMap(ImmutableMap.of("a", "foo")));
+    Assert.assertEquals(
+        ExprEval.of(false, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNullSearch()
+  {
+    if (NullHandling.sqlCompatible()) {
+      expectException(IllegalArgumentException.class, "Function[contains_string] substring must be a string literal");
+    }
+
+    final ExprEval<?> result = eval("contains_string(a, null)", Parser.withMap(ImmutableMap.of("a", "foo")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testEmptyStringSearch()
+  {
+    final ExprEval<?> result = eval("contains_string(a, '')", Parser.withMap(ImmutableMap.of("a", "foo")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNullSearchOnEmptyString()
+  {
+    if (NullHandling.sqlCompatible()) {
+      expectException(IllegalArgumentException.class, "Function[contains_string] substring must be a string literal");
+    }
+
+    final ExprEval<?> result = eval("contains_string(a, null)", Parser.withMap(ImmutableMap.of("a", "")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testEmptyStringSearchOnEmptyString()
+  {
+    final ExprEval<?> result = eval("contains_string(a, '')", Parser.withMap(ImmutableMap.of("a", "")));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testNullSearchOnNull()
+  {
+    if (NullHandling.sqlCompatible()) {
+      expectException(IllegalArgumentException.class, "Function[contains_string] substring must be a string literal");
+    }
+
+    final ExprEval<?> result = eval("contains_string(a, null)", Parser.withSuppliers(ImmutableMap.of("a", () -> null)));
+    Assert.assertEquals(
+        ExprEval.of(true, ExprType.LONG).value(),
+        result.value()
+    );
+  }
+
+  @Test
+  public void testEmptyStringSearchOnNull()
+  {
+    final ExprEval<?> result = eval("contains_string(a, '')", Parser.withSuppliers(ImmutableMap.of("a", () -> null)));
+    Assert.assertEquals(
+        ExprEval.of(!NullHandling.sqlCompatible(), ExprType.LONG).value(),
+        result.value()
+    );
+  }
+}

--- a/server/src/main/java/org/apache/druid/guice/ExpressionModule.java
+++ b/server/src/main/java/org/apache/druid/guice/ExpressionModule.java
@@ -25,6 +25,8 @@ import com.google.inject.Binder;
 import com.google.inject.multibindings.Multibinder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.expression.CaseInsensitiveContainsExprMacro;
+import org.apache.druid.query.expression.ContainsExprMacro;
 import org.apache.druid.query.expression.GuiceExprMacroTable;
 import org.apache.druid.query.expression.IPv4AddressMatchExprMacro;
 import org.apache.druid.query.expression.IPv4AddressParseExprMacro;
@@ -52,6 +54,8 @@ public class ExpressionModule implements DruidModule
           .add(LikeExprMacro.class)
           .add(RegexpExtractExprMacro.class)
           .add(RegexpLikeExprMacro.class)
+          .add(ContainsExprMacro.class)
+          .add(CaseInsensitiveContainsExprMacro.class)
           .add(TimestampCeilExprMacro.class)
           .add(TimestampExtractExprMacro.class)
           .add(TimestampFloorExprMacro.class)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.expression.builtin;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.SearchQueryDimFilter;
+import org.apache.druid.query.search.ContainsSearchQuerySpec;
+import org.apache.druid.query.search.SearchQuerySpec;
+import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.Expressions;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class ContainsOperatorConversion extends DirectOperatorConversion
+{
+  private static final String CASE_SENSITIVE_FN_NAME = "contains";
+  private static final String CASE_INSENSITIVE_FN_NAME = "icontains";
+  private final boolean caseSensitive;
+
+  public ContainsOperatorConversion(
+      final SqlFunction sqlFunction,
+      final String functionName,
+      final boolean caseSensitive
+  )
+  {
+    super(sqlFunction, functionName);
+    this.caseSensitive = caseSensitive;
+  }
+
+  public static SqlOperatorConversion createOperatorConversion(boolean caseSensitive)
+  {
+    final String functionName = caseSensitive ? CASE_SENSITIVE_FN_NAME : CASE_INSENSITIVE_FN_NAME;
+    final SqlFunction sqlFunction = createSqlFunction(functionName);
+    return new ContainsOperatorConversion(sqlFunction, functionName, caseSensitive);
+  }
+
+  private static SqlFunction createSqlFunction(final String functionName)
+  {
+    return OperatorConversions
+        .operatorBuilder(StringUtils.toUpperCase(functionName))
+        .operandTypes(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)
+        .requiredOperands(2)
+        .literalOperands(1)
+        .returnTypeNonNull(SqlTypeName.BOOLEAN)
+        .functionCategory(SqlFunctionCategory.STRING)
+        .build();
+  }
+
+  @Nullable
+  @Override
+  public DimFilter toDruidFilter(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      @Nullable VirtualColumnRegistry virtualColumnRegistry,
+      RexNode rexNode
+  )
+  {
+    final List<RexNode> operands = ((RexCall) rexNode).getOperands();
+    final DruidExpression druidExpression = Expressions.toDruidExpression(
+        plannerContext,
+        rowSignature,
+        operands.get(0)
+    );
+
+    if (druidExpression == null) {
+      return null;
+    }
+
+    final String search = RexLiteral.stringValue(operands.get(1));
+    final SearchQuerySpec spec = new ContainsSearchQuerySpec(search, caseSensitive);
+
+    if (druidExpression.isSimpleExtraction()) {
+      return new SearchQueryDimFilter(
+          druidExpression.getSimpleExtraction().getColumn(),
+          spec,
+          druidExpression.getSimpleExtraction().getExtractionFn(),
+          null
+      );
+    } else if (virtualColumnRegistry != null) {
+      VirtualColumn v = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
+          plannerContext,
+          druidExpression,
+          operands.get(0).getType()
+      );
+
+      return new SearchQueryDimFilter(
+          v.getOutputName(), spec, null, null);
+    } else {
+      return null;
+    }
+  }
+
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
@@ -46,8 +46,8 @@ import java.util.List;
 
 public class ContainsOperatorConversion implements SqlOperatorConversion
 {
-  private static final String CASE_SENSITIVE_FN_NAME = "contains_str";
-  private static final String CASE_INSENSITIVE_FN_NAME = "icontains_str";
+  private static final String CASE_SENSITIVE_FN_NAME = "contains_string";
+  private static final String CASE_INSENSITIVE_FN_NAME = "icontains_string";
   private final SqlOperator operator;
   private final boolean caseSensitive;
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
@@ -46,8 +46,8 @@ import java.util.List;
 
 public class ContainsOperatorConversion extends DirectOperatorConversion
 {
-  private static final String CASE_SENSITIVE_FN_NAME = "contains";
-  private static final String CASE_INSENSITIVE_FN_NAME = "icontains";
+  private static final String CASE_SENSITIVE_FN_NAME = "contains_str";
+  private static final String CASE_INSENSITIVE_FN_NAME = "icontains_str";
   private final boolean caseSensitive;
 
   public ContainsOperatorConversion(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
@@ -44,6 +44,11 @@ import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
 import javax.annotation.Nullable;
 import java.util.List;
 
+/**
+ * Register {@code contains_string} and {@code icontains_string} functions with calcite that internally
+ * translate these functions into {@link SearchQueryDimFilter} with {@link ContainsSearchQuerySpec} as
+ * search query spec.
+ */
 public class ContainsOperatorConversion implements SqlOperatorConversion
 {
   private static final String CASE_SENSITIVE_FN_NAME = "contains_string";
@@ -53,7 +58,6 @@ public class ContainsOperatorConversion implements SqlOperatorConversion
 
   public ContainsOperatorConversion(
       final SqlFunction sqlFunction,
-      final String functionName,
       final boolean caseSensitive
   )
   {
@@ -64,13 +68,13 @@ public class ContainsOperatorConversion implements SqlOperatorConversion
   public static SqlOperatorConversion caseSensitive()
   {
     final SqlFunction sqlFunction = createSqlFunction(CASE_SENSITIVE_FN_NAME);
-    return new ContainsOperatorConversion(sqlFunction, CASE_SENSITIVE_FN_NAME, true);
+    return new ContainsOperatorConversion(sqlFunction, true);
   }
 
   public static SqlOperatorConversion caseInsensitive()
   {
     final SqlFunction sqlFunction = createSqlFunction(CASE_INSENSITIVE_FN_NAME);
-    return new ContainsOperatorConversion(sqlFunction, CASE_INSENSITIVE_FN_NAME, false);
+    return new ContainsOperatorConversion(sqlFunction, false);
   }
 
   private static SqlFunction createSqlFunction(final String functionName)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ContainsOperatorConversion.java
@@ -56,7 +56,7 @@ public class ContainsOperatorConversion implements SqlOperatorConversion
   private final SqlOperator operator;
   private final boolean caseSensitive;
 
-  public ContainsOperatorConversion(
+  private ContainsOperatorConversion(
       final SqlFunction sqlFunction,
       final boolean caseSensitive
   )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -182,8 +182,8 @@ public class DruidOperatorTable implements SqlOperatorTable
           .add(new AliasedOperatorConversion(new TruncateOperatorConversion(), "TRUNC"))
           .add(new LPadOperatorConversion())
           .add(new RPadOperatorConversion())
-          .add(ContainsOperatorConversion.createOperatorConversion(true))
-          .add(ContainsOperatorConversion.createOperatorConversion(false))
+          .add(ContainsOperatorConversion.caseSensitive())
+          .add(ContainsOperatorConversion.caseInsensitive())
           .build();
 
   private static final List<SqlOperatorConversion> VALUE_COERCION_OPERATOR_CONVERSIONS =

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -61,6 +61,7 @@ import org.apache.druid.sql.calcite.expression.builtin.BTrimOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.CastOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.CeilOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ConcatOperatorConversion;
+import org.apache.druid.sql.calcite.expression.builtin.ContainsOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.DateTruncOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ExtractOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.FloorOperatorConversion;
@@ -181,6 +182,8 @@ public class DruidOperatorTable implements SqlOperatorTable
           .add(new AliasedOperatorConversion(new TruncateOperatorConversion(), "TRUNC"))
           .add(new LPadOperatorConversion())
           .add(new RPadOperatorConversion())
+          .add(ContainsOperatorConversion.createOperatorConversion(true))
+          .add(ContainsOperatorConversion.createOperatorConversion(false))
           .build();
 
   private static final List<SqlOperatorConversion> VALUE_COERCION_OPERATOR_CONVERSIONS =

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
@@ -38,7 +38,9 @@ import org.apache.druid.query.filter.ValueMatcher;
 import org.apache.druid.segment.RowAdapters;
 import org.apache.druid.segment.RowBasedColumnSelectorFactory;
 import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.virtual.VirtualizedColumnSelectorFactory;
 import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
@@ -283,11 +285,14 @@ class ExpressionTestHelper
     );
 
     final ValueMatcher matcher = expectedFilter.toFilter().makeMatcher(
-        RowBasedColumnSelectorFactory.create(
-            RowAdapters.standardRow(),
-            () -> new MapBasedRow(0L, bindings),
-            rowSignature,
-            false
+        new VirtualizedColumnSelectorFactory(
+            RowBasedColumnSelectorFactory.create(
+                RowAdapters.standardRow(),
+                () -> new MapBasedRow(0L, bindings),
+                rowSignature,
+                false
+            ),
+            VirtualColumns.create(virtualColumns)
         )
     );
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1185,16 +1185,6 @@ public class ExpressionsTest extends ExpressionTestBase
         DruidExpression.fromExpression("(icontains_string(\"spacey\",'There') && ('yes' == 'yes'))"),
         1L
     );
-
-    testHelper.testExpression(
-        ContainsOperatorConversion.caseSensitive().calciteOperator(),
-        ImmutableList.of(
-            testHelper.makeInputRef("spacey"),
-            testHelper.makeLiteral("")
-        ),
-        DruidExpression.fromExpression("contains_string(\"spacey\",'')"),
-        NullHandling.replaceWithDefault() ? 0L : 1L
-    );
   }
 
   @Test
@@ -1308,33 +1298,6 @@ public class ExpressionsTest extends ExpressionTestBase
         Collections.emptyList(),
         new SearchQueryDimFilter("spacey", new ContainsSearchQuerySpec("", true), null),
         true
-    );
-  }
-
-  @Test(expected = IAE.class)
-  public void testContainsIncorrectArgs()
-  {
-    testHelper.testExpression(
-        ContainsOperatorConversion.caseSensitive().calciteOperator(),
-        ImmutableList.of(
-            testHelper.makeInputRef("spacey")
-        ),
-        DruidExpression.fromExpression("contains_string(\"spacey\")"),
-        0L
-    );
-  }
-
-  @Test(expected = IAE.class)
-  public void testContainsSecondArgNotLiteral()
-  {
-    testHelper.testExpression(
-        ContainsOperatorConversion.caseSensitive().calciteOperator(),
-        ImmutableList.of(
-            testHelper.makeInputRef("spacey"),
-            testHelper.makeInputRef("spacey")
-        ),
-        DruidExpression.fromExpression("contains_string(\"spacey\",\"spacey\")"),
-        1L
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1078,6 +1078,119 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testContains()
   {
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeInputRef("spacey"),
+            testHelper.makeLiteral("there")
+        ),
+        DruidExpression.fromExpression("contains_string(\"spacey\",'there')"),
+        1L
+    );
+
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeInputRef("spacey"),
+            testHelper.makeLiteral("There")
+        ),
+        DruidExpression.fromExpression("contains_string(\"spacey\",'There')"),
+        0L
+    );
+
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseInsensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeInputRef("spacey"),
+            testHelper.makeLiteral("There")
+        ),
+        DruidExpression.fromExpression("icontains_string(\"spacey\",'There')"),
+        1L
+    );
+
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeCall(
+                SqlStdOperatorTable.CONCAT,
+                testHelper.makeLiteral("what is"),
+                testHelper.makeInputRef("spacey")
+            ),
+            testHelper.makeLiteral("what")
+        ),
+        DruidExpression.fromExpression("contains_string(concat('what is',\"spacey\"),'what')"),
+        1L
+    );
+
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeCall(
+                SqlStdOperatorTable.CONCAT,
+                testHelper.makeLiteral("what is"),
+                testHelper.makeInputRef("spacey")
+            ),
+            testHelper.makeLiteral("there")
+        ),
+        DruidExpression.fromExpression("contains_string(concat('what is',\"spacey\"),'there')"),
+        1L
+    );
+
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseInsensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeCall(
+                SqlStdOperatorTable.CONCAT,
+                testHelper.makeLiteral("what is"),
+                testHelper.makeInputRef("spacey")
+            ),
+            testHelper.makeLiteral("There")
+        ),
+        DruidExpression.fromExpression("icontains_string(concat('what is',\"spacey\"),'There')"),
+        1L
+    );
+
+    testHelper.testExpression(
+        SqlStdOperatorTable.AND,
+        ImmutableList.of(
+            testHelper.makeCall(
+                ContainsOperatorConversion.caseSensitive().calciteOperator(),
+                testHelper.makeInputRef("spacey"),
+                testHelper.makeLiteral("there")
+            ),
+            testHelper.makeCall(
+                SqlStdOperatorTable.EQUALS,
+                testHelper.makeLiteral("yes"),
+                testHelper.makeLiteral("yes")
+            )
+        ),
+        DruidExpression.fromExpression("(contains_string(\"spacey\",'there') && ('yes' == 'yes'))"),
+        1L
+    );
+
+    testHelper.testExpression(
+        SqlStdOperatorTable.AND,
+        ImmutableList.of(
+            testHelper.makeCall(
+                ContainsOperatorConversion.caseInsensitive().calciteOperator(),
+                testHelper.makeInputRef("spacey"),
+                testHelper.makeLiteral("There")
+            ),
+            testHelper.makeCall(
+                SqlStdOperatorTable.EQUALS,
+                testHelper.makeLiteral("yes"),
+                testHelper.makeLiteral("yes")
+            )
+        ),
+        DruidExpression.fromExpression("(icontains_string(\"spacey\",'There') && ('yes' == 'yes'))"),
+        1L
+    );
+
+  }
+
+  @Test
+  public void testContainsAsFilter()
+  {
     testHelper.testFilter(
         ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1186,6 +1186,15 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeInputRef("spacey"),
+            testHelper.makeLiteral("")
+        ),
+        DruidExpression.fromExpression("contains_string(\"spacey\",'')"),
+        NullHandling.replaceWithDefault() ? 0L : 1L
+    );
   }
 
   @Test
@@ -1288,6 +1297,44 @@ public class ExpressionsTest extends ExpressionTestBase
         ),
         new SearchQueryDimFilter("v0", new ContainsSearchQuerySpec("What", false), null),
         true
+    );
+
+    testHelper.testFilter(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeInputRef("spacey"),
+            testHelper.makeLiteral("")
+        ),
+        Collections.emptyList(),
+        new SearchQueryDimFilter("spacey", new ContainsSearchQuerySpec("", true), null),
+        true
+    );
+  }
+
+  @Test(expected = IAE.class)
+  public void testContainsIncorrectArgs()
+  {
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeInputRef("spacey")
+        ),
+        DruidExpression.fromExpression("contains_string(\"spacey\")"),
+        0L
+    );
+  }
+
+  @Test(expected = IAE.class)
+  public void testContainsSecondArgNotLiteral()
+  {
+    testHelper.testExpression(
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
+        ImmutableList.of(
+            testHelper.makeInputRef("spacey"),
+            testHelper.makeInputRef("spacey")
+        ),
+        DruidExpression.fromExpression("contains_string(\"spacey\",\"spacey\")"),
+        1L
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1079,7 +1079,7 @@ public class ExpressionsTest extends ExpressionTestBase
   public void testContains()
   {
     testHelper.testFilter(
-        ContainsOperatorConversion.createOperatorConversion(true).calciteOperator(),
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("spacey"),
             testHelper.makeLiteral("there")
@@ -1090,7 +1090,7 @@ public class ExpressionsTest extends ExpressionTestBase
     );
 
     testHelper.testFilter(
-        ContainsOperatorConversion.createOperatorConversion(true).calciteOperator(),
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("spacey"),
             testHelper.makeLiteral("There")
@@ -1101,7 +1101,7 @@ public class ExpressionsTest extends ExpressionTestBase
     );
 
     testHelper.testFilter(
-        ContainsOperatorConversion.createOperatorConversion(false).calciteOperator(),
+        ContainsOperatorConversion.caseInsensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("spacey"),
             testHelper.makeLiteral("There")
@@ -1112,7 +1112,7 @@ public class ExpressionsTest extends ExpressionTestBase
     );
 
     testHelper.testFilter(
-        ContainsOperatorConversion.createOperatorConversion(true).calciteOperator(),
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
                 SqlStdOperatorTable.CONCAT,
@@ -1134,7 +1134,7 @@ public class ExpressionsTest extends ExpressionTestBase
     );
 
     testHelper.testFilter(
-        ContainsOperatorConversion.createOperatorConversion(true).calciteOperator(),
+        ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
                 SqlStdOperatorTable.CONCAT,
@@ -1156,7 +1156,7 @@ public class ExpressionsTest extends ExpressionTestBase
     );
 
     testHelper.testFilter(
-        ContainsOperatorConversion.createOperatorConversion(false).calciteOperator(),
+        ContainsOperatorConversion.caseInsensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
                 SqlStdOperatorTable.CONCAT,

--- a/website/.spelling
+++ b/website/.spelling
@@ -1094,6 +1094,8 @@ nvl
 parse_long
 regexp_extract
 regexp_like
+contains_string
+icontains_string
 result1
 result2
 rint
@@ -1513,8 +1515,6 @@ total_size
 useApproximateCountDistinct
 useApproximateTopN
 wikipedia
-CONTAINS_STRING
-ICONTAINS_STRING
  - ../docs/querying/timeseriesquery.md
 fieldName1
 fieldName2

--- a/website/.spelling
+++ b/website/.spelling
@@ -1513,8 +1513,8 @@ total_size
 useApproximateCountDistinct
 useApproximateTopN
 wikipedia
-CONTAINS_STR
-ICONTAINS_STR
+CONTAINS_STRING
+ICONTAINS_STRING
  - ../docs/querying/timeseriesquery.md
 fieldName1
 fieldName2

--- a/website/.spelling
+++ b/website/.spelling
@@ -1513,6 +1513,8 @@ total_size
 useApproximateCountDistinct
 useApproximateTopN
 wikipedia
+CONTAINS_STR
+ICONTAINS_STR
  - ../docs/querying/timeseriesquery.md
 fieldName1
 fieldName2


### PR DESCRIPTION
### Description

Native druid query has `SearchQueryDimFilter` that is faster and supports case-insensitive search. This patch adds the `SearchQueryDimFilter` via two new functions - `contains_str` and `icontains_str` 

I have not chosen `contains`/`icontains` name as the function names since `contains` is a standard operator in calcite similar to `like`. However, in calcite, `contains` [only support periods/date as an input ](https://issues.apache.org/jira/browse/CALCITE-715). To avoid conflicts with `contains` on `strings`, I have chosen different names altogether. 

From `org.apache.calcite.sql.SqlKind`
```
/**
   * The "CONTAINS" operator for periods.
   */
  CONTAINS,
```

The method name for case insensitive search is different as it is more in line with standard SQL (`like` and `ilike`). The other reason is that we can in the future add more arguments to support extra functionality. E.g. to support [fragment search](https://druid.apache.org/docs/latest/querying/searchquery.html#fragment), one can do something as follows

`contains_str(expr, string1, string2, string3,..)`
`icontains_str(expr, string1, string2, string3,..)`

It seems cleaner to carve out a different function for case insensitive search so that the method signature is cleaner and easier to understand. 

I didn't add the support for multi-string input right away as I could not find a way to specify a type checker as follows 
 ```
.operandTypeChecker(OperandTypes.sequence("expr, string", OperandTypes.repeat(
            SqlOperandCountRanges.from(1),
            OperandTypes.and(OperandTypes.LITERAL, OperandTypes.STRING)
        )))
```
Above is not a valid syntax as `OperandTypes.sequence` takes `SqlSingleOperandTypeChecker` as input while `OperandTypes.repeat` returns `CompositeOperandTypeChecker`. 
<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key added classes in this PR
 * `ContainsOperatorConversion`
