### PR TITLE
Ignore CVEs from htrace and ambari transitive deps

### DIFF
--- a/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.ambari</groupId>
       <artifactId>ambari-metrics-common</artifactId>
-      <version>2.6.1.0.0</version>
+      <version>2.7.0.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.jackson</groupId>

--- a/extensions-contrib/ambari-metrics-emitter/src/main/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitter.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/main/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitter.java
@@ -185,6 +185,24 @@ public class AmbariMetricsEmitter extends AbstractTimelineMetricsSink implements
     return config.getHostname();
   }
 
+  @Override
+  protected boolean isHostInMemoryAggregationEnabled()
+  {
+    return false;
+  }
+
+  @Override
+  protected int getHostInMemoryAggregationPort()
+  {
+    return 0;  // since host in-memory aggregation is disabled, this return value is unimportant
+  }
+
+  @Override
+  protected String getHostInMemoryAggregationProtocol()
+  {
+    return "";  // since host in-memory aggregation is disabled, this return value is unimportant
+  }
+
   private class ConsumerRunnable implements Runnable
   {
     @Override

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
@@ -66,5 +66,9 @@ public class AmbariMetricsEmitterTest
     Assert.assertEquals("hostname", emitter.getHostname());
     Assert.assertNull(emitter.getZookeeperQuorum());
     Assert.assertEquals(Collections.singleton("hostname"), emitter.getConfiguredCollectorHosts());
+
+    Assert.assertFalse(emitter.isHostInMemoryAggregationEnabled());
+    Assert.assertEquals(0, emitter.getHostInMemoryAggregationPort());
+    Assert.assertEquals("", emitter.getHostInMemoryAggregationProtocol());
   }
 }

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -147,7 +147,7 @@
     <cve>CVE-2019-17195</cve>
   </suppress>
   <suppress>
-      <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-stroage -->
+      <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
       <notes><![CDATA[
    file name: libthrift-0.6.1.jar
    ]]></notes>
@@ -157,7 +157,7 @@
       <cve>CVE-2019-0205</cve>
   </suppress>
   <suppress>
-    <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-stroage -->
+    <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
     <notes><![CDATA[
     file name: snakeyaml-1.6.jar
     ]]></notes>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -157,6 +157,28 @@
       <cve>CVE-2019-0205</cve>
   </suppress>
   <suppress>
+    <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-stroage -->
+    <notes><![CDATA[
+    file name: snakeyaml-1.6.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@1.6$</packageUrl>
+    <cve>CVE-2017-18640</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: htrace-core4-4.0.1-incubating.jar (shaded: com.fasterxml.jackson.core:jackson-annotations:2.4.0)
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@2.4.0$</packageUrl>
+    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-annotations:2.4.0 since it is via htrace-core4 -->
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: htrace-core4-4.0.1-incubating.jar (shaded: com.fasterxml.jackson.core:jackson-core:2.4.0)
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-core@2.4.0$</packageUrl>
+    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-core:2.4.0 since it is via htrace-core4 -->
+  </suppress>
+  <suppress>
     <!--
       ~ TODO: Fix by updating hadoop-common used by extensions-core/parquet-extensions. Possibly need to change
       ~ HdfsStorageDruidModule.configure()->FileSystem.get(conf) as well.
@@ -173,10 +195,10 @@
       ~ TODO: Fix by updating parquet version in extensions-core/parquet-extensions.
       -->
     <notes><![CDATA[
-   file name: parquet-jackson-1.11.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.9.10)
+   file name: parquet-jackson-1.11.0.jar (shaded: com.fasterxml.jackson.core:jackson-{core,databind}:2.9.10)
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@2.9.10$</packageUrl>
-    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-databind:2.9.0 since it is via parquet transitive dependencies -->
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-.*@2.9.10$</packageUrl>
+    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-{core,databind}:2.9.0 since it is via parquet transitive dependencies -->
   </suppress>
   <suppress>
      <notes><![CDATA[
@@ -228,5 +250,35 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/log4j/log4j@1.2.17$</packageUrl>
     <cve>CVE-2019-17571</cve>
+  </suppress>
+  <suppress>
+     <!--
+       - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
+       -->
+     <notes><![CDATA[
+     file name: ambari-metrics-common-2.7.0.0.0.jar (shaded: io.netty:netty:3.10.5.Final)
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/io\.netty/netty@3.10.5.Final$</packageUrl>
+     <cve>CVE-2019-16869</cve>
+     <cve>CVE-2019-20444</cve>
+     <cve>CVE-2019-20445</cve>
+  </suppress>
+  <suppress>
+       <!--
+         - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
+         -->
+     <notes><![CDATA[
+     file name: ambari-metrics-common-2.7.0.0.0.jar (shaded: org.apache.hadoop:hadoop-annotations:2.6.0)
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop/hadoop\-annotations@.*$</packageUrl>
+     <cve>CVE-2015-1776</cve>
+     <cve>CVE-2016-3086</cve>
+     <cve>CVE-2016-5393</cve>
+     <cve>CVE-2016-6811</cve>
+     <cve>CVE-2017-3162</cve>
+     <cve>CVE-2018-11768</cve>
+     <cve>CVE-2018-1296</cve>
+     <cve>CVE-2018-8009</cve>
+     <cve>CVE-2018-8029</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
htrace CVEs are suppressed for now as addressing them requires updating the hadoop version.

ambari CVEs are suppressed for now since ambari is updated to the latest version and is no longer actively maintained.

After these suppressions, the security scan passes.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been manually tested by running `mvn dependency-check:check`.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->