### PR TITLE
Avoid large limits causing int overflow in buffer size checks

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -375,10 +375,10 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
 
   public boolean validateBufferCapacity(int bufferCapacity)
   {
-    int numBucketsNeeded = (int) Math.ceil((limit + 1) / maxLoadFactor);
-    int targetTableArenaSize = numBucketsNeeded * bucketSize * 2;
-    int heapSize = (limit + 1) * (Integer.BYTES);
-    int requiredSize = targetTableArenaSize + heapSize;
+    long numBucketsNeeded = (long) Math.ceil((limit + 1) / maxLoadFactor);
+    long targetTableArenaSize = numBucketsNeeded * bucketSize * 2;
+    long heapSize = (limit + 1) * (Integer.BYTES);
+    long requiredSize = targetTableArenaSize + heapSize;
 
     if (bufferCapacity < requiredSize) {
       log.debug(

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -377,7 +377,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
   {
     long numBucketsNeeded = (long) Math.ceil((limit + 1) / maxLoadFactor);
     long targetTableArenaSize = numBucketsNeeded * bucketSize * 2;
-    long heapSize = (limit + 1) * (Integer.BYTES);
+    long heapSize = ((long) limit + 1) * (Integer.BYTES);
     long requiredSize = targetTableArenaSize + heapSize;
 
     if (bufferCapacity < requiredSize) {


### PR DESCRIPTION
### Description

The size check in LimitedBufferHashGrouper can overflow and hence pass inadvertently. This results in the limited grouper being used when the buffer is too small and so the buffer.limit call within init fails with an IllegalArgumentException. 

This is likely to only occur at large limits which aren't common but we've seen it occur on our production cluster. The following test added to LimitedBufferHashGrouperTest fails prior to this commit and passes after, I'm not sure it's useful enough to include in the commit itself but included here for anyone interested

```
  @Test
  public void testBufferTooSmallOverflowingLimit()
  {
    expectedException.expect(IAE.class);
    expectedException.expectMessage("LimitedBufferHashGrouper initialized with insufficient buffer capacity");
    final TestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
    // Bucket size for the grouper is 28 bytes
    int limitToOverflow = Integer.MAX_VALUE / Integer.BYTES / 28;
    makeGrouper(columnSelectorFactory, 10000, 50000, limitToOverflow);
  }
```


This PR has:
- [x] been self-reviewed.