### PR TITLE
fix injection failure of StorageLocationSelectorStrategy objects

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1409,7 +1409,7 @@ These Historical configurations can be defined in the `historical/runtime.proper
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.segmentCache.locations`|Segments assigned to a Historical process are first stored on the local file system (in a disk cache) and then served by the Historical process. These locations define where that local cache resides. This value cannot be NULL or EMPTY. Here is an example `druid.segmentCache.locations=[{"path": "/mnt/druidSegments", "maxSize": "10k", "freeSpacePercent": 1.0}]`. "freeSpacePercent" is optional, if provided then enforces that much of free disk partition space while storing segments. But, it depends on File.getTotalSpace() and File.getFreeSpace() methods, so enable if only if they work for your File System.| none |
-|`druid.segmentCache.locationSelectorStrategy.type`|The strategy used to select a location from the configured `druid.segmentCache.locations` for segment distribution. Possible values are `leastBytesUsed`, `roundRobin`, `random`, or `mostAvailableSize`. |leastBytesUsed|
+|`druid.segmentCache.locationSelector.strategy`|The strategy used to select a location from the configured `druid.segmentCache.locations` for segment distribution. Possible values are `leastBytesUsed`, `roundRobin`, `random`, or `mostAvailableSize`. |leastBytesUsed|
 |`druid.segmentCache.deleteOnRemove`|Delete segment files from cache once a process is no longer serving a segment.|true|
 |`druid.segmentCache.dropSegmentDelayMillis`|How long a process delays before completely dropping segment.|30000 (30 seconds)|
 |`druid.segmentCache.infoDir`|Historical processes keep track of the segments they are serving so that when the process is restarted they can reload the same segments without waiting for the Coordinator to reassign. This path defines where this metadata is kept. Directory will be created if needed.|${first_location}/info_dir|
@@ -1421,7 +1421,7 @@ These Historical configurations can be defined in the `historical/runtime.proper
 
 In `druid.segmentCache.locations`, *freeSpacePercent* was added because *maxSize* setting is only a theoretical limit and assumes that much space will always be available for storing segments. In case of any druid bug leading to unaccounted segment files left alone on disk or some other process writing stuff to disk, This check can start failing segment loading early before filling up the disk completely and leaving the host usable otherwise.
 
-In `druid.segmentCache.locationSelectorStrategy.type`, one of `leastBytesUsed`, `roundRobin`, `random`, or `mostAvailableSize` could be specified to represent the strategy to distribute segments across multiple segment cache locations.
+In `druid.segmentCache.locationSelector.strategy`, one of `leastBytesUsed`, `roundRobin`, `random`, or `mostAvailableSize` could be specified to represent the strategy to distribute segments across multiple segment cache locations.
 
 |Strategy|Description|
 |--------|-----------|

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1409,7 +1409,7 @@ These Historical configurations can be defined in the `historical/runtime.proper
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.segmentCache.locations`|Segments assigned to a Historical process are first stored on the local file system (in a disk cache) and then served by the Historical process. These locations define where that local cache resides. This value cannot be NULL or EMPTY. Here is an example `druid.segmentCache.locations=[{"path": "/mnt/druidSegments", "maxSize": "10k", "freeSpacePercent": 1.0}]`. "freeSpacePercent" is optional, if provided then enforces that much of free disk partition space while storing segments. But, it depends on File.getTotalSpace() and File.getFreeSpace() methods, so enable if only if they work for your File System.| none |
-|`druid.segmentCache.locationSelectorStrategy`|The strategy used to select a location from the configured `druid.segmentCache.locations` for segment distribution. Possible values are `leastBytesUsed`, `roundRobin`, `random`, or `mostAvailableSize`. |leastBytesUsed|
+|`druid.segmentCache.locationSelectorStrategy.type`|The strategy used to select a location from the configured `druid.segmentCache.locations` for segment distribution. Possible values are `leastBytesUsed`, `roundRobin`, `random`, or `mostAvailableSize`. |leastBytesUsed|
 |`druid.segmentCache.deleteOnRemove`|Delete segment files from cache once a process is no longer serving a segment.|true|
 |`druid.segmentCache.dropSegmentDelayMillis`|How long a process delays before completely dropping segment.|30000 (30 seconds)|
 |`druid.segmentCache.infoDir`|Historical processes keep track of the segments they are serving so that when the process is restarted they can reload the same segments without waiting for the Coordinator to reassign. This path defines where this metadata is kept. Directory will be created if needed.|${first_location}/info_dir|
@@ -1421,7 +1421,7 @@ These Historical configurations can be defined in the `historical/runtime.proper
 
 In `druid.segmentCache.locations`, *freeSpacePercent* was added because *maxSize* setting is only a theoretical limit and assumes that much space will always be available for storing segments. In case of any druid bug leading to unaccounted segment files left alone on disk or some other process writing stuff to disk, This check can start failing segment loading early before filling up the disk completely and leaving the host usable otherwise.
 
-In `druid.segmentCache.locationSelectorStrategy`, one of leastBytesUsed, roundRobin, random, or mostAvailableSize could be specified to represent the strategy to distribute segments across multiple segment cache locations.
+In `druid.segmentCache.locationSelectorStrategy.type`, one of `leastBytesUsed`, `roundRobin`, `random`, or `mostAvailableSize` could be specified to represent the strategy to distribute segments across multiple segment cache locations.
 
 |Strategy|Description|
 |--------|-----------|

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -231,6 +231,7 @@ libraries:
   - com.fasterxml.jackson.jaxrs: jackson-jaxrs-json-provider
   - com.fasterxml.jackson.jaxrs: jackson-jaxrs-smile-provider
   - com.fasterxml.jackson.module: jackson-module-jaxb-annotations
+  - com.fasterxml.jackson.module: jackson-module-guice
 notice: |
   # Jackson JSON processor
 
@@ -4123,16 +4124,6 @@ license_name: Apache License version 2.0
 version: v1-rev20190607-1.26.0
 libraries:
   - com.google.apis: google-api-services-compute
-
----
-
-name: "Jackson Module: Guice"
-license_category: binary
-module: java-core
-license_name: Apache License version 2.0
-version: 2.6.7
-libraries:
-  - com.fasterxml.jackson.module: jackson-module-guice
 
 ---
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -315,6 +315,10 @@
             <groupId>io.timeandspace</groupId>
             <artifactId>cron-scheduler</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-guice</artifactId>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/server/src/main/java/org/apache/druid/guice/StorageNodeModule.java
+++ b/server/src/main/java/org/apache/druid/guice/StorageNodeModule.java
@@ -55,7 +55,7 @@ public class StorageNodeModule implements Module
   {
     JsonConfigProvider.bind(binder, "druid.server", DruidServerConfig.class);
     JsonConfigProvider.bind(binder, "druid.segmentCache", SegmentLoaderConfig.class);
-    JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelectorStrategy", StorageLocationSelectorStrategy.class);
+    JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelector.strategy", StorageLocationSelectorStrategy.class);
 
     binder.bind(ServerTypeConfig.class).toProvider(Providers.of(null));
     binder.bind(ColumnConfig.class).to(DruidProcessingConfig.class);

--- a/server/src/main/java/org/apache/druid/guice/StorageNodeModule.java
+++ b/server/src/main/java/org/apache/druid/guice/StorageNodeModule.java
@@ -55,7 +55,7 @@ public class StorageNodeModule implements Module
   {
     JsonConfigProvider.bind(binder, "druid.server", DruidServerConfig.class);
     JsonConfigProvider.bind(binder, "druid.segmentCache", SegmentLoaderConfig.class);
-    JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelector.strategy", StorageLocationSelectorStrategy.class);
+    bindLocationSelectorStrategy(binder);
 
     binder.bind(ServerTypeConfig.class).toProvider(Providers.of(null));
     binder.bind(ColumnConfig.class).to(DruidProcessingConfig.class);
@@ -131,5 +131,13 @@ public class StorageNodeModule implements Module
   public List<StorageLocation> provideStorageLocation(SegmentLoaderConfig config)
   {
     return config.toStorageLocations();
+  }
+
+  /**
+   * a helper method for both storage module and independent unit test cases
+   */
+  public static void bindLocationSelectorStrategy(Binder binder)
+  {
+    JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelector", StorageLocationSelectorStrategy.class);
   }
 }

--- a/server/src/main/java/org/apache/druid/guice/StorageNodeModule.java
+++ b/server/src/main/java/org/apache/druid/guice/StorageNodeModule.java
@@ -33,11 +33,14 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.loading.SegmentLoaderConfig;
+import org.apache.druid.segment.loading.StorageLocation;
+import org.apache.druid.segment.loading.StorageLocationSelectorStrategy;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  */
@@ -52,6 +55,7 @@ public class StorageNodeModule implements Module
   {
     JsonConfigProvider.bind(binder, "druid.server", DruidServerConfig.class);
     JsonConfigProvider.bind(binder, "druid.segmentCache", SegmentLoaderConfig.class);
+    JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelectorStrategy", StorageLocationSelectorStrategy.class);
 
     binder.bind(ServerTypeConfig.class).toProvider(Providers.of(null));
     binder.bind(ColumnConfig.class).to(DruidProcessingConfig.class);
@@ -116,5 +120,16 @@ public class StorageNodeModule implements Module
   public Boolean isSegmentCacheConfigured(SegmentLoaderConfig segmentLoaderConfig)
   {
     return !segmentLoaderConfig.getLocations().isEmpty();
+  }
+
+  /**
+   * provide a list of StorageLocation
+   * so that it can be injected into objects such as implementations of {@link StorageLocationSelectorStrategy}
+   */
+  @Provides
+  @LazySingleton
+  public List<StorageLocation> provideStorageLocation(SegmentLoaderConfig config)
+  {
+    return config.toStorageLocations();
   }
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
@@ -34,7 +34,7 @@ import java.util.List;
 public class LeastBytesUsedStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
   private static final Ordering<StorageLocation> ORDERING = Ordering.from(Comparator
-                                                                              .comparingLong(StorageLocation::currSizeBytes));
+      .comparingLong(StorageLocation::currSizeBytes));
 
   private List<StorageLocation> storageLocations;
 

--- a/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 
 import java.util.Comparator;
@@ -36,7 +38,13 @@ public class LeastBytesUsedStorageLocationSelectorStrategy implements StorageLoc
 
   private List<StorageLocation> storageLocations;
 
-  public LeastBytesUsedStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  @JsonCreator
+  public LeastBytesUsedStorageLocationSelectorStrategy() {
+
+  }
+
+  @VisibleForTesting
+  LeastBytesUsedStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -45,6 +53,12 @@ public class LeastBytesUsedStorageLocationSelectorStrategy implements StorageLoc
   public Iterator<StorageLocation> getLocations()
   {
     return ORDERING.sortedCopy(this.storageLocations).iterator();
+  }
+
+  @Override
+  public void setLocations(List<StorageLocation> locations)
+  {
+    this.storageLocations = locations;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
@@ -34,13 +34,13 @@ import java.util.List;
 public class LeastBytesUsedStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
   private static final Ordering<StorageLocation> ORDERING = Ordering.from(Comparator
-      .comparingLong(StorageLocation::currSizeBytes));
+                                                                              .comparingLong(StorageLocation::currSizeBytes));
 
   private List<StorageLocation> storageLocations;
 
   @JsonCreator
-  public LeastBytesUsedStorageLocationSelectorStrategy() {
-
+  public LeastBytesUsedStorageLocationSelectorStrategy()
+  {
   }
 
   @VisibleForTesting

--- a/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LeastBytesUsedStorageLocationSelectorStrategy.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 
 import java.util.Comparator;
@@ -36,15 +36,10 @@ public class LeastBytesUsedStorageLocationSelectorStrategy implements StorageLoc
   private static final Ordering<StorageLocation> ORDERING = Ordering.from(Comparator
       .comparingLong(StorageLocation::currSizeBytes));
 
-  private List<StorageLocation> storageLocations;
+  private final List<StorageLocation> storageLocations;
 
   @JsonCreator
-  public LeastBytesUsedStorageLocationSelectorStrategy()
-  {
-  }
-
-  @VisibleForTesting
-  LeastBytesUsedStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  public LeastBytesUsedStorageLocationSelectorStrategy(@JacksonInject final List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -53,12 +48,6 @@ public class LeastBytesUsedStorageLocationSelectorStrategy implements StorageLoc
   public Iterator<StorageLocation> getLocations()
   {
     return ORDERING.sortedCopy(this.storageLocations).iterator();
-  }
-
-  @Override
-  public void setLocations(List<StorageLocation> locations)
-  {
-    this.storageLocations = locations;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 
 import java.util.Comparator;
@@ -37,15 +37,10 @@ public class MostAvailableSizeStorageLocationSelectorStrategy implements Storage
       .comparingLong(StorageLocation::availableSizeBytes)
       .reversed());
 
-  private List<StorageLocation> storageLocations;
+  private final List<StorageLocation> storageLocations;
 
   @JsonCreator
-  public MostAvailableSizeStorageLocationSelectorStrategy()
-  {
-  }
-
-  @VisibleForTesting
-  MostAvailableSizeStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  public MostAvailableSizeStorageLocationSelectorStrategy(@JacksonInject final List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -54,12 +49,6 @@ public class MostAvailableSizeStorageLocationSelectorStrategy implements Storage
   public Iterator<StorageLocation> getLocations()
   {
     return ORDERING.sortedCopy(this.storageLocations).iterator();
-  }
-
-  @Override
-  public void setLocations(List<StorageLocation> locations)
-  {
-    this.storageLocations = locations;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
@@ -34,14 +34,14 @@ import java.util.List;
 public class MostAvailableSizeStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
   private static final Ordering<StorageLocation> ORDERING = Ordering.from(Comparator
-      .comparingLong(StorageLocation::availableSizeBytes)
-      .reversed());
+                                                                              .comparingLong(StorageLocation::availableSizeBytes)
+                                                                              .reversed());
 
   private List<StorageLocation> storageLocations;
 
   @JsonCreator
-  public MostAvailableSizeStorageLocationSelectorStrategy() {
-
+  public MostAvailableSizeStorageLocationSelectorStrategy()
+  {
   }
 
   @VisibleForTesting

--- a/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 
 import java.util.Comparator;
@@ -37,7 +39,13 @@ public class MostAvailableSizeStorageLocationSelectorStrategy implements Storage
 
   private List<StorageLocation> storageLocations;
 
-  public MostAvailableSizeStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  @JsonCreator
+  public MostAvailableSizeStorageLocationSelectorStrategy() {
+
+  }
+
+  @VisibleForTesting
+  MostAvailableSizeStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -46,6 +54,12 @@ public class MostAvailableSizeStorageLocationSelectorStrategy implements Storage
   public Iterator<StorageLocation> getLocations()
   {
     return ORDERING.sortedCopy(this.storageLocations).iterator();
+  }
+
+  @Override
+  public void setLocations(List<StorageLocation> locations)
+  {
+    this.storageLocations = locations;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/MostAvailableSizeStorageLocationSelectorStrategy.java
@@ -34,8 +34,8 @@ import java.util.List;
 public class MostAvailableSizeStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
   private static final Ordering<StorageLocation> ORDERING = Ordering.from(Comparator
-                                                                              .comparingLong(StorageLocation::availableSizeBytes)
-                                                                              .reversed());
+      .comparingLong(StorageLocation::availableSizeBytes)
+      .reversed());
 
   private List<StorageLocation> storageLocations;
 

--- a/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
@@ -34,7 +34,7 @@ import java.util.List;
 public class RandomStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
 
-  private List<StorageLocation> storageLocations = null;
+  private List<StorageLocation> storageLocations;
 
   @JsonCreator
   public RandomStorageLocationSelectorStrategy()

--- a/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
@@ -19,6 +19,10 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -31,9 +35,15 @@ import java.util.List;
 public class RandomStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
 
-  private final List<StorageLocation> storageLocations;
+  private List<StorageLocation> storageLocations = null;
 
-  public RandomStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  @JsonCreator
+  public RandomStorageLocationSelectorStrategy() {
+
+  }
+
+  @VisibleForTesting
+  RandomStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -44,6 +54,12 @@ public class RandomStorageLocationSelectorStrategy implements StorageLocationSel
     List<StorageLocation> copyLocation = new ArrayList<>(storageLocations);
     Collections.shuffle(copyLocation);
     return copyLocation.iterator();
+  }
+
+  @Override
+  public void setLocations(List<StorageLocation> locations)
+  {
+    this.storageLocations = locations;
   }
 
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,15 +34,10 @@ import java.util.List;
 public class RandomStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
 
-  private List<StorageLocation> storageLocations;
+  private final List<StorageLocation> storageLocations;
 
   @JsonCreator
-  public RandomStorageLocationSelectorStrategy()
-  {
-  }
-
-  @VisibleForTesting
-  RandomStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  public RandomStorageLocationSelectorStrategy(@JacksonInject final List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -54,11 +49,4 @@ public class RandomStorageLocationSelectorStrategy implements StorageLocationSel
     Collections.shuffle(copyLocation);
     return copyLocation.iterator();
   }
-
-  @Override
-  public void setLocations(List<StorageLocation> locations)
-  {
-    this.storageLocations = locations;
-  }
-
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RandomStorageLocationSelectorStrategy.java
@@ -20,7 +20,6 @@
 package org.apache.druid.segment.loading;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
@@ -38,8 +37,8 @@ public class RandomStorageLocationSelectorStrategy implements StorageLocationSel
   private List<StorageLocation> storageLocations = null;
 
   @JsonCreator
-  public RandomStorageLocationSelectorStrategy() {
-
+  public RandomStorageLocationSelectorStrategy()
+  {
   }
 
   @VisibleForTesting

--- a/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -32,11 +35,16 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class RoundRobinStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
-
-  private final List<StorageLocation> storageLocations;
+  private List<StorageLocation> storageLocations = null;
   private final AtomicInteger startIndex = new AtomicInteger(0);
 
-  public RoundRobinStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  @JsonCreator
+  public RoundRobinStorageLocationSelectorStrategy() {
+
+  }
+
+  @VisibleForTesting
+  RoundRobinStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -72,6 +80,12 @@ public class RoundRobinStorageLocationSelectorStrategy implements StorageLocatio
         return nextLocation;
       }
     };
+  }
+
+  @Override
+  public void setLocations(List<StorageLocation> locations)
+  {
+    this.storageLocations = locations;
   }
 
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class RoundRobinStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
-  private List<StorageLocation> storageLocations = null;
+  private List<StorageLocation> storageLocations;
   private final AtomicInteger startIndex = new AtomicInteger(0);
 
   @JsonCreator

--- a/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
@@ -39,8 +39,8 @@ public class RoundRobinStorageLocationSelectorStrategy implements StorageLocatio
   private final AtomicInteger startIndex = new AtomicInteger(0);
 
   @JsonCreator
-  public RoundRobinStorageLocationSelectorStrategy() {
-
+  public RoundRobinStorageLocationSelectorStrategy()
+  {
   }
 
   @VisibleForTesting
@@ -52,7 +52,8 @@ public class RoundRobinStorageLocationSelectorStrategy implements StorageLocatio
   @Override
   public Iterator<StorageLocation> getLocations()
   {
-    return new Iterator<StorageLocation>() {
+    return new Iterator<StorageLocation>()
+    {
 
       private final int numStorageLocations = storageLocations.size();
       private int remainingIterations = numStorageLocations;

--- a/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Iterator;
 import java.util.List;
@@ -35,16 +35,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class RoundRobinStorageLocationSelectorStrategy implements StorageLocationSelectorStrategy
 {
-  private List<StorageLocation> storageLocations;
+  private final List<StorageLocation> storageLocations;
   private final AtomicInteger startIndex = new AtomicInteger(0);
 
   @JsonCreator
-  public RoundRobinStorageLocationSelectorStrategy()
-  {
-  }
-
-  @VisibleForTesting
-  RoundRobinStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  public RoundRobinStorageLocationSelectorStrategy(@JacksonInject List<StorageLocation> storageLocations)
   {
     this.storageLocations = storageLocations;
   }
@@ -82,11 +77,4 @@ public class RoundRobinStorageLocationSelectorStrategy implements StorageLocatio
       }
     };
   }
-
-  @Override
-  public void setLocations(List<StorageLocation> locations)
-  {
-    this.storageLocations = locations;
-  }
-
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
@@ -101,11 +101,11 @@ public class SegmentLoaderConfig
     return numBootstrapThreads == null ? numLoadingThreads : numBootstrapThreads;
   }
 
-  public StorageLocationSelectorStrategy getStorageLocationSelectorStrategy(List<StorageLocation> storageLocations)
+  public StorageLocationSelectorStrategy getStorageLocationSelectorStrategy()
   {
     if (locationSelectorStrategy == null) {
       // default strategy if no strategy is specified in the config
-      locationSelectorStrategy = new LeastBytesUsedStorageLocationSelectorStrategy(storageLocations);
+      locationSelectorStrategy = new LeastBytesUsedStorageLocationSelectorStrategy();
     }
     return locationSelectorStrategy;
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
@@ -20,7 +20,6 @@
 package org.apache.druid.segment.loading;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.apache.druid.utils.JvmUtils;
 
@@ -28,6 +27,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -54,9 +54,6 @@ public class SegmentLoaderConfig
 
   @JsonProperty("numBootstrapThreads")
   private Integer numBootstrapThreads = null;
-
-  @JsonProperty("locationSelectorStrategy")
-  private StorageLocationSelectorStrategy locationSelectorStrategy;
 
   @JsonProperty
   private File infoDir = null;
@@ -101,15 +98,6 @@ public class SegmentLoaderConfig
     return numBootstrapThreads == null ? numLoadingThreads : numBootstrapThreads;
   }
 
-  public StorageLocationSelectorStrategy getStorageLocationSelectorStrategy()
-  {
-    if (locationSelectorStrategy == null) {
-      // default strategy if no strategy is specified in the config
-      locationSelectorStrategy = new LeastBytesUsedStorageLocationSelectorStrategy();
-    }
-    return locationSelectorStrategy;
-  }
-
   public File getInfoDir()
   {
     if (infoDir == null) {
@@ -140,11 +128,19 @@ public class SegmentLoaderConfig
     return retVal;
   }
 
-  @VisibleForTesting
-  SegmentLoaderConfig withStorageLocationSelectorStrategy(StorageLocationSelectorStrategy strategy)
+  /**
+   * Convert StorageLocationConfig objects to StorageLocation objects
+   *
+   * Note: {@link #getLocations} is called instead of variable access because some testcases overrides this method
+   */
+  public List<StorageLocation> toStorageLocations()
   {
-    this.locationSelectorStrategy = strategy;
-    return this;
+    return this.getLocations()
+               .stream()
+               .map(locationConfig -> new StorageLocation(locationConfig.getPath(),
+                                                          locationConfig.getMaxSize(),
+                                                          locationConfig.getFreeSpacePercent()))
+               .collect(Collectors.toList());
   }
 
   @Override
@@ -154,7 +150,6 @@ public class SegmentLoaderConfig
            "locations=" + locations +
            ", deleteOnRemove=" + deleteOnRemove +
            ", dropSegmentDelayMillis=" + dropSegmentDelayMillis +
-           ", locationSelectorStrategy=" + locationSelectorStrategy +
            ", infoDir=" + infoDir +
            '}';
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -102,7 +102,7 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
 
     this.strategy = config.getStorageLocationSelectorStrategy();
     this.strategy.setLocations(locations);
-    log.info("using storage location strategy: %s", this.strategy.getClass().getSimpleName());
+    log.info("Using storage location strategy: [%s]", this.strategy.getClass().getSimpleName());
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -102,6 +102,7 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
 
     this.strategy = config.getStorageLocationSelectorStrategy();
     this.strategy.setLocations(locations);
+    log.info("using storage location strategy: %s", this.strategy.getClass().getSimpleName());
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -99,6 +99,7 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
           )
       );
     }
+
     this.strategy = config.getStorageLocationSelectorStrategy();
     this.strategy.setLocations(locations);
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -99,7 +99,8 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
           )
       );
     }
-    this.strategy = config.getStorageLocationSelectorStrategy(locations);
+    this.strategy = config.getStorageLocationSelectorStrategy();
+    this.strategy.setLocations(locations);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -30,9 +30,9 @@ import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.timeline.DataSegment;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,6 +82,38 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
   @Inject
   public SegmentLoaderLocalCacheManager(
       IndexIO indexIO,
+      List<StorageLocation> locations,
+      SegmentLoaderConfig config,
+      @Nonnull StorageLocationSelectorStrategy strategy,
+      @Json ObjectMapper mapper
+  )
+  {
+    this.indexIO = indexIO;
+    this.config = config;
+    this.jsonMapper = mapper;
+    this.locations = locations;
+    this.strategy = strategy;
+    log.info("Using storage location strategy: [%s]", this.strategy.getClass().getSimpleName());
+  }
+
+  @VisibleForTesting
+  SegmentLoaderLocalCacheManager(
+      IndexIO indexIO,
+      SegmentLoaderConfig config,
+      @Nonnull StorageLocationSelectorStrategy strategy,
+      @Json ObjectMapper mapper
+  )
+  {
+    this(indexIO, config.toStorageLocations(), config, strategy, mapper);
+  }
+
+  /**
+   * creates instance with default storage location selector strategy
+   *
+   * This ctor is mainly for test cases, including test cases in other modules
+   */
+  public SegmentLoaderLocalCacheManager(
+      IndexIO indexIO,
       SegmentLoaderConfig config,
       @Json ObjectMapper mapper
   )
@@ -89,19 +121,8 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
     this.indexIO = indexIO;
     this.config = config;
     this.jsonMapper = mapper;
-    this.locations = new ArrayList<>();
-    for (StorageLocationConfig locationConfig : config.getLocations()) {
-      locations.add(
-          new StorageLocation(
-              locationConfig.getPath(),
-              locationConfig.getMaxSize(),
-              locationConfig.getFreeSpacePercent()
-          )
-      );
-    }
-
-    this.strategy = config.getStorageLocationSelectorStrategy();
-    this.strategy.setLocations(locations);
+    this.locations = config.toStorageLocations();
+    this.strategy = new LeastBytesUsedStorageLocationSelectorStrategy(locations);
     log.info("Using storage location strategy: [%s]", this.strategy.getClass().getSimpleName());
   }
 

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategy.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
  * https://github.com/apache/druid/pull/8038#discussion_r325520829 of PR https://github
  * .com/apache/druid/pull/8038 for more details.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl =
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "strategy", defaultImpl =
     LeastBytesUsedStorageLocationSelectorStrategy.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "leastBytesUsed", value = LeastBytesUsedStorageLocationSelectorStrategy.class),

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategy.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.timeline.DataSegment;
 
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * This interface describes the storage location selection strategy which is responsible for ordering the
@@ -56,4 +57,6 @@ public interface StorageLocationSelectorStrategy
    * @return An iterator of {@link StorageLocation}s from which the callers can iterate and pick a location.
    */
   Iterator<StorageLocation> getLocations();
+
+  void setLocations(List<StorageLocation> locations);
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategy.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.timeline.DataSegment;
 
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * This interface describes the storage location selection strategy which is responsible for ordering the
@@ -57,6 +56,4 @@ public interface StorageLocationSelectorStrategy
    * @return An iterator of {@link StorageLocation}s from which the callers can iterate and pick a location.
    */
   Iterator<StorageLocation> getLocations();
-
-  void setLocations(List<StorageLocation> locations);
 }

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
@@ -422,9 +422,8 @@ public class SegmentLoaderLocalCacheManagerTest
 
     manager = new SegmentLoaderLocalCacheManager(
       TestHelper.getTestIndexIO(),
-      new SegmentLoaderConfig().withLocations(locationConfigs).withStorageLocationSelectorStrategy(
-        new RoundRobinStorageLocationSelectorStrategy(locations)
-      ),
+      new SegmentLoaderConfig().withLocations(locationConfigs),
+      new RoundRobinStorageLocationSelectorStrategy(locations),
       jsonMapper
     );
     final File segmentSrcFolder = tmpFolder.newFolder("segmentSrcFolder");
@@ -669,21 +668,12 @@ public class SegmentLoaderLocalCacheManagerTest
     locationConfigs.add(locationConfig2);
     locationConfigs.add(locationConfig3);
 
-    List<StorageLocation> locations = new ArrayList<>();
-    for (StorageLocationConfig locConfig : locationConfigs) {
-      locations.add(
-              new StorageLocation(
-                      locConfig.getPath(),
-                      locConfig.getMaxSize(),
-                      null
-              )
-      );
-    }
+    SegmentLoaderConfig segmentLoaderConfig = new SegmentLoaderConfig().withLocations(locationConfigs);
+
     manager = new SegmentLoaderLocalCacheManager(
             TestHelper.getTestIndexIO(),
-            new SegmentLoaderConfig().withLocations(locationConfigs).withStorageLocationSelectorStrategy(
-                    new RandomStorageLocationSelectorStrategy(locations)
-            ),
+            new SegmentLoaderConfig().withLocations(locationConfigs),
+            new RandomStorageLocationSelectorStrategy(segmentLoaderConfig.toStorageLocations()),
             jsonMapper
     );
 

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
@@ -271,7 +271,7 @@ public class StorageLocationSelectorStrategyTest
   }
 
   @Test
-  public void testDefaultSelectorStrategyConfig() throws Exception
+  public void testDefaultSelectorStrategyConfig()
   {
     //no druid.segmentCache.locationSelectorStrategy.type specified
     final Properties props = new Properties();
@@ -281,40 +281,40 @@ public class StorageLocationSelectorStrategyTest
   }
 
   @Test
-  public void testRoundRobinSelectorStrategyConfig() throws Exception
+  public void testRoundRobinSelectorStrategyConfig()
   {
     final Properties props = new Properties();
-    props.put("druid.segmentCache.locationSelectorStrategy.type", "roundRobin");
+    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "roundRobin");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
     Assert.assertEquals(RoundRobinStorageLocationSelectorStrategy.class,
                         loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   @Test
-  public void testLeastBytesUsedSelectorStrategyConfig() throws Exception
+  public void testLeastBytesUsedSelectorStrategyConfig()
   {
     final Properties props = new Properties();
-    props.put("druid.segmentCache.locationSelectorStrategy.type", "leastBytesUsed");
+    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "leastBytesUsed");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
     Assert.assertEquals(LeastBytesUsedStorageLocationSelectorStrategy.class,
                         loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   @Test
-  public void testRandomSelectorStrategyConfig() throws Exception
+  public void testRandomSelectorStrategyConfig()
   {
     final Properties props = new Properties();
-    props.put("druid.segmentCache.locationSelectorStrategy.type", "random");
+    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "random");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
     Assert.assertEquals(RandomStorageLocationSelectorStrategy.class,
                         loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   @Test
-  public void testMostAvailableSizeSelectorStrategyConfig() throws Exception
+  public void testMostAvailableSizeSelectorStrategyConfig()
   {
     final Properties props = new Properties();
-    props.put("druid.segmentCache.locationSelectorStrategy.type", "mostAvailableSize");
+    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "mostAvailableSize");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
     Assert.assertEquals(MostAvailableSizeStorageLocationSelectorStrategy.class,
                         loaderConfig.getStorageLocationSelectorStrategy().getClass());

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.guice.DruidGuiceExtensions;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.StorageNodeModule;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -362,7 +363,7 @@ public class StorageLocationSelectorStrategyTest
               binder.bind(Properties.class).toInstance(props);
 
               JsonConfigProvider.bind(binder, "druid.segmentCache", SegmentLoaderConfig.class);
-              JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelector", StorageLocationSelectorStrategy.class);
+              StorageNodeModule.bindLocationSelectorStrategy(binder);
             }
 
             @Provides

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
@@ -276,7 +276,8 @@ public class StorageLocationSelectorStrategyTest
     //no druid.segmentCache.locationSelectorStrategy.type specified
     final Properties props = new Properties();
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
-    Assert.assertEquals( LeastBytesUsedStorageLocationSelectorStrategy.class ,loaderConfig.getStorageLocationSelectorStrategy().getClass());
+    Assert.assertEquals(LeastBytesUsedStorageLocationSelectorStrategy.class,
+                        loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   @Test
@@ -285,7 +286,8 @@ public class StorageLocationSelectorStrategyTest
     final Properties props = new Properties();
     props.put("druid.segmentCache.locationSelectorStrategy.type", "roundRobin");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
-    Assert.assertEquals( RoundRobinStorageLocationSelectorStrategy.class ,loaderConfig.getStorageLocationSelectorStrategy().getClass());
+    Assert.assertEquals(RoundRobinStorageLocationSelectorStrategy.class,
+                        loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   @Test
@@ -294,7 +296,8 @@ public class StorageLocationSelectorStrategyTest
     final Properties props = new Properties();
     props.put("druid.segmentCache.locationSelectorStrategy.type", "leastBytesUsed");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
-    Assert.assertEquals( LeastBytesUsedStorageLocationSelectorStrategy.class ,loaderConfig.getStorageLocationSelectorStrategy().getClass());
+    Assert.assertEquals(LeastBytesUsedStorageLocationSelectorStrategy.class,
+                        loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   @Test
@@ -303,7 +306,8 @@ public class StorageLocationSelectorStrategyTest
     final Properties props = new Properties();
     props.put("druid.segmentCache.locationSelectorStrategy.type", "random");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
-    Assert.assertEquals( RandomStorageLocationSelectorStrategy.class ,loaderConfig.getStorageLocationSelectorStrategy().getClass());
+    Assert.assertEquals(RandomStorageLocationSelectorStrategy.class,
+                        loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   @Test
@@ -312,7 +316,8 @@ public class StorageLocationSelectorStrategyTest
     final Properties props = new Properties();
     props.put("druid.segmentCache.locationSelectorStrategy.type", "mostAvailableSize");
     SegmentLoaderConfig loaderConfig = makeInjectorWithProperties(props).getInstance(SegmentLoaderConfig.class);
-    Assert.assertEquals( MostAvailableSizeStorageLocationSelectorStrategy.class ,loaderConfig.getStorageLocationSelectorStrategy().getClass());
+    Assert.assertEquals(MostAvailableSizeStorageLocationSelectorStrategy.class,
+                        loaderConfig.getStorageLocationSelectorStrategy().getClass());
   }
 
   private Injector makeInjectorWithProperties(final Properties props)

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
@@ -274,7 +274,7 @@ public class StorageLocationSelectorStrategyTest
   @Test
   public void testDefaultSelectorStrategyConfig()
   {
-    //no druid.segmentCache.locationSelectorStrategy.type specified
+    //no druid.segmentCache.locationSelector.strategy specified, the default will be used
     final Properties props = new Properties();
     props.setProperty("druid.segmentCache.locations", "[{\"path\": \"/tmp/druid/indexCache\"}]");
 
@@ -289,7 +289,7 @@ public class StorageLocationSelectorStrategyTest
   {
     final Properties props = new Properties();
     props.setProperty("druid.segmentCache.locations", "[{\"path\": \"/tmp/druid/indexCache\"}]");
-    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "roundRobin");
+    props.setProperty("druid.segmentCache.locationSelector.strategy", "roundRobin");
 
     Injector injector = makeInjectorWithProperties(props);
     StorageLocationSelectorStrategy strategy = injector.getInstance(StorageLocationSelectorStrategy.class);
@@ -304,7 +304,7 @@ public class StorageLocationSelectorStrategyTest
   {
     final Properties props = new Properties();
     props.setProperty("druid.segmentCache.locations", "[{\"path\": \"/tmp/druid/indexCache\"}]");
-    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "leastBytesUsed");
+    props.setProperty("druid.segmentCache.locationSelector.strategy", "leastBytesUsed");
 
     Injector injector = makeInjectorWithProperties(props);
     StorageLocationSelectorStrategy strategy = injector.getInstance(StorageLocationSelectorStrategy.class);
@@ -319,7 +319,7 @@ public class StorageLocationSelectorStrategyTest
   {
     final Properties props = new Properties();
     props.setProperty("druid.segmentCache.locations", "[{\"path\": \"/tmp/druid/indexCache\"}]");
-    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "random");
+    props.setProperty("druid.segmentCache.locationSelector.strategy", "random");
 
     Injector injector = makeInjectorWithProperties(props);
     StorageLocationSelectorStrategy strategy = injector.getInstance(StorageLocationSelectorStrategy.class);
@@ -333,7 +333,7 @@ public class StorageLocationSelectorStrategyTest
   public void testMostAvailableSizeSelectorStrategyConfig()
   {
     final Properties props = new Properties();
-    props.setProperty("druid.segmentCache.locationSelectorStrategy.type", "mostAvailableSize");
+    props.setProperty("druid.segmentCache.locationSelector.strategy", "mostAvailableSize");
     props.setProperty("druid.segmentCache.locations", "[{\"path\": \"/tmp/druid/indexCache\"}]");
 
     Injector injector = makeInjectorWithProperties(props);
@@ -362,7 +362,7 @@ public class StorageLocationSelectorStrategyTest
               binder.bind(Properties.class).toInstance(props);
 
               JsonConfigProvider.bind(binder, "druid.segmentCache", SegmentLoaderConfig.class);
-              JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelectorStrategy", StorageLocationSelectorStrategy.class);
+              JsonConfigProvider.bind(binder, "druid.segmentCache.locationSelector", StorageLocationSelectorStrategy.class);
             }
 
             @Provides


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

This PR fixes #10348 , which is caused by injection failure of storage selector strategy. 

### Description

Currently, all 4 implementations of `StorageLocationSelectorStrategy` requires a list of `StorageLocation` objects during construction. And `StorageLocation` differs from `StorageLocationConfig` deserialized from configuration file, and the former is instantiated by `SegmentLoaderLocalCacheManager`. This also means `StorageLocation` could not be injected into `StorageLocationSelectorStrategy` when they are being constructed.

In this PR,
1. the ctor of implementations of `StorageLocationSelectorStrategy` are removed, instead, a setter of storage location method is provided in this interface so that `SegmentLoaderLocalCacheManager` could pass the objects to the strategy object

2. based on the original code, configuration property should be `druid.segmentCache.locationSelectorStrategy.type`, related docs are also updated

3. some unit test cases are added to check whether these strategy objects are correctly instantiated from configuration properties.

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->



<hr>

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>
