### PR TITLE
Inject ObjectMapper instead of manually setting it for TaskReportFileWriter

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -2714,7 +2714,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         EasyMock.createNiceMock(DruidNode.class),
         new LookupNodeService("tier"),
         new DataNodeService("tier", 1, ServerType.INDEXER_EXECUTOR, 0),
-        new SingleFileTaskReportFileWriter(reportsFile),
+        new SingleFileTaskReportFileWriter(reportsFile, objectMapper),
         null,
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
         new NoopChatHandlerProvider(),

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -2972,7 +2972,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         EasyMock.createNiceMock(DruidNode.class),
         new LookupNodeService("tier"),
         new DataNodeService("tier", 1, ServerType.INDEXER_EXECUTOR, 0),
-        new SingleFileTaskReportFileWriter(reportsFile),
+        new SingleFileTaskReportFileWriter(reportsFile, objectMapper),
         null,
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
         new NoopChatHandlerProvider(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/IngestionStatsAndErrorsTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/IngestionStatsAndErrorsTaskReport.java
@@ -30,7 +30,7 @@ public class IngestionStatsAndErrorsTaskReport implements TaskReport
   public static final String REPORT_KEY = "ingestionStatsAndErrors";
 
   @JsonProperty
-  private String taskId;
+  private final String taskId;
 
   @JsonProperty
   private IngestionStatsAndErrorsTaskReportData payload;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
@@ -20,7 +20,9 @@
 package org.apache.druid.indexing.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
 import org.apache.commons.io.FileUtils;
+import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -33,7 +35,13 @@ public class MultipleFileTaskReportFileWriter implements TaskReportFileWriter
 
   private final Map<String, File> taskReportFiles = new HashMap<>();
 
-  private ObjectMapper objectMapper;
+  private final ObjectMapper jsonMapper;
+
+  @Inject
+  public MultipleFileTaskReportFileWriter(@Json ObjectMapper jsonMapper)
+  {
+    this.jsonMapper = jsonMapper;
+  }
 
   @Override
   public void write(String taskId, Map<String, TaskReport> reports)
@@ -49,17 +57,11 @@ public class MultipleFileTaskReportFileWriter implements TaskReportFileWriter
       if (reportsFileParent != null) {
         FileUtils.forceMkdir(reportsFileParent);
       }
-      objectMapper.writeValue(reportsFile, reports);
+      jsonMapper.writeValue(reportsFile, reports);
     }
     catch (Exception e) {
       log.error(e, "Encountered exception in write().");
     }
-  }
-
-  @Override
-  public void setObjectMapper(ObjectMapper objectMapper)
-  {
-    this.objectMapper = objectMapper;
   }
 
   public void add(String taskId, File reportsFile)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexing.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.commons.io.FileUtils;
@@ -37,7 +38,13 @@ public class SingleFileTaskReportFileWriter implements TaskReportFileWriter
   private final ObjectMapper jsonMapper;
 
   @Inject
-  public SingleFileTaskReportFileWriter(@Named("taskReportPath") File reportsFile, @Json ObjectMapper jsonMapper)
+  public SingleFileTaskReportFileWriter(@Named("taskReportPath") String reportsFilePath, @Json ObjectMapper jsonMapper)
+  {
+    this(new File(reportsFilePath), jsonMapper);
+  }
+
+  @VisibleForTesting
+  public SingleFileTaskReportFileWriter(File reportsFile, ObjectMapper jsonMapper)
   {
     this.reportsFile = reportsFile;
     this.jsonMapper = jsonMapper;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
@@ -20,7 +20,10 @@
 package org.apache.druid.indexing.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import org.apache.commons.io.FileUtils;
+import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -31,11 +34,13 @@ public class SingleFileTaskReportFileWriter implements TaskReportFileWriter
   private static final Logger log = new Logger(SingleFileTaskReportFileWriter.class);
 
   private final File reportsFile;
-  private ObjectMapper objectMapper;
+  private final ObjectMapper jsonMapper;
 
-  public SingleFileTaskReportFileWriter(File reportsFile)
+  @Inject
+  public SingleFileTaskReportFileWriter(@Named("taskReportPath") File reportsFile, @Json ObjectMapper jsonMapper)
   {
     this.reportsFile = reportsFile;
+    this.jsonMapper = jsonMapper;
   }
 
   @Override
@@ -46,17 +51,10 @@ public class SingleFileTaskReportFileWriter implements TaskReportFileWriter
       if (reportsFileParent != null) {
         FileUtils.forceMkdir(reportsFileParent);
       }
-      objectMapper.writeValue(reportsFile, reports);
+      jsonMapper.writeValue(reportsFile, reports);
     }
     catch (Exception e) {
       log.error(e, "Encountered exception in write().");
     }
-  }
-
-
-  @Override
-  public void setObjectMapper(ObjectMapper objectMapper)
-  {
-    this.objectMapper = objectMapper;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskReportFileWriter.java
@@ -19,13 +19,9 @@
 
 package org.apache.druid.indexing.common;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.Map;
 
 public interface TaskReportFileWriter
 {
   void write(String taskId, Map<String, TaskReport> reports);
-
-  void setObjectMapper(ObjectMapper objectMapper);
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
@@ -196,7 +196,6 @@ public class TaskToolbox
     this.lookupNodeService = lookupNodeService;
     this.dataNodeService = dataNodeService;
     this.taskReportFileWriter = taskReportFileWriter;
-    this.taskReportFileWriter.setObjectMapper(this.jsonMapper);
     this.intermediaryDataManager = intermediaryDataManager;
     this.authorizerMapper = authorizerMapper;
     this.chatHandlerProvider = chatHandlerProvider;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -89,7 +89,7 @@ public abstract class WorkerTaskManager
   private final ConcurrentMap<String, Task> assignedTasks = new ConcurrentHashMap<>();
 
   // ZK_CLEANUP_TODO : these are marked protected to be used in subclass WorkerTaskMonitor that updates ZK.
-  // should be marked private alongwith WorkerTaskMonitor removal.
+  // should be marked private along with WorkerTaskMonitor removal.
   protected final ConcurrentMap<String, TaskDetails> runningTasks = new ConcurrentHashMap<>();
   protected final ConcurrentMap<String, TaskAnnouncement> completedTasks = new ConcurrentHashMap<>();
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -1585,7 +1585,7 @@ public class AppenderatorDriverRealtimeIndexTaskTest
         EasyMock.createNiceMock(DruidNode.class),
         new LookupNodeService("tier"),
         new DataNodeService("tier", 1000, ServerType.INDEXER_EXECUTOR, 0),
-        new SingleFileTaskReportFileWriter(reportsFile),
+        new SingleFileTaskReportFileWriter(reportsFile, mapper),
         null,
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
         new NoopChatHandlerProvider(),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -322,7 +322,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
             null,
             null,
             null,
-            new SingleFileTaskReportFileWriter(taskReportsFile),
+            new SingleFileTaskReportFileWriter(taskReportsFile, objectMapper),
             null,
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
             new NoopChatHandlerProvider(),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTestTaskReportFileWriter.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTestTaskReportFileWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.indexing.common.task;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.TaskReportFileWriter;
 
@@ -30,11 +29,5 @@ public class NoopTestTaskReportFileWriter implements TaskReportFileWriter
   @Override
   public void write(String id, Map<String, TaskReport> reports)
   {
-  }
-
-  @Override
-  public void setObjectMapper(ObjectMapper objectMapper)
-  {
-
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
@@ -119,7 +119,7 @@ public class SingleTaskBackgroundRunnerTest
         node,
         null,
         null,
-        new SingleFileTaskReportFileWriter(new File("fake")),
+        new SingleFileTaskReportFileWriter(new File("fake"), utils.getTestObjectMapper()),
         null,
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
         new NoopChatHandlerProvider(),

--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -122,7 +122,7 @@ public class CliIndexer extends ServerRunnable
 
             CliPeon.bindTaskConfigAndClients(binder);
 
-            binder.bind(TaskReportFileWriter.class).toInstance(new MultipleFileTaskReportFileWriter());
+            binder.bind(TaskReportFileWriter.class).to(MultipleFileTaskReportFileWriter.class).in(LazySingleton.class);
 
             binder.bind(TaskRunner.class).to(ThreadingTaskRunner.class);
             binder.bind(QuerySegmentWalker.class).to(ThreadingTaskRunner.class);

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -212,8 +212,8 @@ public class CliPeon extends GuiceRunnable
                     .setStatusFile(new File(taskStatusPath))
             );
 
-            binder.bind(TaskReportFileWriter.class)
-                  .toInstance(new SingleFileTaskReportFileWriter(new File(taskReportPath)));
+            binder.bindConstant().annotatedWith(Names.named("taskReportPath")).to(taskReportPath);
+            binder.bind(TaskReportFileWriter.class).to(SingleFileTaskReportFileWriter.class).in(LazySingleton.class);
 
             binder.bind(TaskRunner.class).to(SingleTaskBackgroundRunner.class);
             binder.bind(QuerySegmentWalker.class).to(SingleTaskBackgroundRunner.class);


### PR DESCRIPTION
### Description

A simple cleanup around objectMapper injection for `TaskReportFileWriter`.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.