### PR TITLE
Auto-compaction snapshot status API

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -24,9 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.ISE;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 public class AutoCompactionSnapshot

--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -224,7 +224,8 @@ public class AutoCompactionSnapshot
       this.scheduledTaskIds = new ArrayList<>();
     }
 
-    public Builder addScheduledTaskId(String taskId) {
+    public Builder addScheduledTaskId(String taskId)
+    {
       scheduledTaskIds.add(taskId);
       return this;
     }

--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -222,6 +222,15 @@ public class AutoCompactionSnapshot
       this.dataSource = dataSource;
       this.scheduleStatus = scheduleStatus;
       this.scheduledTaskIds = new ArrayList<>();
+      this.bytesAwaitingCompaction = 0;
+      this.bytesCompacted = 0;
+      this.bytesSkipped = 0;
+      this.segmentCountAwaitingCompaction = 0;
+      this.segmentCountCompacted = 0;
+      this.segmentCountSkipped = 0;
+      this.intervalCountAwaitingCompaction = 0;
+      this.intervalCountCompacted = 0;
+      this.intervalCountSkipped = 0;
     }
 
     public Builder addScheduledTaskId(String taskId)
@@ -230,57 +239,57 @@ public class AutoCompactionSnapshot
       return this;
     }
 
-    public Builder setBytesAwaitingCompaction(long bytesAwaitingCompaction)
+    public Builder incrementBytesAwaitingCompaction(long incrementValue)
     {
-      this.bytesAwaitingCompaction = bytesAwaitingCompaction;
+      this.bytesAwaitingCompaction = this.bytesAwaitingCompaction + incrementValue;
       return this;
     }
 
-    public Builder setBytesCompacted(long bytesCompacted)
+    public Builder incrementBytesCompacted(long incrementValue)
     {
-      this.bytesCompacted = bytesCompacted;
+      this.bytesCompacted = this.bytesCompacted + incrementValue;
       return this;
     }
 
-    public Builder setSegmentCountAwaitingCompaction(long segmentCountAwaitingCompaction)
+    public Builder incrementSegmentCountAwaitingCompaction(long incrementValue)
     {
-      this.segmentCountAwaitingCompaction = segmentCountAwaitingCompaction;
+      this.segmentCountAwaitingCompaction = this.segmentCountAwaitingCompaction + incrementValue;
       return this;
     }
 
-    public Builder setSegmentCountCompacted(long segmentCountCompacted)
+    public Builder incrementSegmentCountCompacted(long incrementValue)
     {
-      this.segmentCountCompacted = segmentCountCompacted;
+      this.segmentCountCompacted = this.segmentCountCompacted + incrementValue;
       return this;
     }
 
-    public Builder setIntervalCountAwaitingCompaction(long intervalCountAwaitingCompaction)
+    public Builder incrementIntervalCountAwaitingCompaction(long incrementValue)
     {
-      this.intervalCountAwaitingCompaction = intervalCountAwaitingCompaction;
+      this.intervalCountAwaitingCompaction = this.intervalCountAwaitingCompaction + incrementValue;
       return this;
     }
 
-    public Builder setIntervalCountCompacted(long intervalCountCompacted)
+    public Builder incrementIntervalCountCompacted(long incrementValue)
     {
-      this.intervalCountCompacted = intervalCountCompacted;
+      this.intervalCountCompacted = this.intervalCountCompacted + incrementValue;
       return this;
     }
 
-    public Builder setBytesSkipped(long bytesSkipped)
+    public Builder incrementBytesSkipped(long incrementValue)
     {
-      this.bytesSkipped = bytesSkipped;
+      this.bytesSkipped = this.bytesSkipped + incrementValue;
       return this;
     }
 
-    public Builder setSegmentCountSkipped(long segmentCountSkipped)
+    public Builder incrementSegmentCountSkipped(long incrementValue)
     {
-      this.segmentCountSkipped = segmentCountSkipped;
+      this.segmentCountSkipped = this.segmentCountSkipped + incrementValue;
       return this;
     }
 
-    public Builder setIntervalCountSkipped(long intervalCountSkipped)
+    public Builder incrementIntervalCountSkipped(long incrementValue)
     {
-      this.intervalCountSkipped = intervalCountSkipped;
+      this.intervalCountSkipped = this.intervalCountSkipped + incrementValue;
       return this;
     }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -41,9 +41,9 @@ public class AutoCompactionSnapshot
   @JsonProperty
   private String latestScheduledTaskId;
   @JsonProperty
-  private long byteAwaitingCompaction;
+  private long byteCountAwaitingCompaction;
   @JsonProperty
-  private long byteProcessed;
+  private long byteCountProcessed;
   @JsonProperty
   private long segmentCountAwaitingCompaction;
   @JsonProperty
@@ -81,14 +81,14 @@ public class AutoCompactionSnapshot
     return latestScheduledTaskId;
   }
 
-  public long getByteAwaitingCompaction()
+  public long getByteCountAwaitingCompaction()
   {
-    return byteAwaitingCompaction;
+    return byteCountAwaitingCompaction;
   }
 
-  public long getByteProcessed()
+  public long getByteCountProcessed()
   {
-    return byteProcessed;
+    return byteCountProcessed;
   }
 
   public long getSegmentCountAwaitingCompaction()
@@ -121,14 +121,14 @@ public class AutoCompactionSnapshot
     this.latestScheduledTaskId = latestScheduledTaskId;
   }
 
-  public void setByteAwaitingCompaction(long byteAwaitingCompaction)
+  public void setByteCountAwaitingCompaction(long byteCountAwaitingCompaction)
   {
-    this.byteAwaitingCompaction = byteAwaitingCompaction;
+    this.byteCountAwaitingCompaction = byteCountAwaitingCompaction;
   }
 
-  public void setByteProcessed(long byteProcessed)
+  public void setByteCountProcessed(long byteCountProcessed)
   {
-    this.byteProcessed = byteProcessed;
+    this.byteCountProcessed = byteCountProcessed;
   }
 
   public void setSegmentCountAwaitingCompaction(long segmentCountAwaitingCompaction)
@@ -163,8 +163,8 @@ public class AutoCompactionSnapshot
       return false;
     }
     AutoCompactionSnapshot that = (AutoCompactionSnapshot) o;
-    return byteAwaitingCompaction == that.byteAwaitingCompaction &&
-           byteProcessed == that.byteProcessed &&
+    return byteCountAwaitingCompaction == that.byteCountAwaitingCompaction &&
+           byteCountProcessed == that.byteCountProcessed &&
            segmentCountAwaitingCompaction == that.segmentCountAwaitingCompaction &&
            segmentCountProcessed == that.segmentCountProcessed &&
            intervalCountAwaitingCompaction == that.intervalCountAwaitingCompaction &&
@@ -181,8 +181,8 @@ public class AutoCompactionSnapshot
         dataSource,
         scheduleStatus,
         latestScheduledTaskId,
-        byteAwaitingCompaction,
-        byteProcessed,
+        byteCountAwaitingCompaction,
+        byteCountProcessed,
         segmentCountAwaitingCompaction,
         segmentCountProcessed,
         intervalCountAwaitingCompaction,

--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+public class AutoCompactionSnapshot
+{
+  public enum AutoCompactionScheduleStatus
+  {
+    NOT_ENABLED,
+    RUNNING
+  }
+
+  private String dataSource;
+  private AutoCompactionScheduleStatus scheduleStatus;
+  private String latestScheduledTaskId;
+
+  private long byteAwaitingCompaction;
+  private long byteCompacted;
+
+  private long segmentCountAwaitingCompaction;
+  private long segmentCountCompacted;
+
+  private long intervalCountAwaitingCompaction;
+  private long intervalCountCompacted;
+
+  public AutoCompactionSnapshot(
+      @NotNull String dataSource,
+      @NotNull AutoCompactionScheduleStatus scheduleStatus
+  )
+  {
+    this.dataSource = dataSource;
+    this.scheduleStatus = scheduleStatus;
+  }
+
+  @NotNull
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+
+  @NotNull
+  public AutoCompactionScheduleStatus getScheduleStatus()
+  {
+    return scheduleStatus;
+  }
+
+  @Nullable
+  public String getLatestScheduledTaskId()
+  {
+    return latestScheduledTaskId;
+  }
+
+  public long getByteAwaitingCompaction()
+  {
+    return byteAwaitingCompaction;
+  }
+
+  public long getByteCompacted()
+  {
+    return byteCompacted;
+  }
+
+  public long getSegmentCountAwaitingCompaction()
+  {
+    return segmentCountAwaitingCompaction;
+  }
+
+  public long getSegmentCountCompacted()
+  {
+    return segmentCountCompacted;
+  }
+
+  public long getIntervalCountAwaitingCompaction()
+  {
+    return intervalCountAwaitingCompaction;
+  }
+
+  public long getIntervalCountCompacted()
+  {
+    return intervalCountCompacted;
+  }
+
+  public void setScheduleStatus(AutoCompactionScheduleStatus scheduleStatus)
+  {
+    this.scheduleStatus = scheduleStatus;
+  }
+
+  public void setLatestScheduledTaskId(String latestScheduledTaskId)
+  {
+    this.latestScheduledTaskId = latestScheduledTaskId;
+  }
+
+  public void setByteAwaitingCompaction(long byteAwaitingCompaction)
+  {
+    this.byteAwaitingCompaction = byteAwaitingCompaction;
+  }
+
+  public void setByteCompacted(long byteCompacted)
+  {
+    this.byteCompacted = byteCompacted;
+  }
+
+  public void setSegmentCountAwaitingCompaction(long segmentCountAwaitingCompaction)
+  {
+    this.segmentCountAwaitingCompaction = segmentCountAwaitingCompaction;
+  }
+
+  public void setSegmentCountCompacted(long segmentCountCompacted)
+  {
+    this.segmentCountCompacted = segmentCountCompacted;
+  }
+
+  public void setIntervalCountAwaitingCompaction(long intervalCountAwaitingCompaction)
+  {
+    this.intervalCountAwaitingCompaction = intervalCountAwaitingCompaction;
+  }
+
+  public void setIntervalCountCompacted(long intervalCountCompacted)
+  {
+    this.intervalCountCompacted = intervalCountCompacted;
+  }
+
+
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AutoCompactionSnapshot that = (AutoCompactionSnapshot) o;
+    return byteAwaitingCompaction == that.byteAwaitingCompaction &&
+           byteCompacted == that.byteCompacted &&
+           segmentCountAwaitingCompaction == that.segmentCountAwaitingCompaction &&
+           segmentCountCompacted == that.segmentCountCompacted &&
+           intervalCountAwaitingCompaction == that.intervalCountAwaitingCompaction &&
+           intervalCountCompacted == that.intervalCountCompacted &&
+           dataSource.equals(that.dataSource) &&
+           Objects.equals(scheduleStatus, that.scheduleStatus) &&
+           Objects.equals(latestScheduledTaskId, that.latestScheduledTaskId);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(
+        dataSource,
+        scheduleStatus,
+        latestScheduledTaskId,
+        byteAwaitingCompaction,
+        byteCompacted,
+        segmentCountAwaitingCompaction,
+        segmentCountCompacted,
+        intervalCountAwaitingCompaction,
+        intervalCountCompacted
+    );
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.server.coordinator;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
@@ -31,22 +34,29 @@ public class AutoCompactionSnapshot
     RUNNING
   }
 
+  @JsonProperty
   private String dataSource;
+  @JsonProperty
   private AutoCompactionScheduleStatus scheduleStatus;
+  @JsonProperty
   private String latestScheduledTaskId;
-
+  @JsonProperty
   private long byteAwaitingCompaction;
-  private long byteCompacted;
-
+  @JsonProperty
+  private long byteProcessed;
+  @JsonProperty
   private long segmentCountAwaitingCompaction;
-  private long segmentCountCompacted;
-
+  @JsonProperty
+  private long segmentCountProcessed;
+  @JsonProperty
   private long intervalCountAwaitingCompaction;
-  private long intervalCountCompacted;
+  @JsonProperty
+  private long intervalCountProcessed;
 
+  @JsonCreator
   public AutoCompactionSnapshot(
-      @NotNull String dataSource,
-      @NotNull AutoCompactionScheduleStatus scheduleStatus
+      @JsonProperty @NotNull String dataSource,
+      @JsonProperty @NotNull AutoCompactionScheduleStatus scheduleStatus
   )
   {
     this.dataSource = dataSource;
@@ -76,9 +86,9 @@ public class AutoCompactionSnapshot
     return byteAwaitingCompaction;
   }
 
-  public long getByteCompacted()
+  public long getByteProcessed()
   {
-    return byteCompacted;
+    return byteProcessed;
   }
 
   public long getSegmentCountAwaitingCompaction()
@@ -86,9 +96,9 @@ public class AutoCompactionSnapshot
     return segmentCountAwaitingCompaction;
   }
 
-  public long getSegmentCountCompacted()
+  public long getSegmentCountProcessed()
   {
-    return segmentCountCompacted;
+    return segmentCountProcessed;
   }
 
   public long getIntervalCountAwaitingCompaction()
@@ -96,9 +106,9 @@ public class AutoCompactionSnapshot
     return intervalCountAwaitingCompaction;
   }
 
-  public long getIntervalCountCompacted()
+  public long getIntervalCountProcessed()
   {
-    return intervalCountCompacted;
+    return intervalCountProcessed;
   }
 
   public void setScheduleStatus(AutoCompactionScheduleStatus scheduleStatus)
@@ -116,9 +126,9 @@ public class AutoCompactionSnapshot
     this.byteAwaitingCompaction = byteAwaitingCompaction;
   }
 
-  public void setByteCompacted(long byteCompacted)
+  public void setByteProcessed(long byteProcessed)
   {
-    this.byteCompacted = byteCompacted;
+    this.byteProcessed = byteProcessed;
   }
 
   public void setSegmentCountAwaitingCompaction(long segmentCountAwaitingCompaction)
@@ -126,9 +136,9 @@ public class AutoCompactionSnapshot
     this.segmentCountAwaitingCompaction = segmentCountAwaitingCompaction;
   }
 
-  public void setSegmentCountCompacted(long segmentCountCompacted)
+  public void setSegmentCountProcessed(long segmentCountProcessed)
   {
-    this.segmentCountCompacted = segmentCountCompacted;
+    this.segmentCountProcessed = segmentCountProcessed;
   }
 
   public void setIntervalCountAwaitingCompaction(long intervalCountAwaitingCompaction)
@@ -136,9 +146,9 @@ public class AutoCompactionSnapshot
     this.intervalCountAwaitingCompaction = intervalCountAwaitingCompaction;
   }
 
-  public void setIntervalCountCompacted(long intervalCountCompacted)
+  public void setIntervalCountProcessed(long intervalCountProcessed)
   {
-    this.intervalCountCompacted = intervalCountCompacted;
+    this.intervalCountProcessed = intervalCountProcessed;
   }
 
 
@@ -154,11 +164,11 @@ public class AutoCompactionSnapshot
     }
     AutoCompactionSnapshot that = (AutoCompactionSnapshot) o;
     return byteAwaitingCompaction == that.byteAwaitingCompaction &&
-           byteCompacted == that.byteCompacted &&
+           byteProcessed == that.byteProcessed &&
            segmentCountAwaitingCompaction == that.segmentCountAwaitingCompaction &&
-           segmentCountCompacted == that.segmentCountCompacted &&
+           segmentCountProcessed == that.segmentCountProcessed &&
            intervalCountAwaitingCompaction == that.intervalCountAwaitingCompaction &&
-           intervalCountCompacted == that.intervalCountCompacted &&
+           intervalCountProcessed == that.intervalCountProcessed &&
            dataSource.equals(that.dataSource) &&
            Objects.equals(scheduleStatus, that.scheduleStatus) &&
            Objects.equals(latestScheduledTaskId, that.latestScheduledTaskId);
@@ -172,11 +182,11 @@ public class AutoCompactionSnapshot
         scheduleStatus,
         latestScheduledTaskId,
         byteAwaitingCompaction,
-        byteCompacted,
+        byteProcessed,
         segmentCountAwaitingCompaction,
-        segmentCountCompacted,
+        segmentCountProcessed,
         intervalCountAwaitingCompaction,
-        intervalCountCompacted
+        intervalCountProcessed
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -21,9 +21,12 @@ package org.apache.druid.server.coordinator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.ISE;
 
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class AutoCompactionSnapshot
@@ -39,28 +42,54 @@ public class AutoCompactionSnapshot
   @JsonProperty
   private AutoCompactionScheduleStatus scheduleStatus;
   @JsonProperty
-  private String latestScheduledTaskId;
+  private List<String> scheduledTaskIds;
   @JsonProperty
-  private long byteCountAwaitingCompaction;
+  private long bytesAwaitingCompaction;
   @JsonProperty
-  private long byteCountProcessed;
+  private long bytesCompacted;
+  @JsonProperty
+  private long bytesSkipped;
   @JsonProperty
   private long segmentCountAwaitingCompaction;
   @JsonProperty
-  private long segmentCountProcessed;
+  private long segmentCountCompacted;
+  @JsonProperty
+  private long segmentCountSkipped;
   @JsonProperty
   private long intervalCountAwaitingCompaction;
   @JsonProperty
-  private long intervalCountProcessed;
+  private long intervalCountCompacted;
+  @JsonProperty
+  private long intervalCountSkipped;
 
   @JsonCreator
   public AutoCompactionSnapshot(
       @JsonProperty @NotNull String dataSource,
-      @JsonProperty @NotNull AutoCompactionScheduleStatus scheduleStatus
+      @JsonProperty @NotNull AutoCompactionScheduleStatus scheduleStatus,
+      @JsonProperty @NotNull List<String> scheduledTaskIds,
+      @JsonProperty long bytesAwaitingCompaction,
+      @JsonProperty long bytesCompacted,
+      @JsonProperty long bytesSkipped,
+      @JsonProperty long segmentCountAwaitingCompaction,
+      @JsonProperty long segmentCountCompacted,
+      @JsonProperty long segmentCountSkipped,
+      @JsonProperty long intervalCountAwaitingCompaction,
+      @JsonProperty long intervalCountCompacted,
+      @JsonProperty long intervalCountSkipped
   )
   {
     this.dataSource = dataSource;
     this.scheduleStatus = scheduleStatus;
+    this.scheduledTaskIds = Collections.unmodifiableList(scheduledTaskIds);
+    this.bytesAwaitingCompaction = bytesAwaitingCompaction;
+    this.bytesCompacted = bytesCompacted;
+    this.bytesSkipped = bytesSkipped;
+    this.segmentCountAwaitingCompaction = segmentCountAwaitingCompaction;
+    this.segmentCountCompacted = segmentCountCompacted;
+    this.segmentCountSkipped = segmentCountSkipped;
+    this.intervalCountAwaitingCompaction = intervalCountAwaitingCompaction;
+    this.intervalCountCompacted = intervalCountCompacted;
+    this.intervalCountSkipped = intervalCountSkipped;
   }
 
   @NotNull
@@ -75,20 +104,25 @@ public class AutoCompactionSnapshot
     return scheduleStatus;
   }
 
-  @Nullable
-  public String getLatestScheduledTaskId()
+  @NotNull
+  public List<String> getScheduledTaskIds()
   {
-    return latestScheduledTaskId;
+    return scheduledTaskIds;
   }
 
-  public long getByteCountAwaitingCompaction()
+  public long getBytesAwaitingCompaction()
   {
-    return byteCountAwaitingCompaction;
+    return bytesAwaitingCompaction;
   }
 
-  public long getByteCountProcessed()
+  public long getBytesCompacted()
   {
-    return byteCountProcessed;
+    return bytesCompacted;
+  }
+
+  public long getBytesSkipped()
+  {
+    return bytesSkipped;
   }
 
   public long getSegmentCountAwaitingCompaction()
@@ -96,9 +130,14 @@ public class AutoCompactionSnapshot
     return segmentCountAwaitingCompaction;
   }
 
-  public long getSegmentCountProcessed()
+  public long getSegmentCountCompacted()
   {
-    return segmentCountProcessed;
+    return segmentCountCompacted;
+  }
+
+  public long getSegmentCountSkipped()
+  {
+    return segmentCountSkipped;
   }
 
   public long getIntervalCountAwaitingCompaction()
@@ -106,52 +145,15 @@ public class AutoCompactionSnapshot
     return intervalCountAwaitingCompaction;
   }
 
-  public long getIntervalCountProcessed()
+  public long getIntervalCountCompacted()
   {
-    return intervalCountProcessed;
+    return intervalCountCompacted;
   }
 
-  public void setScheduleStatus(AutoCompactionScheduleStatus scheduleStatus)
+  public long getIntervalCountSkipped()
   {
-    this.scheduleStatus = scheduleStatus;
+    return intervalCountSkipped;
   }
-
-  public void setLatestScheduledTaskId(String latestScheduledTaskId)
-  {
-    this.latestScheduledTaskId = latestScheduledTaskId;
-  }
-
-  public void setByteCountAwaitingCompaction(long byteCountAwaitingCompaction)
-  {
-    this.byteCountAwaitingCompaction = byteCountAwaitingCompaction;
-  }
-
-  public void setByteCountProcessed(long byteCountProcessed)
-  {
-    this.byteCountProcessed = byteCountProcessed;
-  }
-
-  public void setSegmentCountAwaitingCompaction(long segmentCountAwaitingCompaction)
-  {
-    this.segmentCountAwaitingCompaction = segmentCountAwaitingCompaction;
-  }
-
-  public void setSegmentCountProcessed(long segmentCountProcessed)
-  {
-    this.segmentCountProcessed = segmentCountProcessed;
-  }
-
-  public void setIntervalCountAwaitingCompaction(long intervalCountAwaitingCompaction)
-  {
-    this.intervalCountAwaitingCompaction = intervalCountAwaitingCompaction;
-  }
-
-  public void setIntervalCountProcessed(long intervalCountProcessed)
-  {
-    this.intervalCountProcessed = intervalCountProcessed;
-  }
-
-
 
   @Override
   public boolean equals(Object o)
@@ -163,15 +165,18 @@ public class AutoCompactionSnapshot
       return false;
     }
     AutoCompactionSnapshot that = (AutoCompactionSnapshot) o;
-    return byteCountAwaitingCompaction == that.byteCountAwaitingCompaction &&
-           byteCountProcessed == that.byteCountProcessed &&
+    return bytesAwaitingCompaction == that.bytesAwaitingCompaction &&
+           bytesCompacted == that.bytesCompacted &&
+           bytesSkipped == that.bytesSkipped &&
            segmentCountAwaitingCompaction == that.segmentCountAwaitingCompaction &&
-           segmentCountProcessed == that.segmentCountProcessed &&
+           segmentCountCompacted == that.segmentCountCompacted &&
+           segmentCountSkipped == that.segmentCountSkipped &&
            intervalCountAwaitingCompaction == that.intervalCountAwaitingCompaction &&
-           intervalCountProcessed == that.intervalCountProcessed &&
+           intervalCountCompacted == that.intervalCountCompacted &&
+           intervalCountSkipped == that.intervalCountSkipped &&
            dataSource.equals(that.dataSource) &&
-           Objects.equals(scheduleStatus, that.scheduleStatus) &&
-           Objects.equals(latestScheduledTaskId, that.latestScheduledTaskId);
+           scheduleStatus == that.scheduleStatus &&
+           scheduledTaskIds.equals(that.scheduledTaskIds);
   }
 
   @Override
@@ -180,13 +185,126 @@ public class AutoCompactionSnapshot
     return Objects.hash(
         dataSource,
         scheduleStatus,
-        latestScheduledTaskId,
-        byteCountAwaitingCompaction,
-        byteCountProcessed,
+        scheduledTaskIds,
+        bytesAwaitingCompaction,
+        bytesCompacted,
+        bytesSkipped,
         segmentCountAwaitingCompaction,
-        segmentCountProcessed,
+        segmentCountCompacted,
+        segmentCountSkipped,
         intervalCountAwaitingCompaction,
-        intervalCountProcessed
+        intervalCountCompacted,
+        intervalCountSkipped
     );
+  }
+
+  public static class Builder
+  {
+    private String dataSource;
+    private AutoCompactionScheduleStatus scheduleStatus;
+    private List<String> scheduledTaskIds;
+    private long bytesAwaitingCompaction;
+    private long bytesCompacted;
+    private long bytesSkipped;
+    private long segmentCountAwaitingCompaction;
+    private long segmentCountCompacted;
+    private long segmentCountSkipped;
+    private long intervalCountAwaitingCompaction;
+    private long intervalCountCompacted;
+    private long intervalCountSkipped;
+
+
+    public Builder(
+        @NotNull String dataSource,
+        @NotNull AutoCompactionScheduleStatus scheduleStatus
+    )
+    {
+      this.dataSource = dataSource;
+      this.scheduleStatus = scheduleStatus;
+      this.scheduledTaskIds = new ArrayList<>();
+    }
+
+    public Builder addScheduledTaskId(String taskId) {
+      scheduledTaskIds.add(taskId);
+      return this;
+    }
+
+    public Builder setBytesAwaitingCompaction(long bytesAwaitingCompaction)
+    {
+      this.bytesAwaitingCompaction = bytesAwaitingCompaction;
+      return this;
+    }
+
+    public Builder setBytesCompacted(long bytesCompacted)
+    {
+      this.bytesCompacted = bytesCompacted;
+      return this;
+    }
+
+    public Builder setSegmentCountAwaitingCompaction(long segmentCountAwaitingCompaction)
+    {
+      this.segmentCountAwaitingCompaction = segmentCountAwaitingCompaction;
+      return this;
+    }
+
+    public Builder setSegmentCountCompacted(long segmentCountCompacted)
+    {
+      this.segmentCountCompacted = segmentCountCompacted;
+      return this;
+    }
+
+    public Builder setIntervalCountAwaitingCompaction(long intervalCountAwaitingCompaction)
+    {
+      this.intervalCountAwaitingCompaction = intervalCountAwaitingCompaction;
+      return this;
+    }
+
+    public Builder setIntervalCountCompacted(long intervalCountCompacted)
+    {
+      this.intervalCountCompacted = intervalCountCompacted;
+      return this;
+    }
+
+    public Builder setBytesSkipped(long bytesSkipped)
+    {
+      this.bytesSkipped = bytesSkipped;
+      return this;
+    }
+
+    public Builder setSegmentCountSkipped(long segmentCountSkipped)
+    {
+      this.segmentCountSkipped = segmentCountSkipped;
+      return this;
+    }
+
+    public Builder setIntervalCountSkipped(long intervalCountSkipped)
+    {
+      this.intervalCountSkipped = intervalCountSkipped;
+      return this;
+    }
+
+    public AutoCompactionSnapshot build()
+    {
+      if (dataSource == null || dataSource.isEmpty()) {
+        throw new ISE("Invalid dataSource name");
+      }
+      if (scheduleStatus == null) {
+        throw new ISE("scheduleStatus cannot be null");
+      }
+      return new AutoCompactionSnapshot(
+          dataSource,
+          scheduleStatus,
+          scheduledTaskIds,
+          bytesAwaitingCompaction,
+          bytesCompacted,
+          bytesSkipped,
+          segmentCountAwaitingCompaction,
+          segmentCountCompacted,
+          segmentCountSkipped,
+          intervalCountAwaitingCompaction,
+          intervalCountCompacted,
+          intervalCountSkipped
+      );
+    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -42,8 +42,6 @@ public class AutoCompactionSnapshot
   @JsonProperty
   private AutoCompactionScheduleStatus scheduleStatus;
   @JsonProperty
-  private List<String> scheduledTaskIds;
-  @JsonProperty
   private long bytesAwaitingCompaction;
   @JsonProperty
   private long bytesCompacted;
@@ -66,7 +64,6 @@ public class AutoCompactionSnapshot
   public AutoCompactionSnapshot(
       @JsonProperty @NotNull String dataSource,
       @JsonProperty @NotNull AutoCompactionScheduleStatus scheduleStatus,
-      @JsonProperty @NotNull List<String> scheduledTaskIds,
       @JsonProperty long bytesAwaitingCompaction,
       @JsonProperty long bytesCompacted,
       @JsonProperty long bytesSkipped,
@@ -80,7 +77,6 @@ public class AutoCompactionSnapshot
   {
     this.dataSource = dataSource;
     this.scheduleStatus = scheduleStatus;
-    this.scheduledTaskIds = Collections.unmodifiableList(scheduledTaskIds);
     this.bytesAwaitingCompaction = bytesAwaitingCompaction;
     this.bytesCompacted = bytesCompacted;
     this.bytesSkipped = bytesSkipped;
@@ -102,12 +98,6 @@ public class AutoCompactionSnapshot
   public AutoCompactionScheduleStatus getScheduleStatus()
   {
     return scheduleStatus;
-  }
-
-  @NotNull
-  public List<String> getScheduledTaskIds()
-  {
-    return scheduledTaskIds;
   }
 
   public long getBytesAwaitingCompaction()
@@ -175,8 +165,7 @@ public class AutoCompactionSnapshot
            intervalCountCompacted == that.intervalCountCompacted &&
            intervalCountSkipped == that.intervalCountSkipped &&
            dataSource.equals(that.dataSource) &&
-           scheduleStatus == that.scheduleStatus &&
-           scheduledTaskIds.equals(that.scheduledTaskIds);
+           scheduleStatus == that.scheduleStatus;
   }
 
   @Override
@@ -185,7 +174,6 @@ public class AutoCompactionSnapshot
     return Objects.hash(
         dataSource,
         scheduleStatus,
-        scheduledTaskIds,
         bytesAwaitingCompaction,
         bytesCompacted,
         bytesSkipped,
@@ -202,7 +190,6 @@ public class AutoCompactionSnapshot
   {
     private String dataSource;
     private AutoCompactionScheduleStatus scheduleStatus;
-    private List<String> scheduledTaskIds;
     private long bytesAwaitingCompaction;
     private long bytesCompacted;
     private long bytesSkipped;
@@ -221,7 +208,6 @@ public class AutoCompactionSnapshot
     {
       this.dataSource = dataSource;
       this.scheduleStatus = scheduleStatus;
-      this.scheduledTaskIds = new ArrayList<>();
       this.bytesAwaitingCompaction = 0;
       this.bytesCompacted = 0;
       this.bytesSkipped = 0;
@@ -231,12 +217,6 @@ public class AutoCompactionSnapshot
       this.intervalCountAwaitingCompaction = 0;
       this.intervalCountCompacted = 0;
       this.intervalCountSkipped = 0;
-    }
-
-    public Builder addScheduledTaskId(String taskId)
-    {
-      scheduledTaskIds.add(taskId);
-      return this;
     }
 
     public Builder incrementBytesAwaitingCompaction(long incrementValue)
@@ -304,7 +284,6 @@ public class AutoCompactionSnapshot
       return new AutoCompactionSnapshot(
           dataSource,
           scheduleStatus,
-          scheduledTaskIds,
           bytesAwaitingCompaction,
           bytesCompacted,
           bytesSkipped,

--- a/server/src/main/java/org/apache/druid/server/coordinator/CompactionStatistics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CompactionStatistics.java
@@ -41,7 +41,8 @@ public class CompactionStatistics
     this.segmentIntervalCountSum = segmentIntervalCountSum;
   }
 
-  public static CompactionStatistics initializeCompactionStatistics() {
+  public static CompactionStatistics initializeCompactionStatistics()
+  {
     return new CompactionStatistics(0, 0, 0, 0);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/CompactionStatistics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CompactionStatistics.java
@@ -19,23 +19,18 @@
 
 package org.apache.druid.server.coordinator;
 
-import javax.annotation.Nullable;
-
 public class CompactionStatistics
 {
-  private Integer compactedTaskCount;
   private long byteSum;
   private long segmentNumberCountSum;
   private long segmentIntervalCountSum;
 
   public CompactionStatistics(
-      Integer compactedTaskCount,
       long byteSum,
       long segmentNumberCountSum,
       long segmentIntervalCountSum
   )
   {
-    this.compactedTaskCount = compactedTaskCount;
     this.byteSum = byteSum;
     this.segmentNumberCountSum = segmentNumberCountSum;
     this.segmentIntervalCountSum = segmentIntervalCountSum;
@@ -43,13 +38,7 @@ public class CompactionStatistics
 
   public static CompactionStatistics initializeCompactionStatistics()
   {
-    return new CompactionStatistics(0, 0, 0, 0);
-  }
-
-  @Nullable
-  public int getCompactedTaskCount()
-  {
-    return compactedTaskCount;
+    return new CompactionStatistics(0, 0, 0);
   }
 
   public long getByteSum()
@@ -65,14 +54,6 @@ public class CompactionStatistics
   public long getSegmentIntervalCountSum()
   {
     return segmentIntervalCountSum;
-  }
-
-  public void incrementCompactedTasks(int incrementValue)
-  {
-    if (compactedTaskCount == null) {
-      compactedTaskCount = 0;
-    }
-    compactedTaskCount = compactedTaskCount + incrementValue;
   }
 
   public void incrementCompactedByte(long incrementValue)

--- a/server/src/main/java/org/apache/druid/server/coordinator/CompactionStatistics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CompactionStatistics.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator;
+
+import javax.annotation.Nullable;
+
+public class CompactionStatistics
+{
+  private Integer compactedTaskCount;
+  private long byteSum;
+  private long segmentNumberCountSum;
+  private long segmentIntervalCountSum;
+
+  public CompactionStatistics(
+      Integer compactedTaskCount,
+      long byteSum,
+      long segmentNumberCountSum,
+      long segmentIntervalCountSum
+  )
+  {
+    this.compactedTaskCount = compactedTaskCount;
+    this.byteSum = byteSum;
+    this.segmentNumberCountSum = segmentNumberCountSum;
+    this.segmentIntervalCountSum = segmentIntervalCountSum;
+  }
+
+  public static CompactionStatistics initializeCompactionStatistics() {
+    return new CompactionStatistics(0, 0, 0, 0);
+  }
+
+  @Nullable
+  public int getCompactedTaskCount()
+  {
+    return compactedTaskCount;
+  }
+
+  public long getByteSum()
+  {
+    return byteSum;
+  }
+
+  public long getSegmentNumberCountSum()
+  {
+    return segmentNumberCountSum;
+  }
+
+  public long getSegmentIntervalCountSum()
+  {
+    return segmentIntervalCountSum;
+  }
+
+  public void incrementCompactedTasks(int incrementValue)
+  {
+    if (compactedTaskCount == null) {
+      compactedTaskCount = 0;
+    }
+    compactedTaskCount = compactedTaskCount + incrementValue;
+  }
+
+  public void incrementCompactedByte(long incrementValue)
+  {
+    byteSum = byteSum + incrementValue;
+  }
+
+  public void incrementCompactedSegments(long incrementValue)
+  {
+    segmentNumberCountSum = segmentNumberCountSum + incrementValue;
+  }
+
+  public void incrementCompactedIntervals(long incrementValue)
+  {
+    segmentIntervalCountSum = segmentIntervalCountSum + incrementValue;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -580,7 +580,7 @@ public class DruidCoordinator
       }
 
       for (final Pair<? extends DutiesRunnable, Duration> dutiesRunnable : dutiesRunnables) {
-        ScheduledExecutors.scheduleWithFixedDelay(
+        ScheduledExecutors.scheduleAtFixedRate(
             exec,
             config.getCoordinatorStartDelay(),
             dutiesRunnable.rhs,
@@ -643,8 +643,9 @@ public class DruidCoordinator
   {
     List<CoordinatorDuty> duties = new ArrayList<>();
     duties.add(new LogUsedSegments());
-    duties.addAll(makeCompactSegmentsDuty());
     duties.addAll(indexingServiceDuties);
+    // CompactSegmentsDuty should be the last duty as it can takea long time
+    duties.addAll(makeCompactSegmentsDuty());
 
     log.debug(
         "Done making indexing service duties %s",

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -363,6 +363,16 @@ public class DruidCoordinator
     return compactSegments.getTotalSizeOfSegmentsAwaitingCompaction(dataSource);
   }
 
+  @Nullable
+  public AutoCompactionSnapshot getAutoCompactionSnapshotForDataSource(String dataSource)
+  {
+    return compactSegments.getAutoCompactionSnapshot(dataSource);
+  }
+
+  public Map<String, AutoCompactionSnapshot> getAutoCompactionSnapshot() {
+    return compactSegments.getAutoCompactionSnapshot();
+  }
+
   public CoordinatorDynamicConfig getDynamicConfigs()
   {
     return CoordinatorDynamicConfig.current(configManager);

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -369,7 +369,8 @@ public class DruidCoordinator
     return compactSegments.getAutoCompactionSnapshot(dataSource);
   }
 
-  public Map<String, AutoCompactionSnapshot> getAutoCompactionSnapshot() {
+  public Map<String, AutoCompactionSnapshot> getAutoCompactionSnapshot()
+  {
     return compactSegments.getAutoCompactionSnapshot();
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -580,6 +580,10 @@ public class DruidCoordinator
       }
 
       for (final Pair<? extends DutiesRunnable, Duration> dutiesRunnable : dutiesRunnables) {
+        // CompactSegmentsDuty can takes a non trival amount of time to complete.
+        // Hence, we schedule at fixed rate to make sure the other tasks still run at approximately every
+        // config.getCoordinatorIndexingPeriod() period. Note that cautious should be taken
+        // if setting config.getCoordinatorIndexingPeriod() lower than the default value.
         ScheduledExecutors.scheduleAtFixedRate(
             exec,
             config.getCoordinatorStartDelay(),
@@ -644,7 +648,7 @@ public class DruidCoordinator
     List<CoordinatorDuty> duties = new ArrayList<>();
     duties.add(new LogUsedSegments());
     duties.addAll(indexingServiceDuties);
-    // CompactSegmentsDuty should be the last duty as it can takea long time
+    // CompactSegmentsDuty should be the last duty as it can take a long time to complete
     duties.addAll(makeCompactSegmentsDuty());
 
     log.debug(

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -90,17 +90,17 @@ public class CompactSegments implements CoordinatorDuty
 
     final CoordinatorCompactionConfig dynamicConfig = params.getCoordinatorCompactionConfig();
     final CoordinatorStats stats = new CoordinatorStats();
-    List<DataSourceCompactionConfig> compactionConfigList = dynamicConfig.getCompactionConfigs();
-    Map<String, DataSourceCompactionConfig> compactionConfigs = compactionConfigList
-        .stream()
-        .collect(Collectors.toMap(DataSourceCompactionConfig::getDataSource, Function.identity()));
-    updateAutoCompactionSnapshot(compactionConfigs);
 
     if (dynamicConfig.getMaxCompactionTaskSlots() > 0) {
       Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources =
           params.getUsedSegmentsTimelinesPerDataSource();
+      List<DataSourceCompactionConfig> compactionConfigList = dynamicConfig.getCompactionConfigs();
 
       if (compactionConfigList != null && !compactionConfigList.isEmpty()) {
+        Map<String, DataSourceCompactionConfig> compactionConfigs = compactionConfigList
+            .stream()
+            .collect(Collectors.toMap(DataSourceCompactionConfig::getDataSource, Function.identity()));
+        updateAutoCompactionSnapshot(compactionConfigs);
         final List<TaskStatusPlus> compactionTasks = filterNonCompactionTasks(indexingServiceClient.getActiveTasks());
         // dataSource -> list of intervals of compaction tasks
         final Map<String, List<Interval>> compactionTaskIntervals = Maps.newHashMapWithExpectedSize(

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -77,7 +77,9 @@ public class CompactSegments implements CoordinatorDuty
   private final CompactionSegmentSearchPolicy policy;
   private final IndexingServiceClient indexingServiceClient;
 
-  private AtomicReference<Map<String, AutoCompactionSnapshot>> autoCompactionSnapshotPerDataSource = new AtomicReference<>();
+  // This variable is updated by the Coordinator thread executing duties and
+  // read by HTTP threads processing Coordinator API calls.
+  private final AtomicReference<Map<String, AutoCompactionSnapshot>> autoCompactionSnapshotPerDataSource = new AtomicReference<>();
 
   @Inject
   public CompactSegments(
@@ -343,7 +345,7 @@ public class CompactSegments implements CoordinatorDuty
     // Iterate through all the remaining segments in the iterator.
     // As these segments could be compacted but were not compacted due to lack of task slot, we will aggregates
     // the statistic to the AwaitingCompaction statistics
-    for (; iterator.hasNext();) {
+    while(iterator.hasNext()) {
       final List<DataSegment> segmentsToCompact = iterator.next();
       if (!segmentsToCompact.isEmpty()) {
         final String dataSourceName = segmentsToCompact.get(0).getDataSource();

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -29,8 +29,8 @@ import org.apache.druid.client.indexing.TaskPayloadResponse;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.server.coordinator.CompactionStatistics;
 import org.apache.druid.server.coordinator.AutoCompactionSnapshot;
+import org.apache.druid.server.coordinator.CompactionStatistics;
 import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
 import org.apache.druid.server.coordinator.CoordinatorStats;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
@@ -372,7 +372,8 @@ public class CompactSegments implements CoordinatorDuty
     return autoCompactionSnapshotPerDataSource.get(dataSource);
   }
 
-  public Map<String, AutoCompactionSnapshot> getAutoCompactionSnapshot() {
+  public Map<String, AutoCompactionSnapshot> getAutoCompactionSnapshot()
+  {
     return autoCompactionSnapshotPerDataSource;
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -44,6 +44,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -53,9 +55,14 @@ public class CompactSegments implements CoordinatorDuty
   static final String AVAILABLE_COMPACTION_TASK_SLOT = "availableCompactionTaskSlot";
   static final String MAX_COMPACTION_TASK_SLOT = "maxCompactionTaskSlot";
 
-  static final String TOTAL_SIZE_OF_SEGMENTS_AWAITING_COMPACTION = "segmentSizeWaitCompact";
-  static final String TOTAL_COUNT_OF_SEGMENTS_AWAITING_COMPACTION = "segmentCountWaitCompact";
-  static final String TOTAL_INTERVAL_OF_SEGMENTS_AWAITING_COMPACTION = "segmentIntervalWaitCompact";
+  static final String TOTAL_SIZE_OF_SEGMENTS_SKIPPED = "segmentSizeSkippedCompact";
+  static final String TOTAL_COUNT_OF_SEGMENTS_SKIPPED = "segmentCountSkippedCompact";
+  static final String TOTAL_INTERVAL_OF_SEGMENTS_SKIPPED = "segmentIntervalSkippedCompact";
+
+  static final String TOTAL_SIZE_OF_SEGMENTS_AWAITING = "segmentSizeWaitCompact";
+  static final String TOTAL_COUNT_OF_SEGMENTS_AWAITING = "segmentCountWaitCompact";
+  static final String TOTAL_INTERVAL_OF_SEGMENTS_AWAITING = "segmentIntervalWaitCompact";
+
   static final String TOTAL_SIZE_OF_SEGMENTS_COMPACTED = "segmentSizeCompacted";
   static final String TOTAL_COUNT_OF_SEGMENTS_COMPACTED = "segmentCountCompacted";
   static final String TOTAL_INTERVAL_OF_SEGMENTS_COMPACTED = "segmentIntervalCompacted";
@@ -70,7 +77,7 @@ public class CompactSegments implements CoordinatorDuty
   private final CompactionSegmentSearchPolicy policy;
   private final IndexingServiceClient indexingServiceClient;
 
-  private HashMap<String, AutoCompactionSnapshot> autoCompactionSnapshotPerDataSource = new HashMap<>();
+  private AtomicReference<Map<String, AutoCompactionSnapshot>> autoCompactionSnapshotPerDataSource = new AtomicReference<>();
 
   @Inject
   public CompactSegments(
@@ -80,6 +87,7 @@ public class CompactSegments implements CoordinatorDuty
   {
     this.policy = new NewestSegmentFirstPolicy(objectMapper);
     this.indexingServiceClient = indexingServiceClient;
+    autoCompactionSnapshotPerDataSource.set(new HashMap<>());
   }
 
   @Override
@@ -89,77 +97,79 @@ public class CompactSegments implements CoordinatorDuty
 
     final CoordinatorCompactionConfig dynamicConfig = params.getCoordinatorCompactionConfig();
     final CoordinatorStats stats = new CoordinatorStats();
-
+    final Map<String, AutoCompactionSnapshot.Builder> currentRunAutoCompactionSnapshotBuilders = new HashMap<>();
+    List<DataSourceCompactionConfig> compactionConfigList = dynamicConfig.getCompactionConfigs();
+    updateAutoCompactionSnapshot(compactionConfigList, currentRunAutoCompactionSnapshotBuilders);
     if (dynamicConfig.getMaxCompactionTaskSlots() > 0) {
       Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources =
           params.getUsedSegmentsTimelinesPerDataSource();
-      List<DataSourceCompactionConfig> compactionConfigList = dynamicConfig.getCompactionConfigs();
-      if (compactionConfigList != null) {
+      if (compactionConfigList != null && !compactionConfigList.isEmpty()) {
         Map<String, DataSourceCompactionConfig> compactionConfigs = compactionConfigList
             .stream()
             .collect(Collectors.toMap(DataSourceCompactionConfig::getDataSource, Function.identity()));
-        updateAutoCompactionSnapshot(compactionConfigs);
-        if (!compactionConfigList.isEmpty()) {
-          final List<TaskStatusPlus> compactionTasks = filterNonCompactionTasks(indexingServiceClient.getActiveTasks());
-          // dataSource -> list of intervals of compaction tasks
-          final Map<String, List<Interval>> compactionTaskIntervals = Maps.newHashMapWithExpectedSize(
-              compactionConfigList.size());
-          int numEstimatedNonCompleteCompactionTasks = 0;
-          for (TaskStatusPlus status : compactionTasks) {
-            final TaskPayloadResponse response = indexingServiceClient.getTaskPayload(status.getId());
-            if (response == null) {
-              throw new ISE("Got a null paylord from overlord for task[%s]", status.getId());
-            }
-            if (COMPACTION_TASK_TYPE.equals(response.getPayload().getType())) {
-              final ClientCompactionTaskQuery compactionTaskQuery = (ClientCompactionTaskQuery) response.getPayload();
-              final Interval interval = compactionTaskQuery.getIoConfig().getInputSpec().getInterval();
-              compactionTaskIntervals.computeIfAbsent(status.getDataSource(), k -> new ArrayList<>()).add(interval);
-              final int numSubTasks = findNumMaxConcurrentSubTasks(compactionTaskQuery.getTuningConfig());
-              numEstimatedNonCompleteCompactionTasks += numSubTasks + 1; // count the compaction task itself
-            } else {
-              throw new ISE("task[%s] is not a compactionTask", status.getId());
-            }
+        final List<TaskStatusPlus> compactionTasks = filterNonCompactionTasks(indexingServiceClient.getActiveTasks());
+        // dataSource -> list of intervals of compaction tasks
+        final Map<String, List<Interval>> compactionTaskIntervals = Maps.newHashMapWithExpectedSize(
+            compactionConfigList.size());
+        int numEstimatedNonCompleteCompactionTasks = 0;
+        for (TaskStatusPlus status : compactionTasks) {
+          final TaskPayloadResponse response = indexingServiceClient.getTaskPayload(status.getId());
+          if (response == null) {
+            throw new ISE("Got a null paylord from overlord for task[%s]", status.getId());
           }
-
-          final CompactionSegmentIterator iterator =
-              policy.reset(compactionConfigs, dataSources, compactionTaskIntervals);
-
-          final int compactionTaskCapacity = (int) Math.min(
-              indexingServiceClient.getTotalWorkerCapacity() * dynamicConfig.getCompactionTaskSlotRatio(),
-              dynamicConfig.getMaxCompactionTaskSlots()
-          );
-          final int numAvailableCompactionTaskSlots;
-          if (numEstimatedNonCompleteCompactionTasks > 0) {
-            numAvailableCompactionTaskSlots = Math.max(
-                0,
-                compactionTaskCapacity - numEstimatedNonCompleteCompactionTasks
-            );
+          if (COMPACTION_TASK_TYPE.equals(response.getPayload().getType())) {
+            final ClientCompactionTaskQuery compactionTaskQuery = (ClientCompactionTaskQuery) response.getPayload();
+            final Interval interval = compactionTaskQuery.getIoConfig().getInputSpec().getInterval();
+            compactionTaskIntervals.computeIfAbsent(status.getDataSource(), k -> new ArrayList<>()).add(interval);
+            final int numSubTasks = findNumMaxConcurrentSubTasks(compactionTaskQuery.getTuningConfig());
+            numEstimatedNonCompleteCompactionTasks += numSubTasks + 1; // count the compaction task itself
           } else {
-            // compactionTaskCapacity might be 0 if totalWorkerCapacity is low.
-            // This guarantees that at least one slot is available if
-            // compaction is enabled and numEstimatedNonCompleteCompactionTasks is 0.
-            numAvailableCompactionTaskSlots = Math.max(1, compactionTaskCapacity);
+            throw new ISE("task[%s] is not a compactionTask", status.getId());
           }
-
-          LOG.info(
-              "Found [%d] available task slots for compaction out of [%d] max compaction task capacity",
-              numAvailableCompactionTaskSlots,
-              compactionTaskCapacity
-          );
-          stats.addToGlobalStat(AVAILABLE_COMPACTION_TASK_SLOT, numAvailableCompactionTaskSlots);
-          stats.addToGlobalStat(MAX_COMPACTION_TASK_SLOT, compactionTaskCapacity);
-
-          if (numAvailableCompactionTaskSlots > 0) {
-            stats.accumulate(doRun(compactionConfigs, numAvailableCompactionTaskSlots, iterator));
-          } else {
-            stats.accumulate(makeStats(0, iterator));
-          }
-        } else {
-          LOG.info("compactionConfig is empty. Skip.");
         }
+
+        final CompactionSegmentIterator iterator =
+            policy.reset(compactionConfigs, dataSources, compactionTaskIntervals);
+
+        final int compactionTaskCapacity = (int) Math.min(
+            indexingServiceClient.getTotalWorkerCapacity() * dynamicConfig.getCompactionTaskSlotRatio(),
+            dynamicConfig.getMaxCompactionTaskSlots()
+        );
+        final int numAvailableCompactionTaskSlots;
+        if (numEstimatedNonCompleteCompactionTasks > 0) {
+          numAvailableCompactionTaskSlots = Math.max(
+              0,
+              compactionTaskCapacity - numEstimatedNonCompleteCompactionTasks
+          );
+        } else {
+          // compactionTaskCapacity might be 0 if totalWorkerCapacity is low.
+          // This guarantees that at least one slot is available if
+          // compaction is enabled and numEstimatedNonCompleteCompactionTasks is 0.
+          numAvailableCompactionTaskSlots = Math.max(1, compactionTaskCapacity);
+        }
+
+        LOG.info(
+            "Found [%d] available task slots for compaction out of [%d] max compaction task capacity",
+            numAvailableCompactionTaskSlots,
+            compactionTaskCapacity
+        );
+        stats.addToGlobalStat(AVAILABLE_COMPACTION_TASK_SLOT, numAvailableCompactionTaskSlots);
+        stats.addToGlobalStat(MAX_COMPACTION_TASK_SLOT, compactionTaskCapacity);
+
+        if (numAvailableCompactionTaskSlots > 0) {
+          stats.accumulate(
+              doRun(compactionConfigs, currentRunAutoCompactionSnapshotBuilders, numAvailableCompactionTaskSlots, iterator)
+          );
+        } else {
+          stats.accumulate(makeStats(currentRunAutoCompactionSnapshotBuilders, 0, iterator));
+        }
+      } else {
+        LOG.info("compactionConfig is empty. Skip.");
+        updateAutoCompactionSnapshotWhenNoCompactTaskScheduled(currentRunAutoCompactionSnapshotBuilders);
       }
     } else {
       LOG.info("maxCompactionTaskSlots was set to 0. Skip compaction");
+      updateAutoCompactionSnapshotWhenNoCompactTaskScheduled(currentRunAutoCompactionSnapshotBuilders);
     }
 
     return params.buildFromExisting()
@@ -186,20 +196,29 @@ public class CompactSegments implements CoordinatorDuty
     }
   }
 
-  private void updateAutoCompactionSnapshot(Map<String, DataSourceCompactionConfig> compactionConfigs)
+  private void updateAutoCompactionSnapshot(
+      List<DataSourceCompactionConfig> compactionConfigList,
+      Map<String, AutoCompactionSnapshot.Builder> currentRunAutoCompactionSnapshotBuilders)
   {
+
+    Set<String> enabledDatasources = compactionConfigList.stream()
+                                                         .map(dataSourceCompactionConfig -> dataSourceCompactionConfig.getDataSource())
+                                                         .collect(Collectors.toSet());
     // Update AutoCompactionScheduleStatus for dataSource that now has auto compaction disabled
-    for (Map.Entry<String, AutoCompactionSnapshot> snapshot : autoCompactionSnapshotPerDataSource.entrySet()) {
-      if (!compactionConfigs.containsKey(snapshot.getKey())) {
-        snapshot.getValue().setScheduleStatus(AutoCompactionSnapshot.AutoCompactionScheduleStatus.NOT_ENABLED);
+    for (Map.Entry<String, AutoCompactionSnapshot> snapshot : autoCompactionSnapshotPerDataSource.get().entrySet()) {
+      if (!enabledDatasources.contains(snapshot.getKey())) {
+        currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
+            snapshot.getKey(),
+            k -> new AutoCompactionSnapshot.Builder(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.NOT_ENABLED)
+        );
       }
     }
 
     // Create and Update snapshot for dataSource that has auto compaction enabled
-    for (String compactionConfigDataSource : compactionConfigs.keySet()) {
-      autoCompactionSnapshotPerDataSource.computeIfAbsent(
+    for (String compactionConfigDataSource : enabledDatasources) {
+      currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
           compactionConfigDataSource,
-          k -> new AutoCompactionSnapshot(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+          k -> new AutoCompactionSnapshot.Builder(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
       );
     }
   }
@@ -221,6 +240,7 @@ public class CompactSegments implements CoordinatorDuty
 
   private CoordinatorStats doRun(
       Map<String, DataSourceCompactionConfig> compactionConfigs,
+      Map<String, AutoCompactionSnapshot.Builder> currentRunAutoCompactionSnapshotBuilders,
       int numAvailableCompactionTaskSlots,
       CompactionSegmentIterator iterator
   )
@@ -241,7 +261,7 @@ public class CompactSegments implements CoordinatorDuty
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment()),
             newAutoCompactionContext(config.getTaskContext())
         );
-        autoCompactionSnapshotPerDataSource.get(dataSourceName).setLatestScheduledTaskId(taskId);
+        currentRunAutoCompactionSnapshotBuilders.get(dataSourceName).addScheduledTaskId(taskId);
 
         LOG.info(
             "Submitted a compactionTask[%s] for %s segments",
@@ -256,7 +276,7 @@ public class CompactSegments implements CoordinatorDuty
       }
     }
 
-    return makeStats(numSubmittedTasks, iterator);
+    return makeStats(currentRunAutoCompactionSnapshotBuilders, numSubmittedTasks, iterator);
   }
 
   private Map<String, Object> newAutoCompactionContext(@Nullable Map<String, Object> configuredContext)
@@ -268,25 +288,68 @@ public class CompactSegments implements CoordinatorDuty
     return newContext;
   }
 
-  private CoordinatorStats makeStats(int numCompactionTasks, CompactionSegmentIterator iterator)
+  /**
+   * This method can be use to atomically update the snapshots in {@code autoCompactionSnapshotPerDataSource} when
+   * no compaction task is schedule in this run. Currently, this method does not update compaction statistics
+   * (bytes, interval count, segment count, etc) since we skip iterating through the segments and cannot get an update
+   * on those statistics. Thus, this method only updates the schedule status and task list (compaction statistics
+   * remains the same as the previous snapshot).
+   */
+  private void updateAutoCompactionSnapshotWhenNoCompactTaskScheduled(
+      Map<String, AutoCompactionSnapshot.Builder> currentRunAutoCompactionSnapshotBuilders
+  )
+  {
+    Map<String, AutoCompactionSnapshot> previousSnapshots = autoCompactionSnapshotPerDataSource.get();
+    for (Map.Entry<String, AutoCompactionSnapshot.Builder> autoCompactionSnapshotBuilderEntry : currentRunAutoCompactionSnapshotBuilders.entrySet()) {
+      final String dataSource = autoCompactionSnapshotBuilderEntry.getKey();
+      AutoCompactionSnapshot previousSnapshot = previousSnapshots.get(dataSource);
+      if (previousSnapshot != null) {
+        autoCompactionSnapshotBuilderEntry.getValue().setBytesAwaitingCompaction(previousSnapshot.getBytesAwaitingCompaction());
+        autoCompactionSnapshotBuilderEntry.getValue().setBytesCompacted(previousSnapshot.getBytesCompacted());
+        autoCompactionSnapshotBuilderEntry.getValue().setBytesSkipped(previousSnapshot.getBytesSkipped());
+        autoCompactionSnapshotBuilderEntry.getValue().setSegmentCountAwaitingCompaction(previousSnapshot.getSegmentCountAwaitingCompaction());
+        autoCompactionSnapshotBuilderEntry.getValue().setSegmentCountCompacted(previousSnapshot.getSegmentCountCompacted());
+        autoCompactionSnapshotBuilderEntry.getValue().setSegmentCountSkipped(previousSnapshot.getSegmentCountSkipped());
+        autoCompactionSnapshotBuilderEntry.getValue().setIntervalCountAwaitingCompaction(previousSnapshot.getIntervalCountAwaitingCompaction());
+        autoCompactionSnapshotBuilderEntry.getValue().setIntervalCountCompacted(previousSnapshot.getIntervalCountCompacted());
+        autoCompactionSnapshotBuilderEntry.getValue().setIntervalCountSkipped(previousSnapshot.getIntervalCountSkipped());
+      }
+    }
+
+    Map<String, AutoCompactionSnapshot> currentAutoCompactionSnapshotPerDataSource = Maps.transformValues(
+        currentRunAutoCompactionSnapshotBuilders,
+        AutoCompactionSnapshot.Builder::build
+    );
+    // Atomic update of autoCompactionSnapshotPerDataSource with the latest from this coordinator run
+    autoCompactionSnapshotPerDataSource.set(currentAutoCompactionSnapshotPerDataSource);
+  }
+
+  private CoordinatorStats makeStats(
+      Map<String, AutoCompactionSnapshot.Builder> currentRunAutoCompactionSnapshotBuilders,
+      int numCompactionTasks,
+      CompactionSegmentIterator iterator
+  )
   {
     final CoordinatorStats stats = new CoordinatorStats();
     stats.addToGlobalStat(COMPACTION_TASK_COUNT, numCompactionTasks);
 
     // Make sure that the iterator iterate through all the remaining segments so that we can get accurate and correct
-    // statistics (remaining, skipped, processed, etc.). The reason we have to do this explicitly here is because
+    // statistics (remaining, skipped, compacted). The reason we have to do this explicitly here is because
     // earlier (when we are iterating to submit compaction tasks) we may have ran out of task slot and were not able
     // to iterate to the first segment that needs compaction for some datasource.
     iterator.flushAllSegments();
     // Statistics of all segments that still need compaction after this run
     Map<String, CompactionStatistics> allRemainingStatistics = iterator.totalRemainingStatistics();
-    // Statistics of all segments either compacted or skipped after this run
-    Map<String, CompactionStatistics> allProcessedStatistics = iterator.totalProcessedStatistics();
+    // Statistics of all segments considered compacted after this run
+    Map<String, CompactionStatistics> allCompactedStatistics = iterator.totalCompactedStatistics();
+    // Statistics of all segments considered skipped after this run
+    Map<String, CompactionStatistics> allSkippedStatistics = iterator.totalSkippedStatistics();
 
-    for (Map.Entry<String, AutoCompactionSnapshot> autoCompactionSnapshotEntry : autoCompactionSnapshotPerDataSource.entrySet()) {
-      final String dataSource = autoCompactionSnapshotEntry.getKey();
+    for (Map.Entry<String, AutoCompactionSnapshot.Builder> autoCompactionSnapshotBuilderEntry : currentRunAutoCompactionSnapshotBuilders.entrySet()) {
+      final String dataSource = autoCompactionSnapshotBuilderEntry.getKey();
       CompactionStatistics remainingStatistics = allRemainingStatistics.get(dataSource);
-      CompactionStatistics processedStatistics = allProcessedStatistics.get(dataSource);
+      CompactionStatistics compactedStatistics = allCompactedStatistics.get(dataSource);
+      CompactionStatistics skippedStatistics = allSkippedStatistics.get(dataSource);
 
       long byteAwaitingCompaction = 0;
       long segmentCountAwaitingCompaction = 0;
@@ -299,53 +362,88 @@ public class CompactSegments implements CoordinatorDuty
         intervalCountAwaitingCompaction = remainingStatistics.getSegmentIntervalCountSum();
       }
 
-      long byteProcessed = 0;
-      long segmentCountProcessed = 0;
-      long intervalCountProcessed = 0;
-      if (processedStatistics != null) {
-        byteProcessed = processedStatistics.getByteSum();
-        segmentCountProcessed = processedStatistics.getSegmentNumberCountSum();
-        intervalCountProcessed = processedStatistics.getSegmentIntervalCountSum();
+      long byteCompacted = 0;
+      long segmentCountCompacted = 0;
+      long intervalCountCompacted = 0;
+      if (compactedStatistics != null) {
+        byteCompacted = compactedStatistics.getByteSum();
+        segmentCountCompacted = compactedStatistics.getSegmentNumberCountSum();
+        intervalCountCompacted = compactedStatistics.getSegmentIntervalCountSum();
       }
 
-      autoCompactionSnapshotEntry.getValue().setByteCountAwaitingCompaction(byteAwaitingCompaction);
-      autoCompactionSnapshotEntry.getValue().setByteCountProcessed(byteProcessed);
-      autoCompactionSnapshotEntry.getValue().setSegmentCountAwaitingCompaction(segmentCountAwaitingCompaction);
-      autoCompactionSnapshotEntry.getValue().setSegmentCountProcessed(segmentCountProcessed);
-      autoCompactionSnapshotEntry.getValue().setIntervalCountAwaitingCompaction(intervalCountAwaitingCompaction);
-      autoCompactionSnapshotEntry.getValue().setIntervalCountProcessed(intervalCountProcessed);
+      long byteSkipped = 0;
+      long segmentCountSkipped = 0;
+      long intervalCountSkipped = 0;
+      if (skippedStatistics != null) {
+        byteSkipped = skippedStatistics.getByteSum();
+        segmentCountSkipped = skippedStatistics.getSegmentNumberCountSum();
+        intervalCountSkipped = skippedStatistics.getSegmentIntervalCountSum();
+      }
+
+      autoCompactionSnapshotBuilderEntry.getValue().setBytesAwaitingCompaction(byteAwaitingCompaction);
+      autoCompactionSnapshotBuilderEntry.getValue().setBytesCompacted(byteCompacted);
+      autoCompactionSnapshotBuilderEntry.getValue().setBytesSkipped(byteSkipped);
+      autoCompactionSnapshotBuilderEntry.getValue().setSegmentCountAwaitingCompaction(segmentCountAwaitingCompaction);
+      autoCompactionSnapshotBuilderEntry.getValue().setSegmentCountCompacted(segmentCountCompacted);
+      autoCompactionSnapshotBuilderEntry.getValue().setSegmentCountSkipped(segmentCountSkipped);
+      autoCompactionSnapshotBuilderEntry.getValue().setIntervalCountAwaitingCompaction(intervalCountAwaitingCompaction);
+      autoCompactionSnapshotBuilderEntry.getValue().setIntervalCountCompacted(intervalCountCompacted);
+      autoCompactionSnapshotBuilderEntry.getValue().setIntervalCountSkipped(intervalCountSkipped);
+
 
       stats.addToDataSourceStat(
-          TOTAL_SIZE_OF_SEGMENTS_AWAITING_COMPACTION,
+          TOTAL_SIZE_OF_SEGMENTS_AWAITING,
           dataSource,
           byteAwaitingCompaction
       );
       stats.addToDataSourceStat(
-          TOTAL_COUNT_OF_SEGMENTS_AWAITING_COMPACTION,
+          TOTAL_COUNT_OF_SEGMENTS_AWAITING,
           dataSource,
           segmentCountAwaitingCompaction
       );
       stats.addToDataSourceStat(
-          TOTAL_INTERVAL_OF_SEGMENTS_AWAITING_COMPACTION,
+          TOTAL_INTERVAL_OF_SEGMENTS_AWAITING,
           dataSource,
           intervalCountAwaitingCompaction
       );
       stats.addToDataSourceStat(
           TOTAL_SIZE_OF_SEGMENTS_COMPACTED,
           dataSource,
-          byteProcessed
+          byteCompacted
       );
       stats.addToDataSourceStat(
           TOTAL_COUNT_OF_SEGMENTS_COMPACTED,
           dataSource,
-          segmentCountProcessed
+          segmentCountCompacted
       );
       stats.addToDataSourceStat(
           TOTAL_INTERVAL_OF_SEGMENTS_COMPACTED,
           dataSource,
-          intervalCountProcessed
+          intervalCountCompacted
+      );
+      stats.addToDataSourceStat(
+          TOTAL_SIZE_OF_SEGMENTS_SKIPPED,
+          dataSource,
+          byteSkipped
+      );
+      stats.addToDataSourceStat(
+          TOTAL_COUNT_OF_SEGMENTS_SKIPPED,
+          dataSource,
+          segmentCountSkipped
+      );
+      stats.addToDataSourceStat(
+          TOTAL_INTERVAL_OF_SEGMENTS_SKIPPED,
+          dataSource,
+          intervalCountSkipped
       );
     }
+
+    Map<String, AutoCompactionSnapshot> currentAutoCompactionSnapshotPerDataSource = Maps.transformValues(
+        currentRunAutoCompactionSnapshotBuilders,
+        AutoCompactionSnapshot.Builder::build
+    );
+    // Atomic update of autoCompactionSnapshotPerDataSource with the latest from this coordinator run
+    autoCompactionSnapshotPerDataSource.set(currentAutoCompactionSnapshotPerDataSource);
 
     return stats;
   }
@@ -353,21 +451,21 @@ public class CompactSegments implements CoordinatorDuty
   @Nullable
   public Long getTotalSizeOfSegmentsAwaitingCompaction(String dataSource)
   {
-    AutoCompactionSnapshot autoCompactionSnapshot = autoCompactionSnapshotPerDataSource.get(dataSource);
+    AutoCompactionSnapshot autoCompactionSnapshot = autoCompactionSnapshotPerDataSource.get().get(dataSource);
     if (autoCompactionSnapshot == null) {
       return null;
     }
-    return autoCompactionSnapshotPerDataSource.get(dataSource).getByteCountAwaitingCompaction();
+    return autoCompactionSnapshot.getBytesAwaitingCompaction();
   }
 
   @Nullable
   public AutoCompactionSnapshot getAutoCompactionSnapshot(String dataSource)
   {
-    return autoCompactionSnapshotPerDataSource.get(dataSource);
+    return autoCompactionSnapshotPerDataSource.get().get(dataSource);
   }
 
   public Map<String, AutoCompactionSnapshot> getAutoCompactionSnapshot()
   {
-    return autoCompactionSnapshotPerDataSource;
+    return autoCompactionSnapshotPerDataSource.get();
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -269,7 +269,6 @@ public class CompactSegments implements CoordinatorDuty
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment()),
             newAutoCompactionContext(config.getTaskContext())
         );
-        currentRunAutoCompactionSnapshotBuilders.get(dataSourceName).addScheduledTaskId(taskId);
 
         LOG.info(
             "Submitted a compactionTask[%s] for %s segments",

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -271,6 +271,12 @@ public class CompactSegments implements CoordinatorDuty
   {
     final CoordinatorStats stats = new CoordinatorStats();
     stats.addToGlobalStat(COMPACTION_TASK_COUNT, numCompactionTasks);
+
+    // Make sure that the iterator iterate through all the compacted segments so that we can get accurate and correct
+    // statistics (remaining, skipped, processed, etc.). The reason we have to do this explicitly here is because
+    // earlier (when we are iterating to submit compaction tasks) we may have ran out of task slot and were not able
+    // to iterate to the first segment that needs compaction for some datasource.
+    iterator.iterateAllCompactedSegments();
     // Statistics of all segments that was not iterated (during this run)
     Map<String, CompactionStatistics> totalRemainingStatistics = iterator.totalRemainingStatistics();
     // Statistics of all segments iterated but not scheduled in compaction task (during this run) since segments

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -345,7 +345,7 @@ public class CompactSegments implements CoordinatorDuty
     // Iterate through all the remaining segments in the iterator.
     // As these segments could be compacted but were not compacted due to lack of task slot, we will aggregates
     // the statistic to the AwaitingCompaction statistics
-    while(iterator.hasNext()) {
+    while (iterator.hasNext()) {
       final List<DataSegment> segmentsToCompact = iterator.next();
       if (!segmentsToCompact.isEmpty()) {
         final String dataSourceName = segmentsToCompact.get(0).getDataSource();

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -307,8 +307,8 @@ public class CompactSegments implements CoordinatorDuty
         intervalCountProcessed = processedStatistics.getSegmentIntervalCountSum();
       }
 
-      autoCompactionSnapshotEntry.getValue().setByteAwaitingCompaction(byteAwaitingCompaction);
-      autoCompactionSnapshotEntry.getValue().setByteProcessed(byteProcessed);
+      autoCompactionSnapshotEntry.getValue().setByteCountAwaitingCompaction(byteAwaitingCompaction);
+      autoCompactionSnapshotEntry.getValue().setByteCountProcessed(byteProcessed);
       autoCompactionSnapshotEntry.getValue().setSegmentCountAwaitingCompaction(segmentCountAwaitingCompaction);
       autoCompactionSnapshotEntry.getValue().setSegmentCountProcessed(segmentCountProcessed);
       autoCompactionSnapshotEntry.getValue().setIntervalCountAwaitingCompaction(intervalCountAwaitingCompaction);
@@ -356,7 +356,7 @@ public class CompactSegments implements CoordinatorDuty
     if (autoCompactionSnapshot == null) {
       return null;
     }
-    return autoCompactionSnapshotPerDataSource.get(dataSource).getByteAwaitingCompaction();
+    return autoCompactionSnapshotPerDataSource.get(dataSource).getByteCountAwaitingCompaction();
   }
 
   @Nullable

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
@@ -33,32 +33,31 @@ import java.util.Map;
 public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
 {
   /**
-   * Iterate through all the compacted segments for all datasources currently in this iterator.
-   * This method can be use before calling {@code totalRemainingStatistics}, {@code totalProcessedStatistics},
-   * {@code totalSkippedStatistics} to get correct statistics for the datasources regardless of
+   * Iterate through all the remaining segments for all datasources currently in this iterator.
+   * This method can be use before calling {@code totalRemainingStatistics} and {@code totalProcessedStatistics}
+   * to get correct statistics for the datasources regardless of
    * how many (or none) times this iterator was iterated.
+   * This method should determines remaining segments as needs compaction or does not needs compaction
+   * and aggregates the segment's statistics accordingly.
    *
-   * WARNING: this may iterate the underlying iterator and causes segments from intervals that needs compaction
-   * AND intervals that does not needs compaction to be iterated. This method should only be called when
-   * iteration of this iterator is no longer required.
+   * WARNING: this method iterate the underlying iterator and causes segments to be iterated.
+   * This method should only be called when iteration of this iterator is no longer required.
    */
-  void iterateAllCompactedSegments();
+  void flushAllSegments();
 
   /**
    * Return a map of (dataSource, CompactionStatistics) for all dataSources.
-   * This method should consider all segments except the segments iterated by {@link #next()}.
+   * This method should consider only segments that was not iterated by {@link #next()} and was not deemed as
+   * needs compaction by {@link #flushAllSegments()}.
    */
   Map<String, CompactionStatistics> totalRemainingStatistics();
 
   /**
    * Return a map of (dataSource, CompactionStatistics) for all dataSources.
-   * This method should consider only segments that was iterated and returned by {@link #next().
+   * This method should consider only segments that has one of the following:
+   * - iterated and returned by {@link #next()} (needs compaction)
+   * - Skipped from iteration as segments does not needs compaction
+   * - Deemed as does not needs compaction by {@link #flushAllSegments()}
    */
   Map<String, CompactionStatistics> totalProcessedStatistics();
-
-  /**
-   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
-   * This method should consider only segments that was iterated but not returned by {@link #next().
-   */
-  Map<String, CompactionStatistics> totalSkippedStatistics();
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
@@ -19,11 +19,12 @@
 
 package org.apache.druid.server.coordinator.duty;
 
-import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import org.apache.druid.server.coordinator.CompactionStatistics;
 import org.apache.druid.timeline.DataSegment;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Segments in the lists which are the elements of this iterator are sorted according to the natural segment order
@@ -33,8 +34,9 @@ public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
 {
   long UNKNOWN_TOTAL_REMAINING_SEGMENTS_SIZE = -1L;
   /**
-   * Return a map of (dataSource, total size of remaining segments) for all dataSources.
+   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
    * This method should consider all segments except the segments returned by {@link #next()}.
    */
-  Object2LongOpenHashMap<String> totalRemainingSegmentsSizeBytes();
+  Map<String, CompactionStatistics> totalRemainingStatistics();
+
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
@@ -32,11 +32,21 @@ import java.util.Map;
  */
 public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
 {
-  long UNKNOWN_TOTAL_REMAINING_SEGMENTS_SIZE = -1L;
   /**
    * Return a map of (dataSource, CompactionStatistics) for all dataSources.
-   * This method should consider all segments except the segments returned by {@link #next()}.
+   * This method should consider all segments except the segments iterated by {@link #next()}.
    */
   Map<String, CompactionStatistics> totalRemainingStatistics();
 
+  /**
+   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
+   * This method should consider only segments that was iterated and returned by {@link #next().
+   */
+  Map<String, CompactionStatistics> totalProcessedStatistics();
+
+  /**
+   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
+   * This method should consider only segments that was iterated but not returned by {@link #next().
+   */
+  Map<String, CompactionStatistics> totalSkippedStatistics();
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
@@ -33,6 +33,18 @@ import java.util.Map;
 public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
 {
   /**
+   * Iterate through all the compacted segments for all datasources currently in this iterator.
+   * This method can be use before calling {@code totalRemainingStatistics}, {@code totalProcessedStatistics},
+   * {@code totalSkippedStatistics} to get correct statistics for the datasources regardless of
+   * how many (or none) times this iterator was iterated.
+   *
+   * WARNING: this may iterate the underlying iterator and causes segments from intervals that needs compaction
+   * AND intervals that does not needs compaction to be iterated. This method should only be called when
+   * iteration of this iterator is no longer required.
+   */
+  void iterateAllCompactedSegments();
+
+  /**
    * Return a map of (dataSource, CompactionStatistics) for all dataSources.
    * This method should consider all segments except the segments iterated by {@link #next()}.
    */

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
@@ -55,9 +55,15 @@ public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
   /**
    * Return a map of (dataSource, CompactionStatistics) for all dataSources.
    * This method should consider only segments that has one of the following:
-   * - iterated and returned by {@link #next()} (needs compaction)
-   * - Skipped from iteration as segments does not needs compaction
-   * - Deemed as does not needs compaction by {@link #flushAllSegments()}
+   * - iterated and returned by {@link #next()}
+   * - Segments was already compacted and does not need to be compacted again
    */
-  Map<String, CompactionStatistics> totalProcessedStatistics();
+  Map<String, CompactionStatistics> totalCompactedStatistics();
+
+  /**
+   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
+   * This method should consider only segments that cannot be compacted and hence was skipped from iteration
+   */
+  Map<String, CompactionStatistics> totalSkippedStatistics();
+
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
@@ -33,36 +33,18 @@ import java.util.Map;
 public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
 {
   /**
-   * Iterate through all the remaining segments for all datasources currently in this iterator.
-   * This method can be use before calling {@code totalRemainingStatistics} and {@code totalProcessedStatistics}
-   * to get correct statistics for the datasources regardless of
-   * how many (or none) times this iterator was iterated.
-   * This method should determines remaining segments as needs compaction or does not needs compaction
-   * and aggregates the segment's statistics accordingly.
-   *
-   * WARNING: this method iterate the underlying iterator and causes segments to be iterated.
-   * This method should only be called when iteration of this iterator is no longer required.
-   */
-  void flushAllSegments();
-
-  /**
-   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
-   * This method should consider only segments that was not iterated by {@link #next()} and was not deemed as
-   * needs compaction by {@link #flushAllSegments()}.
-   */
-  Map<String, CompactionStatistics> totalRemainingStatistics();
-
-  /**
-   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
-   * This method should consider only segments that has one of the following:
-   * - iterated and returned by {@link #next()}
-   * - Segments was already compacted and does not need to be compacted again
+   * Return a map of dataSourceName to CompactionStatistics.
+   * This method returns the aggregated statistics of segments that was already compacted and does not need to be compacted
+   * again. Hence, segment that were not returned by the {@link Iterator#next()} becuase it does not needs compaction.
+   * Note that the aggregations returned by this method is only up to the current point of the iterator being iterated.
    */
   Map<String, CompactionStatistics> totalCompactedStatistics();
 
   /**
-   * Return a map of (dataSource, CompactionStatistics) for all dataSources.
-   * This method should consider only segments that cannot be compacted and hence was skipped from iteration
+   * Return a map of dataSourceName to CompactionStatistics.
+   * This method returns the aggregated statistics of segments that was skipped as it cannot be compacted.
+   * Hence, segment that were not returned by the {@link Iterator#next()} becuase it cannot be compacted.
+   * Note that the aggregations returned by this method is only up to the current point of the iterator being iterated.
    */
   Map<String, CompactionStatistics> totalSkippedStatistics();
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -296,21 +296,21 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
 
     emitter.emit(
         new ServiceMetricEvent.Builder().build(
-            "compact/task/scheduled/count",
+            "compact/task/count",
             stats.getGlobalStat(CompactSegments.COMPACTION_TASK_COUNT)
         )
     );
 
     emitter.emit(
         new ServiceMetricEvent.Builder().build(
-            "compact/task/maxSlot/count",
+            "compact/maxSlot/count",
             stats.getGlobalStat(CompactSegments.MAX_COMPACTION_TASK_SLOT)
         )
     );
 
     emitter.emit(
         new ServiceMetricEvent.Builder().build(
-            "compact/task/availableSlot/count",
+            "compact/availableSlot/count",
             stats.getGlobalStat(CompactSegments.AVAILABLE_COMPACTION_TASK_SLOT)
         )
     );

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -303,14 +303,14 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
 
     emitter.emit(
         new ServiceMetricEvent.Builder().build(
-            "compact/maxSlot/count",
+            "compactTask/maxSlot/count",
             stats.getGlobalStat(CompactSegments.MAX_COMPACTION_TASK_SLOT)
         )
     );
 
     emitter.emit(
         new ServiceMetricEvent.Builder().build(
-            "compact/availableSlot/count",
+            "compactTask/availableSlot/count",
             stats.getGlobalStat(CompactSegments.AVAILABLE_COMPACTION_TASK_SLOT)
         )
     );
@@ -321,7 +321,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/waitCompact/segmentBytes", count)
+                  .build("segment/waitCompact/bytes", count)
           );
         }
     );
@@ -332,7 +332,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/waitCompact/segmentCount", count)
+                  .build("segment/waitCompact/count", count)
           );
         }
     );
@@ -343,7 +343,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/waitCompact/intervalCount", count)
+                  .build("interval/waitCompact/count", count)
           );
         }
     );
@@ -354,7 +354,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/skipCompact/segmentBytes", count)
+                  .build("segment/skipCompact/bytes", count)
           );
         }
     );
@@ -365,7 +365,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/skipCompact/segmentCount", count)
+                  .build("segment/skipCompact/count", count)
           );
         }
     );
@@ -376,7 +376,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/skipCompact/intervalCount", count)
+                  .build("interval/skipCompact/count", count)
           );
         }
     );
@@ -387,7 +387,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/compacted/segmentBytes", count)
+                  .build("segment/compacted/bytes", count)
           );
         }
     );
@@ -398,7 +398,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/compacted/segmentCount", count)
+                  .build("segment/compacted/count", count)
           );
         }
     );
@@ -409,7 +409,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/compacted/intervalCount", count)
+                  .build("interval/compacted/count", count)
           );
         }
     );

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -296,18 +296,87 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
 
     emitter.emit(
         new ServiceMetricEvent.Builder().build(
-            "compact/task/count",
+            "compact/task/scheduled/count",
             stats.getGlobalStat(CompactSegments.COMPACTION_TASK_COUNT)
         )
     );
 
+    emitter.emit(
+        new ServiceMetricEvent.Builder().build(
+            "compact/task/maxSlot/count",
+            stats.getGlobalStat(CompactSegments.MAX_COMPACTION_TASK_SLOT)
+        )
+    );
+
+    emitter.emit(
+        new ServiceMetricEvent.Builder().build(
+            "compact/task/availableSlot/count",
+            stats.getGlobalStat(CompactSegments.AVAILABLE_COMPACTION_TASK_SLOT)
+        )
+    );
+
     stats.forEachDataSourceStat(
-        "segmentsWaitCompact",
+        CompactSegments.TOTAL_SIZE_OF_SEGMENTS_AWAITING_COMPACTION,
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/waitCompact/count", count)
+                  .build("segment/waitCompact/segmentByte", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_COUNT_OF_SEGMENTS_AWAITING_COMPACTION,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/waitCompact/segmentCount", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_INTERVAL_OF_SEGMENTS_AWAITING_COMPACTION,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/waitCompact/intervalCount", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_SIZE_OF_SEGMENTS_COMPACTED,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/compacted/segmentByte", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_COUNT_OF_SEGMENTS_COMPACTED,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/compacted/segmentCount", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_INTERVAL_OF_SEGMENTS_COMPACTED,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/compacted/intervalCount", count)
           );
         }
     );

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -316,18 +316,18 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     );
 
     stats.forEachDataSourceStat(
-        CompactSegments.TOTAL_SIZE_OF_SEGMENTS_AWAITING_COMPACTION,
+        CompactSegments.TOTAL_SIZE_OF_SEGMENTS_AWAITING,
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/waitCompact/segmentByte", count)
+                  .build("segment/waitCompact/segmentBytes", count)
           );
         }
     );
 
     stats.forEachDataSourceStat(
-        CompactSegments.TOTAL_COUNT_OF_SEGMENTS_AWAITING_COMPACTION,
+        CompactSegments.TOTAL_COUNT_OF_SEGMENTS_AWAITING,
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
@@ -338,7 +338,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     );
 
     stats.forEachDataSourceStat(
-        CompactSegments.TOTAL_INTERVAL_OF_SEGMENTS_AWAITING_COMPACTION,
+        CompactSegments.TOTAL_INTERVAL_OF_SEGMENTS_AWAITING,
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
@@ -349,12 +349,45 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     );
 
     stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_SIZE_OF_SEGMENTS_SKIPPED,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/skipCompact/segmentBytes", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_COUNT_OF_SEGMENTS_SKIPPED,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/skipCompact/segmentCount", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
+        CompactSegments.TOTAL_INTERVAL_OF_SEGMENTS_SKIPPED,
+        (final String dataSource, final long count) -> {
+          emitter.emit(
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .build("segment/skipCompact/intervalCount", count)
+          );
+        }
+    );
+
+    stats.forEachDataSourceStat(
         CompactSegments.TOTAL_SIZE_OF_SEGMENTS_COMPACTED,
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
-                  .build("segment/compacted/segmentByte", count)
+                  .build("segment/compacted/segmentBytes", count)
           );
         }
     );

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -22,7 +22,6 @@ package org.apache.druid.server.coordinator.duty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -24,7 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
-import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -376,7 +376,8 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
 
         if (isCompactibleSize && needsCompaction) {
           CompactionStatistics statistics = returnedSegments.computeIfAbsent(
-              dataSourceName, v -> CompactionStatistics.initializeCompactionStatistics()
+              dataSourceName,
+              v -> CompactionStatistics.initializeCompactionStatistics()
           );
           statistics.incrementCompactedByte(candidates.getTotalSize());
           statistics.incrementCompactedIntervals(candidates.getNumberOfIntervals());
@@ -384,7 +385,8 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
           return candidates;
         } else {
           CompactionStatistics statistics = skippedSegments.computeIfAbsent(
-              dataSourceName, v -> CompactionStatistics.initializeCompactionStatistics()
+              dataSourceName,
+              v -> CompactionStatistics.initializeCompactionStatistics()
           );
           statistics.incrementCompactedByte(candidates.getTotalSize());
           statistics.incrementCompactedIntervals(candidates.getNumberOfIntervals());

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -20,9 +20,11 @@
 package org.apache.druid.server.http;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
+import org.apache.druid.server.coordinator.AutoCompactionSnapshot;
 import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.http.security.ConfigResourceFilter;
 import org.apache.druid.server.http.security.StateResourceFilter;
@@ -34,6 +36,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collection;
 
 @Path("/druid/coordinator/v1/compaction")
 public class CompactionResource
@@ -75,5 +78,31 @@ public class CompactionResource
     } else {
       return Response.ok(ImmutableMap.of("remainingSegmentSize", notCompactedSegmentSizeBytes)).build();
     }
+  }
+
+  @GET
+  @Path("/snapshot")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ResourceFilters(StateResourceFilter.class)
+  public Response getCompactionSnapshotForDataSource(
+      @QueryParam("dataSource") String dataSource
+  )
+  {
+    final AutoCompactionSnapshot autoCompactionSnapshot = coordinator.getAutoCompactionSnapshotForDataSource(dataSource);
+    if (autoCompactionSnapshot == null) {
+      return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", "unknown dataSource")).build();
+    } else {
+      return Response.ok(ImmutableMap.of("latestSnapshots", ImmutableList.of(autoCompactionSnapshot))).build();
+    }
+  }
+
+  @GET
+  @Path("/snapshot")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ResourceFilters(StateResourceFilter.class)
+  public Response getCompactionSnapshot()
+  {
+    final Collection<AutoCompactionSnapshot> snapshots = coordinator.getAutoCompactionSnapshot().values();
+    return Response.ok(ImmutableMap.of("latestSnapshots", snapshots)).build();
   }
 }

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -36,7 +36,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 @Path("/druid/coordinator/v1/compaction")
 public class CompactionResource
@@ -88,21 +90,16 @@ public class CompactionResource
       @QueryParam("dataSource") String dataSource
   )
   {
-    final AutoCompactionSnapshot autoCompactionSnapshot = coordinator.getAutoCompactionSnapshotForDataSource(dataSource);
-    if (autoCompactionSnapshot == null) {
-      return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", "unknown dataSource")).build();
+    final Collection<AutoCompactionSnapshot> snapshots;
+    if (dataSource == null || dataSource.isEmpty()) {
+      snapshots = coordinator.getAutoCompactionSnapshot().values();
     } else {
-      return Response.ok(ImmutableMap.of("latestSnapshots", ImmutableList.of(autoCompactionSnapshot))).build();
+      AutoCompactionSnapshot autoCompactionSnapshot = coordinator.getAutoCompactionSnapshotForDataSource(dataSource);
+      if (autoCompactionSnapshot == null) {
+        return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", "unknown dataSource")).build();
+      }
+      snapshots = ImmutableList.of(autoCompactionSnapshot);
     }
-  }
-
-  @GET
-  @Path("/snapshot")
-  @Produces(MediaType.APPLICATION_JSON)
-  @ResourceFilters(StateResourceFilter.class)
-  public Response getCompactionSnapshot()
-  {
-    final Collection<AutoCompactionSnapshot> snapshots = coordinator.getAutoCompactionSnapshot().values();
     return Response.ok(ImmutableMap.of("latestSnapshots", snapshots)).build();
   }
 }

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -81,7 +81,7 @@ public class CompactionResource
   }
 
   @GET
-  @Path("/snapshot")
+  @Path("/status")
   @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(StateResourceFilter.class)
   public Response getCompactionSnapshotForDataSource(

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -36,9 +36,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 @Path("/druid/coordinator/v1/compaction")
 public class CompactionResource

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -98,6 +98,6 @@ public class CompactionResource
       }
       snapshots = ImmutableList.of(autoCompactionSnapshot);
     }
-    return Response.ok(ImmutableMap.of("latestSnapshots", snapshots)).build();
+    return Response.ok(ImmutableMap.of("latestStatus", snapshots)).build();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.server.coordinator;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,12 +28,8 @@ public class AutoCompactionSnapshotTest
   public void testAutoCompactionSnapshotBuilder()
   {
     final String expectedDataSource = "data";
-    final String expectedTask1 = "task1";
-    final String expectedTask2 = "task2";
     final AutoCompactionSnapshot.AutoCompactionScheduleStatus expectedStatus = AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING;
     AutoCompactionSnapshot.Builder builder = new AutoCompactionSnapshot.Builder(expectedDataSource, expectedStatus);
-    builder.addScheduledTaskId(expectedTask1);
-    builder.addScheduledTaskId(expectedTask2);
 
     // Increment every stats twice
     for (int i = 0; i < 2; i++) {
@@ -65,15 +60,10 @@ public class AutoCompactionSnapshotTest
     Assert.assertEquals(26, actual.getSegmentCountAwaitingCompaction());
     Assert.assertEquals(AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING, actual.getScheduleStatus());
     Assert.assertEquals(expectedDataSource, actual.getDataSource());
-    Assert.assertNotNull(actual.getScheduledTaskIds());
-    Assert.assertEquals(2, actual.getScheduledTaskIds().size());
-    Assert.assertTrue(actual.getScheduledTaskIds().contains(expectedTask1));
-    Assert.assertTrue(actual.getScheduledTaskIds().contains(expectedTask2));
 
     AutoCompactionSnapshot expected = new AutoCompactionSnapshot(
         expectedDataSource,
         AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
-        ImmutableList.of(expectedTask1, expectedTask2),
         26,
         26,
         26,

--- a/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AutoCompactionSnapshotTest
+{
+  @Test
+  public void testAutoCompactionSnapshotBuilder()
+  {
+    final String expectedDataSource = "data";
+    final String expectedTask1 = "task1";
+    final String expectedTask2 = "task2";
+    final AutoCompactionSnapshot.AutoCompactionScheduleStatus expectedStatus = AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING;
+    AutoCompactionSnapshot.Builder builder = new AutoCompactionSnapshot.Builder(expectedDataSource, expectedStatus);
+    builder.addScheduledTaskId(expectedTask1);
+    builder.addScheduledTaskId(expectedTask2);
+
+    // Increment every stats twice
+    for (int i = 0; i < 2; i++) {
+      builder.incrementIntervalCountSkipped(13);
+      builder.incrementBytesSkipped(13);
+      builder.incrementSegmentCountSkipped(13);
+
+      builder.incrementIntervalCountCompacted(13);
+      builder.incrementBytesCompacted(13);
+      builder.incrementSegmentCountCompacted(13);
+
+      builder.incrementIntervalCountAwaitingCompaction(13);
+      builder.incrementBytesAwaitingCompaction(13);
+      builder.incrementSegmentCountAwaitingCompaction(13);
+    }
+
+    AutoCompactionSnapshot actual = builder.build();
+
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(26, actual.getSegmentCountSkipped());
+    Assert.assertEquals(26, actual.getIntervalCountSkipped());
+    Assert.assertEquals(26, actual.getBytesSkipped());
+    Assert.assertEquals(26, actual.getBytesCompacted());
+    Assert.assertEquals(26, actual.getIntervalCountCompacted());
+    Assert.assertEquals(26, actual.getSegmentCountCompacted());
+    Assert.assertEquals(26, actual.getBytesAwaitingCompaction());
+    Assert.assertEquals(26, actual.getIntervalCountAwaitingCompaction());
+    Assert.assertEquals(26, actual.getSegmentCountAwaitingCompaction());
+    Assert.assertEquals(AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING, actual.getScheduleStatus());
+    Assert.assertEquals(expectedDataSource, actual.getDataSource());
+    Assert.assertNotNull(actual.getScheduledTaskIds());
+    Assert.assertEquals(2, actual.getScheduledTaskIds().size());
+    Assert.assertTrue(actual.getScheduledTaskIds().contains(expectedTask1));
+    Assert.assertTrue(actual.getScheduledTaskIds().contains(expectedTask2));
+
+    AutoCompactionSnapshot expected = new AutoCompactionSnapshot(
+        expectedDataSource,
+        AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
+        ImmutableList.of(expectedTask1, expectedTask2),
+        26,
+        26,
+        26,
+        26,
+        26,
+        26,
+        26,
+        26,
+        26
+    );
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -337,7 +337,7 @@ public class CompactSegmentsTest
           Assert.assertEquals(TOTAL_INTERVAL_PER_DATASOURCE - (compaction_run_count + 1), snapshot.getIntervalCountAwaitingCompaction());
           Assert.assertEquals((compaction_run_count + 1), snapshot.getIntervalCountProcessed());
           Assert.assertEquals(TOTAL_SEGMENT_PER_DATASOURCE - 4 * (compaction_run_count + 1), snapshot.getSegmentCountAwaitingCompaction());
-          Assert.assertEquals( 2 * (compaction_run_count + 1), snapshot.getSegmentCountProcessed());
+          Assert.assertEquals(2 * (compaction_run_count + 1), snapshot.getSegmentCountProcessed());
         } else {
           AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(DATA_SOURCE_PREFIX + i);
           Assert.assertEquals(DATA_SOURCE_PREFIX + i, snapshot.getDataSource());

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -429,7 +429,8 @@ public class CompactSegmentsTest
       long expectedIntervalCountProcessed,
       long expectedSegmentCountAwaitingCompaction,
       long expectedSegmentCountProcessed
-  ) {
+  )
+  {
     Map<String, AutoCompactionSnapshot> autoCompactionSnapshots = compactSegments.getAutoCompactionSnapshot();
     AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(dataSourceName);
     Assert.assertEquals(dataSourceName, snapshot.getDataSource());

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.indexing.ClientCompactionTaskQuery;
@@ -429,7 +428,8 @@ public class CompactSegmentsTest
       long expectedIntervalCountAwaitingCompaction,
       long expectedIntervalCountProcessed,
       long expectedSegmentCountAwaitingCompaction,
-      long expectedSegmentCountProcessed) {
+      long expectedSegmentCountProcessed
+  ) {
     Map<String, AutoCompactionSnapshot> autoCompactionSnapshots = compactSegments.getAutoCompactionSnapshot();
     AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(dataSourceName);
     Assert.assertEquals(dataSourceName, snapshot.getDataSource());

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -100,9 +100,9 @@ public class CompactSegmentsTest
   private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
   private static final String DATA_SOURCE_PREFIX = "dataSource_";
   // Each dataSource starts with 440 byte, 44 segments, and 11 intervals needing compaction
-  int TOTAL_BYTE_PER_DATASOURCE = 440;
-  int TOTAL_SEGMENT_PER_DATASOURCE = 44;
-  int TOTAL_INTERVAL_PER_DATASOURCE = 11;
+  private static final int TOTAL_BYTE_PER_DATASOURCE = 440;
+  private static final int TOTAL_SEGMENT_PER_DATASOURCE = 44;
+  private static final int TOTAL_INTERVAL_PER_DATASOURCE = 11;
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> constructorFeeder()
@@ -300,8 +300,8 @@ public class CompactSegmentsTest
       AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(DATA_SOURCE_PREFIX + i);
       Assert.assertEquals(DATA_SOURCE_PREFIX + i, snapshot.getDataSource());
       Assert.assertEquals(AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING, snapshot.getScheduleStatus());
-      Assert.assertEquals(0, snapshot.getByteAwaitingCompaction());
-      Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE, snapshot.getByteProcessed());
+      Assert.assertEquals(0, snapshot.getByteCountAwaitingCompaction());
+      Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE, snapshot.getByteCountProcessed());
       Assert.assertEquals(0, snapshot.getIntervalCountAwaitingCompaction());
       Assert.assertEquals(TOTAL_INTERVAL_PER_DATASOURCE, snapshot.getIntervalCountProcessed());
       Assert.assertEquals(0, snapshot.getSegmentCountAwaitingCompaction());
@@ -332,8 +332,8 @@ public class CompactSegmentsTest
           AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(DATA_SOURCE_PREFIX + i);
           Assert.assertEquals(DATA_SOURCE_PREFIX + i, snapshot.getDataSource());
           Assert.assertEquals(AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING, snapshot.getScheduleStatus());
-          Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE - 40 * (compaction_run_count + 1), snapshot.getByteAwaitingCompaction());
-          Assert.assertEquals(40 * (compaction_run_count + 1), snapshot.getByteProcessed());
+          Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE - 40 * (compaction_run_count + 1), snapshot.getByteCountAwaitingCompaction());
+          Assert.assertEquals(40 * (compaction_run_count + 1), snapshot.getByteCountProcessed());
           Assert.assertEquals(TOTAL_INTERVAL_PER_DATASOURCE - (compaction_run_count + 1), snapshot.getIntervalCountAwaitingCompaction());
           Assert.assertEquals((compaction_run_count + 1), snapshot.getIntervalCountProcessed());
           Assert.assertEquals(TOTAL_SEGMENT_PER_DATASOURCE - 4 * (compaction_run_count + 1), snapshot.getSegmentCountAwaitingCompaction());
@@ -342,8 +342,8 @@ public class CompactSegmentsTest
           AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(DATA_SOURCE_PREFIX + i);
           Assert.assertEquals(DATA_SOURCE_PREFIX + i, snapshot.getDataSource());
           Assert.assertEquals(AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING, snapshot.getScheduleStatus());
-          Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE - 40 * (compaction_run_count + 1), snapshot.getByteAwaitingCompaction());
-          Assert.assertEquals(40 * (compaction_run_count + 1), snapshot.getByteProcessed());
+          Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE - 40 * (compaction_run_count + 1), snapshot.getByteCountAwaitingCompaction());
+          Assert.assertEquals(40 * (compaction_run_count + 1), snapshot.getByteCountProcessed());
           Assert.assertEquals(TOTAL_INTERVAL_PER_DATASOURCE - (compaction_run_count + 1), snapshot.getIntervalCountAwaitingCompaction());
           Assert.assertEquals((compaction_run_count + 1), snapshot.getIntervalCountProcessed());
           Assert.assertEquals(TOTAL_SEGMENT_PER_DATASOURCE - 4 * (compaction_run_count + 1), snapshot.getSegmentCountAwaitingCompaction());
@@ -356,8 +356,8 @@ public class CompactSegmentsTest
         AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(DATA_SOURCE_PREFIX + i);
         Assert.assertEquals(DATA_SOURCE_PREFIX + i, snapshot.getDataSource());
         Assert.assertEquals(AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING, snapshot.getScheduleStatus());
-        Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE - 40 * compaction_run_count, snapshot.getByteAwaitingCompaction());
-        Assert.assertEquals(40 * compaction_run_count, snapshot.getByteProcessed());
+        Assert.assertEquals(TOTAL_BYTE_PER_DATASOURCE - 40 * compaction_run_count, snapshot.getByteCountAwaitingCompaction());
+        Assert.assertEquals(40 * compaction_run_count, snapshot.getByteCountProcessed());
         Assert.assertEquals(TOTAL_INTERVAL_PER_DATASOURCE - compaction_run_count, snapshot.getIntervalCountAwaitingCompaction());
         Assert.assertEquals(compaction_run_count, snapshot.getIntervalCountProcessed());
         Assert.assertEquals(TOTAL_SEGMENT_PER_DATASOURCE - 4 * compaction_run_count, snapshot.getSegmentCountAwaitingCompaction());

--- a/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.http;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.server.coordinator.AutoCompactionSnapshot;
+import org.apache.druid.server.coordinator.DruidCoordinator;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class CompactionResourceTest
+{
+  private DruidCoordinator mock;
+
+  @Before
+  public void setUp()
+  {
+    mock = EasyMock.createStrictMock(DruidCoordinator.class);
+  }
+
+  @After
+  public void tearDown()
+  {
+    EasyMock.verify(mock);
+  }
+
+  @Test
+  public void testGetCompactionSnapshotForDataSourceWithEmptyQueryParameter()
+  {
+    String dataSourceName = "datasource_1";
+    Map<String, AutoCompactionSnapshot> expected = ImmutableMap.of(
+        dataSourceName,
+        new AutoCompactionSnapshot(dataSourceName, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+    );
+
+    EasyMock.expect(mock.getAutoCompactionSnapshot()).andReturn(expected).once();
+    EasyMock.replay(mock);
+
+    final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource("");
+    Assert.assertEquals(ImmutableMap.of("latestSnapshots", expected.values()), response.getEntity());
+    Assert.assertEquals(200, response.getStatus());
+  }
+
+  @Test
+  public void testGetCompactionSnapshotForDataSourceWithNullQueryParameter()
+  {
+    String dataSourceName = "datasource_1";
+    Map<String, AutoCompactionSnapshot> expected = ImmutableMap.of(
+        dataSourceName,
+        new AutoCompactionSnapshot(dataSourceName, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+    );
+
+    EasyMock.expect(mock.getAutoCompactionSnapshot()).andReturn(expected).once();
+    EasyMock.replay(mock);
+
+    final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource(null);
+    Assert.assertEquals(ImmutableMap.of("latestSnapshots", expected.values()), response.getEntity());
+    Assert.assertEquals(200, response.getStatus());
+  }
+
+  @Test
+  public void testGetCompactionSnapshotForDataSourceWithValidQueryParameter()
+  {
+    String dataSourceName = "datasource_1";
+    AutoCompactionSnapshot expected = new AutoCompactionSnapshot(dataSourceName, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING);
+
+    EasyMock.expect(mock.getAutoCompactionSnapshotForDataSource(dataSourceName)).andReturn(expected).once();
+    EasyMock.replay(mock);
+
+    final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource(dataSourceName);
+    Assert.assertEquals(ImmutableMap.of("latestSnapshots", ImmutableList.of(expected)), response.getEntity());
+    Assert.assertEquals(200, response.getStatus());
+  }
+
+  @Test
+  public void testGetCompactionSnapshotForDataSourceWithInvalidQueryParameter()
+  {
+    String dataSourceName = "invalid_datasource";
+
+    EasyMock.expect(mock.getAutoCompactionSnapshotForDataSource(dataSourceName)).andReturn(null).once();
+    EasyMock.replay(mock);
+
+    final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource(dataSourceName);
+    Assert.assertEquals(400, response.getStatus());
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
@@ -39,7 +39,6 @@ public class CompactionResourceTest
   private AutoCompactionSnapshot expectedSnapshot = new AutoCompactionSnapshot(
       dataSourceName,
       AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
-      ImmutableList.of("task123"),
       1,
       1,
       1,

--- a/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
@@ -35,6 +35,21 @@ import java.util.Map;
 public class CompactionResourceTest
 {
   private DruidCoordinator mock;
+  private String dataSourceName = "datasource_1";
+  private AutoCompactionSnapshot expectedSnapshot = new AutoCompactionSnapshot(
+      dataSourceName,
+      AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
+      ImmutableList.of("task123"),
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+  );
 
   @Before
   public void setUp()
@@ -51,17 +66,16 @@ public class CompactionResourceTest
   @Test
   public void testGetCompactionSnapshotForDataSourceWithEmptyQueryParameter()
   {
-    String dataSourceName = "datasource_1";
     Map<String, AutoCompactionSnapshot> expected = ImmutableMap.of(
         dataSourceName,
-        new AutoCompactionSnapshot(dataSourceName, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+        expectedSnapshot
     );
 
     EasyMock.expect(mock.getAutoCompactionSnapshot()).andReturn(expected).once();
     EasyMock.replay(mock);
 
     final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource("");
-    Assert.assertEquals(ImmutableMap.of("latestSnapshots", expected.values()), response.getEntity());
+    Assert.assertEquals(ImmutableMap.of("latestStatus", expected.values()), response.getEntity());
     Assert.assertEquals(200, response.getStatus());
   }
 
@@ -71,14 +85,14 @@ public class CompactionResourceTest
     String dataSourceName = "datasource_1";
     Map<String, AutoCompactionSnapshot> expected = ImmutableMap.of(
         dataSourceName,
-        new AutoCompactionSnapshot(dataSourceName, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+        expectedSnapshot
     );
 
     EasyMock.expect(mock.getAutoCompactionSnapshot()).andReturn(expected).once();
     EasyMock.replay(mock);
 
     final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource(null);
-    Assert.assertEquals(ImmutableMap.of("latestSnapshots", expected.values()), response.getEntity());
+    Assert.assertEquals(ImmutableMap.of("latestStatus", expected.values()), response.getEntity());
     Assert.assertEquals(200, response.getStatus());
   }
 
@@ -86,13 +100,12 @@ public class CompactionResourceTest
   public void testGetCompactionSnapshotForDataSourceWithValidQueryParameter()
   {
     String dataSourceName = "datasource_1";
-    AutoCompactionSnapshot expected = new AutoCompactionSnapshot(dataSourceName, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING);
 
-    EasyMock.expect(mock.getAutoCompactionSnapshotForDataSource(dataSourceName)).andReturn(expected).once();
+    EasyMock.expect(mock.getAutoCompactionSnapshotForDataSource(dataSourceName)).andReturn(expectedSnapshot).once();
     EasyMock.replay(mock);
 
     final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource(dataSourceName);
-    Assert.assertEquals(ImmutableMap.of("latestSnapshots", ImmutableList.of(expected)), response.getEntity());
+    Assert.assertEquals(ImmutableMap.of("latestStatus", ImmutableList.of(expectedSnapshot)), response.getEntity());
     Assert.assertEquals(200, response.getStatus());
   }
 


### PR DESCRIPTION
Add Auto-compaction snapshot status API

### Description

Right now, after users set up auto-compaction, the main ways of understanding how far it's progressed, whether it is progressing or stuck, if datasources are properly compacted, etc, are either:

1. Looking at the segments yourself and deciding if they look good enough.
2. Reading messages logged by the Coordinator periodically.

Neither of these is a great solution. Instead this PR adds an API that tells you what you need to know regarding your auto compaction status and progress.

This API provides the status of the latest auto compaction run (coordinator duty run) including statistics and information from the coordinator. The API provides getting for a single dataSource or for all dataSources.

The API is in the format of:
`/druid/coordinator/v1/compaction/status?dataSource={dataSource}`
`/druid/coordinator/v1/compaction/status`

More details:
- only returns datasource which has/had auto compaction enabled.
- Auto compaction scheduling status: "NOT_ENABLED" and "RUNNING" w.r.t the dataSource having an auto compaction config submitted to `/druid/coordinator/v1/config/compaction/` or not.
- Datasource with auto compaction scheduling set to NOT_ENABLED will not have it's "bytesAwaitingCompaction", "bytesCompressed", "bytesSkipped", "segmentCountAwaitingCompaction", "segmentCountCompressed", "segmentCountSkipped", "intervalCountAwaitingCompaction", "
intervalCountCompressed", "intervalCountSkipped" update in subsequent auto compaction runs.

```
Example response:
{
"latestSnapshots":[
 {
        "dataSource":"wikipedia",
        "scheduleStatus": "RUNNING",
        "bytesAwaitingCompaction": 3000,
        "bytesCompressed": 5000,
        "bytesSkipped": 30,
        "segmentCountAwaitingCompaction": 200,
        "segmentCountCompressed": 500,
        "segmentCountSkipped": 2,
        "intervalCountAwaitingCompaction": 30,
        "intervalCountCompressed": 50
        "intervalCountSkipped": 5,
    }
]
}
```

Description of field in response:
     

- "dataSource": name of the datasource for this status information
- "scheduleStatus": auto compaction scheduling status: "NOT_ENABLED" and "RUNNING" w.r.t the dataSource having an auto compaction config submitted to `/druid/coordinator/v1/config/compaction/` or not
- "bytesAwaitingCompaction": total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
- "bytesCompressed":  total byte of this datasource that is already compacted with the spec set in the auto compaction.
- "bytesSkipped":  total byte of this datasource that is skipped by the auto compaction.
- "segmentCountAwaitingCompaction": total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
- "segmentCountCompressed": total number of segments of this datasource that is already compacted with the spec set in the auto compaction.
- "segmentCountSkipped":  total number of segments of this datasource that is skipped by the auto compaction.
- "intervalCountAwaitingCompaction":  total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
- "intervalCountCompressed": total number of intervals of this datasource that is already compacted with the spec set in the auto compaction.
- "intervalCountSkipped":  total number of intervals of this datasource that is skipped by the auto compaction.

Description of metrics:

These are global
- compact/task/count: Number of task issued in this autocompaction run at this time
- compactTask/maxSlot/count: Number of max task slot in this autocompaction run at this time (this is min of ratio * total slot or max compact slot set)
- compactTask/availableSlot/count: Number of available task slot in this autocompaction run at this time (this is max slot minus any currently running compaction task)

These are per datasource (datasource is a dimension)
- segment/waitCompact/bytes:  total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
- segment/waitCompact/count: total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
- interval/waitCompact/count: total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
- segment/compacted/bytes: total byte of this datasource that is already compacted with the spec set in the auto compaction.
- segment/compacted/count: total number of segments of this datasource that is already compacted with the spec set in the auto compaction.
- interval/compacted/count: total number of intervals of this datasource that is already compacted with the spec set in the auto compaction.
- segment/skipCompact/bytes:  total byte of this datasource that is skipped by the auto compaction
- segment/skipCompact/count: total number of segments of this datasource that is skipped by the auto compaction
- interval/skipCompact/count: total number of intervals of this datasource that is skipped by the auto compaction

This PR also fix and improve the emitted metrics for auto-compaction via the CoordinatorStats.
- Emits the above Compacted vs Remaining stats
- Emits details for auto compaction task scheduling. These are tasks scheduled, max compaction slot and available compaction slot during each auto compaction duty run

Concurrency:
This PR deals with an existing concurrency issue in CompactSegment class. Updating `totalSizesOfSegmentsAwaitingCompactionPerDataSource` was not thread-safe, but it should be. This applies same to `autoCompactionSnapshotPerDataSource` (`totalSizesOfSegmentsAwaitingCompactionPerDataSource` is replace with `autoCompactionSnapshotPerDataSource` in this PR). The concurrency issue is solved by storing `autoCompactionSnapshotPerDataSource` in an AtomicReference so that we can atomically update the reference to the hash map whenever we compute new snapshots.

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.


