### PR TITLE
Adding more dimensions to the audit log entry

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -337,7 +337,7 @@ Coordinator and Overlord log changes to lookups, segment load/drop rules, dynami
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.audit.manager.auditHistoryMillis`|Default duration for querying audit history.|1 week|
-|`druid.audit.manager.addPayloadToAuditMetricDimension`|Boolean flag on whether to add `payload` column in service metric.|false|
+|`druid.audit.manager.includePayloadAsDimensionInMetric`|Boolean flag on whether to add `payload` column in service metric.|false|
 
 ### Enabling Metrics
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -330,6 +330,15 @@ Switching Request Logger routes native query's request logs to one request logge
 |`druid.request.logging.nativeQueryLogger`|request logger for emitting native query's request logs.|none|
 |`druid.request.logging.sqlQueryLogger`|request logger for emitting SQL query's request logs.|none|
 
+### Audit Logging
+
+Coordinator and Overlord log changes to lookups, segment load/drop rules, dynamic configuration changes for auditing
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.audit.manager.auditHistoryMillis`|Default duration for querying audit history.|1 week|
+|`druid.audit.manager.addPayloadToAuditMetricDimension`|Boolean flag on whether to add `payload` column in service metric.|false|
+
 ### Enabling Metrics
 
 Druid processes periodically emit metrics and different metrics monitors can be included. Each process can overwrite the default list of monitors.

--- a/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
+++ b/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
@@ -98,6 +98,10 @@ public class SQLAuditManager implements AuditManager
             .setDimension("key", auditEntry.getKey())
             .setDimension("type", auditEntry.getType())
             .setDimension("author", auditEntry.getAuditInfo().getAuthor())
+            .setDimension("comment", auditEntry.getAuditInfo().getComment())
+            .setDimension("remote_address", auditEntry.getAuditInfo().getIp())
+            .setDimension("created_date", auditEntry.getAuditTime().toString())
+            .setDimension("payload", auditEntry.getPayload())
             .build("config/audit", 1)
     );
 

--- a/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
+++ b/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
@@ -93,17 +93,19 @@ public class SQLAuditManager implements AuditManager
   @Override
   public void doAudit(AuditEntry auditEntry, Handle handle) throws IOException
   {
-    emitter.emit(
-        new ServiceMetricEvent.Builder()
-            .setDimension("key", auditEntry.getKey())
-            .setDimension("type", auditEntry.getType())
-            .setDimension("author", auditEntry.getAuditInfo().getAuthor())
-            .setDimension("comment", auditEntry.getAuditInfo().getComment())
-            .setDimension("remote_address", auditEntry.getAuditInfo().getIp())
-            .setDimension("created_date", auditEntry.getAuditTime().toString())
-            .setDimension("payload", auditEntry.getPayload())
-            .build("config/audit", 1)
-    );
+    ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder()
+                                                .setDimension("key", auditEntry.getKey())
+                                                .setDimension("type", auditEntry.getType())
+                                                .setDimension("author", auditEntry.getAuditInfo().getAuthor())
+                                                .setDimension("comment", auditEntry.getAuditInfo().getComment())
+                                                .setDimension("remote_address", auditEntry.getAuditInfo().getIp())
+                                                .setDimension("created_date", auditEntry.getAuditTime().toString());
+
+    if (config.getAddPayloadToAuditMetricDimension()) {
+      builder.setDimension("payload", auditEntry.getPayload());
+    }
+
+    emitter.emit(builder.build("config/audit", 1));
 
     handle.createStatement(
         StringUtils.format(

--- a/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
+++ b/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.audit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.inject.Inject;
 import org.apache.druid.audit.AuditEntry;
@@ -90,22 +91,28 @@ public class SQLAuditManager implements AuditManager
     );
   }
 
-  @Override
-  public void doAudit(AuditEntry auditEntry, Handle handle) throws IOException
+  @VisibleForTesting
+  ServiceMetricEvent.Builder getAuditMetricEventBuilder(AuditEntry auditEntry)
   {
     ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder()
-                                                .setDimension("key", auditEntry.getKey())
-                                                .setDimension("type", auditEntry.getType())
-                                                .setDimension("author", auditEntry.getAuditInfo().getAuthor())
-                                                .setDimension("comment", auditEntry.getAuditInfo().getComment())
-                                                .setDimension("remote_address", auditEntry.getAuditInfo().getIp())
-                                                .setDimension("created_date", auditEntry.getAuditTime().toString());
+            .setDimension("key", auditEntry.getKey())
+            .setDimension("type", auditEntry.getType())
+            .setDimension("author", auditEntry.getAuditInfo().getAuthor())
+            .setDimension("comment", auditEntry.getAuditInfo().getComment())
+            .setDimension("remote_address", auditEntry.getAuditInfo().getIp())
+            .setDimension("created_date", auditEntry.getAuditTime().toString());
 
-    if (config.getAddPayloadToAuditMetricDimension()) {
+    if (config.getIncludePayloadAsDimensionInMetric()) {
       builder.setDimension("payload", auditEntry.getPayload());
     }
 
-    emitter.emit(builder.build("config/audit", 1));
+    return builder;
+  }
+
+  @Override
+  public void doAudit(AuditEntry auditEntry, Handle handle) throws IOException
+  {
+    emitter.emit(getAuditMetricEventBuilder(auditEntry).build("config/audit", 1));
 
     handle.createStatement(
         StringUtils.format(

--- a/server/src/main/java/org/apache/druid/server/audit/SQLAuditManagerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/audit/SQLAuditManagerConfig.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.server.audit;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -31,16 +30,6 @@ public class SQLAuditManagerConfig
 
   @JsonProperty
   private boolean includePayloadAsDimensionInMetric = false;
-
-  @JsonCreator
-  public SQLAuditManagerConfig(
-          @JsonProperty("auditHistoryMillis") long auditHistoryMillis,
-          @JsonProperty("includePayloadAsDimensionInMetric") boolean includePayloadAsDimensionInMetric
-  )
-  {
-    this.auditHistoryMillis = auditHistoryMillis;
-    this.includePayloadAsDimensionInMetric = includePayloadAsDimensionInMetric;
-  }
 
   public long getAuditHistoryMillis()
   {

--- a/server/src/main/java/org/apache/druid/server/audit/SQLAuditManagerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/audit/SQLAuditManagerConfig.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.audit;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -29,15 +30,25 @@ public class SQLAuditManagerConfig
   private long auditHistoryMillis = 7 * 24 * 60 * 60 * 1000L; // 1 WEEK
 
   @JsonProperty
-  private boolean addPayloadToAuditMetricDimension = false;
+  private boolean includePayloadAsDimensionInMetric = false;
+
+  @JsonCreator
+  public SQLAuditManagerConfig(
+          @JsonProperty("auditHistoryMillis") long auditHistoryMillis,
+          @JsonProperty("includePayloadAsDimensionInMetric") boolean includePayloadAsDimensionInMetric
+  )
+  {
+    this.auditHistoryMillis = auditHistoryMillis;
+    this.includePayloadAsDimensionInMetric = includePayloadAsDimensionInMetric;
+  }
 
   public long getAuditHistoryMillis()
   {
     return auditHistoryMillis;
   }
 
-  public boolean getAddPayloadToAuditMetricDimension()
+  public boolean getIncludePayloadAsDimensionInMetric()
   {
-    return addPayloadToAuditMetricDimension;
+    return includePayloadAsDimensionInMetric;
   }
 }

--- a/server/src/main/java/org/apache/druid/server/audit/SQLAuditManagerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/audit/SQLAuditManagerConfig.java
@@ -28,8 +28,16 @@ public class SQLAuditManagerConfig
   @JsonProperty
   private long auditHistoryMillis = 7 * 24 * 60 * 60 * 1000L; // 1 WEEK
 
+  @JsonProperty
+  private boolean addPayloadToAuditMetricDimension = false;
+
   public long getAuditHistoryMillis()
   {
     return auditHistoryMillis;
+  }
+
+  public boolean getAddPayloadToAuditMetricDimension()
+  {
+    return addPayloadToAuditMetricDimension;
   }
 }

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -69,7 +69,7 @@ public class SQLMetadataRuleManagerTest
         Suppliers.ofInstance(tablesConfig),
         new NoopServiceEmitter(),
         mapper,
-        new SQLAuditManagerConfig(7 * 24 * 60 * 60 * 1000L, false)
+        new SQLAuditManagerConfig()
     );
 
     connector.createRulesTable();

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -69,7 +69,7 @@ public class SQLMetadataRuleManagerTest
         Suppliers.ofInstance(tablesConfig),
         new NoopServiceEmitter(),
         mapper,
-        new SQLAuditManagerConfig()
+        new SQLAuditManagerConfig(7 * 24 * 60 * 60 * 1000L, false)
     );
 
     connector.createRulesTable();

--- a/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.junit.After;
@@ -47,6 +48,7 @@ public class SQLAuditManagerTest
 
   private TestDerbyConnector connector;
   private AuditManager auditManager;
+  private final String PAYLOAD_DIMENSION_KEY = "payload";
 
   private final ObjectMapper mapper = new DefaultObjectMapper();
 
@@ -60,7 +62,7 @@ public class SQLAuditManagerTest
         derbyConnectorRule.metadataTablesConfigSupplier(),
         new NoopServiceEmitter(),
         mapper,
-        new SQLAuditManagerConfig()
+        new SQLAuditManagerConfig(7 * 24 * 60 * 60 * 1000L, false)
     );
   }
 
@@ -81,6 +83,36 @@ public class SQLAuditManagerTest
     ObjectMapper mapper = new DefaultObjectMapper();
     AuditEntry serde = mapper.readValue(mapper.writeValueAsString(entry), AuditEntry.class);
     Assert.assertEquals(entry, serde);
+  }
+
+  @Test
+  public void testAuditMetricEventBuilderConfig() throws IOException
+  {
+    AuditEntry entry = new AuditEntry(
+            "testKey",
+            "testType",
+            new AuditInfo(
+                    "testAuthor",
+                    "testComment",
+                    "127.0.0.1"
+            ),
+            "testPayload",
+            DateTimes.of("2013-01-01T00:00:00Z")
+    );
+
+    SQLAuditManager auditManagerWithPayloadAsDimension = new SQLAuditManager(
+            connector,
+            derbyConnectorRule.metadataTablesConfigSupplier(),
+            new NoopServiceEmitter(),
+            mapper,
+            new SQLAuditManagerConfig(10, true)
+    );
+
+    ServiceMetricEvent.Builder auditEntryBuilder = ((SQLAuditManager) auditManager).getAuditMetricEventBuilder(entry);
+    Assert.assertEquals(null, auditEntryBuilder.getDimension(PAYLOAD_DIMENSION_KEY));
+
+    ServiceMetricEvent.Builder auditEntryBuilderWithPayload = auditManagerWithPayloadAsDimension.getAuditMetricEventBuilder(entry);
+    Assert.assertEquals("testPayload", auditEntryBuilderWithPayload.getDimension(PAYLOAD_DIMENSION_KEY));
   }
 
   @Test(timeout = 60_000L)

--- a/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
@@ -62,7 +62,7 @@ public class SQLAuditManagerTest
         derbyConnectorRule.metadataTablesConfigSupplier(),
         new NoopServiceEmitter(),
         mapper,
-        new SQLAuditManagerConfig(7 * 24 * 60 * 60 * 1000L, false)
+        new SQLAuditManagerConfig()
     );
   }
 
@@ -86,7 +86,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  public void testAuditMetricEventBuilderConfig() throws IOException
+  public void testAuditMetricEventBuilderConfig()
   {
     AuditEntry entry = new AuditEntry(
             "testKey",
@@ -101,11 +101,18 @@ public class SQLAuditManagerTest
     );
 
     SQLAuditManager auditManagerWithPayloadAsDimension = new SQLAuditManager(
-            connector,
-            derbyConnectorRule.metadataTablesConfigSupplier(),
-            new NoopServiceEmitter(),
-            mapper,
-            new SQLAuditManagerConfig(10, true)
+        connector,
+        derbyConnectorRule.metadataTablesConfigSupplier(),
+        new NoopServiceEmitter(),
+        mapper,
+        new SQLAuditManagerConfig()
+        {
+          @Override
+          public boolean getIncludePayloadAsDimensionInMetric()
+          {
+            return true;
+          }
+        }
     );
 
     ServiceMetricEvent.Builder auditEntryBuilder = ((SQLAuditManager) auditManager).getAuditMetricEventBuilder(entry);


### PR DESCRIPTION
Fixes #10372.

Adding more dimensions to the service metric for audit log

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.