### PR TITLE
Fix typo

### DIFF
--- a/docs/operations/pull-deps.md
+++ b/docs/operations/pull-deps.md
@@ -27,7 +27,7 @@ title: "pull-deps tool"
 
 `pull-deps` has several command line options, they are as follows:
 
-`-c` or `--coordinate` (Can be specified multiply times)
+`-c` or `--coordinate` (Can be specified multiple times)
 
 Extension coordinate to pull down, followed by a maven coordinate, e.g. org.apache.druid.extensions:mysql-metadata-storage
 


### PR DESCRIPTION
### Description

Fixed a typo in documentation for pull-deps tool.

<hr>

This PR has:
- [x] been self-reviewed.(Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
