### PR TITLE
Skip coverage check for tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,11 +149,14 @@ jobs:
         - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
         - free -m
         - ${MVN} -pl ${MAVEN_PROJECTS} jacoco:report
-        # Add merge target branch to determine diff (see https://github.com/travis-ci/travis-ci/issues/6069)
+        # Add merge target branch to determine diff (see https://github.com/travis-ci/travis-ci/issues/6069).
+        # This is not needed for build triggered by tags, since there will be no code diff.
         - echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}"  # for debugging
-        - git remote set-branches --add origin ${TRAVIS_BRANCH} && git fetch
+        - if [[ -z "${TRAVIS_TAG}" ]]; then git remote set-branches --add origin ${TRAVIS_BRANCH} && git fetch; fi
         # Determine the modified files that match the maven projects being tested. We use maven project lists that
         # either exclude (starts with "!") or include (does not start with "!"), so both cases need to be handled.
+        # If the build is triggered by a tag, an error will be printed, but `all_files` will be correctly set to empty
+        # so that the coverage check is skipped.
         - all_files="$(git diff --name-only origin/${TRAVIS_BRANCH}...HEAD | grep "\.java$" || [[ $? == 1 ]])"
         - for f in ${all_files}; do echo $f; done  # for debugging
         - >


### PR DESCRIPTION
### Description

The code coverage diff calculation assumes the `TRAVIS_BRANCH` environment variable is the name of a branch; however, for tag builds it is the name of the tag so the diff calculation fails. Since builds triggered by tags do not have a code diff, the coverage check should be skipped to avoid the error and to save some CI resources.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] tested new tag does not cause coverage check to fail:
   - https://travis-ci.org/github/ccaominh/druid/builds/726445429
- [x] tested coverage check is still able to flag uncovered changes in PR:
   - https://github.com/ccaominh/druid/pull/5
   - https://travis-ci.org/github/ccaominh/druid/jobs/726474544