### PR TITLE
Issue fix  for CSV loading with header and skip header not parsing well.

### DIFF
--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespaceTest.java
@@ -96,7 +96,25 @@ public class UriExtractionNamespaceTest
     );
     Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
   }
-
+  @Test
+  public void testCSVWithHeader()
+  {
+    UriExtractionNamespace.CSVFlatDataParser parser = new UriExtractionNamespace.CSVFlatDataParser(
+        ImmutableList.of("col1", "col2", "col3"),
+        "col2",
+        "col3",
+        true,
+        1
+    );
+    // parser return empyt list as the 1 row header need to be skipped.
+    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("row to skip "));
+    //Header also need to be skipped.
+    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("col1,col2,col3"));
+    // test the header is parsed
+    Assert.assertEquals(ImmutableList.of("col1", "col2", "col3"), parser.getParser().getFieldNames());
+    // The third row will parse to data
+    Assert.assertEquals(ImmutableMap.of("val2", "val3"), parser.getParser().parseToMap("val1,val2,val3"));
+  }
   @Test(expected = IllegalArgumentException.class)
   public void testBadCSV()
   {
@@ -144,6 +162,26 @@ public class UriExtractionNamespaceTest
         "\\u0002", "col2",
         "col3"
     );
+    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A\\u0001B\\u0001C"));
+  }
+  @Test
+  public void testWithHeaderAndListDelimiterTSV()
+  {
+    UriExtractionNamespace.TSVFlatDataParser parser = new UriExtractionNamespace.TSVFlatDataParser(
+        ImmutableList.of("col1", "col2", "col3"),
+        "\\u0001",
+        "\\u0002", "col2",
+        "col3",
+        true,
+        1
+    );
+    // skipping one row
+    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("Skipping some rows"));
+    // skip the header as well
+    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("col1\\u0001col2\\u0001col3"));
+    // test if the headers are parsed well.
+    Assert.assertEquals(ImmutableList.of("col1", "col2", "col3"), parser.getParser().getFieldNames());
+    // test if the data row is parsed correctly
     Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A\\u0001B\\u0001C"));
   }
 


### PR DESCRIPTION
Fixes #10393.

### Description

This PR fixes the bug while loading the lookup from CSV file or from TSV file .   The root reason is because after initializing the parser startFileFromBeginning was not called.  This method initialize  hasParsedHeader and skippedHeaderRows . 
This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `UriExtractionNamespace`
 * `UriExtractionNamespaceTest`

