### PR TITLE
Web console: clean up styling imports

### DIFF
--- a/web-console/src/blueprint-overrides/_index.scss
+++ b/web-console/src/blueprint-overrides/_index.scss
@@ -16,18 +16,4 @@
  * limitations under the License.
  */
 
-.spec-dialog {
-  &.bp3-dialog {
-    top: 5%;
-    width: 90%;
-  }
-
-  .spec-dialog-textarea {
-    background-color: #232c35;
-    margin-bottom: 10px;
-
-    .ace-solarized-dark {
-      background-color: #232c35;
-    }
-  }
-}
+@import "common/colors";

--- a/web-console/src/blueprint-overrides/_index.scss
+++ b/web-console/src/blueprint-overrides/_index.scss
@@ -16,4 +16,4 @@
  * limitations under the License.
  */
 
-@import "common/colors";
+@import 'common/colors';

--- a/web-console/src/blueprint-overrides/common/_colors.scss
+++ b/web-console/src/blueprint-overrides/common/_colors.scss
@@ -16,18 +16,8 @@
  * limitations under the License.
  */
 
-.spec-dialog {
-  &.bp3-dialog {
-    top: 5%;
-    width: 90%;
-  }
-
-  .spec-dialog-textarea {
-    background-color: #232c35;
-    margin-bottom: 10px;
-
-    .ace-solarized-dark {
-      background-color: #232c35;
-    }
-  }
-}
+$blue1: #0e5a8a;
+$blue2: #106ba3;
+$blue3: #137cbe; // Changed as a proof of concept
+$blue4: #2b95d6;
+$blue5: #48aff0;

--- a/web-console/src/components/auto-form/auto-form.scss
+++ b/web-console/src/components/auto-form/auto-form.scss
@@ -17,8 +17,8 @@
  */
 
 .auto-form {
-  .ace_scroller {
-    background-color: #212c36;
+  .ace-solarized-dark {
+    background-color: #212e37;
   }
 
   // Popover in info label

--- a/web-console/src/dialogs/lookup-edit-dialog/lookup-edit-dialog.scss
+++ b/web-console/src/dialogs/lookup-edit-dialog/lookup-edit-dialog.scss
@@ -33,7 +33,7 @@
     margin-bottom: 5px;
   }
 
-  .ace_scroller {
+  .ace-solarized-dark {
     background-color: #232c35;
   }
 

--- a/web-console/src/entry.scss
+++ b/web-console/src/entry.scss
@@ -17,8 +17,9 @@
  */
 
 @import '../node_modules/normalize.css/normalize';
-@import '../node_modules/@blueprintjs/core/lib/css/blueprint';
-@import '../node_modules/@blueprintjs/datetime/lib/css/blueprint-datetime';
+@import './blueprint-overrides';
+@import '~@blueprintjs/core/src/blueprint';
+@import '~@blueprintjs/datetime/src/blueprint-datetime';
 @import '../lib/react-table';
 @import '../node_modules/react-splitter-layout/lib/index.css';
 

--- a/web-console/src/views/load-data-view/load-data-view.scss
+++ b/web-console/src/views/load-data-view/load-data-view.scss
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+@import '~@blueprintjs/core/src/common/colors';
 @import '../../variables';
 
 .load-data-view {
@@ -258,7 +259,7 @@
   }
 
   .edit-controls {
-    background: #30404c;
+    background: rgba($gray3, 0.15);
     padding: 10px;
     border-radius: 2px;
     margin-bottom: 15px;
@@ -282,5 +283,9 @@
     position: absolute;
     width: 100%;
     height: 100% !important;
+  }
+
+  .ace-solarized-dark {
+    background-color: #232c35;
   }
 }

--- a/web-console/src/views/query-view/query-input/query-input.scss
+++ b/web-console/src/views/query-view/query-input/query-input.scss
@@ -24,7 +24,7 @@
     width: 100%;
     height: 100%;
 
-    .ace_scroller {
+    .ace-solarized-dark {
       background-color: #232c35;
     }
 


### PR DESCRIPTION
This PR makes changes the blueprint style imports from css to the scss source this allows us to override their styles as needed. A proof of concept override is also supplied by changing one of the 'blue' colors by the smallest increment (not noticeable in practice). Some other colors are fixed as well.

This PR sets up the framework that can be used to better style the console.