### PR TITLE
Add last_compaction_state to sys.segments table

### DIFF
--- a/core/src/main/java/org/apache/druid/timeline/DataSegment.java
+++ b/core/src/main/java/org/apache/druid/timeline/DataSegment.java
@@ -100,7 +100,7 @@ public class DataSegment implements Comparable<DataSegment>, Overshadowable<Data
   /**
    * Stores some configurations of the compaction task which created this segment.
    * This field is filled in the metadata store only when "storeCompactionState" is set true in the context of the
-   * compaction task (true by default).
+   * task. True by default see {@link org.apache.druid.indexing.common.task.Tasks#DEFAULT_STORE_COMPACTION_STATE}.
    * Also, this field can be pruned in many Druid modules when this class is loaded from the metadata store.
    * See {@link PruneLastCompactionState} for details.
    */

--- a/core/src/main/java/org/apache/druid/timeline/DataSegment.java
+++ b/core/src/main/java/org/apache/druid/timeline/DataSegment.java
@@ -100,7 +100,7 @@ public class DataSegment implements Comparable<DataSegment>, Overshadowable<Data
   /**
    * Stores some configurations of the compaction task which created this segment.
    * This field is filled in the metadata store only when "storeCompactionState" is set true in the context of the
-   * compaction task which is false by default.
+   * compaction task (true by default).
    * Also, this field can be pruned in many Druid modules when this class is loaded from the metadata store.
    * See {@link PruneLastCompactionState} for details.
    */

--- a/core/src/main/java/org/apache/druid/timeline/PruneLastCompactionState.java
+++ b/core/src/main/java/org/apache/druid/timeline/PruneLastCompactionState.java
@@ -33,6 +33,8 @@ import java.lang.annotation.Target;
  *
  * - In auto compaction of the coordinator, "lastCompactionState" is used to determine whether the given
  *   segment needs further compaction or not.
+ * - In Metadata store information API of the coordinator, "lastCompactionState" is used to determine whether the
+ *   is compacted or not
  * - In parallel indexing, "lastCompactionState" should be serialized and deserialized properly when
  *   the sub tasks report the pushed segments to the supervisor task.
  */

--- a/core/src/main/java/org/apache/druid/timeline/PruneLastCompactionState.java
+++ b/core/src/main/java/org/apache/druid/timeline/PruneLastCompactionState.java
@@ -33,8 +33,7 @@ import java.lang.annotation.Target;
  *
  * - In auto compaction of the coordinator, "lastCompactionState" is used to determine whether the given
  *   segment needs further compaction or not.
- * - In Metadata store information API of the coordinator, "lastCompactionState" is used to determine whether the
- *   is compacted or not
+ * - In Metadata store information API of the coordinator, "lastCompactionState" is part of the sys.segments table
  * - In parallel indexing, "lastCompactionState" should be serialized and deserialized properly when
  *   the sub tasks report the pushed segments to the supervisor task.
  */

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -1086,7 +1086,7 @@ Segments table provides details on all Druid segments, whether they are publishe
 |shardSpec|STRING|The toString of specific `ShardSpec`|
 |dimensions|STRING|The dimensions of the segment|
 |metrics|STRING|The metrics of the segment|
-|is_compacted|LONG|Boolean is represented as long type where 1 = true, 0 = false. 1 if this segment was compacted, and 0 if this segment was not compacted yet. Note that this does not imply that the segment was compacted with the current config in auto compaction and hence, the segment may still be picked up by auto compaction|
+|last_compaction_state|STRING|The configurations of the compaction task which created this segment. May be null if segment was not created by compaction task.|
 
 For example to retrieve all segments for datasource "wikipedia", use the query:
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -1086,6 +1086,7 @@ Segments table provides details on all Druid segments, whether they are publishe
 |shardSpec|STRING|The toString of specific `ShardSpec`|
 |dimensions|STRING|The dimensions of the segment|
 |metrics|STRING|The metrics of the segment|
+|is_compacted|LONG|Boolean is represented as long type where 1 = true, 0 = false. 1 if this segment was compacted, and 0 if this segment was not compacted yet. Note that this does not imply that the segment was compacted with the current config in auto compaction and hence, the segment may still be picked up by auto compaction|
 
 For example to retrieve all segments for datasource "wikipedia", use the query:
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -1108,6 +1108,18 @@ GROUP BY 1
 ORDER BY 2 DESC
 ```
 
+If you want to retrieve segment that was compacted (ANY compaction):
+
+```sql
+SELECT * FROM sys.segments WHERE last_compaction_state is not null
+```
+
+or if you want to retrieve segment that was compacted only by a particular compaction spec (such as that of the auto compaction):
+
+```sql
+SELECT * FROM sys.segments WHERE last_compaction_state == 'SELECT * FROM sys.segments where last_compaction_state = 'CompactionState{partitionsSpec=DynamicPartitionsSpec{maxRowsPerSegment=5000000, maxTotalRows=9223372036854775807}, indexSpec={bitmap={type=roaring, compressRunOnSerialization=true}, dimensionCompression=lz4, metricCompression=lz4, longEncoding=longs, segmentLoader=null}}'
+```
+
 *Caveat:* Note that a segment can be served by more than one stream ingestion tasks or Historical processes, in that case it would have multiple replicas. These replicas are weakly consistent with each other when served by multiple ingestion tasks, until a segment is eventually served by a Historical, at that point the segment is immutable. Broker prefers to query a segment from Historical over an ingestion task. But if a segment has multiple realtime replicas, for e.g.. Kafka index tasks, and one task is slower than other, then the sys.segments query results can vary for the duration of the tasks because only one of the ingestion tasks is queried by the Broker and it is not guaranteed that the same task gets picked every time. The `num_rows` column of segments table can have inconsistent values during this period. There is an open [issue](https://github.com/apache/druid/issues/5915) about this inconsistency with stream ingestion tasks.
 
 #### SERVERS table

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -422,6 +422,7 @@ public class CompactionTask extends AbstractBatchIndexTask
   {
     final Map<String, Object> newContext = new HashMap<>(getContext());
     newContext.put(CTX_KEY_APPENDERATOR_TRACKING_TASK_ID, getId());
+    newContext.put(CompactSegments.STORE_COMPACTION_STATE_KEY, getContextValue(Tasks.STORE_COMPACTION_STATE_KEY, true));
     // Set the priority of the compaction task.
     newContext.put(Tasks.PRIORITY_KEY, getPriority());
     return newContext;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -126,6 +126,8 @@ public class CompactionTask extends AbstractBatchIndexTask
 
   private static final String TYPE = "compact";
 
+  private static final boolean STORE_COMPACTION_STATE = true;
+
   static {
     Verify.verify(TYPE.equals(CompactSegments.COMPACTION_TASK_TYPE));
   }
@@ -422,7 +424,7 @@ public class CompactionTask extends AbstractBatchIndexTask
   {
     final Map<String, Object> newContext = new HashMap<>(getContext());
     newContext.put(CTX_KEY_APPENDERATOR_TRACKING_TASK_ID, getId());
-    newContext.put(CompactSegments.STORE_COMPACTION_STATE_KEY, getContextValue(Tasks.STORE_COMPACTION_STATE_KEY, true));
+    newContext.putIfAbsent(CompactSegments.STORE_COMPACTION_STATE_KEY, STORE_COMPACTION_STATE);
     // Set the priority of the compaction task.
     newContext.put(Tasks.PRIORITY_KEY, getPriority());
     return newContext;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
@@ -45,13 +45,13 @@ public class Tasks
   public static final int DEFAULT_TASK_PRIORITY = 0;
   public static final long DEFAULT_LOCK_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
   public static final boolean DEFAULT_FORCE_TIME_CHUNK_LOCK = true;
-  public static final boolean DEFAULT_STORE_COMPACTION_STATE = false;
+  public static final boolean DEFAULT_STORE_COMPACTION_STATE = true;
 
   public static final String PRIORITY_KEY = "priority";
   public static final String LOCK_TIMEOUT_KEY = "taskLockTimeout";
   public static final String FORCE_TIME_CHUNK_LOCK_KEY = "forceTimeChunkLock";
   /**
-   * This context is used in auto compaction. When it is set in the context, the segments created by the task
+   * This context is used in compaction. When it is set in the context, the segments created by the task
    * will fill 'lastCompactionState' in its metadata. This will be used to track what segments are compacted or not.
    * See {@link org.apache.druid.timeline.DataSegment} and {@link
    * org.apache.druid.server.coordinator.duty.NewestSegmentFirstIterator} for more details.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
@@ -45,7 +45,7 @@ public class Tasks
   public static final int DEFAULT_TASK_PRIORITY = 0;
   public static final long DEFAULT_LOCK_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
   public static final boolean DEFAULT_FORCE_TIME_CHUNK_LOCK = true;
-  public static final boolean DEFAULT_STORE_COMPACTION_STATE = true;
+  public static final boolean DEFAULT_STORE_COMPACTION_STATE = false;
 
   public static final String PRIORITY_KEY = "priority";
   public static final String LOCK_TIMEOUT_KEY = "taskLockTimeout";

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -130,6 +130,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
       false,
       0
   );
+
+  // Expecte compaction state to exist after compaction as we store compaction state by default
   private static CompactionState DEFAULT_COMPACTION_STATE;
 
   private static final List<String> TEST_ROWS = ImmutableList.of(
@@ -853,7 +855,6 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final TaskToolbox box = createTaskToolbox(objectMapper, task);
 
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    task.addToContext(Tasks.STORE_COMPACTION_STATE_KEY, true);
     if (task.isReady(box.getTaskActionClient())) {
       if (readyLatchToCountDown != null) {
         readyLatchToCountDown.countDown();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -763,6 +763,9 @@ public class CompactionTaskRunTest extends IngestionTestBase
         null
     );
 
+    // This is a regular index so we need to explicitly add this context to store the CompactionState
+    indexTask.addToContext(Tasks.STORE_COMPACTION_STATE_KEY, true);
+
     final Pair<TaskStatus, List<DataSegment>> resultPair = runTask(indexTask);
 
     Assert.assertTrue(resultPair.lhs.isSuccess());

--- a/integration-tests/src/test/resources/results/auth_test_sys_schema_segments.json
+++ b/integration-tests/src/test/resources/results/auth_test_sys_schema_segments.json
@@ -15,6 +15,7 @@
     "is_overshadowed": 0,
     "shardSpec": "NoneShardSpec",
     "dimensions": "[anonymous, area_code, city, continent_code, country_name, dma_code, geo, language, namespace, network, newpage, page, postal_code, region_lookup, robot, unpatrolled, user]",
-    "metrics": "[added, count, deleted, delta, delta_hist, unique_users, variation]"
+    "metrics": "[added, count, deleted, delta, delta_hist, unique_users, variation]",
+    "last_compaction_state": null
   }
 ]

--- a/services/src/main/java/org/apache/druid/cli/CliBroker.java
+++ b/services/src/main/java/org/apache/druid/cli/CliBroker.java
@@ -67,7 +67,6 @@ import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.apache.druid.server.metrics.QueryCountStatsProvider;
 import org.apache.druid.server.router.TieredBrokerConfig;
 import org.apache.druid.sql.guice.SqlModule;
-import org.apache.druid.timeline.PruneLastCompactionState;
 import org.apache.druid.timeline.PruneLoadSpec;
 import org.eclipse.jetty.server.Server;
 
@@ -102,7 +101,6 @@ public class CliBroker extends ServerRunnable
           binder.bindConstant().annotatedWith(Names.named("servicePort")).to(8082);
           binder.bindConstant().annotatedWith(Names.named("tlsServicePort")).to(8282);
           binder.bindConstant().annotatedWith(PruneLoadSpec.class).to(true);
-          binder.bindConstant().annotatedWith(PruneLastCompactionState.class).to(true);
           binder.bind(ResponseContextConfig.class).toInstance(ResponseContextConfig.newConfig(false));
 
           binder.bind(CachingClusteredClient.class).in(LazySingleton.class);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -126,6 +126,8 @@ public class SystemSchema extends AbstractSchema
   private static final long IS_AVAILABLE_TRUE = 1L;
   private static final long IS_OVERSHADOWED_FALSE = 0L;
   private static final long IS_OVERSHADOWED_TRUE = 1L;
+  private static final long IS_COMPACTED_FALSE = 0L;
+  private static final long IS_COMPACTED_TRUE = 1L;
 
   static final RowSignature SEGMENTS_SIGNATURE = RowSignature
       .builder()
@@ -145,6 +147,7 @@ public class SystemSchema extends AbstractSchema
       .add("shardSpec", ValueType.STRING)
       .add("dimensions", ValueType.STRING)
       .add("metrics", ValueType.STRING)
+      .add("is_compacted", ValueType.LONG)
       .build();
 
   static final RowSignature SERVERS_SIGNATURE = RowSignature
@@ -311,7 +314,8 @@ public class SystemSchema extends AbstractSchema
                 val.isOvershadowed() ? IS_OVERSHADOWED_TRUE : IS_OVERSHADOWED_FALSE,
                 segment.getShardSpec(),
                 segment.getDimensions(),
-                segment.getMetrics()
+                segment.getMetrics(),
+                segment.getLastCompactionState() == null ? IS_COMPACTED_FALSE : IS_COMPACTED_TRUE
             };
           });
 
@@ -343,7 +347,8 @@ public class SystemSchema extends AbstractSchema
                 IS_OVERSHADOWED_FALSE, // there is an assumption here that unpublished segments are never overshadowed
                 val.getValue().getSegment().getShardSpec(),
                 val.getValue().getSegment().getDimensions(),
-                val.getValue().getSegment().getMetrics()
+                val.getValue().getSegment().getMetrics(),
+                IS_COMPACTED_FALSE // unpublished segments from realtime tasks cannot be compacted yet
             };
           });
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -126,8 +126,6 @@ public class SystemSchema extends AbstractSchema
   private static final long IS_AVAILABLE_TRUE = 1L;
   private static final long IS_OVERSHADOWED_FALSE = 0L;
   private static final long IS_OVERSHADOWED_TRUE = 1L;
-  private static final long IS_COMPACTED_FALSE = 0L;
-  private static final long IS_COMPACTED_TRUE = 1L;
 
   static final RowSignature SEGMENTS_SIGNATURE = RowSignature
       .builder()
@@ -147,7 +145,7 @@ public class SystemSchema extends AbstractSchema
       .add("shardSpec", ValueType.STRING)
       .add("dimensions", ValueType.STRING)
       .add("metrics", ValueType.STRING)
-      .add("is_compacted", ValueType.LONG)
+      .add("last_compaction_state", ValueType.STRING)
       .build();
 
   static final RowSignature SERVERS_SIGNATURE = RowSignature
@@ -315,7 +313,7 @@ public class SystemSchema extends AbstractSchema
                 segment.getShardSpec(),
                 segment.getDimensions(),
                 segment.getMetrics(),
-                segment.getLastCompactionState() == null ? IS_COMPACTED_FALSE : IS_COMPACTED_TRUE
+                segment.getLastCompactionState()
             };
           });
 
@@ -348,7 +346,7 @@ public class SystemSchema extends AbstractSchema
                 val.getValue().getSegment().getShardSpec(),
                 val.getValue().getSegment().getDimensions(),
                 val.getValue().getSegment().getMetrics(),
-                IS_COMPACTED_FALSE // unpublished segments from realtime tasks cannot be compacted yet
+                null // unpublished segments from realtime tasks will not be compacted yet
             };
           });
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -273,6 +273,10 @@ public class SystemSchemaTest extends CalciteTestBase
     );
   }
 
+  private final CompactionState expectedCompactionState = new CompactionState(
+      new DynamicPartitionsSpec(null, null),
+      Collections.singletonMap("test", "map")
+  );
 
   private final DataSegment publishedCompactedSegment1 = new DataSegment(
       "wikipedia1",
@@ -282,10 +286,7 @@ public class SystemSchemaTest extends CalciteTestBase
       ImmutableList.of("dim1", "dim2"),
       ImmutableList.of("met1", "met2"),
       null,
-      new CompactionState(
-          new DynamicPartitionsSpec(null, null),
-          Collections.singletonMap("test", "map")
-      ),
+      expectedCompactionState,
       1,
       53000L
   );
@@ -297,10 +298,7 @@ public class SystemSchemaTest extends CalciteTestBase
       ImmutableList.of("dim1", "dim2"),
       ImmutableList.of("met1", "met2"),
       null,
-      new CompactionState(
-          new DynamicPartitionsSpec(null, null),
-          Collections.singletonMap("test", "map")
-      ),
+      expectedCompactionState,
       1,
       83000L
   );
@@ -588,7 +586,7 @@ public class SystemSchemaTest extends CalciteTestBase
         1L, //is_available
         0L, //is_realtime
         1L, //is_overshadowed
-        0L //is_compacted
+        null //is_compacted
     );
 
     verifyRow(
@@ -602,7 +600,7 @@ public class SystemSchemaTest extends CalciteTestBase
         1L, //is_available
         0L, //is_realtime
         0L, //is_overshadowed,
-        0L //is_compacted
+        null //is_compacted
     );
 
     //segment test3 is unpublished and has a NumberedShardSpec with partitionNum = 2
@@ -617,7 +615,7 @@ public class SystemSchemaTest extends CalciteTestBase
         1L, //is_available
         0L, //is_realtime
         0L, //is_overshadowed
-        0L //is_compacted
+        null //is_compacted
     );
 
     verifyRow(
@@ -631,7 +629,7 @@ public class SystemSchemaTest extends CalciteTestBase
         1L, //is_available
         1L, //is_realtime
         0L, //is_overshadowed
-        0L //is_compacted
+        null //is_compacted
     );
 
     verifyRow(
@@ -645,7 +643,7 @@ public class SystemSchemaTest extends CalciteTestBase
         1L, //is_available
         1L, //is_realtime
         0L, //is_overshadowed
-        0L //is_compacted
+        null //is_compacted
     );
 
     // wikipedia segments are published and unavailable, num_replicas is 0
@@ -661,7 +659,7 @@ public class SystemSchemaTest extends CalciteTestBase
         0L, //is_available
         0L, //is_realtime
         1L, //is_overshadowed
-        1L //is_compacted
+        expectedCompactionState //is_compacted
     );
 
     verifyRow(
@@ -675,7 +673,7 @@ public class SystemSchemaTest extends CalciteTestBase
         0L, //is_available
         0L, //is_realtime
         0L, //is_overshadowed
-        1L //is_compacted
+        expectedCompactionState //is_compacted
     );
 
     verifyRow(
@@ -689,7 +687,7 @@ public class SystemSchemaTest extends CalciteTestBase
         0L, //is_available
         0L, //is_realtime
         0L, //is_overshadowed
-        0L //is_compacted
+        null //is_compacted
     );
 
     // Verify value types.
@@ -707,7 +705,7 @@ public class SystemSchemaTest extends CalciteTestBase
       long isAvailable,
       long isRealtime,
       long isOvershadowed,
-      long isCompacted
+      CompactionState compactionState
   )
   {
     Assert.assertEquals(segmentId, row[0].toString());
@@ -724,7 +722,7 @@ public class SystemSchemaTest extends CalciteTestBase
     Assert.assertEquals(isAvailable, row[10]);
     Assert.assertEquals(isRealtime, row[11]);
     Assert.assertEquals(isOvershadowed, row[12]);
-    Assert.assertEquals(isCompacted, row[16]);
+    Assert.assertEquals(compactionState, row[16]);
   }
 
   @Test
@@ -1293,6 +1291,8 @@ public class SystemSchemaTest extends CalciteTestBase
               expectedClass = SegmentId.class;
             } else if (signature.getColumnName(i).equals("shardSpec")) {
               expectedClass = ShardSpec.class;
+            } else if (signature.getColumnName(i).equals("last_compaction_state")) {
+              expectedClass = CompactionState.class;
             } else if (signature.getColumnName(i).equals("dimensions") || signature.getColumnName(i).equals("metrics")) {
               expectedClass = List.class;
             } else {

--- a/website/.spelling
+++ b/website/.spelling
@@ -1498,6 +1498,7 @@ is_overshadowed
 is_published
 is_realtime
 java.sql.Types
+last_compaction_state
 max_size
 num_replicas
 num_rows


### PR DESCRIPTION
Add last_compaction_state to sys.segments table

### Description

Segments being compacted or not compacted have a big impact on query performance. 
Currently it is not easy to verify questions like:
- if performance of query can be improve by compaction 
- if a performance of query is bad, was it because segments for that interval was not compacted.
- if a segment was compacted, what was it compacted with? was it compacted with the auto compaction config set?

This PR expose the lastCompactionState via the sys.segments table (so user can do query with slice/dice, group, time filter, etc) by using the lastCompactionState stored within the segment metadata. If a compactionState exist then the segment was compacted. This PR also change storing lastCompactionState as default for manual compaction in addition to auto compaction.

For example, if you want to know if the segment was compacted or not (ANY compaction), you can do `WHERE last_compaction_state is not null` and if you want to know if the segment was compacted with current auto compaction configs, you can do `WHERE last_compaction_state == '{current_auto_compact_config}'` 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
