### PR TITLE
Support to show leader of coordinators in `Services` web console view

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -559,7 +559,8 @@ public class SystemSchema extends AbstractSchema
     private static Object[] buildRowForLeader(DiscoveryDruidNode discoveryDruidNode, URL leader)
     {
       final DruidNode node = discoveryDruidNode.getDruidNode();
-      final boolean isLeader = node.getHost().equals(leader.getHost()) && node.getPortToUse() == leader.getPort();
+      final boolean isLeader = leader == null ?
+                               false : node.getPortToUse() == leader.getPort() && node.getHost().equals(leader.getHost());
       return new Object[]{
           node.getHostAndPortToUse(),
           node.getHost(),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -1014,6 +1014,7 @@ public class CalciteTests
           throw new UnsupportedOperationException();
         }
     );
+    druidLeaderClient.start();
 
     return new SystemSchema(
         druidSchema,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

This PR resolves #10329, which was proposed to show which coordinator node is the current leader on web console so that it saves us some time to find leader when addressing problems of druid clusters.

### Description

In this PR, only backend service is involved to meet this need. 

The `ServersTable` now requests leader information of coordinators and overlords and marks corresponding node as leader in the `Tier` field before returning the query results.

With this PR, Web console automatically shows the leader information in the `Service` view
![image](https://user-images.githubusercontent.com/6525742/93849891-9d964900-fcdf-11ea-99a9-3d158951f035.png)


<hr>

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
