### PR TITLE
Automatically determine numShards for parallel ingestion hash partitioning

### DIFF
--- a/core/src/main/java/org/apache/druid/indexer/partitions/HashedPartitionsSpec.java
+++ b/core/src/main/java/org/apache/druid/indexer/partitions/HashedPartitionsSpec.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 
 public class HashedPartitionsSpec implements DimensionBasedPartitionsSpec
 {
-  static final String NAME = "hashed";
+  public static final String NAME = "hashed";
   @VisibleForTesting
   static final String NUM_SHARDS = "numShards";
 
@@ -160,7 +160,7 @@ public class HashedPartitionsSpec implements DimensionBasedPartitionsSpec
   @Override
   public String getForceGuaranteedRollupIncompatiblityReason()
   {
-    return getNumShards() == null ? NUM_SHARDS + " must be specified" : FORCE_GUARANTEED_ROLLUP_COMPATIBLE;
+    return FORCE_GUARANTEED_ROLLUP_COMPATIBLE;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpec.java
@@ -159,7 +159,6 @@ public class HashBasedNumberedShardSpec extends NumberedShardSpec
     }
   }
 
-  @VisibleForTesting
   public static List<Object> getGroupKey(final List<String> partitionDimensions, final long timestamp, final InputRow inputRow)
   {
     if (partitionDimensions.isEmpty()) {

--- a/core/src/main/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpec.java
@@ -47,7 +47,7 @@ import java.util.Set;
 
 public class HashBasedNumberedShardSpec extends NumberedShardSpec
 {
-  static final List<String> DEFAULT_PARTITION_DIMENSIONS = ImmutableList.of();
+  public static final List<String> DEFAULT_PARTITION_DIMENSIONS = ImmutableList.of();
 
   private static final HashFunction HASH_FUNCTION = Hashing.murmur3_32();
 
@@ -160,7 +160,7 @@ public class HashBasedNumberedShardSpec extends NumberedShardSpec
   }
 
   @VisibleForTesting
-  static List<Object> getGroupKey(final List<String> partitionDimensions, final long timestamp, final InputRow inputRow)
+  public static List<Object> getGroupKey(final List<String> partitionDimensions, final long timestamp, final InputRow inputRow)
   {
     if (partitionDimensions.isEmpty()) {
       return Rows.toGroupKey(timestamp, inputRow);

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -294,16 +294,17 @@ How the worker task creates segments is:
 |property|description|default|required?|
 |--------|-----------|-------|---------|
 |type|This should always be `hashed`|none|yes|
-|numShards|Directly specify the number of shards to create. If this is specified and `intervals` is specified in the `granularitySpec`, the index task can skip the determine intervals/partitions pass through the data.|null|no|
+|numShards|Directly specify the number of shards to create. If this is specified and `intervals` is specified in the `granularitySpec`, the index task can skip the determine intervals/partitions pass through the data. This property and `targetRowsPerSegment` cannot both be set.|null|no|
 |partitionDimensions|The dimensions to partition on. Leave blank to select all dimensions.|null|no|
+|targetRowsPerSegment|A target row count for each partition. If `numShards` is left unspecified, the Parallel task will determine a partition count automatically such that each partition has a row count close to the target, assuming evenly distributed keys in the input data. A target per-segment row count of 5 million is used if both `numShards` and `targetRowsPerSegment` are null. |null (or 5,000,000 if both `numShards` and `targetRowsPerSegment` are null)|no|
 
 The Parallel task with hash-based partitioning is similar to [MapReduce](https://en.wikipedia.org/wiki/MapReduce).
-The task runs in up to 3 phases: `partial_dimension_cardinality`, `partial segment generation` and `partial segment merge`.
-- The `partial_dimension_cardinality` phase is an optional phase that only runs if `numShards` is not specified.
+The task runs in up to 3 phases: `partial dimension cardinality`, `partial segment generation` and `partial segment merge`.
+- The `partial dimension cardinality` phase is an optional phase that only runs if `numShards` is not specified.
 The Parallel task splits the input data and assigns them to worker tasks based on the split hint spec.
-Each worker task (type `partial_dimension_cardinality`) gathers estimates of partitioning dimensions cardinality for
+Each worker task (type `partial dimension cardinality`) gathers estimates of partitioning dimensions cardinality for
 each time chunk. The Parallel task will aggregate these estimates from the worker tasks and determine the highest
-cardinality across all of the time chunks in the input data, dividing this cardinality by `maxRowsPerSegment` to
+cardinality across all of the time chunks in the input data, dividing this cardinality by `targetRowsPerSegment` to
 automatically determine `numShards`.
 - In the `partial segment generation` phase, just like the Map phase in MapReduce,
 the Parallel task splits the input data based on the split hint spec

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -294,11 +294,17 @@ How the worker task creates segments is:
 |property|description|default|required?|
 |--------|-----------|-------|---------|
 |type|This should always be `hashed`|none|yes|
-|numShards|Directly specify the number of shards to create. If this is specified and `intervals` is specified in the `granularitySpec`, the index task can skip the determine intervals/partitions pass through the data.|null|yes|
+|numShards|Directly specify the number of shards to create. If this is specified and `intervals` is specified in the `granularitySpec`, the index task can skip the determine intervals/partitions pass through the data.|null|no|
 |partitionDimensions|The dimensions to partition on. Leave blank to select all dimensions.|null|no|
 
 The Parallel task with hash-based partitioning is similar to [MapReduce](https://en.wikipedia.org/wiki/MapReduce).
-The task runs in 2 phases, i.e., `partial segment generation` and `partial segment merge`.
+The task runs in up to 3 phases: `partial_dimension_cardinality`, `partial segment generation` and `partial segment merge`.
+- The `partial_dimension_cardinality` phase is an optional phase that only runs if `numShards` is not specified.
+The Parallel task splits the input data and assigns them to worker tasks based on the split hint spec.
+Each worker task (type `partial_dimension_cardinality`) gathers estimates of partitioning dimensions cardinality for
+each time chunk. The Parallel task will aggregate these estimates from the worker tasks and determine the highest
+cardinality across all of the time chunks in the input data, dividing this cardinality by `maxRowsPerSegment` to
+automatically determine `numShards`.
 - In the `partial segment generation` phase, just like the Map phase in MapReduce,
 the Parallel task splits the input data based on the split hint spec
 and assigns each split to a worker task. Each worker task (type `partial_index_generate`) reads the assigned split,

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -302,7 +302,7 @@ The Parallel task with hash-based partitioning is similar to [MapReduce](https:/
 The task runs in up to 3 phases: `partial dimension cardinality`, `partial segment generation` and `partial segment merge`.
 - The `partial dimension cardinality` phase is an optional phase that only runs if `numShards` is not specified.
 The Parallel task splits the input data and assigns them to worker tasks based on the split hint spec.
-Each worker task (type `partial dimension cardinality`) gathers estimates of partitioning dimensions cardinality for
+Each worker task (type `partial_dimension_cardinality`) gathers estimates of partitioning dimensions cardinality for
 each time chunk. The Parallel task will aggregate these estimates from the worker tasks and determine the highest
 cardinality across all of the time chunks in the input data, dividing this cardinality by `targetRowsPerSegment` to
 automatically determine `numShards`.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -131,8 +131,9 @@ import java.util.function.Predicate;
 
 public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
 {
+  public static final HashFunction HASH_FUNCTION = Hashing.murmur3_128();
+
   private static final Logger log = new Logger(IndexTask.class);
-  private static final HashFunction HASH_FUNCTION = Hashing.murmur3_128();
   private static final String TYPE = "index";
 
   private static String makeGroupId(IndexIngestionSpec ingestionSchema)
@@ -599,7 +600,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       if (partitionsSpec.getType() == SecondaryPartitionType.HASH) {
         return PartialHashSegmentGenerateTask.createHashPartitionAnalysisFromPartitionsSpec(
             granularitySpec,
-            (HashedPartitionsSpec) partitionsSpec
+            (HashedPartitionsSpec) partitionsSpec,
+            null // not overriding numShards
         );
       } else if (partitionsSpec.getType() == SecondaryPartitionType.LINEAR) {
         return createLinearPartitionAnalysis(granularitySpec, (DynamicPartitionsSpec) partitionsSpec);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -28,6 +28,7 @@ import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.batch.parallel.LegacySinglePhaseSubTask;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask;
+import org.apache.druid.indexing.common.task.batch.parallel.PartialDimensionCardinalityTask;
 import org.apache.druid.indexing.common.task.batch.parallel.PartialDimensionDistributionTask;
 import org.apache.druid.indexing.common.task.batch.parallel.PartialGenericSegmentMergeTask;
 import org.apache.druid.indexing.common.task.batch.parallel.PartialHashSegmentGenerateTask;
@@ -62,6 +63,7 @@ import java.util.Map;
     // for backward compatibility
     @Type(name = SinglePhaseSubTask.OLD_TYPE_NAME, value = LegacySinglePhaseSubTask.class),
     @Type(name = PartialHashSegmentGenerateTask.TYPE, value = PartialHashSegmentGenerateTask.class),
+    @Type(name = PartialDimensionCardinalityTask.TYPE, value = PartialDimensionCardinalityTask.class),
     @Type(name = PartialRangeSegmentGenerateTask.TYPE, value = PartialRangeSegmentGenerateTask.class),
     @Type(name = PartialDimensionDistributionTask.TYPE, value = PartialDimensionDistributionTask.class),
     @Type(name = PartialGenericSegmentMergeTask.TYPE, value = PartialGenericSegmentMergeTask.class),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReport.java
@@ -41,7 +41,7 @@ public class DimensionCardinalityReport implements SubTaskReport
   private final String taskId;
 
   /**
-   * A map of intervals to byte arrays, representing {@link org.apache.datasketches.hll.HllSketch} objects,
+   * A map of intervals to byte arrays, representing {@link HllSketch} objects,
    * serialized using {@link HllSketch#toCompactByteArray()}.
    *
    * The HllSketch objects should be created with the HLL_SKETCH_LOG_K constant defined in this class.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReport.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.hll.HyperLogLogCollector;
+import org.joda.time.Interval;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class DimensionCardinalityReport implements SubTaskReport
+{
+  static final String TYPE = "dimension_cardinality";
+  private static final String PROP_CARDINALITIES = "cardinalities";
+
+  private final String taskId;
+
+  /**
+   * A map of intervals to byte arrays, representing {@link org.apache.druid.hll.HyperLogLogCollector} objects,
+   * serialized using {@link HyperLogLogCollector#toByteArray()}.
+   *
+   * The collector is used to determine cardinality estimates for each interval.
+   */
+  private final Map<Interval, byte[]> intervalToCardinalities;
+
+  @JsonCreator
+  public DimensionCardinalityReport(
+      @JsonProperty("taskId") String taskId,
+      @JsonProperty(PROP_CARDINALITIES) Map<Interval, byte[]> intervalToCardinalities
+  )
+  {
+    this.taskId = taskId;
+    this.intervalToCardinalities = intervalToCardinalities;
+  }
+
+  @Override
+  @JsonProperty
+  public String getTaskId()
+  {
+    return taskId;
+  }
+
+  @JsonProperty(PROP_CARDINALITIES)
+  public Map<Interval, byte[]> getIntervalToCardinalities()
+  {
+    return intervalToCardinalities;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DimensionCardinalityReport{" +
+           "taskId='" + taskId + '\'' +
+           ", intervalToCardinalities=" + intervalToCardinalities +
+           '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DimensionCardinalityReport that = (DimensionCardinalityReport) o;
+    return Objects.equals(getTaskId(), that.getTaskId()) &&
+           Objects.equals(getIntervalToCardinalities(), that.getIntervalToCardinalities());
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(getTaskId(), getIntervalToCardinalities());
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReport.java
@@ -35,7 +35,7 @@ public class DimensionCardinalityReport implements SubTaskReport
   private final String taskId;
 
   /**
-   * A map of intervals to byte arrays, representing {@link org.apache.druid.hll.HyperLogLogCollector} objects,
+   * A map of intervals to byte arrays, representing {@link HyperLogLogCollector} objects,
    * serialized using {@link HyperLogLogCollector#toByteArray()}.
    *
    * The collector is used to determine cardinality estimates for each interval.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -530,7 +530,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
     final Integer numShardsOverride;
     HashedPartitionsSpec partitionsSpec = (HashedPartitionsSpec) ingestionSchema.getTuningConfig().getPartitionsSpec();
-    if (ingestionSchema.getTuningConfig().isForceGuaranteedRollup() && partitionsSpec.getNumShards() == null) {
+    if (partitionsSpec.getNumShards() == null) {
       // 0. need to determine numShards by scanning the data
       ParallelIndexTaskRunner<PartialDimensionCardinalityTask, DimensionCardinalityReport> cardinalityRunner =
           createRunner(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -675,7 +675,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     });
 
     // determine the highest cardinality in any interval
-    long maxCardinality = Long.MIN_VALUE;
+    long maxCardinality = 0;
     for (Union union : finalCollectors.values()) {
       maxCardinality = Math.max(maxCardinality, (long) union.getEstimate());
     }
@@ -692,7 +692,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       return Math.toIntExact(numShards);
     }
     catch (ArithmeticException ae) {
-      return Integer.MAX_VALUE;
+      throw new ISE("Estimated numShards [%s] exceeds integer bounds.", numShards);
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -523,7 +523,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     if (!(ingestionSchema.getTuningConfig().getPartitionsSpec() instanceof HashedPartitionsSpec)) {
       // only range and hash partitioning is supported for multiphase parallel ingestion, see runMultiPhaseParallel()
       throw new ISE(
-          "forceGuaranteedRollup is set but partitionsSpec [%s] is not a ranged or hash partition spec.",
+          "forceGuaranteedRollup is set but partitionsSpec [%s] is not a single_dim or hash partition spec.",
           ingestionSchema.getTuningConfig().getPartitionsSpec()
       );
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityParallelIndexTaskRunner.java
@@ -25,26 +25,29 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import java.util.Map;
 
 /**
- * {@link ParallelIndexTaskRunner} for the phase to create hash partitioned segments in multi-phase parallel indexing.
+ * {@link ParallelIndexTaskRunner} for the phase to determine cardinalities of dimension values in
+ * multi-phase parallel indexing.
  */
-class PartialHashSegmentGenerateParallelIndexTaskRunner
-    extends InputSourceSplitParallelIndexTaskRunner<PartialHashSegmentGenerateTask, GeneratedPartitionsReport<GenericPartitionStat>>
+class PartialDimensionCardinalityParallelIndexTaskRunner
+    extends InputSourceSplitParallelIndexTaskRunner<PartialDimensionCardinalityTask, DimensionCardinalityReport>
 {
-  private static final String PHASE_NAME = "partial segment generation";
+  private static final String PHASE_NAME = "partial dimension cardinality";
 
-  private Integer numShardsOverride;
-
-  PartialHashSegmentGenerateParallelIndexTaskRunner(
+  PartialDimensionCardinalityParallelIndexTaskRunner(
       TaskToolbox toolbox,
       String taskId,
       String groupId,
       ParallelIndexIngestionSpec ingestionSchema,
-      Map<String, Object> context,
-      Integer numShardsOverride
+      Map<String, Object> context
   )
   {
-    super(toolbox, taskId, groupId, ingestionSchema, context);
-    this.numShardsOverride = numShardsOverride;
+    super(
+        toolbox,
+        taskId,
+        groupId,
+        ingestionSchema,
+        context
+    );
   }
 
   @Override
@@ -54,7 +57,7 @@ class PartialHashSegmentGenerateParallelIndexTaskRunner
   }
 
   @Override
-  SubTaskSpec<PartialHashSegmentGenerateTask> createSubTaskSpec(
+  SubTaskSpec<PartialDimensionCardinalityTask> createSubTaskSpec(
       String id,
       String groupId,
       String supervisorTaskId,
@@ -63,7 +66,7 @@ class PartialHashSegmentGenerateParallelIndexTaskRunner
       ParallelIndexIngestionSpec subTaskIngestionSpec
   )
   {
-    return new SubTaskSpec<PartialHashSegmentGenerateTask>(
+    return new SubTaskSpec<PartialDimensionCardinalityTask>(
         id,
         groupId,
         supervisorTaskId,
@@ -72,17 +75,17 @@ class PartialHashSegmentGenerateParallelIndexTaskRunner
     )
     {
       @Override
-      public PartialHashSegmentGenerateTask newSubTask(int numAttempts)
+      public PartialDimensionCardinalityTask newSubTask(int numAttempts)
       {
-        return new PartialHashSegmentGenerateTask(
+        return new PartialDimensionCardinalityTask(
             null,
-            groupId,
+            getGroupId(),
             null,
-            supervisorTaskId,
+            getSupervisorTaskId(),
             numAttempts,
             subTaskIngestionSpec,
-            context,
-            numShardsOverride
+            getContext(),
+            getToolbox().getJsonMapper()
         );
       }
     };

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import org.apache.druid.data.input.HandlingInputRowIterator;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputSource;
+import org.apache.druid.hll.HyperLogLogCollector;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.task.AbstractBatchIndexTask;
+import org.apache.druid.indexing.common.task.ClientBasedTaskInfoProvider;
+import org.apache.druid.indexing.common.task.IndexTask;
+import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.common.task.batch.parallel.iterator.DefaultIndexTaskInputRowIteratorBuilder;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.segment.incremental.ParseExceptionHandler;
+import org.apache.druid.segment.incremental.RowIngestionMeters;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.indexing.granularity.GranularitySpec;
+import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
+{
+  public static final String TYPE = "partial_dimension_cardinality";
+  private static final Logger LOG = new Logger(PartialDimensionCardinalityTask.class);
+
+  private final int numAttempts;
+  private final ParallelIndexIngestionSpec ingestionSchema;
+  private final String supervisorTaskId;
+
+  private final ObjectMapper jsonMapper;
+
+  @JsonCreator
+  PartialDimensionCardinalityTask(
+      // id shouldn't be null except when this task is created by ParallelIndexSupervisorTask
+      @JsonProperty("id") @Nullable String id,
+      @JsonProperty("groupId") final String groupId,
+      @JsonProperty("resource") final TaskResource taskResource,
+      @JsonProperty("supervisorTaskId") final String supervisorTaskId,
+      @JsonProperty("numAttempts") final int numAttempts, // zero-based counting
+      @JsonProperty("spec") final ParallelIndexIngestionSpec ingestionSchema,
+      @JsonProperty("context") final Map<String, Object> context,
+      @JacksonInject ObjectMapper jsonMapper
+  )
+  {
+    super(
+        getOrMakeId(id, TYPE, ingestionSchema.getDataSchema().getDataSource()),
+        groupId,
+        taskResource,
+        ingestionSchema.getDataSchema(),
+        ingestionSchema.getTuningConfig(),
+        context
+    );
+
+    Preconditions.checkArgument(
+        ingestionSchema.getTuningConfig().getPartitionsSpec() instanceof HashedPartitionsSpec,
+        "%s partitionsSpec required",
+        HashedPartitionsSpec.NAME
+    );
+
+    this.numAttempts = numAttempts;
+    this.ingestionSchema = ingestionSchema;
+    this.supervisorTaskId = supervisorTaskId;
+    this.jsonMapper = jsonMapper;
+  }
+
+  @JsonProperty
+  private int getNumAttempts()
+  {
+    return numAttempts;
+  }
+
+  @JsonProperty("spec")
+  private ParallelIndexIngestionSpec getIngestionSchema()
+  {
+    return ingestionSchema;
+  }
+
+  @JsonProperty
+  private String getSupervisorTaskId()
+  {
+    return supervisorTaskId;
+  }
+
+  @Override
+  public String getType()
+  {
+    return TYPE;
+  }
+
+  @Override
+  public boolean isReady(TaskActionClient taskActionClient) throws Exception
+  {
+    return tryTimeChunkLock(
+        taskActionClient,
+        getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals()
+    );
+  }
+
+  @Override
+  public TaskStatus runTask(TaskToolbox toolbox) throws Exception
+  {
+    DataSchema dataSchema = ingestionSchema.getDataSchema();
+    GranularitySpec granularitySpec = dataSchema.getGranularitySpec();
+    ParallelIndexTuningConfig tuningConfig = ingestionSchema.getTuningConfig();
+
+    HashedPartitionsSpec partitionsSpec = (HashedPartitionsSpec) tuningConfig.getPartitionsSpec();
+    Preconditions.checkNotNull(partitionsSpec, "partitionsSpec required in tuningConfig");
+
+    List<String> partitionDimensions = partitionsSpec.getPartitionDimensions();
+    if (partitionDimensions == null) {
+      partitionDimensions = HashBasedNumberedShardSpec.DEFAULT_PARTITION_DIMENSIONS;
+    }
+
+    InputSource inputSource = ingestionSchema.getIOConfig().getNonNullInputSource(
+        ingestionSchema.getDataSchema().getParser()
+    );
+    InputFormat inputFormat = inputSource.needsFormat()
+                              ? ParallelIndexSupervisorTask.getInputFormat(ingestionSchema)
+                              : null;
+    final RowIngestionMeters buildSegmentsMeters = toolbox.getRowIngestionMetersFactory().createRowIngestionMeters();
+    final ParseExceptionHandler parseExceptionHandler = new ParseExceptionHandler(
+        buildSegmentsMeters,
+        tuningConfig.isLogParseExceptions(),
+        tuningConfig.getMaxParseExceptions(),
+        tuningConfig.getMaxSavedParseExceptions()
+    );
+
+    try (
+        final CloseableIterator<InputRow> inputRowIterator = AbstractBatchIndexTask.inputSourceReader(
+            toolbox.getIndexingTmpDir(),
+            dataSchema,
+            inputSource,
+            inputFormat,
+            AbstractBatchIndexTask.defaultRowFilter(granularitySpec),
+            buildSegmentsMeters,
+            parseExceptionHandler
+        );
+        HandlingInputRowIterator iterator =
+            new DefaultIndexTaskInputRowIteratorBuilder()
+                .delegate(inputRowIterator)
+                .granularitySpec(granularitySpec)
+                .build()
+    ) {
+      Map<Interval, byte[]> cardinalities = determineCardinalities(
+          iterator,
+          granularitySpec,
+          partitionDimensions
+      );
+
+      sendReport(
+          toolbox,
+          new DimensionCardinalityReport(getId(), cardinalities)
+      );
+    }
+
+    return TaskStatus.success(getId());
+  }
+
+  private Map<Interval, byte[]> determineCardinalities(
+      HandlingInputRowIterator inputRowIterator,
+      GranularitySpec granularitySpec,
+      List<String> partitionDimensions
+  )
+  {
+    Map<Interval, HyperLogLogCollector> intervalToCardinalities = new HashMap<>();
+    while (inputRowIterator.hasNext()) {
+      InputRow inputRow = inputRowIterator.next();
+      if (inputRow == null) {
+        continue;
+      }
+
+      DateTime timestamp = inputRow.getTimestamp();
+
+      //noinspection OptionalGetWithoutIsPresent (InputRowIterator returns rows with present intervals)
+      Interval interval = granularitySpec.bucketInterval(timestamp).get();
+
+      LOG.info("TS: " + timestamp + " INTV: " + interval + " GSC: " + granularitySpec.getClass());
+
+      HyperLogLogCollector hllCollector = intervalToCardinalities.computeIfAbsent(
+          interval,
+          (intervalKey) -> {
+            return HyperLogLogCollector.makeLatestCollector();
+          }
+      );
+
+      List<Object> groupKey = HashBasedNumberedShardSpec.getGroupKey(
+          partitionDimensions,
+          interval.getStartMillis(),
+          inputRow
+      );
+
+      try {
+        hllCollector.add(
+            IndexTask.HASH_FUNCTION.hashBytes(jsonMapper.writeValueAsBytes(groupKey)).asBytes()
+        );
+      }
+      catch (JsonProcessingException jpe) {
+        throw new RuntimeException(jpe);
+      }
+    }
+
+    // Serialize the collectors for sending to the supervisor task
+    Map<Interval, byte[]> newMap = new HashMap<>();
+    for (Map.Entry<Interval, HyperLogLogCollector> entry : intervalToCardinalities.entrySet()) {
+      newMap.put(entry.getKey(), entry.getValue().toByteArray());
+    }
+    return newMap;
+  }
+
+  private void sendReport(TaskToolbox toolbox, DimensionCardinalityReport report)
+  {
+    final ParallelIndexSupervisorTaskClient taskClient = toolbox.getSupervisorTaskClientFactory().build(
+        new ClientBasedTaskInfoProvider(toolbox.getIndexingServiceClient()),
+        getId(),
+        1, // always use a single http thread
+        ingestionSchema.getTuningConfig().getChatHandlerTimeout(),
+        ingestionSchema.getTuningConfig().getChatHandlerNumRetries()
+    );
+    taskClient.report(supervisorTaskId, report);
+  }
+
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
@@ -206,11 +206,8 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
       }
 
       DateTime timestamp = inputRow.getTimestamp();
-
       //noinspection OptionalGetWithoutIsPresent (InputRowIterator returns rows with present intervals)
       Interval interval = granularitySpec.bucketInterval(timestamp).get();
-
-      LOG.info("TS: " + timestamp + " INTV: " + interval + " GSC: " + granularitySpec.getClass());
 
       HyperLogLogCollector hllCollector = intervalToCardinalities.computeIfAbsent(
           interval,
@@ -218,7 +215,6 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
             return HyperLogLogCollector.makeLatestCollector();
           }
       );
-
       List<Object> groupKey = HashBasedNumberedShardSpec.getGroupKey(
           partitionDimensions,
           interval.getStartMillis(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
@@ -36,6 +36,7 @@ import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.task.AbstractBatchIndexTask;
 import org.apache.druid.indexing.common.task.ClientBasedTaskInfoProvider;
 import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
@@ -197,6 +198,7 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
       DateTime timestamp = inputRow.getTimestamp();
       //noinspection OptionalGetWithoutIsPresent (InputRowIterator returns rows with present intervals)
       Interval interval = granularitySpec.bucketInterval(timestamp).get();
+      Granularity queryGranularity = granularitySpec.getQueryGranularity();
 
       HllSketch hllSketch = intervalToCardinalities.computeIfAbsent(
           interval,
@@ -206,7 +208,7 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
       );
       List<Object> groupKey = HashBasedNumberedShardSpec.getGroupKey(
           partitionDimensions,
-          interval.getStartMillis(),
+          queryGranularity.bucketStart(timestamp).getMillis(),
           inputRow
       );
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
@@ -114,12 +114,6 @@ public class PartialHashSegmentGenerateTask extends PartialSegmentGenerateTask<G
   @Override
   public boolean isReady(TaskActionClient taskActionClient) throws Exception
   {
-    // If numShardsOverride is set, this indicates that we ran a cardinality scanning phase before this,
-    // so we already have the locks.
-    if (numShardsOverride != null) {
-      return true;
-    }
-
     return tryTimeChunkLock(
         taskActionClient,
         getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
@@ -114,6 +114,12 @@ public class PartialHashSegmentGenerateTask extends PartialSegmentGenerateTask<G
   @Override
   public boolean isReady(TaskActionClient taskActionClient) throws Exception
   {
+    // If numShardsOverride is set, this indicates that we ran a cardinality scanning phase before this,
+    // so we already have the locks.
+    if (numShardsOverride != null) {
+      return true;
+    }
+
     return tryTimeChunkLock(
         taskActionClient,
         getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SubTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SubTaskReport.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 @JsonSubTypes(value = {
     @Type(name = PushedSegmentsReport.TYPE, value = PushedSegmentsReport.class),
     @Type(name = DimensionDistributionReport.TYPE, value = DimensionDistributionReport.class),
+    @Type(name = DimensionCardinalityReport.TYPE, value = DimensionCardinalityReport.class),
     @Type(name = GeneratedPartitionsMetadataReport.TYPE, value = GeneratedPartitionsMetadataReport.class)
 })
 public interface SubTaskReport

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -535,7 +535,8 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         new NamedType(PartialHashSegmentGenerateTask.class, PartialHashSegmentGenerateTask.TYPE),
         new NamedType(PartialRangeSegmentGenerateTask.class, PartialRangeSegmentGenerateTask.TYPE),
         new NamedType(PartialGenericSegmentMergeTask.class, PartialGenericSegmentMergeTask.TYPE),
-        new NamedType(PartialDimensionDistributionTask.class, PartialDimensionDistributionTask.TYPE)
+        new NamedType(PartialDimensionDistributionTask.class, PartialDimensionDistributionTask.TYPE),
+        new NamedType(PartialDimensionCardinalityTask.class, PartialDimensionCardinalityTask.TYPE)
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.datasketches.hll.HllSketch;
 import org.apache.druid.hll.HyperLogLogCollector;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.java.util.common.Intervals;
@@ -71,38 +72,38 @@ public class DimensionCardinalityReportTest
   {
     List<DimensionCardinalityReport> reports = new ArrayList<>();
 
-    HyperLogLogCollector collector1 = HyperLogLogCollector.makeLatestCollector();
-    collector1.add(IndexTask.HASH_FUNCTION.hashLong(1L).asBytes());
-    collector1.add(IndexTask.HASH_FUNCTION.hashLong(200L).asBytes());
+    HllSketch collector1 = DimensionCardinalityReport.createHllSketchForReport();
+    collector1.update(IndexTask.HASH_FUNCTION.hashLong(1L).asBytes());
+    collector1.update(IndexTask.HASH_FUNCTION.hashLong(200L).asBytes());
     DimensionCardinalityReport report1 = new DimensionCardinalityReport(
         "taskA",
         ImmutableMap.of(
             Intervals.of("1970-01-01T00:00:00.000Z/1970-01-02T00:00:00.000Z"),
-            collector1.toByteArray()
+            collector1.toCompactByteArray()
         )
     );
     reports.add(report1);
 
-    HyperLogLogCollector collector2 = HyperLogLogCollector.makeLatestCollector();
-    collector2.add(IndexTask.HASH_FUNCTION.hashLong(1000L).asBytes());
-    collector2.add(IndexTask.HASH_FUNCTION.hashLong(30000L).asBytes());
+    HllSketch collector2 = DimensionCardinalityReport.createHllSketchForReport();
+    collector2.update(IndexTask.HASH_FUNCTION.hashLong(1000L).asBytes());
+    collector2.update(IndexTask.HASH_FUNCTION.hashLong(30000L).asBytes());
     DimensionCardinalityReport report2 = new DimensionCardinalityReport(
         "taskB",
         ImmutableMap.of(
             Intervals.of("1970-01-01T00:00:00.000Z/1970-01-02T00:00:00.000Z"),
-            collector2.toByteArray()
+            collector2.toCompactByteArray()
         )
     );
     reports.add(report2);
 
     // Separate interval with only 1 value
-    HyperLogLogCollector collector3 = HyperLogLogCollector.makeLatestCollector();
-    collector3.add(IndexTask.HASH_FUNCTION.hashLong(99000L).asBytes());
+    HllSketch collector3 = DimensionCardinalityReport.createHllSketchForReport();
+    collector3.update(IndexTask.HASH_FUNCTION.hashLong(99000L).asBytes());
     DimensionCardinalityReport report3 = new DimensionCardinalityReport(
         "taskC",
         ImmutableMap.of(
             Intervals.of("1970-01-02T00:00:00.000Z/1970-01-03T00:00:00.000Z"),
-            collector3.toByteArray()
+            collector3.toCompactByteArray()
         )
     );
     reports.add(report3);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
@@ -61,7 +61,7 @@ public class DimensionCardinalityReportTest
   @Test
   public void abidesEqualsContract()
   {
-    EqualsVerifier.forClass(DimensionDistributionReport.class)
+    EqualsVerifier.forClass(DimensionCardinalityReport.class)
                   .usingGetClass()
                   .verify();
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.hll.HyperLogLogCollector;
+import org.apache.druid.indexing.common.task.IndexTask;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.segment.TestHelper;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DimensionCardinalityReportTest
+{
+  private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();
+
+  private DimensionCardinalityReport target;
+
+  @Before
+  public void setup()
+  {
+    Interval interval = Intervals.ETERNITY;
+    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    Map<Interval, byte[]> intervalToCardinality = Collections.singletonMap(interval, collector.toByteArray());
+    String taskId = "abc";
+    target = new DimensionCardinalityReport(taskId, intervalToCardinality);
+  }
+
+  @Test
+  public void serializesDeserializes()
+  {
+    TestHelper.testSerializesDeserializes(OBJECT_MAPPER, target);
+  }
+
+  @Test
+  public void abidesEqualsContract()
+  {
+    EqualsVerifier.forClass(DimensionDistributionReport.class)
+                  .usingGetClass()
+                  .verify();
+  }
+
+  @Test
+  public void testSupervisorDetermineNumShardsFromCardinalityReport()
+  {
+    List<DimensionCardinalityReport> reports = new ArrayList<>();
+
+    HyperLogLogCollector collector1 = HyperLogLogCollector.makeLatestCollector();
+    collector1.add(IndexTask.HASH_FUNCTION.hashLong(1L).asBytes());
+    collector1.add(IndexTask.HASH_FUNCTION.hashLong(200L).asBytes());
+    DimensionCardinalityReport report1 = new DimensionCardinalityReport(
+        "taskA",
+        ImmutableMap.of(
+            Intervals.of("1970-01-01T00:00:00.000Z/1970-01-02T00:00:00.000Z"),
+            collector1.toByteArray()
+        )
+    );
+    reports.add(report1);
+
+    HyperLogLogCollector collector2 = HyperLogLogCollector.makeLatestCollector();
+    collector2.add(IndexTask.HASH_FUNCTION.hashLong(1000L).asBytes());
+    collector2.add(IndexTask.HASH_FUNCTION.hashLong(30000L).asBytes());
+    DimensionCardinalityReport report2 = new DimensionCardinalityReport(
+        "taskB",
+        ImmutableMap.of(
+            Intervals.of("1970-01-01T00:00:00.000Z/1970-01-02T00:00:00.000Z"),
+            collector2.toByteArray()
+        )
+    );
+    reports.add(report2);
+
+    // Separate interval with only 1 value
+    HyperLogLogCollector collector3 = HyperLogLogCollector.makeLatestCollector();
+    collector3.add(IndexTask.HASH_FUNCTION.hashLong(99000L).asBytes());
+    DimensionCardinalityReport report3 = new DimensionCardinalityReport(
+        "taskC",
+        ImmutableMap.of(
+            Intervals.of("1970-01-02T00:00:00.000Z/1970-01-03T00:00:00.000Z"),
+            collector3.toByteArray()
+        )
+    );
+    reports.add(report3);
+
+    // first interval in test has cardinality 4
+    int numShards = ParallelIndexSupervisorTask.determineNumShardsFromCardinalityReport(
+        reports,
+        1
+    );
+    Assert.assertEquals(4L, numShards);
+
+    numShards = ParallelIndexSupervisorTask.determineNumShardsFromCardinalityReport(
+        reports,
+        2
+    );
+    Assert.assertEquals(2L, numShards);
+
+    numShards = ParallelIndexSupervisorTask.determineNumShardsFromCardinalityReport(
+        reports,
+        3
+    );
+    Assert.assertEquals(2L, numShards);
+
+    numShards = ParallelIndexSupervisorTask.determineNumShardsFromCardinalityReport(
+        reports,
+        4
+    );
+    Assert.assertEquals(1L, numShards);
+
+    numShards = ParallelIndexSupervisorTask.determineNumShardsFromCardinalityReport(
+        reports,
+        5
+    );
+    Assert.assertEquals(1L, numShards);
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LocalInputSource;
@@ -55,6 +56,10 @@ import java.util.Map;
 
 public class ParallelIndexSupervisorTaskSerdeTest
 {
+  static {
+    NullHandling.initializeForTests();
+  }
+
   private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
   private static final List<Interval> INTERVALS = Collections.singletonList(Intervals.of("2018/2019"));
 
@@ -108,13 +113,8 @@ public class ParallelIndexSupervisorTaskSerdeTest
   @Test
   public void forceGuaranteedRollupWithHashPartitionsMissingNumShards()
   {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage(
-        "forceGuaranteedRollup is incompatible with partitionsSpec: numShards must be specified"
-    );
-
     Integer numShards = null;
-    new ParallelIndexSupervisorTaskBuilder()
+    ParallelIndexSupervisorTask task = new ParallelIndexSupervisorTaskBuilder()
         .ingestionSpec(
             new ParallelIndexIngestionSpecBuilder()
                 .forceGuaranteedRollup(true)
@@ -123,6 +123,9 @@ public class ParallelIndexSupervisorTaskSerdeTest
                 .build()
         )
         .build();
+
+    PartitionsSpec partitionsSpec = task.getIngestionSchema().getTuningConfig().getPartitionsSpec();
+    Assert.assertThat(partitionsSpec, CoreMatchers.instanceOf(HashedPartitionsSpec.class));
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -98,7 +98,7 @@ public class PartialDimensionCardinalityTaskTest
       exception.expect(IllegalArgumentException.class);
       exception.expectMessage("hashed partitionsSpec required");
 
-      PartitionsSpec partitionsSpec = new SingleDimensionPartitionsSpec(null, 1, null, false);
+      PartitionsSpec partitionsSpec = new SingleDimensionPartitionsSpec(null, 1, "a", false);
       ParallelIndexTuningConfig tuningConfig =
           new ParallelIndexTestingFactory.TuningConfigBuilder().partitionsSpec(partitionsSpec).build();
 
@@ -134,7 +134,7 @@ public class PartialDimensionCardinalityTaskTest
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .id(ParallelIndexTestingFactory.AUTOMATIC_ID)
           .build();
-      Assert.assertThat(task.getId(), Matchers.startsWith(PartialDimensionDistributionTask.TYPE));
+      Assert.assertThat(task.getId(), Matchers.startsWith(PartialDimensionCardinalityTask.TYPE));
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.apache.druid.client.indexing.NoopIndexingServiceClient;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputSource;
+import org.apache.druid.data.input.impl.InlineInputSource;
+import org.apache.druid.hll.HyperLogLogCollector;
+import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
+import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
+import org.apache.druid.indexing.common.TaskInfoProvider;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
+import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.incremental.ParseExceptionHandler;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
+import org.apache.druid.testing.junit.LoggerCaptureRule;
+import org.apache.logging.log4j.core.LogEvent;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.hamcrest.Matchers;
+import org.joda.time.Duration;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(Enclosed.class)
+public class PartialDimensionCardinalityTaskTest
+{
+  private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();
+  private static final HashedPartitionsSpec HASHED_PARTITIONS_SPEC = HashedPartitionsSpec.defaultSpec();
+
+  public static class ConstructorTest
+  {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void requiresForceGuaranteedRollup()
+    {
+      exception.expect(IllegalArgumentException.class);
+      exception.expectMessage("forceGuaranteedRollup must be set");
+
+      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
+          .forceGuaranteedRollup(false)
+          .partitionsSpec(new DynamicPartitionsSpec(null, null))
+          .build();
+
+      new PartialDimensionCardinalityTaskBuilder()
+          .tuningConfig(tuningConfig)
+          .build();
+    }
+
+    @Test
+    public void requiresHashedPartitions()
+    {
+      exception.expect(IllegalArgumentException.class);
+      exception.expectMessage("hashed partitionsSpec required");
+
+      PartitionsSpec partitionsSpec = new SingleDimensionPartitionsSpec(null, 1, null, false);
+      ParallelIndexTuningConfig tuningConfig =
+          new ParallelIndexTestingFactory.TuningConfigBuilder().partitionsSpec(partitionsSpec).build();
+
+      new PartialDimensionCardinalityTaskBuilder()
+          .tuningConfig(tuningConfig)
+          .build();
+    }
+
+    @Test
+    public void requiresGranularitySpecInputIntervals()
+    {
+      exception.expect(IllegalArgumentException.class);
+      exception.expectMessage("Missing intervals in granularitySpec");
+
+      DataSchema dataSchema = ParallelIndexTestingFactory.createDataSchema(Collections.emptyList());
+
+      new PartialDimensionCardinalityTaskBuilder()
+          .dataSchema(dataSchema)
+          .build();
+    }
+
+    @Test
+    public void serializesDeserializes()
+    {
+      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+          .build();
+      TestHelper.testSerializesDeserializes(OBJECT_MAPPER, task);
+    }
+
+    @Test
+    public void hasCorrectPrefixForAutomaticId()
+    {
+      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+          .id(ParallelIndexTestingFactory.AUTOMATIC_ID)
+          .build();
+      Assert.assertThat(task.getId(), Matchers.startsWith(PartialDimensionDistributionTask.TYPE));
+    }
+  }
+
+  public static class RunTaskTest
+  {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
+
+    private Capture<SubTaskReport> reportCapture;
+    private TaskToolbox taskToolbox;
+
+    @Before
+    public void setup()
+    {
+      reportCapture = Capture.newInstance();
+      ParallelIndexSupervisorTaskClient taskClient = EasyMock.mock(ParallelIndexSupervisorTaskClient.class);
+      taskClient.report(EasyMock.eq(ParallelIndexTestingFactory.SUPERVISOR_TASK_ID), EasyMock.capture(reportCapture));
+      EasyMock.replay(taskClient);
+      taskToolbox = EasyMock.mock(TaskToolbox.class);
+      EasyMock.expect(taskToolbox.getIndexingTmpDir()).andStubReturn(temporaryFolder.getRoot());
+      EasyMock.expect(taskToolbox.getSupervisorTaskClientFactory()).andReturn(
+          new IndexTaskClientFactory<ParallelIndexSupervisorTaskClient>()
+          {
+            @Override
+            public ParallelIndexSupervisorTaskClient build(
+                TaskInfoProvider taskInfoProvider,
+                String callerId,
+                int numThreads,
+                Duration httpTimeout,
+                long numRetries
+            )
+            {
+              return taskClient;
+            }
+          }
+      );
+      EasyMock.expect(taskToolbox.getIndexingServiceClient()).andReturn(new NoopIndexingServiceClient());
+      EasyMock.expect(taskToolbox.getRowIngestionMetersFactory()).andReturn(new DropwizardRowIngestionMetersFactory());
+      EasyMock.replay(taskToolbox);
+    }
+
+    @Test
+    public void requiresPartitionDimension() throws Exception
+    {
+      exception.expect(IllegalArgumentException.class);
+      exception.expectMessage("partitionDimension must be specified");
+
+      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
+          .partitionsSpec(
+              new ParallelIndexTestingFactory.SingleDimensionPartitionsSpecBuilder().partitionDimension(null).build()
+          )
+          .build();
+      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+          .tuningConfig(tuningConfig)
+          .build();
+
+      task.runTask(taskToolbox);
+    }
+
+    @Test
+    public void logsParseExceptionsIfEnabled() throws Exception
+    {
+      long invalidTimestamp = Long.MAX_VALUE;
+      InputSource inlineInputSource = new InlineInputSource(
+          ParallelIndexTestingFactory.createRow(invalidTimestamp, "a")
+      );
+      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
+          .partitionsSpec(HASHED_PARTITIONS_SPEC)
+          .logParseExceptions(true)
+          .build();
+      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+          .inputSource(inlineInputSource)
+          .tuningConfig(tuningConfig)
+          .build();
+
+      task.runTask(taskToolbox);
+
+      List<LogEvent> logEvents = logger.getLogEvents();
+      Assert.assertEquals(1, logEvents.size());
+      String logMessage = logEvents.get(0).getMessage().getFormattedMessage();
+      Assert.assertThat(logMessage, Matchers.containsString("Encountered parse exception"));
+    }
+
+    @Test
+    public void doesNotLogParseExceptionsIfDisabled() throws Exception
+    {
+      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
+          .partitionsSpec(HASHED_PARTITIONS_SPEC)
+          .logParseExceptions(false)
+          .build();
+      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+          .tuningConfig(tuningConfig)
+          .build();
+
+      task.runTask(taskToolbox);
+
+      Assert.assertEquals(Collections.emptyList(), logger.getLogEvents());
+    }
+
+    @Test
+    public void failsWhenTooManyParseExceptions() throws Exception
+    {
+      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
+          .partitionsSpec(HASHED_PARTITIONS_SPEC)
+          .maxParseExceptions(0)
+          .build();
+      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+          .tuningConfig(tuningConfig)
+          .build();
+
+      exception.expect(RuntimeException.class);
+      exception.expectMessage("Max parse exceptions[0] exceeded");
+
+      task.runTask(taskToolbox);
+    }
+
+    @Test
+    public void sendsCorrectReportWhenRowHasMultipleDimensionValues()
+    {
+      InputSource inlineInputSource = new InlineInputSource(
+          ParallelIndexTestingFactory.createRow(0, Arrays.asList("a", "b"))
+      );
+      PartialDimensionCardinalityTaskBuilder taskBuilder = new PartialDimensionCardinalityTaskBuilder()
+          .inputSource(inlineInputSource);
+
+      DimensionCardinalityReport report = runTask(taskBuilder);
+
+      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Map<Interval, byte[]> intervalToCardinalities = report.getIntervalToCardinalities();
+      byte[] hllCollectorBytes = Iterables.getOnlyElement(intervalToCardinalities.values());
+      HyperLogLogCollector hllCollector = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(hllCollectorBytes));
+      Assert.assertNotNull(hllCollector);
+      Assert.assertEquals(1L, hllCollector.estimateCardinalityRound());
+    }
+
+    @Test
+    public void sendsCorrectReportWithMultipleIntervalsInData()
+    {
+      InputSource inlineInputSource = new InlineInputSource(
+          ParallelIndexTestingFactory.createRow(1, "a") + "\n" +
+          ParallelIndexTestingFactory.createRow(100000000, "b") + "\n" +
+          ParallelIndexTestingFactory.createRow(100000002, "c")
+      );
+      PartialDimensionCardinalityTaskBuilder taskBuilder = new PartialDimensionCardinalityTaskBuilder()
+          .inputSource(inlineInputSource);
+
+      DimensionCardinalityReport report = runTask(taskBuilder);
+
+      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Map<Interval, byte[]> intervalToCardinalities = report.getIntervalToCardinalities();
+      Assert.assertEquals(2, intervalToCardinalities.size());
+
+      byte[] hllCollectorBytes;
+      HyperLogLogCollector hllCollector;
+      hllCollectorBytes = intervalToCardinalities.get(Intervals.of("1970-01-01T00:00:00.000Z/1970-01-02T00:00:00.000Z"));
+      hllCollector = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(hllCollectorBytes));
+      Assert.assertNotNull(hllCollector);
+      Assert.assertEquals(1L, hllCollector.estimateCardinalityRound());
+
+      hllCollectorBytes = intervalToCardinalities.get(Intervals.of("1970-01-02T00:00:00.000Z/1970-01-03T00:00:00.000Z"));
+      hllCollector = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(hllCollectorBytes));
+      Assert.assertNotNull(hllCollector);
+      Assert.assertEquals(2L, hllCollector.estimateCardinalityRound());
+    }
+
+    @Test
+    public void returnsSuccessIfNoExceptions() throws Exception
+    {
+      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+          .build();
+
+      TaskStatus taskStatus = task.runTask(taskToolbox);
+
+      Assert.assertEquals(ParallelIndexTestingFactory.ID, taskStatus.getId());
+      Assert.assertEquals(TaskState.SUCCESS, taskStatus.getStatusCode());
+    }
+
+    private DimensionCardinalityReport runTask(PartialDimensionCardinalityTaskBuilder taskBuilder)
+    {
+      try {
+        taskBuilder.build()
+                   .runTask(taskToolbox);
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+
+      return (DimensionCardinalityReport) reportCapture.getValue();
+    }
+  }
+
+  private static class PartialDimensionCardinalityTaskBuilder
+  {
+    private static final InputFormat INPUT_FORMAT = ParallelIndexTestingFactory.getInputFormat();
+
+    private String id = ParallelIndexTestingFactory.ID;
+    private InputSource inputSource = new InlineInputSource("row-with-invalid-timestamp");
+    private ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
+        .partitionsSpec(HASHED_PARTITIONS_SPEC)
+        .build();
+    private DataSchema dataSchema =
+        ParallelIndexTestingFactory
+            .createDataSchema(ParallelIndexTestingFactory.INPUT_INTERVALS)
+            .withGranularitySpec(
+                new UniformGranularitySpec(
+                    Granularities.DAY,
+                    Granularities.DAY,
+                    ImmutableList.of(Intervals.of("1970-01-01T00:00:00Z/P10D"))
+                )
+            );
+
+    @SuppressWarnings("SameParameterValue")
+    PartialDimensionCardinalityTaskBuilder id(String id)
+    {
+      this.id = id;
+      return this;
+    }
+
+    PartialDimensionCardinalityTaskBuilder inputSource(InputSource inputSource)
+    {
+      this.inputSource = inputSource;
+      return this;
+    }
+
+    PartialDimensionCardinalityTaskBuilder tuningConfig(ParallelIndexTuningConfig tuningConfig)
+    {
+      this.tuningConfig = tuningConfig;
+      return this;
+    }
+
+    PartialDimensionCardinalityTaskBuilder dataSchema(DataSchema dataSchema)
+    {
+      this.dataSchema = dataSchema;
+      return this;
+    }
+
+
+    PartialDimensionCardinalityTask build()
+    {
+      ParallelIndexIngestionSpec ingestionSpec =
+          ParallelIndexTestingFactory.createIngestionSpec(inputSource, INPUT_FORMAT, tuningConfig, dataSchema);
+
+      return new PartialDimensionCardinalityTask(
+          id,
+          ParallelIndexTestingFactory.GROUP_ID,
+          ParallelIndexTestingFactory.TASK_RESOURCE,
+          ParallelIndexTestingFactory.SUPERVISOR_TASK_ID,
+          ParallelIndexTestingFactory.NUM_ATTEMPTS,
+          ingestionSpec,
+          ParallelIndexTestingFactory.CONTEXT,
+          OBJECT_MAPPER
+      );
+    }
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
@@ -60,7 +60,8 @@ public class PartialHashSegmentGenerateTaskTest
         ParallelIndexTestingFactory.SUPERVISOR_TASK_ID,
         ParallelIndexTestingFactory.NUM_ATTEMPTS,
         INGESTION_SPEC,
-        ParallelIndexTestingFactory.CONTEXT
+        ParallelIndexTestingFactory.CONTEXT,
+        null
     );
   }
 
@@ -93,7 +94,8 @@ public class PartialHashSegmentGenerateTaskTest
                 Granularities.NONE,
                 intervals
             ),
-            new HashedPartitionsSpec(null, expectedNumBuckets, null)
+            new HashedPartitionsSpec(null, expectedNumBuckets, null),
+            null
         );
     Assert.assertEquals(intervals.size(), partitionAnalysis.getNumTimePartitions());
     for (Interval interval : intervals) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PerfectRollupWorkerTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PerfectRollupWorkerTaskTest.java
@@ -56,11 +56,8 @@ public class PerfectRollupWorkerTaskTest
   }
 
   @Test
-  public void failsWithInvalidPartitionsSpec()
+  public void succeedsWithUnspecifiedNumShards()
   {
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("forceGuaranteedRollup is incompatible with partitionsSpec");
-
     new PerfectRollupWorkerTaskBuilder()
         .partitionsSpec(HashedPartitionsSpec.defaultSpec())
         .build();

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.indexer.partitions.SecondaryPartitionType;
+import org.apache.druid.indexing.common.task.batch.parallel.PartialDimensionCardinalityTask;
 import org.apache.druid.indexing.common.task.batch.parallel.PartialDimensionDistributionTask;
 import org.apache.druid.indexing.common.task.batch.parallel.PartialGenericSegmentMergeTask;
 import org.apache.druid.indexing.common.task.batch.parallel.PartialHashSegmentGenerateTask;
@@ -321,6 +322,7 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
                     } else {
                       return t.getType().equalsIgnoreCase(PartialHashSegmentGenerateTask.TYPE)
                              || t.getType().equalsIgnoreCase(PartialDimensionDistributionTask.TYPE)
+                             || t.getType().equalsIgnoreCase(PartialDimensionCardinalityTask.TYPE)
                              || t.getType().equalsIgnoreCase(PartialRangeSegmentGenerateTask.TYPE)
                              || t.getType().equalsIgnoreCase(PartialGenericSegmentMergeTask.TYPE);
                     }


### PR DESCRIPTION
This PR allows parallel batch ingestion to automatically determine `numShards` when `forceGuaranteedRollup` is used with hash partitioning.

This is accomplished with a new phase of subtasks (`PartialDimensionCardinalityTask`). These subtasks build a map of `<Interval, HyperLogLogCollector>` where the HLL collector records the cardinality of the partitioning dimensions for each segment granularity interval in the input data.

The supervisor task aggregates the HLL collectors by interval, and determines the highest cardinality across all the intervals. This max cardinality is divided by `maxRowsPerSegment` to determine `numShards` automatically.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.