### PR TITLE
Add ingestion merge count metric

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -162,6 +162,7 @@ These metrics are only available if the RealtimeMetricsMonitor is included in th
 |`ingest/persists/backPressure`|Milliseconds spent creating persist tasks and blocking waiting for them to finish.|dataSource, taskId, taskType.|0 or very low|
 |`ingest/persists/failed`|Number of persists that failed.|dataSource, taskId, taskType.|0|
 |`ingest/handoff/failed`|Number of handoffs that failed.|dataSource, taskId, taskType.|0|
+|`ingest/merge/count`|Number of intermediate persists that have been merged into final segments that will be published.|dataSource, taskId, taskType.|Depends on configuration. Should be close to `ingest/persists/count`.|
 |`ingest/merge/time`|Milliseconds spent merging intermediate segments|dataSource, taskId, taskType.|Depends on configuration. Generally a few minutes at most.|
 |`ingest/merge/cpu`|Cpu time in Nanoseconds spent on merging intermediate segments.|dataSource, taskId, taskType.|Depends on configuration. Generally a few minutes at most.|
 |`ingest/handoff/count`|Number of handoffs that happened.|dataSource, taskId, taskType.|Varies. Generally greater than 0 once every segment granular period if cluster operating normally|

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/stats/TaskRealtimeMetricsMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/stats/TaskRealtimeMetricsMonitor.java
@@ -115,6 +115,7 @@ public class TaskRealtimeMetricsMonitor extends AbstractMonitor
     );
     emitter.emit(builder.build("ingest/persists/failed", metrics.failedPersists() - previousFireDepartmentMetrics.failedPersists()));
     emitter.emit(builder.build("ingest/handoff/failed", metrics.failedHandoffs() - previousFireDepartmentMetrics.failedHandoffs()));
+    emitter.emit(builder.build("ingest/merge/count", metrics.mergeCount() - previousFireDepartmentMetrics.mergeCount()));
     emitter.emit(builder.build("ingest/merge/time", metrics.mergeTimeMillis() - previousFireDepartmentMetrics.mergeTimeMillis()));
     emitter.emit(builder.build("ingest/merge/cpu", metrics.mergeCpuTime() - previousFireDepartmentMetrics.mergeCpuTime()));
     emitter.emit(builder.build("ingest/handoff/count", metrics.handOffCount() - previousFireDepartmentMetrics.handOffCount()));

--- a/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
@@ -38,6 +38,7 @@ public class FireDepartmentMetrics
   private final AtomicLong persistBackPressureMillis = new AtomicLong(0);
   private final AtomicLong failedPersists = new AtomicLong(0);
   private final AtomicLong failedHandoffs = new AtomicLong(0);
+  private final AtomicLong mergeCount = new AtomicLong(0);
   private final AtomicLong mergeTimeMillis = new AtomicLong(0);
   private final AtomicLong mergeCpuTime = new AtomicLong(0);
   private final AtomicLong persistCpuTime = new AtomicLong(0);
@@ -99,6 +100,11 @@ public class FireDepartmentMetrics
   public void incrementFailedHandoffs()
   {
     failedHandoffs.incrementAndGet();
+  }
+
+  public void incrementMergeCount(long count)
+  {
+    mergeCount.addAndGet(count);
   }
 
   public void incrementMergeTimeMillis(long millis)
@@ -186,6 +192,11 @@ public class FireDepartmentMetrics
     return failedHandoffs.get();
   }
 
+  public long mergeCount()
+  {
+    return mergeCount.get();
+  }
+
   public long mergeTimeMillis()
   {
     return mergeTimeMillis.get();
@@ -235,6 +246,7 @@ public class FireDepartmentMetrics
     retVal.persistBackPressureMillis.set(persistBackPressureMillis.get());
     retVal.failedPersists.set(failedPersists.get());
     retVal.failedHandoffs.set(failedHandoffs.get());
+    retVal.mergeCount.set(mergeCount.get());
     retVal.mergeTimeMillis.set(mergeTimeMillis.get());
     retVal.mergeCpuTime.set(mergeCpuTime.get());
     retVal.persistCpuTime.set(persistCpuTime.get());
@@ -265,6 +277,7 @@ public class FireDepartmentMetrics
     persistBackPressureMillis.addAndGet(otherSnapshot.persistBackPressureMillis());
     failedPersists.addAndGet(otherSnapshot.failedPersists());
     failedHandoffs.addAndGet(otherSnapshot.failedHandoffs());
+    mergeCount.addAndGet(otherSnapshot.mergeCount());
     mergeTimeMillis.addAndGet(otherSnapshot.mergeTimeMillis());
     mergeCpuTime.addAndGet(otherSnapshot.mergeCpuTime());
     persistCpuTime.addAndGet(otherSnapshot.persistCpuTime());

--- a/server/src/main/java/org/apache/druid/segment/realtime/RealtimeMetricsMonitor.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/RealtimeMetricsMonitor.java
@@ -109,6 +109,7 @@ public class RealtimeMetricsMonitor extends AbstractMonitor
       );
       emitter.emit(builder.build("ingest/persists/failed", metrics.failedPersists() - previous.failedPersists()));
       emitter.emit(builder.build("ingest/handoff/failed", metrics.failedHandoffs() - previous.failedHandoffs()));
+      emitter.emit(builder.build("ingest/merge/count", metrics.mergeCount() - previous.mergeCount()));
       emitter.emit(builder.build("ingest/merge/time", metrics.mergeTimeMillis() - previous.mergeTimeMillis()));
       emitter.emit(builder.build("ingest/merge/cpu", metrics.mergeCpuTime() - previous.mergeCpuTime()));
       emitter.emit(builder.build("ingest/handoff/count", metrics.handOffCount() - previous.handOffCount()));

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -448,6 +448,7 @@ public class RealtimePlumber implements Plumber
               }
 
               // emit merge metrics before publishing segment
+              metrics.incrementMergeCount(indexes.size());
               metrics.incrementMergeCpuTime(JvmUtils.safeGetThreadCpuTime() - mergeThreadCpuTime);
               metrics.incrementMergeTimeMillis(mergeStopwatch.elapsed(TimeUnit.MILLISECONDS));
 


### PR DESCRIPTION
This PR adds a new `ingest/merge/count` metric that records how many intermediate persists have been merged for publishing.

Additionally, this PR enables the existing `ingest/merge/time` and `ingest/merge/cpu` metrics for `AppenderatorImpl`, which were only being updated in `RealtimePlumber`.

Marking WIP since in a test cluster I'm seeing discrepancies in the total sums of `ingest/persist/count` and the new `ingest/merge/count`, which I would expect to be the same, need to investigate that further. Also I observed ingestion related metrics not being emitted when a batch task shuts down, which should be looked into as well.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
