### PR TITLE
Improve lookup state update to avoid query failures

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactory.java
@@ -231,6 +231,13 @@ public class NamespaceLookupExtractorFactory implements LookupExtractorFactory
     }
   }
 
+  @Override
+  public boolean isReady()
+  {
+    final CacheScheduler.CacheState cacheState = entry.getCacheState();
+    return !(cacheState instanceof CacheScheduler.NoCache);
+  }
+
   @VisibleForTesting
   CacheScheduler getCacheScheduler()
   {

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractorFactory.java
@@ -67,6 +67,17 @@ public interface LookupExtractorFactory extends Supplier<LookupExtractor>
   }
 
   /**
+   * <p>
+   *   This method will be called to check if {@link LookupExtractor} is ready.
+   * </p>
+   * @return Returns false if the {@link LookupExtractor} is not ready otherwise returns true
+   */
+  default boolean isReady()
+  {
+    return true;
+  }
+
+  /**
    * This method is deprecated and is not removed only to allow 0.10.0 to 0.10.1 transition. It is not used
    * on a cluster that is running 0.10.1. It will be removed in a later release.
    */

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -163,6 +163,7 @@ public class LookupReferencesManagerTest
   {
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory.isReady()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
 
@@ -205,6 +206,7 @@ public class LookupReferencesManagerTest
   {
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createStrictMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory.isReady()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory.close()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
     Map<String, Object> lookupMap = new HashMap<>();
@@ -238,6 +240,7 @@ public class LookupReferencesManagerTest
   {
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createStrictMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory.isReady()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
 
@@ -299,10 +302,12 @@ public class LookupReferencesManagerTest
   {
     LookupExtractorFactory lookupExtractorFactory1 = EasyMock.createNiceMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory1.start()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory1.isReady()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory1.destroy()).andReturn(true).once();
 
     LookupExtractorFactory lookupExtractorFactory2 = EasyMock.createNiceMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory2.start()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory2.isReady()).andReturn(true).once();
 
     EasyMock.replay(lookupExtractorFactory1, lookupExtractorFactory2);
     Map<String, Object> lookupMap = new HashMap<>();
@@ -535,6 +540,7 @@ public class LookupReferencesManagerTest
 
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
+    EasyMock.expect(lookupExtractorFactory.isReady()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.replay(lookupExtractorFactory);
     Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));


### PR DESCRIPTION
### Description
Druid queries related to a cachedNamespace lookup table may failed when a external workflow triggers updating the lookup(setting pollPeriod = null and firstCacheTimeout = 0) with higher version. In this use case, the cachedNamespace lookup loads data asynchronously, while the LookupReferencesManager will switch to the higher version lookup directly without checking if the lookup extractor is ready. 
<details>
<summary>error log</summary>
<p>

```
2020-09-18T10:54:38,870 ERROR [processing-21] org.apache.druid.query.ChainedExecutionQueryRunner - Exception with one of the sequences!
org.apache.druid.java.util.common.ISE: namespace [JdbcExtractionNamespace{connectorConfig=DbConnectorConfig{createTables=false, connectURI='jdbc:mysql://mysql-db-host:3306/lookup_table_db?characterEncoding=utf8&useSSL=false', user='mysql_user', passwordProvider=org.apache.druid.metadata.DefaultPasswordProvider, dbcpProperties=null}, table='category_view', keyColumn='item_id', valueColumn='cat_name', tsColumn='null', filter='null', pollPeriod=PT0S}] : org.apache.druid.server.lookup.namespace.cache.CacheScheduler$EntryImpl@63a9847e: CACHE_NOT_INITIALIZED, extractorID = namespace-factory-JdbcExtractionNamespace{connectorConfig=DbConnectorConfig{createTables=false, connectURI='jdbc:mysql://mysql-db-host:3306/lookup_table_db?characterEncoding=utf8&useSSL=false', user='mysql_user', passwordProvider=org.apache.druid.metadata.DefaultPasswordProvider, dbcpProperties=null}, table='category_view', keyColumn='item_id', valueColumn='cat_name', tsColumn='null', filter='null', pollPeriod=PT0S}-b6515de8-2d7c-4daa-aec3-3d68899f4a4c
        at org.apache.druid.query.lookup.NamespaceLookupExtractorFactory.get(NamespaceLookupExtractorFactory.java:208) ~[?:?]
        at org.apache.druid.query.lookup.NamespaceLookupExtractorFactory.get(NamespaceLookupExtractorFactory.java:43) ~[?:?]
        at org.apache.druid.query.lookup.RegisteredLookupExtractionFn.ensureDelegate(RegisteredLookupExtractionFn.java:152) ~[druid-processing-0.16.1-incubating.jar:0.16.2-incubating-SNAPSHOT]
        at org.apache.druid.query.lookup.RegisteredLookupExtractionFn.getCacheKey(RegisteredLookupExtractionFn.java:101) ~[druid-processing-0.16.1-incubating.jar:0.16.2-incubating-SNAPSHOT]
        at org.apache.druid.query.filter.InDimFilter.getCacheKey(InDimFilter.java:146) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.filter.DimFilterUtils.computeCacheKey(DimFilterUtils.java:68) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.filter.AndDimFilter.getCacheKey(AndDimFilter.java:69) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.cache.CacheKeyBuilder.cacheableToByteArray(CacheKeyBuilder.java:108) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.cache.CacheKeyBuilder.appendCacheable(CacheKeyBuilder.java:279) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest$4.computeCacheKey(TimeseriesQueryQueryToolChest.java:270) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest$4.computeCacheKey(TimeseriesQueryQueryToolChest.java:254) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.client.CachingQueryRunner.run(CachingQueryRunner.java:88) ~[druid-server-0.16.1-incubating.jar:0.16.2-incubating-SNAPSHOT]
        at org.apache.druid.query.BySegmentQueryRunner.run(BySegmentQueryRunner.java:74) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.MetricsEmittingQueryRunner.lambda$run$0(MetricsEmittingQueryRunner.java:97) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.LazySequence.accumulate(LazySequence.java:40) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.WrappingSequence$1.get(WrappingSequence.java:50) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.SequenceWrapper.wrap(SequenceWrapper.java:55) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.WrappingSequence.accumulate(WrappingSequence.java:45) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.spec.SpecificSegmentQueryRunner$1.accumulate(SpecificSegmentQueryRunner.java:79) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.WrappingSequence$1.get(WrappingSequence.java:50) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.spec.SpecificSegmentQueryRunner.doNamed(SpecificSegmentQueryRunner.java:163) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.spec.SpecificSegmentQueryRunner.access$100(SpecificSegmentQueryRunner.java:42) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.spec.SpecificSegmentQueryRunner$2.wrap(SpecificSegmentQueryRunner.java:145) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.WrappingSequence.accumulate(WrappingSequence.java:45) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.WrappingSequence$1.get(WrappingSequence.java:50) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.CPUTimeMetricQueryRunner$1.wrap(CPUTimeMetricQueryRunner.java:74) ~[druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.WrappingSequence.accumulate(WrappingSequence.java:45) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.java.util.common.guava.Sequence.toList(Sequence.java:85) ~[druid-core-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.ChainedExecutionQueryRunner$1$1.call(ChainedExecutionQueryRunner.java:124) [druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at org.apache.druid.query.ChainedExecutionQueryRunner$1$1.call(ChainedExecutionQueryRunner.java:114) [druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_181]
        at org.apache.druid.query.PrioritizedListenableFutureTask.run(PrioritizedExecutorService.java:247) [druid-processing-0.16.1-incubating.jar:0.16.1-incubating]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_181]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_181]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_181]
```

</p>
</details> 

This PR tries to improve this use case by adding a `StatusNotice` to poll the loading status of a lookup.


<hr>

This PR has:
- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `LookupReferencesManager`
 * `LookupExtractorFactory`
 * `NamespaceLookupExtractorFactory`
