### PR TITLE
add light weight version of /druid/coordinator/v1/lookups/nodeStatus

### DIFF
--- a/docs/querying/lookups.md
+++ b/docs/querying/lookups.md
@@ -347,7 +347,7 @@ These end points can be used to get the propagation status of configured lookups
 
 ### List lookup state of all processes
 
-`GET /druid/coordinator/v1/lookups/nodeStatus` with optional query parameter `discover` to discover tiers or configured lookup tiers are listed. The default response will include the which lookups are loaded, being loaded, or being dropped on each node for each tier, including the complete lookup spec. Add the optional query parameter `detailed=false` to only include the 'version' of the lookup instead of the complete spec.
+`GET /druid/coordinator/v1/lookups/nodeStatus` with optional query parameter `discover` to discover tiers advertised by other Druid nodes, or by default, returning all configured lookup tiers. The default response will also include the lookups which are loaded, being loaded, or being dropped on each node, for each tier, including the complete lookup spec. Add the optional query parameter `detailed=false` to only include the 'version' of the lookup instead of the complete spec.
 
 ### List lookup state of processes in a tier
 

--- a/docs/querying/lookups.md
+++ b/docs/querying/lookups.md
@@ -347,7 +347,7 @@ These end points can be used to get the propagation status of configured lookups
 
 ### List lookup state of all processes
 
-`GET /druid/coordinator/v1/lookups/nodeStatus` with optional query parameter `discover` to discover tiers or configured lookup tiers are listed.
+`GET /druid/coordinator/v1/lookups/nodeStatus` with optional query parameter `discover` to discover tiers or configured lookup tiers are listed. The default response will include the which lookups are loaded, being loaded, or being dropped on each node for each tier, including the complete lookup spec. Add the optional query parameter `detailed=false` to only include the 'version' of the lookup instead of the complete spec.
 
 ### List lookup state of processes in a tier
 

--- a/server/src/main/java/org/apache/druid/server/http/LookupCoordinatorResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/LookupCoordinatorResource.java
@@ -42,6 +42,7 @@ import org.apache.druid.server.http.security.ConfigResourceFilter;
 import org.apache.druid.server.lookup.cache.LookupCoordinatorManager;
 import org.apache.druid.server.lookup.cache.LookupExtractorFactoryMapContainer;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -66,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Contains information about lookups exposed through the coordinator
@@ -540,9 +542,12 @@ public class LookupCoordinatorResource
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/nodeStatus")
   public Response getAllNodesStatus(
-      @QueryParam("discover") boolean discover
+      @QueryParam("discover") boolean discover,
+      @QueryParam("detailed") @Nullable  Boolean detailed
   )
   {
+    boolean full = detailed == null || detailed;
+
     try {
       Collection<String> tiers;
       if (discover) {
@@ -558,28 +563,66 @@ public class LookupCoordinatorResource
         tiers = configuredLookups.keySet();
       }
 
-      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager
-          .getLastKnownLookupsStateOnNodes();
+      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts =
+          lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
 
-      Map<String, Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>>> result = new HashMap<>();
+      // 'full' response will include the entire lookup spec JSON, while non will just include the version
+      if (full) {
+        Map<String, Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>>> result = new HashMap<>();
+        for (String tier : tiers) {
+          Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> tierNodesStatus = new HashMap<>();
+          result.put(tier, tierNodesStatus);
 
-      for (String tier : tiers) {
-        Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> tierNodesStatus = new HashMap<>();
-        result.put(tier, tierNodesStatus);
+          Collection<HostAndPort> nodes = lookupCoordinatorManager.discoverNodesInTier(tier);
 
-        Collection<HostAndPort> nodes = lookupCoordinatorManager.discoverNodesInTier(tier);
-
-        for (HostAndPort node : nodes) {
-          LookupsState<LookupExtractorFactoryMapContainer> lookupsState = lookupsStateOnHosts.get(node);
-          if (lookupsState == null) {
-            tierNodesStatus.put(node, new LookupsState<>(null, null, null));
-          } else {
-            tierNodesStatus.put(node, lookupsState);
+          for (HostAndPort node : nodes) {
+            LookupsState<LookupExtractorFactoryMapContainer> lookupsState = lookupsStateOnHosts.get(node);
+            if (lookupsState == null) {
+              tierNodesStatus.put(node, new LookupsState<>(null, null, null));
+            } else {
+              tierNodesStatus.put(node, lookupsState);
+            }
           }
         }
-      }
+        return Response.ok(result).build();
+      } else {
+        // lookups to load per host by version
+        Map<String, Map<HostAndPort, LookupsState<String>>> result = new HashMap<>();
+        for (String tier : tiers) {
+          Map<HostAndPort, LookupsState<String>> tierNodesStatus = new HashMap<>();
+          result.put(tier, tierNodesStatus);
 
-      return Response.ok(result).build();
+          Collection<HostAndPort> nodes = lookupCoordinatorManager.discoverNodesInTier(tier);
+
+          for (HostAndPort node : nodes) {
+            LookupsState<LookupExtractorFactoryMapContainer> lookupsState = lookupsStateOnHosts.get(node);
+            if (lookupsState == null) {
+              tierNodesStatus.put(node, new LookupsState<>(null, null, null));
+            } else {
+              Map<String, String> current = lookupsState.getCurrent()
+                                                        .entrySet()
+                                                        .stream()
+                                                        .collect(
+                                                            Collectors.toMap(
+                                                                Map.Entry::getKey,
+                                                                e -> e.getValue().getVersion()
+                                                            )
+                                                        );
+              Map<String, String> toLoad = lookupsState.getToLoad()
+                                                       .entrySet()
+                                                       .stream()
+                                                       .collect(
+                                                           Collectors.toMap(
+                                                               Map.Entry::getKey,
+                                                               e -> e.getValue().getVersion()
+                                                           )
+                                                       );
+              tierNodesStatus.put(node, new LookupsState<>(current, toLoad, lookupsState.getToDrop()));
+            }
+          }
+        }
+        return Response.ok(result).build();
+      }
     }
     catch (Exception ex) {
       LOG.error(ex, "Error getting node status.");

--- a/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
@@ -1058,7 +1058,7 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
 
-    final Response response = lookupCoordinatorResource.getAllNodesStatus(false);
+    final Response response = lookupCoordinatorResource.getAllNodesStatus(false, null);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(
         ImmutableMap.of(
@@ -1067,7 +1067,44 @@ public class LookupCoordinatorResourceTest
                 LOOKUP_NODE,
                 LOOKUP_STATE
             )
-        ), response.getEntity()
+        ),
+        response.getEntity()
+    );
+
+    EasyMock.verify(lookupCoordinatorManager);
+  }
+
+  @Test
+  public void testGetAllNodesStatusDetailedFalse()
+  {
+    final LookupCoordinatorManager lookupCoordinatorManager = EasyMock.createStrictMock(
+        LookupCoordinatorManager.class
+    );
+    EasyMock.expect(lookupCoordinatorManager.getKnownLookups()).andReturn(SINGLE_TIER_MAP);
+    EasyMock.expect(lookupCoordinatorManager.getLastKnownLookupsStateOnNodes()).andReturn(NODES_LOOKUP_STATE);
+    EasyMock.expect(lookupCoordinatorManager.discoverNodesInTier(LOOKUP_TIER)).andReturn(ImmutableList.of(LOOKUP_NODE));
+
+    EasyMock.replay(lookupCoordinatorManager);
+
+    final LookupCoordinatorResource lookupCoordinatorResource = new LookupCoordinatorResource(
+        lookupCoordinatorManager,
+        MAPPER,
+        MAPPER
+    );
+
+    final Response response = lookupCoordinatorResource.getAllNodesStatus(false, false);
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(
+        ImmutableMap.of(
+            LOOKUP_TIER,
+            ImmutableMap.of(
+                LOOKUP_NODE,
+                new LookupsState(
+                    ImmutableMap.of(LOOKUP_NAME, SINGLE_LOOKUP.getVersion()), null, null
+                )
+            )
+        ),
+        response.getEntity()
     );
 
     EasyMock.verify(lookupCoordinatorManager);


### PR DESCRIPTION
### Description
Adds a light weight verison of `/druid/coordinator/v1/lookups/nodeStatus`, which currently include the lookup spec JSON, which can be sort of large for inline map lookups:

```json
{
  "__default": {
    "localhost:8083": {
      "current": {
        "lookup_table": {
          "version": "2020-06-11T10:48:17.033Z",
          "lookupExtractorFactory": {
            "type": "cachedNamespace",
            "extractionNamespace": {
              "type": "uri",
              "uri": null,
              "uriPrefix": "file:/Users/clint/workspace/data/druid/lookups/lookup-simple.json",
              "fileRegex": null,
              "namespaceParseSpec": {
                "format": "simpleJson"
              },
              "pollPeriod": "PT0S"
            },
            "firstCacheTimeout": 0,
            "injective": true
          }
        }
      },
      "toLoad": {},
      "toDrop": []
    }
  }
}
```

Using `/druid/coordinator/v1/lookups/nodeStatus?detailed=false` will instead just include the 'version' string instead of the complete lookup JSON spec:

```json
{
  "__default": {
    "localhost:8083": {
      "current": {
        "lookup_table": "2020-06-11T10:48:17.033Z"
      },
      "toLoad": {},
      "toDrop": []
    }
  }
}
```

The new parameter defaults to true if not set to preserve existing behavior.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

