### PR TITLE
more timeout handling in JsonParserIterator

### DIFF
--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -110,7 +110,14 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
       return retVal;
     }
     catch (IOException e) {
-      throw new RuntimeException(e);
+      // check for timeout, a failure here might be related to a timeout, so lets just attribute it
+      if (checkTimeout()) {
+        TimeoutException timeoutException = timeoutQuery();
+        timeoutException.addSuppressed(e);
+        throw interruptQuery(timeoutException);
+      } else {
+        throw interruptQuery(e);
+      }
     }
   }
 
@@ -118,45 +125,6 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
   public void remove()
   {
     throw new UnsupportedOperationException();
-  }
-
-  private void init()
-  {
-    if (jp == null) {
-      try {
-        long timeLeftMillis = timeoutAt - System.currentTimeMillis();
-        if (hasTimeout && timeLeftMillis < 1) {
-          throw new TimeoutException(StringUtils.format("url[%s] timed out", url));
-        }
-        InputStream is = hasTimeout
-                         ? future.get(timeLeftMillis, TimeUnit.MILLISECONDS)
-                         : future.get();
-        if (is != null) {
-          jp = objectMapper.getFactory().createParser(is);
-        } else {
-          interruptQuery(
-              new ResourceLimitExceededException(
-                  "url[%s] timed out or max bytes limit reached.",
-                  url
-              )
-          );
-        }
-        final JsonToken nextToken = jp.nextToken();
-        if (nextToken == JsonToken.START_ARRAY) {
-          jp.nextToken();
-          objectCodec = jp.getCodec();
-        } else if (nextToken == JsonToken.START_OBJECT) {
-          interruptQuery(jp.getCodec().readValue(jp, QueryInterruptedException.class));
-        } else {
-          interruptQuery(
-              new IAE("Next token wasn't a START_ARRAY, was[%s] from url[%s]", jp.getCurrentToken(), url)
-          );
-        }
-      }
-      catch (IOException | InterruptedException | ExecutionException | CancellationException | TimeoutException e) {
-        interruptQuery(e);
-      }
-    }
   }
 
   @Override
@@ -167,10 +135,66 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
     }
   }
 
-  private void interruptQuery(Exception cause)
+  private boolean checkTimeout()
+  {
+    long timeLeftMillis = timeoutAt - System.currentTimeMillis();
+    return checkTimeout(timeLeftMillis);
+  }
+
+  private boolean checkTimeout(long timeLeftMillis)
+  {
+    if (hasTimeout && timeLeftMillis < 1) {
+      return true;
+    }
+    return false;
+  }
+
+  private void init()
+  {
+    if (jp == null) {
+      try {
+        long timeLeftMillis = timeoutAt - System.currentTimeMillis();
+        if (checkTimeout(timeLeftMillis)) {
+          throw interruptQuery(timeoutQuery());
+        }
+        InputStream is = hasTimeout ? future.get(timeLeftMillis, TimeUnit.MILLISECONDS) : future.get();
+
+        if (is != null) {
+          jp = objectMapper.getFactory().createParser(is);
+        } else if (checkTimeout()) {
+          throw interruptQuery(timeoutQuery());
+        } else {
+          // if we haven't timed out completing the future, then this is the likely cause
+          throw interruptQuery(new ResourceLimitExceededException("url[%s] max bytes limit reached.", url));
+        }
+
+        final JsonToken nextToken = jp.nextToken();
+        if (nextToken == JsonToken.START_ARRAY) {
+          jp.nextToken();
+          objectCodec = jp.getCodec();
+        } else if (nextToken == JsonToken.START_OBJECT) {
+          throw interruptQuery(jp.getCodec().readValue(jp, QueryInterruptedException.class));
+        } else {
+          throw interruptQuery(
+              new IAE("Next token wasn't a START_ARRAY, was[%s] from url[%s]", jp.getCurrentToken(), url)
+          );
+        }
+      }
+      catch (IOException | InterruptedException | ExecutionException | CancellationException | TimeoutException e) {
+        throw interruptQuery(e);
+      }
+    }
+  }
+
+  private TimeoutException timeoutQuery()
+  {
+    return new TimeoutException(StringUtils.format("url[%s] timed out", url));
+  }
+
+  private QueryInterruptedException interruptQuery(Exception cause)
   {
     LOG.warn(cause, "Query [%s] to host [%s] interrupted", queryId, host);
-    throw new QueryInterruptedException(cause, host);
+    return new QueryInterruptedException(cause, host);
   }
 }
 


### PR DESCRIPTION
### Description
This PR adds more robust timeout checking in `JsonParserIterator`, as well as more consistent exceptions thrown from the class (everything should now be wrapped in a `QueryInterruptedException`). Not entirely sure where to begin to try to write a test for this, so.. i haven't for now. However, none of the codepaths have really changed, everywhere that was previously throwing some subclass of RuntimeException will continue to do so, there is just a bit more variation on which exceptions will be thrown.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

