### PR TITLE
allow server selection to be aware of query

### DIFF
--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -588,7 +588,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
     {
       final SortedMap<DruidServer, List<SegmentDescriptor>> serverSegments = new TreeMap<>();
       for (SegmentServerSelector segmentServer : segments) {
-        final QueryableDruidServer queryableDruidServer = segmentServer.getServer().pick();
+        final QueryableDruidServer queryableDruidServer = segmentServer.getServer().pick(query);
 
         if (queryableDruidServer == null) {
           log.makeAlert(

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -812,7 +812,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
       Hasher hasher = Hashing.sha1().newHasher();
       boolean hasOnlyHistoricalSegments = true;
       for (SegmentServerSelector p : segments) {
-        if (!p.getServer().pick().getServer().isSegmentReplicationTarget()) {
+        if (!p.getServer().pick(null).getServer().isSegmentReplicationTarget()) {
           hasOnlyHistoricalSegments = false;
           break;
         }

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -812,7 +812,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
       Hasher hasher = Hashing.sha1().newHasher();
       boolean hasOnlyHistoricalSegments = true;
       for (SegmentServerSelector p : segments) {
-        if (!p.getServer().pick(null).getServer().isSegmentReplicationTarget()) {
+        if (!p.getServer().pick(query).getServer().isSegmentReplicationTarget()) {
           hasOnlyHistoricalSegments = false;
           break;
         }

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -812,7 +812,8 @@ public class CachingClusteredClient implements QuerySegmentWalker
       Hasher hasher = Hashing.sha1().newHasher();
       boolean hasOnlyHistoricalSegments = true;
       for (SegmentServerSelector p : segments) {
-        if (!p.getServer().pick(query).getServer().isSegmentReplicationTarget()) {
+        QueryableDruidServer queryableServer = p.getServer().pick(query);
+        if (queryableServer == null || !queryableServer.getServer().isSegmentReplicationTarget()) {
           hasOnlyHistoricalSegments = false;
           break;
         }

--- a/server/src/main/java/org/apache/druid/client/selector/AbstractTierSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/AbstractTierSelectorStrategy.java
@@ -21,6 +21,7 @@ package org.apache.druid.client.selector;
 
 import com.google.common.collect.Iterables;
 import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
+import org.apache.druid.query.Query;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
@@ -38,15 +39,12 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
   {
     this.serverSelectorStrategy = serverSelectorStrategy;
   }
-
+  
   @Nullable
   @Override
-  public QueryableDruidServer pick(
-      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
-      DataSegment segment
-  )
+  public QueryableDruidServer pick(Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment)
   {
-    return Iterables.getOnlyElement(pick(prioritizedServers, segment, 1), null);
+    return pick(null, prioritizedServers, segment);
   }
 
   @Override
@@ -56,9 +54,31 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
       int numServersToPick
   )
   {
+    return pick(null, prioritizedServers, segment, numServersToPick);
+  }
+
+  @Nullable
+  @Override
+  public <T> QueryableDruidServer pick(
+      Query<T> query,
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
+      DataSegment segment
+  )
+  {
+    return Iterables.getOnlyElement(pick(query, prioritizedServers, segment, 1), null);
+  }
+
+  @Override
+  public <T> List<QueryableDruidServer> pick(
+      Query<T> query,
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
+      DataSegment segment,
+      int numServersToPick
+  )
+  {
     List<QueryableDruidServer> result = new ArrayList<>(numServersToPick);
     for (Set<QueryableDruidServer> priorityServers : prioritizedServers.values()) {
-      result.addAll(serverSelectorStrategy.pick(priorityServers, segment, numServersToPick - result.size()));
+      result.addAll(serverSelectorStrategy.pick(query, priorityServers, segment, numServersToPick - result.size()));
       if (result.size() == numServersToPick) {
         break;
       }

--- a/server/src/main/java/org/apache/druid/client/selector/AbstractTierSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/AbstractTierSelectorStrategy.java
@@ -42,23 +42,6 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
   
   @Nullable
   @Override
-  public QueryableDruidServer pick(Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment)
-  {
-    return pick(null, prioritizedServers, segment);
-  }
-
-  @Override
-  public List<QueryableDruidServer> pick(
-      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
-      DataSegment segment,
-      int numServersToPick
-  )
-  {
-    return pick(null, prioritizedServers, segment, numServersToPick);
-  }
-
-  @Nullable
-  @Override
   public <T> QueryableDruidServer pick(
       Query<T> query,
       Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,

--- a/server/src/main/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategy.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Ordering;
 import org.apache.druid.client.DirectDruidClient;
 import org.apache.druid.timeline.DataSegment;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -34,6 +35,7 @@ public class ConnectionCountServerSelectorStrategy implements ServerSelectorStra
   private static final Comparator<QueryableDruidServer> COMPARATOR =
       Comparator.comparingInt(s -> ((DirectDruidClient) s.getQueryRunner()).getNumOpenConnections());
 
+  @Nullable
   @Override
   public QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment)
   {

--- a/server/src/main/java/org/apache/druid/client/selector/RandomServerSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/RandomServerSelectorStrategy.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.druid.timeline.DataSegment;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -31,6 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class RandomServerSelectorStrategy implements ServerSelectorStrategy
 {
+  @Nullable
   @Override
   public QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment)
   {

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  */
-public class ServerSelector implements DiscoverySelector<QueryableDruidServer>, Overshadowable<ServerSelector>
+public class ServerSelector implements Overshadowable<ServerSelector>
 {
 
   private final Int2ObjectRBTreeMap<Set<QueryableDruidServer>> historicalServers;
@@ -160,17 +160,7 @@ public class ServerSelector implements DiscoverySelector<QueryableDruidServer>, 
     return servers;
   }
 
-  @Nullable
-  @Override
-  public QueryableDruidServer pick()
-  {
-    if (!historicalServers.isEmpty()) {
-      return strategy.pick(historicalServers, segment.get());
-    }
-    return strategy.pick(realtimeServers, segment.get());
-  }
-
-  public <T> QueryableDruidServer pick(Query<T> query)
+  public <T> QueryableDruidServer pick(@Nullable Query<T> query)
   {
     synchronized (this) {
       if (!historicalServers.isEmpty()) {

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
@@ -21,6 +21,7 @@ package org.apache.druid.client.selector;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 import org.apache.druid.client.DataSegmentInterner;
+import org.apache.druid.query.Query;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
@@ -163,11 +164,19 @@ public class ServerSelector implements DiscoverySelector<QueryableDruidServer>, 
   @Override
   public QueryableDruidServer pick()
   {
+    if (!historicalServers.isEmpty()) {
+      return strategy.pick(historicalServers, segment.get());
+    }
+    return strategy.pick(realtimeServers, segment.get());
+  }
+
+  public <T> QueryableDruidServer pick(Query<T> query)
+  {
     synchronized (this) {
       if (!historicalServers.isEmpty()) {
-        return strategy.pick(historicalServers, segment.get());
+        return strategy.pick(query, historicalServers, segment.get());
       }
-      return strategy.pick(realtimeServers, segment.get());
+      return strategy.pick(query, realtimeServers, segment.get());
     }
   }
 

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
@@ -160,6 +160,7 @@ public class ServerSelector implements Overshadowable<ServerSelector>
     return servers;
   }
 
+  @Nullable
   public <T> QueryableDruidServer pick(@Nullable Query<T> query)
   {
     synchronized (this) {

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelectorStrategy.java
@@ -36,6 +36,7 @@ import java.util.Set;
 })
 public interface ServerSelectorStrategy
 {
+  @Nullable
   default <T> QueryableDruidServer pick(@Nullable Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment)
   {
     return Iterables.getOnlyElement(pick(query, servers, segment, 1), null);
@@ -48,6 +49,7 @@ public interface ServerSelectorStrategy
   }
 
   @Deprecated
+  @Nullable
   default QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment)
   {
     return pick(null, servers, segment);

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelectorStrategy.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Iterables;
 import org.apache.druid.query.Query;
 import org.apache.druid.timeline.DataSegment;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 
@@ -35,18 +36,27 @@ import java.util.Set;
 })
 public interface ServerSelectorStrategy
 {
-  default <T> QueryableDruidServer pick(Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment)
+  default <T> QueryableDruidServer pick(@Nullable Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment)
   {
     return Iterables.getOnlyElement(pick(query, servers, segment, 1), null);
   }
 
-  default <T> List<QueryableDruidServer> pick(Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment,
+  default <T> List<QueryableDruidServer> pick(@Nullable Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment,
       int numServersToPick)
   {
     return pick(servers, segment, numServersToPick);
   }
 
-  QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment);
+  @Deprecated
+  default QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment)
+  {
+    return pick(null, servers, segment);
+  }
 
-  List<QueryableDruidServer> pick(Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick);
+  @Deprecated
+  default List<QueryableDruidServer> pick(Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick)
+  {
+    return pick(null, servers, segment, numServersToPick);
+  }
+
 }

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelectorStrategy.java
@@ -21,6 +21,8 @@ package org.apache.druid.client.selector;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.Iterables;
+import org.apache.druid.query.Query;
 import org.apache.druid.timeline.DataSegment;
 
 import java.util.List;
@@ -33,6 +35,17 @@ import java.util.Set;
 })
 public interface ServerSelectorStrategy
 {
+  default <T> QueryableDruidServer pick(Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment)
+  {
+    return Iterables.getOnlyElement(pick(query, servers, segment, 1), null);
+  }
+
+  default <T> List<QueryableDruidServer> pick(Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment,
+      int numServersToPick)
+  {
+    return pick(servers, segment, numServersToPick);
+  }
+
   QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment);
 
   List<QueryableDruidServer> pick(Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick);

--- a/server/src/main/java/org/apache/druid/client/selector/TierSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/TierSelectorStrategy.java
@@ -43,16 +43,24 @@ public interface TierSelectorStrategy
 {
   Comparator<Integer> getComparator();
 
+  @Deprecated
   @Nullable
-  QueryableDruidServer pick(Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment);
+  default QueryableDruidServer pick(Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment)
+  {
+    return pick(null, prioritizedServers, segment);
+  }
 
-  List<QueryableDruidServer> pick(
+  @Deprecated
+  default List<QueryableDruidServer> pick(
       Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
       DataSegment segment,
-      int numServersToPick);
+      int numServersToPick)
+  {
+    return pick(null, prioritizedServers, segment, numServersToPick);
+  }
 
   @Nullable
-  default <T> QueryableDruidServer pick(Query<T> query,
+  default <T> QueryableDruidServer pick(@Nullable Query<T> query,
       Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
       DataSegment segment)
   {
@@ -60,7 +68,7 @@ public interface TierSelectorStrategy
   }
 
   default <T> List<QueryableDruidServer> pick(
-      Query<T> query,
+      @Nullable Query<T> query,
       Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
       DataSegment segment,
       int numServersToPick)

--- a/server/src/main/java/org/apache/druid/client/selector/TierSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/TierSelectorStrategy.java
@@ -22,9 +22,11 @@ package org.apache.druid.client.selector;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
+import org.apache.druid.query.Query;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -47,6 +49,22 @@ public interface TierSelectorStrategy
   List<QueryableDruidServer> pick(
       Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
       DataSegment segment,
-      int numServersToPick
-  );
+      int numServersToPick);
+
+  @Nullable
+  default <T> QueryableDruidServer pick(Query<T> query,
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
+      DataSegment segment)
+  {
+    return pick(prioritizedServers, segment);
+  }
+
+  default <T> List<QueryableDruidServer> pick(
+      Query<T> query,
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
+      DataSegment segment,
+      int numServersToPick)
+  {
+    return pick(prioritizedServers, segment, numServersToPick);
+  }
 }

--- a/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
@@ -135,7 +135,7 @@ public class BrokerServerViewTest extends CuratorTestBase
     ServerSelector selector = (actualPartitionHolder.iterator().next()).getObject();
     Assert.assertFalse(selector.isEmpty());
     Assert.assertEquals(segment, selector.getSegment());
-    Assert.assertEquals(druidServer, selector.pick().getServer());
+    Assert.assertEquals(druidServer, selector.pick(null).getServer());
 
     unannounceSegmentForServer(druidServer, segment, zkPathsConfig);
     Assert.assertTrue(timing.forWaiting().awaitLatch(segmentRemovedLatch));
@@ -384,7 +384,7 @@ public class BrokerServerViewTest extends CuratorTestBase
       ServerSelector selector = ((SingleElementPartitionChunk<ServerSelector>) actualPartitionHolder.iterator()
                                                                                                     .next()).getObject();
       Assert.assertFalse(selector.isEmpty());
-      Assert.assertEquals(expectedPair.rhs.rhs.lhs, selector.pick().getServer());
+      Assert.assertEquals(expectedPair.rhs.rhs.lhs, selector.pick(null).getServer());
       Assert.assertEquals(expectedPair.rhs.rhs.rhs, selector.getSegment());
     }
   }

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientCacheKeyManagerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientCacheKeyManagerTest.java
@@ -332,7 +332,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         0
     );
     expect(server.isSegmentReplicationTarget()).andReturn(isHistorical).anyTimes();
-    expect(serverSelector.pick()).andReturn(queryableDruidServer).anyTimes();
+    expect(serverSelector.pick(null)).andReturn(queryableDruidServer).anyTimes();
     expect(queryableDruidServer.getServer()).andReturn(server).anyTimes();
     expect(serverSelector.getSegment()).andReturn(segment).anyTimes();
     replay(serverSelector, queryableDruidServer, server);

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientCacheKeyManagerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientCacheKeyManagerTest.java
@@ -332,7 +332,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         0
     );
     expect(server.isSegmentReplicationTarget()).andReturn(isHistorical).anyTimes();
-    expect(serverSelector.pick(null)).andReturn(queryableDruidServer).anyTimes();
+    expect(serverSelector.pick(query)).andReturn(queryableDruidServer).anyTimes();
     expect(queryableDruidServer.getServer()).andReturn(server).anyTimes();
     expect(serverSelector.getSegment()).andReturn(segment).anyTimes();
     replay(serverSelector, queryableDruidServer, server);

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -223,7 +223,7 @@ public class DirectDruidClientTest
 
     Assert.assertEquals(2, client2.getNumOpenConnections());
 
-    Assert.assertEquals(serverSelector.pick(), queryableDruidServer2);
+    Assert.assertEquals(serverSelector.pick(null), queryableDruidServer2);
 
     EasyMock.verify(httpClient);
   }

--- a/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
@@ -236,7 +236,7 @@ public class TierSelectorStrategyTest
       serverSelector.addServerAndUpdateSegment(server, serverSelector.getSegment());
     }
 
-    Assert.assertEquals(expectedSelection[0], serverSelector.pick());
+    Assert.assertEquals(expectedSelection[0], serverSelector.pick(null));
     Assert.assertEquals(expectedSelection[0], serverSelector.pick(EasyMock.createMock(Query.class)));
     Assert.assertEquals(expectedCandidates, serverSelector.getCandidates(-1));
     Assert.assertEquals(expectedCandidates.subList(0, 2), serverSelector.getCandidates(2));

--- a/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
@@ -259,6 +259,7 @@ public class TierSelectorStrategyTest
     Assert.assertEquals(strategy.pick(servers, EasyMock.createMock(DataSegment.class)), p0);
     Assert.assertEquals(strategy.pick(EasyMock.createMock(Query.class), servers, EasyMock.createMock(DataSegment.class)), p0);
     ServerSelectorStrategy defaultDeprecatedServerSelectorStrategy = new ServerSelectorStrategy() {
+      @Override
       public <T> List<QueryableDruidServer> pick(@Nullable Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment,
           int numServersToPick)
       {


### PR DESCRIPTION
### Description

This PR supports https://github.com/apache/druid/issues/10294 where an issue is discussed that queries with lookups may sometimes fail unnecessarily due to the lookup only being available on some historicals. The query can succeed by avoiding those historicals. In this PR is an extension that tracks lookup status on the broker and adds a new ServerSelectorStrategy to avoid historicals that are missing required lookups. 

This PR https://github.com/apache/druid/pull/10427 is a small change to make server selection aware of the Query and would allow this extension so solve this issue without any other changes in core Druid. 

This change just adds Query as a parameter to the ServerSelectorStratey and TierSelectorStrategy and provides this parameter in CachingClusteredClient, after segments  are found for a query and they are being fanned out across the cluster. A default method was added to the interface so existing implementations would not need to change. 

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [X] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `ServerSelectorStrategy`
 * `TierSelectorStrategy`
 * `CachingClusteredClient`
