### PR TITLE
Web console: better query view initial state

### DIFF
--- a/web-console/src/views/query-view/query-view.scss
+++ b/web-console/src/views/query-view/query-view.scss
@@ -99,6 +99,17 @@ $nav-width: 250px;
         width: 100%;
         height: 100%;
       }
+
+      .init-state {
+        background: #232d35;
+        text-align: center;
+
+        p {
+          position: relative;
+          top: 38%;
+          font-size: 14px;
+        }
+      }
     }
   }
 

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Intent, Switch, Tooltip } from '@blueprintjs/core';
+import { Code, Intent, Switch, Tooltip } from '@blueprintjs/core';
 import axios from 'axios';
 import classNames from 'classnames';
 import { QueryResult, QueryRunner, SqlQuery } from 'druid-query-toolkit';
@@ -295,9 +295,11 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
   }
 
   componentDidMount(): void {
+    const { liveQueryMode, queryString } = this.state;
+
     this.metadataQueryManager.runQuery(null);
 
-    if (this.state.liveQueryMode !== 'off') {
+    if (liveQueryMode !== 'off' && queryString) {
       this.handleRun();
     }
   }
@@ -521,6 +523,13 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
                 this.queryManager.cancelCurrent();
               }}
             />
+          )}
+          {queryResultState.isInit() && (
+            <div className="init-state">
+              <p>
+                Enter a query and click <Code>Run</Code>
+              </p>
+            </div>
           )}
         </div>
       </SplitterLayout>


### PR DESCRIPTION
Make the web console not auto run the query if it blank - changes the initial impression that a first time user gets of the query view.

Before:

![image](https://user-images.githubusercontent.com/177816/94087172-f50ce580-fdc1-11ea-8c69-0bcfc4f59378.png)

After:

![image](https://user-images.githubusercontent.com/177816/94087194-0655f200-fdc2-11ea-8368-b73b88bc27e1.png)

