### PR TITLE
Web console: Display compaction status

### DIFF
--- a/web-console/src/components/json-input/json-input.tsx
+++ b/web-console/src/components/json-input/json-input.tsx
@@ -80,12 +80,11 @@ export const JsonInput = React.memo(function JsonInput(props: JsonInputProps) {
   const aceEditor = useRef<Editor | undefined>();
 
   useEffect(() => {
-    if (!deepEqual(value, internalValue.value)) {
-      setInternalValue({
-        value,
-        stringified: stringifyJson(value),
-      });
-    }
+    if (deepEqual(value, internalValue.value)) return;
+    setInternalValue({
+      value,
+      stringified: stringifyJson(value),
+    });
   }, [value]);
 
   const internalValueError = internalValue.error;
@@ -149,8 +148,8 @@ export const JsonInput = React.memo(function JsonInput(props: JsonInputProps) {
             const rc = extractRowColumnFromHjsonError(internalValueError);
             if (!rc) return;
 
+            aceEditor.current.focus(); // Grab the focus
             aceEditor.current.getSelection().moveCursorTo(rc.row, rc.column);
-            aceEditor.current.focus(); // Grab the focus also
           }}
         >
           {internalValueError.message}

--- a/web-console/src/components/more-button/more-button.tsx
+++ b/web-console/src/components/more-button/more-button.tsx
@@ -18,14 +18,19 @@
 
 import { Button, Menu, Popover, Position } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
+import React, { useState } from 'react';
+
+type OpenState = 'open' | 'alt-open';
 
 export interface MoreButtonProps {
-  children: React.ReactNode;
+  children: React.ReactNode | React.ReactNode[];
+  altExtra?: React.ReactNode;
 }
 
 export const MoreButton = React.memo(function MoreButton(props: MoreButtonProps) {
-  const { children } = props;
+  const { children, altExtra } = props;
+
+  const [openState, setOpenState] = useState<OpenState | undefined>();
 
   let childCount = 0;
   // Sadly React.Children.count does not ignore nulls correctly
@@ -36,8 +41,18 @@ export const MoreButton = React.memo(function MoreButton(props: MoreButtonProps)
   return (
     <Popover
       className="more-button"
-      content={<Menu>{children}</Menu>}
+      isOpen={Boolean(openState)}
+      content={
+        <Menu>
+          {children}
+          {openState === 'alt-open' && altExtra}
+        </Menu>
+      }
       position={Position.BOTTOM_LEFT}
+      onInteraction={(nextOpenState, e: any) => {
+        if (!e) return; // For some reason this function is always called twice once with e and once without
+        setOpenState(nextOpenState ? (e.altKey ? 'alt-open' : 'open') : undefined);
+      }}
     >
       <Button icon={IconNames.MORE} disabled={!childCount} />
     </Popover>

--- a/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
@@ -38,6 +38,12 @@ exports[`CompactionDialog matches snapshot with compactionConfig (dynamic partit
               The offset for searching segments to be compacted. Strongly recommended to set for realtime dataSources.
             </p>,
             "name": "skipOffsetFromLatest",
+            "suggestions": Array [
+              "PT0H",
+              "PT1H",
+              "P1D",
+              "P3D",
+            ],
             "type": "string",
           },
           Object {
@@ -265,6 +271,12 @@ exports[`CompactionDialog matches snapshot with compactionConfig (hashed partiti
               The offset for searching segments to be compacted. Strongly recommended to set for realtime dataSources.
             </p>,
             "name": "skipOffsetFromLatest",
+            "suggestions": Array [
+              "PT0H",
+              "PT1H",
+              "P1D",
+              "P3D",
+            ],
             "type": "string",
           },
           Object {
@@ -492,6 +504,12 @@ exports[`CompactionDialog matches snapshot with compactionConfig (single_dim par
               The offset for searching segments to be compacted. Strongly recommended to set for realtime dataSources.
             </p>,
             "name": "skipOffsetFromLatest",
+            "suggestions": Array [
+              "PT0H",
+              "PT1H",
+              "P1D",
+              "P3D",
+            ],
             "type": "string",
           },
           Object {
@@ -719,6 +737,12 @@ exports[`CompactionDialog matches snapshot without compactionConfig 1`] = `
               The offset for searching segments to be compacted. Strongly recommended to set for realtime dataSources.
             </p>,
             "name": "skipOffsetFromLatest",
+            "suggestions": Array [
+              "PT0H",
+              "PT1H",
+              "P1D",
+              "P3D",
+            ],
             "type": "string",
           },
           Object {

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -24,8 +24,6 @@ import { deepGet, deepSet } from '../../utils/object-change';
 
 import './compaction-dialog.scss';
 
-export const DEFAULT_MAX_ROWS_PER_SEGMENT = 5000000;
-
 type Tabs = 'form' | 'json';
 
 type CompactionConfig = Record<string, any>;

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -33,6 +33,7 @@ const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
     name: 'skipOffsetFromLatest',
     type: 'string',
     defaultValue: 'P1D',
+    suggestions: ['PT0H', 'PT1H', 'P1D', 'P3D'],
     info: (
       <p>
         The offset for searching segments to be compacted. Strongly recommended to set for realtime

--- a/web-console/src/utils/compaction.spec.ts
+++ b/web-console/src/utils/compaction.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  CompactionConfig,
+  CompactionStatus,
+  formatCompactionConfigAndStatus,
+  zeroCompactionStatus,
+} from './compaction';
+
+describe('compaction', () => {
+  const BASIC_CONFIG: CompactionConfig = {};
+  const ZERO_STATUS: CompactionStatus = {
+    dataSource: 'tbl',
+    scheduleStatus: 'RUNNING',
+    bytesAwaitingCompaction: 0,
+    bytesCompacted: 0,
+    bytesSkipped: 0,
+    segmentCountAwaitingCompaction: 0,
+    segmentCountCompacted: 0,
+    segmentCountSkipped: 0,
+    intervalCountAwaitingCompaction: 0,
+    intervalCountCompacted: 0,
+    intervalCountSkipped: 0,
+  };
+
+  it('zeroCompactionStatus', () => {
+    expect(zeroCompactionStatus(ZERO_STATUS)).toEqual(true);
+
+    expect(
+      zeroCompactionStatus({
+        dataSource: 'tbl',
+        scheduleStatus: 'RUNNING',
+        bytesAwaitingCompaction: 1,
+        bytesCompacted: 0,
+        bytesSkipped: 0,
+        segmentCountAwaitingCompaction: 0,
+        segmentCountCompacted: 0,
+        segmentCountSkipped: 0,
+        intervalCountAwaitingCompaction: 0,
+        intervalCountCompacted: 0,
+        intervalCountSkipped: 0,
+      }),
+    ).toEqual(false);
+  });
+
+  it('formatCompactionConfigAndStatus', () => {
+    expect(formatCompactionConfigAndStatus(undefined, undefined)).toEqual('Not enabled');
+
+    expect(formatCompactionConfigAndStatus(BASIC_CONFIG, undefined)).toEqual('Awaiting first run');
+
+    expect(formatCompactionConfigAndStatus(undefined, ZERO_STATUS)).toEqual('Running');
+
+    expect(formatCompactionConfigAndStatus(BASIC_CONFIG, ZERO_STATUS)).toEqual('Running');
+
+    expect(
+      formatCompactionConfigAndStatus(BASIC_CONFIG, {
+        dataSource: 'tbl',
+        scheduleStatus: 'RUNNING',
+        bytesAwaitingCompaction: 0,
+        bytesCompacted: 100,
+        bytesSkipped: 0,
+        segmentCountAwaitingCompaction: 0,
+        segmentCountCompacted: 10,
+        segmentCountSkipped: 0,
+        intervalCountAwaitingCompaction: 0,
+        intervalCountCompacted: 10,
+        intervalCountSkipped: 0,
+      }),
+    ).toEqual('Fully compacted');
+  });
+});

--- a/web-console/src/utils/compaction.ts
+++ b/web-console/src/utils/compaction.ts
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function capitalizeFirst(str: string): string {
+  return str.slice(0, 1).toUpperCase() + str.slice(1).toLowerCase();
+}
+
+export interface CompactionStatus {
+  dataSource: string;
+  scheduleStatus: string;
+  bytesAwaitingCompaction: number;
+  bytesCompacted: number;
+  bytesSkipped: number;
+  segmentCountAwaitingCompaction: number;
+  segmentCountCompacted: number;
+  segmentCountSkipped: number;
+  intervalCountAwaitingCompaction: number;
+  intervalCountCompacted: number;
+  intervalCountSkipped: number;
+}
+
+export type CompactionConfig = Record<string, any>;
+
+export function zeroCompactionStatus(compactionStatus: CompactionStatus): boolean {
+  return (
+    !compactionStatus.bytesAwaitingCompaction &&
+    !compactionStatus.bytesCompacted &&
+    !compactionStatus.bytesSkipped &&
+    !compactionStatus.segmentCountAwaitingCompaction &&
+    !compactionStatus.segmentCountCompacted &&
+    !compactionStatus.segmentCountSkipped &&
+    !compactionStatus.intervalCountAwaitingCompaction &&
+    !compactionStatus.intervalCountCompacted &&
+    !compactionStatus.intervalCountSkipped
+  );
+}
+
+export function formatCompactionConfigAndStatus(
+  compactionConfig: CompactionConfig | undefined,
+  compactionStatus: CompactionStatus | undefined,
+) {
+  if (compactionStatus) {
+    if (compactionStatus.bytesAwaitingCompaction === 0 && !zeroCompactionStatus(compactionStatus)) {
+      return 'Fully compacted';
+    } else {
+      return capitalizeFirst(compactionStatus.scheduleStatus);
+    }
+  } else if (compactionConfig) {
+    return 'Awaiting first run';
+  } else {
+    return 'Not enabled';
+  }
+}

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -18,6 +18,11 @@
 
 import {
   alphanumericCompare,
+  formatBytes,
+  formatBytesCompact,
+  formatInteger,
+  formatMegabytes,
+  formatPercent,
   sortWithPrefixSuffix,
   sqlQueryCustomTableFilter,
   swapElements,
@@ -81,6 +86,36 @@ describe('general', () => {
     it('works downward', () => {
       expect(swapElements(array, 2, 3)).toEqual(['a', 'b', 'd', 'c', 'e']);
       expect(swapElements(array, 2, 4)).toEqual(['a', 'b', 'e', 'd', 'c']);
+    });
+  });
+
+  describe('formatInteger', () => {
+    it('works', () => {
+      expect(formatInteger(10000)).toEqual('10,000');
+    });
+  });
+
+  describe('formatBytes', () => {
+    it('works', () => {
+      expect(formatBytes(10000)).toEqual('10.00 KB');
+    });
+  });
+
+  describe('formatBytesCompact', () => {
+    it('works', () => {
+      expect(formatBytesCompact(10000)).toEqual('10.00KB');
+    });
+  });
+
+  describe('formatMegabytes', () => {
+    it('works', () => {
+      expect(formatMegabytes(30000000)).toEqual('28.6');
+    });
+  });
+
+  describe('formatPercent', () => {
+    it('works', () => {
+      expect(formatPercent(2 / 3)).toEqual('66.67%');
     });
   });
 });

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -231,6 +231,10 @@ export function formatMegabytes(n: number): string {
   return numeral(n / 1048576).format('0,0.0');
 }
 
+export function formatPercent(n: number): string {
+  return (n * 100).toFixed(2) + '%';
+}
+
 function pad2(str: string | number): string {
   return ('00' + str).substr(-2);
 }

--- a/web-console/src/utils/index.tsx
+++ b/web-console/src/utils/index.tsx
@@ -24,3 +24,4 @@ export * from './query-manager';
 export * from './query-cursor';
 export * from './local-storage-keys';
 export * from './column-metadata';
+export * from './compaction';

--- a/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
+++ b/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
@@ -11,7 +11,20 @@ exports[`data source view matches snapshot 1`] = `
       localStorageKey="datasources-refresh-rate"
       onRefresh={[Function]}
     />
-    <Memo(MoreButton)>
+    <Memo(MoreButton)
+      altExtra={
+        <Blueprint3.MenuItem
+          disabled={false}
+          icon="compressed"
+          intent="danger"
+          multiline={false}
+          onClick={[Function]}
+          popoverProps={Object {}}
+          shouldDismissPopover={true}
+          text="Force compaction run (debug)"
+        />
+      }
+    >
       <Blueprint3.MenuItem
         disabled={false}
         icon="application"
@@ -55,6 +68,8 @@ exports[`data source view matches snapshot 1`] = `
           "Avg. row size",
           "Replicated size",
           "Compaction",
+          "% Compacted",
+          "Left to be compacted",
           "Retention",
           "Actions",
         ]
@@ -137,6 +152,7 @@ exports[`data source view matches snapshot 1`] = `
           "accessor": [Function],
           "filterable": false,
           "id": "availability",
+          "minWidth": 200,
           "show": true,
           "sortMethod": [Function],
         },
@@ -150,6 +166,7 @@ exports[`data source view matches snapshot 1`] = `
           "accessor": "num_segments_to_load",
           "filterable": false,
           "id": "load-drop",
+          "minWidth": 100,
           "show": true,
         },
         Object {
@@ -174,7 +191,7 @@ exports[`data source view matches snapshot 1`] = `
           "accessor": "avg_segment_size",
           "filterable": false,
           "show": true,
-          "width": 200,
+          "width": 150,
         },
         Object {
           "Cell": [Function],
@@ -217,8 +234,35 @@ exports[`data source view matches snapshot 1`] = `
           "Header": "Compaction",
           "accessor": [Function],
           "filterable": false,
-          "id": "compaction",
+          "id": "compactionStatus",
           "show": true,
+          "width": 150,
+        },
+        Object {
+          "Cell": [Function],
+          "Header": <React.Fragment>
+            % Compacted
+            <br />
+            bytes / segments / intervals
+          </React.Fragment>,
+          "accessor": [Function],
+          "filterable": false,
+          "id": "percentCompacted",
+          "show": true,
+          "width": 200,
+        },
+        Object {
+          "Cell": [Function],
+          "Header": <React.Fragment>
+            Left to be
+            <br />
+            compacted
+          </React.Fragment>,
+          "accessor": [Function],
+          "filterable": false,
+          "id": "leftToBeCompacted",
+          "show": true,
+          "width": 100,
         },
         Object {
           "Cell": [Function],
@@ -226,6 +270,7 @@ exports[`data source view matches snapshot 1`] = `
           "accessor": [Function],
           "filterable": false,
           "id": "retention",
+          "minWidth": 100,
           "show": true,
         },
         Object {

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -42,8 +42,11 @@ import { DatasourceTableActionDialog } from '../../dialogs/datasource-table-acti
 import { AppToaster } from '../../singletons/toaster';
 import {
   addFilter,
+  CompactionConfig,
+  CompactionStatus,
   countBy,
   formatBytes,
+  formatCompactionConfigAndStatus,
   formatInteger,
   formatMegabytes,
   formatPercent,
@@ -54,6 +57,7 @@ import {
   queryDruidSql,
   QueryManager,
   QueryState,
+  zeroCompactionStatus,
 } from '../../utils';
 import { BasicAction } from '../../utils/basic-action';
 import { Capabilities, CapabilitiesMode } from '../../utils/capabilities';
@@ -138,58 +142,7 @@ function progress(done: number, awaiting: number): number {
   return done / d;
 }
 
-function capitalizeFirst(str: string): string {
-  return str.slice(0, 1).toUpperCase() + str.slice(1).toLowerCase();
-}
-
 const PERCENT_BRACES = ['100.00%'];
-
-interface CompactionStatus {
-  dataSource: string;
-  scheduleStatus: string;
-  bytesAwaitingCompaction: number;
-  bytesCompacted: number;
-  bytesSkipped: number;
-  segmentCountAwaitingCompaction: number;
-  segmentCountCompacted: number;
-  segmentCountSkipped: number;
-  intervalCountAwaitingCompaction: number;
-  intervalCountCompacted: number;
-  intervalCountSkipped: number;
-}
-
-function zeroCompactionStatus(compactionStatus: CompactionStatus): boolean {
-  return (
-    !compactionStatus.bytesAwaitingCompaction &&
-    !compactionStatus.bytesCompacted &&
-    !compactionStatus.bytesSkipped &&
-    !compactionStatus.segmentCountAwaitingCompaction &&
-    !compactionStatus.segmentCountCompacted &&
-    !compactionStatus.segmentCountSkipped &&
-    !compactionStatus.intervalCountAwaitingCompaction &&
-    !compactionStatus.intervalCountCompacted &&
-    !compactionStatus.intervalCountSkipped
-  );
-}
-
-type CompactionConfig = Record<string, any>;
-
-function formatCompactionConfigAndStatus(
-  compactionConfig: CompactionConfig | undefined,
-  compactionStatus: CompactionStatus | undefined,
-) {
-  if (compactionStatus) {
-    if (compactionStatus.bytesAwaitingCompaction === 0 && !zeroCompactionStatus(compactionStatus)) {
-      return 'Fully compacted';
-    } else {
-      return capitalizeFirst(compactionStatus.scheduleStatus);
-    }
-  } else if (compactionConfig) {
-    return 'Awaiting first run';
-  } else {
-    return 'Not enabled';
-  }
-}
 
 interface Datasource {
   datasource: string;

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -142,7 +142,7 @@ function progress(done: number, awaiting: number): number {
   return done / d;
 }
 
-const PERCENT_BRACES = ['100.00%'];
+const PERCENT_BRACES = [formatPercent(1)];
 
 interface Datasource {
   datasource: string;

--- a/web-console/src/views/query-view/query-input/query-input.tsx
+++ b/web-console/src/views/query-view/query-input/query-input.tsx
@@ -214,7 +214,7 @@ export class QueryInput extends React.PureComponent<QueryInputProps, QueryInputS
   public goToPosition(rowColumn: RowColumn) {
     const { aceEditor } = this;
     if (!aceEditor) return;
-    aceEditor.focus(); // Grab the focus also
+    aceEditor.focus(); // Grab the focus
     aceEditor.getSelection().moveCursorTo(rowColumn.row, rowColumn.column);
     if (rowColumn.endRow && rowColumn.endColumn) {
       aceEditor


### PR DESCRIPTION
This PR adds a column to display the (new) compaction status API

![image](https://user-images.githubusercontent.com/177816/94326243-9d07e780-ff57-11ea-9f80-256fa08580f0.png)

This PR also:

- Adds suggestion options for the `skipOffsetFromLatest` parameter
- Improves error cursor placement in the JsonInput
- adds an alt + click option to the `...` button allowing for a secret undocumented API option to run compaction immediately. This is very useful for debugging and the copy is made suitably scary to ensure users are dissuade from using this option.

