### PR TITLE
vectorize constant expressions with optimized selectors

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/vector/ConstantVectorSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/ConstantVectorSelectors.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.vector;
+
+import org.apache.druid.segment.IdLookup;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+public class ConstantVectorSelectors
+{
+  public static VectorValueSelector vectorValueSelector(VectorSizeInspector inspector, @Nullable Number constant)
+  {
+    if (constant == null) {
+      return NilVectorSelector.create(inspector);
+    }
+    final long[] longVector = new long[inspector.getMaxVectorSize()];
+    final float[] floatVector = new float[inspector.getMaxVectorSize()];
+    final double[] doubleVector = new double[inspector.getMaxVectorSize()];
+    Arrays.fill(longVector, constant.longValue());
+    Arrays.fill(floatVector, constant.floatValue());
+    Arrays.fill(doubleVector, constant.doubleValue());
+    return new VectorValueSelector()
+    {
+      @Override
+      public long[] getLongVector()
+      {
+        return longVector;
+      }
+
+      @Override
+      public float[] getFloatVector()
+      {
+        return floatVector;
+      }
+
+      @Override
+      public double[] getDoubleVector()
+      {
+        return doubleVector;
+      }
+
+      @Nullable
+      @Override
+      public boolean[] getNullVector()
+      {
+        return null;
+      }
+
+      @Override
+      public int getMaxVectorSize()
+      {
+        return inspector.getMaxVectorSize();
+      }
+
+      @Override
+      public int getCurrentVectorSize()
+      {
+        return inspector.getCurrentVectorSize();
+      }
+    };
+  }
+
+  public static VectorObjectSelector vectorObjectSelector(
+      VectorSizeInspector inspector,
+      @Nullable Object object
+  )
+  {
+    if (object == null) {
+      return NilVectorSelector.create(inspector);
+    }
+
+    final Object[] objects = new Object[inspector.getMaxVectorSize()];
+    Arrays.fill(objects, object);
+
+    return new VectorObjectSelector()
+    {
+      @Override
+      public Object[] getObjectVector()
+      {
+        return objects;
+      }
+
+      @Override
+      public int getMaxVectorSize()
+      {
+        return inspector.getMaxVectorSize();
+      }
+
+      @Override
+      public int getCurrentVectorSize()
+      {
+        return inspector.getCurrentVectorSize();
+      }
+    };
+  }
+
+  public static SingleValueDimensionVectorSelector singleValueDimensionVectorSelector(
+      VectorSizeInspector inspector,
+      @Nullable String value
+  )
+  {
+    if (value == null) {
+      return NilVectorSelector.create(inspector);
+    }
+
+    final int[] row = new int[inspector.getMaxVectorSize()];
+    return new SingleValueDimensionVectorSelector()
+    {
+      @Override
+      public int[] getRowVector()
+      {
+        return row;
+      }
+
+      @Override
+      public int getValueCardinality()
+      {
+        return 1;
+      }
+
+      @Nullable
+      @Override
+      public String lookupName(int id)
+      {
+        return value;
+      }
+
+      @Override
+      public boolean nameLookupPossibleInAdvance()
+      {
+        return true;
+      }
+
+      @Nullable
+      @Override
+      public IdLookup idLookup()
+      {
+        return null;
+      }
+
+      @Override
+      public int getMaxVectorSize()
+      {
+        return inspector.getMaxVectorSize();
+      }
+
+      @Override
+      public int getCurrentVectorSize()
+      {
+        return inspector.getCurrentVectorSize();
+      }
+    };
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
@@ -100,6 +100,11 @@ public class ExpressionPlan
     this.unappliedInputs = unappliedInputs;
   }
 
+  public boolean isConstant()
+  {
+    return analysis.getRequiredBindings().isEmpty();
+  }
+
   public Expr getExpression()
   {
     return expression;

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVectorSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVectorSelectorsTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExprType;
 import org.apache.druid.math.expr.Parser;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnValueSelector;
@@ -39,6 +40,7 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.generator.SegmentGenerator;
+import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
 import org.apache.druid.segment.vector.VectorCursor;
 import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.vector.VectorValueSelector;
@@ -75,7 +77,11 @@ public class ExpressionVectorSelectorsTest
       "parse_long(string1)",
       "parse_long(string1) * double3",
       "parse_long(string5) * parse_long(string1)",
-      "parse_long(string5) * parse_long(string1) * double3"
+      "parse_long(string5) * parse_long(string1) * double3",
+      "'string constant'",
+      "1",
+      "192412.24124",
+      "null"
   );
 
   private static final int ROWS_PER_SEGMENT = 100_000;
@@ -167,7 +173,8 @@ public class ExpressionVectorSelectorsTest
             )
         )
     );
-    VectorCursor cursor = new QueryableIndexStorageAdapter(index).makeVectorCursor(
+    final QueryableIndexStorageAdapter storageAdapter = new QueryableIndexStorageAdapter(index);
+    VectorCursor cursor = storageAdapter.makeVectorCursor(
         null,
         index.getDataInterval(),
         virtualColumns,
@@ -176,40 +183,55 @@ public class ExpressionVectorSelectorsTest
         null
     );
 
-    VectorValueSelector selector = null;
-    VectorObjectSelector objectSelector = null;
-    if (outputType.isNumeric()) {
-      selector = cursor.getColumnSelectorFactory().makeValueSelector("v");
-    } else {
-      objectSelector = cursor.getColumnSelectorFactory().makeObjectSelector("v");
-    }
-    int rowCount = 0;
-    while (!cursor.isDone()) {
-      boolean[] nulls;
-      switch (outputType) {
-        case LONG:
-          nulls = selector.getNullVector();
-          long[] longs = selector.getLongVector();
-          for (int i = 0; i < selector.getCurrentVectorSize(); i++, rowCount++) {
-            results.add(nulls != null && nulls[i] ? null : longs[i]);
-          }
-          break;
-        case DOUBLE:
-          nulls = selector.getNullVector();
-          double[] doubles = selector.getDoubleVector();
-          for (int i = 0; i < selector.getCurrentVectorSize(); i++, rowCount++) {
-            results.add(nulls != null && nulls[i] ? null : doubles[i]);
-          }
-          break;
-        case STRING:
-          Object[] objects = objectSelector.getObjectVector();
-          for (int i = 0; i < objectSelector.getCurrentVectorSize(); i++, rowCount++) {
-            results.add(objects[i]);
-          }
-          break;
-      }
+    ColumnCapabilities capabilities = virtualColumns.getColumnCapabilities(storageAdapter, "v");
 
-      cursor.advance();
+    int rowCount = 0;
+    if (capabilities.isDictionaryEncoded().isTrue()) {
+      SingleValueDimensionVectorSelector selector = cursor.getColumnSelectorFactory().makeSingleValueDimensionSelector(
+          DefaultDimensionSpec.of("v")
+      );
+      while (!cursor.isDone()) {
+        int[] row = selector.getRowVector();
+        for (int i = 0; i < selector.getCurrentVectorSize(); i++, rowCount++) {
+          results.add(selector.lookupName(row[i]));
+        }
+        cursor.advance();
+      }
+    } else {
+      VectorValueSelector selector = null;
+      VectorObjectSelector objectSelector = null;
+      if (outputType.isNumeric()) {
+        selector = cursor.getColumnSelectorFactory().makeValueSelector("v");
+      } else {
+        objectSelector = cursor.getColumnSelectorFactory().makeObjectSelector("v");
+      }
+      while (!cursor.isDone()) {
+        boolean[] nulls;
+        switch (outputType) {
+          case LONG:
+            nulls = selector.getNullVector();
+            long[] longs = selector.getLongVector();
+            for (int i = 0; i < selector.getCurrentVectorSize(); i++, rowCount++) {
+              results.add(nulls != null && nulls[i] ? null : longs[i]);
+            }
+            break;
+          case DOUBLE:
+            nulls = selector.getNullVector();
+            double[] doubles = selector.getDoubleVector();
+            for (int i = 0; i < selector.getCurrentVectorSize(); i++, rowCount++) {
+              results.add(nulls != null && nulls[i] ? null : doubles[i]);
+            }
+            break;
+          case STRING:
+            Object[] objects = objectSelector.getObjectVector();
+            for (int i = 0; i < objectSelector.getCurrentVectorSize(); i++, rowCount++) {
+              results.add(objects[i]);
+            }
+            break;
+        }
+
+        cursor.advance();
+      }
     }
     closer.register(cursor);
 
@@ -224,10 +246,15 @@ public class ExpressionVectorSelectorsTest
 
     int rowCountCursor = cursors
         .map(nonVectorized -> {
-          final ColumnValueSelector nonSelector = nonVectorized.getColumnSelectorFactory().makeColumnValueSelector("v");
+          final ColumnValueSelector nonSelector = nonVectorized.getColumnSelectorFactory()
+                                                               .makeColumnValueSelector("v");
           int rows = 0;
           while (!nonVectorized.isDone()) {
-            Assert.assertEquals(StringUtils.format("Failed at row %s", rows), nonSelector.getObject(), results.get(rows));
+            Assert.assertEquals(
+                StringUtils.format("Failed at row %s", rows),
+                nonSelector.getObject(),
+                results.get(rows)
+            );
             rows++;
             nonVectorized.advance();
           }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlVectorizedExpressionSanityTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlVectorizedExpressionSanityTest.java
@@ -91,6 +91,7 @@ public class SqlVectorizedExpressionSanityTest extends InitializedNullHandlingTe
       "SELECT SUM(PARSE_LONG(string1)) FROM foo",
       "SELECT SUM(PARSE_LONG(string3)) FROM foo",
       "SELECT TIME_FLOOR(__time, 'PT1H'), string2, SUM(long1 * double4) FROM foo GROUP BY 1,2 ORDER BY 3",
+      "SELECT TIME_FLOOR(__time, 'PT1H'), string2, SUM(long1 * double4) FROM foo WHERE string2 = '10' GROUP BY 1,2 ORDER BY 3",
       "SELECT TIME_FLOOR(__time, 'PT1H'), SUM(long1 * long4) FROM foo GROUP BY 1 ORDER BY 1",
       "SELECT TIME_FLOOR(__time, 'PT1H'), SUM(long1 * long4) FROM foo GROUP BY 1 ORDER BY 2",
       "SELECT TIME_FLOOR(TIMESTAMPADD(DAY, -1, __time), 'PT1H'), SUM(long1 * long4) FROM foo GROUP BY 1 ORDER BY 1",


### PR DESCRIPTION
### Description
This PR builds on top of #10401, and adds optimized selectors for constant expressions of all types, including single value dimension vector selectors. To aid in this, it adds a new utility class `ConstantVectorSelectors` to provide methods for creating constant `SingleValueDimensionVectorSelector`, `VectorValueSelector`, and `VectorObjectSelector`, for use for constant expression in `ExpressionVectorSelectors.makeSingleValueDimensionVectorSelector` (new in this PR), `ExpressionVectorSelectors.makeVectorValueSelector`, and `ExpressionVectorSelectors.makeVectorObjectSelector`.

Supporting single value dimension selector constants is important because SQL queries such as:
 
```
SELECT TIME_FLOOR(__time, 'PT1H'), string2, SUM(long1 * double4) FROM foo WHERE string2 = '10' GROUP BY 1,2 ORDER BY 3
```

plan into a native group by query with an expression virtual column with '10' as the constant expression in place of the 'string2' dimension, because Calcite assumes that a constant is cheaper than reading the column. However, since the single value dimension vector selector was not yet implemented, this would cause the query to be unable to vectorize, which is fixed in this PR (and a test added).

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

