### PR TITLE
Compaction config UI optional numShards

### DIFF
--- a/web-console/e2e-tests/auto-compaction.spec.ts
+++ b/web-console/e2e-tests/auto-compaction.spec.ts
@@ -68,7 +68,7 @@ describe('Auto-compaction', () => {
       const compactionConfig = new CompactionConfig({
         skipOffsetFromLatest: 'PT0S',
         partitionsSpec: new CompactionHashPartitionsSpec({
-          numShards: 1,
+          numShards: null,
         }),
       });
       await configureCompaction(page, datasourceName, compactionConfig);

--- a/web-console/e2e-tests/component/datasources/compaction.ts
+++ b/web-console/e2e-tests/component/datasources/compaction.ts
@@ -37,7 +37,9 @@ export class CompactionHashPartitionsSpec implements CompactionPartitionsSpec {
 
   async apply(page: playwright.Page): Promise<void> {
     await setInput(page, PARTITIONING_TYPE, this.type);
-    await setInput(page, 'Num shards', String(this.numShards));
+    if (this.numShards != null) {
+      await setInput(page, 'Num shards', String(this.numShards));
+    }
   }
 }
 
@@ -48,7 +50,7 @@ async function setInput(page: playwright.Page, label: string, value: string): Pr
 }
 
 interface CompactionHashPartitionsSpecProps {
-  readonly numShards: number;
+  readonly numShards: number | null;
 }
 
 export interface CompactionHashPartitionsSpec extends CompactionHashPartitionsSpecProps {}

--- a/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
@@ -442,7 +442,7 @@ exports[`CompactionDialog matches snapshot with compactionConfig (hashed partiti
         text="Close"
       />
       <Blueprint3.Button
-        disabled={true}
+        disabled={false}
         intent="primary"
         onClick={[Function]}
         text="Submit"

--- a/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
@@ -92,7 +92,6 @@ exports[`CompactionDialog matches snapshot with compactionConfig (dynamic partit
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",
-            "required": true,
             "type": "number",
           },
           Object {
@@ -319,7 +318,6 @@ exports[`CompactionDialog matches snapshot with compactionConfig (hashed partiti
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",
-            "required": true,
             "type": "number",
           },
           Object {
@@ -546,7 +544,6 @@ exports[`CompactionDialog matches snapshot with compactionConfig (single_dim par
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",
-            "required": true,
             "type": "number",
           },
           Object {
@@ -773,7 +770,6 @@ exports[`CompactionDialog matches snapshot without compactionConfig 1`] = `
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",
-            "required": true,
             "type": "number",
           },
           Object {

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -77,7 +77,6 @@ const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
     name: 'tuningConfig.partitionsSpec.numShards',
     label: 'Num shards',
     type: 'number',
-    required: true, // ToDo: this will no longer be required after https://github.com/apache/druid/pull/10419 is merged
     defined: (t: CompactionConfig) => deepGet(t, 'tuningConfig.partitionsSpec.type') === 'hashed',
     info: (
       <>
@@ -211,13 +210,7 @@ function validCompactionConfig(compactionConfig: CompactionConfig): boolean {
     deepGet(compactionConfig, 'tuningConfig.partitionsSpec.type') || 'dynamic';
   switch (partitionsSpecType) {
     // case 'dynamic': // Nothing to check for dynamic
-    case 'hashed':
-      // ToDo: this will no longer be required after https://github.com/apache/druid/pull/10419 is merged
-      if (!deepGet(compactionConfig, 'tuningConfig.partitionsSpec.numShards')) {
-        return false;
-      }
-      break;
-
+    // case 'hashed': // Nothing to check for hashed
     case 'single_dim':
       if (!deepGet(compactionConfig, 'tuningConfig.partitionsSpec.partitionDimension')) {
         return false;

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -2114,10 +2114,6 @@ export function invalidTuningConfig(tuningConfig: TuningConfig, intervals: any):
 
   if (!intervals) return true;
   switch (deepGet(tuningConfig, 'partitionsSpec.type')) {
-    case 'hashed':
-      if (!deepGet(tuningConfig, 'partitionsSpec.numShards')) return true;
-      break;
-
     case 'single_dim':
       if (!deepGet(tuningConfig, 'partitionsSpec.partitionDimension')) return true;
       const hasTargetRowsPerSegment = Boolean(
@@ -2190,7 +2186,6 @@ export function getPartitionRelatedTuningSpecFormFields(
           label: 'Num shards',
           type: 'number',
           defined: (t: TuningConfig) => deepGet(t, 'partitionsSpec.type') === 'hashed',
-          required: true,
           info: (
             <>
               Directly specify the number of shards to create. If this is specified and 'intervals'


### PR DESCRIPTION
### Description

Specifying `numShards` for hashed partitions is no longer required after https://github.com/apache/druid/pull/10419. Update the UI make`numShards` an optional field for hash partitions.

#### Compaction config UI
![compaction-config-optional-num-shards](https://user-images.githubusercontent.com/9208416/94331910-4b765180-ff85-11ea-924a-5a8c30f28ff0.png)

#### Data loader UI
![data-loader-partition-optional-num-shards](https://user-images.githubusercontent.com/9208416/94331914-53ce8c80-ff85-11ea-8cde-1f14d05d163d.png)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

