### PR TITLE
Any virtual column on "__time" should be a pre-join virtual column

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -34,6 +34,7 @@ import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
@@ -305,6 +306,7 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
   )
   {
     final Set<String> baseColumns = new HashSet<>();
+    baseColumns.add(ColumnHolder.TIME_COLUMN_NAME);
     Iterables.addAll(baseColumns, baseAdapter.getAvailableDimensions());
     Iterables.addAll(baseColumns, baseAdapter.getAvailableMetrics());
 

--- a/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
@@ -27,7 +27,9 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.lookup.LookupExtractor;
 import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysisKey;
@@ -240,6 +242,21 @@ public class BaseHashJoinSegmentStorageAdapterTest
             virtualColumns,
             originalFilter
         )
+    );
+  }
+
+  protected VirtualColumn makeExpressionVirtualColumn(String expression)
+  {
+    return makeExpressionVirtualColumn(expression, "virtual");
+  }
+
+  protected VirtualColumn makeExpressionVirtualColumn(String expression, String columnName)
+  {
+    return new ExpressionVirtualColumn(
+        columnName,
+        expression,
+        ValueType.STRING,
+        ExprMacroTable.nil()
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.query.filter.ExpressionDimFilter;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.OrDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ValueType;
@@ -38,10 +39,10 @@ import org.apache.druid.segment.filter.SelectorFilter;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
-import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -1502,12 +1503,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     VirtualColumns virtualColumns = VirtualColumns.create(
         Collections.singletonList(
-            new ExpressionVirtualColumn(
-                "virtual",
-                "concat(substring(countryIsoCode, 0, 1),'L')",
-                ValueType.STRING,
-                ExprMacroTable.nil()
-            )
+            makeExpressionVirtualColumn("concat(substring(countryIsoCode, 0, 1),'L')")
         )
     );
 
@@ -1563,12 +1559,7 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
 
     VirtualColumns virtualColumns = VirtualColumns.create(
         Collections.singletonList(
-            new ExpressionVirtualColumn(
-                "virtual",
-                "concat(substring(countryIsoCode, 0, 1),'L')",
-                ValueType.STRING,
-                ExprMacroTable.nil()
-            )
+            makeExpressionVirtualColumn("concat(substring(countryIsoCode, 0, 1),'L')")
         )
     );
 
@@ -2026,6 +2017,42 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
         false,
         null
     );
+  }
+
+  @Test
+  public void test_determineBaseColumnsWithPreAndPostJoinVirtualColumns()
+  {
+    List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
+    JoinFilterPreAnalysis analysis = makeDefaultConfigPreAnalysis(null, joinableClauses, VirtualColumns.EMPTY);
+    HashJoinSegmentStorageAdapter adapter = new HashJoinSegmentStorageAdapter(
+        factSegment.asStorageAdapter(),
+        joinableClauses,
+        analysis
+    );
+    List<VirtualColumn> expectedPreJoin = ImmutableList.of(
+        makeExpressionVirtualColumn("concat(countryIsoCode,'L')", "v0"),
+        makeExpressionVirtualColumn("concat(countryIsoCode, countryNumber)", "v1"),
+        makeExpressionVirtualColumn("channel_uniques - 1", "v2"),
+        makeExpressionVirtualColumn("channel_uniques - __time", "v3")
+    );
+
+    List<VirtualColumn> expectedPostJoin = ImmutableList.of(
+        makeExpressionVirtualColumn("concat(countryIsoCode, dummyColumn)", "v4"),
+        makeExpressionVirtualColumn("dummyMetric - __time", "v5")
+    );
+    List<VirtualColumn> actualPreJoin = new ArrayList<>();
+    List<VirtualColumn> actualPostJoin = new ArrayList<>();
+    List<VirtualColumn> allVirtualColumns = new ArrayList<>();
+    allVirtualColumns.addAll(expectedPreJoin);
+    allVirtualColumns.addAll(expectedPostJoin);
+    adapter.determineBaseColumnsWithPreAndPostJoinVirtualColumns(
+        VirtualColumns.create(allVirtualColumns),
+        actualPreJoin,
+        actualPostJoin
+    );
+
+    Assert.assertEquals(expectedPreJoin, actualPreJoin);
+    Assert.assertEquals(expectedPostJoin, actualPostJoin);
   }
 
 }


### PR DESCRIPTION
If there is a virtual column with `__time` and base table columns as required columns, the virtual column can still be created past join. This PR avoids that from happening. 

<hr>

This PR has:
- [x] been self-reviewed.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>