### PR TITLE
Close aggregators in HashVectorGrouper.close()

### DIFF
--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -244,6 +244,11 @@
             <artifactId>log4j-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouper.java
@@ -265,7 +265,7 @@ public class HashVectorGrouper implements VectorGrouper
   @Override
   public void close()
   {
-    // Nothing to do.
+    aggregators.close();
   }
 
 

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.groupby.epinephelinae;
+
+import com.google.common.base.Suppliers;
+import org.apache.druid.query.aggregation.AggregatorAdapters;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+
+public class HashVectorGrouperTest
+{
+  @Test
+  public void testCloseAggregatorAdaptorsShouldBeClosed()
+  {
+    final ByteBuffer buffer = ByteBuffer.wrap(new byte[4096]);
+    final AggregatorAdapters aggregatorAdapters = Mockito.mock(AggregatorAdapters.class);
+    final HashVectorGrouper grouper = new HashVectorGrouper(
+        Suppliers.ofInstance(buffer),
+        1024,
+        aggregatorAdapters,
+        Integer.MAX_VALUE,
+        0.f,
+        0
+    );
+    grouper.initVectorized(512);
+    grouper.close();
+    Mockito.verify(aggregatorAdapters, Mockito.times(1)).close();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/vector/VectorGroupByEngineTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/vector/VectorGroupByEngineTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.groupby.epinephelinae.vector;
+
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.query.QueryRunnerTestHelper;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.groupby.GroupByQuery;
+import org.apache.druid.query.groupby.GroupByQueryConfig;
+import org.apache.druid.query.groupby.ResultRow;
+import org.apache.druid.segment.QueryableIndexStorageAdapter;
+import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.joda.time.Interval;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+
+public class VectorGroupByEngineTest extends InitializedNullHandlingTest
+{
+  @Test
+  public void testProcessCreateNewGrouperWhenDelegateIsCreated()
+  {
+    final Interval interval = TestIndex.DATA_INTERVAL;
+    final AggregatorFactory factory = Mockito.spy(new DoubleSumAggregatorFactory("index", "index"));
+    final GroupByQuery query = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
+        .setInterval(interval)
+        .setDimensions(new DefaultDimensionSpec("market", null, null))
+        .setAggregatorSpecs(factory)
+        .build();
+    final StorageAdapter storageAdapter = Mockito.spy(new QueryableIndexStorageAdapter(TestIndex.getMMappedTestIndex()));
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[4096]);
+
+    final Sequence<ResultRow> sequence = VectorGroupByEngine.process(
+        query,
+        storageAdapter,
+        byteBuffer,
+        null,
+        null,
+        interval,
+        new GroupByQueryConfig()
+    );
+    sequence.toList();
+    // GroupByQueryEngineV2.getCardinalityForArrayAggregation() should be called whenever it creates a new grouper.
+    Mockito.verify(storageAdapter, Mockito.times(94)).getDimensionCardinality("market");
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/TestIndex.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestIndex.java
@@ -134,8 +134,8 @@ public class TestIndex
 
   public static final String[] DOUBLE_METRICS = new String[]{"index", "indexMin", "indexMaxPlusTen"};
   public static final String[] FLOAT_METRICS = new String[]{"indexFloat", "indexMinFloat", "indexMaxFloat"};
+  public static final Interval DATA_INTERVAL = Intervals.of("2011-01-12T00:00:00.000Z/2011-05-01T00:00:00.000Z");
   private static final Logger log = new Logger(TestIndex.class);
-  private static final Interval DATA_INTERVAL = Intervals.of("2011-01-12T00:00:00.000Z/2011-05-01T00:00:00.000Z");
   private static final VirtualColumns VIRTUAL_COLUMNS = VirtualColumns.create(
       Collections.singletonList(
           new ExpressionVirtualColumn("expr", "index + 10", ValueType.FLOAT, TestExprMacroTable.INSTANCE)


### PR DESCRIPTION
### Description

There are 2 issues in `VectorGroupByEngine`.

- When `HashVectorGrouper` is used, `AggregatorAdaptors` is never closed.
- When `BufferArrayGrouper` is used, the same `AggregatorAdaptors` can be used after it is closed since the same `grouper` instance is used to create `delegate`s which are `CloseableGrouperIterator`.

The von-vectorized groupBy engine doesn't have this issue because it creates a new `grouper` per `delegate`. This PR fixes the issue in `VectorGroupByEngine` by closing the `grouper` when the outer `VectorGroupByEngineIterator` is closed.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.