### PR TITLE
Fix the config initialization on container restart

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -46,6 +46,7 @@ echo "$(date -Is) startup service $SERVICE"
 # We put all the config in /tmp/conf to allow for a
 # read-only root filesystem
 mkdir -p /tmp/conf/
+test -d /tmp/conf/druid && rm -r /tmp/conf/druid
 cp -r /opt/druid/conf/druid /tmp/conf/druid
 
 getConfPath() {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

The following PR fixes the bug outlined below:

On the initial docker container run, the config is copied to the /tmp dir as follows:

```
mkdir -p /tmp/conf/
cp -r /opt/druid/conf/druid /tmp/conf/druid
```

Which effectively creates the directory `/tmp/conf` and copies __the directory__ `druid` to it.
Therefore, we end up with the structure as follows:

```
/tmp/conf/druid/
--------------------> [druid configs]
```

Which is the wanted behaviour.

However, after executing `docker restart druid-container` or restarting the container in any other way, the `cp` program copies __the directory__ `druid` to __the directory__ /tmp/conf/__druid__, which leads to the structure `/tmp/conf/druid/druid`, i.e.

```
/tmp/conf/druid/
--------------------> [druid configs]
--------------------> druid/[druid configs]
```

This makes it impossible to modify the mounted configuration without completely removing the file system of the container (recreating it).

#### Fixed the bug

Added the test for the existing target config directory in `/tmp` and its removal.

<hr>

[seems irrelevant for the change like this]

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>
