### PR TITLE
Fix UI datasources view edit action compaction

### DIFF
--- a/web-console/e2e-tests/auto-compaction.spec.ts
+++ b/web-console/e2e-tests/auto-compaction.spec.ts
@@ -126,6 +126,11 @@ async function configureCompaction(
 ) {
   const datasourcesOverview = new DatasourcesOverview(page, UNIFIED_CONSOLE_URL);
   await datasourcesOverview.setCompactionConfiguration(datasourceName, compactionConfig);
+
+  const savedCompactionConfig = await datasourcesOverview.getCompactionConfiguration(
+    datasourceName,
+  );
+  expect(savedCompactionConfig).toEqual(compactionConfig);
 }
 
 async function triggerCompaction() {

--- a/web-console/e2e-tests/util/playwright.ts
+++ b/web-console/e2e-tests/util/playwright.ts
@@ -49,6 +49,13 @@ export async function createPage(browser: playwright.Browser): Promise<playwrigh
   return page;
 }
 
+export async function getLabeledInput(page: playwright.Page, label: string): Promise<string> {
+  return await page.$eval(
+    `//*[text()="${label}"]/following-sibling::div//input`,
+    el => (el as HTMLInputElement).value,
+  );
+}
+
 export async function setLabeledInput(
   page: playwright.Page,
   label: string,

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -1209,12 +1209,12 @@ GROUP BY 1`;
               width: ACTION_COLUMN_WIDTH,
               filterable: false,
               Cell: ({ value: datasource, original }) => {
-                const { unused, rules, compaction } = original;
+                const { unused, rules, compactionConfig } = original;
                 const datasourceActions = this.getDatasourceActions(
                   datasource,
                   unused,
                   rules,
-                  compaction,
+                  compactionConfig,
                 );
                 return (
                   <ActionCell


### PR DESCRIPTION
### Description

Restore the web console's ability to view a datasource's compaction configuration via the "action" menu. Refactoring done in https://github.com/apache/druid/pull/10438 introduced a regression that always caused the default compaction configuration to be shown via the "action" menu instead.

Regression test is added in e2e-tests/auto-compaction.spec.ts.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>