### PR TITLE
adjustments to Kafka integration tests to allow running against Azure Event Hubs streams

### DIFF
--- a/integration-tests/src/main/java/org/apache/druid/testing/DockerConfigProvider.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/DockerConfigProvider.java
@@ -277,16 +277,18 @@ public class DockerConfigProvider implements IntegrationTestingConfigProvider
     public Map<String, String> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
         throws IOException
     {
-      // reading like this results in a map that has both nested objects and also flattened string pairs
-      // so the map looks something like this:
-
+      // given some config input, such as
+      //    druid.test.config.properites.a.b.c=d
+      // calling jsonParser.readValueAs(Map.class) here results in a map that has both nested objects and also
+      // flattened string pairs, so the map looks something like this (in JSON form):
       //    {
       //      "a" : { "b": { "c" : "d" }}},
       //      "a.b.c":"d"
       //    }
-
-      // filtering out the top level keys which do not have string values produces what we want here that
-      // '-Ddruid.test.config.properites.some.property.key=foo' -> { "some.property.key":"foo"}
+      // The string pairs are the values we want to populate this map with, so filtering out the top level keys which
+      // do not have string values leaves us with
+      //    { "a.b.c":"d"}
+      // from the given example, which is what we want
       Map<String, Object> parsed = jsonParser.readValueAs(Map.class);
       Map<String, String> flat = new HashMap<>();
       for (Map.Entry<String, Object> entry : parsed.entrySet()) {

--- a/integration-tests/src/main/java/org/apache/druid/testing/DockerConfigProvider.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/DockerConfigProvider.java
@@ -61,7 +61,7 @@ public class DockerConfigProvider implements IntegrationTestingConfigProvider
 
   @JsonProperty
   @JsonDeserialize(using = ArbitraryPropertiesJsonDeserializer.class)
-  private Map<String, String> properties;
+  private Map<String, String> properties = new HashMap<>();
 
   @Override
   public IntegrationTestingConfig get()

--- a/integration-tests/src/main/java/org/apache/druid/testing/DockerConfigProvider.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/DockerConfigProvider.java
@@ -292,7 +292,7 @@ public class DockerConfigProvider implements IntegrationTestingConfigProvider
       Map<String, Object> parsed = jsonParser.readValueAs(Map.class);
       Map<String, String> flat = new HashMap<>();
       for (Map.Entry<String, Object> entry : parsed.entrySet()) {
-        if (entry.getValue() instanceof String) {
+        if (!(entry.getValue() instanceof Map)) {
           flat.put(entry.getKey(), (String) entry.getValue());
         }
       }

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaAdminClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaAdminClient.java
@@ -43,8 +43,8 @@ public class KafkaAdminClient implements StreamAdminClient
   public KafkaAdminClient(IntegrationTestingConfig config)
   {
     Properties properties = new Properties();
-    KafkaUtil.addPropertiesFromTestConfig(config, properties);
     properties.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getKafkaHost());
+    KafkaUtil.addPropertiesFromTestConfig(config, properties);
     adminClient = AdminClient.create(properties);
   }
 

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaEventWriter.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaEventWriter.java
@@ -43,7 +43,6 @@ public class KafkaEventWriter implements StreamEventWriter
   {
     Properties properties = new Properties();
     properties.setProperty("bootstrap.servers", config.getKafkaHost());
-    KafkaUtil.addPropertiesFromTestConfig(config, properties);
     properties.setProperty("acks", "all");
     properties.setProperty("retries", "3");
     properties.setProperty("key.serializer", ByteArraySerializer.class.getName());
@@ -53,6 +52,7 @@ public class KafkaEventWriter implements StreamEventWriter
       properties.setProperty("enable.idempotence", "true");
       properties.setProperty("transactional.id", IdUtils.getRandomId());
     }
+    KafkaUtil.addPropertiesFromTestConfig(config, properties);
     this.producer = new KafkaProducer<>(
         properties,
         new StringSerializer(),

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaEventWriter.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaEventWriter.java
@@ -42,8 +42,8 @@ public class KafkaEventWriter implements StreamEventWriter
   public KafkaEventWriter(IntegrationTestingConfig config, boolean txnEnabled)
   {
     Properties properties = new Properties();
-    KafkaUtil.addPropertiesFromTestConfig(config, properties);
     properties.setProperty("bootstrap.servers", config.getKafkaHost());
+    KafkaUtil.addPropertiesFromTestConfig(config, properties);
     properties.setProperty("acks", "all");
     properties.setProperty("retries", "3");
     properties.setProperty("key.serializer", ByteArraySerializer.class.getName());

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KafkaUtil.java
@@ -21,12 +21,16 @@ package org.apache.druid.testing.utils;
 
 import org.apache.druid.testing.IntegrationTestingConfig;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 public class KafkaUtil
 {
   private static final String TEST_PROPERTY_PREFIX = "kafka.test.property.";
+  private static final String TEST_CONFIG_PROPERTY_PREFIX = "kafka.test.config.";
+
+  public static final String TEST_CONFIG_TRANSACTION_ENABLED = "transactionEnabled";
 
   public static void addPropertiesFromTestConfig(IntegrationTestingConfig config, Properties properties)
   {
@@ -35,5 +39,16 @@ public class KafkaUtil
         properties.setProperty(entry.getKey().substring(TEST_PROPERTY_PREFIX.length()), entry.getValue());
       }
     }
+  }
+
+  public static Map<String, String> getAdditionalKafkaTestConfigFromProperties(IntegrationTestingConfig config)
+  {
+    Map<String, String> theMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : config.getProperties().entrySet()) {
+      if (entry.getKey().startsWith(TEST_CONFIG_PROPERTY_PREFIX)) {
+        theMap.put(entry.getKey().substring(TEST_CONFIG_PROPERTY_PREFIX.length()), entry.getValue());
+      }
+    }
+    return theMap;
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKafkaIndexingServiceTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractKafkaIndexingServiceTest.java
@@ -58,9 +58,9 @@ public abstract class AbstractKafkaIndexingServiceTest extends AbstractStreamInd
   {
     final Map<String, Object> consumerConfigs = KafkaConsumerConfigs.getConsumerProperties();
     final Properties consumerProperties = new Properties();
-    KafkaUtil.addPropertiesFromTestConfig(config, consumerProperties);
     consumerProperties.putAll(consumerConfigs);
     consumerProperties.setProperty("bootstrap.servers", config.getKafkaInternalHost());
+    KafkaUtil.addPropertiesFromTestConfig(config, consumerProperties);
     return spec -> {
       try {
         spec = StringUtils.replace(

--- a/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKafkaIndexingServiceDataFormatTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/parallelized/ITKafkaIndexingServiceDataFormatTest.java
@@ -22,7 +22,9 @@ package org.apache.druid.tests.parallelized;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
+import org.apache.druid.testing.utils.KafkaUtil;
 import org.apache.druid.tests.TestNGGroup;
 import org.apache.druid.tests.indexer.AbstractKafkaIndexingServiceTest;
 import org.apache.druid.tests.indexer.AbstractStreamIndexingTest;
@@ -78,6 +80,9 @@ public class ITKafkaIndexingServiceDataFormatTest extends AbstractKafkaIndexingS
   @Inject
   private @Json ObjectMapper jsonMapper;
 
+  @Inject
+  private IntegrationTestingConfig config;
+
   @BeforeClass
   public void beforeClass() throws Exception
   {
@@ -88,7 +93,15 @@ public class ITKafkaIndexingServiceDataFormatTest extends AbstractKafkaIndexingS
   public void testIndexData(boolean transactionEnabled, String serializerPath, String parserType, String specPath)
       throws Exception
   {
-    doTestIndexDataStableState(transactionEnabled, serializerPath, parserType, specPath);
+    Map<String, String> testConfig = KafkaUtil.getAdditionalKafkaTestConfigFromProperties(config);
+    boolean txnEnable = Boolean.parseBoolean(
+        testConfig.getOrDefault(KafkaUtil.TEST_CONFIG_TRANSACTION_ENABLED, "false")
+    );
+    if (txnEnable != transactionEnabled) {
+      // do nothing
+      return;
+    }
+    doTestIndexDataStableState(txnEnable, serializerPath, parserType, specPath);
   }
 
   @Override


### PR DESCRIPTION
### Description
This PR adjust the Kafka integration tests to slightly adjust the order in which the `druid.test.config.properties.kafka.test.property.*` overrides are applied, allowing `bootstrap.servers` to be overridden in the docker tests to point at Azure event hubs. Additionally, an option to disable transaction tests (Azure Event Hubs does not support Kafka transactions) in `ITKafkaIndexingServiceDataFormatTest`. Note that this PR does not actually add any new integration tests, it just allows more configurability making this stuff possible.

With these adjustments I was able to run `ITKafkaIndexingServiceDataFormatTest` and `ITKafkaIndexingServiceNonTransactionalSerializedTest` with all tests passing by overriding the kafka configs with something like this:

```
-Ddruid.test.config.properties.kafka.test.property.security.protocol=SASL_SSL
-Ddruid.test.config.properties.kafka.test.property.sasl.mechanism=PLAIN
-Ddruid.test.config.properties.kafka.test.property.sasl.jaas.config="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"Endpoint=sb://{my-hub-name}.servicebus.windows.net/;SharedAccessKeyName={key-name};SharedAccessKey={shared-key}";"
-Ddruid.test.config.properties.kafka.test.property.bootstrap.servers={my-hub-name}.servicebus.windows.net:9093
```
For `ITKafkaIndexingServiceNonTransactionalParallelizedTest`, I encountered an exception in the test itself with the admin client API trying to change the partition count for `testKafkaIndexDataWithKafkaReshardSplit`:

```
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidRequestException: This most likely occurs because of a request being malformed by the client library or the message was sent to an incompatible broker. See the broker logs for more details.

	at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45)
	at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32)
	at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:89)
	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:260)
	at org.apache.druid.testing.utils.KafkaAdminClient.updatePartitionCount(KafkaAdminClient.java:82)
	at org.apache.druid.tests.indexer.AbstractStreamIndexingTest.testIndexWithStreamReshardHelper(AbstractStreamIndexingTest.java:427)
```

so it cannot be run successfully at this time (the other test, `testKafkaIndexDataWithStartStopSupervisor` does succeed), and none of the transactional tests can run since it isn't supported.


<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.

