### PR TITLE
Improve UI E2E test usability

### DIFF
--- a/web-console/README.md
+++ b/web-console/README.md
@@ -23,7 +23,7 @@ This is the unified Druid web console that servers as a data management layer fo
 
 ## How to watch and run for development
 
-1. You need to be withing the `web-console` directory
+1. You need to be within the `web-console` directory
 2. Install the modules with `npm install`
 3. Run `npm start` will start in development mode and will proxy druid requests to `localhost:8888`
 
@@ -82,26 +82,24 @@ From the web-console directory:
 3. Run end-to-end tests: `npm run test-e2e`
 4. Stop druid cluster: `script/druid stop`
 
+If you already have a druid cluster running on the standard ports, the steps to build/start/stop a druid cluster can
+be skipped.
+
 ### Debugging
 
 #### Screenshots
 
 `e2e-tests/util/debug.ts:saveScreenshotIfError()` is used to save a screenshot of the web console
-when the test fails. For example, if `e2e-tests/tutotrial-batch.spec.ts` fails, it will create
+when the test fails. For example, if `e2e-tests/tutorial-batch.spec.ts` fails, it will create
 `load-data-from-local-disk-error-screenshot.png`.
 
 #### Disabling Headless Mode
 
-Disabling headless mode while running the tests can be helpful. One way of doing this is by using
-`e2e-tests/util/playwright:createBrowserDebug()`. For example, the test can be modified to change
+Disabling headless mode while running the tests can be helpful. This can be done via the `DRUID_E2E_TEST_HEADLESS`
+environment variable, which defaults to `true`.
 
-```
-import { createBrowserNormal as createBrowser } from './util/playwright'
-```
+#### Running Against Alternate Web Console
 
-to
-
-```
-import { createBrowserDebug as createBrowser } from './util/playwright'`
-```
-
+The environment variable `DRUID_E2E_TEST_UNIFIED_CONSOLE_PORT` can be used to target a web console running on a
+non-default port (i.e., not port `8888`). For example, this environment variable can be used to target the
+development mode of the web console (started via `npm start`), which runs on port `18081`.

--- a/web-console/e2e-tests/auto-compaction.spec.ts
+++ b/web-console/e2e-tests/auto-compaction.spec.ts
@@ -18,7 +18,7 @@
 
 import axios from 'axios';
 import path from 'path';
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { CompactionConfig } from './component/datasources/compaction';
 import { Datasource } from './component/datasources/datasource';
@@ -29,7 +29,7 @@ import { COORDINATOR_URL } from './util/druid';
 import { DRUID_EXAMPLES_QUICKSTART_TUTORIAL_DIR } from './util/druid';
 import { UNIFIED_CONSOLE_URL } from './util/druid';
 import { runIndexTask } from './util/druid';
-import { createBrowserNormal as createBrowser } from './util/playwright';
+import { createBrowser } from './util/playwright';
 import { createPage } from './util/playwright';
 import { retryIfJestAssertionError } from './util/retry';
 import { waitTillWebConsoleReady } from './util/setup';

--- a/web-console/e2e-tests/component/datasources/overview.ts
+++ b/web-console/e2e-tests/component/datasources/overview.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { clickButton } from '../../util/playwright';
 import { getLabeledInput } from '../../util/playwright';
@@ -61,7 +61,7 @@ export class DatasourcesOverview {
 
   async getDatasources(): Promise<Datasource[]> {
     await this.page.goto(this.baseUrl);
-    await this.page.reload({ waitUntil: 'networkidle0' });
+    await this.page.reload({ waitUntil: 'networkidle' });
 
     const data = await extractTable(this.page, 'div div.rt-tr-group', 'div.rt-td');
 
@@ -116,6 +116,6 @@ export class DatasourcesOverview {
 
     const editActions = await this.page.$$('span[icon=wrench]');
     editActions[index].click();
-    await this.page.waitFor('ul.bp3-menu');
+    await this.page.waitForSelector('ul.bp3-menu');
   }
 }

--- a/web-console/e2e-tests/component/ingestion/overview.ts
+++ b/web-console/e2e-tests/component/ingestion/overview.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { extractTable } from '../../util/table';
 
@@ -50,7 +50,7 @@ export class IngestionOverview {
 
   async getTasks(): Promise<IngestionTask[]> {
     await this.page.goto(this.baseUrl);
-    await this.page.reload({ waitUntil: 'networkidle0' });
+    await this.page.reload({ waitUntil: 'networkidle' });
 
     const data = await extractTable(this.page, 'div.bottom-pane div.rt-tr-group', 'div.rt-td');
 

--- a/web-console/e2e-tests/component/load-data/config/partition.ts
+++ b/web-console/e2e-tests/component/load-data/config/partition.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { selectSuggestibleInput } from '../../../util/playwright';
 import { getLabeledInput } from '../../../util/playwright';

--- a/web-console/e2e-tests/component/load-data/data-connector/data-connector.ts
+++ b/web-console/e2e-tests/component/load-data/data-connector/data-connector.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { clickButton } from '../../../util/playwright';
 

--- a/web-console/e2e-tests/component/load-data/data-connector/local-file.ts
+++ b/web-console/e2e-tests/component/load-data/data-connector/local-file.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { setLabeledInput } from '../../../util/playwright';
 

--- a/web-console/e2e-tests/component/load-data/data-connector/reindex.ts
+++ b/web-console/e2e-tests/component/load-data/data-connector/reindex.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { setLabeledInput } from '../../../util/playwright';
 

--- a/web-console/e2e-tests/component/load-data/data-loader.ts
+++ b/web-console/e2e-tests/component/load-data/data-loader.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { clickButton } from '../../util/playwright';
 import { clickLabeledButton } from '../../util/playwright';
@@ -60,7 +60,8 @@ export class DataLoader {
   }
 
   private async start() {
-    await this.page.click(`"${this.connector.name}"`);
+    const cardSelector = `//*[contains(@class,"bp3-card")][p[contains(text(),"${this.connector.name}")]]`;
+    await this.page.click(cardSelector);
     await clickButton(this.page, 'Connect data');
   }
 
@@ -73,53 +74,54 @@ export class DataLoader {
 
   private async validateConnect(validator: (preview: string) => void) {
     const previewSelector = '.raw-lines';
-    await this.page.waitFor(previewSelector);
+    await this.page.waitForSelector(previewSelector);
     const preview = await this.page.$eval(previewSelector, el => (el as HTMLTextAreaElement).value);
     validator(preview!);
   }
 
   private async parseData() {
-    await this.page.waitFor('.parse-data-table');
+    await this.page.waitForSelector('.parse-data-table');
     await clickButton(this.page, 'Next: Parse time');
   }
 
   private async parseTime() {
-    await this.page.waitFor('.parse-time-table');
+    await this.page.waitForSelector('.parse-time-table');
     await clickButton(this.page, 'Next: Transform');
   }
 
   private async transform() {
-    await this.page.waitFor('.transform-table');
+    await this.page.waitForSelector('.transform-table');
     await clickButton(this.page, 'Next: Filter');
   }
 
   private async filter() {
-    await this.page.waitFor('.filter-table');
+    await this.page.waitForSelector('.filter-table');
     await clickButton(this.page, 'Next: Configure schema');
   }
 
   private async configureSchema(configureSchemaConfig: ConfigureSchemaConfig) {
-    await this.page.waitFor('.schema-table');
+    await this.page.waitForSelector('.schema-table');
     await this.applyConfigureSchemaConfig(configureSchemaConfig);
     await clickButton(this.page, 'Next: Partition');
   }
 
   private async applyConfigureSchemaConfig(configureSchemaConfig: ConfigureSchemaConfig) {
-    const rollup = await this.page.$('//*[text()="Rollup"]/input');
-    const rollupChecked = await rollup!.evaluate(el => (el as HTMLInputElement).checked);
+    const rollupSelector = '//*[text()="Rollup"]';
+    const rollupInput = await this.page.$(`${rollupSelector}/input`);
+    const rollupChecked = await rollupInput!.evaluate(el => (el as HTMLInputElement).checked);
     if (rollupChecked !== configureSchemaConfig.rollup) {
-      await rollup!.click();
+      await this.page.click(rollupSelector);
       const confirmationDialogSelector = '//*[contains(@class,"bp3-alert-body")]';
-      await this.page.waitFor(confirmationDialogSelector);
+      await this.page.waitForSelector(confirmationDialogSelector);
       await clickButton(this.page, 'Yes');
       const statusMessageSelector = '.recipe-toaster';
-      await this.page.waitFor(statusMessageSelector);
+      await this.page.waitForSelector(statusMessageSelector);
       await this.page.click(`${statusMessageSelector} button`);
     }
   }
 
   private async partition(partitionConfig: PartitionConfig) {
-    await this.page.waitFor('div.load-data-view.partition');
+    await this.page.waitForSelector('div.load-data-view.partition');
     await this.applyPartitionConfig(partitionConfig);
     await clickButton(this.page, 'Next: Tune');
   }
@@ -140,12 +142,12 @@ export class DataLoader {
   }
 
   private async tune() {
-    await this.page.waitFor('div.load-data-view.tuning');
+    await this.page.waitForSelector('div.load-data-view.tuning');
     await clickButton(this.page, 'Next: Publish');
   }
 
   private async publish(publishConfig: PublishConfig) {
-    await this.page.waitFor('div.load-data-view.publish');
+    await this.page.waitForSelector('div.load-data-view.publish');
     await this.applyPublishConfig(publishConfig);
     await clickButton(this.page, 'Edit spec');
   }
@@ -157,7 +159,7 @@ export class DataLoader {
   }
 
   private async editSpec() {
-    await this.page.waitFor('div.load-data-view.spec');
+    await this.page.waitForSelector('div.load-data-view.spec');
     await clickButton(this.page, 'Submit');
   }
 }

--- a/web-console/e2e-tests/component/query/overview.ts
+++ b/web-console/e2e-tests/component/query/overview.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { clickButton } from '../../util/playwright';
 import { setInput } from '../../util/playwright';
@@ -36,12 +36,12 @@ export class QueryOverview {
 
   async runQuery(query: string): Promise<string[][]> {
     await this.page.goto(this.baseUrl);
-    await this.page.reload({ waitUntil: 'networkidle0' });
+    await this.page.reload({ waitUntil: 'networkidle' });
 
     const input = await this.page.$('div.query-input textarea');
     await setInput(input!, query);
     await clickButton(this.page, 'Run');
-    await this.page.waitFor('div.query-info');
+    await this.page.waitForSelector('div.query-info');
 
     return await extractTable(this.page, 'div.query-output div.rt-tr-group', 'div.rt-td');
   }

--- a/web-console/e2e-tests/reindexing.spec.ts
+++ b/web-console/e2e-tests/reindexing.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import path from 'path';
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { DatasourcesOverview } from './component/datasources/overview';
 import { IngestionOverview } from './component/ingestion/overview';
@@ -32,7 +32,7 @@ import { saveScreenshotIfError } from './util/debug';
 import { DRUID_EXAMPLES_QUICKSTART_TUTORIAL_DIR } from './util/druid';
 import { UNIFIED_CONSOLE_URL } from './util/druid';
 import { runIndexTask } from './util/druid';
-import { createBrowserNormal as createBrowser } from './util/playwright';
+import { createBrowser } from './util/playwright';
 import { createPage } from './util/playwright';
 import { retryIfJestAssertionError } from './util/retry';
 import { waitTillWebConsoleReady } from './util/setup';

--- a/web-console/e2e-tests/tutorial-batch.spec.ts
+++ b/web-console/e2e-tests/tutorial-batch.spec.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 import { DatasourcesOverview } from './component/datasources/overview';
 import { IngestionOverview } from './component/ingestion/overview';
@@ -28,8 +28,9 @@ import { LocalFileDataConnector } from './component/load-data/data-connector/loc
 import { DataLoader } from './component/load-data/data-loader';
 import { QueryOverview } from './component/query/overview';
 import { saveScreenshotIfError } from './util/debug';
+import { DRUID_EXAMPLES_QUICKSTART_TUTORIAL_DIR } from './util/druid';
 import { UNIFIED_CONSOLE_URL } from './util/druid';
-import { createBrowserNormal as createBrowser } from './util/playwright';
+import { createBrowser } from './util/playwright';
 import { createPage } from './util/playwright';
 import { retryIfJestAssertionError } from './util/retry';
 import { waitTillWebConsoleReady } from './util/setup';
@@ -57,7 +58,7 @@ describe('Tutorial: Loading a file', () => {
     const testName = 'load-data-from-local-disk-';
     const datasourceName = testName + new Date().toISOString();
     const dataConnector = new LocalFileDataConnector(page, {
-      baseDirectory: 'quickstart/tutorial/',
+      baseDirectory: DRUID_EXAMPLES_QUICKSTART_TUTORIAL_DIR,
       fileFilter: 'wikiticker-2015-09-12-sampled.json.gz',
     });
     const configureSchemaConfig = new ConfigureSchemaConfig({ rollup: false });

--- a/web-console/e2e-tests/util/debug.ts
+++ b/web-console/e2e-tests/util/debug.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 export async function saveScreenshotIfError(
   filenamePrefix: string,

--- a/web-console/e2e-tests/util/druid.ts
+++ b/web-console/e2e-tests/util/druid.ts
@@ -19,7 +19,8 @@
 import { execSync } from 'child_process';
 import path from 'path';
 
-export const UNIFIED_CONSOLE_URL = 'http://localhost:8888/unified-console.html';
+const UNIFIED_CONSOLE_PORT = process.env['DRUID_E2E_TEST_UNIFIED_CONSOLE_PORT'] || '8888';
+export const UNIFIED_CONSOLE_URL = `http://localhost:${UNIFIED_CONSOLE_PORT}/unified-console.html`;
 export const COORDINATOR_URL = 'http://localhost:8081';
 
 const UTIL_DIR = __dirname;

--- a/web-console/e2e-tests/util/playwright.ts
+++ b/web-console/e2e-tests/util/playwright.ts
@@ -16,22 +16,16 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
-const DEBUG = true;
+const TRUE = 'true';
 const WIDTH = 1920;
 const HEIGHT = 1080;
 const PADDING = 128;
 
-export async function createBrowserNormal(): Promise<playwright.Browser> {
-  return createBrowserInternal(!DEBUG);
-}
-
-export async function createBrowserDebug(): Promise<playwright.Browser> {
-  return createBrowserInternal(DEBUG);
-}
-
-async function createBrowserInternal(debug: boolean): Promise<playwright.Browser> {
+export async function createBrowser(): Promise<playwright.Browser> {
+  const headless = process.env['DRUID_E2E_TEST_HEADLESS'] || TRUE;
+  const debug = headless !== TRUE;
   const launchOptions: any = {
     args: [`--window-size=${WIDTH},${HEIGHT + PADDING}`],
   };

--- a/web-console/e2e-tests/util/setup.ts
+++ b/web-console/e2e-tests/util/setup.ts
@@ -17,7 +17,7 @@
  */
 
 import { UNIFIED_CONSOLE_URL } from './druid';
-import { createBrowserNormal as createBrowser } from './playwright';
+import { createBrowser } from './playwright';
 import { createPage } from './playwright';
 
 export async function waitTillWebConsoleReady() {
@@ -26,8 +26,8 @@ export async function waitTillWebConsoleReady() {
   try {
     const page = await createPage(browser);
     await page.goto(UNIFIED_CONSOLE_URL);
-    await page.waitFor('//*[contains(text(),"console will not function at the moment")]', {
-      visibility: 'hidden',
+    await page.waitForSelector('//*[contains(text(),"console will not function at the moment")]', {
+      state: 'hidden',
     });
   } finally {
     await browser.close();

--- a/web-console/e2e-tests/util/table.ts
+++ b/web-console/e2e-tests/util/table.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import * as playwright from 'playwright-core';
+import * as playwright from 'playwright-chromium';
 
 /**
  * Extracts an HTML table into a text representation.
@@ -29,10 +29,10 @@ export async function extractTable(
   tableSelector: string,
   rowSelector: string,
 ): Promise<string[][]> {
-  await page.waitFor(tableSelector);
+  await page.waitForSelector(tableSelector);
 
   return page.evaluate(
-    (tableSelector, rowSelector) => {
+    ([tableSelector, rowSelector]) => {
       const BLANK_VALUE = '\xa0';
       const data = [];
       const rows = document.querySelectorAll(tableSelector);
@@ -51,7 +51,6 @@ export async function extractTable(
       }
       return data;
     },
-    tableSelector,
-    rowSelector,
+    [tableSelector, rowSelector],
   );
 }

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -1635,6 +1635,16 @@
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "dev": true
     },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -2857,6 +2867,12 @@
           "dev": true
         }
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4913,25 +4929,40 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -4998,9 +5029,9 @@
       }
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -7828,9 +7859,9 @@
       }
     },
     "jpeg-js": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
       "dev": true
     },
     "js-base64": {
@@ -9767,61 +9798,56 @@
       }
     },
     "playwright-chromium": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-0.11.1.tgz",
-      "integrity": "sha512-7b9fdpMaEBDT/bazkfzHGiKGJ7+PzlVoxwnW94lIxV3uDUSSAHxkFwwD1ks1NZnvBQuTE9IksOP9hKYA1gby5A==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.4.2.tgz",
+      "integrity": "sha512-Yj4QKRL0TB1oZ1InAhqmqoVgu1MeeYnKgwCyaEnA1+tjhYYcieINq4HO8bMMgUDHa/ccMWyHA8qyP9WEdz8v0A==",
       "dev": true,
       "requires": {
-        "playwright-core": "=0.11.1"
-      }
-    },
-    "playwright-core": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.11.1.tgz",
-      "integrity": "sha512-9xsSkXlglvHIAofyNInA1p3beOAOBMWHZgiuH99gX1R8VL6fTXgfWD7pIvt+rJhVMJWMDAyMXRo4TYtYtdspIg==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^3.0.0",
-        "jpeg-js": "^0.3.6",
-        "pngjs": "^3.4.0",
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
         "progress": "^2.0.3",
-        "proxy-from-env": "^1.0.0",
+        "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
-        "uuid": "^3.4.0",
-        "ws": "^6.1.0"
+        "ws": "^7.3.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "agent-base": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "https-proxy-agent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-          "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "dev": true,
           "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "dev": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
+            "agent-base": "6",
+            "debug": "4"
           }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -9838,20 +9864,11 @@
             "glob": "^7.1.3"
           }
         },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "dev": true
         }
       }
     },
@@ -9862,9 +9879,9 @@
       "dev": true
     },
     "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "dev": true
     },
     "popper.js": {
@@ -10686,9 +10703,9 @@
       }
     },
     "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "prr": {
@@ -15126,12 +15143,13 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yn": {

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -126,7 +126,7 @@
     "license-checker": "^25.0.1",
     "node-sass": "^4.13.1",
     "node-sass-chokidar": "^1.4.0",
-    "playwright-chromium": "^0.11.1",
+    "playwright-chromium": "^1.4.2",
     "postcss-cli": "^6.1.3",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.7.0",

--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -50,25 +50,6 @@ function _get_druid_version() {
   _get_maven_property_value "project.version"
 }
 
-function _get_zookeeper_version() {
-  _get_maven_property_value "zookeeper.version"
-}
-
-function _download_zookeeper() {
-  local dest="$1"
-  local zk_version
-  zk_version="$(_get_zookeeper_version)"
-  #zk_tar=apache-zookeeper-${zk_version}-bin # for zk 3.5.x
-  zk_tar=zookeeper-${zk_version} # for zk 3.4.x
-
-  _log "Downloading zookeeper"
-  curl -s "https://archive.apache.org/dist/zookeeper/zookeeper-${zk_version}/$zk_tar.tar.gz" \
-    | tar xz \
-  && rm -rf "$dest" \
-  && mv "$zk_tar" "$dest" \
-  && rm -f "$zk_tar"
-}
-
 function _build_distribution() {
   _log "Building druid distribution"
 
@@ -109,8 +90,7 @@ DRUID_PID_FILE=".druid.pid"
 
 function build() {
   _log "Building druid"
-  _build_distribution \
-  && _download_zookeeper "$(_get_code_root)/distribution/target/apache-druid-$(_get_druid_version)/zk"
+  _build_distribution
   _log "Done building druid"
 }
 


### PR DESCRIPTION
### Description

Various improvements to improve usability of web console end-to-end tests:

- Update playwright to latest version
- Provide environment variable to disable/enable headless mode
- Allow running E2E tests against any druid cluster running on standard
  ports (tutorial-batch.spec.ts now uses an absolute instead of relative
  path for the input data)
- Provide environment variable to change target web console port
- Druid setup does not need to download zookeeper

<hr>

This PR has:
- [x] been self-reviewed.
(Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.