### PR TITLE
Fix FileUtilsTest test failure in case of restricted root directory access

### DIFF
--- a/core/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
@@ -103,12 +103,14 @@ public class FileUtilsTest
   @Test
   public void testCreateTempDirNonexistentBase()
   {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("java.io.tmpdir (/nonexistent) does not exist");
-
     final String oldJavaTmpDir = System.getProperty("java.io.tmpdir");
+    final String nonExistentDir = oldJavaTmpDir + "/nonexistent";
+
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage(StringUtils.format("java.io.tmpdir (%s) does not exist", nonExistentDir));
+
     try {
-      System.setProperty("java.io.tmpdir", "/nonexistent");
+      System.setProperty("java.io.tmpdir", nonExistentDir);
       FileUtils.createTempDir();
     }
     finally {


### PR DESCRIPTION
Depending on the environment, the test `FileUtilsTest.testCreateTempDirNonexistentBase` may not pass if the user running the test does not have read/write access to the root directory. In this case, the test will fail as the exception received would be an AccessDeniedException instead of NoSuchFileException. This PR should fix the test to be consistent across all environments.