### PR TITLE
improve retention rule management with import rules

### DIFF
--- a/docs/operations/rule-configuration.md
+++ b/docs/operations/rule-configuration.md
@@ -220,6 +220,19 @@ Period broadcast rules are of the form:
 
 The interval of a segment will be compared against the specified period. The period is from some time in the past to the future or to the current time, which depends on `includeFuture` is true or false. The rule matches if the period *overlaps* the interval.
 
+### Import Rule
+
+Import rules are of the form:
+
+```json
+    {
+      "importedRuleset": "stuff_other_source",
+      "type": "importRules"
+    }
+```
+* `type` - this should always be "importRules"
+* `importedRuleset` - A datasource from which to include rules. Changes to rules on the imported datasource will be reflected dynamically. 
+
 ## Permanently deleting data
 
 Druid can fully drop data from the cluster, wipe the metadata store entry, and remove the data from deep storage for any

--- a/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
@@ -36,7 +36,7 @@ public interface MetadataRuleManager
   void poll();
 
   Map<String, List<Rule>> getAllRules();
-    
+
   List<Rule> getRules(String dataSource);
 
   List<Rule> getRulesWithDefault(String dataSource);

--- a/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
@@ -36,7 +36,7 @@ public interface MetadataRuleManager
   void poll();
 
   Map<String, List<Rule>> getAllRules();
-
+    
   List<Rule> getRules(String dataSource);
 
   List<Rule> getRulesWithDefault(String dataSource);

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ImportRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ImportRule.java
@@ -19,32 +19,59 @@
 
 package org.apache.druid.server.coordinator.rules;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.server.coordinator.CoordinatorStats;
+import org.apache.druid.server.coordinator.DruidCoordinator;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
+import java.util.Objects;
+
 /**
  */
-public class ForeverDropRule extends DropRule
+public class ImportRule implements Rule
 {
+
+  private final String importedRuleset;
+
+  @JsonCreator
+  public ImportRule(@JsonProperty("importedRuleset") String importedRuleset)
+  {
+    this.importedRuleset = importedRuleset;
+  }
+
   @Override
   @JsonProperty
   public String getType()
   {
-    return "dropForever";
+    return "importRules";
+  }
+
+  @JsonProperty
+  public String getImportedRuleset()
+  {
+    return importedRuleset;
   }
 
   @Override
   public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
   {
-    return true;
+    return false;
   }
 
   @Override
   public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
   {
-    return true;
+    return false;
+  }
+
+  @Override
+  public CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment)
+  {
+    return new CoordinatorStats();
   }
   
   @Override
@@ -53,12 +80,23 @@ public class ForeverDropRule extends DropRule
     if (this == o) {
       return true;
     }
-    return o != null && getClass() == o.getClass();
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ImportRule that = (ImportRule) o;
+    return Objects.equals(importedRuleset, that.importedRuleset);
   }
   
   @Override
-  public int hashCode()
+  public int hashCode() 
   {
-    return ForeverDropRule.class.hashCode();
+    return Objects.hash(importedRuleset);
   }
+
+  @Override
+  public boolean canLoadSegments()
+  {
+    return false;
+  }
+
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
@@ -26,14 +26,14 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 
+import java.util.Objects;
+
 public class PeriodDropBeforeRule extends DropRule
 {
   private final Period period;
 
   @JsonCreator
-  public PeriodDropBeforeRule(
-      @JsonProperty("period") Period period
-  )
+  public PeriodDropBeforeRule(@JsonProperty("period") Period period)
   {
     this.period = period;
   }
@@ -62,5 +62,30 @@ public class PeriodDropBeforeRule extends DropRule
   {
     final DateTime periodAgo = referenceTimestamp.minus(period);
     return theInterval.getEndMillis() <= periodAgo.getMillis();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PeriodDropBeforeRule that = (PeriodDropBeforeRule) o;
+
+    if (period != null ? !period.equals(that.period) : that.period != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(period);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
@@ -26,6 +26,8 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 
+import java.util.Objects;
+
 /**
  */
 public class PeriodDropRule extends DropRule
@@ -80,4 +82,30 @@ public class PeriodDropRule extends DropRule
       return currInterval.contains(theInterval);
     }
   }
+  
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PeriodDropRule that = (PeriodDropRule) o;
+
+    if (period != null ? !period.equals(that.period) : that.period != null) {
+      return false;
+    }
+
+    return includeFuture == that.includeFuture;
+  }
+  
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(period, includeFuture);
+  }
 }
+

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -30,6 +30,7 @@ import org.joda.time.Interval;
 import org.joda.time.Period;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  */
@@ -98,5 +99,30 @@ public class PeriodLoadRule extends LoadRule
   public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
   {
     return Rules.eligibleForLoad(period, interval, referenceTimestamp, includeFuture);
+  }
+  
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PeriodLoadRule that = (PeriodLoadRule) o;
+
+    if (period != null ? !period.equals(that.period) : that.period != null) {
+      return false;
+    }
+
+    return includeFuture == that.includeFuture && Objects.equals(tieredReplicants, that.tieredReplicants);
+  }
+  
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(period, includeFuture, tieredReplicants);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -44,6 +44,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = "dropBeforeByPeriod", value = PeriodDropBeforeRule.class),
     @JsonSubTypes.Type(name = "dropByInterval", value = IntervalDropRule.class),
     @JsonSubTypes.Type(name = "dropForever", value = ForeverDropRule.class),
+    @JsonSubTypes.Type(name = "importRules", value = ImportRule.class),
     @JsonSubTypes.Type(name = ForeverBroadcastDistributionRule.TYPE, value = ForeverBroadcastDistributionRule.class),
     @JsonSubTypes.Type(name = IntervalBroadcastDistributionRule.TYPE, value = IntervalBroadcastDistributionRule.class),
     @JsonSubTypes.Type(name = PeriodBroadcastDistributionRule.TYPE, value = PeriodBroadcastDistributionRule.class)

--- a/server/src/main/java/org/apache/druid/server/http/RulesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/RulesResource.java
@@ -45,7 +45,11 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  */
@@ -70,8 +74,16 @@ public class RulesResource
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(StateResourceFilter.class)
-  public Response getRules()
+  public Response getRules(@QueryParam("full") final String full)
   {
+    if (full != null) {
+      Map<String, List<Rule>> expandedRules = new HashMap<String, List<Rule>>();
+      Set<String> allRulesets = databaseRuleManager.getAllRules().keySet();
+      for (String ds : allRulesets) {
+        expandedRules.put(ds, databaseRuleManager.getRulesWithDefault(ds));
+      }
+      return Response.ok(expandedRules).build();
+    }
     return Response.ok(databaseRuleManager.getAllRules()).build();
   }
 

--- a/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
+++ b/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
@@ -43,7 +43,6 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Duration;
 
 import javax.annotation.concurrent.GuardedBy;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +134,7 @@ public class CoordinatorRuleManager
   {
     try {
       StringFullResponseHolder response = druidLeaderClient.go(
-          druidLeaderClient.makeRequest(HttpMethod.GET, RulesResource.RULES_ENDPOINT)
+          druidLeaderClient.makeRequest(HttpMethod.GET, RulesResource.RULES_ENDPOINT + "?full")
       );
 
       if (!response.getStatus().equals(HttpResponseStatus.OK)) {
@@ -158,17 +157,10 @@ public class CoordinatorRuleManager
 
   public List<Rule> getRulesWithDefault(final String dataSource)
   {
-    List<Rule> rulesWithDefault = new ArrayList<>();
-    Map<String, List<Rule>> theRules = rules.get();
-    List<Rule> dataSourceRules = theRules.get(dataSource);
-    if (dataSourceRules != null) {
-      rulesWithDefault.addAll(dataSourceRules);
+    if (!rules.get().containsKey(dataSource)) {
+      return rules.get().get(config.get().getDefaultRule());
     }
-    List<Rule> defaultRules = theRules.get(config.get().getDefaultRule());
-    if (defaultRules != null) {
-      rulesWithDefault.addAll(defaultRules);
-    }
-    return rulesWithDefault;
+    return rules.get().get(dataSource);
   }
 
   /**

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverDropRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverDropRuleTest.java
@@ -19,46 +19,16 @@
 
 package org.apache.druid.server.coordinator.rules;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 
 /**
  */
-public class ForeverDropRule extends DropRule
+public class ForeverDropRuleTest
 {
-  @Override
-  @JsonProperty
-  public String getType()
+  @Test
+  public void testEquals()
   {
-    return "dropForever";
-  }
-
-  @Override
-  public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-
-  @Override
-  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-  
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    return o != null && getClass() == o.getClass();
-  }
-  
-  @Override
-  public int hashCode()
-  {
-    return ForeverDropRule.class.hashCode();
+    EqualsVerifier.forClass(ForeverDropRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
@@ -87,5 +88,21 @@ public class ForeverLoadRuleTest
 
     ObjectMapper jsonMapper = new DefaultObjectMapper();
     Rule reread = jsonMapper.readValue(jsonMapper.writeValueAsString(rule), Rule.class);
+  }
+  
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(ForeverLoadRule.class)
+      .usingGetClass()
+      .withIgnoredFields("targetReplicants", "currentReplicants", "strategyCache")
+      .verify();
+  }
+  
+  @Test
+  public void testDefaultReplicants()
+  {
+    ForeverLoadRule rule = new ForeverLoadRule(null);
+    Assert.assertEquals(rule.getNumReplicants(DruidServer.DEFAULT_TIER), DruidServer.DEFAULT_NUM_REPLICANTS);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ImportRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ImportRuleTest.java
@@ -19,46 +19,15 @@
 
 package org.apache.druid.server.coordinator.rules;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 
-/**
- */
-public class ForeverDropRule extends DropRule
+public class ImportRuleTest
 {
-  @Override
-  @JsonProperty
-  public String getType()
+  @Test
+  public void testEquals()
   {
-    return "dropForever";
+    EqualsVerifier.forClass(ImportRule.class).usingGetClass().verify();
   }
 
-  @Override
-  public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-
-  @Override
-  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-  
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    return o != null && getClass() == o.getClass();
-  }
-  
-  @Override
-  public int hashCode()
-  {
-    return ForeverDropRule.class.hashCode();
-  }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalDropRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalDropRuleTest.java
@@ -19,46 +19,14 @@
 
 package org.apache.druid.server.coordinator.rules;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 
-/**
- */
-public class ForeverDropRule extends DropRule
+public class IntervalDropRuleTest
 {
-  @Override
-  @JsonProperty
-  public String getType()
+  @Test
+  public void testEquals()
   {
-    return "dropForever";
-  }
-
-  @Override
-  public boolean appliesTo(DataSegment segment, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-
-  @Override
-  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-  
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    return o != null && getClass() == o.getClass();
-  }
-  
-  @Override
-  public int hashCode()
-  {
-    return ForeverDropRule.class.hashCode();
+    EqualsVerifier.forClass(IntervalDropRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
@@ -80,5 +81,13 @@ public class IntervalLoadRuleTest
     IntervalLoadRule inputIntervalLoadRule = jsonMapper.readValue(inputJson, IntervalLoadRule.class);
     IntervalLoadRule expectedIntervalLoadRule = jsonMapper.readValue(expectedJson, IntervalLoadRule.class);
     Assert.assertEquals(expectedIntervalLoadRule, inputIntervalLoadRule);
+  }
+  
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(IntervalLoadRule.class)
+                  .usingGetClass()
+                  .withIgnoredFields("targetReplicants", "currentReplicants", "strategyCache").verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRuleTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.timeline.DataSegment;
@@ -84,5 +85,11 @@ public class PeriodDropBeforeRuleTest
             now
         )
     );
+  }
+  
+  @Test
+  public void testEquals() 
+  {
+    EqualsVerifier.forClass(PeriodDropBeforeRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropRuleTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.coordinator.rules;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
@@ -132,5 +133,11 @@ public class PeriodDropRuleTest
             now
         )
     );
+  }
+  
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(PeriodDropRule.class).usingGetClass().verify();
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
@@ -57,6 +58,15 @@ public class PeriodLoadRuleTest
     Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("2012-01-01/2012-12-31")).build(), now));
     Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("1000-01-01/2012-12-31")).build(), now));
     Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("0500-01-01/2100-12-31")).build(), now));
+  }
+  
+  @Test
+  public void testEquals() 
+  {
+    EqualsVerifier.forClass(PeriodLoadRule.class)
+            .usingGetClass()
+            .withIgnoredFields("targetReplicants", "currentReplicants", "strategyCache")
+            .verify();
   }
 
   @Test
@@ -185,5 +195,12 @@ public class PeriodLoadRuleTest
     Assert.assertEquals(expectedPeriodLoadRule.getTieredReplicants(), inputPeriodLoadRule.getTieredReplicants());
     Assert.assertEquals(expectedPeriodLoadRule.getPeriod(), inputPeriodLoadRule.getPeriod());
     Assert.assertEquals(expectedPeriodLoadRule.isIncludeFuture(), inputPeriodLoadRule.isIncludeFuture());
+  }
+  
+  @Test
+  public void testDefaultReplicants()
+  {
+    PeriodLoadRule rule = new PeriodLoadRule(new Period("P1D"), null, null);
+    Assert.assertEquals(rule.getNumReplicants(DruidServer.DEFAULT_TIER), DruidServer.DEFAULT_NUM_REPLICANTS);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/router/CoordinatorRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/router/CoordinatorRuleManagerTest.java
@@ -119,13 +119,14 @@ public class CoordinatorRuleManagerTest
   {
     final Map<String, List<Rule>> rules = ImmutableMap.of(
         DATASOURCE1,
-        ImmutableList.of(new ForeverLoadRule(null)),
+        ImmutableList.of(new ForeverLoadRule(null), new ForeverLoadRule(ImmutableMap.of("__default", 2))),
         DATASOURCE2,
-        ImmutableList.of(new ForeverLoadRule(null), new IntervalDropRule(Intervals.of("2020-01-01/2020-01-02"))),
+        ImmutableList.of(new ForeverLoadRule(null), new IntervalDropRule(Intervals.of("2020-01-01/2020-01-02")), new ForeverLoadRule(ImmutableMap.of("__default", 2))),
         "datasource3",
         ImmutableList.of(
             new PeriodLoadRule(new Period("P1M"), true, null),
-            new ForeverDropRule()
+            new ForeverDropRule(),
+            new ForeverLoadRule(ImmutableMap.of("__default", 2))
         ),
         TieredBrokerConfig.DEFAULT_RULE_NAME,
         ImmutableList.of(new ForeverLoadRule(ImmutableMap.of("__default", 2)))

--- a/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
+++ b/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
@@ -139,6 +139,11 @@ exports[`rule editor matches snapshot no tier in rule 1`] = `
                   >
                     broadcastByPeriod
                   </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
+                  </option>
                 </select>
                 <span
                   class="bp3-icon bp3-icon-double-caret-vertical"
@@ -353,6 +358,11 @@ exports[`rule editor matches snapshot with broadcast rule 1`] = `
                   >
                     broadcastByPeriod
                   </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
+                  </option>
                 </select>
                 <span
                   class="bp3-icon bp3-icon-double-caret-vertical"
@@ -532,6 +542,11 @@ exports[`rule editor matches snapshot with existing tier and non existing tier i
                     value="broadcastByPeriod"
                   >
                     broadcastByPeriod
+                  </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
                   </option>
                 </select>
                 <span
@@ -1076,6 +1091,11 @@ exports[`rule editor matches snapshot with existing tier in rule 1`] = `
                   >
                     broadcastByPeriod
                   </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
+                  </option>
                 </select>
                 <span
                   class="bp3-icon bp3-icon-double-caret-vertical"
@@ -1461,6 +1481,11 @@ exports[`rule editor matches snapshot with non existing tier in rule 1`] = `
                     value="broadcastByPeriod"
                   >
                     broadcastByPeriod
+                  </option>
+                  <option
+                    value="importRules"
+                  >
+                    importRules
                   </option>
                 </select>
                 <span

--- a/web-console/src/components/rule-editor/rule-editor.spec.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.spec.tsx
@@ -26,6 +26,7 @@ describe('rule editor', () => {
     const ruleEditor = (
       <RuleEditor
         rule={{ type: 'loadForever' }}
+        allRules={{ _default: [{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }] }}
         tiers={['test', 'test', 'test']}
         onChange={() => {}}
         onDelete={() => {}}
@@ -45,6 +46,7 @@ describe('rule editor', () => {
           period: '2010-01-01/2015-01-01',
           tieredReplicants: { nonexist: 2 },
         }}
+        allRules={{ _default: [{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }] }}
         tiers={['test1', 'test2', 'test3']}
         onChange={() => {}}
         onDelete={() => {}}
@@ -64,6 +66,7 @@ describe('rule editor', () => {
           period: '2010-01-01/2015-01-01',
           tieredReplicants: { test1: 2 },
         }}
+        allRules={{ _default: [{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }] }}
         tiers={['test1', 'test2', 'test3']}
         onChange={() => {}}
         onDelete={() => {}}
@@ -86,6 +89,7 @@ describe('rule editor', () => {
             nonexist: 1,
           },
         }}
+        allRules={{ _default: [{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }] }}
         tiers={['test1', 'test2', 'test3']}
         onChange={() => {}}
         onDelete={() => {}}
@@ -104,6 +108,7 @@ describe('rule editor', () => {
           type: 'broadcastByInterval',
           period: '2010-01-01/2015-01-01',
         }}
+        allRules={{ _default: [{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }] }}
         tiers={[]}
         onChange={() => {}}
         onDelete={() => {}}

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -21,6 +21,7 @@ import {
   Card,
   Collapse,
   ControlGroup,
+  Divider,
   FormGroup,
   HTMLSelect,
   InputGroup,
@@ -40,6 +41,7 @@ const PERIOD_SUGGESTIONS: string[] = ['P1D', 'P7D', 'P1M', 'P1Y', 'P1000Y'];
 export interface RuleEditorProps {
   rule: Rule;
   tiers: any[];
+  allRules: Record<string, Rule[]>;
   onChange: (newRule: Rule) => void;
   onDelete: () => void;
   moveUp: (() => void) | undefined;
@@ -47,7 +49,7 @@ export interface RuleEditorProps {
 }
 
 export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps) {
-  const { rule, onChange, tiers, onDelete, moveUp, moveDown } = props;
+  const { rule, onChange, allRules, tiers, onDelete, moveUp, moveDown } = props;
   const [isOpen, setIsOpen] = useState(true);
 
   function removeTier(key: string) {
@@ -139,6 +141,14 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
     );
   }
 
+  function renderImportedRule(rule: Rule, index: number) {
+    return (
+      <div className="default-rule" key={index}>
+        <Button disabled>{RuleUtil.ruleToString(rule)}</Button>
+      </div>
+    );
+  }
+
   return (
     <div className="rule-editor">
       <div className="title">
@@ -174,6 +184,22 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
                   );
                 })}
               </HTMLSelect>
+              {RuleUtil.hasImport(rule) && (
+                <HTMLSelect
+                  value={rule.importedRuleset}
+                  onChange={(e: any) =>
+                    onChange(RuleUtil.changeImport(rule, e.target.value as any))
+                  }
+                >
+                  {Object.keys(allRules).map((type: any) => {
+                    return (
+                      <option key={type} value={type}>
+                        {type}
+                      </option>
+                    );
+                  })}
+                </HTMLSelect>
+              )}
               {RuleUtil.hasPeriod(rule) && (
                 <SuggestibleInput
                   value={rule.period || ''}
@@ -213,6 +239,15 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
               {renderTiers()}
               {renderTierAdder()}
             </FormGroup>
+          )}
+          {RuleUtil.hasImport(rule) && rule.importedRuleset !== undefined && (
+            <>
+              <Divider />
+              <FormGroup>
+                <p>Imported Rules:</p>
+                {allRules[rule.importedRuleset].map(renderImportedRule)}
+              </FormGroup>
+            </>
           )}
         </Card>
       </Collapse>

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -210,6 +210,11 @@ exports[`retention dialog matches snapshot 1`] = `
                                 >
                                   broadcastByPeriod
                                 </option>
+                                <option
+                                  value="importRules"
+                                >
+                                  importRules
+                                </option>
                               </select>
                               <span
                                 class="bp3-icon bp3-icon-double-caret-vertical"

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.spec.tsx
@@ -34,6 +34,7 @@ describe('retention dialog', () => {
             type: 'loadByPeriod',
           },
         ]}
+        allRules={{ _default: [{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }] }}
         defaultRules={[{ tieredReplicants: { _default_tier: 2 }, type: 'loadForever' }]}
         tiers={['tier1', 'tier2']}
         onEditDefaults={() => {}}

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
@@ -33,6 +33,7 @@ import './retention-dialog.scss';
 export interface RetentionDialogProps {
   datasource: string;
   rules: Rule[];
+  allRules: Record<string, Rule[]>;
   defaultRules: Rule[];
   tiers: string[];
   onEditDefaults: () => void;
@@ -41,7 +42,7 @@ export interface RetentionDialogProps {
 }
 
 export const RetentionDialog = React.memo(function RetentionDialog(props: RetentionDialogProps) {
-  const { datasource, onCancel, onEditDefaults, rules, defaultRules, tiers } = props;
+  const { datasource, onCancel, onEditDefaults, rules, defaultRules, tiers, allRules } = props;
   const [currentRules, setCurrentRules] = useState(props.rules);
 
   const [historyQueryState] = useQueryManager<string, any[]>({
@@ -85,6 +86,7 @@ export const RetentionDialog = React.memo(function RetentionDialog(props: Retent
       <RuleEditor
         rule={rule}
         tiers={tiers}
+        allRules={allRules}
         key={index}
         onChange={r => changeRule(r, index)}
         onDelete={() => deleteRule(index)}

--- a/web-console/src/utils/load-rule.ts
+++ b/web-console/src/utils/load-rule.ts
@@ -28,12 +28,14 @@ export type RuleType =
   | 'dropBeforeByPeriod'
   | 'broadcastForever'
   | 'broadcastByInterval'
-  | 'broadcastByPeriod';
+  | 'broadcastByPeriod'
+  | 'importRules';
 
 export interface Rule {
   type: RuleType;
   interval?: string;
   period?: string;
+  importedRuleset?: string;
   includeFuture?: boolean;
   tieredReplicants?: Record<string, number>;
 }
@@ -50,6 +52,7 @@ export class RuleUtil {
     'broadcastForever',
     'broadcastByInterval',
     'broadcastByPeriod',
+    'importRules',
   ];
 
   static ruleToString(rule: Rule): string {
@@ -57,6 +60,7 @@ export class RuleUtil {
       rule.type,
       rule.period ? `(${rule.period}${rule.includeFuture ? `+future` : ''})` : '',
       rule.interval ? `(${rule.interval})` : '',
+      rule.importedRuleset ? `(${rule.importedRuleset})` : '',
     ].join('');
   }
 
@@ -68,6 +72,12 @@ export class RuleUtil {
     } else {
       delete newRule.period;
       delete newRule.includeFuture;
+    }
+
+    if (RuleUtil.hasImport(newRule)) {
+      if (!newRule.importedRuleset) newRule.importedRuleset = '_default';
+    } else {
+      delete newRule.importedRuleset;
     }
 
     if (RuleUtil.hasInterval(newRule)) {
@@ -83,6 +93,14 @@ export class RuleUtil {
     }
 
     return newRule;
+  }
+
+  static hasImport(rule: Rule): boolean {
+    return rule.type.startsWith('import');
+  }
+
+  static changeImport(rule: Rule, importedRuleset: string): Rule {
+    return deepSet(rule, 'importedRuleset', importedRuleset);
   }
 
   static hasPeriod(rule: Rule): boolean {

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -155,6 +155,7 @@ interface Datasource {
 interface DatasourcesAndDefaultRules {
   datasources: Datasource[];
   defaultRules: Rule[];
+  allRules: Record<string, Rule[]>;
 }
 
 interface DatasourceQueryResultRow {
@@ -328,6 +329,7 @@ GROUP BY 1`;
           return {
             datasources,
             defaultRules: [],
+            allRules: {},
           };
         }
 
@@ -370,6 +372,7 @@ GROUP BY 1`;
         return {
           datasources: allDatasources,
           defaultRules: rules['_default'],
+          allRules: rules,
         };
       },
       onStateChange: datasourcesAndDefaultRulesState => {
@@ -814,9 +817,10 @@ GROUP BY 1`;
 
   renderRetentionDialog(): JSX.Element | undefined {
     const { retentionDialogOpenOn, tiersState, datasourcesAndDefaultRulesState } = this.state;
-    const { defaultRules } = datasourcesAndDefaultRulesState.data || {
+    const { defaultRules, allRules } = datasourcesAndDefaultRulesState.data || {
       datasources: [],
       defaultRules: [],
+      allRules: {},
     };
     if (!retentionDialogOpenOn) return;
 
@@ -826,6 +830,7 @@ GROUP BY 1`;
         rules={retentionDialogOpenOn.rules}
         tiers={tiersState.data || []}
         onEditDefaults={this.editDefaultRules}
+        allRules={allRules}
         defaultRules={defaultRules}
         onCancel={() => this.setState({ retentionDialogOpenOn: undefined })}
         onSave={this.saveRules}
@@ -857,10 +862,12 @@ GROUP BY 1`;
       hiddenColumns,
     } = this.state;
 
-    let { datasources, defaultRules } = datasourcesAndDefaultRulesState.data
-      ? datasourcesAndDefaultRulesState.data
-      : { datasources: [], defaultRules: [] };
-
+    let datasources: Datasource[] = [];
+    let defaultRules: Rule[] = [];
+    if (datasourcesAndDefaultRulesState.data) {
+      datasources = datasourcesAndDefaultRulesState.data.datasources;
+      defaultRules = datasourcesAndDefaultRulesState.data.defaultRules;
+    }
     if (!showUnused) {
       datasources = datasources.filter(d => !d.unused);
     }

--- a/website/.spelling
+++ b/website/.spelling
@@ -262,6 +262,7 @@ http
 https
 idempotency
 i.e.
+importRules
 influxdb
 ingestionSpec
 injective


### PR DESCRIPTION
Discussion of the general problem of Increase reusability of retention rule configurations is here [Issue #10237 ](https://github.com/apache/druid/issues/10237)
This pull request implements a new rule type that imports rules from any other rule set, including rules from other data sources. The back end code is the same as the previous PR #10129 and the UI changes have been ported to incorporate the recent UI changes. 


### Description

This branch adds a new ImportRule type that specifies an imported rule set. Whenever rules are used, they are expanded to include the default rules for the cluster. This changes the getRulesWithDefault to also expand any import rules found at the time they are retrieved. This is functionally equivalent to the original list as the rules are replaced before evaluation. Rules are also used in CoordinatorRuleManager in the router, where getRulesWithDefault was implemented again. Here, that implementation is left at one place, in SQLRuleManager and a new method is added to RulesResource to allow CoordinatorRuleManager to retrieve the expanded list of rules without knowing how it was generated. 

In the implementation, the function of getRulesWithDefault has diverged a little bit from the name, maybe a name like getExpandedRules would be better. Also, the implementation for ImportRule is specifically in SQLMetadataRuleManager maybe it should be interface methods or in a utility class for use by other implementations in the future. 

<img width="743" alt="Screen Shot 2020-10-07 at 2 46 29 PM" src="https://user-images.githubusercontent.com/8482587/95377733-f99cc800-08b0-11eb-9a1d-c8132a9de54d.png">

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `SQLMetadataRuleManager`
 * `ImportRule`
 * `CoordinatorRuleManager`
 * `RulesResource`
