### PR TITLE
Suppress CVE-2018-11765 for hadoop dependencies

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -281,4 +281,11 @@
      <cve>CVE-2018-8009</cve>
      <cve>CVE-2018-8029</cve>
   </suppress>
+  <suppress>
+     <notes><![CDATA[
+     file name: hadoop-*-2.8.5.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop/hadoop\-.*@.*$</packageUrl>
+     <cve>CVE-2018-11765</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
This PR suppresses warnings for https://nvd.nist.gov/vuln/detail/CVE-2018-11765, which was updated today and is causing failures when building the release package, e.g.:

```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:5.3.2:check
(default) on project druid-kerberos:
[ERROR]
[ERROR] One or more dependencies were identified with vulnerabilities that
have a CVSS score greater than or equal to '7.0':
[ERROR]
[ERROR] hadoop-auth-2.8.5.jar: CVE-2018-11765
[ERROR]
[ERROR] See the dependency-check report for more details.
[ERROR]
[ERROR]
[ERROR] -> [Help 1]
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:5.3.2:check
(default) on project ambari-metrics-emitter:
[ERROR]
[ERROR] One or more dependencies were identified with vulnerabilities that
have a CVSS score greater than or equal to '7.0':
[ERROR]
[ERROR] hadoop-annotations-2.8.5.jar: CVE-2018-11765
[ERROR]
[ERROR] See the dependency-check report for more details.
[ERROR]
```

Based on the mitigation advice here (https://lists.apache.org/thread.html/r2c7f899911a04164ed1707083fcd4135f8427e04778c87d83509b0da%40%3Cgeneral.hadoop.apache.org%3E), I don't think we are affected as our Kerberos extension uses SPNEGO:

https://druid.apache.org/docs/latest/development/extensions-core/druid-kerberos.html