### PR TITLE
Added Request log updates for status change on cooridnator / overlord…

### DIFF
--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyRequestLog.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyRequestLog.java
@@ -25,10 +25,14 @@ import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 
+import javax.ws.rs.HttpMethod;
+
 
 public class JettyRequestLog extends AbstractLifeCycle implements RequestLog
 {
   private static final Logger logger = new Logger("org.apache.druid.jetty.RequestLog");
+  private static final String COORDINATOR = "/coordinator";
+  private static final String OVERLORD = "/indexer";
 
   @Override
   public void log(Request request, Response response)
@@ -40,6 +44,20 @@ public class JettyRequestLog extends AbstractLifeCycle implements RequestLog
           request.getMethod(),
           request.getHttpURI().toString(),
           request.getProtocol()
+      );
+    } else if ((HttpMethod.POST.equals(request.getMethod())
+        || HttpMethod.DELETE.equals(request.getMethod())
+        || HttpMethod.PUT.equals(request.getMethod()))
+        && (request.getHttpURI().toString().contains(COORDINATOR)
+        || request.getHttpURI().toString().contains(OVERLORD))) {
+      logger.info(
+          "%s %s %s %s %s",
+          request.getRemoteAddr(),
+          request.getMethod(),
+          request.getHttpURI().toString(),
+          request.getProtocol(),
+          ((request.getRemoteUser() != null) ? request.getRemoteUser() :
+              (request.getUserPrincipal() != null ? request.getUserPrincipal().getName() : ""))
       );
     }
   }

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyRequestLog.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyRequestLog.java
@@ -51,13 +51,11 @@ public class JettyRequestLog extends AbstractLifeCycle implements RequestLog
         && (request.getHttpURI().toString().contains(COORDINATOR)
         || request.getHttpURI().toString().contains(OVERLORD))) {
       logger.info(
-          "%s %s %s %s %s",
+          "%s %s %s %s",
           request.getRemoteAddr(),
           request.getMethod(),
           request.getHttpURI().toString(),
-          request.getProtocol(),
-          ((request.getRemoteUser() != null) ? request.getRemoteUser() :
-              (request.getUserPrincipal() != null ? request.getUserPrincipal().getName() : ""))
+          request.getProtocol()
       );
     }
   }

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/JettyRequestLogTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/JettyRequestLogTest.java
@@ -29,16 +29,12 @@ import org.junit.Test;
 
 import javax.ws.rs.HttpMethod;
 
-import java.security.Principal;
-
 public class JettyRequestLogTest
 {
   private static final String COORDINATOR = "/coordinator";
   private static final String OVERLORD = "/indexer";
   private static final String WORKER = "/worker";
   private static final String HTTP_PROTOCOL = "HTTP";
-  private static final String REMOTE_USER = "remote_user";
-  private static final String CERT_USER = "cert_user";
   private static final String REMOTE_ADDRESS = "druid.apache.org";
   private static final String INFO = "INFO";
   private static final String ERROR = "ERROR";
@@ -52,11 +48,9 @@ public class JettyRequestLogTest
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(COORDINATOR);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.GET).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(ERROR));
     JettyRequestLog logger = new JettyRequestLog();
@@ -73,11 +67,8 @@ public class JettyRequestLogTest
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.GET).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(DEBUG));
     JettyRequestLog logger = new JettyRequestLog();
@@ -86,7 +77,7 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithPostDebugEnabled()
+  public void testRequestLogWithPostDebugEnabledCoordinator()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
@@ -94,11 +85,8 @@ public class JettyRequestLogTest
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(DEBUG));
     JettyRequestLog logger = new JettyRequestLog();
@@ -107,108 +95,53 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserNonCoordinator()
+  public void testRequestLogWithPostDebugEnabledOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(DEBUG));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+
+  @Test
+  public void testRequestLogWithPostDebugEnabledNonCoordinatorOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(WORKER);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
+        Level.getLevel(DEBUG));
     JettyRequestLog logger = new JettyRequestLog();
     logger.log(req, resp);
     EasyMock.verify(req);
   }
 
   @Test
-  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithPostDebugDisabledNullRemoteUserNonNullCertCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithPostDebugDisabledNullRemoteUserNullCertCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
-    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserNonOverlord()
+  public void testRequestLogWithPostDebugDisabledNonCoordinatorOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(WORKER);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(INFO));
     JettyRequestLog logger = new JettyRequestLog();
@@ -217,20 +150,34 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserOverlord()
+  public void testRequestLogWithPostDebugDisabledCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(OVERLORD);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(INFO));
     JettyRequestLog logger = new JettyRequestLog();
@@ -239,151 +186,70 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithPostDebugDisabledNullRemoteUserNonNullCertOverlord()
+  public void testRequestLogWithDeleteDebugEnabledCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(DEBUG));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugEnabledOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(OVERLORD);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
+        Level.getLevel(DEBUG));
     JettyRequestLog logger = new JettyRequestLog();
     logger.log(req, resp);
     EasyMock.verify(req);
   }
 
   @Test
-  public void testRequestLogWithPostDebugDisabledNullRemoteUserNullCertOverlord()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(OVERLORD);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
-    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserNonCoordinator()
+  public void testRequestLogWithDeleteDebugEnabledNonCoordinatorOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(WORKER);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
+        Level.getLevel(DEBUG));
     JettyRequestLog logger = new JettyRequestLog();
     logger.log(req, resp);
     EasyMock.verify(req);
   }
 
   @Test
-  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNonNullCertCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNullCertCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
-    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-  @Test
-  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserNonOverlord()
+  public void testRequestLogWithDeleteDebugDisabledNonCoordinatorOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(WORKER);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(INFO));
     JettyRequestLog logger = new JettyRequestLog();
@@ -392,20 +258,34 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserOverlord()
+  public void testRequestLogWithDeleteDebugDisabledCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(OVERLORD);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(INFO));
     JettyRequestLog logger = new JettyRequestLog();
@@ -414,151 +294,70 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNonNullCertOverlord()
+  public void testRequestLogWithPutDebugEnabledCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(DEBUG));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugEnabledOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(OVERLORD);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
+        Level.getLevel(DEBUG));
     JettyRequestLog logger = new JettyRequestLog();
     logger.log(req, resp);
     EasyMock.verify(req);
   }
 
   @Test
-  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNullCertOverlord()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(OVERLORD);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
-    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserNonCoordinator()
+  public void testRequestLogWithPutDebugEnabledNonCoordinatorOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(WORKER);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
+        Level.getLevel(DEBUG));
     JettyRequestLog logger = new JettyRequestLog();
     logger.log(req, resp);
     EasyMock.verify(req);
   }
 
   @Test
-  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithPutDebugDisabledNullRemoteUserNonNullCertCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithPutDebugDisabledNullRemoteUserNullCertCoordinator()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(COORDINATOR);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
-    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-  @Test
-  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserNonOverlord()
+  public void testRequestLogWithPutDebugDisabledNonCoordinatorOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(WORKER);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(INFO));
     JettyRequestLog logger = new JettyRequestLog();
@@ -567,20 +366,16 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserOverlord()
+  public void testRequestLogWithPutDebugDisabledCoordinator()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(OVERLORD);
+    HttpURI foo = new HttpURI(COORDINATOR);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(INFO));
     JettyRequestLog logger = new JettyRequestLog();
@@ -589,42 +384,16 @@ public class JettyRequestLogTest
   }
 
   @Test
-  public void testRequestLogWithPutDebugDisabledNullRemoteUserNonNullCertOverlord()
+  public void testRequestLogWithPutDebugDisabledOverlord()
   {
     Request req = EasyMock.createMock(Request.class);
     Response resp = EasyMock.createMock(Response.class);
     HttpURI foo = new HttpURI(OVERLORD);
     EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
-    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
     EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
     EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
     EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
-    Configurator.setLevel(REQUEST_LOG,
-        Level.getLevel(INFO));
-    JettyRequestLog logger = new JettyRequestLog();
-    logger.log(req, resp);
-    EasyMock.verify(req);
-  }
-
-  @Test
-  public void testRequestLogWithPutDebugDisabledNullRemoteUserNullCertOverlord()
-  {
-    Request req = EasyMock.createMock(Request.class);
-    Response resp = EasyMock.createMock(Response.class);
-    HttpURI foo = new HttpURI(OVERLORD);
-    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
-    Principal p = EasyMock.createMock(Principal.class);
-    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
-    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
-    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
-    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
-    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
-    EasyMock.replay(p, req, resp);
+    EasyMock.replay(req, resp);
     Configurator.setLevel(REQUEST_LOG,
         Level.getLevel(INFO));
     JettyRequestLog logger = new JettyRequestLog();
@@ -632,4 +401,3 @@ public class JettyRequestLogTest
     EasyMock.verify(req);
   }
 }
-

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/JettyRequestLogTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/JettyRequestLogTest.java
@@ -1,0 +1,635 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.initialization.jetty;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.easymock.EasyMock;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.junit.Test;
+
+import javax.ws.rs.HttpMethod;
+
+import java.security.Principal;
+
+public class JettyRequestLogTest
+{
+  private static final String COORDINATOR = "/coordinator";
+  private static final String OVERLORD = "/indexer";
+  private static final String WORKER = "/worker";
+  private static final String HTTP_PROTOCOL = "HTTP";
+  private static final String REMOTE_USER = "remote_user";
+  private static final String CERT_USER = "cert_user";
+  private static final String REMOTE_ADDRESS = "druid.apache.org";
+  private static final String INFO = "INFO";
+  private static final String ERROR = "ERROR";
+  private static final String DEBUG = "DEBUG";
+  private static final String REQUEST_LOG = "org.apache.druid.jetty.RequestLog";
+
+  @Test
+  public void testRequestLogWithGetDebugDisabled()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.GET).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(ERROR));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithGetDebugEnabled()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.GET).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(DEBUG));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugEnabled()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(DEBUG));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserNonCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(WORKER);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNullRemoteUserNonNullCertCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNullRemoteUserNullCertCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
+    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserNonOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(WORKER);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNonNullRemoteUserOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNullRemoteUserNonNullCertOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPostDebugDisabledNullRemoteUserNullCertOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
+    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.POST).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserNonCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(WORKER);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNonNullCertCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNullCertCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
+    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserNonOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(WORKER);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNonNullRemoteUserOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNonNullCertOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithDeleteDebugDisabledNullRemoteUserNullCertOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
+    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.DELETE).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserNonCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(WORKER);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugDisabledNullRemoteUserNonNullCertCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugDisabledNullRemoteUserNullCertCoordinator()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(COORDINATOR);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
+    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+  @Test
+  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserNonOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(WORKER);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugDisabledNonNullRemoteUserOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(REMOTE_USER).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugDisabledNullRemoteUserNonNullCertOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(p.getName()).andReturn(CERT_USER).anyTimes();
+    EasyMock.expect(req.getUserPrincipal()).andReturn(p).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+
+  @Test
+  public void testRequestLogWithPutDebugDisabledNullRemoteUserNullCertOverlord()
+  {
+    Request req = EasyMock.createMock(Request.class);
+    Response resp = EasyMock.createMock(Response.class);
+    HttpURI foo = new HttpURI(OVERLORD);
+    EasyMock.expect(req.getHttpURI()).andReturn(foo).anyTimes();
+    Principal p = EasyMock.createMock(Principal.class);
+    EasyMock.expect(req.getUserPrincipal()).andReturn(null).anyTimes();
+    EasyMock.expect(p.getName()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getRemoteAddr()).andReturn(REMOTE_ADDRESS).anyTimes();
+    EasyMock.expect(req.getRemoteUser()).andReturn(null).anyTimes();
+    EasyMock.expect(req.getProtocol()).andReturn(HTTP_PROTOCOL).anyTimes();
+    EasyMock.expect(req.getMethod()).andReturn(HttpMethod.PUT).anyTimes();
+    EasyMock.replay(p, req, resp);
+    Configurator.setLevel(REQUEST_LOG,
+        Level.getLevel(INFO));
+    JettyRequestLog logger = new JettyRequestLog();
+    logger.log(req, resp);
+    EasyMock.verify(req);
+  }
+}
+


### PR DESCRIPTION
This PR Describes changes applied to the Requestlog.
  
The Requestlog has been updated to capture state changing api calls such as (POST/DELETE/UPDATE), so that this can be used to audit, debugging logs in order to identify who, what , when.  The code has been tested on our internal clusters. The log generated is presented as follows

xx.xx.xx.xx DELETE https://druid-coord.xxxxxx.comm:4443/druid/coordinator/v1/datasources/testdata_A1M_02_01 HTTP/1.1
xx.xx.xx.xx POST https://druid-coord.xxxxxx.com:4443/druid/coordinator/v1/datasources/testdata_A1M_02_02/markUnused HTTP/1.1

If the community feels that it is too much to capture these details , in future we can provide updates  to capture in a separate file.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

This enhances RequestLog for audit and debugging.

https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * Requestlog