### PR TITLE
Web console: show segment sizes in rows not bytes

### DIFF
--- a/web-console/.gitignore
+++ b/web-console/.gitignore
@@ -16,3 +16,4 @@ lib/sql-docs.js
 tscommand-*.tmp.txt
 
 licenses.json
+.druid.pid

--- a/web-console/README.md
+++ b/web-console/README.md
@@ -47,12 +47,6 @@ As part of this repo:
 - `script/` - Some helper bash scripts for running this console
 - `src/` - This directory (together with `lib`) constitutes all the source code for this console
 
-Generated/copied dynamically
-
-- `index.html` - Entry file for the coordinator console
-- `pages/` - The files for the older coordinator console
-- `coordinator-console/` - Files for the coordinator console
-
 ## List of non SQL data reading APIs used
 
 ```

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/apache/druid/"
+    "url": "https://github.com/apache/druid"
   },
   "jest": {
     "preset": "ts-jest",

--- a/web-console/src/utils/druid-query.spec.ts
+++ b/web-console/src/utils/druid-query.spec.ts
@@ -16,8 +16,9 @@
  * limitations under the License.
  */
 
-import { DruidError } from './druid-query';
 import { sane } from 'druid-query-toolkit/build/test-utils';
+
+import { DruidError } from './druid-query';
 
 describe('DruidQuery', () => {
   describe('DruidError.parsePosition', () => {

--- a/web-console/src/utils/druid-query.ts
+++ b/web-console/src/utils/druid-query.ts
@@ -162,6 +162,8 @@ export class DruidError extends Error {
   public canceled?: boolean;
   public error?: string;
   public errorMessage?: string;
+  public errorMessageWithoutExpectation?: string;
+  public expectation?: string;
   public position?: RowColumn;
   public errorClass?: string;
   public host?: string;
@@ -195,6 +197,14 @@ export class DruidError extends Error {
       if (this.errorMessage) {
         this.position = DruidError.parsePosition(this.errorMessage);
         this.suggestion = DruidError.getSuggestion(this.errorMessage);
+
+        const expectationIndex = this.errorMessage.indexOf('Was expecting one of');
+        if (expectationIndex >= 0) {
+          this.errorMessageWithoutExpectation = this.errorMessage.slice(0, expectationIndex).trim();
+          this.expectation = this.errorMessage.slice(expectationIndex).trim();
+        } else {
+          this.errorMessageWithoutExpectation = this.errorMessage;
+        }
       }
     }
   }

--- a/web-console/src/utils/druid-query.ts
+++ b/web-console/src/utils/druid-query.ts
@@ -105,7 +105,6 @@ export class DruidError extends Error {
   }
 
   static getSuggestion(errorMessage: string): QuerySuggestion | undefined {
-    console.log(errorMessage);
     // == is used instead of =
     // ex: Encountered "= =" at line 3, column 15. Was expecting one of
     const matchEquals = errorMessage.match(/Encountered "= =" at line (\d+), column (\d+)./);
@@ -116,7 +115,6 @@ export class DruidError extends Error {
         label: `Replace == with =`,
         fn: str => {
           const index = DruidError.positionToIndex(str, line, column);
-          console.log(index, str);
           if (!str.slice(index).startsWith('==')) return;
           return `${str.slice(0, index)}=${str.slice(index + 2)}`;
         },

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -22,6 +22,7 @@ import {
   formatBytesCompact,
   formatInteger,
   formatMegabytes,
+  formatMillions,
   formatPercent,
   sortWithPrefixSuffix,
   sqlQueryCustomTableFilter,
@@ -116,6 +117,15 @@ describe('general', () => {
   describe('formatPercent', () => {
     it('works', () => {
       expect(formatPercent(2 / 3)).toEqual('66.67%');
+    });
+  });
+
+  describe('formatMillions', () => {
+    it('works', () => {
+      expect(formatMillions(1e6)).toEqual('1.000 M');
+      expect(formatMillions(1e6 + 1)).toEqual('1.000 M');
+      expect(formatMillions(1234567)).toEqual('1.235 M');
+      expect(formatMillions(345.2)).toEqual('345');
     });
   });
 });

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -235,6 +235,12 @@ export function formatPercent(n: number): string {
   return (n * 100).toFixed(2) + '%';
 }
 
+export function formatMillions(n: number): string {
+  const s = (n / 1e6).toFixed(3);
+  if (s === '0.000') return String(Math.round(n));
+  return s + ' M';
+}
+
 function pad2(str: string | number): string {
   return ('00' + str).substr(-2);
 }

--- a/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
+++ b/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
@@ -186,12 +186,12 @@ exports[`data source view matches snapshot 1`] = `
           "Header": <React.Fragment>
             Segment size (rows)
             <br />
-            min / avg / max
+            minimum / average / maximum
           </React.Fragment>,
           "accessor": "avg_segment_size",
           "filterable": false,
           "show": true,
-          "width": 150,
+          "width": 220,
         },
         Object {
           "Cell": [Function],

--- a/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
+++ b/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
@@ -188,7 +188,7 @@ exports[`data source view matches snapshot 1`] = `
             <br />
             minimum / average / maximum
           </React.Fragment>,
-          "accessor": "avg_segment_size",
+          "accessor": "avg_segment_rows",
           "filterable": false,
           "show": true,
           "width": 220,

--- a/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
+++ b/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
@@ -184,7 +184,7 @@ exports[`data source view matches snapshot 1`] = `
         Object {
           "Cell": [Function],
           "Header": <React.Fragment>
-            Segment size (MB)
+            Segment size (rows)
             <br />
             min / avg / max
           </React.Fragment>,

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -48,7 +48,6 @@ import {
   formatBytes,
   formatCompactionConfigAndStatus,
   formatInteger,
-  formatMegabytes,
   formatPercent,
   getDruidErrorMessage,
   LocalStorageKeys,
@@ -120,7 +119,7 @@ function formatLoadDrop(segmentsToLoad: number, segmentsToDrop: number): string 
 }
 
 const formatTotalDataSize = formatBytes;
-const formatSegmentSize = formatMegabytes;
+const formatSegmentSize = formatInteger;
 const formatTotalRows = formatInteger;
 const formatAvgRowSize = formatInteger;
 const formatReplicatedSize = formatBytes;
@@ -230,12 +229,9 @@ export class DatasourcesView extends React.PureComponent<
   COUNT(*) FILTER (WHERE is_available = 1 AND NOT ((is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1)) AS num_segments_to_drop,
   SUM("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS total_data_size,
   SUM("size" * "num_replicas") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS replicated_size,
-  MIN("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS min_segment_size,
-  (
-    SUM("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) /
-    COUNT(*) FILTER (WHERE is_published = 1 AND is_overshadowed = 0)
-  ) AS avg_segment_size,
-  MAX("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS max_segment_size,
+  MIN("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS min_segment_size,
+  AVG("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS avg_segment_size,
+  MAX("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS max_segment_size,
   SUM("num_rows") FILTER (WHERE (is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1) AS total_rows,
   (
     SUM("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) /
@@ -1010,11 +1006,11 @@ GROUP BY 1`;
               ),
             },
             {
-              Header: twoLines('Segment size (MB)', 'min / avg / max'),
+              Header: twoLines('Segment size (rows)', 'minimum / average / maximum'),
               show: hiddenColumns.exists('Segment size'),
               accessor: 'avg_segment_size',
               filterable: false,
-              width: 150,
+              width: 220,
               Cell: ({ value, original }) => (
                 <>
                   <BracedText

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -88,7 +88,6 @@ const tableColumns: Record<CapabilitiesMode, string[]> = {
     'Availability',
     'Segment load/drop queues',
     'Total data size',
-    'Segment size',
     'Compaction',
     '% Compacted',
     'Left to be compacted',
@@ -120,7 +119,7 @@ function formatLoadDrop(segmentsToLoad: number, segmentsToDrop: number): string 
 }
 
 const formatTotalDataSize = formatBytes;
-const formatSegmentSize = formatMillions;
+const formatSegmentRows = formatMillions;
 const formatTotalRows = formatInteger;
 const formatAvgRowSize = formatInteger;
 const formatReplicatedSize = formatBytes;
@@ -152,9 +151,9 @@ interface DatasourceQueryResultRow {
   readonly num_segments_to_drop: number;
   readonly total_data_size: number;
   readonly replicated_size: number;
-  readonly min_segment_size: number;
-  readonly avg_segment_size: number;
-  readonly max_segment_size: number;
+  readonly min_segment_rows: number;
+  readonly avg_segment_rows: number;
+  readonly max_segment_rows: number;
   readonly total_rows: number;
   readonly avg_row_size: number;
 }
@@ -230,14 +229,18 @@ export class DatasourcesView extends React.PureComponent<
   COUNT(*) FILTER (WHERE is_available = 1 AND NOT ((is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1)) AS num_segments_to_drop,
   SUM("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS total_data_size,
   SUM("size" * "num_replicas") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS replicated_size,
-  MIN("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS min_segment_size,
-  AVG("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS avg_segment_size,
-  MAX("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS max_segment_size,
+  MIN("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS min_segment_rows,
+  AVG("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS avg_segment_rows,
+  MAX("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) AS max_segment_rows,
   SUM("num_rows") FILTER (WHERE (is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1) AS total_rows,
-  (
-    SUM("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) /
-    SUM("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0)
-  ) AS avg_row_size
+  CASE
+    WHEN SUM("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) <> 0
+    THEN (
+      SUM("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) /
+      SUM("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0)
+    )
+    ELSE 0
+  END AS avg_row_size
 FROM sys.segments
 GROUP BY 1`;
 
@@ -305,9 +308,9 @@ GROUP BY 1`;
                 num_segments_to_drop: 0,
                 replicated_size: -1,
                 total_data_size: totalDataSize,
-                min_segment_size: -1,
-                avg_segment_size: totalDataSize / numSegments,
-                max_segment_size: -1,
+                min_segment_rows: -1,
+                avg_segment_rows: -1,
+                max_segment_rows: -1,
                 total_rows: -1,
                 avg_row_size: -1,
               };
@@ -865,11 +868,11 @@ GROUP BY 1`;
 
     const totalDataSizeValues = datasources.map(d => formatTotalDataSize(d.total_data_size));
 
-    const minSegmentSizeValues = datasources.map(d => formatSegmentSize(d.min_segment_size));
+    const minSegmentRowsValues = datasources.map(d => formatSegmentRows(d.min_segment_rows));
 
-    const avgSegmentSizeValues = datasources.map(d => formatSegmentSize(d.avg_segment_size));
+    const avgSegmentRowsValues = datasources.map(d => formatSegmentRows(d.avg_segment_rows));
 
-    const maxSegmentSizeValues = datasources.map(d => formatSegmentSize(d.max_segment_size));
+    const maxSegmentRowsValues = datasources.map(d => formatSegmentRows(d.max_segment_rows));
 
     const totalRowsValues = datasources.map(d => formatTotalRows(d.total_rows));
 
@@ -1008,22 +1011,22 @@ GROUP BY 1`;
             },
             {
               Header: twoLines('Segment size (rows)', 'minimum / average / maximum'),
-              show: hiddenColumns.exists('Segment size'),
-              accessor: 'avg_segment_size',
+              show: capabilities.hasSql() && hiddenColumns.exists('Segment size'),
+              accessor: 'avg_segment_rows',
               filterable: false,
               width: 220,
               Cell: ({ value, original }) => (
                 <>
                   <BracedText
-                    text={formatSegmentSize(original.min_segment_size)}
-                    braces={minSegmentSizeValues}
+                    text={formatSegmentRows(original.min_segment_rows)}
+                    braces={minSegmentRowsValues}
                   />{' '}
                   &nbsp;{' '}
-                  <BracedText text={formatSegmentSize(value)} braces={avgSegmentSizeValues} />{' '}
+                  <BracedText text={formatSegmentRows(value)} braces={avgSegmentRowsValues} />{' '}
                   &nbsp;{' '}
                   <BracedText
-                    text={formatSegmentSize(original.max_segment_size)}
-                    braces={maxSegmentSizeValues}
+                    text={formatSegmentRows(original.max_segment_rows)}
+                    braces={maxSegmentRowsValues}
                   />
                 </>
               ),
@@ -1040,7 +1043,7 @@ GROUP BY 1`;
             },
             {
               Header: twoLines('Avg. row size', '(bytes)'),
-              show: hiddenColumns.exists('Avg. row size'),
+              show: capabilities.hasSql() && hiddenColumns.exists('Avg. row size'),
               accessor: 'avg_row_size',
               filterable: false,
               width: 100,

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -48,6 +48,7 @@ import {
   formatBytes,
   formatCompactionConfigAndStatus,
   formatInteger,
+  formatMillions,
   formatPercent,
   getDruidErrorMessage,
   LocalStorageKeys,
@@ -119,7 +120,7 @@ function formatLoadDrop(segmentsToLoad: number, segmentsToDrop: number): string 
 }
 
 const formatTotalDataSize = formatBytes;
-const formatSegmentSize = formatInteger;
+const formatSegmentSize = formatMillions;
 const formatTotalRows = formatInteger;
 const formatAvgRowSize = formatInteger;
 const formatReplicatedSize = formatBytes;

--- a/web-console/src/views/query-view/query-error/query-error.scss
+++ b/web-console/src/views/query-view/query-error/query-error.scss
@@ -21,6 +21,7 @@
   padding: 20px 22px;
 
   .cursor-link,
+  .more-or-less,
   .suggestion {
     color: #2aabd2;
     text-decoration: underline;

--- a/web-console/src/views/query-view/query-error/query-error.scss
+++ b/web-console/src/views/query-view/query-error/query-error.scss
@@ -20,7 +20,8 @@
   background: #232d35;
   padding: 20px 22px;
 
-  .cursor-link {
+  .cursor-link,
+  .suggestion {
     color: #2aabd2;
     text-decoration: underline;
     cursor: pointer;

--- a/web-console/src/views/query-view/query-error/query-error.tsx
+++ b/web-console/src/views/query-view/query-error/query-error.tsx
@@ -26,16 +26,38 @@ import './query-error.scss';
 export interface QueryErrorProps {
   error: DruidError;
   moveCursorTo: (rowColumn: RowColumn) => void;
+  queryString?: string;
+  onQueryStringChange?: (newQueryString: string, run?: boolean) => void;
 }
 
 export const QueryError = React.memo(function QueryError(props: QueryErrorProps) {
-  const { error, moveCursorTo } = props;
+  const { error, moveCursorTo, queryString, onQueryStringChange } = props;
 
   if (!error.errorMessage) {
     return <div className="query-error">{error.message}</div>;
   }
 
-  const { position } = error;
+  const { position, suggestion } = error;
+  let suggestionElement: JSX.Element | undefined;
+  if (suggestion && queryString && onQueryStringChange) {
+    const newQuery = suggestion.fn(queryString);
+    if (newQuery) {
+      suggestionElement = (
+        <p>
+          Suggestion:{' '}
+          <span
+            className="suggestion"
+            onClick={() => {
+              onQueryStringChange(newQuery, true);
+            }}
+          >
+            {suggestion.label}
+          </span>
+        </p>
+      );
+    }
+  }
+
   return (
     <div className="query-error">
       {error.error && <p>{`Error: ${error.error}`}</p>}
@@ -62,6 +84,7 @@ export const QueryError = React.memo(function QueryError(props: QueryErrorProps)
         </p>
       )}
       {error.errorClass && <p>{error.errorClass}</p>}
+      {suggestionElement}
     </div>
   );
 });

--- a/web-console/src/views/query-view/query-error/query-error.tsx
+++ b/web-console/src/views/query-view/query-error/query-error.tsx
@@ -60,6 +60,7 @@ export const QueryError = React.memo(function QueryError(props: QueryErrorProps)
 
   return (
     <div className="query-error">
+      {suggestionElement}
       {error.error && <p>{`Error: ${error.error}`}</p>}
       {error.errorMessage && (
         <p>
@@ -84,7 +85,6 @@ export const QueryError = React.memo(function QueryError(props: QueryErrorProps)
         </p>
       )}
       {error.errorClass && <p>{error.errorClass}</p>}
-      {suggestionElement}
     </div>
   );
 });

--- a/web-console/src/views/query-view/query-error/query-error.tsx
+++ b/web-console/src/views/query-view/query-error/query-error.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { HighlightText } from '../../../components';
 import { DruidError, RowColumn } from '../../../utils';
@@ -32,6 +32,7 @@ export interface QueryErrorProps {
 
 export const QueryError = React.memo(function QueryError(props: QueryErrorProps) {
   const { error, moveCursorTo, queryString, onQueryStringChange } = props;
+  const [showMode, setShowMore] = useState(false);
 
   if (!error.errorMessage) {
     return <div className="query-error">{error.message}</div>;
@@ -62,11 +63,11 @@ export const QueryError = React.memo(function QueryError(props: QueryErrorProps)
     <div className="query-error">
       {suggestionElement}
       {error.error && <p>{`Error: ${error.error}`}</p>}
-      {error.errorMessage && (
+      {error.errorMessageWithoutExpectation && (
         <p>
           {position ? (
             <HighlightText
-              text={error.errorMessage}
+              text={error.errorMessageWithoutExpectation}
               find={position.match}
               replace={
                 <span
@@ -80,8 +81,24 @@ export const QueryError = React.memo(function QueryError(props: QueryErrorProps)
               }
             />
           ) : (
-            error.errorMessage
+            error.errorMessageWithoutExpectation
           )}
+          {error.expectation && !showMode && (
+            <>
+              {' '}
+              <span className="more-or-less" onClick={() => setShowMore(true)}>
+                More...
+              </span>
+            </>
+          )}
+        </p>
+      )}
+      {error.expectation && showMode && (
+        <p>
+          {error.expectation}{' '}
+          <span className="more-or-less" onClick={() => setShowMore(false)}>
+            Less...
+          </span>
         </p>
       )}
       {error.errorClass && <p>{error.errorClass}</p>}

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -514,6 +514,8 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
               moveCursorTo={position => {
                 this.moveToPosition(position);
               }}
+              queryString={queryString}
+              onQueryStringChange={this.handleQueryStringChange}
             />
           )}
           {queryResultState.loading && (


### PR DESCRIPTION
This PR addresses the feedback from the recent work on the new segment distribution in the console. Segment sizes should be in rows not megabytes to fit with the new Druid documentation https://github.com/apache/druid/blob/master/docs/operations/segment-optimization.md

Old:

![image](https://user-images.githubusercontent.com/177816/95518897-e2291200-0978-11eb-8ab7-6c65902c71b5.png)

New:

![image](https://user-images.githubusercontent.com/177816/95519023-20becc80-0979-11eb-83c8-da54b24b1bcc.png)

This PR also cleans up some types and adds a nice little error action hint for 3 of the most common SQL query errors (see bottom of screenshot):

![image](https://user-images.githubusercontent.com/177816/95518778-a42bee00-0978-11eb-982f-ec50f7e8d699.png)

Also fixes #10507