### PR TITLE
Web console: targetRowsPerSegment for hashed partionin

### DIFF
--- a/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
@@ -80,7 +80,26 @@ exports[`CompactionDialog matches snapshot with compactionConfig (dynamic partit
           Object {
             "defined": [Function],
             "info": <React.Fragment>
-              Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              <p>
+                If the segments generated are a sub-optimal size for the requested partition dimensions, consider setting this field.
+              </p>
+              <p>
+                A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
+              </p>
+            </React.Fragment>,
+            "label": "Target rows per segment",
+            "name": "tuningConfig.partitionsSpec.targetRowsPerSegment",
+            "type": "number",
+          },
+          Object {
+            "defined": [Function],
+            "info": <React.Fragment>
+              <p>
+                If you know the optimal number of shards and want to speed up the time it takes for compaction to run, set this field.
+              </p>
+              <p>
+                Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              </p>
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",
@@ -298,7 +317,26 @@ exports[`CompactionDialog matches snapshot with compactionConfig (hashed partiti
           Object {
             "defined": [Function],
             "info": <React.Fragment>
-              Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              <p>
+                If the segments generated are a sub-optimal size for the requested partition dimensions, consider setting this field.
+              </p>
+              <p>
+                A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
+              </p>
+            </React.Fragment>,
+            "label": "Target rows per segment",
+            "name": "tuningConfig.partitionsSpec.targetRowsPerSegment",
+            "type": "number",
+          },
+          Object {
+            "defined": [Function],
+            "info": <React.Fragment>
+              <p>
+                If you know the optimal number of shards and want to speed up the time it takes for compaction to run, set this field.
+              </p>
+              <p>
+                Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              </p>
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",
@@ -516,7 +554,26 @@ exports[`CompactionDialog matches snapshot with compactionConfig (single_dim par
           Object {
             "defined": [Function],
             "info": <React.Fragment>
-              Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              <p>
+                If the segments generated are a sub-optimal size for the requested partition dimensions, consider setting this field.
+              </p>
+              <p>
+                A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
+              </p>
+            </React.Fragment>,
+            "label": "Target rows per segment",
+            "name": "tuningConfig.partitionsSpec.targetRowsPerSegment",
+            "type": "number",
+          },
+          Object {
+            "defined": [Function],
+            "info": <React.Fragment>
+              <p>
+                If you know the optimal number of shards and want to speed up the time it takes for compaction to run, set this field.
+              </p>
+              <p>
+                Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              </p>
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",
@@ -734,7 +791,26 @@ exports[`CompactionDialog matches snapshot without compactionConfig 1`] = `
           Object {
             "defined": [Function],
             "info": <React.Fragment>
-              Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              <p>
+                If the segments generated are a sub-optimal size for the requested partition dimensions, consider setting this field.
+              </p>
+              <p>
+                A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
+              </p>
+            </React.Fragment>,
+            "label": "Target rows per segment",
+            "name": "tuningConfig.partitionsSpec.targetRowsPerSegment",
+            "type": "number",
+          },
+          Object {
+            "defined": [Function],
+            "info": <React.Fragment>
+              <p>
+                If you know the optimal number of shards and want to speed up the time it takes for compaction to run, set this field.
+              </p>
+              <p>
+                Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
+              </p>
             </React.Fragment>,
             "label": "Num shards",
             "name": "tuningConfig.partitionsSpec.numShards",

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -242,7 +242,7 @@ function validCompactionConfig(compactionConfig: CompactionConfig): boolean {
     case 'hashed':
       return !(
         Boolean(deepGet(compactionConfig, 'tuningConfig.partitionsSpec.targetRowsPerSegment')) &&
-        Boolean(deepGet(compactionConfig, 'tuningConfig.partitionsSpec.targetRowsPerSegment'))
+        Boolean(deepGet(compactionConfig, 'tuningConfig.partitionsSpec.numShards'))
       );
       break;
     case 'single_dim':

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -82,12 +82,16 @@ const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
       deepGet(t, 'tuningConfig.partitionsSpec.type') === 'hashed' &&
       !deepGet(t, 'tuningConfig.partitionsSpec.numShards'),
     info: (
-      <p>
-        If you have skewed data, you may want to set this field to generate evenly sized segments.
-        <br />
-        <br /> A target row count for each partition. Each partition will have a row count close to
-        the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
-      </p>
+      <>
+        <p>
+          If the segments generated are a sub-optimal size for the requested partition dimensions,
+          consider setting this field.
+        </p>
+        <p>
+          A target row count for each partition. Each partition will have a row count close to the
+          target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
+        </p>
+      </>
     ),
   },
   {
@@ -98,15 +102,17 @@ const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
       deepGet(t, 'tuningConfig.partitionsSpec.type') === 'hashed' &&
       !deepGet(t, 'tuningConfig.partitionsSpec.targetRowsPerSegment'),
     info: (
-      <p>
-        If you know the optimal number of shards and want to speed up the time it takes for
-        compaction to run, set this field.
-        <br />
-        <br />
-        Directly specify the number of shards to create. If this is specified and 'intervals' is
-        specified in the granularitySpec, the index task can skip the determine intervals/partitions
-        pass through the data.
-      </p>
+      <>
+        <p>
+          If you know the optimal number of shards and want to speed up the time it takes for
+          compaction to run, set this field.
+        </p>
+        <p>
+          Directly specify the number of shards to create. If this is specified and 'intervals' is
+          specified in the granularitySpec, the index task can skip the determine
+          intervals/partitions pass through the data.
+        </p>
+      </>
     ),
   },
   {
@@ -233,7 +239,12 @@ function validCompactionConfig(compactionConfig: CompactionConfig): boolean {
     deepGet(compactionConfig, 'tuningConfig.partitionsSpec.type') || 'dynamic';
   switch (partitionsSpecType) {
     // case 'dynamic': // Nothing to check for dynamic
-    // case 'hashed': // Nothing to check for hashed
+    case 'hashed':
+      return !(
+        Boolean(deepGet(compactionConfig, 'tuningConfig.partitionsSpec.targetRowsPerSegment')) &&
+        Boolean(deepGet(compactionConfig, 'tuningConfig.partitionsSpec.targetRowsPerSegment'))
+      );
+      break;
     case 'single_dim':
       if (!deepGet(compactionConfig, 'tuningConfig.partitionsSpec.partitionDimension')) {
         return false;

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -75,16 +75,38 @@ const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
   },
   // partitionsSpec type: hashed
   {
+    name: 'tuningConfig.partitionsSpec.targetRowsPerSegment',
+    label: 'Target rows per segment',
+    type: 'number',
+    defined: (t: CompactionConfig) =>
+      deepGet(t, 'tuningConfig.partitionsSpec.type') === 'hashed' &&
+      !deepGet(t, 'tuningConfig.partitionsSpec.numShards'),
+    info: (
+      <p>
+        If you have skewed data, you may want to set this field to generate evenly sized segments.
+        <br />
+        <br /> A target row count for each partition. Each partition will have a row count close to
+        the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
+      </p>
+    ),
+  },
+  {
     name: 'tuningConfig.partitionsSpec.numShards',
     label: 'Num shards',
     type: 'number',
-    defined: (t: CompactionConfig) => deepGet(t, 'tuningConfig.partitionsSpec.type') === 'hashed',
+    defined: (t: CompactionConfig) =>
+      deepGet(t, 'tuningConfig.partitionsSpec.type') === 'hashed' &&
+      !deepGet(t, 'tuningConfig.partitionsSpec.targetRowsPerSegment'),
     info: (
-      <>
+      <p>
+        If you know the optimal number of shards and want to speed up the time it takes for
+        compaction to run, set this field.
+        <br />
+        <br />
         Directly specify the number of shards to create. If this is specified and 'intervals' is
         specified in the granularitySpec, the index task can skip the determine intervals/partitions
         pass through the data.
-      </>
+      </p>
     ),
   },
   {

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -2114,6 +2114,11 @@ export function invalidTuningConfig(tuningConfig: TuningConfig, intervals: any):
 
   if (!intervals) return true;
   switch (deepGet(tuningConfig, 'partitionsSpec.type')) {
+    case 'hashed':
+      return (
+        Boolean(deepGet(tuningConfig, 'partitionsSpec.targetRowsPerSegment')) &&
+        Boolean(deepGet(tuningConfig, 'partitionsSpec.targetRowsPerSegment'))
+      );
     case 'single_dim':
       if (!deepGet(tuningConfig, 'partitionsSpec.partitionDimension')) return true;
       const hasTargetRowsPerSegment = Boolean(
@@ -2189,14 +2194,17 @@ export function getPartitionRelatedTuningSpecFormFields(
             deepGet(t, 'partitionsSpec.type') === 'hashed' &&
             !deepGet(t, 'partitionsSpec.numShards'),
           info: (
-            <p>
-              If you have skewed data, you may want to set this field to generate evenly sized
-              segments.
-              <br />
-              <br /> A target row count for each partition. Each partition will have a row count
-              close to the target assuming evenly distributed keys. Defaults to 5 million if
-              numShards is null.
-            </p>
+            <>
+              <p>
+                If the segments generated are a sub-optimal size for the requested partition
+                dimensions, consider setting this field.
+              </p>
+              <p>
+                A target row count for each partition. Each partition will have a row count close to
+                the target assuming evenly distributed keys. Defaults to 5 million if numShards is
+                null.
+              </p>
+            </>
           ),
         },
         {
@@ -2207,15 +2215,17 @@ export function getPartitionRelatedTuningSpecFormFields(
             deepGet(t, 'partitionsSpec.type') === 'hashed' &&
             !deepGet(t, 'partitionsSpec.targetRowsPerSegment'),
           info: (
-            <p>
-              If you know the optimal number of shards and want to speed up the time it takes for
-              compaction to run, set this field.
-              <br />
-              <br />
-              Directly specify the number of shards to create. If this is specified and 'intervals'
-              is specified in the granularitySpec, the index task can skip the determine
-              intervals/partitions pass through the data.
-            </p>
+            <>
+              <p>
+                If you know the optimal number of shards and want to speed up the time it takes for
+                compaction to run, set this field.
+              </p>
+              <p>
+                Directly specify the number of shards to create. If this is specified and
+                'intervals' is specified in the granularitySpec, the index task can skip the
+                determine intervals/partitions pass through the data.
+              </p>
+            </>
           ),
         },
         {

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -2117,7 +2117,7 @@ export function invalidTuningConfig(tuningConfig: TuningConfig, intervals: any):
     case 'hashed':
       return (
         Boolean(deepGet(tuningConfig, 'partitionsSpec.targetRowsPerSegment')) &&
-        Boolean(deepGet(tuningConfig, 'partitionsSpec.targetRowsPerSegment'))
+        Boolean(deepGet(tuningConfig, 'partitionsSpec.numShards'))
       );
     case 'single_dim':
       if (!deepGet(tuningConfig, 'partitionsSpec.partitionDimension')) return true;

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -2182,16 +2182,40 @@ export function getPartitionRelatedTuningSpecFormFields(
         },
         // partitionsSpec type: hashed
         {
+          name: 'partitionsSpec.targetRowsPerSegment',
+          label: 'Target rows per segment',
+          type: 'number',
+          defined: (t: TuningConfig) =>
+            deepGet(t, 'partitionsSpec.type') === 'hashed' &&
+            !deepGet(t, 'partitionsSpec.numShards'),
+          info: (
+            <p>
+              If you have skewed data, you may want to set this field to generate evenly sized
+              segments.
+              <br />
+              <br /> A target row count for each partition. Each partition will have a row count
+              close to the target assuming evenly distributed keys. Defaults to 5 million if
+              numShards is null.
+            </p>
+          ),
+        },
+        {
           name: 'partitionsSpec.numShards',
           label: 'Num shards',
           type: 'number',
-          defined: (t: TuningConfig) => deepGet(t, 'partitionsSpec.type') === 'hashed',
+          defined: (t: TuningConfig) =>
+            deepGet(t, 'partitionsSpec.type') === 'hashed' &&
+            !deepGet(t, 'partitionsSpec.targetRowsPerSegment'),
           info: (
-            <>
+            <p>
+              If you know the optimal number of shards and want to speed up the time it takes for
+              compaction to run, set this field.
+              <br />
+              <br />
               Directly specify the number of shards to create. If this is specified and 'intervals'
               is specified in the granularitySpec, the index task can skip the determine
               intervals/partitions pass through the data.
-            </>
+            </p>
           ),
         },
         {


### PR DESCRIPTION
Added `targetRowsPerSegment` to the web console for hashed partition for both
the auto compaction view and as part of the ingestion workflow.

The help text was also updated to indicate when a user should care about
updating these fields

**View in Auto-compaction form for hashed partitioning**
<img width="500" alt="Screen Shot 2020-10-09 at 7 19 20 PM" src="https://user-images.githubusercontent.com/44787917/95643989-fc8de900-0a67-11eb-9394-f23e762fad3a.png">

**Help text for `targetRowsPerSegment`** 
<img width="500" alt="Screen Shot 2020-10-09 at 7 19 31 PM" src="https://user-images.githubusercontent.com/44787917/95643988-fbf55280-0a67-11eb-8164-e088a4bff63f.png">

**View in the Partition tab of the ingestion flow**
<img width="692" alt="Screen Shot 2020-10-09 at 7 42 32 PM" src="https://user-images.githubusercontent.com/44787917/95643986-fa2b8f00-0a67-11eb-9db8-8bc7ac67c746.png">