### PR TITLE
Avro union support

### DIFF
--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -40,13 +40,19 @@ Make sure to [include](../../development/extensions.md#loading-extensions) `drui
 Druid supports most Avro types natively, there are however some exceptions which are detailed here.
 
 #### Unions
-Druid has two modes for supporting `union` types. The original legacy mode can only support unions of the form `[null, otherType]`.
-The newer mode can be enabled by setting `extractUnions` on the Avro parser in which case unions will be expanded according to the following rules:
+Druid has two modes for supporting `union` types.
+
+The default mode will treat unions as a single value regardless of the type it is poulated with.
+
+If you wish to operate on each different member of a union however you can set `extractUnionsByType` on the Avro parser in which case unions will be expanded into nested objects according to the following rules:
 * Primitive types and unnamed complex types are keyed their type name. i.e `int`, `string`
 * Complex named types are keyed by their names, this includes `record`, `fixed` and `enum`.
-* The Avro null type is elided as it's value can only ever be null
+* The Avro null type is elided as its value can only ever be null
 
-This is safe because an Avro union can only contain a single member of each unnamed type and duplicates of the same named type are not allowed. i.e only a single array is allowed, multiple records (or other named types) are allowed as long as each has a unique name.
+This is safe because an Avro union can only contain a single member of each unnamed type and duplicates of the same named type are not allowed.
+i.e only a single array is allowed, multiple records (or other named types) are allowed as long as each has a unique name.
+
+The members can then be accessed using a [flattenSpec](../../ingestion/data-formats.md#flattenspec) similar other nested types.
 
 #### Binary types
 `bytes` and `fixed` Avro types will be returned by default as base64 encoded strings unless the `binaryAsString` option is enabled on the Avro parser.

--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -42,8 +42,8 @@ Druid supports most Avro types natively, there are however some exceptions which
 #### Unions
 Druid has two modes for supporting `union` types. The original legacy mode can only support unions of the form `[null, otherType]`.
 The newer mode can be enabled by setting `explodeUnions` on the Avro parser in which case unions will be expanded according to the following rules:
-* Primitive types and unnamed complex types are keyed their type name. i.e `int`, ``
-* Complex named types are keyed by their names.
+* Primitive types and unnamed complex types are keyed their type name. i.e `int`, `string`
+* Complex named types are keyed by their names, this includes `record`, `fixed` and `enum`.
 * The Avro null type is elided as it's value can only ever be null
 
 This is safe because an Avro union can only contain a single member of each unnamed type and duplicates of the same named type are not allowed. i.e only a single array is allowed, multiple records (or other named types) are allowed as long as each has a unique name.

--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -41,7 +41,7 @@ Druid supports most Avro types natively, there are however some exceptions which
 
 #### Unions
 Druid has two modes for supporting `union` types. The original legacy mode can only support unions of the form `[null, otherType]`.
-The newer mode can be enabled by setting `explodeUnions` on the Avro parser in which case unions will be expanded according to the following rules:
+The newer mode can be enabled by setting `extractUnions` on the Avro parser in which case unions will be expanded according to the following rules:
 * Primitive types and unnamed complex types are keyed their type name. i.e `int`, `string`
 * Complex named types are keyed by their names, this includes `record`, `fixed` and `enum`.
 * The Avro null type is elided as it's value can only ever be null

--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -39,13 +39,24 @@ Make sure to [include](../../development/extensions.md#loading-extensions) `drui
 
 Druid supports most Avro types natively, there are however some exceptions which are detailed here.
 
-`union` types which aren't of the form `[null, otherType]` aren't supported at this time.
+#### Unions
+Druid has two modes for supporting `union` types. The original legacy mode can only support unions of the form `[null, otherType]`.
+The newer mode can be enabled by setting `explodeUnions` on the Avro parser in which case unions will be expanded according to the following rules:
+* Primitive types and unnamed complex types are keyed their type name. i.e `int`, ``
+* Complex named types are keyed by their names.
+* The Avro null type is elided as it's value can only ever be null
 
+This is safe because an Avro union can only contain a single member of each unnamed type and duplicates of the same named type are not allowed. i.e only a single array is allowed, multiple records (or other named types) are allowed as long as each has a unique name.
+
+#### Binary types
 `bytes` and `fixed` Avro types will be returned by default as base64 encoded strings unless the `binaryAsString` option is enabled on the Avro parser.
 This setting will decode these types as UTF-8 strings.
 
+#### Enums
 `enum` types will be returned as `string` of the enum symbol.
 
+#### Complex types
 `record` and `map` types representing nested data can be ingested using [flattenSpec](../../ingestion/data-formats.md#flattenspec) on the parser.
 
+#### Logical types
 Druid doesn't currently support Avro logical types, they will be ignored and fields will be handled according to the underlying primitive type.

--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -42,7 +42,7 @@ Druid supports most Avro types natively, there are however some exceptions which
 #### Unions
 Druid has two modes for supporting `union` types.
 
-The default mode will treat unions as a single value regardless of the type it is poulated with.
+The default mode will treat unions as a single value regardless of the type it is populated with.
 
 If you wish to operate on each different member of a union however you can set `extractUnionsByType` on the Avro parser in which case unions will be expanded into nested objects according to the following rules:
 * Primitive types and unnamed complex types are keyed their type name. i.e `int`, `string`

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroHadoopInputRowParser.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroHadoopInputRowParser.java
@@ -34,18 +34,24 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
 {
   private final ParseSpec parseSpec;
   private final boolean fromPigAvroStorage;
+  private final boolean binaryAsString;
+  private final boolean explodeUnions;
   private final ObjectFlattener<GenericRecord> avroFlattener;
   private final MapInputRowParser mapParser;
 
   @JsonCreator
   public AvroHadoopInputRowParser(
       @JsonProperty("parseSpec") ParseSpec parseSpec,
-      @JsonProperty("fromPigAvroStorage") Boolean fromPigAvroStorage
+      @JsonProperty("fromPigAvroStorage") Boolean fromPigAvroStorage,
+      @JsonProperty("binaryAsString") Boolean binaryAsString,
+      @JsonProperty("explodeUnions") Boolean explodeUnions
   )
   {
     this.parseSpec = parseSpec;
-    this.fromPigAvroStorage = fromPigAvroStorage == null ? false : fromPigAvroStorage;
-    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, this.fromPigAvroStorage, false);
+    this.fromPigAvroStorage = fromPigAvroStorage != null && fromPigAvroStorage;
+    this.binaryAsString = binaryAsString != null && binaryAsString;
+    this.explodeUnions = explodeUnions != null && explodeUnions;
+    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, this.fromPigAvroStorage, this.binaryAsString, this.explodeUnions);
     this.mapParser = new MapInputRowParser(parseSpec);
   }
 
@@ -71,6 +77,6 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
   @Override
   public InputRowParser withParseSpec(ParseSpec parseSpec)
   {
-    return new AvroHadoopInputRowParser(parseSpec, fromPigAvroStorage);
+    return new AvroHadoopInputRowParser(parseSpec, fromPigAvroStorage, binaryAsString, explodeUnions);
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroHadoopInputRowParser.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroHadoopInputRowParser.java
@@ -35,7 +35,7 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
   private final ParseSpec parseSpec;
   private final boolean fromPigAvroStorage;
   private final boolean binaryAsString;
-  private final boolean explodeUnions;
+  private final boolean extractUnions;
   private final ObjectFlattener<GenericRecord> avroFlattener;
   private final MapInputRowParser mapParser;
 
@@ -44,14 +44,14 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
       @JsonProperty("parseSpec") ParseSpec parseSpec,
       @JsonProperty("fromPigAvroStorage") Boolean fromPigAvroStorage,
       @JsonProperty("binaryAsString") Boolean binaryAsString,
-      @JsonProperty("explodeUnions") Boolean explodeUnions
+      @JsonProperty("extractUnions") Boolean extractUnions
   )
   {
     this.parseSpec = parseSpec;
     this.fromPigAvroStorage = fromPigAvroStorage != null && fromPigAvroStorage;
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.explodeUnions = explodeUnions != null && explodeUnions;
-    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, this.fromPigAvroStorage, this.binaryAsString, this.explodeUnions);
+    this.extractUnions = extractUnions != null && extractUnions;
+    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, this.fromPigAvroStorage, this.binaryAsString, this.extractUnions);
     this.mapParser = new MapInputRowParser(parseSpec);
   }
 
@@ -77,6 +77,6 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
   @Override
   public InputRowParser withParseSpec(ParseSpec parseSpec)
   {
-    return new AvroHadoopInputRowParser(parseSpec, fromPigAvroStorage, binaryAsString, explodeUnions);
+    return new AvroHadoopInputRowParser(parseSpec, fromPigAvroStorage, binaryAsString, extractUnions);
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroHadoopInputRowParser.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroHadoopInputRowParser.java
@@ -35,7 +35,7 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
   private final ParseSpec parseSpec;
   private final boolean fromPigAvroStorage;
   private final boolean binaryAsString;
-  private final boolean extractUnions;
+  private final boolean extractUnionsByType;
   private final ObjectFlattener<GenericRecord> avroFlattener;
   private final MapInputRowParser mapParser;
 
@@ -44,14 +44,14 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
       @JsonProperty("parseSpec") ParseSpec parseSpec,
       @JsonProperty("fromPigAvroStorage") Boolean fromPigAvroStorage,
       @JsonProperty("binaryAsString") Boolean binaryAsString,
-      @JsonProperty("extractUnions") Boolean extractUnions
+      @JsonProperty("extractUnionsByType") Boolean extractUnionsByType
   )
   {
     this.parseSpec = parseSpec;
     this.fromPigAvroStorage = fromPigAvroStorage != null && fromPigAvroStorage;
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.extractUnions = extractUnions != null && extractUnions;
-    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, this.fromPigAvroStorage, this.binaryAsString, this.extractUnions);
+    this.extractUnionsByType = extractUnionsByType != null && extractUnionsByType;
+    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, this.fromPigAvroStorage, this.binaryAsString, this.extractUnionsByType);
     this.mapParser = new MapInputRowParser(parseSpec);
   }
 
@@ -77,6 +77,6 @@ public class AvroHadoopInputRowParser implements InputRowParser<GenericRecord>
   @Override
   public InputRowParser withParseSpec(ParseSpec parseSpec)
   {
-    return new AvroHadoopInputRowParser(parseSpec, fromPigAvroStorage, binaryAsString, extractUnions);
+    return new AvroHadoopInputRowParser(parseSpec, fromPigAvroStorage, binaryAsString, extractUnionsByType);
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroStreamInputRowParser.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroStreamInputRowParser.java
@@ -36,6 +36,8 @@ import java.util.Objects;
 public class AvroStreamInputRowParser implements ByteBufferInputRowParser
 {
   private final ParseSpec parseSpec;
+  private final Boolean binaryAsString;
+  private final Boolean explodeUnions;
   private final AvroBytesDecoder avroBytesDecoder;
   private final ObjectFlattener<GenericRecord> avroFlattener;
   private final MapInputRowParser mapParser;
@@ -43,12 +45,16 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
   @JsonCreator
   public AvroStreamInputRowParser(
       @JsonProperty("parseSpec") ParseSpec parseSpec,
-      @JsonProperty("avroBytesDecoder") AvroBytesDecoder avroBytesDecoder
+      @JsonProperty("avroBytesDecoder") AvroBytesDecoder avroBytesDecoder,
+      @JsonProperty("binaryAsString") Boolean binaryAsString,
+      @JsonProperty("explodeUnions") Boolean explodeUnions
   )
   {
     this.parseSpec = Preconditions.checkNotNull(parseSpec, "parseSpec");
     this.avroBytesDecoder = Preconditions.checkNotNull(avroBytesDecoder, "avroBytesDecoder");
-    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, false, false);
+    this.binaryAsString = binaryAsString != null && binaryAsString;
+    this.explodeUnions = explodeUnions != null && explodeUnions;
+    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, false, this.binaryAsString, this.explodeUnions);
     this.mapParser = new MapInputRowParser(parseSpec);
   }
 
@@ -76,7 +82,9 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
   {
     return new AvroStreamInputRowParser(
         parseSpec,
-        avroBytesDecoder
+        avroBytesDecoder,
+        binaryAsString,
+        explodeUnions
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroStreamInputRowParser.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroStreamInputRowParser.java
@@ -37,7 +37,7 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
 {
   private final ParseSpec parseSpec;
   private final Boolean binaryAsString;
-  private final Boolean explodeUnions;
+  private final Boolean extractUnions;
   private final AvroBytesDecoder avroBytesDecoder;
   private final ObjectFlattener<GenericRecord> avroFlattener;
   private final MapInputRowParser mapParser;
@@ -47,14 +47,14 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
       @JsonProperty("parseSpec") ParseSpec parseSpec,
       @JsonProperty("avroBytesDecoder") AvroBytesDecoder avroBytesDecoder,
       @JsonProperty("binaryAsString") Boolean binaryAsString,
-      @JsonProperty("explodeUnions") Boolean explodeUnions
+      @JsonProperty("extractUnions") Boolean extractUnions
   )
   {
     this.parseSpec = Preconditions.checkNotNull(parseSpec, "parseSpec");
     this.avroBytesDecoder = Preconditions.checkNotNull(avroBytesDecoder, "avroBytesDecoder");
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.explodeUnions = explodeUnions != null && explodeUnions;
-    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, false, this.binaryAsString, this.explodeUnions);
+    this.extractUnions = extractUnions != null && extractUnions;
+    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, false, this.binaryAsString, this.extractUnions);
     this.mapParser = new MapInputRowParser(parseSpec);
   }
 
@@ -84,7 +84,7 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
         parseSpec,
         avroBytesDecoder,
         binaryAsString,
-        explodeUnions
+        extractUnions
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroStreamInputRowParser.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/AvroStreamInputRowParser.java
@@ -37,7 +37,7 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
 {
   private final ParseSpec parseSpec;
   private final Boolean binaryAsString;
-  private final Boolean extractUnions;
+  private final Boolean extractUnionsByType;
   private final AvroBytesDecoder avroBytesDecoder;
   private final ObjectFlattener<GenericRecord> avroFlattener;
   private final MapInputRowParser mapParser;
@@ -47,14 +47,14 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
       @JsonProperty("parseSpec") ParseSpec parseSpec,
       @JsonProperty("avroBytesDecoder") AvroBytesDecoder avroBytesDecoder,
       @JsonProperty("binaryAsString") Boolean binaryAsString,
-      @JsonProperty("extractUnions") Boolean extractUnions
+      @JsonProperty("extractUnionsByType") Boolean extractUnionsByType
   )
   {
     this.parseSpec = Preconditions.checkNotNull(parseSpec, "parseSpec");
     this.avroBytesDecoder = Preconditions.checkNotNull(avroBytesDecoder, "avroBytesDecoder");
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.extractUnions = extractUnions != null && extractUnions;
-    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, false, this.binaryAsString, this.extractUnions);
+    this.extractUnionsByType = extractUnionsByType != null && extractUnionsByType;
+    this.avroFlattener = AvroParsers.makeFlattener(parseSpec, false, this.binaryAsString, this.extractUnionsByType);
     this.mapParser = new MapInputRowParser(parseSpec);
   }
 
@@ -84,7 +84,7 @@ public class AvroStreamInputRowParser implements ByteBufferInputRowParser
         parseSpec,
         avroBytesDecoder,
         binaryAsString,
-        extractUnions
+        extractUnionsByType
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -94,12 +94,12 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
    * @param fromPigAvroStorage boolean to specify the data file is stored using AvroStorage
    * @param binaryAsString boolean to encode the byte[] as a string.
    */
-  public AvroFlattenerMaker(final boolean fromPigAvroStorage, final boolean binaryAsString, final boolean explodeUnions)
+  public AvroFlattenerMaker(final boolean fromPigAvroStorage, final boolean binaryAsString, final boolean extractUnions)
   {
     this.fromPigAvroStorage = fromPigAvroStorage;
     this.binaryAsString = binaryAsString;
 
-    this.avroJsonProvider = new GenericAvroJsonProvider(explodeUnions);
+    this.avroJsonProvider = new GenericAvroJsonProvider(extractUnions);
     this.jsonPathConfiguration =
         Configuration.builder()
                      .jsonProvider(avroJsonProvider)

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -99,7 +99,7 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
     this.fromPigAvroStorage = fromPigAvroStorage;
     this.binaryAsString = binaryAsString;
 
-    this.avroJsonProvider= new GenericAvroJsonProvider(explodeUnions);
+    this.avroJsonProvider = new GenericAvroJsonProvider(explodeUnions);
     this.jsonPathConfiguration =
         Configuration.builder()
                      .jsonProvider(avroJsonProvider)

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -94,12 +94,12 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
    * @param fromPigAvroStorage boolean to specify the data file is stored using AvroStorage
    * @param binaryAsString boolean to encode the byte[] as a string.
    */
-  public AvroFlattenerMaker(final boolean fromPigAvroStorage, final boolean binaryAsString, final boolean extractUnions)
+  public AvroFlattenerMaker(final boolean fromPigAvroStorage, final boolean binaryAsString, final boolean extractUnionsByType)
   {
     this.fromPigAvroStorage = fromPigAvroStorage;
     this.binaryAsString = binaryAsString;
 
-    this.avroJsonProvider = new GenericAvroJsonProvider(extractUnions);
+    this.avroJsonProvider = new GenericAvroJsonProvider(extractUnionsByType);
     this.jsonPathConfiguration =
         Configuration.builder()
                      .jsonProvider(avroJsonProvider)

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
@@ -33,6 +33,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.Null;
 import java.io.File;
 import java.util.Map;
 import java.util.Objects;
@@ -42,6 +43,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
   private static final Logger LOGGER = new Logger(AvroOCFInputFormat.class);
 
   private final boolean binaryAsString;
+  private final boolean explodeUnions;
   @Nullable
   private final Schema readerSchema;
 
@@ -50,7 +52,8 @@ public class AvroOCFInputFormat extends NestedInputFormat
       @JacksonInject @Json ObjectMapper mapper,
       @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
       @JsonProperty("schema") @Nullable Map<String, Object> schema,
-      @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString
+      @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString,
+      @JsonProperty("explodeUnions") @Nullable Boolean explodeUnions
   ) throws Exception
   {
     super(flattenSpec);
@@ -62,7 +65,8 @@ public class AvroOCFInputFormat extends NestedInputFormat
     } else {
       this.readerSchema = null;
     }
-    this.binaryAsString = binaryAsString == null ? false : binaryAsString;
+    this.binaryAsString = binaryAsString != null && binaryAsString;
+    this.explodeUnions = explodeUnions != null && explodeUnions;
   }
 
   @Override
@@ -82,7 +86,8 @@ public class AvroOCFInputFormat extends NestedInputFormat
         temporaryDirectory,
         readerSchema,
         getFlattenSpec(),
-        binaryAsString
+        binaryAsString,
+        explodeUnions
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
@@ -42,7 +42,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
   private static final Logger LOGGER = new Logger(AvroOCFInputFormat.class);
 
   private final boolean binaryAsString;
-  private final boolean explodeUnions;
+  private final boolean extractUnions;
   @Nullable
   private final Schema readerSchema;
 
@@ -52,7 +52,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
       @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
       @JsonProperty("schema") @Nullable Map<String, Object> schema,
       @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString,
-      @JsonProperty("explodeUnions") @Nullable Boolean explodeUnions
+      @JsonProperty("extractUnions") @Nullable Boolean extractUnions
   ) throws Exception
   {
     super(flattenSpec);
@@ -65,7 +65,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
       this.readerSchema = null;
     }
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.explodeUnions = explodeUnions != null && explodeUnions;
+    this.extractUnions = extractUnions != null && extractUnions;
   }
 
   @Override
@@ -86,7 +86,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
         readerSchema,
         getFlattenSpec(),
         binaryAsString,
-        explodeUnions
+        extractUnions
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
@@ -42,7 +42,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
   private static final Logger LOGGER = new Logger(AvroOCFInputFormat.class);
 
   private final boolean binaryAsString;
-  private final boolean extractUnions;
+  private final boolean extractUnionsByType;
   @Nullable
   private final Schema readerSchema;
 
@@ -52,7 +52,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
       @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
       @JsonProperty("schema") @Nullable Map<String, Object> schema,
       @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString,
-      @JsonProperty("extractUnions") @Nullable Boolean extractUnions
+      @JsonProperty("extractUnionsByType") @Nullable Boolean extractUnionsByType
   ) throws Exception
   {
     super(flattenSpec);
@@ -65,7 +65,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
       this.readerSchema = null;
     }
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.extractUnions = extractUnions != null && extractUnions;
+    this.extractUnionsByType = extractUnionsByType != null && extractUnionsByType;
   }
 
   @Override
@@ -86,7 +86,7 @@ public class AvroOCFInputFormat extends NestedInputFormat
         readerSchema,
         getFlattenSpec(),
         binaryAsString,
-        extractUnions
+        extractUnionsByType
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFInputFormat.java
@@ -33,7 +33,6 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.Null;
 import java.io.File;
 import java.util.Map;
 import java.util.Objects;

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
@@ -56,14 +56,15 @@ public class AvroOCFReader extends IntermediateRowParsingReader<GenericRecord>
       File temporaryDirectory,
       @Nullable Schema readerSchema,
       JSONPathSpec flattenSpec,
-      boolean binaryAsString
+      boolean binaryAsString,
+      boolean explodeUnions
   )
   {
     this.inputRowSchema = inputRowSchema;
     this.source = source;
     this.temporaryDirectory = temporaryDirectory;
     this.readerSchema = readerSchema;
-    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString));
+    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, explodeUnions));
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
@@ -57,14 +57,14 @@ public class AvroOCFReader extends IntermediateRowParsingReader<GenericRecord>
       @Nullable Schema readerSchema,
       JSONPathSpec flattenSpec,
       boolean binaryAsString,
-      boolean explodeUnions
+      boolean extractUnions
   )
   {
     this.inputRowSchema = inputRowSchema;
     this.source = source;
     this.temporaryDirectory = temporaryDirectory;
     this.readerSchema = readerSchema;
-    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, explodeUnions));
+    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, extractUnions));
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
@@ -57,14 +57,14 @@ public class AvroOCFReader extends IntermediateRowParsingReader<GenericRecord>
       @Nullable Schema readerSchema,
       JSONPathSpec flattenSpec,
       boolean binaryAsString,
-      boolean extractUnions
+      boolean extractUnionsByType
   )
   {
     this.inputRowSchema = inputRowSchema;
     this.source = source;
     this.temporaryDirectory = temporaryDirectory;
     this.readerSchema = readerSchema;
-    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, extractUnions));
+    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, extractUnionsByType));
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroParsers.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroParsers.java
@@ -39,7 +39,8 @@ public class AvroParsers
   public static ObjectFlattener<GenericRecord> makeFlattener(
       final ParseSpec parseSpec,
       final boolean fromPigAvroStorage,
-      final boolean binaryAsString
+      final boolean binaryAsString,
+      final boolean explodeUnions
   )
   {
     final JSONPathSpec flattenSpec;
@@ -49,7 +50,7 @@ public class AvroParsers
       flattenSpec = JSONPathSpec.DEFAULT;
     }
 
-    return ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(fromPigAvroStorage, binaryAsString));
+    return ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(fromPigAvroStorage, binaryAsString, explodeUnions));
   }
 
   public static List<InputRow> parseGenericRecord(

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroParsers.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroParsers.java
@@ -40,7 +40,7 @@ public class AvroParsers
       final ParseSpec parseSpec,
       final boolean fromPigAvroStorage,
       final boolean binaryAsString,
-      final boolean extractUnions
+      final boolean extractUnionsByType
   )
   {
     final JSONPathSpec flattenSpec;
@@ -50,7 +50,7 @@ public class AvroParsers
       flattenSpec = JSONPathSpec.DEFAULT;
     }
 
-    return ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(fromPigAvroStorage, binaryAsString, extractUnions));
+    return ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(fromPigAvroStorage, binaryAsString, extractUnionsByType));
   }
 
   public static List<InputRow> parseGenericRecord(

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroParsers.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroParsers.java
@@ -40,7 +40,7 @@ public class AvroParsers
       final ParseSpec parseSpec,
       final boolean fromPigAvroStorage,
       final boolean binaryAsString,
-      final boolean explodeUnions
+      final boolean extractUnions
   )
   {
     final JSONPathSpec flattenSpec;
@@ -50,7 +50,7 @@ public class AvroParsers
       flattenSpec = JSONPathSpec.DEFAULT;
     }
 
-    return ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(fromPigAvroStorage, binaryAsString, explodeUnions));
+    return ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(fromPigAvroStorage, binaryAsString, extractUnions));
   }
 
   public static List<InputRow> parseGenericRecord(

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 public class AvroStreamInputFormat extends NestedInputFormat
 {
   private final boolean binaryAsString;
-  private final boolean extractUnions;
+  private final boolean extractUnionsByType;
 
   private final AvroBytesDecoder avroBytesDecoder;
 
@@ -44,13 +44,13 @@ public class AvroStreamInputFormat extends NestedInputFormat
       @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
       @JsonProperty("avroBytesDecoder") AvroBytesDecoder avroBytesDecoder,
       @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString,
-      @JsonProperty("extractUnions") @Nullable Boolean extractUnions
+      @JsonProperty("extractUnionsByType") @Nullable Boolean extractUnionsByType
   )
   {
     super(flattenSpec);
     this.avroBytesDecoder = avroBytesDecoder;
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.extractUnions = extractUnions != null && extractUnions;
+    this.extractUnionsByType = extractUnionsByType != null && extractUnionsByType;
   }
 
   @Override
@@ -80,7 +80,7 @@ public class AvroStreamInputFormat extends NestedInputFormat
         avroBytesDecoder,
         getFlattenSpec(),
         binaryAsString,
-        extractUnions
+        extractUnionsByType
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 public class AvroStreamInputFormat extends NestedInputFormat
 {
   private final boolean binaryAsString;
-  private final boolean explodeUnions;
+  private final boolean extractUnions;
 
   private final AvroBytesDecoder avroBytesDecoder;
 
@@ -44,13 +44,13 @@ public class AvroStreamInputFormat extends NestedInputFormat
       @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
       @JsonProperty("avroBytesDecoder") AvroBytesDecoder avroBytesDecoder,
       @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString,
-      @JsonProperty("explodeUnions") @Nullable Boolean explodeUnions
+      @JsonProperty("extractUnions") @Nullable Boolean extractUnions
   )
   {
     super(flattenSpec);
     this.avroBytesDecoder = avroBytesDecoder;
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.explodeUnions = explodeUnions != null && explodeUnions;
+    this.extractUnions = extractUnions != null && extractUnions;
   }
 
   @Override
@@ -80,7 +80,7 @@ public class AvroStreamInputFormat extends NestedInputFormat
         avroBytesDecoder,
         getFlattenSpec(),
         binaryAsString,
-        explodeUnions
+        extractUnions
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 public class AvroStreamInputFormat extends NestedInputFormat
 {
   private final boolean binaryAsString;
+  private final boolean explodeUnions;
 
   private final AvroBytesDecoder avroBytesDecoder;
 
@@ -42,12 +43,14 @@ public class AvroStreamInputFormat extends NestedInputFormat
   public AvroStreamInputFormat(
       @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
       @JsonProperty("avroBytesDecoder") AvroBytesDecoder avroBytesDecoder,
-      @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString
+      @JsonProperty("binaryAsString") @Nullable Boolean binaryAsString,
+      @JsonProperty("explodeUnions") @Nullable Boolean explodeUnions
   )
   {
     super(flattenSpec);
     this.avroBytesDecoder = avroBytesDecoder;
-    this.binaryAsString = binaryAsString == null ? false : binaryAsString;
+    this.binaryAsString = binaryAsString != null && binaryAsString;
+    this.explodeUnions = explodeUnions != null && explodeUnions;
   }
 
   @Override
@@ -76,7 +79,8 @@ public class AvroStreamInputFormat extends NestedInputFormat
         source,
         avroBytesDecoder,
         getFlattenSpec(),
-        binaryAsString
+        binaryAsString,
+        explodeUnions
     );
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
@@ -53,13 +53,13 @@ public class AvroStreamReader extends IntermediateRowParsingReader<GenericRecord
       AvroBytesDecoder avroBytesDecoder,
       JSONPathSpec flattenSpec,
       boolean binaryAsString,
-      boolean extractUnions
+      boolean extractUnionsByType
   )
   {
     this.inputRowSchema = inputRowSchema;
     this.source = source;
     this.avroBytesDecoder = avroBytesDecoder;
-    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, extractUnions));
+    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, extractUnionsByType));
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
@@ -53,13 +53,13 @@ public class AvroStreamReader extends IntermediateRowParsingReader<GenericRecord
       AvroBytesDecoder avroBytesDecoder,
       JSONPathSpec flattenSpec,
       boolean binaryAsString,
-      boolean explodeUnions
+      boolean extractUnions
   )
   {
     this.inputRowSchema = inputRowSchema;
     this.source = source;
     this.avroBytesDecoder = avroBytesDecoder;
-    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, explodeUnions));
+    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, extractUnions));
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
@@ -52,13 +52,14 @@ public class AvroStreamReader extends IntermediateRowParsingReader<GenericRecord
       InputEntity source,
       AvroBytesDecoder avroBytesDecoder,
       JSONPathSpec flattenSpec,
-      boolean binaryAsString
+      boolean binaryAsString,
+      boolean explodeUnions
   )
   {
     this.inputRowSchema = inputRowSchema;
     this.source = source;
     this.avroBytesDecoder = avroBytesDecoder;
-    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString));
+    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new AvroFlattenerMaker(false, binaryAsString, explodeUnions));
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
@@ -19,15 +19,19 @@
 
 package org.apache.druid.data.input.avro;
 
+import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 
 import javax.annotation.Nullable;
 
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,6 +45,11 @@ import java.util.stream.Collectors;
  */
 public class GenericAvroJsonProvider implements JsonProvider
 {
+  private final boolean explodeUnions;
+  GenericAvroJsonProvider(final boolean explodeUnions) {
+    this.explodeUnions = explodeUnions;
+  }
+
   @Override
   public Object parse(final String s) throws InvalidJsonException
   {
@@ -148,7 +157,11 @@ public class GenericAvroJsonProvider implements JsonProvider
     if (o == null) {
       return null;
     } else if (o instanceof GenericRecord) {
-      return ((GenericRecord) o).get(s);
+      final GenericRecord record = (GenericRecord) o;
+      if (explodeUnions && isExplodableUnion(record.getSchema().getField(s))) {
+        return explodeUnion(record.get(s));
+      }
+      return record.get(s);
     } else if (o instanceof Map) {
       final Map theMap = (Map) o;
       if (theMap.containsKey(s)) {
@@ -194,5 +207,46 @@ public class GenericAvroJsonProvider implements JsonProvider
   public Object unwrap(final Object o)
   {
     return o;
+  }
+
+  private boolean isExplodableUnion(final Schema.Field field) {
+    return field.schema().isUnion() &&
+           field.schema().getTypes().stream().filter(type -> type.getType() != Schema.Type.NULL).count() > 1;
+  }
+
+  private Map<String, Object> explodeUnion(final Object o)
+  {
+    // Primitive types and unnamped complex types are keyed their type name.
+    // Complex named types are keyed by their names.
+    // This is safe because an Avro union can only contain a single member of each unnamed type and duplicates
+    // of the same named type are not allowed. i.e only a single array is allowed, multiple records are allowed as
+    // long as each has a unique name.
+    // The Avro null type is elided as it's value can only ever be null
+    if (o instanceof Integer) {
+      return ImmutableMap.of("int", o);
+    } else if (o instanceof Long) {
+      return ImmutableMap.of("long", o);
+    } else if (o instanceof Float) {
+      return ImmutableMap.of("float", o);
+    } else if (o instanceof Double) {
+      return ImmutableMap.of("double", o);
+    } else if (o instanceof Boolean) {
+      return ImmutableMap.of("boolean", o);
+    } else if (o instanceof Utf8) {
+      return ImmutableMap.of("string", o);
+    } else if (o instanceof ByteBuffer) {
+      return ImmutableMap.of("bytes", o);
+    } else if (o instanceof Map) {
+      return ImmutableMap.of("map", o);
+    } else if (o instanceof List) {
+      return ImmutableMap.of("array", o);
+    } else if (o instanceof GenericRecord) {
+      return ImmutableMap.of(((GenericRecord) o).getSchema().getName(), o);
+    } else if (o instanceof GenericFixed) {
+      return ImmutableMap.of(((GenericFixed) o).getSchema().getName(), o);
+    } else if (o instanceof GenericEnumSymbol) {
+      return ImmutableMap.of(((GenericEnumSymbol<?>) o).getSchema().getName(), o);
+    }
+    return ImmutableMap.of();
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
@@ -45,11 +45,11 @@ import java.util.stream.Collectors;
  */
 public class GenericAvroJsonProvider implements JsonProvider
 {
-  private final boolean explodeUnions;
+  private final boolean extractUnions;
 
-  GenericAvroJsonProvider(final boolean explodeUnions)
+  GenericAvroJsonProvider(final boolean extractUnions)
   {
-    this.explodeUnions = explodeUnions;
+    this.extractUnions = extractUnions;
   }
 
   @Override
@@ -160,7 +160,7 @@ public class GenericAvroJsonProvider implements JsonProvider
       return null;
     } else if (o instanceof GenericRecord) {
       final GenericRecord record = (GenericRecord) o;
-      if (explodeUnions && isExplodableUnion(record.getSchema().getField(s))) {
+      if (extractUnions && isExplodableUnion(record.getSchema().getField(s))) {
         return explodeUnion(record.get(s));
       }
       return record.get(s);

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
@@ -46,7 +46,9 @@ import java.util.stream.Collectors;
 public class GenericAvroJsonProvider implements JsonProvider
 {
   private final boolean explodeUnions;
-  GenericAvroJsonProvider(final boolean explodeUnions) {
+
+  GenericAvroJsonProvider(final boolean explodeUnions)
+  {
     this.explodeUnions = explodeUnions;
   }
 
@@ -209,7 +211,8 @@ public class GenericAvroJsonProvider implements JsonProvider
     return o;
   }
 
-  private boolean isExplodableUnion(final Schema.Field field) {
+  private boolean isExplodableUnion(final Schema.Field field)
+  {
     return field.schema().isUnion() &&
            field.schema().getTypes().stream().filter(type -> type.getType() != Schema.Type.NULL).count() > 1;
   }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
@@ -45,11 +45,11 @@ import java.util.stream.Collectors;
  */
 public class GenericAvroJsonProvider implements JsonProvider
 {
-  private final boolean extractUnions;
+  private final boolean extractUnionsByType;
 
-  GenericAvroJsonProvider(final boolean extractUnions)
+  GenericAvroJsonProvider(final boolean extractUnionsByType)
   {
-    this.extractUnions = extractUnions;
+    this.extractUnionsByType = extractUnionsByType;
   }
 
   @Override
@@ -160,8 +160,8 @@ public class GenericAvroJsonProvider implements JsonProvider
       return null;
     } else if (o instanceof GenericRecord) {
       final GenericRecord record = (GenericRecord) o;
-      if (extractUnions && isExtractableUnion(record.getSchema().getField(s))) {
-        return extractUnion(record.get(s));
+      if (extractUnionsByType && isExtractableUnion(record.getSchema().getField(s))) {
+        return extractUnionTypes(record.get(s));
       }
       return record.get(s);
     } else if (o instanceof Map) {
@@ -217,7 +217,7 @@ public class GenericAvroJsonProvider implements JsonProvider
            field.schema().getTypes().stream().filter(type -> type.getType() != Schema.Type.NULL).count() > 1;
   }
 
-  private Map<String, Object> extractUnion(final Object o)
+  private Map<String, Object> extractUnionTypes(final Object o)
   {
     // Primitive types and unnamped complex types are keyed their type name.
     // Complex named types are keyed by their names.

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
@@ -160,8 +160,8 @@ public class GenericAvroJsonProvider implements JsonProvider
       return null;
     } else if (o instanceof GenericRecord) {
       final GenericRecord record = (GenericRecord) o;
-      if (extractUnions && isExplodableUnion(record.getSchema().getField(s))) {
-        return explodeUnion(record.get(s));
+      if (extractUnions && isExtractableUnion(record.getSchema().getField(s))) {
+        return extractUnion(record.get(s));
       }
       return record.get(s);
     } else if (o instanceof Map) {
@@ -211,13 +211,13 @@ public class GenericAvroJsonProvider implements JsonProvider
     return o;
   }
 
-  private boolean isExplodableUnion(final Schema.Field field)
+  private boolean isExtractableUnion(final Schema.Field field)
   {
     return field.schema().isUnion() &&
            field.schema().getTypes().stream().filter(type -> type.getType() != Schema.Type.NULL).count() > 1;
   }
 
-  private Map<String, Object> explodeUnion(final Object o)
+  private Map<String, Object> extractUnion(final Object o)
   {
     // Primitive types and unnamped complex types are keyed their type name.
     // Complex named types are keyed by their names.

--- a/extensions-core/avro-extensions/src/test/avro/some-datum.avsc
+++ b/extensions-core/avro-extensions/src/test/avro/some-datum.avsc
@@ -13,6 +13,12 @@
 		{"name":"someIntValueMap","type":{"type":"map","values":"int"}},
 		{"name":"someStringValueMap","type":{"type":"map","values":"string"}},
 		{"name":"someUnion","type":["null","string"]},
+		{"name":"someMultiMemberUnion", "type": ["string", "int", {
+		  "type": "record", "name": "UnionSubRecord", "fields": [
+		    {"name": "subString", "type": "string"},
+		    {"name": "subFloat", "type": "float"}
+		  ]
+		}]},
 		{"name":"someNull","type":"null"},
     {"name":"someFixed","type":{"type":"fixed","size":16,"name":"MyFixed"}},
     {"name":"someBytes","type":"bytes"},

--- a/extensions-core/avro-extensions/src/test/avro/some-datum.avsc
+++ b/extensions-core/avro-extensions/src/test/avro/some-datum.avsc
@@ -1,44 +1,181 @@
-[{
-  "namespace": "org.apache.druid.data.input",
-	"name": "SomeAvroDatum",
-	"type": "record",
-	"fields" : [
-		{"name":"timestamp","type":"long"},
-		{"name":"eventType","type":"string"},
-		{"name":"id","type":"long"},
-		{"name":"someOtherId","type":"long"},
-		{"name":"isValid","type":"boolean"},
-		{"name":"someIntArray","type":{"type":"array","items":"int"}},
-		{"name":"someStringArray","type":{"type":"array","items":"string"}},
-		{"name":"someIntValueMap","type":{"type":"map","values":"int"}},
-		{"name":"someStringValueMap","type":{"type":"map","values":"string"}},
-		{"name":"someUnion","type":["null","string"]},
-		{"name":"someMultiMemberUnion", "type": ["string", "int", {
-		  "type": "record", "name": "UnionSubRecord", "fields": [
-		    {"name": "subString", "type": "string"},
-		    {"name": "subFloat", "type": "float"}
-		  ]
-		}]},
-		{"name":"someNull","type":"null"},
-    {"name":"someFixed","type":{"type":"fixed","size":16,"name":"MyFixed"}},
-    {"name":"someBytes","type":"bytes"},
-    {"name":"someEnum","type":{"type":"enum","name":"MyEnum","symbols":["ENUM0","ENUM1","ENUM2"]}},
-    {"name":"someRecord","type":{
-      "type":"record","name":"MySubRecord","fields":[
-        {"name":"subInt","type":"int"},
-        {"name":"subLong","type":"long"}
-      ]
-    }},
-
-   	{"name":"someLong","type":"long"},
-		{"name":"someInt","type":"int"},
-		{"name":"someFloat","type":"float"},
-		{"name":"someRecordArray","type":{
-		  "type":"array","items":{
-		   "type":"record","name":"MyNestedRecord","fields":[
-		    {"name":"nestedString","type":"string"}
+[
+  {
+    "namespace": "org.apache.druid.data.input",
+    "name": "SomeAvroDatum",
+    "type": "record",
+    "fields": [
+      {
+        "name": "timestamp",
+        "type": "long"
+      },
+      {
+        "name": "eventType",
+        "type": "string"
+      },
+      {
+        "name": "id",
+        "type": "long"
+      },
+      {
+        "name": "someOtherId",
+        "type": "long"
+      },
+      {
+        "name": "isValid",
+        "type": "boolean"
+      },
+      {
+        "name": "someIntArray",
+        "type": {
+          "type": "array",
+          "items": "int"
+        }
+      },
+      {
+        "name": "someStringArray",
+        "type": {
+          "type": "array",
+          "items": "string"
+        }
+      },
+      {
+        "name": "someIntValueMap",
+        "type": {
+          "type": "map",
+          "values": "int"
+        }
+      },
+      {
+        "name": "someStringValueMap",
+        "type": {
+          "type": "map",
+          "values": "string"
+        }
+      },
+      {
+        "name": "someUnion",
+        "type": [
+          "null",
+          "string"
         ]
-       }
-     }}
-	]
-}]
+      },
+      {
+        "name": "someMultiMemberUnion",
+        "type": [
+          "int",
+          "long",
+          "float",
+          "double",
+          "boolean",
+          "string",
+          "bytes",
+          {
+            "type": "map",
+            "values": "string"
+          },
+          {
+            "type": "array",
+            "items": "int"
+          },
+          {
+            "type": "record",
+            "name": "UnionSubRecord",
+            "fields": [
+              {
+                "name": "subString",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "UnionSubFixed",
+            "type": "fixed",
+            "size": 10
+          },
+          {
+            "type": "enum",
+            "name": "UnionSubEnum",
+            "symbols": [
+              "ENUM0",
+              "ENUM1",
+              "ENUM2"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "someNull",
+        "type": "null"
+      },
+      {
+        "name": "someFixed",
+        "type": {
+          "type": "fixed",
+          "size": 16,
+          "name": "MyFixed"
+        }
+      },
+      {
+        "name": "someBytes",
+        "type": "bytes"
+      },
+      {
+        "name": "someEnum",
+        "type": {
+          "type": "enum",
+          "name": "MyEnum",
+          "symbols": [
+            "ENUM0",
+            "ENUM1",
+            "ENUM2"
+          ]
+        }
+      },
+      {
+        "name": "someRecord",
+        "type": {
+          "type": "record",
+          "name": "MySubRecord",
+          "fields": [
+            {
+              "name": "subInt",
+              "type": "int"
+            },
+            {
+              "name": "subLong",
+              "type": "long"
+            }
+          ]
+        }
+      },
+      {
+        "name": "someLong",
+        "type": "long"
+      },
+      {
+        "name": "someInt",
+        "type": "int"
+      },
+      {
+        "name": "someFloat",
+        "type": "float"
+      },
+      {
+        "name": "someRecordArray",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "MyNestedRecord",
+            "fields": [
+              {
+                "name": "nestedString",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroHadoopInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroHadoopInputRowParserTest.java
@@ -62,7 +62,7 @@ public class AvroHadoopInputRowParserTest
 
   private void testParse(GenericRecord record, boolean fromPigAvroStorage) throws IOException
   {
-    AvroHadoopInputRowParser parser = new AvroHadoopInputRowParser(AvroStreamInputRowParserTest.PARSE_SPEC, fromPigAvroStorage);
+    AvroHadoopInputRowParser parser = new AvroHadoopInputRowParser(AvroStreamInputRowParserTest.PARSE_SPEC, fromPigAvroStorage, false, false);
     AvroHadoopInputRowParser parser2 = jsonMapper.readValue(
         jsonMapper.writeValueAsBytes(parser),
         AvroHadoopInputRowParser.class

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -118,6 +118,7 @@ public class AvroStreamInputFormatTest
     AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
         flattenSpec,
         new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository),
+        false,
         false
     );
     NestedInputFormat inputFormat2 = jsonMapper.readValue(
@@ -134,6 +135,7 @@ public class AvroStreamInputFormatTest
     AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
         flattenSpec,
         new SchemaRegistryBasedAvroBytesDecoder("http://test:8081", 100, null, null, null),
+        false,
         false
     );
     NestedInputFormat inputFormat2 = jsonMapper.readValue(
@@ -150,6 +152,7 @@ public class AvroStreamInputFormatTest
     AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
         flattenSpec,
         new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository),
+        false,
         false
     );
     NestedInputFormat inputFormat2 = jsonMapper.readValue(
@@ -193,6 +196,7 @@ public class AvroStreamInputFormatTest
     AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
         flattenSpec,
         new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository),
+        false,
         false
     );
     NestedInputFormat inputFormat2 = jsonMapper.readValue(

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
@@ -151,6 +151,7 @@ public class AvroStreamInputRowParserTest
       }
   );
   private static final String SOME_UNION_VALUE = "string as union";
+  private static final Integer SOME_UNION_MEMBER_VALUE = 1;
   private static final ByteBuffer SOME_BYTES_VALUE = ByteBuffer.allocate(8);
   private static final String SOME_RECORD_STRING_VALUE = "string in record";
   private static final List<MyNestedRecord> SOME_RECORD_ARRAY_VALUE = Collections.singletonList(MyNestedRecord.newBuilder()
@@ -176,7 +177,9 @@ public class AvroStreamInputRowParserTest
     Repository repository = new Avro1124RESTRepositoryClientWrapper("http://github.io");
     AvroStreamInputRowParser parser = new AvroStreamInputRowParser(
         PARSE_SPEC,
-        new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository)
+        new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository),
+        false,
+        false
     );
     ByteBufferInputRowParser parser2 = jsonMapper.readValue(
         jsonMapper.writeValueAsString(parser),
@@ -193,7 +196,9 @@ public class AvroStreamInputRowParserTest
     Repository repository = new InMemoryRepository(null);
     AvroStreamInputRowParser parser = new AvroStreamInputRowParser(
         PARSE_SPEC,
-        new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository)
+        new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository),
+        false,
+        false
     );
     ByteBufferInputRowParser parser2 = jsonMapper.readValue(
         jsonMapper.writeValueAsString(parser),
@@ -234,7 +239,9 @@ public class AvroStreamInputRowParserTest
     Repository repository = new InMemoryRepository(null);
     AvroStreamInputRowParser parser = new AvroStreamInputRowParser(
         PARSE_SPEC_SCHEMALESS,
-        new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository)
+        new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository),
+        false,
+        false
     );
     ByteBufferInputRowParser parser2 = jsonMapper.readValue(
         jsonMapper.writeValueAsString(parser),
@@ -370,6 +377,7 @@ public class AvroStreamInputRowParserTest
                         .setSomeIntValueMap(SOME_INT_VALUE_MAP_VALUE)
                         .setSomeStringValueMap(SOME_STRING_VALUE_MAP_VALUE)
                         .setSomeUnion(SOME_UNION_VALUE)
+                        .setSomeMultiMemberUnion(SOME_UNION_MEMBER_VALUE)
                         .setSomeFixed(SOME_FIXED_VALUE)
                         .setSomeBytes(SOME_BYTES_VALUE)
                         .setSomeNull(null)

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
@@ -361,7 +361,7 @@ public class AvroStreamInputRowParserTest
     Assert.assertEquals(SOME_INT_VALUE, inputRow.getMetric("someInt"));
   }
 
-  public static SomeAvroDatum buildSomeAvroDatum()
+  private static SomeAvroDatum.Builder createSomeAvroDatumBuilderDefaults()
   {
     return SomeAvroDatum.newBuilder()
                         .setTimestamp(DATE_TIME.toInstant().toEpochMilli())
@@ -383,7 +383,18 @@ public class AvroStreamInputRowParserTest
                         .setSomeNull(null)
                         .setSomeEnum(MyEnum.ENUM1)
                         .setSomeRecord(SOME_RECORD_VALUE)
-                        .setSomeRecordArray(SOME_RECORD_ARRAY_VALUE)
-                        .build();
+                        .setSomeRecordArray(SOME_RECORD_ARRAY_VALUE);
+  }
+
+  public static SomeAvroDatum buildSomeAvroDatum()
+  {
+    return createSomeAvroDatumBuilderDefaults().build();
+  }
+
+  public static SomeAvroDatum buildSomeAvroDatumWithUnionValue(Object unionValue)
+  {
+    return createSomeAvroDatumBuilderDefaults()
+        .setSomeMultiMemberUnion(unionValue)
+        .build();
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -224,7 +224,8 @@ public class AvroFlattenerMakerTest
   }
 
   @Test
-  public void jsonPathExtractorExplodeUnions() {
+  public void jsonPathExtractorExplodeUnions()
+  {
     final SomeAvroDatum record = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, true);
 

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -232,7 +232,7 @@ public class AvroFlattenerMakerTest
   }
 
   @Test
-  public void jsonPathExtractorExplodeUnions()
+  public void jsonPathExtractorextractUnions()
   {
     final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, true);
 

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -19,11 +19,19 @@
 
 package org.apache.druid.data.input.avro;
 
+import org.apache.avro.util.Utf8;
 import org.apache.druid.data.input.AvroStreamInputRowParserTest;
 import org.apache.druid.data.input.SomeAvroDatum;
+import org.apache.druid.data.input.UnionSubEnum;
+import org.apache.druid.data.input.UnionSubFixed;
+import org.apache.druid.data.input.UnionSubRecord;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 public class AvroFlattenerMakerTest
@@ -226,13 +234,65 @@ public class AvroFlattenerMakerTest
   @Test
   public void jsonPathExtractorExplodeUnions()
   {
-    final SomeAvroDatum record = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, true);
 
-    Assert.assertEquals(
-        record.getSomeMultiMemberUnion(),
-        flattener.makeJsonPathExtractor("$.someMultiMemberUnion.int").apply(record)
-    );
+    // Unmamed types are accessed by type
+
+    // int
+    Assert.assertEquals(1, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.int").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(1)));
+
+    // long
+    Assert.assertEquals(1L, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.long").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(1L)));
+
+    // float
+    Assert.assertEquals((float) 1.0, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.float").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue((float) 1.0)));
+
+    // double
+    Assert.assertEquals(1.0, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.double").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(1.0)));
+
+    // string
+    Assert.assertEquals("string", flattener.makeJsonPathExtractor("$.someMultiMemberUnion.string").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(new Utf8("string"))));
+
+    // bytes
+    Assert.assertArrayEquals(new byte[] {1}, (byte[]) flattener.makeJsonPathExtractor("$.someMultiMemberUnion.bytes").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(ByteBuffer.wrap(new byte[] {1}))));
+
+    // map
+    Assert.assertEquals(2, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.map.two").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(new HashMap<String, Integer>() {{
+            put("one", 1);
+            put("two", 2);
+            put("three", 3);
+          }
+        }
+        )));
+
+    // array
+    Assert.assertEquals(3, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.array[2]").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(Arrays.asList(1, 2, 3))));
+
+    // Named types are accessed by name
+
+    // record
+    Assert.assertEquals("subRecordString", flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubRecord.subString").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(
+            UnionSubRecord.newBuilder()
+                          .setSubString("subRecordString")
+                          .build())));
+
+    // fixed
+    final byte[] fixedBytes = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    Assert.assertEquals(fixedBytes, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubFixed").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(new UnionSubFixed(fixedBytes))));
+
+    // enum
+    Assert.assertEquals(String.valueOf(UnionSubEnum.ENUM1), flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubEnum").apply(
+        AvroStreamInputRowParserTest.buildSomeAvroDatumWithUnionValue(UnionSubEnum.ENUM1)));
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -33,7 +33,7 @@ public class AvroFlattenerMakerTest
   public void getRootField()
   {
     final SomeAvroDatum record = AvroStreamInputRowParserTest.buildSomeAvroDatum();
-    final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false);
+    final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, true);
 
     Assert.assertEquals(
         record.getTimestamp(),
@@ -120,7 +120,7 @@ public class AvroFlattenerMakerTest
   public void makeJsonPathExtractor()
   {
     final SomeAvroDatum record = AvroStreamInputRowParserTest.buildSomeAvroDatum();
-    final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false);
+    final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, true);
 
     Assert.assertEquals(
         record.getTimestamp(),
@@ -161,6 +161,10 @@ public class AvroFlattenerMakerTest
     Assert.assertEquals(
         record.getSomeUnion(),
         flattener.makeJsonPathExtractor("$.someUnion").apply(record)
+    );
+    Assert.assertEquals(
+        record.getSomeMultiMemberUnion(),
+        flattener.makeJsonPathExtractor("$.someMultiMemberUnion.int").apply(record)
     );
     Assert.assertEquals(
         record.getSomeNull(),
@@ -219,11 +223,22 @@ public class AvroFlattenerMakerTest
     );
   }
 
+  @Test
+  public void jsonPathExtractorExplodeUnions() {
+    final SomeAvroDatum record = AvroStreamInputRowParserTest.buildSomeAvroDatum();
+    final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, true);
+
+    Assert.assertEquals(
+        record.getSomeMultiMemberUnion(),
+        flattener.makeJsonPathExtractor("$.someMultiMemberUnion.int").apply(record)
+    );
+  }
+
   @Test(expected = UnsupportedOperationException.class)
   public void makeJsonQueryExtractor()
   {
     final SomeAvroDatum record = AvroStreamInputRowParserTest.buildSomeAvroDatum();
-    final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false);
+    final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, false);
 
     Assert.assertEquals(
         record.getTimestamp(),

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -232,7 +232,7 @@ public class AvroFlattenerMakerTest
   }
 
   @Test
-  public void jsonPathExtractorextractUnions()
+  public void jsonPathExtractorExtractUnionsByType()
   {
     final AvroFlattenerMaker flattener = new AvroFlattenerMaker(false, false, true);
 

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
@@ -201,7 +201,7 @@ public class AvroOCFReaderTest
     final DimensionsSpec dimensionsSpec = new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
         "eventType")));
 
-    final AvroOCFInputFormat inputFormat = new AvroOCFInputFormat(mapper, null, readerSchema, null);
+    final AvroOCFInputFormat inputFormat = new AvroOCFInputFormat(mapper, null, readerSchema, null, null);
     final InputRowSchema schema = new InputRowSchema(timestampSpec, dimensionsSpec, ColumnsFilter.all());
     final FileEntity entity = new FileEntity(someAvroFile);
     return inputFormat.createReader(schema, entity, temporaryFolder.newFolder());

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
@@ -144,7 +144,7 @@ public class AvroOCFReaderTest
       Assert.assertFalse(iterator.hasNext());
       final Map<String, Object> rawColumns = row.getRawValues();
       Assert.assertNotNull(rawColumns);
-      Assert.assertEquals(19, rawColumns.size());
+      Assert.assertEquals(20, rawColumns.size());
       final List<InputRow> inputRows = row.getInputRows();
       Assert.assertNotNull(inputRows);
       final InputRow inputRow = Iterables.getOnlyElement(inputRows);

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/avro/ParquetAvroHadoopInputRowParser.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/avro/ParquetAvroHadoopInputRowParser.java
@@ -51,6 +51,7 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
 {
   private final ParseSpec parseSpec;
   private final boolean binaryAsString;
+  private final boolean explodeUnions;
   private final TimestampSpec timestampSpec;
   private final ObjectFlattener<GenericRecord> recordFlattener;
   private final List<String> dimensions;
@@ -58,13 +59,15 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
   @JsonCreator
   public ParquetAvroHadoopInputRowParser(
       @JsonProperty("parseSpec") ParseSpec parseSpec,
-      @JsonProperty("binaryAsString") Boolean binaryAsString
+      @JsonProperty("binaryAsString") Boolean binaryAsString,
+      @JsonProperty("explodeUnions") Boolean explodeUnions
   )
   {
     this.parseSpec = parseSpec;
     this.timestampSpec = parseSpec.getTimestampSpec();
     this.dimensions = parseSpec.getDimensionsSpec().getDimensionNames();
-    this.binaryAsString = binaryAsString == null ? false : binaryAsString;
+    this.binaryAsString = binaryAsString != null && binaryAsString;
+    this.explodeUnions = explodeUnions != null && explodeUnions;
 
     final JSONPathSpec flattenSpec;
     if (parseSpec instanceof AvroParseSpec) {
@@ -75,7 +78,7 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
 
     this.recordFlattener = ObjectFlatteners.create(
         flattenSpec,
-        new AvroFlattenerMaker(false, this.binaryAsString)
+        new AvroFlattenerMaker(false, this.binaryAsString, this.explodeUnions)
     );
   }
 
@@ -131,6 +134,6 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
   @Override
   public InputRowParser withParseSpec(ParseSpec parseSpec)
   {
-    return new ParquetAvroHadoopInputRowParser(parseSpec, binaryAsString);
+    return new ParquetAvroHadoopInputRowParser(parseSpec, binaryAsString, explodeUnions);
   }
 }

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/avro/ParquetAvroHadoopInputRowParser.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/avro/ParquetAvroHadoopInputRowParser.java
@@ -51,7 +51,7 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
 {
   private final ParseSpec parseSpec;
   private final boolean binaryAsString;
-  private final boolean explodeUnions;
+  private final boolean extractUnions;
   private final TimestampSpec timestampSpec;
   private final ObjectFlattener<GenericRecord> recordFlattener;
   private final List<String> dimensions;
@@ -60,14 +60,14 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
   public ParquetAvroHadoopInputRowParser(
       @JsonProperty("parseSpec") ParseSpec parseSpec,
       @JsonProperty("binaryAsString") Boolean binaryAsString,
-      @JsonProperty("explodeUnions") Boolean explodeUnions
+      @JsonProperty("extractUnions") Boolean extractUnions
   )
   {
     this.parseSpec = parseSpec;
     this.timestampSpec = parseSpec.getTimestampSpec();
     this.dimensions = parseSpec.getDimensionsSpec().getDimensionNames();
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.explodeUnions = explodeUnions != null && explodeUnions;
+    this.extractUnions = extractUnions != null && extractUnions;
 
     final JSONPathSpec flattenSpec;
     if (parseSpec instanceof AvroParseSpec) {
@@ -78,7 +78,7 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
 
     this.recordFlattener = ObjectFlatteners.create(
         flattenSpec,
-        new AvroFlattenerMaker(false, this.binaryAsString, this.explodeUnions)
+        new AvroFlattenerMaker(false, this.binaryAsString, this.extractUnions)
     );
   }
 
@@ -134,6 +134,6 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
   @Override
   public InputRowParser withParseSpec(ParseSpec parseSpec)
   {
-    return new ParquetAvroHadoopInputRowParser(parseSpec, binaryAsString, explodeUnions);
+    return new ParquetAvroHadoopInputRowParser(parseSpec, binaryAsString, extractUnions);
   }
 }

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/avro/ParquetAvroHadoopInputRowParser.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/avro/ParquetAvroHadoopInputRowParser.java
@@ -51,7 +51,7 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
 {
   private final ParseSpec parseSpec;
   private final boolean binaryAsString;
-  private final boolean extractUnions;
+  private final boolean extractUnionsByType;
   private final TimestampSpec timestampSpec;
   private final ObjectFlattener<GenericRecord> recordFlattener;
   private final List<String> dimensions;
@@ -60,14 +60,14 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
   public ParquetAvroHadoopInputRowParser(
       @JsonProperty("parseSpec") ParseSpec parseSpec,
       @JsonProperty("binaryAsString") Boolean binaryAsString,
-      @JsonProperty("extractUnions") Boolean extractUnions
+      @JsonProperty("extractUnionsByType") Boolean extractUnionsByType
   )
   {
     this.parseSpec = parseSpec;
     this.timestampSpec = parseSpec.getTimestampSpec();
     this.dimensions = parseSpec.getDimensionsSpec().getDimensionNames();
     this.binaryAsString = binaryAsString != null && binaryAsString;
-    this.extractUnions = extractUnions != null && extractUnions;
+    this.extractUnionsByType = extractUnionsByType != null && extractUnionsByType;
 
     final JSONPathSpec flattenSpec;
     if (parseSpec instanceof AvroParseSpec) {
@@ -78,7 +78,7 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
 
     this.recordFlattener = ObjectFlatteners.create(
         flattenSpec,
-        new AvroFlattenerMaker(false, this.binaryAsString, this.extractUnions)
+        new AvroFlattenerMaker(false, this.binaryAsString, this.extractUnionsByType)
     );
   }
 
@@ -134,6 +134,6 @@ public class ParquetAvroHadoopInputRowParser implements InputRowParser<GenericRe
   @Override
   public InputRowParser withParseSpec(ParseSpec parseSpec)
   {
-    return new ParquetAvroHadoopInputRowParser(parseSpec, binaryAsString, extractUnions);
+    return new ParquetAvroHadoopInputRowParser(parseSpec, binaryAsString, extractUnionsByType);
   }
 }

--- a/website/.spelling
+++ b/website/.spelling
@@ -74,6 +74,7 @@ EMR
 EMRFS
 ETL
 Elasticsearch
+Enums
 FirehoseFactory
 FlattenSpec
 Float.NEGATIVE_INFINITY


### PR DESCRIPTION
Fixes #10493 

### Description

Implements better support for Avro unions in the Avro extensions.
Currently when ingesting data that contains unions unless the union is always the same value it will return mixed type results.
This PR addresses the problem by exploding union fields into maps keyed by the union member type or type name in the case of named types (enums, fixed, records).
The method was chosen as it's similar to what is done on other systems that support ingesting Avro data, such as Google BigQuery which details their Avro compatibility here: https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#avro_conversions

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `AvroFlattenerMaker`
 * `GenericAvroJsonProvider`