### PR TITLE
Reduce docker image size by half

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -45,14 +45,14 @@ LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 COPY --from=busybox /bin/busybox /busybox/busybox
 RUN ["/busybox/busybox", "--install", "/bin"]
 
-COPY --from=builder /opt /opt
-COPY distribution/docker/druid.sh /druid.sh
-
 RUN addgroup -S -g 1000 druid \
  && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid \
  && mkdir -p /opt/druid/var \
  && chown -R druid:druid /opt \
  && chmod 775 /opt/druid/var
+
+COPY --chown=druid:druid --from=builder /opt /opt
+COPY distribution/docker/druid.sh /druid.sh
 
 USER druid
 VOLUME /opt/druid/var

--- a/distribution/docker/Dockerfile.java11
+++ b/distribution/docker/Dockerfile.java11
@@ -45,14 +45,14 @@ LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 COPY --from=busybox /bin/busybox /busybox/busybox
 RUN ["/busybox/busybox", "--install", "/bin"]
 
-COPY --from=builder /opt /opt
-COPY distribution/docker/druid.sh /druid.sh
-
 RUN addgroup -S -g 1000 druid \
  && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid \
  && mkdir -p /opt/druid/var \
  && chown -R druid:druid /opt \
  && chmod 775 /opt/druid/var
+
+COPY --chown=druid:druid --from=builder /opt /opt
+COPY distribution/docker/druid.sh /druid.sh
 
 USER druid
 VOLUME /opt/druid/var


### PR DESCRIPTION
Fixes all distribution files are committed twice in docker image.

### Description

Currently the build dist is copied in a first step and in a second step the owner is set to druid:druid.
This leads to two times the image size (https://hub.docker.com/layers/apache/druid/0.20.0-rc2/images/sha256-75f14a2bbf00950d4da9d2e9d566fab07f62453524ec77d7e479fced48bf69ae?context=explore)

The change does first create the user and set the owner of the build dist directly on copy.
/druid.sh keeps the same.