### PR TITLE
Add docs and integration tests for Auto-compaction snapshot status API

### DIFF
--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -414,27 +414,27 @@ This is only valid for dataSource which has compaction enabled.
 
 * `/druid/coordinator/v1/compaction/status`
 
-Returns the status and statistics from the latest auto compaction run of all dataSource which has/had auto compaction enabled.
-The response payload includes a list of `latestStatus` object. Each `latestStatus` represent the status for a dataSource (which has/had auto compaction enabled). 
+Returns the status and statistics from the latest auto compaction run of all dataSources which have/had auto compaction enabled.
+The response payload includes a list of `latestStatus` objects. Each `latestStatus` represents the status for a dataSource (which has/had auto compaction enabled). 
 The `latestStatus` object has the following keys:
 * `dataSource`: name of the datasource for this status information
 * `scheduleStatus`: auto compaction scheduling status. Possible values are `NOT_ENABLED` and `RUNNING`. Returns `RUNNING ` if the dataSource has an active auto compaction config submitted otherwise, `NOT_ENABLED`
-* `bytesAwaitingCompaction`: total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
-* `bytesCompacted`: total byte of this datasource that is already compacted with the spec set in the auto compaction config.
-* `bytesSkipped`: total byte of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.
-* `segmentCountAwaitingCompaction`: total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
-* `segmentCountCompacted`: total number of segments of this datasource that is already compacted with the spec set in the auto compaction config.
-* `segmentCountSkipped`: total number of segments of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.
-* `intervalCountAwaitingCompaction`: total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
-* `intervalCountCompacted`: total number of intervals of this datasource that is already compacted with the spec set in the auto compaction config.
-* `intervalCountSkipped`: total number of intervals of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.
+* `bytesAwaitingCompaction`: total bytes of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that are eligible for auto compaction)
+* `bytesCompacted`: total bytes of this datasource that are already compacted with the spec set in the auto compaction config.
+* `bytesSkipped`: total bytes of this datasource that are skipped (not eligible for auto compaction) by the auto compaction.
+* `segmentCountAwaitingCompaction`: total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that are eligible for auto compaction)
+* `segmentCountCompacted`: total number of segments of this datasource that are already compacted with the spec set in the auto compaction config.
+* `segmentCountSkipped`: total number of segments of this datasource that are skipped (not eligible for auto compaction) by the auto compaction.
+* `intervalCountAwaitingCompaction`: total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that are eligible for auto compaction)
+* `intervalCountCompacted`: total number of intervals of this datasource that are already compacted with the spec set in the auto compaction config.
+* `intervalCountSkipped`: total number of intervals of this datasource that are skipped (not eligible for auto compaction) by the auto compaction.
 
 ##### GET
 
 * `/druid/coordinator/v1/compaction/status?dataSource={dataSource}`
 
 Similar to the API `/druid/coordinator/v1/compaction/status` above but filters response to only return information for the {dataSource} given. 
-Note that {dataSource} given must has/had auto compaction enabled.
+Note that {dataSource} given must have/had auto compaction enabled.
 
 #### Compaction Configuration
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -414,20 +414,20 @@ This is only valid for dataSource which has compaction enabled.
 
 * `/druid/coordinator/v1/compaction/status`
 
-Returns the latest status (statistics and informations) from the latest auto compaction run of all dataSource which has/had auto compaction enabled.
-The response payload includes a list of `latestStatus` object. Each `latestStatus` respresent the status for a dataSource (which has/had auto compaction enabled). 
+Returns the status and statistics from the latest auto compaction run of all dataSource which has/had auto compaction enabled.
+The response payload includes a list of `latestStatus` object. Each `latestStatus` represent the status for a dataSource (which has/had auto compaction enabled). 
 The `latestStatus` object has the following keys:
 * `dataSource`: name of the datasource for this status information
 * `scheduleStatus`: auto compaction scheduling status. Possible values are `NOT_ENABLED` and `RUNNING`. Returns `RUNNING ` if the dataSource has an active auto compaction config submitted otherwise, `NOT_ENABLED`
 * `bytesAwaitingCompaction`: total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
 * `bytesCompacted`: total byte of this datasource that is already compacted with the spec set in the auto compaction config.
-* `bytesSkipped`: total byte of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.
+* `bytesSkipped`: total byte of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.
 * `segmentCountAwaitingCompaction`: total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
 * `segmentCountCompacted`: total number of segments of this datasource that is already compacted with the spec set in the auto compaction config.
-* `segmentCountSkipped`: total number of segments of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.
+* `segmentCountSkipped`: total number of segments of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.
 * `intervalCountAwaitingCompaction`: total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
 * `intervalCountCompacted`: total number of intervals of this datasource that is already compacted with the spec set in the auto compaction config.
-* `intervalCountSkipped`: total number of intervals of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.
+* `intervalCountSkipped`: total number of intervals of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.
 
 ##### GET
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -410,6 +410,32 @@ Returns total size and count for each datasource for each interval within given 
 Returns the total size of segments awaiting compaction for the given dataSource. 
 This is only valid for dataSource which has compaction enabled. 
 
+##### GET
+
+* `/druid/coordinator/v1/compaction/status`
+
+Returns the latest status (statistics and informations) from the latest auto compaction run of all dataSource which has/had auto compaction enabled.
+The response payload includes a list of `latestStatus` object. Each `latestStatus` respresent the status for a dataSource (which has/had auto compaction enabled). 
+The `latestStatus` object has the following keys:
+* `dataSource`: name of the datasource for this status information
+* `scheduleStatus`: auto compaction scheduling status. Possible values are `NOT_ENABLED` and `RUNNING`. Returns `RUNNING ` if the dataSource has an active auto compaction config submitted otherwise, `NOT_ENABLED`
+* `bytesAwaitingCompaction`: total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
+* `bytesCompacted`: total byte of this datasource that is already compacted with the spec set in the auto compaction config.
+* `bytesSkipped`: total byte of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.
+* `segmentCountAwaitingCompaction`: total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
+* `segmentCountCompacted`: total number of segments of this datasource that is already compacted with the spec set in the auto compaction config.
+* `segmentCountSkipped`: total number of segments of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.
+* `intervalCountAwaitingCompaction`: total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction)
+* `intervalCountCompacted`: total number of intervals of this datasource that is already compacted with the spec set in the auto compaction config.
+* `intervalCountSkipped`: total number of intervals of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.
+
+##### GET
+
+* `/druid/coordinator/v1/compaction/status?dataSource={dataSource}`
+
+Similar to the API `/druid/coordinator/v1/compaction/status` above but filters response to only return information for the {dataSource} given. 
+Note that {dataSource} given must has/had auto compaction enabled.
+
 #### Compaction Configuration
 
 ##### GET

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -222,13 +222,25 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`segment/dropQueue/count`|Number of segments to drop.|server.|Varies.|
 |`segment/size`|Total size of used segments in a data source. Emitted only for data sources to which at least one used segment belongs.|dataSource.|Varies.|
 |`segment/count`|Number of used segments belonging to a data source. Emitted only for data sources to which at least one used segment belongs.|dataSource.|< max|
-|`segment/overShadowed/count`|Number of overshadowed segments.||Varies.|
+|`segment/overShadowed/count`|Number of overshadowed segments.| |Varies.|
 |`segment/unavailable/count`|Number of segments (not including replicas) left to load until segments that should be loaded in the cluster are available for queries.|dataSource.|0|
 |`segment/underReplicated/count`|Number of segments (including replicas) left to load until segments that should be loaded in the cluster are available for queries.|tier, dataSource.|0|
 |`tier/historical/count`|Number of available historical nodes in each tier.|tier.|Varies.|
 |`tier/replication/factor`|Configured maximum replication factor in each tier.|tier.|Varies.|
 |`tier/required/capacity`|Total capacity in bytes required in each tier.|tier.|Varies.|
 |`tier/total/capacity`|Total capacity in bytes available in each tier.|tier.|Varies.|
+|`compact/task/count`|Number of task issued in the autocompaction run.| |Varies.|
+|`compactTask/maxSlot/count`|Number of max task slot that can be used for auto compaction tasks in the autocompaction run.| |Varies.|
+|`compactTask/availableSlot/count`|Number of available task slot that can be used for auto compaction tasks in the autocompaction run. (this is max slot minus any currently running compaction task)| |Varies.|
+|`segment/waitCompact/bytes`|Total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
+|`segment/waitCompact/count`|Total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
+|`interval/waitCompact/count`|Total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
+|`segment/compacted/bytes`|Total byte of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
+|`segment/compacted/count`|Total number of segments of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
+|`interval/compacted/count`|Total number of intervals of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
+|`segment/skipCompact/bytes`|Total byte of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`segment/skipCompact/count`|Total number of segments of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`interval/skipCompact/count`|Total number of intervals of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.|datasource.|Varies.|
 
 If `emitBalancingStats` is set to `true` in the Coordinator [dynamic configuration](
 ../configuration/index.html#dynamic-configuration), then [log entries](../configuration/logging.md) for class

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -229,18 +229,18 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`tier/replication/factor`|Configured maximum replication factor in each tier.|tier.|Varies.|
 |`tier/required/capacity`|Total capacity in bytes required in each tier.|tier.|Varies.|
 |`tier/total/capacity`|Total capacity in bytes available in each tier.|tier.|Varies.|
-|`compact/task/count`|Number of task issued in the auto compaction run.| |Varies.|
-|`compactTask/maxSlot/count`|Number of max task slot that can be used for auto compaction tasks in the auto compaction run.| |Varies.|
-|`compactTask/availableSlot/count`|Number of available task slot that can be used for auto compaction tasks in the auto compaction run. (this is max slot minus any currently running compaction task)| |Varies.|
-|`segment/waitCompact/bytes`|Total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
-|`segment/waitCompact/count`|Total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
-|`interval/waitCompact/count`|Total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
-|`segment/compacted/bytes`|Total byte of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
-|`segment/compacted/count`|Total number of segments of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
-|`interval/compacted/count`|Total number of intervals of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
-|`segment/skipCompact/bytes`|Total byte of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
-|`segment/skipCompact/count`|Total number of segments of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
-|`interval/skipCompact/count`|Total number of intervals of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`compact/task/count`|Number of tasks issued in the auto compaction run.| |Varies.|
+|`compactTask/maxSlot/count`|Max number of task slots that can be used for auto compaction tasks in the auto compaction run.| |Varies.|
+|`compactTask/availableSlot/count`|Number of available task slots that can be used for auto compaction tasks in the auto compaction run. (this is max slot minus any currently running compaction task)| |Varies.|
+|`segment/waitCompact/bytes`|Total bytes of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that are eligible for auto compaction).|datasource.|Varies.|
+|`segment/waitCompact/count`|Total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that are eligible for auto compaction).|datasource.|Varies.|
+|`interval/waitCompact/count`|Total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that are eligible for auto compaction).|datasource.|Varies.|
+|`segment/compacted/bytes`|Total bytes of this datasource that are already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
+|`segment/compacted/count`|Total number of segments of this datasource that are already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
+|`interval/compacted/count`|Total number of intervals of this datasource that are already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
+|`segment/skipCompact/bytes`|Total bytes of this datasource that are skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`segment/skipCompact/count`|Total number of segments of this datasource that are skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`interval/skipCompact/count`|Total number of intervals of this datasource that are skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
 
 If `emitBalancingStats` is set to `true` in the Coordinator [dynamic configuration](
 ../configuration/index.html#dynamic-configuration), then [log entries](../configuration/logging.md) for class

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -229,18 +229,18 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`tier/replication/factor`|Configured maximum replication factor in each tier.|tier.|Varies.|
 |`tier/required/capacity`|Total capacity in bytes required in each tier.|tier.|Varies.|
 |`tier/total/capacity`|Total capacity in bytes available in each tier.|tier.|Varies.|
-|`compact/task/count`|Number of task issued in the autocompaction run.| |Varies.|
-|`compactTask/maxSlot/count`|Number of max task slot that can be used for auto compaction tasks in the autocompaction run.| |Varies.|
-|`compactTask/availableSlot/count`|Number of available task slot that can be used for auto compaction tasks in the autocompaction run. (this is max slot minus any currently running compaction task)| |Varies.|
+|`compact/task/count`|Number of task issued in the auto compaction run.| |Varies.|
+|`compactTask/maxSlot/count`|Number of max task slot that can be used for auto compaction tasks in the auto compaction run.| |Varies.|
+|`compactTask/availableSlot/count`|Number of available task slot that can be used for auto compaction tasks in the auto compaction run. (this is max slot minus any currently running compaction task)| |Varies.|
 |`segment/waitCompact/bytes`|Total byte of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
 |`segment/waitCompact/count`|Total number of segments of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
 |`interval/waitCompact/count`|Total number of intervals of this datasource waiting to be compacted by the auto compaction (only consider intervals/segments that is eligible for auto compaction).|datasource.|Varies.|
 |`segment/compacted/bytes`|Total byte of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
 |`segment/compacted/count`|Total number of segments of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
 |`interval/compacted/count`|Total number of intervals of this datasource that is already compacted with the spec set in the auto compaction config.|datasource.|Varies.|
-|`segment/skipCompact/bytes`|Total byte of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.|datasource.|Varies.|
-|`segment/skipCompact/count`|Total number of segments of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.|datasource.|Varies.|
-|`interval/skipCompact/count`|Total number of intervals of this datasource that is skipped (not elligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`segment/skipCompact/bytes`|Total byte of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`segment/skipCompact/count`|Total number of segments of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
+|`interval/skipCompact/count`|Total number of intervals of this datasource that is skipped (not eligible for auto compaction) by the auto compaction.|datasource.|Varies.|
 
 If `emitBalancingStats` is set to `true` in the Coordinator [dynamic configuration](
 ../configuration/index.html#dynamic-configuration), then [log entries](../configuration/logging.md) for class

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
@@ -36,6 +36,7 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 public class CompactionResourceTestClient
@@ -174,5 +175,22 @@ public class CompactionResourceTestClient
       );
     }
     return jsonMapper.readValue(response.getContent(), new TypeReference<Map<String, String>>() {});
+  }
+
+  public Map<String, String> getCompactionStatus(String dataSource) throws Exception
+  {
+    String url = StringUtils.format("%scompaction/status?dataSource=%s", getCoordinatorURL(), StringUtils.urlEncode(dataSource));
+    StatusResponseHolder response = httpClient.go(
+        new Request(HttpMethod.GET, new URL(url)), responseHandler
+    ).get();
+    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+      throw new ISE(
+          "Error while getting compaction status status[%s] content[%s]",
+          response.getStatus(),
+          response.getContent()
+      );
+    }
+    Map<String, List<Map<String, String>>> latestSnapshots = jsonMapper.readValue(response.getContent(), new TypeReference<Map<String, List<Map<String, String>>>>() {});
+    return latestSnapshots.get("latestStatus").get(0);
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -476,16 +476,14 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
     Map<String, String> actualStatus = compactionResource.getCompactionStatus(fullDatasourceName);
     Assert.assertNotNull(actualStatus);
     Assert.assertEquals(actualStatus.get("scheduleStatus"), scheduleStatus.toString());
-    Assert.assertEquals(actualStatus.get("bytesAwaitingCompaction"), bytesAwaitingCompaction);
-    Assert.assertEquals(actualStatus.get("bytesCompacted"), bytesCompacted);
-    Assert.assertEquals(actualStatus.get("bytesSkipped"), bytesSkipped);
-    Assert.assertEquals(actualStatus.get("segmentCountAwaitingCompaction"), segmentCountAwaitingCompaction);
-    Assert.assertEquals(actualStatus.get("segmentCountCompacted"), segmentCountCompacted);
-    Assert.assertEquals(actualStatus.get("segmentCountSkipped"), segmentCountSkipped);
-    Assert.assertEquals(actualStatus.get("intervalCountAwaitingCompaction"), intervalCountAwaitingCompaction);
-    Assert.assertEquals(actualStatus.get("intervalCountCompacted"), intervalCountCompacted);
-    Assert.assertEquals(actualStatus.get("intervalCountSkipped"), intervalCountSkipped);
-
-
+    Assert.assertEquals(Long.parseLong(actualStatus.get("bytesAwaitingCompaction")), bytesAwaitingCompaction);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("bytesCompacted")), bytesCompacted);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("bytesSkipped")), bytesSkipped);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("segmentCountAwaitingCompaction")), segmentCountAwaitingCompaction);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("segmentCountCompacted")), segmentCountCompacted);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("segmentCountSkipped")), segmentCountSkipped);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("intervalCountAwaitingCompaction")), intervalCountAwaitingCompaction);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("intervalCountCompacted")), intervalCountCompacted);
+    Assert.assertEquals(Long.parseLong(actualStatus.get("intervalCountSkipped")), intervalCountSkipped);
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.coordinator.AutoCompactionSnapshot;
 import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.server.coordinator.UserCompactionTaskQueryTuningConfig;
@@ -52,6 +53,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Test(groups = {TestNGGroup.COMPACTION})
@@ -97,13 +99,36 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(1, MAX_ROWS_PER_SEGMENT_COMPACTED);
       checkCompactionIntervals(intervalsBeforeCompaction);
-
+      getAndAssertCompactionStatus(
+          fullDatasourceName,
+          AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
+          0,
+          14312,
+          0,
+          0,
+          2,
+          0,
+          0,
+          1,
+          0);
       submitCompactionConfig(MAX_ROWS_PER_SEGMENT_COMPACTED, NO_SKIP_OFFSET);
       //...compacted into 1 new segment for the remaining one day. 2 day compacted and 0 day uncompacted. (2 total)
       forceTriggerAutoCompaction(2);
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(2, MAX_ROWS_PER_SEGMENT_COMPACTED);
       checkCompactionIntervals(intervalsBeforeCompaction);
+      getAndAssertCompactionStatus(
+          fullDatasourceName,
+          AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
+          0,
+          22489,
+          0,
+          0,
+          3,
+          0,
+          0,
+          2,
+          0);
     }
   }
 
@@ -200,7 +225,18 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(0, null);
       checkCompactionIntervals(intervalsBeforeCompaction);
-
+      getAndAssertCompactionStatus(
+          fullDatasourceName,
+          AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0);
       // Update compaction slots to be 1
       updateCompactionTaskSlot(1, 1);
       // One day compacted (1 new segment) and one day remains uncompacted. (3 total)
@@ -208,6 +244,18 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(1, MAX_ROWS_PER_SEGMENT_COMPACTED);
       checkCompactionIntervals(intervalsBeforeCompaction);
+      getAndAssertCompactionStatus(
+          fullDatasourceName,
+          AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
+          14312,
+          14311,
+          0,
+          2,
+          2,
+          0,
+          1,
+          1,
+          0);
       Assert.assertEquals(compactionResource.getCompactionProgress(fullDatasourceName).get("remainingSegmentSize"), "14312");
       // Run compaction again to compact the remaining day
       // Remaining day compacted (1 new segment). Now both days compacted (2 total)
@@ -215,6 +263,18 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(2, MAX_ROWS_PER_SEGMENT_COMPACTED);
       checkCompactionIntervals(intervalsBeforeCompaction);
+      getAndAssertCompactionStatus(
+          fullDatasourceName,
+          AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
+          0,
+          22489,
+          0,
+          0,
+          3,
+          0,
+          0,
+          2,
+          0);
     }
   }
 
@@ -397,5 +457,35 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
     CoordinatorCompactionConfig coordinatorCompactionConfig = compactionResource.getCoordinatorCompactionConfigs();
     Assert.assertEquals(coordinatorCompactionConfig.getCompactionTaskSlotRatio(), compactionTaskSlotRatio);
     Assert.assertEquals(coordinatorCompactionConfig.getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
+  }
+
+  private void getAndAssertCompactionStatus(
+      String fullDatasourceName,
+      AutoCompactionSnapshot.AutoCompactionScheduleStatus scheduleStatus,
+      long bytesAwaitingCompaction,
+      long bytesCompacted,
+      long bytesSkipped,
+      long segmentCountAwaitingCompaction,
+      long segmentCountCompacted,
+      long segmentCountSkipped,
+      long intervalCountAwaitingCompaction,
+      long intervalCountCompacted,
+      long intervalCountSkipped
+  ) throws Exception
+  {
+    Map<String, String> actualStatus = compactionResource.getCompactionStatus(fullDatasourceName);
+    Assert.assertNotNull(actualStatus);
+    Assert.assertEquals(actualStatus.get("scheduleStatus"), scheduleStatus.toString());
+    Assert.assertEquals(actualStatus.get("bytesAwaitingCompaction"), bytesAwaitingCompaction);
+    Assert.assertEquals(actualStatus.get("bytesCompacted"), bytesCompacted);
+    Assert.assertEquals(actualStatus.get("bytesSkipped"), bytesSkipped);
+    Assert.assertEquals(actualStatus.get("segmentCountAwaitingCompaction"), segmentCountAwaitingCompaction);
+    Assert.assertEquals(actualStatus.get("segmentCountCompacted"), segmentCountCompacted);
+    Assert.assertEquals(actualStatus.get("segmentCountSkipped"), segmentCountSkipped);
+    Assert.assertEquals(actualStatus.get("intervalCountAwaitingCompaction"), intervalCountAwaitingCompaction);
+    Assert.assertEquals(actualStatus.get("intervalCountCompacted"), intervalCountCompacted);
+    Assert.assertEquals(actualStatus.get("intervalCountSkipped"), intervalCountSkipped);
+
+
   }
 }


### PR DESCRIPTION
Add docs and integration tests for Auto-compaction snapshot status API

### Description
This is a follow up PR to https://github.com/apache/druid/pull/10371
This PR adds documentation and integration tests for Auto-compaction snapshot status API of the above referenced PR.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [ ] been tested in a test Druid cluster.
