### PR TITLE
update quickstart docker-compose example, add to release instructions

### DIFF
--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -59,7 +59,17 @@ and update the script tag top level html file, [unified-console.html](../web-con
 <script src="public/web-console-0.18.0.js"></script>
 ```
 
-and open a PR to the master branch.
+Finally, the sample [`docker-compose.yml`](https://github.com/apache/druid/blob/master/distribution/docker/docker-compose.yml) used in the Docker quickstart documentation should be updated to reflect the upcoming release:
+
+```yaml
+...
+  coordinator:
+    image: apache/druid:0.18.0
+    container_name: coordinator
+...
+```
+
+Once this is completed, open a PR to the master branch. Also be sure to confirm that these versions are all correct in the release branch, otherwise fix them and open a backport PR to the relese branch.
 
 ### Release branch hygiene
 

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -59,7 +59,7 @@ and update the script tag top level html file, [unified-console.html](../web-con
 <script src="public/web-console-0.18.0.js"></script>
 ```
 
-Finally, the sample [`docker-compose.yml`](https://github.com/apache/druid/blob/master/distribution/docker/docker-compose.yml) used in the Docker quickstart documentation should be updated to reflect the upcoming release:
+Finally, the sample [`docker-compose.yml`](https://github.com/apache/druid/blob/master/distribution/docker/docker-compose.yml) used in the Docker quickstart documentation should be updated to reflect the version for the next release:
 
 ```yaml
 ...

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -69,7 +69,7 @@ Finally, the sample [`docker-compose.yml`](https://github.com/apache/druid/blob/
 ...
 ```
 
-Once this is completed, open a PR to the master branch. Also be sure to confirm that these versions are all correct in the release branch, otherwise fix them and open a backport PR to the relese branch.
+Once this is completed, open a PR to the master branch. Also, be sure to confirm that these versions are all correct in the release branch, otherwise fix them and open a backport PR to the release branch.
 
 ### Release branch hygiene
 

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ZOO_MY_ID=1
 
   coordinator:
-    image: apache/druid:0.17.0
+    image: apache/druid:0.20.0
     container_name: coordinator
     volumes:
       - ./storage:/opt/data
@@ -62,7 +62,7 @@ services:
       - environment
 
   broker:
-    image: apache/druid:0.17.0
+    image: apache/druid:0.20.0
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
@@ -78,7 +78,7 @@ services:
       - environment
 
   historical:
-    image: apache/druid:0.17.0
+    image: apache/druid:0.20.0
     container_name: historical
     volumes:
       - ./storage:/opt/data
@@ -95,7 +95,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:0.17.0
+    image: apache/druid:0.20.0
     container_name: middlemanager
     volumes:
       - ./storage:/opt/data
@@ -112,7 +112,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:0.17.0
+    image: apache/druid:0.20.0
     container_name: router
     volumes:
       - router_var:/opt/druid/var

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -32,11 +32,11 @@ Before beginning the quickstart, it is helpful to read the [general Druid overvi
 
 ## Getting started
 
-The Druid source code contains [an example `docker-compose.yml`](https://github.com/apache/druid/blob/master/distribution/docker/docker-compose.yml) which can pull an image from Docker Hub and is suited to be used as an example environment and to experiment with Docker based Druid configuration and deployments.
+The Druid source code contains [an example `docker-compose.yml`](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/docker-compose.yml) which can pull an image from Docker Hub and is suited to be used as an example environment and to experiment with Docker based Druid configuration and deployments.
 
 ### Compose file
 
-The example `docker-compose.yml` will create a container for each Druid service, as well as Zookeeper and a PostgreSQL container as the metadata store. Deep storage will be a local directory, by default configured as `./storage` relative to your `docker-compose.yml` file, and will be mounted as `/opt/data` and shared between Druid containers which require access to deep storage. The Druid containers are configured via an [environment file](https://github.com/apache/druid/blob/master/distribution/docker/environment).
+The example `docker-compose.yml` will create a container for each Druid service, as well as Zookeeper and a PostgreSQL container as the metadata store. Deep storage will be a local directory, by default configured as `./storage` relative to your `docker-compose.yml` file, and will be mounted as `/opt/data` and shared between Druid containers which require access to deep storage. The Druid containers are configured via an [environment file](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/environment).
 
 ### Configuration
 


### PR DESCRIPTION
We should backport this to 0.20.0 branch and update the doc website, after which we could go ahead and make another PR to bump the versions here to the next release version (0.21.0) so it will be already prepared for the release.