### PR TITLE
Add support for domain allow/deny list for HTTPInputSource

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSourceConfig.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSourceConfig.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
+public class HttpInputSourceConfig
+{
+  @JsonProperty
+  private final List<String> allowListDomains;
+  @JsonProperty
+  private final List<String> denyListDomains;
+
+  @JsonCreator
+  public HttpInputSourceConfig(
+      @JsonProperty("allowListDomains") List<String> allowListDomains,
+      @JsonProperty("denyListDomains") List<String> denyListDomains
+  )
+  {
+    this.allowListDomains = allowListDomains;
+    this.denyListDomains = denyListDomains;
+    Preconditions.checkArgument(
+        this.denyListDomains == null || this.allowListDomains == null,
+        "Can only use one of allowList or blackList"
+    );
+  }
+
+  public List<String> getAllowListDomains()
+  {
+    return allowListDomains;
+  }
+
+  public List<String> getDenyListDomains()
+  {
+    return denyListDomains;
+  }
+
+  private static boolean matchesAny(List<String> domains, URI uri)
+  {
+    for (String domain : domains) {
+      if (uri.getHost().endsWith(domain)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean isURIAllowed(URI uri)
+  {
+    if (allowListDomains != null) {
+      return matchesAny(allowListDomains, uri);
+    }
+    if (denyListDomains != null) {
+      return !matchesAny(denyListDomains, uri);
+    }
+    // No blacklist/allowList configured, all URLs are allowed
+    return true;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "HttpInputSourceConfig{" +
+           "allowListDomains=" + allowListDomains +
+           ", denyListDomains=" + denyListDomains +
+           '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HttpInputSourceConfig config = (HttpInputSourceConfig) o;
+    return Objects.equals(allowListDomains, config.allowListDomains) &&
+           Objects.equals(denyListDomains, config.denyListDomains);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(allowListDomains, denyListDomains);
+  }
+}
+

--- a/core/src/test/java/org/apache/druid/data/input/impl/HttpInputSourceTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/HttpInputSourceTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.impl;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.InputSource;
@@ -28,20 +29,91 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
 
 public class HttpInputSourceTest
 {
   @Test
   public void testSerde() throws IOException
   {
+    HttpInputSourceConfig httpInputSourceConfig = new HttpInputSourceConfig(
+        null,
+        null
+    );
     final ObjectMapper mapper = new ObjectMapper();
+    mapper.setInjectableValues(new InjectableValues.Std().addValue(
+        HttpInputSourceConfig.class,
+        httpInputSourceConfig
+    ));
     final HttpInputSource source = new HttpInputSource(
         ImmutableList.of(URI.create("http://test.com/http-test")),
         "myName",
-        new DefaultPasswordProvider("myPassword")
+        new DefaultPasswordProvider("myPassword"),
+        httpInputSourceConfig
     );
     final byte[] json = mapper.writeValueAsBytes(source);
     final HttpInputSource fromJson = (HttpInputSource) mapper.readValue(json, InputSource.class);
     Assert.assertEquals(source, fromJson);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDenyListDomainThrowsException()
+  {
+    new HttpInputSource(
+        ImmutableList.of(URI.create("http://deny.com/http-test")),
+        "myName",
+        new DefaultPasswordProvider("myPassword"),
+        new HttpInputSourceConfig(null, Collections.singletonList("deny.com"))
+    );
+  }
+
+  @Test
+  public void testDenyListDomainNoMatch()
+  {
+    new HttpInputSource(
+        ImmutableList.of(URI.create("http://allow.com/http-test")),
+        "myName",
+        new DefaultPasswordProvider("myPassword"),
+        new HttpInputSourceConfig(null, Collections.singletonList("deny.com"))
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAllowListDomainThrowsException()
+  {
+    new HttpInputSource(
+        ImmutableList.of(URI.create("http://deny.com/http-test")),
+        "myName",
+        new DefaultPasswordProvider("myPassword"),
+        new HttpInputSourceConfig(Collections.singletonList("allow.com"), null)
+    );
+  }
+
+  @Test
+  public void testAllowListDomainMatch()
+  {
+    new HttpInputSource(
+        ImmutableList.of(URI.create("http://allow.com/http-test")),
+        "myName",
+        new DefaultPasswordProvider("myPassword"),
+        new HttpInputSourceConfig(Collections.singletonList("allow.com"), null)
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyAllowListDomainMatch()
+  {
+    new HttpInputSource(
+        ImmutableList.of(URI.create("http://allow.com/http-test")),
+        "myName",
+        new DefaultPasswordProvider("myPassword"),
+        new HttpInputSourceConfig(Collections.emptyList(), null)
+    );
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCannotSetBothAllowAndDenyList()
+  {
+    new HttpInputSourceConfig(Collections.singletonList("allow.com"), Collections.singletonList("deny.com"));
   }
 }

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1353,6 +1353,15 @@ The amount of direct memory needed by Druid is at least
 ensure at least this amount of direct memory is available by providing `-XX:MaxDirectMemorySize=<VALUE>` at the command
 line.
 
+#### Indexer Security Configuration
+You can optionally configure following additional configs to restrict druid ingestion
+ 
+|Property|Possible Values|Description|Default|
+|--------|---------------|-----------|-------|
+|`druid.ingestion.http.allowListDomains`|List of domains|Allowed domains from which ingestion will be allowed. Only one of allowList or denyList can be set.|empty list|
+|`druid.ingestion.http.denyListDomains`|List of domains|Blacklisted domains from which ingestion will NOT be allowed. Only one of allowList or denyList can be set. |empty list|
+
+
 #### Query Configurations
 
 See [general query configuration](#general-query-configuration).

--- a/server/src/main/java/org/apache/druid/metadata/input/InputSourceModule.java
+++ b/server/src/main/java/org/apache/druid/metadata/input/InputSourceModule.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
+import org.apache.druid.data.input.impl.HttpInputSourceConfig;
+import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.initialization.DruidModule;
 
 import java.util.List;
@@ -47,5 +49,6 @@ public class InputSourceModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
+    JsonConfigProvider.bind(binder, "druid.ingestion.http", HttpInputSourceConfig.class);
   }
 }

--- a/website/.spelling
+++ b/website/.spelling
@@ -1645,6 +1645,7 @@ _default_tier
 addr
 affinityConfig
 allowAll
+allowList
 ANDed
 array_mod
 autoscale
@@ -1658,6 +1659,7 @@ cpuacct
 dataSourceName
 datetime
 defaultHistory
+denyList
 doubleMax
 doubleMin
 doubleSum


### PR DESCRIPTION
### Description
Right now there is no support to restrict druid HTTP based ingestion to deny ingestion from any given hosts.  
Cloud providers have metadata service that can be accessible via HTTP endpoints which can leak sensitive information about the instance on which druid is running. 
* https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html

Other use-case for this config is to restrict access to internal HTTP based service endpoints that are exposed only within VPN. 

this PR adds a new config `druid.ingestion.http.allowListDomains` and  `druid.ingestion.http.denyListDomains` which allows/deny configured IP/domains from being accessed through HTTP based ingestion.

This PR has:
- [*] been self-reviewed.
- [*] added documentation for new or modified features or behaviors.
- [*] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.


<hr>
