### PR TITLE
remove ServerDiscoverySelector i.e. hardcoded zk dependency from DruidLeaderClient

### DIFF
--- a/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
@@ -21,8 +21,6 @@ package org.apache.druid.discovery;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import org.apache.druid.client.selector.DiscoverySelector;
-import org.apache.druid.client.selector.Server;
 import org.apache.druid.concurrent.LifecycleLock;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.ISE;
@@ -71,9 +69,6 @@ public class DruidLeaderClient
 
   private final String leaderRequestPath;
 
-  //Note: This is kept for back compatibility with pre 0.11.0 releases and should be removed in future.
-  private final DiscoverySelector<Server> serverDiscoverySelector;
-
   private LifecycleLock lifecycleLock = new LifecycleLock();
   private DruidNodeDiscovery druidNodeDiscovery;
   private AtomicReference<String> currentKnownLeader = new AtomicReference<>();
@@ -82,15 +77,13 @@ public class DruidLeaderClient
       HttpClient httpClient,
       DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
       NodeRole nodeRoleToWatch,
-      String leaderRequestPath,
-      DiscoverySelector<Server> serverDiscoverySelector
+      String leaderRequestPath
   )
   {
     this.httpClient = httpClient;
     this.druidNodeDiscoveryProvider = druidNodeDiscoveryProvider;
     this.nodeRoleToWatch = nodeRoleToWatch;
     this.leaderRequestPath = leaderRequestPath;
-    this.serverDiscoverySelector = serverDiscoverySelector;
   }
 
   @LifecycleStart
@@ -280,16 +273,6 @@ public class DruidLeaderClient
   @Nullable
   private String pickOneHost()
   {
-    Server server = serverDiscoverySelector.pick();
-    if (server != null) {
-      return StringUtils.format(
-          "%s://%s:%s",
-          server.getScheme(),
-          server.getAddress(),
-          server.getPort()
-      );
-    }
-
     Iterator<DiscoveryDruidNode> iter = druidNodeDiscovery.getAllNodes().iterator();
     if (iter.hasNext()) {
       DiscoveryDruidNode node = iter.next();

--- a/server/src/main/java/org/apache/druid/guice/CoordinatorDiscoveryModule.java
+++ b/server/src/main/java/org/apache/druid/guice/CoordinatorDiscoveryModule.java
@@ -24,8 +24,6 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.coordinator.CoordinatorSelectorConfig;
-import org.apache.druid.curator.discovery.ServerDiscoveryFactory;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
@@ -45,29 +43,16 @@ public class CoordinatorDiscoveryModule implements Module
   @Provides
   @Coordinator
   @ManageLifecycle
-  public ServerDiscoverySelector getServiceProvider(
-      CoordinatorSelectorConfig config,
-      ServerDiscoveryFactory serverDiscoveryFactory
-  )
-  {
-    return serverDiscoveryFactory.createSelector(config.getServiceName());
-  }
-
-  @Provides
-  @Coordinator
-  @ManageLifecycle
   public DruidLeaderClient getLeaderHttpClient(
       @EscalatedGlobal HttpClient httpClient,
-      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
-      @Coordinator ServerDiscoverySelector serverDiscoverySelector
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider
   )
   {
     return new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.COORDINATOR,
-        "/druid/coordinator/v1/leader",
-        serverDiscoverySelector
+        "/druid/coordinator/v1/leader"
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/guice/IndexingServiceDiscoveryModule.java
+++ b/server/src/main/java/org/apache/druid/guice/IndexingServiceDiscoveryModule.java
@@ -24,8 +24,6 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.client.indexing.IndexingServiceSelectorConfig;
-import org.apache.druid.curator.discovery.ServerDiscoveryFactory;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
@@ -45,29 +43,16 @@ public class IndexingServiceDiscoveryModule implements Module
   @Provides
   @IndexingService
   @ManageLifecycle
-  public ServerDiscoverySelector getServiceProvider(
-      IndexingServiceSelectorConfig config,
-      ServerDiscoveryFactory serverDiscoveryFactory
-  )
-  {
-    return serverDiscoveryFactory.createSelector(config.getServiceName());
-  }
-
-  @Provides
-  @IndexingService
-  @ManageLifecycle
   public DruidLeaderClient getLeaderHttpClient(
       @EscalatedGlobal HttpClient httpClient,
-      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
-      @IndexingService ServerDiscoverySelector serverDiscoverySelector
+      DruidNodeDiscoveryProvider druidNodeDiscoveryProvider
   )
   {
     return new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.OVERLORD,
-        "/druid/indexer/v1/leader",
-        serverDiscoverySelector
+        "/druid/indexer/v1/leader"
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
@@ -29,7 +29,6 @@ import com.google.inject.Module;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.servlet.GuiceFilter;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.Jerseys;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -123,8 +122,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -148,8 +146,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -175,8 +172,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -188,9 +184,6 @@ public class DruidLeaderClientTest extends BaseJettyTest
   @Test
   public void testServerFailureAndRedirect() throws Exception
   {
-    ServerDiscoverySelector serverDiscoverySelector = EasyMock.createMock(ServerDiscoverySelector.class);
-    EasyMock.expect(serverDiscoverySelector.pick()).andReturn(null).anyTimes();
-
     DruidNodeDiscovery druidNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
     DiscoveryDruidNode dummyNode = new DiscoveryDruidNode(
         new DruidNode("test", "dummyhost", false, 64231, null, true, false),
@@ -203,14 +196,13 @@ public class DruidLeaderClientTest extends BaseJettyTest
     DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
     EasyMock.expect(druidNodeDiscoveryProvider.getForNodeRole(NodeRole.PEON)).andReturn(druidNodeDiscovery).anyTimes();
 
-    EasyMock.replay(serverDiscoverySelector, druidNodeDiscovery, druidNodeDiscoveryProvider);
+    EasyMock.replay(druidNodeDiscovery, druidNodeDiscoveryProvider);
 
     DruidLeaderClient druidLeaderClient = new DruidLeaderClient(
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        serverDiscoverySelector
+        "/simple/leader"
     );
     druidLeaderClient.start();
 
@@ -236,8 +228,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
         httpClient,
         druidNodeDiscoveryProvider,
         NodeRole.PEON,
-        "/simple/leader",
-        EasyMock.createNiceMock(ServerDiscoverySelector.class)
+        "/simple/leader"
     );
     druidLeaderClient.start();
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -846,7 +846,7 @@ public class CompactSegmentsTest
 
     private TestDruidLeaderClient(ObjectMapper jsonMapper)
     {
-      super(null, new TestNodeDiscoveryProvider(), null, null, null);
+      super(null, new TestNodeDiscoveryProvider(), null, null);
       this.jsonMapper = jsonMapper;
     }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -1009,10 +1009,7 @@ public class CalciteTests
         new FakeHttpClient(),
         provider,
         NodeRole.COORDINATOR,
-        "/simple/leader",
-        () -> {
-          throw new UnsupportedOperationException();
-        }
+        "/simple/leader"
     );
 
     return new SystemSchema(


### PR DESCRIPTION
towards #9053 

Brings back #9481 that was reverted in #9702 because bug #9701 was discovered.

#9701 root cause was really same as that of #8716, both were fixed in #9717

TLDR:
Change in this patch was introduced in the past, an issue was discovered whose root cause was ideally fixed by another change. That couldn't be done at the time to let Druid release go forward quickly, so the change was reverted. Later, original problem got fixed and now it is [rolling eyes] safe to bring the change back.