### PR TITLE
AWS Web Identity / IRSA Support

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSCredentialsUtils.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSCredentialsUtils.java
@@ -24,6 +24,7 @@ import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
 public class AWSCredentialsUtils
@@ -35,6 +36,7 @@ public class AWSCredentialsUtils
         new LazyFileSessionCredentialsProvider(config),
         new EnvironmentVariableCredentialsProvider(),
         new SystemPropertiesCredentialsProvider(),
+        WebIdentityTokenCredentialsProvider.create(),        
         new ProfileCredentialsProvider(),
         new EC2ContainerCredentialsProviderWrapper(),
         InstanceProfileCredentialsProvider.getInstance());

--- a/docs/development/extensions-core/kinesis-ingestion.md
+++ b/docs/development/extensions-core/kinesis-ingestion.md
@@ -236,7 +236,7 @@ To authenticate with AWS, you must provide your AWS access key and AWS secret ke
 -Ddruid.kinesis.accessKey=123 -Ddruid.kinesis.secretKey=456
 ```
 The AWS access key ID and secret access key are used for Kinesis API requests. If this is not provided, the service will
-look for credentials set in environment variables, in the default profile configuration file, and from the EC2 instance
+look for credentials set in environment variables, via [Web Identity Token](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html), in the default profile configuration file, and from the EC2 instance
 profile provider (in this order).
 
 ### Getting Supervisor Status Report

--- a/extensions-core/s3-extensions/pom.xml
+++ b/extensions-core/s3-extensions/pom.xml
@@ -112,6 +112,11 @@
       <artifactId>aws-java-sdk-s3</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <scope>provided</scope>
+    </dependency>    
     <!-- Tests -->
     <dependency>
       <groupId>org.apache.druid</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -151,7 +151,7 @@ name: AWS RDS SDK for Java
 license_category: source
 module: extensions/druid-aws-rds-extensions
 license_name: Apache License version 2.0
-version: 1.11.199
+version: 1.11.884
 libraries:
   - com.amazonaws: aws-java-sdk-rds
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3583,10 +3583,11 @@ name: AWS SDK for Java
 license_category: binary
 module: extensions/druid-kinesis-indexing-service
 license_name: Apache License version 2.0
-version: 1.11.199
+version: 1.11.884
 libraries:
   - com.amazonaws: aws-java-sdk-kinesis
   - com.amazonaws: aws-java-sdk-sts
+  - com.amazonaws: jmespath-java  
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -1282,8 +1282,7 @@
                         <!-- Ignore initialization classes, these are tested by the integration tests. -->
                         <exclude>org/apache/druid/cli/Cli*</exclude>
                         <exclude>org/apache/druid/cli/*JettyServerInitializer*</exclude>
-                        <!-- as per comments, disabling coverage tests-->
-                        <!-- <exclude>org/apache/druid/server/initialization/*Module*</exclude> -->
+                        <exclude>org/apache/druid/server/initialization/*Module*</exclude>
                         <exclude>org/apache/druid/server/initialization/jetty/*Module*</exclude>
                         <exclude>org/apache/druid/guice/http/*</exclude>
 
@@ -1299,7 +1298,9 @@
 
                         <!-- Exceptions -->
                         <exclude>org/apache/druid/query/TruncatedResponseContextException.class</exclude>
-                    </excludes>
+
+                        <exclude>org/apache/druid/common/aws/AWSCredentials*</exclude>                      
+                  </excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <hadoop.compile.version>2.8.5</hadoop.compile.version>
         <mockito.version>3.2.4</mockito.version>
         <powermock.version>2.0.2</powermock.version>
-        <aws.sdk.version>1.11.199</aws.sdk.version>
+        <aws.sdk.version>1.11.884</aws.sdk.version>
         <caffeine.version>2.8.0</caffeine.version>
         <jacoco.version>0.8.5</jacoco.version>
         <!-- Curator requires 3.4.x ZooKeeper clients to maintain compatibility with 3.4.x ZooKeeper servers,
@@ -264,6 +264,11 @@
                 <artifactId>aws-java-sdk-s3</artifactId>
                 <version>${aws.sdk.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-sts</artifactId>
+                <version>${aws.sdk.version}</version>
+            </dependency>            
             <dependency>
                 <groupId>com.ning</groupId>
                 <artifactId>compress-lzf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1282,7 +1282,8 @@
                         <!-- Ignore initialization classes, these are tested by the integration tests. -->
                         <exclude>org/apache/druid/cli/Cli*</exclude>
                         <exclude>org/apache/druid/cli/*JettyServerInitializer*</exclude>
-                        <exclude>org/apache/druid/server/initialization/*Module*</exclude>
+                        <!-- as per comments, disabling coverage tests-->
+                        <!-- <exclude>org/apache/druid/server/initialization/*Module*</exclude> -->
                         <exclude>org/apache/druid/server/initialization/jetty/*Module*</exclude>
                         <exclude>org/apache/druid/guice/http/*</exclude>
 


### PR DESCRIPTION
## Description

Added the latest AWS Web Identity Token Support for Druid.
Required fro IAM Roles for Service Account on kubernetes.

Updated AWS Credential Provider in the same order which AWS SDK does.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
