### PR TITLE
Avatica protobuf

### DIFF
--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -38,6 +38,12 @@
             </Or>
         </And>
     </Match>
+    <Match>
+        <And>
+            <Bug pattern="SE_BAD_FIELD_STORE" />
+            <Class name="org.apache.druid.server.AsyncQueryForwardingServlet" />
+        </And>
+    </Match>
 
     <Bug pattern="AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION"/>
     <Bug pattern="BC_UNCONFIRMED_CAST"/>

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -954,6 +954,14 @@ try (Connection connection = DriverManager.getConnection(url, connectionProperti
 }
 ```
 
+It is also possible to use a protocol buffers JDBC connection with Druid, this offer reduced bloat and potential performance
+improvements for larger result sets. To use it apply the following connection url instead, everything else remains the same
+```
+String url = "jdbc:avatica:remote:url=http://localhost:8082/druid/v2/sql/avatica-protobuf/;serialization=protobuf";
+```
+
+> The protobuf endpoint is also known to work with the official [Golang Avatica driver](https://github.com/apache/calcite-avatica-go)
+
 Table metadata is available over JDBC using `connection.getMetaData()` or by querying the
 ["INFORMATION_SCHEMA" tables](#metadata-tables).
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
@@ -34,7 +34,7 @@ import org.apache.druid.java.util.http.client.CredentialedHttpClient;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.auth.BasicCredentials;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
-import org.apache.druid.sql.avatica.DruidAvaticaHandler;
+import org.apache.druid.sql.avatica.DruidAvaticaJsonHandler;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.clients.CoordinatorResourceTestClient;
 import org.apache.druid.testing.utils.HttpUtil;
@@ -285,12 +285,12 @@ public abstract class AbstractAuthConfigurationTest
 
   String getBrokerAvacticaUrl()
   {
-    return "jdbc:avatica:remote:url=" + config.getBrokerUrl() + DruidAvaticaHandler.AVATICA_PATH;
+    return "jdbc:avatica:remote:url=" + config.getBrokerUrl() + DruidAvaticaJsonHandler.AVATICA_PATH;
   }
 
   String getRouterAvacticaUrl()
   {
-    return "jdbc:avatica:remote:url=" + config.getRouterUrl() + DruidAvaticaHandler.AVATICA_PATH;
+    return "jdbc:avatica:remote:url=" + config.getRouterUrl() + DruidAvaticaJsonHandler.AVATICA_PATH;
   }
 
   void verifyAdminOptionsRequest()

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -319,6 +319,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-guice</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.calcite.avatica</groupId>
+            <artifactId>avatica-core</artifactId>
+        </dependency>
 
         <!-- Tests -->
         <dependency>
@@ -448,11 +452,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.calcite.avatica</groupId>
-            <artifactId>avatica-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
@@ -39,7 +39,8 @@ import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationUtils;
 import org.apache.druid.server.security.Authenticator;
 import org.apache.druid.server.security.AuthenticatorMapper;
-import org.apache.druid.sql.avatica.DruidAvaticaHandler;
+import org.apache.druid.sql.avatica.DruidAvaticaJsonHandler;
+import org.apache.druid.sql.avatica.DruidAvaticaProtobufHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerList;
@@ -57,7 +58,8 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
       // JDBC authentication uses the JDBC connection context instead of HTTP headers, skip the normal auth checks.
       // The router will keep the connection context in the forwarded message, and the broker is responsible for
       // performing the auth checks.
-      DruidAvaticaHandler.AVATICA_PATH
+      DruidAvaticaJsonHandler.AVATICA_PATH,
+      DruidAvaticaProtobufHandler.AVATICA_PATH
   );
 
   private final DruidHttpClientConfig routerHttpClientConfig;

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandler.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.avatica;
+
+import com.google.inject.Inject;
+import org.apache.calcite.avatica.remote.LocalService;
+import org.apache.calcite.avatica.remote.Service;
+import org.apache.calcite.avatica.server.AvaticaJsonHandler;
+import org.apache.druid.guice.annotations.Self;
+import org.apache.druid.server.DruidNode;
+import org.eclipse.jetty.server.Request;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class DruidAvaticaJsonHandler extends AvaticaJsonHandler
+{
+  public static final String AVATICA_PATH = "/druid/v2/sql/avatica/";
+
+  @Inject
+  public DruidAvaticaJsonHandler(
+      final DruidMeta druidMeta,
+      @Self final DruidNode druidNode,
+      final AvaticaMonitor avaticaMonitor
+  )
+  {
+    super(new LocalService(druidMeta), avaticaMonitor);
+    setServerRpcMetadata(new Service.RpcMetadataResponse(druidNode.getHostAndPortToUse()));
+  }
+
+  @Override
+  public void handle(
+      final String target,
+      final Request baseRequest,
+      final HttpServletRequest request,
+      final HttpServletResponse response
+  ) throws IOException, ServletException
+  {
+    if (request.getRequestURI().equals(AVATICA_PATH)) {
+      super.handle(target, baseRequest, request, response);
+    }
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaProtobufHandler.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaProtobufHandler.java
@@ -22,7 +22,7 @@ package org.apache.druid.sql.avatica;
 import com.google.inject.Inject;
 import org.apache.calcite.avatica.remote.LocalService;
 import org.apache.calcite.avatica.remote.Service;
-import org.apache.calcite.avatica.server.AvaticaJsonHandler;
+import org.apache.calcite.avatica.server.AvaticaProtobufHandler;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.server.DruidNode;
 import org.eclipse.jetty.server.Request;
@@ -32,12 +32,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-public class DruidAvaticaHandler extends AvaticaJsonHandler
+public class DruidAvaticaProtobufHandler extends AvaticaProtobufHandler
 {
-  public static final String AVATICA_PATH = "/druid/v2/sql/avatica/";
+  public static final String AVATICA_PATH = "/druid/v2/sql/avatica-protobuf/";
 
   @Inject
-  public DruidAvaticaHandler(
+  public DruidAvaticaProtobufHandler(
       final DruidMeta druidMeta,
       @Self final DruidNode druidNode,
       final AvaticaMonitor avaticaMonitor

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
@@ -104,8 +104,10 @@ public class DruidMeta extends MetaImpl
   {
     // Build connection context.
     final ImmutableMap.Builder<String, Object> context = ImmutableMap.builder();
-    for (Map.Entry<String, String> entry : info.entrySet()) {
-      context.put(entry);
+    if (info != null) {
+      for (Map.Entry<String, String> entry : info.entrySet()) {
+        context.put(entry);
+      }
     }
     openDruidConnection(ch.id, context.build());
   }

--- a/sql/src/test/java/org/apache/druid/sql/avatica/AvaticaModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/AvaticaModuleTest.java
@@ -176,19 +176,36 @@ public class AvaticaModuleTest
   }
 
   @Test
-  public void testDruidAvaticaHandlerIsInjected()
+  public void testDruidAvaticaJsonHandlerIsInjected()
   {
-    DruidAvaticaHandler handler = injector.getInstance(DruidAvaticaHandler.class);
+    DruidAvaticaJsonHandler handler = injector.getInstance(DruidAvaticaJsonHandler.class);
     Assert.assertNotNull(handler);
-    DruidAvaticaHandler other = injector.getInstance(DruidAvaticaHandler.class);
+    DruidAvaticaJsonHandler other = injector.getInstance(DruidAvaticaJsonHandler.class);
     Assert.assertNotSame(handler, other);
   }
 
   @Test
-  public void testDruidAvaticaHandlerIsRegisterdWithJerseyModule()
+  public void testDruidAvaticaProtobufHandlerIsInjected()
+  {
+    DruidAvaticaProtobufHandler handler = injector.getInstance(DruidAvaticaProtobufHandler.class);
+    Assert.assertNotNull(handler);
+    DruidAvaticaProtobufHandler other = injector.getInstance(DruidAvaticaProtobufHandler.class);
+    Assert.assertNotSame(handler, other);
+  }
+
+  @Test
+  public void testDruidAvaticaJsonHandlerIsRegisterdWithJerseyModule()
   {
     Set<Handler> handlers =
         injector.getInstance(Key.get(new TypeLiteral<Set<Handler>>(){}));
-    Assert.assertTrue(handlers.stream().anyMatch(h -> DruidAvaticaHandler.class.equals(h.getClass())));
+    Assert.assertTrue(handlers.stream().anyMatch(h -> DruidAvaticaJsonHandler.class.equals(h.getClass())));
+  }
+
+  @Test
+  public void testDruidAvaticaProtobufHandlerIsRegisterdWithJerseyModule()
+  {
+    Set<Handler> handlers =
+            injector.getInstance(Key.get(new TypeLiteral<Set<Handler>>(){}));
+    Assert.assertTrue(handlers.stream().anyMatch(h -> DruidAvaticaProtobufHandler.class.equals(h.getClass())));
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandlerTest.java
@@ -19,25 +19,29 @@
 
 package org.apache.druid.sql.avatica;
 
-import com.google.inject.Binder;
-import com.google.inject.Module;
-import org.apache.druid.guice.JsonConfigProvider;
-import org.apache.druid.guice.LazySingleton;
-import org.apache.druid.server.initialization.jetty.JettyBindings;
-import org.apache.druid.server.metrics.MetricsModule;
+import org.apache.calcite.avatica.server.AbstractAvaticaHandler;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.server.DruidNode;
 
-/**
- * The module responsible for providing bindings to Avatica.
- */
-public class AvaticaModule implements Module
+public class DruidAvaticaJsonHandlerTest extends DruidAvaticaHandlerTest
 {
   @Override
-  public void configure(Binder binder)
+  protected String getJdbcConnectionString(final int port)
   {
-    JsonConfigProvider.bind(binder, "druid.sql.avatica", AvaticaServerConfig.class);
-    binder.bind(AvaticaMonitor.class).in(LazySingleton.class);
-    JettyBindings.addHandler(binder, DruidAvaticaJsonHandler.class);
-    JettyBindings.addHandler(binder, DruidAvaticaProtobufHandler.class);
-    MetricsModule.register(binder, AvaticaMonitor.class);
+    return StringUtils.format(
+            "jdbc:avatica:remote:url=http://127.0.0.1:%d%s",
+            port,
+            DruidAvaticaJsonHandler.AVATICA_PATH
+    );
+  }
+
+  @Override
+  protected AbstractAvaticaHandler getAvaticaHandler(final DruidMeta druidMeta)
+  {
+    return new DruidAvaticaJsonHandler(
+            druidMeta,
+            new DruidNode("dummy", "dummy", false, 1, null, true, false),
+            new AvaticaMonitor()
+    );
   }
 }

--- a/website/.spelling
+++ b/website/.spelling
@@ -1860,3 +1860,5 @@ MiB
 GiB
 TiB
 PiB
+protobuf
+Golang


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Druid hadn't implemented the `AvaticaProtobufHandler` and only supported Json serialisation for Avatica connections. Protocol buffers have much less overhead than Json and thus I would expect the transfer rate to be increased when using it. I'll try to build some benchmarking tools to test this, circumstantial evidence from test suites seems to indicate a speed increase:

```
... Time elapsed: 14.753 s - in org.apache.druid.sql.avatica.DruidAvaticaJsonHandlerTest
... Time elapsed: 11.482 s - in org.apache.druid.sql.avatica.DruidAvaticaProtobufHandlerTest
```

As a side note, for the officially supported [Avatica Golang driver](https://github.com/apache/calcite-avatica-go) there isn't any Json serialisation support and thus will only work with this patch.

I was forced to add `org.apache.calcite.avatica` to druid-server in order to parse the pb messages and retrieve the connection id. The connection id is used to stabilise the choice of brokers when the request goes through the router.

One further note, I've chosen to add another url (`/druid/v2/sql/avatica-pb/`) for protocol buffers, ideally it would simply be controlled with a `content-type`, that is unfortunately not implemented in the JDBC driver so it will not work for the time being, however, the aforementioned golang driver does send content-type as `application/x-google-protobuf`.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>


