### PR TITLE
Add TravisCI job that builds and tests on ARM64 CPU architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ env:
       MAVEN_SKIP="-Pskip-static-checks -Ddruid.console.skip=true -Dmaven.javadoc.skip=true"
     - MAVEN_SKIP_TESTS="-Pskip-tests"
 
+addons:
+  apt:
+    packages:
+      - maven
+    
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
@@ -131,6 +136,11 @@ jobs:
 
     - <<: *package
       name: "(openjdk11) packaging check"
+      jdk: openjdk11
+    
+    - <<: *package
+      name: "Build and test on ARM64 CPU architecture"
+      arch: arm64
       jdk: openjdk11
 
     - &test_processing_module


### PR DESCRIPTION
More and more software deployment is being done on ARM64 CPU architecture.
It would be good if Apache Druid is being regularly tested on ARM64.

This PR adds an additional TravisCI job that runs the build and tests on ARM64 node.
Apache Maven is not pre-installed on ARM64 so it has to be added as an addon.