### PR TITLE
Bump jetty to latest version

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1661,7 +1661,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.30.v20200611
+version: 9.4.34.v20201102
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.30.v20200611</jetty.version>
+        <jetty.version>9.4.34.v20201102</jetty.version>
         <jersey.version>1.19.3</jersey.version>
         <jackson.version>2.10.2</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>


### PR DESCRIPTION
This addresses CVE-2020-27216 which was flagged by the security vulnerability
job.