### PR TITLE
Introduce query/timeout/count metric

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -57,7 +57,8 @@ Available Metrics
 |`query/count`|number of total queries|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/success/count`|number of queries successfully processed|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/failed/count`|number of failed queries|This metric is only available if the QueryCountStatsMonitor module is included.||
-|`query/interrupted/count`|number of queries interrupted due to cancellation or timeout|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`sqlQuery/time`|Milliseconds taken to complete a SQL query.|id, nativeQueryIds, dataSource, remoteAddress, success.|< 1s|
 |`sqlQuery/bytes`|number of bytes returned in SQL query response.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
 
@@ -74,7 +75,8 @@ Available Metrics
 |`query/count`|number of total queries|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/success/count`|number of queries successfully processed|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/failed/count`|number of failed queries|This metric is only available if the QueryCountStatsMonitor module is included.||
-|`query/interrupted/count`|number of queries interrupted due to cancellation or timeout|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
 
 ### Real-time
 
@@ -86,7 +88,8 @@ Available Metrics
 |`query/count`|number of total queries|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/success/count`|number of queries successfully processed|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/failed/count`|number of failed queries|This metric is only available if the QueryCountStatsMonitor module is included.||
-|`query/interrupted/count`|number of queries interrupted due to cancellation or timeout|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
 
 ### Jetty
 

--- a/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
@@ -19,6 +19,7 @@
   "query/success/count": [],
   "query/failed/count": [],
   "query/interrupted/count": [],
+  "query/timeout/count": [],
   "query/wait/time": [
     "segment"
   ],

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -16,6 +16,7 @@
   "query/success/count" : { "dimensions" : [], "type" : "count" },
   "query/failed/count" : { "dimensions" : [], "type" : "count" },
   "query/interrupted/count" : { "dimensions" : [], "type" : "count" },
+  "query/timeout/count" : { "dimensions" : [], "type" : "count" },
 
   "query/cache/delta/numEntries" : { "dimensions" : [], "type" : "count" },
   "query/cache/delta/sizeBytes" : { "dimensions" : [], "type" : "count" },

--- a/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -425,6 +425,14 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     return interruptedQueryCount.get();
   }
 
+  @Override
+  public long getTimedOutQueryCount()
+  {
+    // Query timeout metric is not relevant here and this metric is already being tracked in the Broker and the
+    // data nodes using QueryResource
+    return 0L;
+  }
+
   @VisibleForTesting
   static String getAvaticaConnectionId(Map<String, Object> requestMap)
   {

--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -108,6 +108,7 @@ public class QueryResource implements QueryCountStatsProvider
   private final AtomicLong successfulQueryCount = new AtomicLong();
   private final AtomicLong failedQueryCount = new AtomicLong();
   private final AtomicLong interruptedQueryCount = new AtomicLong();
+  private final AtomicLong timedOutQueryCount = new AtomicLong();
 
   @Inject
   public QueryResource(
@@ -332,7 +333,7 @@ public class QueryResource implements QueryCountStatsProvider
       return ioReaderWriter.gotError(e);
     }
     catch (QueryTimeoutException timeout) {
-      interruptedQueryCount.incrementAndGet();
+      timedOutQueryCount.incrementAndGet();
       queryLifecycle.emitLogsAndMetrics(timeout, req.getRemoteAddr(), -1);
       return ioReaderWriter.gotTimeout(timeout);
     }
@@ -513,5 +514,11 @@ public class QueryResource implements QueryCountStatsProvider
   public long getInterruptedQueryCount()
   {
     return interruptedQueryCount.get();
+  }
+
+  @Override
+  public long getTimedOutQueryCount()
+  {
+    return timedOutQueryCount.get();
   }
 }

--- a/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsMonitor.java
@@ -48,13 +48,16 @@ public class QueryCountStatsMonitor extends AbstractMonitor
     final long successfulQueryCount = statsProvider.getSuccessfulQueryCount();
     final long failedQueryCount = statsProvider.getFailedQueryCount();
     final long interruptedQueryCount = statsProvider.getInterruptedQueryCount();
+    final long timedOutQueryCount = statsProvider.getTimedOutQueryCount();
+
     Map<String, Long> diff = keyedDiff.to(
         "queryCountStats",
         ImmutableMap.of(
-            "query/count", successfulQueryCount + failedQueryCount + interruptedQueryCount,
+            "query/count", successfulQueryCount + failedQueryCount + interruptedQueryCount + timedOutQueryCount,
             "query/success/count", successfulQueryCount,
             "query/failed/count", failedQueryCount,
-            "query/interrupted/count", interruptedQueryCount
+            "query/interrupted/count", interruptedQueryCount,
+            "query/timeout/count", timedOutQueryCount
         )
     );
     if (diff != null) {

--- a/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsProvider.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsProvider.java
@@ -21,9 +21,23 @@ package org.apache.druid.server.metrics;
 
 public interface QueryCountStatsProvider
 {
+  /**
+   * Returns the number of successful queries processed during the emission period.
+   */
   long getSuccessfulQueryCount();
 
+  /**
+   * Returns the number of failed queries during the emission period.
+   */
   long getFailedQueryCount();
 
+  /**
+   * Returns the number of queries interrupted due to cancellation during the emission period.
+   */
   long getInterruptedQueryCount();
+
+  /**
+   * Returns the number of timed out queries during the emission period.
+   */
+  long getTimedOutQueryCount();
 }

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -684,6 +684,8 @@ public class QueryResourceTest
     }
     Assert.assertEquals("Query Timed Out!", ex.getMessage());
     Assert.assertEquals(QueryTimeoutException.ERROR_CODE, ex.getErrorCode());
+    Assert.assertEquals(1, timeoutQueryResource.getTimedOutQueryCount());
+
   }
 
   @Test(timeout = 60_000L)

--- a/server/src/test/java/org/apache/druid/server/metrics/QueryCountStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/QueryCountStatsMonitorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QueryCountStatsMonitorTest
+{
+  private QueryCountStatsProvider queryCountStatsProvider;
+
+  @Before
+  public void setUp()
+  {
+    queryCountStatsProvider = new QueryCountStatsProvider()
+    {
+      private long successEmitCount = 0;
+      private long failedEmitCount = 0;
+      private long interruptedEmitCount = 0;
+      private long timedOutEmitCount = 0;
+
+      @Override
+      public long getSuccessfulQueryCount()
+      {
+        successEmitCount += 1;
+        return successEmitCount;
+      }
+
+      @Override
+      public long getFailedQueryCount()
+      {
+        failedEmitCount += 2;
+        return failedEmitCount;
+      }
+
+      @Override
+      public long getInterruptedQueryCount()
+      {
+        interruptedEmitCount += 3;
+        return interruptedEmitCount;
+      }
+
+      @Override
+      public long getTimedOutQueryCount()
+      {
+        timedOutEmitCount += 4;
+        return timedOutEmitCount;
+      }
+    };
+  }
+
+  @Test
+  public void testMonitor()
+  {
+    final QueryCountStatsMonitor monitor = new QueryCountStatsMonitor(queryCountStatsProvider);
+    final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
+    monitor.doMonitor(emitter);
+    // Trigger metric emission
+    monitor.doMonitor(emitter);
+    Map<String, Long> resultMap = emitter.getEvents()
+                                         .stream()
+                                         .collect(Collectors.toMap(
+                                             event -> (String) event.toMap().get("metric"),
+                                             event -> (Long) event.toMap().get("value")
+                                         ));
+    Assert.assertEquals(5, resultMap.size());
+    Assert.assertEquals(1L, (long) resultMap.get("query/success/count"));
+    Assert.assertEquals(2L, (long) resultMap.get("query/failed/count"));
+    Assert.assertEquals(3L, (long) resultMap.get("query/interrupted/count"));
+    Assert.assertEquals(4L, (long) resultMap.get("query/timeout/count"));
+    Assert.assertEquals(10L, (long) resultMap.get("query/count"));
+
+  }
+}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Follow-up PR to #10464.

This PR adds a new query metric `query/timeout/count` that represents the number of timed out queries during the emission period. Timed out query counts were previously clubbed under `query/interrupted/count`. Having a separate metric for timed out queries can make it a little easier for cluster operators to diagnose query issues better.

Marking this as `Incompatible` as `query/interrupted/count` no longer represents timed out query counts and user defined alerting/reports may need to be adjusted to factor in `query/timeout/count` along with `query/interrupted/count`.

It would be useful to add metricsMonitors to integration tests so that it provides better testing for PRs such as this.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>
