### PR TITLE
modify access to protected SQLMetadataConnector methods

### DIFF
--- a/extensions-contrib/sqlserver-metadata-storage/src/main/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnector.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/main/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnector.java
@@ -179,13 +179,13 @@ public class SQLServerConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected String getPayloadType()
+  public String getPayloadType()
   {
     return PAYLOAD_TYPE;
   }
 
   @Override
-  protected String getSerialType()
+  public String getSerialType()
   {
     return SERIAL_TYPE;
   }
@@ -197,7 +197,7 @@ public class SQLServerConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected int getStreamingFetchSize()
+  public int getStreamingFetchSize()
   {
     return DEFAULT_STREAMING_RESULT_SIZE;
   }

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -148,19 +148,19 @@ public class MySQLConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected String getPayloadType()
+  public String getPayloadType()
   {
     return PAYLOAD_TYPE;
   }
 
   @Override
-  protected String getSerialType()
+  public String getSerialType()
   {
     return SERIAL_TYPE;
   }
 
   @Override
-  protected String getCollation()
+  public String getCollation()
   {
     return COLLATION;
   }
@@ -172,7 +172,7 @@ public class MySQLConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected int getStreamingFetchSize()
+  public int getStreamingFetchSize()
   {
     // this is MySQL's way of indicating you want results streamed back
     // see http://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-implementation-notes.html

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
@@ -121,13 +121,13 @@ public class PostgreSQLConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected String getPayloadType()
+  public String getPayloadType()
   {
     return PAYLOAD_TYPE;
   }
 
   @Override
-  protected String getSerialType()
+  public String getSerialType()
   {
     return SERIAL_TYPE;
   }
@@ -139,7 +139,7 @@ public class PostgreSQLConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected int getStreamingFetchSize()
+  public int getStreamingFetchSize()
   {
     return DEFAULT_STREAMING_RESULT_SIZE;
   }

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -71,14 +71,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   {
     this.config = config;
     this.tablesConfigSupplier = tablesConfigSupplier;
-    this.shouldRetry = new Predicate<Throwable>()
-    {
-      @Override
-      public boolean apply(Throwable e)
-      {
-        return isTransientException(e);
-      }
-    };
+    this.shouldRetry = this::isTransientException;
   }
 
   /**
@@ -90,7 +83,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
    *
    * @return String representing the SQL type
    */
-  protected String getPayloadType()
+  public String getPayloadType()
   {
     return PAYLOAD_TYPE;
   }
@@ -100,7 +93,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
    *
    * @return the collation for the character set
    */
-  protected String getCollation()
+  public String getCollation()
   {
     return COLLATION;
   }
@@ -114,7 +107,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
    *
    * @return String representing the SQL type and auto-increment statement
    */
-  protected abstract String getSerialType();
+  public abstract String getSerialType();
 
   /**
    * Returns the value that should be passed to statement.setFetchSize to ensure results
@@ -122,7 +115,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
    *
    * @return optimal fetch size to stream results back
    */
-  protected abstract int getStreamingFetchSize();
+  public abstract int getStreamingFetchSize();
 
   /**
    * @return the string that should be used to quote string fields

--- a/server/src/main/java/org/apache/druid/metadata/storage/derby/DerbyConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/storage/derby/DerbyConnector.java
@@ -84,7 +84,7 @@ public class DerbyConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected String getSerialType()
+  public String getSerialType()
   {
     return SERIAL_TYPE;
   }
@@ -102,7 +102,7 @@ public class DerbyConnector extends SQLMetadataConnector
   }
 
   @Override
-  protected int getStreamingFetchSize()
+  public int getStreamingFetchSize()
   {
     // Derby only supports fetch size of 1
     return 1;

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorTest.java
@@ -159,13 +159,13 @@ public class SQLMetadataConnectorTest
     }
 
     @Override
-    protected String getSerialType()
+    public String getSerialType()
     {
       return null;
     }
 
     @Override
-    protected int getStreamingFetchSize()
+    public int getStreamingFetchSize()
     {
       return 0;
     }


### PR DESCRIPTION
Changing access of these methods from `protected` to `public` allows extensions to construct statements and queries against the base `SQLMetadataConnector` provided by another extension, but using implementation specific constructs of that specific extension, such as the 'payload' and 'serial' types (so that correct SQL for a given metadata store implementation can be constructed).