### PR TITLE
Fix scm tag for 0.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <connection>scm:git:ssh://git@github.com/apache/druid.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/apache/druid.git</developerConnection>
         <url>https://github.com/apache/druid.git</url>
-        <tag>0.19.0-SNAPSHOT</tag>
+        <tag>0.20.0-SNAPSHOT</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
Updates the scm tag for the 0.20 release.
@jon-wei Since 0.20.0 is already released, would it be useful to still fix this?