### PR TITLE
Web console: fix data loader schema table column ordering bug and other polish

### DIFF
--- a/web-console/e2e-tests/component/load-data/config/partition.ts
+++ b/web-console/e2e-tests/component/load-data/config/partition.ts
@@ -26,10 +26,10 @@ import { getLabeledInput, selectSuggestibleInput, setLabeledInput } from '../../
  * Possible values for partition step segment granularity.
  */
 export enum SegmentGranularity {
-  HOUR = 'HOUR',
-  DAY = 'DAY',
-  MONTH = 'MONTH',
-  YEAR = 'YEAR',
+  HOUR = 'hour',
+  DAY = 'day',
+  MONTH = 'month',
+  YEAR = 'year',
 }
 
 const PARTITIONING_TYPE = 'Partitioning type';

--- a/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
+++ b/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`auto-form snapshot matches snapshot 1`] = `
+exports[`AutoForm matches snapshot 1`] = `
 <div
   className="auto-form"
 >
@@ -132,5 +132,16 @@ exports[`auto-form snapshot matches snapshot 1`] = `
       placeholder=""
     />
   </Memo(FormGroupWithInfo)>
+  <Blueprint3.FormGroup
+    key="advanced"
+  >
+    <Blueprint3.Button
+      fill={true}
+      minimal={true}
+      onClick={[Function]}
+      rightIcon="chevron-down"
+      text="Show advanced"
+    />
+  </Blueprint3.FormGroup>
 </div>
 `;

--- a/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
+++ b/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
@@ -140,7 +140,7 @@ exports[`AutoForm matches snapshot 1`] = `
       minimal={true}
       onClick={[Function]}
       rightIcon="chevron-down"
-      text="Show advanced"
+      text="Show more"
     />
   </Blueprint3.FormGroup>
 </div>

--- a/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
+++ b/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
@@ -133,7 +133,7 @@ exports[`AutoForm matches snapshot 1`] = `
     />
   </Memo(FormGroupWithInfo)>
   <Blueprint3.FormGroup
-    key="advanced"
+    key="more-or-less"
   >
     <Blueprint3.Button
       fill={true}

--- a/web-console/src/components/auto-form/auto-form.spec.tsx
+++ b/web-console/src/components/auto-form/auto-form.spec.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 import { AutoForm } from './auto-form';
 
-describe('auto-form snapshot', () => {
+describe('AutoForm', () => {
   it('matches snapshot', () => {
     const autoForm = shallow(
       <AutoForm
@@ -34,6 +34,9 @@ describe('auto-form snapshot', () => {
           { name: 'testFive', type: 'string-array' },
           { name: 'testSix', type: 'json' },
           { name: 'testSeven', type: 'json' },
+
+          { name: 'testNotDefined', type: 'string', defined: false },
+          { name: 'testAdvanced', type: 'string', advanced: true },
         ]}
         model={String}
         onChange={() => {}}

--- a/web-console/src/components/auto-form/auto-form.spec.tsx
+++ b/web-console/src/components/auto-form/auto-form.spec.tsx
@@ -36,7 +36,7 @@ describe('AutoForm', () => {
           { name: 'testSeven', type: 'json' },
 
           { name: 'testNotDefined', type: 'string', defined: false },
-          { name: 'testAdvanced', type: 'string', advanced: true },
+          { name: 'testAdvanced', type: 'string', hideInMore: true },
         ]}
         model={String}
         onChange={() => {}}

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -429,7 +429,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
     const { showMore } = this.state;
 
     return (
-      <FormGroup key="advanced">
+      <FormGroup key="more-or-less">
         <Button
           text={showMore ? 'Show less' : 'Show more'}
           rightIcon={showMore ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN}

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -433,6 +433,8 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         <Button
           text={showAdvanced ? 'Hide advanced' : 'Show advanced'}
           rightIcon={showAdvanced ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN}
+          minimal
+          fill
           onClick={() => {
             this.setState(({ showAdvanced }) => ({ showAdvanced: !showAdvanced }));
           }}

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -55,7 +55,7 @@ export interface Field<M> {
   disabled?: Functor<M, boolean>;
   defined?: Functor<M, boolean>;
   required?: Functor<M, boolean>;
-  advanced?: Functor<M, boolean>;
+  hideInMore?: Functor<M, boolean>;
   adjustment?: (model: M) => M;
   issueWithValue?: (value: any) => string | undefined;
 }
@@ -71,7 +71,7 @@ export interface AutoFormProps<M> {
 }
 
 export interface AutoFormState {
-  showAdvanced: boolean;
+  showMore: boolean;
 }
 
 export class AutoForm<T extends Record<string, any>> extends React.PureComponent<
@@ -148,7 +148,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
   constructor(props: AutoFormProps<T>) {
     super(props);
     this.state = {
-      showAdvanced: false,
+      showMore: false,
     };
   }
 
@@ -425,18 +425,18 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
     );
   }
 
-  renderAdvanced() {
-    const { showAdvanced } = this.state;
+  renderMoreOrLess() {
+    const { showMore } = this.state;
 
     return (
       <FormGroup key="advanced">
         <Button
-          text={showAdvanced ? 'Hide advanced' : 'Show advanced'}
-          rightIcon={showAdvanced ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN}
+          text={showMore ? 'Show less' : 'Show more'}
+          rightIcon={showMore ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN}
           minimal
           fill
           onClick={() => {
-            this.setState(({ showAdvanced }) => ({ showAdvanced: !showAdvanced }));
+            this.setState(({ showMore }) => ({ showMore: !showMore }));
           }}
         />
       </FormGroup>
@@ -445,14 +445,14 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
 
   render(): JSX.Element {
     const { fields, model, showCustom } = this.props;
-    const { showAdvanced } = this.state;
+    const { showMore } = this.state;
 
-    let hasAdvanced = false;
+    let shouldShowMore = false;
     const shownFields = fields.filter(field => {
       if (AutoForm.evaluateFunctor(field.defined, model, true)) {
-        if (AutoForm.evaluateFunctor(field.advanced, model, false)) {
-          hasAdvanced = true;
-          return showAdvanced;
+        if (AutoForm.evaluateFunctor(field.hideInMore, model, false)) {
+          shouldShowMore = true;
+          return showMore;
         }
         return true;
       } else {
@@ -464,7 +464,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
       <div className="auto-form">
         {model && shownFields.map(this.renderField)}
         {model && showCustom && showCustom(model) && this.renderCustom()}
-        {hasAdvanced && this.renderAdvanced()}
+        {shouldShowMore && this.renderMoreOrLess()}
       </div>
     );
   }

--- a/web-console/src/dialogs/coordinator-dynamic-config-dialog/__snapshots__/coordinator-dynamic-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/coordinator-dynamic-config-dialog/__snapshots__/coordinator-dynamic-config-dialog.spec.tsx.snap
@@ -17,6 +17,10 @@ exports[`coordinator dynamic config matches snapshot 1`] = `
     </Memo(ExternalLink)>
     .
   </p>
+  <Memo(FormJsonSelector)
+    onChange={[Function]}
+    tab="form"
+  />
   <AutoForm
     fields={
       Array [
@@ -47,13 +51,11 @@ exports[`coordinator dynamic config matches snapshot 1`] = `
         Object {
           "defaultValue": false,
           "info": <React.Fragment>
-            Send kill tasks for ALL dataSources if property
-             
+            Send kill tasks for ALL dataSources if property 
             <Unknown>
               druid.coordinator.kill.on
             </Unknown>
-             is true. If this is set to true then
-             
+             is true. If this is set to true then 
             <Unknown>
               killDataSourceWhitelist
             </Unknown>

--- a/web-console/src/dialogs/overlord-dynamic-config-dialog/overlord-dynamic-config-dialog.tsx
+++ b/web-console/src/dialogs/overlord-dynamic-config-dialog/overlord-dynamic-config-dialog.tsx
@@ -23,6 +23,7 @@ import React, { useState } from 'react';
 
 import { SnitchDialog } from '..';
 import { AutoForm, ExternalLink } from '../../components';
+import { OVERLORD_DYNAMIC_CONFIG_FIELDS, OverlordDynamicConfig } from '../../druid-models';
 import { useQueryManager } from '../../hooks';
 import { getLink } from '../../links';
 import { AppToaster } from '../../singletons/toaster';
@@ -38,7 +39,7 @@ export const OverlordDynamicConfigDialog = React.memo(function OverlordDynamicCo
   props: OverlordDynamicConfigDialogProps,
 ) {
   const { onClose } = props;
-  const [dynamicConfig, setDynamicConfig] = useState<Record<string, any>>({});
+  const [dynamicConfig, setDynamicConfig] = useState<OverlordDynamicConfig>({});
 
   const [historyRecordsState] = useQueryManager<null, any[]>({
     processQuery: async () => {
@@ -108,18 +109,9 @@ export const OverlordDynamicConfigDialog = React.memo(function OverlordDynamicCo
         .
       </p>
       <AutoForm
-        fields={[
-          {
-            name: 'selectStrategy',
-            type: 'json',
-          },
-          {
-            name: 'autoScaler',
-            type: 'json',
-          },
-        ]}
+        fields={OVERLORD_DYNAMIC_CONFIG_FIELDS}
         model={dynamicConfig}
-        onChange={m => setDynamicConfig(m)}
+        onChange={setDynamicConfig}
       />
     </SnitchDialog>
   );

--- a/web-console/src/druid-models/__snapshots__/ingestion-spec.spec.ts.snap
+++ b/web-console/src/druid-models/__snapshots__/ingestion-spec.spec.ts.snap
@@ -13,9 +13,9 @@ Object {
         ],
       },
       "granularitySpec": Object {
-        "queryGranularity": "HOUR",
+        "queryGranularity": "hour",
         "rollup": true,
-        "segmentGranularity": "DAY",
+        "segmentGranularity": "day",
         "type": "uniform",
       },
       "metricsSpec": Array [

--- a/web-console/src/druid-models/coordinator-dynamic-config.tsx
+++ b/web-console/src/druid-models/coordinator-dynamic-config.tsx
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Code } from '@blueprintjs/core';
+import React from 'react';
+
+import { Field } from '../components';
+
+export interface CoordinatorDynamicConfig {
+  maxSegmentsToMove?: number;
+  balancerComputeThreads?: number;
+  emitBalancingStats?: boolean;
+  killAllDataSources?: boolean;
+  killDataSourceWhitelist?: string[];
+  killPendingSegmentsSkipList?: string[];
+  maxSegmentsInNodeLoadingQueue?: number;
+  mergeBytesLimit?: number;
+  mergeSegmentsLimit?: number;
+  millisToWaitBeforeDeleting?: number;
+  replicantLifetime?: number;
+  replicationThrottleLimit?: number;
+  decommissioningNodes?: string[];
+  decommissioningMaxPercentOfMaxSegmentsToMove?: number;
+  pauseCoordination?: boolean;
+}
+
+export const COORDINATOR_DYNAMIC_CONFIG_FIELDS: Field<CoordinatorDynamicConfig>[] = [
+  {
+    name: 'maxSegmentsToMove',
+    type: 'number',
+    defaultValue: 5,
+    info: <>The maximum number of segments that can be moved at any given time.</>,
+  },
+  {
+    name: 'balancerComputeThreads',
+    type: 'number',
+    defaultValue: 1,
+    info: (
+      <>
+        Thread pool size for computing moving cost of segments in segment balancing. Consider
+        increasing this if you have a lot of segments and moving segments starts to get stuck.
+      </>
+    ),
+  },
+  {
+    name: 'emitBalancingStats',
+    type: 'boolean',
+    defaultValue: false,
+    info: (
+      <>
+        Boolean flag for whether or not we should emit balancing stats. This is an expensive
+        operation.
+      </>
+    ),
+  },
+  {
+    name: 'killAllDataSources',
+    type: 'boolean',
+    defaultValue: false,
+    info: (
+      <>
+        Send kill tasks for ALL dataSources if property <Code>druid.coordinator.kill.on</Code> is
+        true. If this is set to true then <Code>killDataSourceWhitelist</Code> must not be specified
+        or be empty list.
+      </>
+    ),
+  },
+  {
+    name: 'killDataSourceWhitelist',
+    type: 'string-array',
+    emptyValue: [],
+    info: (
+      <>
+        List of dataSources for which kill tasks are sent if property{' '}
+        <Code>druid.coordinator.kill.on</Code> is true. This can be a list of comma-separated
+        dataSources or a JSON array.
+      </>
+    ),
+  },
+  {
+    name: 'killPendingSegmentsSkipList',
+    type: 'string-array',
+    emptyValue: [],
+    info: (
+      <>
+        List of dataSources for which pendingSegments are NOT cleaned up if property{' '}
+        <Code>druid.coordinator.kill.pendingSegments.on</Code> is true. This can be a list of
+        comma-separated dataSources or a JSON array.
+      </>
+    ),
+  },
+  {
+    name: 'maxSegmentsInNodeLoadingQueue',
+    type: 'number',
+    defaultValue: 0,
+    info: (
+      <>
+        The maximum number of segments that could be queued for loading to any given server. This
+        parameter could be used to speed up segments loading process, especially if there are "slow"
+        nodes in the cluster (with low loading speed) or if too much segments scheduled to be
+        replicated to some particular node (faster loading could be preferred to better segments
+        distribution). Desired value depends on segments loading speed, acceptable replication time
+        and number of nodes. Value 1000 could be a start point for a rather big cluster. Default
+        value is 0 (loading queue is unbounded)
+      </>
+    ),
+  },
+  {
+    name: 'mergeBytesLimit',
+    type: 'size-bytes',
+    defaultValue: 524288000,
+    info: <>The maximum total uncompressed size in bytes of segments to merge.</>,
+  },
+  {
+    name: 'mergeSegmentsLimit',
+    type: 'number',
+    defaultValue: 100,
+    info: <>The maximum number of segments that can be in a single append task.</>,
+  },
+  {
+    name: 'millisToWaitBeforeDeleting',
+    type: 'number',
+    defaultValue: 900000,
+    info: (
+      <>
+        How long does the Coordinator need to be active before it can start removing (marking
+        unused) segments in metadata storage.
+      </>
+    ),
+  },
+  {
+    name: 'replicantLifetime',
+    type: 'number',
+    defaultValue: 15,
+    info: (
+      <>
+        The maximum number of Coordinator runs for a segment to be replicated before we start
+        alerting.
+      </>
+    ),
+  },
+  {
+    name: 'replicationThrottleLimit',
+    type: 'number',
+    defaultValue: 10,
+    info: <>The maximum number of segments that can be replicated at one time.</>,
+  },
+  {
+    name: 'decommissioningNodes',
+    type: 'string-array',
+    emptyValue: [],
+    info: (
+      <>
+        List of historical services to 'decommission'. Coordinator will not assign new segments to
+        'decommissioning' services, and segments will be moved away from them to be placed on
+        non-decommissioning services at the maximum rate specified by{' '}
+        <Code>decommissioningMaxPercentOfMaxSegmentsToMove</Code>.
+      </>
+    ),
+  },
+  {
+    name: 'decommissioningMaxPercentOfMaxSegmentsToMove',
+    type: 'number',
+    defaultValue: 70,
+    info: (
+      <>
+        The maximum number of segments that may be moved away from 'decommissioning' services to
+        non-decommissioning (that is, active) services during one Coordinator run. This value is
+        relative to the total maximum segment movements allowed during one run which is determined
+        by <Code>maxSegmentsToMove</Code>. If
+        <Code>decommissioningMaxPercentOfMaxSegmentsToMove</Code> is 0, segments will neither be
+        moved from or to 'decommissioning' services, effectively putting them in a sort of
+        "maintenance" mode that will not participate in balancing or assignment by load rules.
+        Decommissioning can also become stalled if there are no available active services to place
+        the segments. By leveraging the maximum percent of decommissioning segment movements, an
+        operator can prevent active services from overload by prioritizing balancing, or decrease
+        decommissioning time instead. The value should be between 0 and 100.
+      </>
+    ),
+  },
+  {
+    name: 'pauseCoordination',
+    type: 'boolean',
+    defaultValue: false,
+    info: (
+      <>
+        Boolean flag for whether or not the coordinator should execute its various duties of
+        coordinating the cluster. Setting this to true essentially pauses all coordination work
+        while allowing the API to remain up.
+      </>
+    ),
+  },
+];

--- a/web-console/src/druid-models/ingestion-spec.spec.ts
+++ b/web-console/src/druid-models/ingestion-spec.spec.ts
@@ -219,7 +219,7 @@ describe('spec utils', () => {
               ],
             },
             "granularitySpec": Object {
-              "queryGranularity": "HOUR",
+              "queryGranularity": "hour",
               "rollup": true,
               "segmentGranularity": "DAY",
               "type": "uniform",

--- a/web-console/src/druid-models/ingestion-spec.spec.ts
+++ b/web-console/src/druid-models/ingestion-spec.spec.ts
@@ -45,8 +45,8 @@ describe('ingestion-spec', () => {
         dataSource: 'wikipedia',
         granularitySpec: {
           type: 'uniform',
-          segmentGranularity: 'DAY',
-          queryGranularity: 'HOUR',
+          segmentGranularity: 'day',
+          queryGranularity: 'hour',
           rollup: true,
         },
         parser: {
@@ -183,8 +183,8 @@ describe('spec utils', () => {
         dataSource: 'wikipedia',
         granularitySpec: {
           type: 'uniform',
-          segmentGranularity: 'DAY',
-          queryGranularity: 'HOUR',
+          segmentGranularity: 'day',
+          queryGranularity: 'hour',
         },
         timestampSpec: {
           column: 'timestamp',
@@ -221,7 +221,7 @@ describe('spec utils', () => {
             "granularitySpec": Object {
               "queryGranularity": "hour",
               "rollup": true,
-              "segmentGranularity": "DAY",
+              "segmentGranularity": "day",
               "type": "uniform",
             },
             "metricsSpec": Array [

--- a/web-console/src/druid-models/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec.tsx
@@ -475,7 +475,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Dimensions',
           type: 'string-array',
           placeholder: '(optional)',
-          advanced: true,
+          hideInMore: true,
           info: (
             <p>
               The list of dimensions to select. If left empty, no dimensions are returned. If left
@@ -488,7 +488,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Metrics',
           type: 'string-array',
           placeholder: '(optional)',
-          advanced: true,
+          hideInMore: true,
           info: (
             <p>
               The list of metrics to select. If left empty, no metrics are returned. If left null or
@@ -501,7 +501,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Filter',
           type: 'json',
           placeholder: '(optional)',
-          advanced: true,
+          hideInMore: true,
           info: (
             <p>
               The{' '}
@@ -1567,6 +1567,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 3,
     defined: (t: TuningConfig) => t.type === 'index_parallel',
+    hideInMore: true,
     info: <>Maximum number of retries on task failures.</>,
   },
   {
@@ -1574,8 +1575,35 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 1000,
     defined: (t: TuningConfig) => t.type === 'index_parallel',
-    advanced: true,
+    hideInMore: true,
     info: <>Polling period in milliseconds to check running task statuses.</>,
+  },
+  {
+    name: 'totalNumMergeTasks',
+    type: 'number',
+    defaultValue: 10,
+    min: 1,
+    defined: (t: TuningConfig) =>
+      Boolean(
+        t.type === 'index_parallel' &&
+          oneOf(deepGet(t, 'partitionsSpec.type'), 'hashed', 'single_dim'),
+      ),
+    info: <>Number of tasks to merge partial segments after shuffle.</>,
+  },
+  {
+    name: 'maxNumSegmentsToMerge',
+    type: 'number',
+    defaultValue: 100,
+    defined: (t: TuningConfig) =>
+      Boolean(
+        t.type === 'index_parallel' &&
+          oneOf(deepGet(t, 'partitionsSpec.type'), 'hashed', 'single_dim'),
+      ),
+    info: (
+      <>
+        Max limit for the number of segments a single task can merge at the same time after shuffle.
+      </>
+    ),
   },
   {
     name: 'maxRowsInMemory',
@@ -1588,33 +1616,6 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     placeholder: 'Default: 1/6 of max JVM memory',
     info: <>Used in determining when intermediate persists to disk should occur.</>,
-  },
-  {
-    name: 'totalNumMergeTasks',
-    type: 'number',
-    defaultValue: 10,
-    min: 1,
-    defined: (t: TuningConfig) =>
-      Boolean(
-        t.type === 'index_parallel' &&
-          oneOf(deepGet(t, 'tuningConfig.partitionsSpec.type'), 'hashed', 'single_dim'),
-      ),
-    info: <>Number of tasks to merge partial segments after shuffle.</>,
-  },
-  {
-    name: 'maxNumSegmentsToMerge',
-    type: 'number',
-    defaultValue: 100,
-    defined: (t: TuningConfig) =>
-      Boolean(
-        t.type === 'index_parallel' &&
-          oneOf(deepGet(t, 'tuningConfig.partitionsSpec.type'), 'hashed', 'single_dim'),
-      ),
-    info: (
-      <>
-        Max limit for the number of segments a single task can merge at the same time after shuffle.
-      </>
-    ),
   },
   {
     name: 'resetOffsetAutomatically',
@@ -1664,7 +1665,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
   {
     name: 'maxPendingPersists',
     type: 'number',
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         Maximum number of persists that can be pending but not started. If this limit would be
@@ -1677,7 +1678,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     name: 'pushTimeout',
     type: 'number',
     defaultValue: 0,
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         Milliseconds to wait for pushing segments. It must be >= 0, where 0 means to wait forever.
@@ -1689,7 +1690,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 0,
     defined: (t: TuningConfig) => oneOf(t.type, 'kafka', 'kinesis'),
-    advanced: true,
+    hideInMore: true,
     info: <>Milliseconds to wait for segment handoff. 0 means to wait forever.</>,
   },
   {
@@ -1698,6 +1699,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'string',
     defaultValue: 'roaring',
     suggestions: ['concise', 'roaring'],
+    hideInMore: true,
     info: <>Compression format for bitmap indexes.</>,
   },
   {
@@ -1706,6 +1708,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'string',
     defaultValue: 'lz4',
     suggestions: ['lz4', 'lzf', 'uncompressed'],
+    hideInMore: true,
     info: <>Compression format for dimension columns.</>,
   },
   {
@@ -1714,6 +1717,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'string',
     defaultValue: 'lz4',
     suggestions: ['lz4', 'lzf', 'uncompressed'],
+    hideInMore: true,
     info: <>Compression format for primitive type metric columns.</>,
   },
   {
@@ -1722,6 +1726,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'string',
     defaultValue: 'longs',
     suggestions: ['longs', 'auto'],
+    hideInMore: true,
     info: (
       <>
         Encoding format for long-typed columns. Applies regardless of whether they are dimensions or
@@ -1736,7 +1741,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'duration',
     defaultValue: 'PT10S',
     defined: (t: TuningConfig) => t.type === 'index_parallel',
-    advanced: true,
+    hideInMore: true,
     info: <>Timeout for reporting the pushed segments in worker tasks.</>,
   },
   {
@@ -1744,7 +1749,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 5,
     defined: (t: TuningConfig) => t.type === 'index_parallel',
-    advanced: true,
+    hideInMore: true,
     info: <>Retries for reporting the pushed segments in worker tasks.</>,
   },
   {
@@ -1761,7 +1766,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     placeholder: 'min(10, taskCount * replicas)',
     defined: (t: TuningConfig) => oneOf(t.type, 'kafka', 'kinesis'),
-    advanced: true,
+    hideInMore: true,
     info: <>The number of threads that will be used for communicating with indexing tasks.</>,
   },
   {
@@ -1769,7 +1774,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 8,
     defined: (t: TuningConfig) => oneOf(t.type, 'kafka', 'kinesis'),
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         The number of times HTTP requests to indexing tasks will be retried before considering tasks
@@ -1789,7 +1794,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'duration',
     defaultValue: 'PT80S',
     defined: (t: TuningConfig) => oneOf(t.type, 'kafka', 'kinesis'),
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         How long to wait for the supervisor to attempt a graceful shutdown of tasks before exiting.
@@ -1825,7 +1830,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 5000,
     defined: (t: TuningConfig) => t.type === 'kinesis',
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         Length of time in milliseconds to wait for space to become available in the buffer before
@@ -1835,7 +1840,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
   },
   {
     name: 'recordBufferFullWait',
-    advanced: true,
+    hideInMore: true,
     type: 'number',
     defaultValue: 5000,
     defined: (t: TuningConfig) => t.type === 'kinesis',
@@ -1851,7 +1856,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 60000,
     defined: (t: TuningConfig) => t.type === 'kinesis',
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         Length of time in milliseconds to wait for Kinesis to return the earliest or latest sequence
@@ -1866,7 +1871,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     placeholder: 'max(1, {numProcessors} - 1)',
     defined: (t: TuningConfig) => t.type === 'kinesis',
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         Size of the pool of threads fetching data from Kinesis. There is no benefit in having more
@@ -1879,7 +1884,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'number',
     defaultValue: 100,
     defined: (t: TuningConfig) => t.type === 'kinesis',
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         The maximum number of records/events to be fetched from buffer per poll. The actual maximum
@@ -1892,7 +1897,7 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     type: 'duration',
     defaultValue: 'PT2M',
     defined: (t: TuningConfig) => t.type === 'kinesis',
-    advanced: true,
+    hideInMore: true,
     info: (
       <>
         <p>

--- a/web-console/src/druid-models/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec.tsx
@@ -1923,8 +1923,8 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     info: (
       <>
         <p>
-          When shards are split or merged, the supervisor will recompute shard -> task group
-          mappings, and signal any running tasks created under the old mappings to stop early at{' '}
+          When shards are split or merged, the supervisor will recompute shard, task group mappings,
+          and signal any running tasks created under the old mappings to stop early at{' '}
           <Code>(current time + repartitionTransitionDuration)</Code>. Stopping the tasks early
           allows Druid to begin reading from the new shards more quickly.
         </p>

--- a/web-console/src/druid-models/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec.tsx
@@ -983,45 +983,6 @@ export function getIoConfigTuningFormFields(
             </>
           ),
         },
-        {
-          name: 'inputSource.maxCacheCapacityBytes',
-          label: 'Max cache capacity bytes',
-          type: 'number',
-          defaultValue: 1073741824,
-          info: (
-            <>
-              <p>
-                Maximum size of the cache space in bytes. 0 means disabling cache. Cached files are
-                not removed until the ingestion task completes.
-              </p>
-            </>
-          ),
-        },
-        {
-          name: 'inputSource.maxFetchCapacityBytes',
-          label: 'Max fetch capacity bytes',
-          type: 'number',
-          defaultValue: 1073741824,
-          info: (
-            <>
-              <p>
-                Maximum size of the fetch space in bytes. 0 means disabling prefetch. Prefetched
-                files are removed immediately once they are read.
-              </p>
-            </>
-          ),
-        },
-        {
-          name: 'inputSource.prefetchTriggerBytes',
-          label: 'Prefetch trigger bytes',
-          type: 'number',
-          placeholder: 'maxFetchCapacityBytes / 2',
-          info: (
-            <>
-              <p>Threshold to trigger prefetching the objects.</p>
-            </>
-          ),
-        },
       ];
 
     case 'index_parallel:local':
@@ -2091,14 +2052,14 @@ export function updateSchemaWithSample(
   }
 
   if (rollup) {
-    newSpec = deepSet(newSpec, 'spec.dataSchema.granularitySpec.queryGranularity', 'HOUR');
+    newSpec = deepSet(newSpec, 'spec.dataSchema.granularitySpec.queryGranularity', 'hour');
 
     const metrics = getMetricSpecs(headerAndRows, typeHints);
     if (metrics) {
       newSpec = deepSet(newSpec, 'spec.dataSchema.metricsSpec', metrics);
     }
   } else {
-    newSpec = deepSet(newSpec, 'spec.dataSchema.granularitySpec.queryGranularity', 'NONE');
+    newSpec = deepSet(newSpec, 'spec.dataSchema.granularitySpec.queryGranularity', 'none');
     newSpec = deepDelete(newSpec, 'spec.dataSchema.metricsSpec');
   }
 

--- a/web-console/src/druid-models/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec.tsx
@@ -1429,6 +1429,8 @@ export function getPartitionRelatedTuningSpecFormFields(
           name: 'partitionsSpec.targetRowsPerSegment',
           label: 'Target rows per segment',
           type: 'number',
+          zeroMeansUndefined: true,
+          defaultValue: 5000000,
           defined: (t: TuningConfig) =>
             deepGet(t, 'partitionsSpec.type') === 'hashed' &&
             !deepGet(t, 'partitionsSpec.numShards'),
@@ -1450,6 +1452,8 @@ export function getPartitionRelatedTuningSpecFormFields(
           name: 'partitionsSpec.numShards',
           label: 'Num shards',
           type: 'number',
+          zeroMeansUndefined: true,
+          hideInMore: true,
           defined: (t: TuningConfig) =>
             deepGet(t, 'partitionsSpec.type') === 'hashed' &&
             !deepGet(t, 'partitionsSpec.targetRowsPerSegment'),
@@ -1975,7 +1979,6 @@ export function updateIngestionType(
 }
 
 export function issueWithSampleData(sampleData: string[]): JSX.Element | undefined {
-  console.log(sampleData);
   if (sampleData.length) {
     const firstData = sampleData[0];
 

--- a/web-console/src/druid-models/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec.tsx
@@ -47,7 +47,7 @@ import {
   getMetricSpecSingleFieldName,
   MetricSpec,
 } from './metric-spec';
-import { PLACEHOLDER_TIMESTAMP_SPEC, TimestampSpec } from './timestamp-spec';
+import { TimestampSpec } from './timestamp-spec';
 import { TransformSpec } from './transform-spec';
 
 export const MAX_INLINE_DATA_LENGTH = 65536;
@@ -475,6 +475,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Dimensions',
           type: 'string-array',
           placeholder: '(optional)',
+          advanced: true,
           info: (
             <p>
               The list of dimensions to select. If left empty, no dimensions are returned. If left
@@ -487,6 +488,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Metrics',
           type: 'string-array',
           placeholder: '(optional)',
+          advanced: true,
           info: (
             <p>
               The list of metrics to select. If left empty, no metrics are returned. If left null or
@@ -499,6 +501,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Filter',
           type: 'json',
           placeholder: '(optional)',
+          advanced: true,
           info: (
             <p>
               The{' '}
@@ -1943,34 +1946,6 @@ export function updateIngestionType(
 
   if (inputSourceType) {
     newSpec = deepSet(newSpec, 'spec.ioConfig.inputSource', { type: inputSourceType });
-
-    if (inputSourceType === 'local') {
-      newSpec = deepSet(newSpec, 'spec.ioConfig.inputSource.filter', '*');
-    }
-  }
-
-  if (!deepGet(spec, 'spec.dataSchema.dataSource')) {
-    newSpec = deepSet(newSpec, 'spec.dataSchema.dataSource', 'new-data-source');
-  }
-
-  if (!deepGet(spec, 'spec.dataSchema.granularitySpec')) {
-    const granularitySpec: GranularitySpec = {
-      type: 'uniform',
-      queryGranularity: 'HOUR',
-    };
-    if (ingestionType !== 'index_parallel') {
-      granularitySpec.segmentGranularity = 'HOUR';
-    }
-
-    newSpec = deepSet(newSpec, 'spec.dataSchema.granularitySpec', granularitySpec);
-  }
-
-  if (!deepGet(spec, 'spec.dataSchema.timestampSpec')) {
-    newSpec = deepSet(newSpec, 'spec.dataSchema.timestampSpec', PLACEHOLDER_TIMESTAMP_SPEC);
-  }
-
-  if (!deepGet(spec, 'spec.dataSchema.dimensionsSpec')) {
-    newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec', {});
   }
 
   return newSpec;
@@ -2091,7 +2066,8 @@ export function updateSchemaWithSample(
   let newSpec = spec;
 
   if (dimensionMode === 'auto-detect') {
-    newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.dimensions', []);
+    newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.dimensions');
+    newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.dimensionExclusions', []);
   } else {
     newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.dimensionExclusions');
 

--- a/web-console/src/druid-models/input-format.tsx
+++ b/web-console/src/druid-models/input-format.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { Code } from '@blueprintjs/core';
 import React from 'react';
 
 import { AutoForm, ExternalLink, Field } from '../components';
@@ -69,12 +70,6 @@ export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
     defined: (p: InputFormat) => p.type === 'javascript',
   },
   {
-    name: 'findColumnsFromHeader',
-    type: 'boolean',
-    required: true,
-    defined: (p: InputFormat) => oneOf(p.type, 'csv', 'tsv'),
-  },
-  {
     name: 'skipHeaderRows',
     type: 'number',
     defaultValue: 0,
@@ -82,9 +77,22 @@ export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
     min: 0,
     info: (
       <>
-        If both skipHeaderRows and hasHeaderRow options are set, skipHeaderRows is first applied.
-        For example, if you set skipHeaderRows to 2 and hasHeaderRow to true, Druid will skip the
-        first two lines and then extract column information from the third line.
+        If this is set, skip the first <Code>skipHeaderRows</Code> rows from each file.
+      </>
+    ),
+  },
+  {
+    name: 'findColumnsFromHeader',
+    type: 'boolean',
+    required: true,
+    defined: (p: InputFormat) => oneOf(p.type, 'csv', 'tsv'),
+    info: (
+      <>
+        If this is set, find the column names from the header row. Note that
+        <Code>skipHeaderRows</Code> will be applied before finding column names from the header. For
+        example, if you set <Code>skipHeaderRows</Code> to 2 and <Code>findColumnsFromHeader</Code>{' '}
+        to true, the task will skip the first two lines and then extract column information from the
+        third line.
       </>
     ),
   },
@@ -93,7 +101,13 @@ export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
     type: 'string-array',
     required: true,
     defined: (p: InputFormat) =>
-      (oneOf(p.type, 'csv', 'tsv') && !p.findColumnsFromHeader) || p.type === 'regex',
+      (oneOf(p.type, 'csv', 'tsv') && p.findColumnsFromHeader === false) || p.type === 'regex',
+    info: (
+      <>
+        Specifies the columns of the data. The columns should be in the same order with the columns
+        of your data.
+      </>
+    ),
   },
   {
     name: 'delimiter',
@@ -106,6 +120,7 @@ export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
     name: 'listDelimiter',
     type: 'string',
     defined: (p: InputFormat) => oneOf(p.type, 'csv', 'tsv', 'regex'),
+    placeholder: '(optional, default = ctrl+A)',
     info: <>A custom delimiter for multi-value dimensions.</>,
   },
   {

--- a/web-console/src/druid-models/overlord-dynamic-config.tsx
+++ b/web-console/src/druid-models/overlord-dynamic-config.tsx
@@ -16,18 +16,20 @@
  * limitations under the License.
  */
 
-export * from './compaction-config';
-export * from './compaction-status';
-export * from './lookup-spec';
-export * from './time';
-export * from './timestamp-spec';
-export * from './transform-spec';
-export * from './input-source';
-export * from './input-format';
-export * from './flatten-spec';
-export * from './filter';
-export * from './dimension-spec';
-export * from './metric-spec';
-export * from './ingestion-spec';
-export * from './coordinator-dynamic-config';
-export * from './overlord-dynamic-config';
+import { Field } from '../components';
+
+export interface OverlordDynamicConfig {
+  selectStrategy?: Record<string, any>;
+  autoScaler?: Record<string, any>;
+}
+
+export const OVERLORD_DYNAMIC_CONFIG_FIELDS: Field<OverlordDynamicConfig>[] = [
+  {
+    name: 'selectStrategy',
+    type: 'json',
+  },
+  {
+    name: 'autoScaler',
+    type: 'json',
+  },
+];

--- a/web-console/src/druid-models/timestamp-spec.tsx
+++ b/web-console/src/druid-models/timestamp-spec.tsx
@@ -123,7 +123,7 @@ export const TIMESTAMP_SPEC_FIELDS: Field<TimestampSpec>[] = [
     ],
     info: (
       <p>
-        Please specify your timestamp format by using the suggestions menu or typing in a{' '}
+        Specify your timestamp format by using the suggestions menu or typing in a{' '}
         <ExternalLink href="https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html">
           format string
         </ExternalLink>
@@ -135,7 +135,10 @@ export const TIMESTAMP_SPEC_FIELDS: Field<TimestampSpec>[] = [
     name: 'missingValue',
     type: 'string',
     placeholder: '(optional)',
-    info: <p>This value will be used if the specified column can not be found.</p>,
+    info: (
+      <p>Specify a static value for cases when the source time column is missing or is null.</p>
+    ),
+    suggestions: ['2020-01-01T00:00:00Z'],
   },
 ];
 

--- a/web-console/src/druid-models/transform-spec.tsx
+++ b/web-console/src/druid-models/transform-spec.tsx
@@ -75,6 +75,7 @@ export function getTimestampExpressionFields(transforms: Transform[]): Field<Tra
         `timestamp_parse(concat("date", ' ', "time"))`,
         `timestamp_parse(concat("date", ' ', "time"), 'M/d/yyyy H:mm:ss')`,
         `timestamp_parse(concat("year", '-', "month", '-', "day"))`,
+        `timestamp_parse("local_time", 'yyyy-MM-dd HH:mm:ss', "timezone")`,
       ],
       info: (
         <>

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -24,6 +24,7 @@ import {
   formatMegabytes,
   formatMillions,
   formatPercent,
+  moveElement,
   sortWithPrefixSuffix,
   sqlQueryCustomTableFilter,
   swapElements,
@@ -93,6 +94,15 @@ describe('general', () => {
     it('works downward', () => {
       expect(swapElements(array, 2, 3)).toEqual(['a', 'b', 'd', 'c', 'e']);
       expect(swapElements(array, 2, 4)).toEqual(['a', 'b', 'e', 'd', 'c']);
+    });
+  });
+
+  describe('moveElement', () => {
+    it('moves items in an array', () => {
+      expect(moveElement(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b']);
+      expect(moveElement(['a', 'b', 'c'], 1, 1)).toEqual(['a', 'b', 'c']);
+      expect(moveElement(['F', 'B', 'W', 'B'], 2, 1)).toEqual(['F', 'W', 'B', 'B']);
+      expect(moveElement([1, 2, 3], 2, 1)).toEqual([1, 3, 2]);
     });
   });
 

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -306,7 +306,7 @@ export function sortWithPrefixSuffix(
   things: readonly string[],
   prefix: readonly string[],
   suffix: readonly string[],
-  cmp: null | ((a: string, b: string) => number),
+  cmp?: (a: string, b: string) => number,
 ): string[] {
   const pre = uniq(prefix.filter(x => things.includes(x)));
   const mid = things.filter(x => !prefix.includes(x) && !suffix.includes(x));
@@ -355,4 +355,29 @@ export function swapElements<T>(items: readonly T[], indexA: number, indexB: num
   newItems[indexA] = newItems[indexB];
   newItems[indexB] = t;
   return newItems;
+}
+
+export function moveElement<T>(items: readonly T[], fromIndex: number, toIndex: number): T[] {
+  const indexDiff = fromIndex - toIndex;
+  if (indexDiff > 0) {
+    // move left
+    return [
+      ...items.slice(0, toIndex),
+      items[fromIndex],
+      ...items.slice(toIndex, fromIndex),
+      ...items.slice(fromIndex + 1, items.length),
+    ];
+  } else if (indexDiff < 0) {
+    // move right
+    const targetIndex = toIndex + 1;
+    return [
+      ...items.slice(0, fromIndex),
+      ...items.slice(fromIndex + 1, targetIndex),
+      items[fromIndex],
+      ...items.slice(targetIndex, items.length),
+    ];
+  } else {
+    // do nothing
+    return items.slice();
+  }
 }

--- a/web-console/src/utils/query-manager.tsx
+++ b/web-console/src/utils/query-manager.tsx
@@ -95,6 +95,7 @@ export class QueryManager<Q, R> {
         this.setState(
           new QueryState<R>({
             data,
+            lastData: this.state.getSomeData(),
           }),
         );
       },
@@ -107,6 +108,7 @@ export class QueryManager<Q, R> {
         this.setState(
           new QueryState<R>({
             error: e,
+            lastData: this.state.getSomeData(),
           }),
         );
       },
@@ -119,6 +121,7 @@ export class QueryManager<Q, R> {
     this.setState(
       new QueryState<R>({
         loading: true,
+        lastData: this.state.getSomeData(),
       }),
     );
 

--- a/web-console/src/utils/query-state.ts
+++ b/web-console/src/utils/query-state.ts
@@ -18,6 +18,13 @@
 
 export type QueryStateState = 'init' | 'loading' | 'data' | 'error';
 
+export interface QueryStateOptions<T, E extends Error = Error> {
+  loading?: boolean;
+  error?: E;
+  data?: T;
+  lastData?: T;
+}
+
 export class QueryState<T, E extends Error = Error> {
   static INIT: QueryState<any> = new QueryState({});
   static LOADING: QueryState<any> = new QueryState({ loading: true });
@@ -25,8 +32,9 @@ export class QueryState<T, E extends Error = Error> {
   public state: QueryStateState = 'init';
   public error?: E;
   public data?: T;
+  public lastData?: T;
 
-  constructor(opts: { loading?: boolean; error?: E; data?: T }) {
+  constructor(opts: QueryStateOptions<T, E>) {
     const hasData = typeof opts.data !== 'undefined';
     if (typeof opts.error !== 'undefined') {
       if (hasData) {
@@ -43,6 +51,7 @@ export class QueryState<T, E extends Error = Error> {
         this.state = opts.loading ? 'loading' : 'init';
       }
     }
+    this.lastData = opts.lastData;
   }
 
   isInit(): boolean {
@@ -70,5 +79,9 @@ export class QueryState<T, E extends Error = Error> {
   isEmpty(): boolean {
     const { data } = this;
     return Boolean(data && Array.isArray(data) && data.length === 0);
+  }
+
+  getSomeData(): T | undefined {
+    return this.data || this.lastData;
   }
 }

--- a/web-console/src/utils/utils.spec.ts
+++ b/web-console/src/utils/utils.spec.ts
@@ -41,8 +41,8 @@ describe('utils', () => {
         dataSource: 'wikipedia',
         granularitySpec: {
           type: 'uniform',
-          segmentGranularity: 'DAY',
-          queryGranularity: 'HOUR',
+          segmentGranularity: 'day',
+          queryGranularity: 'hour',
         },
         timestampSpec: {
           column: 'timestamp',
@@ -89,8 +89,8 @@ describe('utils', () => {
             "dataSource": "wikipedia",
             "dimensionsSpec": Object {},
             "granularitySpec": Object {
-              "queryGranularity": "HOUR",
-              "segmentGranularity": "DAY",
+              "queryGranularity": "hour",
+              "segmentGranularity": "day",
               "type": "uniform",
             },
             "timestampSpec": Object {

--- a/web-console/src/utils/utils.spec.ts
+++ b/web-console/src/utils/utils.spec.ts
@@ -56,8 +56,11 @@ describe('utils', () => {
   // const cacheRows: CacheRows = [{ make: 'Honda', model: 'Civic' }, { make: 'BMW', model: 'M3' }];
 
   it('spec-utils headerFromSampleResponse', () => {
-    expect(headerFromSampleResponse({ data: [{ input: { a: 1 }, parsed: { a: 1 } }] }))
-      .toMatchInlineSnapshot(`
+    expect(
+      headerFromSampleResponse({
+        sampleResponse: { data: [{ input: { a: 1 }, parsed: { a: 1 } }] },
+      }),
+    ).toMatchInlineSnapshot(`
       Array [
         "a",
       ]

--- a/web-console/src/views/load-data-view/__snapshots__/load-data-view.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/__snapshots__/load-data-view.spec.tsx.snap
@@ -46,15 +46,6 @@ exports[`load data view matches snapshot 1`] = `
           onClick={[Function]}
           text="Parse data"
         />
-        <Blueprint3.Button
-          active={false}
-          className="timestamp"
-          disabled={true}
-          icon={false}
-          key="timestamp"
-          onClick={[Function]}
-          text="Parse time"
-        />
       </Blueprint3.ButtonGroup>
     </div>
     <div
@@ -69,6 +60,15 @@ exports[`load data view matches snapshot 1`] = `
       <Blueprint3.ButtonGroup
         className="step-nav-l2"
       >
+        <Blueprint3.Button
+          active={false}
+          className="timestamp"
+          disabled={true}
+          icon={false}
+          key="timestamp"
+          onClick={[Function]}
+          text="Parse time"
+        />
         <Blueprint3.Button
           active={false}
           className="transform"

--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -184,13 +184,13 @@ export const PublishMessage = React.memo(function PublishMessage() {
 export const SpecMessage = React.memo(function SpecMessage() {
   return (
     <Callout className="intro">
-      <p className="optional">Optional</p>
       <p>
         Druid begins ingesting data once you submit a JSON ingestion spec. If you modify any values
         in this view, the values entered in previous sections will update accordingly. If you modify
         any values in previous sections, this spec will automatically update.
       </p>
       <p>Submit the spec to begin loading data into Druid.</p>
+      <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#ingestion-specs`} />
     </Callout>
   );
 });

--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -103,7 +103,6 @@ export const TimestampMessage = React.memo(function TimestampMessage() {
 export const TransformMessage = React.memo(function TransformMessage() {
   return (
     <Callout className="intro">
-      <p className="optional">Optional</p>
       <p>
         Druid can perform per-row{' '}
         <ExternalLink href={`${getLink('DOCS')}/ingestion/transform-spec.html#transforms`}>
@@ -119,11 +118,9 @@ export const TransformMessage = React.memo(function TransformMessage() {
 export const FilterMessage = React.memo(function FilterMessage() {
   return (
     <Callout className="intro">
-      <p className="optional">Optional</p>
       <p>
-        Druid can{' '}
-        <ExternalLink href={`${getLink('DOCS')}/querying/filters.html`}>filter</ExternalLink> out
-        unwanted data by applying per-row filters.
+        Druid can filter out unwanted data by applying per-row{' '}
+        <ExternalLink href={`${getLink('DOCS')}/querying/filters.html`}>filters</ExternalLink>.
       </p>
       <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#filter`} />
     </Callout>
@@ -156,7 +153,6 @@ export const SchemaMessage = React.memo(function SchemaMessage(props: SchemaMess
 export const PartitionMessage = React.memo(function PartitionMessage() {
   return (
     <Callout className="intro">
-      <p className="optional">Optional</p>
       <p>Configure how Druid will partition data.</p>
       <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#partitioning`} />
     </Callout>
@@ -166,7 +162,6 @@ export const PartitionMessage = React.memo(function PartitionMessage() {
 export const TuningMessage = React.memo(function TuningMessage() {
   return (
     <Callout className="intro">
-      <p className="optional">Optional</p>
       <p>Fine tune how Druid will ingest data.</p>
       <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#tuningconfig`} />
     </Callout>

--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -91,9 +91,9 @@ export const TimestampMessage = React.memo(function TimestampMessage() {
       </p>
       <p>Configure how to define the time column for this data.</p>
       <p>
-        If your data does not have a time column, you can select "None" to use a placeholder value.
-        If the time information is spread across multiple columns you can combine them into one by
-        selecting "Expression" and defining a transform expression.
+        If your data does not have a time column, you can select <Code>None</Code> to use a
+        placeholder value. If the time information is spread across multiple columns you can combine
+        them into one by selecting <Code>Expression</Code> and defining a transform expression.
       </p>
       <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#timestampspec`} />
     </Callout>

--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Callout, Code } from '@blueprintjs/core';
+import React from 'react';
+
+import { ExternalLink } from '../../components';
+import { DimensionMode, getIngestionDocLink, IngestionSpec } from '../../druid-models';
+import { getLink } from '../../links';
+
+import { LearnMore } from './learn-more/learn-more';
+
+export interface ConnectMessageProps {
+  inlineMode: boolean;
+  spec: IngestionSpec;
+}
+
+export const ConnectMessage = React.memo(function ConnectMessage(props: ConnectMessageProps) {
+  const { inlineMode, spec } = props;
+
+  return (
+    <Callout className="intro">
+      <p>
+        Druid ingests raw data and converts it into a custom,{' '}
+        <ExternalLink href={`${getLink('DOCS')}/design/segments.html`}>indexed format</ExternalLink>{' '}
+        that is optimized for analytic queries.
+      </p>
+      {inlineMode ? (
+        <>
+          <p>To get started, please paste some data in the box to the left.</p>
+          <p>Click "Apply" to verify your data with Druid.</p>
+        </>
+      ) : (
+        <p>To get started, please specify what data you want to ingest.</p>
+      )}
+      <LearnMore href={getIngestionDocLink(spec)} />
+    </Callout>
+  );
+});
+
+export interface ParserMessageProps {
+  canFlatten: boolean;
+}
+
+export const ParserMessage = React.memo(function ParserMessage(props: ParserMessageProps) {
+  const { canFlatten } = props;
+
+  return (
+    <Callout className="intro">
+      <p>
+        Druid requires flat data (non-nested, non-hierarchical). Each row should represent a
+        discrete event.
+      </p>
+      {canFlatten && (
+        <p>
+          If you have nested data, you can{' '}
+          <ExternalLink href={`${getLink('DOCS')}/ingestion/index.html#flattenspec`}>
+            flatten
+          </ExternalLink>{' '}
+          it here. If the provided flattening capabilities are not sufficient, please pre-process
+          your data before ingesting it into Druid.
+        </p>
+      )}
+      <p>Ensure that your data appears correctly in a row/column orientation.</p>
+      <LearnMore href={`${getLink('DOCS')}/ingestion/data-formats.html`} />
+    </Callout>
+  );
+});
+
+export const TimestampMessage = React.memo(function TimestampMessage() {
+  return (
+    <Callout className="intro">
+      <p>
+        Druid partitions data based on the primary time column of your data. This column is stored
+        internally in Druid as <Code>__time</Code>.
+      </p>
+      <p>Configure how to define the time column for this data.</p>
+      <p>
+        If your data does not have a time column, you can select "None" to use a placeholder value.
+        If the time information is spread across multiple columns you can combine them into one by
+        selecting "Expression" and defining a transform expression.
+      </p>
+      <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#timestampspec`} />
+    </Callout>
+  );
+});
+
+export const TransformMessage = React.memo(function TransformMessage() {
+  return (
+    <Callout className="intro">
+      <p className="optional">Optional</p>
+      <p>
+        Druid can perform per-row{' '}
+        <ExternalLink href={`${getLink('DOCS')}/ingestion/transform-spec.html#transforms`}>
+          transforms
+        </ExternalLink>{' '}
+        of column values allowing you to create new derived columns or alter existing column.
+      </p>
+      <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#transforms`} />
+    </Callout>
+  );
+});
+
+export const FilterMessage = React.memo(function FilterMessage() {
+  return (
+    <Callout className="intro">
+      <p className="optional">Optional</p>
+      <p>
+        Druid can{' '}
+        <ExternalLink href={`${getLink('DOCS')}/querying/filters.html`}>filter</ExternalLink> out
+        unwanted data by applying per-row filters.
+      </p>
+      <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#filter`} />
+    </Callout>
+  );
+});
+
+export interface SchemaMessageProps {
+  dimensionMode: DimensionMode;
+}
+
+export const SchemaMessage = React.memo(function SchemaMessage(props: SchemaMessageProps) {
+  const { dimensionMode } = props;
+
+  return (
+    <Callout className="intro">
+      <p>
+        Each column in Druid must have an assigned type (string, long, float, double, complex, etc).
+      </p>
+      {dimensionMode === 'specific' && (
+        <p>
+          Default primitive types have been automatically assigned to your columns. If you want to
+          change the type, click on the column header.
+        </p>
+      )}
+      <LearnMore href={`${getLink('DOCS')}/ingestion/schema-design.html`} />
+    </Callout>
+  );
+});
+
+export const PartitionMessage = React.memo(function PartitionMessage() {
+  return (
+    <Callout className="intro">
+      <p className="optional">Optional</p>
+      <p>Configure how Druid will partition data.</p>
+      <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#partitioning`} />
+    </Callout>
+  );
+});
+
+export const TuningMessage = React.memo(function TuningMessage() {
+  return (
+    <Callout className="intro">
+      <p className="optional">Optional</p>
+      <p>Fine tune how Druid will ingest data.</p>
+      <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#tuningconfig`} />
+    </Callout>
+  );
+});
+
+export const PublishMessage = React.memo(function PublishMessage() {
+  return (
+    <Callout className="intro">
+      <p>Configure behavior of indexed data once it reaches Druid.</p>
+    </Callout>
+  );
+});
+
+export const SpecMessage = React.memo(function SpecMessage() {
+  return (
+    <Callout className="intro">
+      <p className="optional">Optional</p>
+      <p>
+        Druid begins ingesting data once you submit a JSON ingestion spec. If you modify any values
+        in this view, the values entered in previous sections will update accordingly. If you modify
+        any values in previous sections, this spec will automatically update.
+      </p>
+      <p>Submit the spec to begin loading data into Druid.</p>
+    </Callout>
+  );
+});

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2818,19 +2818,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       });
     };
 
-    const metricsSpec = deepGet(spec, `spec.dataSchema.metricsSpec`);
-
-    const moveTo = (newIndex: number) => {
-      const newMetricsSpec = moveElement(metricsSpec, selectedMetricSpecIndex, newIndex);
-      const newSpec = deepSet(spec, `spec.dataSchema.metricsSpec`, newMetricsSpec);
-      this.updateSpec(newSpec);
-      close();
-    };
-
-    const reorderMetricMenu = (
-      <ReorderMenu things={metricsSpec} selectedIndex={selectedMetricSpecIndex} moveTo={moveTo} />
-    );
-
     const convertToDimension = (type: string) => {
       const specWithoutMetric = deepDelete(
         spec,
@@ -2866,17 +2853,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           model={selectedMetricSpec}
           onChange={selectedMetricSpec => this.setState({ selectedMetricSpec })}
         />
-        {reorderMetricMenu && (
-          <FormGroup>
-            <Popover content={reorderMetricMenu}>
-              <Button
-                icon={IconNames.ARROWS_HORIZONTAL}
-                text="Reorder metric"
-                rightIcon={IconNames.CARET_DOWN}
-              />
-            </Popover>
-          </FormGroup>
-        )}
         {selectedMetricSpecIndex !== -1 && dimensionMode === 'specific' && (
           <FormGroup>
             <Popover content={convertToDimensionMenu}>

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2319,6 +2319,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             <SchemaTable
               sampleBundle={data}
               columnFilter={columnFilter}
+              selectedAutoDimension={selectedAutoDimension}
               selectedDimensionSpecIndex={selectedDimensionSpecIndex}
               selectedMetricSpecIndex={selectedMetricSpecIndex}
               onAutoDimensionSelect={this.onAutoDimensionSelect}
@@ -2634,7 +2635,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     return (
       <div className="edit-controls">
         <FormGroup label="Name">
-          <InputGroup defaultValue={selectedAutoDimension} readOnly />
+          <InputGroup value={selectedAutoDimension} onChange={() => {}} readOnly />
         </FormGroup>
         <FormGroup>
           <Button

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2419,7 +2419,20 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                     name: 'spec.dataSchema.granularitySpec.queryGranularity',
                     label: 'Query granularity',
                     type: 'string',
-                    suggestions: ['NONE', 'SECOND', 'MINUTE', 'HOUR', 'DAY'],
+                    suggestions: [
+                      'none',
+                      'second',
+                      'minute',
+                      'fifteen_minute',
+                      'thirty_minute',
+                      'hour',
+                      'day',
+                      'week',
+                      'month',
+                      'quarter',
+                      'year',
+                      'all',
+                    ],
                     info: (
                       <>
                         This granularity determines how timestamps will be truncated (not at all, to

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -262,8 +262,11 @@ const STEPS: Step[] = [
 ];
 
 const SECTIONS: { name: string; steps: Step[] }[] = [
-  { name: 'Connect and parse raw data', steps: ['welcome', 'connect', 'parser', 'timestamp'] },
-  { name: 'Transform data and configure schema', steps: ['transform', 'filter', 'schema'] },
+  { name: 'Connect and parse raw data', steps: ['welcome', 'connect', 'parser'] },
+  {
+    name: 'Transform data and configure schema',
+    steps: ['timestamp', 'transform', 'filter', 'schema'],
+  },
   { name: 'Tune parameters', steps: ['partition', 'tuning', 'publish'] },
   { name: 'Verify and submit', steps: ['spec'] },
 ];

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -189,6 +189,8 @@ import {
 
 import './load-data-view.scss';
 
+const DEFAULT_ROLLUP_SETTING = false;
+
 function showRawLine(line: SampleEntry): string {
   if (!line.parsed) return 'No parse';
   const raw = line.parsed.raw;
@@ -1885,12 +1887,12 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             if (!transformQueryState.data) return false;
 
             let newSpec = spec;
-            if (!isDruidSource(newSpec)) {
+            if (!deepGet(newSpec, 'spec.dataSchema.dimensionsSpec')) {
               newSpec = updateSchemaWithSample(
                 newSpec,
                 transformQueryState.data,
                 'specific',
-                false,
+                DEFAULT_ROLLUP_SETTING,
               );
             }
 

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -1870,11 +1870,17 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           disabled: !transformQueryState.data,
           onNextStep: () => {
             if (!transformQueryState.data) return;
-            if (!isDruidSource(spec)) {
-              this.updateSpec(
-                updateSchemaWithSample(spec, transformQueryState.data, 'specific', true),
-              );
+
+            let newSpec = spec;
+            if (!isDruidSource(newSpec)) {
+              newSpec = updateSchemaWithSample(newSpec, transformQueryState.data, 'specific', true);
             }
+
+            if (!deepGet(newSpec, 'spec.dataSchema.granularitySpec.type')) {
+              newSpec = deepSet(newSpec, 'spec.dataSchema.granularitySpec.type', 'uniform');
+            }
+
+            this.updateSpec(newSpec);
           },
         })}
       </>
@@ -2507,13 +2513,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               newSpec = deepDelete(newSpec, 'spec.tuningConfig.forceGuaranteedRollup');
             }
 
-            if (!deepGet(newSpec, 'spec.dataSchema.granularitySpec')) {
-              newSpec = deepSet(newSpec, 'spec.dataSchema.granularitySpec', {
-                type: 'uniform',
-                queryGranularity: 'hour',
-              });
-            }
-
             this.updateSpec(newSpec);
           },
         })}
@@ -2944,7 +2943,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               {
                 name: 'segmentGranularity',
                 type: 'string',
-                suggestions: ['HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR'],
+                suggestions: ['hour', 'day', 'week', 'month', 'year'],
                 defined: (g: GranularitySpec) => g.type === 'uniform',
                 required: true,
                 info: (

--- a/web-console/src/views/load-data-view/reorder-menu/reorder-menu.tsx
+++ b/web-console/src/views/load-data-view/reorder-menu/reorder-menu.tsx
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Menu, MenuItem } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import React from 'react';
+
+export interface ReorderMenuProps {
+  things: any[] | undefined;
+  selectedIndex: number;
+  moveTo: (newIndex: number) => void;
+}
+
+export const ReorderMenu = React.memo(function ReorderMenu(props: ReorderMenuProps) {
+  const { things, selectedIndex, moveTo } = props;
+
+  if (!Array.isArray(things) || things.length <= 1 || selectedIndex === -1) return null;
+  const lastIndex = things.length - 1;
+  return (
+    <Menu>
+      {selectedIndex > 0 && (
+        <MenuItem
+          icon={IconNames.DOUBLE_CHEVRON_LEFT}
+          text="Make first"
+          onClick={() => moveTo(0)}
+        />
+      )}
+      {selectedIndex > 0 && (
+        <MenuItem
+          icon={IconNames.CHEVRON_LEFT}
+          text="Move left (earlier in the sort order)"
+          onClick={() => moveTo(selectedIndex - 1)}
+        />
+      )}
+      {selectedIndex < lastIndex && (
+        <MenuItem
+          icon={IconNames.CHEVRON_RIGHT}
+          text="Move right (later in the sort order)"
+          onClick={() => moveTo(selectedIndex + 1)}
+        />
+      )}
+      {selectedIndex < lastIndex && (
+        <MenuItem
+          icon={IconNames.DOUBLE_CHEVRON_RIGHT}
+          text="Make last"
+          onClick={() => moveTo(lastIndex)}
+        />
+      )}
+    </Menu>
+  );
+});

--- a/web-console/src/views/load-data-view/schema-table/__snapshots__/schema-table.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/schema-table/__snapshots__/schema-table.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`schema table matches snapshot 1`] = `
+exports[`SchemaTable matches snapshot 1`] = `
 <div
   class="ReactTable schema-table -striped -highlight"
 >

--- a/web-console/src/views/load-data-view/schema-table/__snapshots__/schema-table.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/schema-table/__snapshots__/schema-table.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`SchemaTable matches snapshot 1`] = `
         <div
           class="rt-th dimension string rt-resizable-header"
           role="columnheader"
-          style="flex: 100 0 auto; width: 100px;"
+          style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           tabindex="-1"
         >
           <div
@@ -62,7 +62,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span
               class="table-cell plain"
@@ -83,7 +83,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -102,7 +102,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -121,7 +121,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -140,7 +140,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -159,7 +159,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -178,7 +178,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -197,7 +197,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -216,7 +216,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -235,7 +235,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -254,7 +254,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -273,7 +273,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -292,7 +292,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -311,7 +311,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -330,7 +330,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -349,7 +349,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -368,7 +368,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -387,7 +387,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -406,7 +406,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -425,7 +425,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -444,7 +444,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -463,7 +463,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -482,7 +482,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -501,7 +501,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -520,7 +520,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -539,7 +539,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -558,7 +558,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -577,7 +577,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -596,7 +596,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -615,7 +615,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -634,7 +634,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -653,7 +653,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -672,7 +672,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -691,7 +691,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -710,7 +710,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -729,7 +729,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -748,7 +748,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -767,7 +767,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -786,7 +786,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -805,7 +805,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -824,7 +824,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -843,7 +843,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -862,7 +862,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -881,7 +881,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -900,7 +900,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -919,7 +919,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -938,7 +938,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -957,7 +957,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -976,7 +976,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                
@@ -995,7 +995,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           <div
             class="rt-td dimension string"
             role="gridcell"
-            style="flex: 100 0 auto; width: 100px;"
+            style="flex: 100 0 auto; width: 100px; max-width: 100px;"
           >
             <span>
                

--- a/web-console/src/views/load-data-view/schema-table/schema-table.spec.tsx
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.spec.tsx
@@ -41,6 +41,7 @@ describe('SchemaTable', () => {
           metricsSpec: [],
         }}
         columnFilter=""
+        selectedAutoDimension={undefined}
         selectedDimensionSpecIndex={-1}
         selectedMetricSpecIndex={-1}
         onAutoDimensionSelect={() => {}}

--- a/web-console/src/views/load-data-view/schema-table/schema-table.spec.tsx
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.spec.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 import { SchemaTable } from './schema-table';
 
-describe('schema table', () => {
+describe('SchemaTable', () => {
   it('matches snapshot', () => {
     const sampleData = {
       header: ['c1'],
@@ -37,13 +37,15 @@ describe('schema table', () => {
       <SchemaTable
         sampleBundle={{
           headerAndRows: sampleData,
-          dimensionsSpec: {},
+          dimensions: [],
           metricsSpec: [],
         }}
         columnFilter=""
         selectedDimensionSpecIndex={-1}
         selectedMetricSpecIndex={-1}
-        onDimensionOrMetricSelect={() => {}}
+        onAutoDimensionSelect={() => {}}
+        onDimensionSelect={() => {}}
+        onMetricSelect={() => {}}
       />
     );
 

--- a/web-console/src/views/load-data-view/schema-table/schema-table.tsx
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.tsx
@@ -101,7 +101,7 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
             Cell: ({ value }) => <TableCell value={value} />,
           };
         } else {
-          const timestamp = columnName === '__time';
+          const isTimestamp = columnName === '__time';
           const dimensionSpecIndex = dimensions
             ? dimensions.findIndex(d => getDimensionSpecName(d) === columnName)
             : -1;
@@ -109,7 +109,7 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
           const dimensionSpecType = dimensionSpec ? getDimensionSpecType(dimensionSpec) : undefined;
 
           const columnClassName = classNames(
-            timestamp ? 'timestamp' : 'dimension',
+            isTimestamp ? 'timestamp' : 'dimension',
             dimensionSpecType || 'string',
             {
               selected:
@@ -122,7 +122,7 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
               <div
                 className="clickable"
                 onClick={() => {
-                  if (timestamp) return;
+                  if (isTimestamp) return;
 
                   if (dimensionSpec) {
                     onDimensionSelect(inflateDimensionSpec(dimensionSpec), dimensionSpecIndex);
@@ -133,15 +133,16 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
               >
                 <div className="column-name">{columnName}</div>
                 <div className="column-detail">
-                  {timestamp ? 'long (time column)' : dimensionSpecType || 'string (auto)'}&nbsp;
+                  {isTimestamp ? 'long (time column)' : dimensionSpecType || 'string (auto)'}&nbsp;
                 </div>
               </div>
             ),
             headerClassName: columnClassName,
             className: columnClassName,
             id: String(i),
+            width: isTimestamp ? 200 : 100,
             accessor: (row: SampleEntry) => (row.parsed ? row.parsed[columnName] : null),
-            Cell: row => <TableCell value={timestamp ? new Date(row.value) : row.value} />,
+            Cell: row => <TableCell value={isTimestamp ? new Date(row.value) : row.value} />,
           };
         }
       })}

--- a/web-console/src/views/load-data-view/schema-table/schema-table.tsx
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.tsx
@@ -41,6 +41,7 @@ export interface SchemaTableProps {
     metricsSpec: MetricSpec[] | undefined;
   };
   columnFilter: string;
+  selectedAutoDimension: string | undefined;
   selectedDimensionSpecIndex: number;
   selectedMetricSpecIndex: number;
   onAutoDimensionSelect: (dimensionName: string) => void;
@@ -58,6 +59,7 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
   const {
     sampleBundle,
     columnFilter,
+    selectedAutoDimension,
     selectedDimensionSpecIndex,
     selectedMetricSpecIndex,
     onAutoDimensionSelect,
@@ -65,6 +67,7 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
     onMetricSelect,
   } = props;
   const { headerAndRows, dimensions, metricsSpec } = sampleBundle;
+
   return (
     <ReactTable
       className="schema-table -striped -highlight"
@@ -109,7 +112,9 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
             timestamp ? 'timestamp' : 'dimension',
             dimensionSpecType || 'string',
             {
-              selected: dimensionSpec && dimensionSpecIndex === selectedDimensionSpecIndex,
+              selected:
+                (dimensionSpec && dimensionSpecIndex === selectedDimensionSpecIndex) ||
+                selectedAutoDimension === columnName,
             },
           );
           return {

--- a/web-console/src/views/load-data-view/schema-table/schema-table.tsx
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.tsx
@@ -23,14 +23,13 @@ import ReactTable from 'react-table';
 import { TableCell } from '../../../components';
 import {
   DimensionSpec,
-  DimensionsSpec,
   getDimensionSpecName,
   getDimensionSpecType,
   getMetricSpecName,
   inflateDimensionSpec,
   MetricSpec,
 } from '../../../druid-models';
-import { caseInsensitiveContains, filterMap, sortWithPrefixSuffix } from '../../../utils';
+import { caseInsensitiveContains, filterMap } from '../../../utils';
 import { HeaderAndRows, SampleEntry } from '../../../utils/sampler';
 
 import './schema-table.scss';
@@ -38,15 +37,18 @@ import './schema-table.scss';
 export interface SchemaTableProps {
   sampleBundle: {
     headerAndRows: HeaderAndRows;
-    dimensionsSpec: DimensionsSpec;
-    metricsSpec: MetricSpec[];
+    dimensions: (string | DimensionSpec)[] | undefined;
+    metricsSpec: MetricSpec[] | undefined;
   };
   columnFilter: string;
   selectedDimensionSpecIndex: number;
   selectedMetricSpecIndex: number;
-  onDimensionOrMetricSelect: (
+  onAutoDimensionSelect: (dimensionName: string) => void;
+  onDimensionSelect: (
     selectedDimensionSpec: DimensionSpec | undefined,
     selectedDimensionSpecIndex: number,
+  ) => void;
+  onMetricSelect: (
     selectedMetricSpec: MetricSpec | undefined,
     selectedMetricSpecIndex: number,
   ) => void;
@@ -58,26 +60,22 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
     columnFilter,
     selectedDimensionSpecIndex,
     selectedMetricSpecIndex,
-    onDimensionOrMetricSelect,
+    onAutoDimensionSelect,
+    onDimensionSelect,
+    onMetricSelect,
   } = props;
-  const { headerAndRows, dimensionsSpec, metricsSpec } = sampleBundle;
-
-  const dimensionMetricSortedHeader = sortWithPrefixSuffix(
-    headerAndRows.header,
-    ['__time'],
-    metricsSpec.map(getMetricSpecName),
-    null,
-  );
-
+  const { headerAndRows, dimensions, metricsSpec } = sampleBundle;
   return (
     <ReactTable
       className="schema-table -striped -highlight"
       data={headerAndRows.rows}
-      columns={filterMap(dimensionMetricSortedHeader, (columnName, i) => {
+      columns={filterMap(headerAndRows.header, (columnName, i) => {
         if (!caseInsensitiveContains(columnName, columnFilter)) return;
 
-        const metricSpecIndex = metricsSpec.findIndex(m => getMetricSpecName(m) === columnName);
-        const metricSpec = metricsSpec[metricSpecIndex];
+        const metricSpecIndex = metricsSpec
+          ? metricsSpec.findIndex(m => getMetricSpecName(m) === columnName)
+          : -1;
+        const metricSpec = metricsSpec ? metricsSpec[metricSpecIndex] : undefined;
 
         if (metricSpec) {
           const columnClassName = classNames('metric', {
@@ -87,9 +85,7 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
             Header: (
               <div
                 className="clickable"
-                onClick={() =>
-                  onDimensionOrMetricSelect(undefined, -1, metricSpec, metricSpecIndex)
-                }
+                onClick={() => onMetricSelect(metricSpec, metricSpecIndex)}
               >
                 <div className="column-name">{columnName}</div>
                 <div className="column-detail">{metricSpec.type}&nbsp;</div>
@@ -103,13 +99,11 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
           };
         } else {
           const timestamp = columnName === '__time';
-          const dimensionSpecIndex = dimensionsSpec.dimensions
-            ? dimensionsSpec.dimensions.findIndex(d => getDimensionSpecName(d) === columnName)
+          const dimensionSpecIndex = dimensions
+            ? dimensions.findIndex(d => getDimensionSpecName(d) === columnName)
             : -1;
-          const dimensionSpec = dimensionsSpec.dimensions
-            ? dimensionsSpec.dimensions[dimensionSpecIndex]
-            : null;
-          const dimensionSpecType = dimensionSpec ? getDimensionSpecType(dimensionSpec) : null;
+          const dimensionSpec = dimensions ? dimensions[dimensionSpecIndex] : undefined;
+          const dimensionSpecType = dimensionSpec ? getDimensionSpecType(dimensionSpec) : undefined;
 
           const columnClassName = classNames(
             timestamp ? 'timestamp' : 'dimension',
@@ -123,18 +117,13 @@ export const SchemaTable = React.memo(function SchemaTable(props: SchemaTablePro
               <div
                 className="clickable"
                 onClick={() => {
-                  if (timestamp) {
-                    onDimensionOrMetricSelect(undefined, -1, undefined, -1);
-                    return;
-                  }
+                  if (timestamp) return;
 
-                  if (!dimensionSpec) return;
-                  onDimensionOrMetricSelect(
-                    inflateDimensionSpec(dimensionSpec),
-                    dimensionSpecIndex,
-                    undefined,
-                    -1,
-                  );
+                  if (dimensionSpec) {
+                    onDimensionSelect(inflateDimensionSpec(dimensionSpec), dimensionSpecIndex);
+                  } else {
+                    onAutoDimensionSelect(columnName);
+                  }
                 }}
               >
                 <div className="column-name">{columnName}</div>

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -459,6 +459,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
       }
     }
 
+    const someQueryResult = queryResultState.getSomeData();
     const runeMode = QueryView.isJsonLike(queryString);
     return (
       <SplitterLayout
@@ -501,10 +502,10 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
           </div>
         </div>
         <div className="output-pane">
-          {queryResult && (
+          {someQueryResult && (
             <QueryOutput
               runeMode={runeMode}
-              queryResult={queryResult}
+              queryResult={someQueryResult}
               onQueryChange={this.handleQueryChange}
             />
           )}


### PR DESCRIPTION
This PR fixes the issue that the columns in the Schema table do not reflect the ordering in the `dimensionsSpec` (and the ordering in the final segment. This makes it impossible to configure `single_dim` partitioning effectively.

![image](https://user-images.githubusercontent.com/177816/99318493-ac4f3700-281c-11eb-8628-cc51a5ce948b.png)

Also this PR contains a bunch of polish:
- Allow column reordering in the `Schema` step
- Default data loader flow to ingest with `rollup: false`
- Added ability to `AutoForm` to fold things into a "Show more" folder
- Fixed bug where `totalNumMergeTasks`, and `maxNumSegmentsToMerge` were not showing up in the form
- Extracted all the data loader callout messages into their own file for easy editing
- Fix issue where all the tables were constantly being re-mounted (losing scroll position / column sizing)
- Misc improvements to data loader flow
- Allow adding dimensions to dimensionExclusion list via point-and-click
- Disallow submitting of an unfinished spec
- Lower cased the segment granularities for aesthetics
- Extracted dynamic configs to the `druid-modals` directory
- Added `repartitionTransitionDuration` to the form - it was missing
- Added helpful warnings for non newline delimited JSON
