### PR TITLE
Updates segment metadata query documentation 

### DIFF
--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -141,8 +141,8 @@ Types of column analyses are described below:
 
 ### cardinality
 
-* `cardinality` in the result will return the estimated floor of cardinality for each column. Only relevant for
-dimension columns.
+* `cardinality` in the result will return the size of the bitmap index or dictionary encoding for string dimensions, or null for other dimension types.
+ If `merge` was set, the result will be the max of this value accross segments. Only relevant for dimension columns.
 
 ### minmax
 

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -142,7 +142,7 @@ Types of column analyses are described below:
 ### cardinality
 
 * `cardinality` in the result will return the size of the bitmap index or dictionary encoding for string dimensions, or null for other dimension types.
- If `merge` was set, the result will be the max of this value accross segments. Only relevant for dimension columns.
+ If `merge` was set, the result will be the max of this value across segments. Only relevant for dimension columns.
 
 ### minmax
 


### PR DESCRIPTION
The existing documentation was a bit unclear, and I needed to dig into the source of `SegmentAnalyzer` and `ColumnAnalysis` to understand my results.  Updated to explain the source of the cardinality estimates on a per segment basis, and explain the way they are merged across segments. 