### PR TITLE
druid-docker-image: add DRUID_DIRS_TO_CREATE variable to customize directories created on startup

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -25,13 +25,15 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY . /src
 WORKDIR /src
-#RUN mvn -B -ff -q dependency:go-offline \
-#      install \
-#      -Pdist,bundle-contrib-exts \
-#      -Pskip-static-checks,skip-tests \
-#      -Dmaven.javadoc.skip=true
+RUN mvn -B -ff -q dependency:go-offline \
+      install \
+      -Pdist,bundle-contrib-exts \
+      -Pskip-static-checks,skip-tests \
+      -Dmaven.javadoc.skip=true
 
-RUN VERSION=0.21.0-SNAPSHOT \
+RUN VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.1.1:evaluate \
+      -Dexpression=project.version -DforceStdout=true \
+    ) \
  && tar -zxf ./distribution/target/apache-druid-${VERSION}-bin.tar.gz -C /opt \
  && ln -s /opt/apache-druid-${VERSION} /opt/druid
 

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -25,15 +25,13 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY . /src
 WORKDIR /src
-RUN mvn -B -ff -q dependency:go-offline \
-      install \
-      -Pdist,bundle-contrib-exts \
-      -Pskip-static-checks,skip-tests \
-      -Dmaven.javadoc.skip=true
+#RUN mvn -B -ff -q dependency:go-offline \
+#      install \
+#      -Pdist,bundle-contrib-exts \
+#      -Pskip-static-checks,skip-tests \
+#      -Dmaven.javadoc.skip=true
 
-RUN VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.1.1:evaluate \
-      -Dexpression=project.version -DforceStdout=true \
-    ) \
+RUN VERSION=0.21.0-SNAPSHOT \
  && tar -zxf ./distribution/target/apache-druid-${VERSION}-bin.tar.gz -C /opt \
  && ln -s /opt/apache-druid-${VERSION} /opt/druid
 

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -148,5 +148,10 @@ then
     echo "$DRUID_LOG4J" >$COMMON_CONF_DIR/log4j2.xml
 fi
 
-mkdir -p var/tmp var/druid/segments var/druid/indexing-logs var/druid/task var/druid/hadoop-tmp var/druid/segment-cache
+DRUID_DIRS_TO_CREATE=${DRUID_DIRS_TO_CREATE-'var/tmp var/druid/segments var/druid/indexing-logs var/druid/task var/druid/hadoop-tmp var/druid/segment-cache'}
+if [ "X${DRUID_DIRS_TO_CREATE}" != "X" ]
+then
+    mkdir -p ${DRUID_DIRS_TO_CREATE}
+fi
+
 exec java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main server $@

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -149,7 +149,7 @@ then
 fi
 
 DRUID_DIRS_TO_CREATE=${DRUID_DIRS_TO_CREATE-'var/tmp var/druid/segments var/druid/indexing-logs var/druid/task var/druid/hadoop-tmp var/druid/segment-cache'}
-if [ "X${DRUID_DIRS_TO_CREATE}" != "X" ]
+if [ -n "${DRUID_DIRS_TO_CREATE}" ]
 then
     mkdir -p ${DRUID_DIRS_TO_CREATE}
 fi


### PR DESCRIPTION
### Description

Small update to druid docker container to enable customization of directories created at startup by specifying `DRUID_DIRS_TO_CREATE` env variable. Default list is only suitable for configuration from druid examples.

User can also set `DRUID_DIRS_TO_CREATE` to empty string to disable any directory creation altogether.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>


