### PR TITLE
Revert "Update google client libraries (#10536)"

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4100,7 +4100,7 @@ name: Google Cloud Storage JSON API
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: v1-rev20200927-1.30.10
+version: v1-rev20190523-1.26.0
 libraries:
   - com.google.apis: google-api-services-storage
 
@@ -4110,7 +4110,7 @@ name: Google Compute Engine API
 license_category: binary
 module: extensions/gce-extensions
 license_name: Apache License version 2.0
-version: v1-rev20201005-1.30.10
+version: v1-rev20190607-1.26.0
 libraries:
   - com.google.apis: google-api-services-compute
 
@@ -4130,7 +4130,7 @@ name: Google APIs Client Library For Java
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.30.10
+version: 1.26.0
 libraries:
   - com.google.api-client: google-api-client
 
@@ -4140,7 +4140,7 @@ name: Google HTTP Client Library For Java
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.37.0
+version: 1.26.0
 libraries:
   - com.google.http-client: google-http-client
   - com.google.http-client: google-http-client-jackson2
@@ -4151,7 +4151,7 @@ name: Google OAuth Client Library For Java
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.31.0
+version: 1.22.0
 libraries:
   - com.google.oauth-client: google-oauth-client
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,10 +117,9 @@
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
         <zookeeper.version>3.4.14</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
-        <com.google.apis.client.version>1.30.10</com.google.apis.client.version>
-        <com.google.http.client.version>1.37.0</com.google.http.client.version>
-        <com.google.apis.compute.version>v1-rev20201005-${com.google.apis.client.version}</com.google.apis.compute.version>
-        <com.google.apis.storage.version>v1-rev20200927-${com.google.apis.client.version}</com.google.apis.storage.version>
+        <com.google.apis.client.version>1.26.0</com.google.apis.client.version>
+        <com.google.apis.compute.version>v1-rev20190607-${com.google.apis.client.version}</com.google.apis.compute.version>
+        <com.google.apis.storage.version>v1-rev20190523-${com.google.apis.client.version}</com.google.apis.storage.version>
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
@@ -1169,12 +1168,12 @@
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client</artifactId>
-                <version>${com.google.http.client.version}</version>
+                <version>${com.google.apis.client.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client-jackson2</artifactId>
-                <version>${com.google.http.client.version}</version>
+                <version>${com.google.apis.client.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This reverts commit 4537016cad4e17786b81e74b0e99013838afe788.

The Google Cloud Storage tests started failing once the libraries were updated. Reverting the change till the tests are also updated so that they pass.

```
[2020-11-21T06:04:00.047Z] [ERROR] Failures: 

[2020-11-21T06:04:00.047Z] [ERROR] org.apache.druid.tests.indexer.ITGcsToGcsParallelIndexTest.testGcsIndexData(org.apache.druid.tests.indexer.ITGcsToGcsParallelIndexTest)

[2020-11-21T06:04:00.047Z] [ERROR]   Run 1: ITGcsToGcsParallelIndexTest.testGcsIndexData:48->AbstractGcsInputSourceParallelIndexTest.doTest:121->AbstractITBatchIndexTest.doIndexTest:131->AbstractITBatchIndexTest.submitTaskAndWait:269 » Runtime

[2020-11-21T06:04:00.047Z] [ERROR]   Run 2: ITGcsToGcsParallelIndexTest.testGcsIndexData:48->AbstractGcsInputSourceParallelIndexTest.doTest:121->AbstractITBatchIndexTest.doIndexTest:131->AbstractITBatchIndexTest.submitTaskAndWait:269 » Runtime

[2020-11-21T06:04:00.047Z] [ERROR]   Run 3: ITGcsToGcsParallelIndexTest.testGcsIndexData:48->AbstractGcsInputSourceParallelIndexTest.doTest:121->AbstractITBatchIndexTest.doIndexTest:131->AbstractITBatchIndexTest.submitTaskAndWait:269 » Runtime

[2020-11-21T06:04:00.047Z] [INFO] 

[2020-11-21T06:04:00.047Z] [ERROR] org.apache.druid.tests.indexer.ITHdfsToGcsParallelIndexTest.testHdfsIndexData(org.apache.druid.tests.indexer.ITHdfsToGcsParallelIndexTest)

[2020-11-21T06:04:00.047Z] [ERROR]   Run 1: ITHdfsToGcsParallelIndexTest.testHdfsIndexData:46->AbstractHdfsInputSourceParallelIndexTest.doTest:111->AbstractITBatchIndexTest.doIndexTest:131->AbstractITBatchIndexTest.submitTaskAndWait:269 » Runtime

[2020-11-21T06:04:00.047Z] [ERROR]   Run 2: ITHdfsToGcsParallelIndexTest.testHdfsIndexData:46->AbstractHdfsInputSourceParallelIndexTest.doTest:111->AbstractITBatchIndexTest.doIndexTest:131->AbstractITBatchIndexTest.submitTaskAndWait:269 » Runtime

[2020-11-21T06:04:00.047Z] [ERROR]   Run 3: ITHdfsToGcsParallelIndexTest.testHdfsIndexData:46->AbstractHdfsInputSourceParallelIndexTest.doTest:111->AbstractITBatchIndexTest.doIndexTest:131->AbstractITBatchIndexTest.submitTaskAndWait:269 » Runtime

[2020-11-21T06:04:00.047Z] [INFO] 

[2020-11-21T06:04:00.047Z] [INFO] 

[2020-11-21T06:04:00.047Z] [ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
```