### PR TITLE
Fix doc about search query

### DIFF
--- a/docs/querying/searchquery.md
+++ b/docs/querying/searchquery.md
@@ -57,7 +57,7 @@ There are several main parts to a search query:
 |--------|-----------|---------|
 |queryType|This String should always be "search"; this is the first thing Apache Druid looks at to figure out how to interpret the query.|yes|
 |dataSource|A String or Object defining the data source to query, very similar to a table in a relational database. See [DataSource](../querying/datasource.md) for more information.|yes|
-|granularity|Defines the granularity of the query. See [Granularities](../querying/granularities.md).|yes|
+|granularity|Defines the granularity of the query. See [Granularities](../querying/granularities.md).|no (default to `all`)|
 |filter|See [Filters](../querying/filters.md).|no|
 |limit| Defines the maximum number per Historical process (parsed as int) of search results to return. |no (default to 1000)|
 |intervals|A JSON Object representing ISO-8601 Intervals. This defines the time ranges to run the query over.|yes|


### PR DESCRIPTION
Fixes #10610

### Description

`granularity` property for  a search query  is not required based [on the code](https://github.com/apache/druid/blob/2560bf0a1919c36b824bd0e4f9286e2899deddd3/processing/src/main/java/org/apache/druid/query/search/SearchQuery.java#L65) which was introduced by #5157 .

This problem only exists for search query while the doc for other queries such as time-series query or group-by query is OK.

This PR fixes the doc to keep it in coincidence with the code. 

<hr>

This PR has:
- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.