### PR TITLE
map-string-string dimension column contrib extension

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -426,6 +426,8 @@
                                         <argument>org.apache.druid.extensions.contrib:gce-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:aliyun-oss-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-map-string-string-column</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/extensions-contrib/druid-map-string-string-col/pom.xml
+++ b/extensions-contrib/druid-map-string-string-col/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.druid.extensions.contrib</groupId>
+  <artifactId>druid-map-string-string-column</artifactId>
+  <name>druid-map-string-string-column</name>
+  <description>druid-map-string-string-column</description>
+
+  <parent>
+    <groupId>org.apache.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>0.21.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-core</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-core</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringColumnMetadata.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringColumnMetadata.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.segment.data.BitmapSerdeFactory;
+
+import java.nio.ByteOrder;
+
+public class MapStringStringColumnMetadata
+{
+  private final ByteOrder byteOrder;
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+  private final String fileNameBase;
+
+  @JsonCreator
+  public MapStringStringColumnMetadata(
+      @JsonProperty("byteOrder") ByteOrder byteOrder,
+      @JsonProperty("bitmapSerdeFactory") BitmapSerdeFactory bitmapSerdeFactory,
+      @JsonProperty("fileNameBase") String fileNameBase
+  )
+  {
+    this.byteOrder = byteOrder;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+    this.fileNameBase = fileNameBase;
+  }
+
+  @JsonProperty
+  public ByteOrder getByteOrder()
+  {
+    return byteOrder;
+  }
+
+  @JsonProperty
+  public BitmapSerdeFactory getBitmapSerdeFactory()
+  {
+    return bitmapSerdeFactory;
+  }
+
+  @JsonProperty
+  public String getFileNameBase()
+  {
+    return fileNameBase;
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringColumnSerializer.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringColumnSerializer.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectAVLTreeSet;
+import it.unimi.dsi.fastutil.objects.ObjectSortedSet;
+import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.collections.bitmap.MutableBitmap;
+import org.apache.druid.common.utils.SerializerUtils;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.guava.Comparators;
+import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedWriter;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.GenericColumnSerializer;
+import org.apache.druid.segment.IndexIO;
+import org.apache.druid.segment.data.BitmapSerdeFactory;
+import org.apache.druid.segment.data.CompressedVSizeColumnarIntsSerializer;
+import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.GenericIndexedWriter;
+import org.apache.druid.segment.data.ObjectStrategy;
+import org.apache.druid.segment.data.SingleValueColumnarIntsSerializer;
+import org.apache.druid.segment.data.VSizeColumnarIntsSerializer;
+import org.apache.druid.segment.serde.DictionaryEncodedColumnPartSerde;
+import org.apache.druid.segment.serde.Serializer;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+
+/**
+ * Serialize the Map<String, String> rows data. For each Map key encountered, one dictionary encoded internal
+ * column is created very similar to Druid's builtin String type column's disk layout.
+ * So this column's disk layout contains several internal "Key Columns".
+ */
+public class MapStringStringColumnSerializer implements GenericColumnSerializer
+{
+  private static final Logger LOGGER = new Logger(MapStringStringColumnSerializer.class);
+
+  public static final byte VERSION = 0x1;
+
+  public static final SerializerUtils SERIALIZER_UTILS = new SerializerUtils();
+
+  // Note: keys are kept sorted which is the order we write them on disk.
+  private final SortedMap<String, KeyColumnValuesHolder> keyColumnValues = new TreeMap<>();
+
+  private int rowCount = 0;
+
+  private GenericIndexedWriter<String> keysWriter;
+
+  private boolean closedForWrite = false;
+
+  private final byte[] versionAndMetadataBytes;
+
+  private final SegmentWriteOutMedium segmentWriteOutMedium;
+  private final String columnName;
+
+  private final BitmapSerdeFactory bitmapSerdeFactory;
+  private final CompressionStrategy compressionStrategy;
+
+  private final ByteOrder byteOrder = IndexIO.BYTE_ORDER;
+
+  private final ObjectMapper jsonMapper;
+
+  public MapStringStringColumnSerializer(
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      String columnName,
+      BitmapSerdeFactory bitmapSerdeFactory,
+      CompressionStrategy compressionStrategy,
+      ObjectMapper jsonMapper
+  )
+  {
+    this.segmentWriteOutMedium = segmentWriteOutMedium;
+    this.columnName = columnName;
+    this.bitmapSerdeFactory = bitmapSerdeFactory;
+    this.compressionStrategy = compressionStrategy;
+    this.jsonMapper = jsonMapper;
+
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      baos.write(VERSION);
+      SERIALIZER_UTILS.writeString(
+          baos,
+          jsonMapper.writeValueAsString(new MapStringStringColumnMetadata(
+            byteOrder,
+            bitmapSerdeFactory,
+            columnName
+            )
+          )
+      );
+
+      this.versionAndMetadataBytes = baos.toByteArray();
+    }
+    catch (IOException ex) {
+      throw new IAE(ex, "Failed to serialize metadata.");
+    }
+  }
+
+  @Override
+  public void open()
+  {
+
+  }
+
+  @Override
+  public void serialize(ColumnValueSelector selector) throws IOException
+  {
+    MapStringStringRow dimRow = (MapStringStringRow) selector.getObject();
+    Map<String, String> rowVal = dimRow.getValues();
+
+    for (String key : rowVal.keySet()) {
+      keyColumnValues.computeIfAbsent(
+          key,
+          unused -> new KeyColumnValuesHolder(rowCount)
+      );
+    }
+
+    for (Map.Entry<String, KeyColumnValuesHolder> e : keyColumnValues.entrySet()) {
+      e.getValue().addValue(rowVal.getOrDefault(e.getKey(), null));
+    }
+
+    rowCount++;
+  }
+
+  @Override
+  public long getSerializedSize() throws IOException
+  {
+    if (!closedForWrite) {
+      closedForWrite = true;
+
+      //Do closing stuff necessary to be able to compute serialized size
+      for (Map.Entry<String, KeyColumnValuesHolder> e : keyColumnValues.entrySet()) {
+        e.getValue().writesFinished(e.getKey());
+      }
+
+      keysWriter = createGenericIndexedWriter(GenericIndexed.STRING_STRATEGY);
+      for (String key : keyColumnValues.keySet()) {
+        keysWriter.write(key);
+      }
+    }
+
+    long serializedSize = versionAndMetadataBytes.length + keysWriter.getSerializedSize();
+
+    LOGGER.info("Column [%s] metadata serialized size is [%d]", columnName, serializedSize);
+    return serializedSize;
+  }
+
+  @Override
+  public void writeTo(
+      WritableByteChannel channel,
+      FileSmoosher smoosher
+  ) throws IOException
+  {
+    Preconditions.checkState(closedForWrite, "WTH! Not Closed Yet.");
+
+    channel.write(ByteBuffer.wrap(versionAndMetadataBytes));
+    keysWriter.writeTo(channel, smoosher);
+
+    LOGGER.info("Column [%s] serialized metadata with [%d] key columns.", columnName, keyColumnValues.size());
+
+    for (Map.Entry<String, KeyColumnValuesHolder> e : keyColumnValues.entrySet()) {
+      e.getValue().writeTo(e.getKey(), smoosher);
+    }
+
+    LOGGER.info("Column [%s] serialized successfully with [%d] key columns.", columnName, keyColumnValues.size());
+  }
+
+  private <T> GenericIndexedWriter<T> createGenericIndexedWriter(ObjectStrategy<T> objectStrategy) throws IOException
+  {
+    GenericIndexedWriter<T> writer = new GenericIndexedWriter<>(segmentWriteOutMedium, columnName, objectStrategy);
+    writer.open();
+    return writer;
+  }
+
+  private <T> GenericIndexedWriter<T> createUnsortedGenericIndexedWriter(
+      ObjectStrategy<T> objectStrategy
+  ) throws IOException
+  {
+    GenericIndexedWriter<T> writer = createGenericIndexedWriter(objectStrategy);
+    writer.setObjectsNotSorted();
+    return writer;
+  }
+
+  public static String getKeyColumnFileName(String key, String fileNameBase)
+  {
+    return StringUtils.format("%s_%s", fileNameBase, key);
+  }
+
+  private class KeyColumnValuesHolder
+  {
+    //Note: this is kept on heap as we want to be able to store unique values.
+    //technically, sorting can be delayed till the end.
+    //If this becomes a bottleneck then we could use an on-disk hash table and sort in the end
+    ObjectSortedSet<String> dictionary = new ObjectAVLTreeSet<>(Comparators.naturalNullsFirst());
+
+    GenericIndexedWriter<String> intermediateValueWriter;
+    Object2ObjectMap<String, MutableBitmap> bitmaps = new Object2ObjectOpenHashMap<>();
+
+    Serializer finalSerializer;
+
+    KeyColumnValuesHolder(int zeroRowCount)
+    {
+      try {
+        intermediateValueWriter = createUnsortedGenericIndexedWriter(GenericIndexed.STRING_STRATEGY);
+
+        if (zeroRowCount > 0) {
+          dictionary.add(null);
+          MutableBitmap nullBitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyMutableBitmap();
+          for (int i = 0; i < zeroRowCount; i++) {
+            nullBitmap.add(i);
+            intermediateValueWriter.write(null);
+          }
+          bitmaps.put(null, nullBitmap);
+        }
+      }
+      catch (IOException ex) {
+        throw new RuntimeException("Unknown ex during serialization.", ex);
+      }
+    }
+
+    void addValue(String value) throws IOException
+    {
+      dictionary.add(value);
+
+      MutableBitmap bitmap = bitmaps.get(value);
+      if (bitmap == null) {
+        bitmap = bitmapSerdeFactory.getBitmapFactory().makeEmptyMutableBitmap();
+        bitmaps.put(value, bitmap);
+      }
+      bitmap.add(rowCount);
+
+      intermediateValueWriter.write(value);
+    }
+
+    void writesFinished(String key) throws IOException
+    {
+      // create dictionary writer
+      GenericIndexedWriter<String> sortedDictionaryWriter = createGenericIndexedWriter(GenericIndexed.STRING_STRATEGY);
+      for (String s : dictionary) {
+        sortedDictionaryWriter.write(s);
+      }
+
+      // create values writer
+      SingleValueColumnarIntsSerializer encodedValueSerializer;
+      if (compressionStrategy != CompressionStrategy.UNCOMPRESSED) {
+        encodedValueSerializer = CompressedVSizeColumnarIntsSerializer.create(
+            key,
+            segmentWriteOutMedium,
+            columnName,
+            dictionary.size(),
+            compressionStrategy
+        );
+      } else {
+        encodedValueSerializer = new VSizeColumnarIntsSerializer(segmentWriteOutMedium, dictionary.size());
+      }
+      encodedValueSerializer.open();
+
+      Object2IntMap<String> dictionaryEncodingLookup = createRankMap(dictionary);
+      for (int i = 0; i < rowCount; i++) {
+        encodedValueSerializer.addValue(dictionaryEncodingLookup.getInt(intermediateValueWriter.get(i)));
+      }
+
+      // create immutable bitmaps, write in same order as dictionary
+      GenericIndexedWriter<ImmutableBitmap> bitmapsWriter = createUnsortedGenericIndexedWriter(bitmapSerdeFactory.getObjectStrategy());
+      for (String value : dictionary) {
+        bitmapsWriter.write(bitmapSerdeFactory.getBitmapFactory().makeImmutableBitmap(bitmaps.get(value)));
+      }
+
+
+      finalSerializer = DictionaryEncodedColumnPartSerde
+          .serializerBuilder()
+          .withDictionary(sortedDictionaryWriter)
+          .withValue(
+              encodedValueSerializer,
+              false,
+              compressionStrategy != CompressionStrategy.UNCOMPRESSED
+          )
+          .withBitmapSerdeFactory(bitmapSerdeFactory)
+          .withBitmapIndex(bitmapsWriter)
+          .withByteOrder(byteOrder)
+          .build()
+          .getSerializer();
+    }
+
+    private <T> Object2IntMap<T> createRankMap(SortedSet<T> dict)
+    {
+      Object2IntMap<T> rankMap = new Object2IntOpenHashMap<>(dict.size());
+      int counter = 0;
+      for (T x : dict) {
+        rankMap.put(x, counter++);
+      }
+      return rankMap;
+    }
+
+    void writeTo(String key, FileSmoosher smoosher) throws IOException
+    {
+      LOGGER.info("Column [%s] serializing [%s] key column of size [%d].", columnName, key, finalSerializer.getSerializedSize());
+      try (SmooshedWriter smooshChannel = smoosher
+          .addWithSmooshedWriter(getKeyColumnFileName(key, columnName), finalSerializer.getSerializedSize())) {
+        finalSerializer.writeTo(smooshChannel, smoosher);
+      }
+    }
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringColumnSupplier.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringColumnSupplier.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.RE;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.segment.column.ColumnBuilder;
+import org.apache.druid.segment.column.ColumnConfig;
+import org.apache.druid.segment.data.GenericIndexed;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class MapStringStringColumnSupplier implements Supplier<MapStringStringComplexColumn>
+{
+  private final MapStringStringColumnMetadata metadata;
+  private final GenericIndexed<String> keys;
+
+  private final ColumnConfig columnConfig;
+  private final SmooshedFileMapper fileMapper;
+
+  public MapStringStringColumnSupplier(
+      ByteBuffer bb,
+      ColumnBuilder columnBuilder,
+      ColumnConfig columnConfig,
+      ObjectMapper jsonMapper
+  )
+  {
+    byte version = bb.get();
+    if (version != MapStringStringColumnSerializer.VERSION) {
+      throw new IAE("Unknown version [%s].", version);
+    }
+
+    try {
+      metadata = jsonMapper.readValue(
+          MapStringStringColumnSerializer.SERIALIZER_UTILS.readString(bb),
+          MapStringStringColumnMetadata.class
+      );
+
+      keys = GenericIndexed.read(bb, GenericIndexed.STRING_STRATEGY);
+    }
+    catch (IOException ex) {
+      throw new RE(ex, "Failed to read metadata.");
+    }
+
+    fileMapper = Preconditions.checkNotNull(columnBuilder.getFileMapper(), "Null fileMapper");
+
+    this.columnConfig = columnConfig;
+  }
+
+  @Override
+  public MapStringStringComplexColumn get()
+  {
+    return new MapStringStringComplexColumn(
+        metadata,
+        keys,
+        columnConfig,
+        fileMapper
+    );
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringComplexColumn.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringComplexColumn.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.RE;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.query.extraction.ExtractionFn;
+import org.apache.druid.query.filter.ValueMatcher;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.IdLookup;
+import org.apache.druid.segment.column.BitmapIndex;
+import org.apache.druid.segment.column.ColumnBuilder;
+import org.apache.druid.segment.column.ColumnConfig;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.ComplexColumn;
+import org.apache.druid.segment.column.StringDictionaryEncodedColumn;
+import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.IndexedInts;
+import org.apache.druid.segment.data.ReadableOffset;
+import org.apache.druid.segment.data.ZeroIndexedInts;
+import org.apache.druid.segment.filter.BooleanValueMatcher;
+import org.apache.druid.segment.historical.SingleValueHistoricalDimensionSelector;
+import org.apache.druid.segment.serde.DictionaryEncodedColumnPartSerde;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MapStringStringComplexColumn implements ComplexColumn
+{
+  private static final NullDimensionSelector NULL_DIMENSION_SELECTOR = new NullDimensionSelector();
+
+  private final MapStringStringColumnMetadata metadata;
+  private final GenericIndexed<String> keys;
+  private final ColumnConfig columnConfig;
+  private final SmooshedFileMapper fileMapper;
+
+  private final ConcurrentHashMap<String, ColumnHolder> columns = new ConcurrentHashMap<>();
+
+  public MapStringStringComplexColumn(
+      MapStringStringColumnMetadata metadata,
+      GenericIndexed<String> keys,
+      ColumnConfig columnConfig,
+      SmooshedFileMapper fileMapper
+  )
+  {
+    this.metadata = metadata;
+    this.keys = keys;
+    this.columnConfig = columnConfig;
+    this.fileMapper = fileMapper;
+  }
+
+  @Override
+  public Class<?> getClazz()
+  {
+    return MapStringStringRow.class;
+  }
+
+  @Override
+  public String getTypeName()
+  {
+    return MapStringStringDruidModule.TYPE_NAME;
+  }
+
+  @Override
+  public Object getRowValue(int rowNum)
+  {
+    MapStringStringRow.Builder builder = new MapStringStringRow.Builder();
+    keys.forEach(
+        key -> {
+          StringDictionaryEncodedColumn col = (StringDictionaryEncodedColumn) getColumn(key).getColumn();
+          String value = col.lookupName(col.getSingleValueRow(rowNum));
+          builder.put(key, value);
+        }
+    );
+    return builder.build();
+  }
+
+  @Override
+  public int getLength()
+  {
+    //This is used by SegmentMetadata query, left out with dummy impl for now.
+    return 0;
+  }
+
+  @Override
+  public void close()
+  {
+
+  }
+
+  public DimensionSelector makeDimensionSelector(String key, ReadableOffset readableOffset, ExtractionFn fn)
+  {
+    Preconditions.checkNotNull(key, "Null key");
+
+    if (keys.indexOf(key) >= 0) {
+      StringDictionaryEncodedColumn col = (StringDictionaryEncodedColumn) getColumn(key).getColumn();
+      return col.makeDimensionSelector(readableOffset, fn);
+    } else {
+      return NULL_DIMENSION_SELECTOR;
+    }
+  }
+
+  public ColumnValueSelector<?> makeColumnValueSelector(String key, ReadableOffset readableOffset)
+  {
+    Preconditions.checkNotNull(key, "Null key");
+
+    if (keys.indexOf(key) >= 0) {
+      StringDictionaryEncodedColumn col = (StringDictionaryEncodedColumn) getColumn(key).getColumn();
+      return col.makeColumnValueSelector(readableOffset);
+    } else {
+      return NULL_DIMENSION_SELECTOR;
+    }
+  }
+
+  public BitmapIndex makeBitmapIndex(String key)
+  {
+    return getColumn(key).getBitmapIndex();
+  }
+
+  private ColumnHolder getColumn(String key)
+  {
+    return columns.computeIfAbsent(
+        key,
+        this::readStringDictionaryEncodedColumn
+    );
+  }
+
+  private ColumnHolder readStringDictionaryEncodedColumn(String key)
+  {
+    try {
+      ByteBuffer dataBuffer = fileMapper.mapFile(MapStringStringColumnSerializer.getKeyColumnFileName(key, metadata.getFileNameBase()));
+      if (dataBuffer == null) {
+        throw new ISE("WTH! Can't find [%s] key data in [%s] file.", key, metadata.getFileNameBase());
+      }
+
+      DictionaryEncodedColumnPartSerde serde = DictionaryEncodedColumnPartSerde.createDeserializer(
+          metadata.getBitmapSerdeFactory(),
+          metadata.getByteOrder()
+      );
+      ColumnBuilder columnBuilder = new ColumnBuilder().setFileMapper(fileMapper);
+      serde.getDeserializer().read(dataBuffer, columnBuilder, columnConfig);
+      return columnBuilder.build();
+    }
+    catch (IOException ex) {
+      throw new RE(ex, "IO error while loading data for [%s]", key);
+    }
+  }
+
+  private static class NullDimensionSelector implements SingleValueHistoricalDimensionSelector, IdLookup
+  {
+    private NullDimensionSelector()
+    {
+      // Singleton.
+    }
+
+    @Override
+    public IndexedInts getRow()
+    {
+      return ZeroIndexedInts.instance();
+    }
+
+    @Override
+    public int getRowValue(int offset)
+    {
+      return 0;
+    }
+
+    @Override
+    public IndexedInts getRow(int offset)
+    {
+      return getRow();
+    }
+
+    @Override
+    public ValueMatcher makeValueMatcher(@Nullable String value)
+    {
+      return BooleanValueMatcher.of(value == null);
+    }
+
+    @Override
+    public ValueMatcher makeValueMatcher(Predicate<String> predicate)
+    {
+      return BooleanValueMatcher.of(predicate.apply(null));
+    }
+
+    @Override
+    public int getValueCardinality()
+    {
+      return 1;
+    }
+
+    @Override
+    @Nullable
+    public String lookupName(int id)
+    {
+      return null;
+    }
+
+    @Override
+    public boolean nameLookupPossibleInAdvance()
+    {
+      return true;
+    }
+
+    @Nullable
+    @Override
+    public IdLookup idLookup()
+    {
+      return this;
+    }
+
+    @Override
+    public int lookupId(@Nullable String name)
+    {
+      return NullHandling.isNullOrEquivalent(name) ? 0 : -1;
+    }
+
+    @Nullable
+    @Override
+    public Object getObject()
+    {
+      return null;
+    }
+
+    @Override
+    public Class classOfObject()
+    {
+      return Object.class;
+    }
+
+    @Override
+    public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+    {
+      // nothing to inspect
+    }
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringComplexMetricSerde.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringComplexMetricSerde.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.segment.GenericColumnSerializer;
+import org.apache.druid.segment.column.ColumnBuilder;
+import org.apache.druid.segment.column.ColumnConfig;
+import org.apache.druid.segment.data.ObjectStrategy;
+import org.apache.druid.segment.serde.ComplexMetricExtractor;
+import org.apache.druid.segment.serde.ComplexMetricSerde;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+
+import java.nio.ByteBuffer;
+
+public class MapStringStringComplexMetricSerde extends ComplexMetricSerde
+{
+  public static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
+
+  public static final MapStringStringComplexMetricSerde INSTANCE = new MapStringStringComplexMetricSerde();
+
+  @Override
+  public String getTypeName()
+  {
+    return MapStringStringDruidModule.TYPE_NAME;
+  }
+
+  @Override
+  public ComplexMetricExtractor getExtractor()
+  {
+    return new ComplexMetricExtractor()
+    {
+      @Override
+      public Class<?> extractedClass()
+      {
+        return Object.class;
+      }
+
+      @Override
+      public Object extractValue(InputRow inputRow, String columnName)
+      {
+        return inputRow.getRaw(columnName);
+      }
+    };
+  }
+
+  @Override
+  public void deserializeColumn(ByteBuffer buffer, ColumnBuilder builder)
+  {
+    throw new UnsupportedOperationException("Not Supported");
+  }
+
+  @Override
+  public void deserializeColumn(ByteBuffer buffer, ColumnBuilder builder, ColumnConfig columnConfig)
+  {
+    MapStringStringColumnSupplier supplier = new MapStringStringColumnSupplier(buffer, builder, columnConfig, JSON_MAPPER);
+    builder.setComplexTypeName(MapStringStringDruidModule.TYPE_NAME);
+    builder.setComplexColumnSupplier(supplier);
+  }
+
+  @Override
+  public GenericColumnSerializer getSerializer(SegmentWriteOutMedium segmentWriteOutMedium, String column)
+  {
+    throw new UnsupportedOperationException("Not needed for dimension column. It is created via DimensionMergerV9.");
+  }
+
+  @Override
+  public ObjectStrategy getObjectStrategy()
+  {
+    throw new UnsupportedOperationException("Not supported");
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionHandler.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionHandler.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionHandler;
+import org.apache.druid.segment.DimensionIndexer;
+import org.apache.druid.segment.DimensionMergerV9;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.ProgressIndicator;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
+import org.apache.druid.segment.selector.settable.SettableObjectColumnValueSelector;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+
+import java.util.Comparator;
+
+public class MapStringStringDimensionHandler implements DimensionHandler<MapStringStringRow, MapStringStringRow, MapStringStringRow>
+{
+  private static Comparator<ColumnValueSelector> COMPARATOR = (s1, s2) ->
+      MapStringStringRow.COMPARATOR.compare((MapStringStringRow) s1.getObject(), (MapStringStringRow) s2.getObject());
+
+  private final String dimensionName;
+
+  public MapStringStringDimensionHandler(String dimensionName)
+  {
+    this.dimensionName = dimensionName;
+  }
+
+  @Override
+  public String getDimensionName()
+  {
+    return dimensionName;
+  }
+
+  @Override
+  public DimensionIndexer<MapStringStringRow, MapStringStringRow, MapStringStringRow> makeIndexer()
+  {
+    return new MapStringStringDimensionIndexer();
+  }
+
+  @Override
+  public DimensionMergerV9 makeMerger(
+      IndexSpec indexSpec,
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      ColumnCapabilities capabilities,
+      ProgressIndicator progress,
+      Closer closer
+  )
+  {
+    return new MapStringStringDimensionMergerV9(dimensionName, segmentWriteOutMedium, indexSpec, progress, closer);
+  }
+
+  @Override
+  public int getLengthOfEncodedKeyComponent(MapStringStringRow dimVals)
+  {
+    return 1;
+  }
+
+  @Override
+  public Comparator<ColumnValueSelector> getEncodedValueSelectorComparator()
+  {
+    return COMPARATOR;
+  }
+
+  @Override
+  public SettableColumnValueSelector makeNewSettableEncodedValueSelector()
+  {
+    return new SettableObjectColumnValueSelector();
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionIndexer.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionIndexer.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.collections.bitmap.MutableBitmap;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionDictionarySelector;
+import org.apache.druid.segment.DimensionIndexer;
+import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.ObjectColumnSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.data.CloseableIndexed;
+import org.apache.druid.segment.incremental.IncrementalIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexRowHolder;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class MapStringStringDimensionIndexer implements DimensionIndexer<MapStringStringRow, MapStringStringRow, MapStringStringRow>
+{
+  @Override
+  public MapStringStringRow processRowValsToUnsortedEncodedKeyComponent(
+      @Nullable Object dimValues,
+      boolean reportParseExceptions
+  )
+  {
+    if (dimValues == null) {
+      return MapStringStringRow.EMPTY_INSTANCE;
+    } else if (dimValues instanceof MapStringStringRow) {
+      MapStringStringRow row = (MapStringStringRow) dimValues;
+      return row;
+    } else if (dimValues instanceof Map) {
+      MapStringStringRow row = MapStringStringRow.create((Map) dimValues);
+      return row;
+    } else {
+      throw new IAE("Unsupported type");
+    }
+  }
+
+  @Override
+  public void setSparseIndexed()
+  {
+  }
+
+  @Override
+  public long estimateEncodedKeyComponentSize(MapStringStringRow key)
+  {
+    return key == null ? 0 : key.getEstimatedOnHeapSize();
+  }
+
+  @Override
+  public MapStringStringRow getUnsortedEncodedValueFromSorted(MapStringStringRow sortedIntermediateValue)
+  {
+    return sortedIntermediateValue;
+  }
+
+  @Override
+  public CloseableIndexed<MapStringStringRow> getSortedIndexedValues()
+  {
+    // no dictionary
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public MapStringStringRow getMinValue()
+  {
+    // This column is only used via VirtualColumn, so we should never reach here.
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public MapStringStringRow getMaxValue()
+  {
+    // This column is only used via VirtualColumn, so we should never reach here.
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public int getCardinality()
+  {
+    return DimensionDictionarySelector.CARDINALITY_UNKNOWN;
+  }
+
+  @Override
+  public ColumnCapabilities getColumnCapabilities()
+  {
+    return new ColumnCapabilitiesImpl().setType(ValueType.COMPLEX)
+                                       .setComplexTypeName(MapStringStringDruidModule.TYPE_NAME);
+  }
+
+  @Override
+  public DimensionSelector makeDimensionSelector(
+      DimensionSpec spec,
+      IncrementalIndexRowHolder currEntry,
+      IncrementalIndex.DimensionDesc desc
+  )
+  {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public ColumnValueSelector<?> makeColumnValueSelector(
+      IncrementalIndexRowHolder currEntry,
+      IncrementalIndex.DimensionDesc desc
+  )
+  {
+    final int dimIndex = desc.getIndex();
+    return new ObjectColumnSelector<MapStringStringRow>()
+    {
+      @Override
+      public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+      {
+
+      }
+
+      @Nullable
+      @Override
+      public MapStringStringRow getObject()
+      {
+        return (MapStringStringRow) currEntry.get().getDims()[dimIndex];
+      }
+
+      @Override
+      public Class<MapStringStringRow> classOfObject()
+      {
+        return MapStringStringRow.class;
+      }
+    };
+  }
+
+  @Override
+  public int compareUnsortedEncodedKeyComponents(
+      @Nullable MapStringStringRow lhs,
+      @Nullable MapStringStringRow rhs
+  )
+  {
+    return MapStringStringRow.COMPARATOR.compare(lhs, rhs);
+  }
+
+  @Override
+  public boolean checkUnsortedEncodedKeyComponentsEqual(
+      @Nullable MapStringStringRow lhs,
+      @Nullable MapStringStringRow rhs
+  )
+  {
+    return MapStringStringRow.COMPARATOR.compare(lhs, rhs) == 0;
+  }
+
+  @Override
+  public int getUnsortedEncodedKeyComponentHashCode(@Nullable MapStringStringRow key)
+  {
+    return key == null ? 0 : key.hashCode();
+  }
+
+  @Override
+  public Object convertUnsortedEncodedKeyComponentToActualList(MapStringStringRow key)
+  {
+    return key;
+  }
+
+  @Override
+  public ColumnValueSelector convertUnsortedValuesToSorted(ColumnValueSelector selectorWithUnsortedValues)
+  {
+    return selectorWithUnsortedValues;
+  }
+
+  @Override
+  public void fillBitmapsFromUnsortedEncodedKeyComponent(
+      MapStringStringRow key,
+      int rowNum, MutableBitmap[] bitmapIndexes,
+      BitmapFactory factory
+  )
+  {
+    throw new UnsupportedOperationException("Not supported");
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionMergerV9.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionMergerV9.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionMergerV9;
+import org.apache.druid.segment.GenericColumnSerializer;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.IndexableAdapter;
+import org.apache.druid.segment.ProgressIndicator;
+import org.apache.druid.segment.column.ColumnDescriptor;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.serde.ComplexColumnPartSerde;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.IntBuffer;
+import java.util.List;
+
+public class MapStringStringDimensionMergerV9 implements DimensionMergerV9
+{
+  private final GenericColumnSerializer serializer;
+
+  public MapStringStringDimensionMergerV9(
+      String dimensionName,
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      IndexSpec indexSpec,
+      ProgressIndicator progressIndicator,
+      Closer closer
+  )
+  {
+    this.serializer = new MapStringStringColumnSerializer(
+        segmentWriteOutMedium,
+        dimensionName,
+        indexSpec.getBitmapSerdeFactory(),
+        indexSpec.getDimensionCompression(),
+        MapStringStringComplexMetricSerde.JSON_MAPPER
+    );
+  }
+
+  @Override
+  public ColumnDescriptor makeColumnDescriptor()
+  {
+    return new ColumnDescriptor.Builder()
+        .setValueType(ValueType.COMPLEX)
+        .setHasMultipleValues(false)
+        .addSerde(ComplexColumnPartSerde.serializerBuilder()
+                                        .withTypeName(MapStringStringDruidModule.TYPE_NAME)
+                                        .withDelegate(serializer)
+                                        .build()
+        )
+        .build();
+  }
+
+  @Override
+  public void writeMergedValueDictionary(List<IndexableAdapter> adapters)
+  {
+
+  }
+
+  @Override
+  public ColumnValueSelector convertSortedSegmentRowValuesToMergedRowValues(
+      int segmentIndex,
+      ColumnValueSelector source
+  )
+  {
+    return source;
+  }
+
+  @Override
+  public void processMergedRow(ColumnValueSelector selector) throws IOException
+  {
+    serializer.serialize(selector);
+  }
+
+  @Override
+  public void writeIndexes(@Nullable List<IntBuffer> segmentRowNumConversions)
+  {
+
+  }
+
+  @Override
+  public boolean canSkip()
+  {
+    return false;
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionSchema.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDimensionSchema.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.data.input.impl.DimensionSchema;
+import org.apache.druid.segment.column.ValueType;
+
+public class MapStringStringDimensionSchema extends DimensionSchema
+{
+  @JsonCreator
+  public MapStringStringDimensionSchema(
+      @JsonProperty("name") String name,
+      @JsonProperty("createBitmapIndex") Boolean createBitmapIndex
+  )
+  {
+    super(name, null, createBitmapIndex == null ? true : createBitmapIndex.booleanValue());
+  }
+
+  @Override
+  public String getTypeName()
+  {
+    return MapStringStringDruidModule.TYPE_NAME;
+  }
+
+  @Override
+  public ValueType getValueType()
+  {
+    return ValueType.COMPLEX;
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDruidModule.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringDruidModule.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.inject.Binder;
+import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.segment.DimensionHandlerUtils;
+import org.apache.druid.segment.serde.ComplexMetrics;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MapStringStringDruidModule implements DruidModule
+{
+  public static final String TYPE_NAME = "mapStringString";
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return Collections.singletonList(
+        new SimpleModule("MapStringStringModule")
+            .registerSubtypes(
+                new NamedType(MapStringStringKeyVirtualColumn.class, "mapStringStringKey")
+            )
+            .registerSubtypes(
+                new NamedType(MapStringStringDimensionSchema.class, "mapStringString")
+            )
+            .registerSubtypes(
+                new NamedType(MapStringStringSelectorInputRowParser.class, "mapStringStringSelector")
+            )
+            .addSerializer(MapStringStringRow.class, new MapStringStringRow.Serializer())
+    );
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    if (ComplexMetrics.getSerdeForType(TYPE_NAME) == null) {
+      ComplexMetrics.registerSerde(TYPE_NAME, MapStringStringComplexMetricSerde.INSTANCE);
+    }
+
+    DimensionHandlerUtils.registerDimensionHandlerProvider(TYPE_NAME, (dimName) -> new MapStringStringDimensionHandler(dimName));
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringKeyVirtualColumn.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringKeyVirtualColumn.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.query.cache.CacheKeyBuilder;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.query.extraction.ExtractionFn;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.BaseSingleValueDimensionSelector;
+import org.apache.druid.segment.ColumnSelector;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.column.BaseColumn;
+import org.apache.druid.segment.column.BitmapIndex;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.data.ReadableOffset;
+import org.apache.druid.segment.virtual.VirtualColumnCacheHelper;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+public class MapStringStringKeyVirtualColumn implements VirtualColumn
+{
+  private final String columnName;
+  private final String key;
+  private final String outputName;
+
+  @JsonCreator
+  public MapStringStringKeyVirtualColumn(
+      @JsonProperty("columnName") String columnName,
+      @JsonProperty("key") String key,
+      @JsonProperty("outputName") String outputName
+  )
+  {
+    this.columnName = columnName;
+    this.key = key;
+    this.outputName = outputName;
+  }
+
+  @Override
+  @JsonProperty
+  public String getOutputName()
+  {
+    return outputName;
+  }
+
+  @JsonProperty
+  public String getColumnName()
+  {
+    return columnName;
+  }
+
+  @JsonProperty
+  public String getKey()
+  {
+    return key;
+  }
+
+  @Override
+  public DimensionSelector makeDimensionSelector(
+      DimensionSpec dimensionSpec,
+      ColumnSelectorFactory factory
+  )
+  {
+    ExtractionFn extractionFn = dimensionSpec.getExtractionFn();
+
+    return new BaseSingleValueDimensionSelector()
+    {
+      @Nullable
+      @Override
+      protected String getValue()
+      {
+        MapStringStringRow rowVal = ((MapStringStringRow) factory.makeColumnValueSelector(columnName).getObject());
+        String value = rowVal.getValue(key);
+        if (extractionFn != null) {
+          value = extractionFn.apply(value);
+        }
+        return value;
+      }
+
+      @Override
+      public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+      {
+
+      }
+    };
+  }
+
+  @Override
+  public DimensionSelector makeDimensionSelector(DimensionSpec dimensionSpec, ColumnSelector columnSelector, ReadableOffset offset)
+  {
+    return dimensionSpec.decorate(
+        getMultiStringDimComplexColumn(columnSelector).makeDimensionSelector(key, offset, dimensionSpec.getExtractionFn())
+    );
+  }
+
+  @Override
+  public ColumnValueSelector<?> makeColumnValueSelector(
+      String columnName,
+      ColumnSelectorFactory factory
+  )
+  {
+    return makeDimensionSelector(new DefaultDimensionSpec(columnName, columnName), factory);
+  }
+
+  @Override
+  public ColumnValueSelector<?> makeColumnValueSelector(String columnName, ColumnSelector columnSelector, ReadableOffset offset)
+  {
+    return makeDimensionSelector(new DefaultDimensionSpec(columnName, columnName), columnSelector, offset);
+  }
+
+  @Override
+  public BitmapIndex getBitmapIndex(String columnName, ColumnSelector selector)
+  {
+    return getMultiStringDimComplexColumn(selector).makeBitmapIndex(key);
+  }
+
+  @Override
+  public ColumnCapabilities capabilities(String columnName)
+  {
+    return new ColumnCapabilitiesImpl()
+        .setType(ValueType.STRING)
+        .setHasMultipleValues(false)
+        .setDictionaryEncoded(true)
+        .setHasBitmapIndexes(true);
+  }
+
+  @Override
+  public List<String> requiredColumns()
+  {
+    return Collections.singletonList(columnName);
+  }
+
+  @Override
+  public boolean usesDotNotation()
+  {
+    return false;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    return new CacheKeyBuilder(VirtualColumnCacheHelper.CACHE_TYPE_ID_USER_DEFINED)
+        .appendByte((byte) 1)
+        .appendString(columnName)
+        .appendString(key)
+        .appendString(outputName)
+        .build();
+  }
+
+  private MapStringStringComplexColumn getMultiStringDimComplexColumn(ColumnSelector columnSelector)
+  {
+    return toMultiStringDimComplexColumn(columnSelector.getColumnHolder(columnName).getColumn());
+  }
+
+  private MapStringStringComplexColumn toMultiStringDimComplexColumn(BaseColumn column)
+  {
+    if (column instanceof MapStringStringComplexColumn) {
+      return (MapStringStringComplexColumn) column;
+    } else {
+      throw new IAE("Unrecognized base column type [%s].", column.getClass().getName());
+    }
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringRow.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringRow.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import org.apache.druid.common.config.NullHandling;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+
+public class MapStringStringRow implements Comparable<MapStringStringRow>
+{
+  private static final Interner<String> STRING_INTERNER = Interners.newWeakInterner();
+
+  public static final Comparator<MapStringStringRow> COMPARATOR = new Comparator<MapStringStringRow>()
+  {
+    @Override
+    public int compare(MapStringStringRow o1, MapStringStringRow o2)
+    {
+      if (o1 == null) {
+        if (o2 == null) {
+          return 0;
+        } else {
+          return -1;
+        }
+      } else if (o2 == null) {
+        return 1;
+      } else {
+        return o1.compareTo(o2);
+      }
+    }
+  };
+
+  public static final MapStringStringRow EMPTY_INSTANCE = new MapStringStringRow(ImmutableMap.of());
+
+  private final ImmutableMap<String, String> values;
+
+  private MapStringStringRow(ImmutableMap<String, String> values)
+  {
+    this.values = values;
+  }
+
+  public static MapStringStringRow create(Map<String, String> in)
+  {
+    if (in == null) {
+      return EMPTY_INSTANCE;
+    }
+
+    Builder builder = new Builder();
+    for (Map.Entry<String, String> e : in.entrySet()) {
+      builder.put(e.getKey(), e.getValue());
+    }
+
+    return builder.build();
+  }
+
+  public String getValue(String key)
+  {
+    return values.get(key);
+  }
+
+  public ImmutableMap<String, String> getValues()
+  {
+    return values;
+  }
+
+  public long getEstimatedOnHeapSize()
+  {
+    // This is a rough approximation, also strings are interned so counting their size directly
+    // would severly overestimate the result. This can be further refined later as usage of this column
+    // becomes more widespread.
+    return values.size() * 2 * Long.BYTES * 4;
+  }
+
+  @Override
+  public int compareTo(MapStringStringRow o)
+  {
+    if (values.equals(o.values)) {
+      return 0;
+    }
+
+    // Note: We just want it to be deterministic
+    return values.hashCode() <= o.values.hashCode() ? -1 : 1;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MapStringStringRow that = (MapStringStringRow) o;
+    return Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(values);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "MapStringStringRow{" +
+           "values=" + values +
+           '}';
+  }
+
+  public static class Builder
+  {
+    private final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+    public void put(String key, String value)
+    {
+      value = NullHandling.emptyToNullIfNeeded(value);
+      if (key != null && value != null) {
+        builder.put(STRING_INTERNER.intern(key), STRING_INTERNER.intern(value));
+      }
+    }
+
+    public MapStringStringRow build()
+    {
+      ImmutableMap<String, String> values = builder.build();
+
+      if (values.isEmpty()) {
+        return EMPTY_INSTANCE;
+      } else {
+        return new MapStringStringRow(values);
+      }
+    }
+  }
+
+  public static class Serializer extends JsonSerializer<MapStringStringRow>
+  {
+    @Override
+    public void serialize(MapStringStringRow row, JsonGenerator jgen, SerializerProvider provider)
+        throws IOException
+    {
+      jgen.writeObject(row.getValues());
+    }
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringSelectorInputRowParser.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/MapStringStringSelectorInputRowParser.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.Row;
+import org.apache.druid.data.input.impl.InputRowParser;
+import org.apache.druid.data.input.impl.ParseSpec;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MapStringStringSelectorInputRowParser<T> implements InputRowParser<T>
+{
+  private final InputRowParser<T> delegate;
+  private final String mapColumnName;
+  private final Set<String> topLevelColumnKeys;
+
+  public MapStringStringSelectorInputRowParser(
+      @JsonProperty("delegate") final InputRowParser<T> delegate,
+      @JsonProperty("mapColumnName") final String mapColumnName,
+      @JsonProperty("topLevelColumnKeys") final Set<String> topLevelColumnKeys
+  )
+  {
+    this.delegate = delegate;
+    this.mapColumnName = mapColumnName;
+    this.topLevelColumnKeys = topLevelColumnKeys;
+  }
+
+  @JsonProperty
+  public InputRowParser<T> getDelegate()
+  {
+    return delegate;
+  }
+
+  @JsonProperty
+  public String getMapColumnName()
+  {
+    return mapColumnName;
+  }
+
+  @JsonProperty
+  public Set<String> getTopLevelColumnKeys()
+  {
+    return topLevelColumnKeys;
+  }
+
+  @Override
+  public List<InputRow> parseBatch(final T row)
+  {
+    return delegate.parseBatch(row).stream().map(TransformedInputRow::new).collect(Collectors.toList());
+  }
+
+  @Override
+  public ParseSpec getParseSpec()
+  {
+    return delegate.getParseSpec();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public InputRowParser<T> withParseSpec(final ParseSpec parseSpec)
+  {
+    return new MapStringStringSelectorInputRowParser<>(delegate.withParseSpec(parseSpec), mapColumnName, topLevelColumnKeys);
+  }
+
+  private class TransformedInputRow implements InputRow
+  {
+    private final InputRow delegate;
+    private final List<String> dimensions;
+
+    public TransformedInputRow(InputRow delegate)
+    {
+      this.delegate = delegate;
+
+      if (delegate.getDimensions() == null || delegate.getDimensions().isEmpty()) {
+        dimensions = Collections.emptyList();
+      } else {
+        dimensions = new ArrayList<>(Math.min(topLevelColumnKeys.size(), delegate.getDimensions().size()) + 1);
+
+        for (String dim : delegate.getDimensions()) {
+          if (topLevelColumnKeys.contains(dim)) {
+            dimensions.add(dim);
+          }
+        }
+
+        dimensions.add(mapColumnName);
+      }
+    }
+
+    @Override
+    public List<String> getDimensions()
+    {
+      return dimensions;
+    }
+
+    @Override
+    public long getTimestampFromEpoch()
+    {
+      return delegate.getTimestampFromEpoch();
+    }
+
+    @Override
+    public DateTime getTimestamp()
+    {
+      return delegate.getTimestamp();
+    }
+
+    @Override
+    public List<String> getDimension(String dimension)
+    {
+      if (topLevelColumnKeys.contains(dimension)) {
+        return delegate.getDimension(dimension);
+      } else {
+        return null;
+      }
+    }
+
+    @Nullable
+    @Override
+    public Object getRaw(String dimension)
+    {
+      if (topLevelColumnKeys.contains(dimension)) {
+        return delegate.getRaw(dimension);
+      } else if (mapColumnName.equals(dimension)) {
+        Map<String, String> data = new HashMap<>();
+        for (String dim : delegate.getDimensions()) {
+          if (!topLevelColumnKeys.contains(dim)) {
+            Object value = delegate.getRaw(dim);
+            data.put(dim, (String) value);
+          }
+        }
+        return data;
+      } else {
+        return null;
+      }
+    }
+
+    @Nullable
+    @Override
+    public Number getMetric(String metric)
+    {
+      return delegate.getMetric(metric);
+    }
+
+    @Override
+    public int compareTo(Row o)
+    {
+      return delegate.compareTo(o);
+    }
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/SampleFirehoseFactory.java
+++ b/extensions-contrib/druid-map-string-string-col/src/main/java/org/apache/druid/mapStringString/SampleFirehoseFactory.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.LineIterator;
+import org.apache.druid.data.input.FiniteFirehoseFactory;
+import org.apache.druid.data.input.Firehose;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.SplitHintSpec;
+import org.apache.druid.data.input.impl.InputRowParser;
+import org.apache.druid.java.util.common.RE;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.java.util.common.parsers.ParseException;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class SampleFirehoseFactory<T extends InputRowParser> implements FiniteFirehoseFactory<T, Object>
+{
+  @Override
+  public Firehose connect(T parser, @Nullable File temporaryDirectory) throws IOException, ParseException
+  {
+    return new SampleFirehose(parser);
+  }
+
+  @Override
+  public Stream<InputSplit<Object>> getSplits(
+      @Nullable SplitHintSpec splitHintSpec
+  ) throws IOException
+  {
+    return Stream.of(new InputSplit(null));
+  }
+
+  @Override
+  public int getNumSplits(@Nullable SplitHintSpec splitHintSpec) throws IOException
+  {
+    return 1;
+  }
+
+  @Override
+  public FiniteFirehoseFactory withSplit(InputSplit split)
+  {
+    return this;
+  }
+
+  private static class SampleFirehose implements Firehose
+  {
+    private static final Logger LOGGER = new Logger(SampleFirehose.class);
+    private final LineIterator lineIterator;
+    private final InputRowParser parser;
+
+    public SampleFirehose(InputRowParser parser)
+    {
+      try {
+        lineIterator = IOUtils.lineIterator(
+            new FileInputStream(
+                "/Users/hgupta/work/druid/examples/quickstart/tutorial/wikiticker-2015-09-12-sampled.json"),
+            StandardCharsets.UTF_8
+        );
+      }
+      catch (IOException ex) {
+        throw new RE(ex, "Data file not found");
+      }
+      this.parser = parser;
+    }
+
+    @Override
+    public boolean hasMore()
+    {
+      return lineIterator.hasNext();
+    }
+
+    @Nullable
+    @Override
+    public InputRow nextRow()
+    {
+      String line = lineIterator.nextLine();
+      byte[] data = line.getBytes(StandardCharsets.UTF_8);
+      List<InputRow> rows = parser.parseBatch(ByteBuffer.wrap(data));
+      if (rows.get(0) == null) {
+        LOGGER.warn("Parser[%s] gave NULL row", parser.getClass().getName());
+      }
+      InputRow row = rows.get(0);
+      LOGGER.warn("Row[%s] dimensions[%s] and tags are [%s]", row.getClass().getName(), row.getDimensions(), row.getRaw("tags"));
+      return row;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+      lineIterator.close();
+    }
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/druid-map-string-string-col/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.mapStringString.MapStringStringDruidModule

--- a/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringColumnMetadataTest.java
+++ b/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringColumnMetadataTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.data.ConciseBitmapSerdeFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteOrder;
+
+public class MapStringStringColumnMetadataTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper jsonMapper = TestHelper.JSON_MAPPER;
+
+    MapStringStringColumnMetadata metadata = new MapStringStringColumnMetadata(ByteOrder.BIG_ENDIAN, new ConciseBitmapSerdeFactory(), "test");
+
+    MapStringStringColumnMetadata metadataAfterSerde = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(metadata),
+        MapStringStringColumnMetadata.class
+    );
+
+    Assert.assertEquals(ByteOrder.BIG_ENDIAN, metadataAfterSerde.getByteOrder());
+    Assert.assertEquals(new ConciseBitmapSerdeFactory(), metadataAfterSerde.getBitmapSerdeFactory());
+    Assert.assertEquals("test", metadataAfterSerde.getFileNameBase());
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringDimensionSchemaTest.java
+++ b/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringDimensionSchemaTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.impl.DimensionSchema;
+import org.apache.druid.segment.column.ValueType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MapStringStringDimensionSchemaTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper jsonMapper = new ObjectMapper();
+    jsonMapper.registerModules(new MapStringStringDruidModule().getJacksonModules());
+
+    MapStringStringDimensionSchema schema = new MapStringStringDimensionSchema("test", null);
+
+    MapStringStringDimensionSchema schemaAfterSerde = (MapStringStringDimensionSchema) jsonMapper.readValue(
+        jsonMapper.writeValueAsString(schema),
+        DimensionSchema.class
+    );
+
+    Assert.assertEquals("test", schemaAfterSerde.getName());
+    Assert.assertEquals(true, schemaAfterSerde.hasBitmapIndex());
+    Assert.assertEquals(MapStringStringDruidModule.TYPE_NAME, schemaAfterSerde.getTypeName());
+    Assert.assertEquals(ValueType.COMPLEX, schemaAfterSerde.getValueType());
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringSelectorInputRowParserTest.java
+++ b/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringSelectorInputRowParserTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import org.apache.druid.data.input.impl.InputRowParser;
+import org.apache.druid.data.input.impl.StringInputRowParser;
+import org.apache.druid.data.input.impl.TimeAndDimsParseSpec;
+import org.junit.Assert;
+
+public class MapStringStringSelectorInputRowParserTest
+{
+  //@Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper jsonMapper = new ObjectMapper();
+    jsonMapper.registerModules(new MapStringStringDruidModule().getJacksonModules());
+
+    MapStringStringSelectorInputRowParser parser = new MapStringStringSelectorInputRowParser(
+        new StringInputRowParser(new TimeAndDimsParseSpec(null, null), null),
+        "tags",
+        Sets.newHashSet("a", "b")
+    );
+
+    System.out.println(jsonMapper.writeValueAsString(parser));
+
+    MapStringStringSelectorInputRowParser deserializedParser = (MapStringStringSelectorInputRowParser) jsonMapper.readValue(
+        jsonMapper.writeValueAsString(parser),
+        InputRowParser.class
+    );
+
+    Assert.assertEquals("tags", deserializedParser.getMapColumnName());
+    Assert.assertTrue(Sets.newHashSet("a", "b").equals(deserializedParser.getTopLevelColumnKeys()));
+    Assert.assertTrue(deserializedParser.getDelegate() instanceof StringInputRowParser);
+  }
+}

--- a/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringTypeTest.java
+++ b/extensions-contrib/druid-map-string-string-col/src/test/java/org/apache/druid/mapStringString/MapStringStringTypeTest.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.mapStringString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.NoopInputRowParser;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.query.Druids;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.aggregation.AggregationTestHelper;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.filter.NotDimFilter;
+import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.query.groupby.GroupByQuery;
+import org.apache.druid.query.groupby.GroupByQueryConfig;
+import org.apache.druid.query.groupby.ResultRow;
+import org.apache.druid.query.scan.ScanQuery;
+import org.apache.druid.query.scan.ScanResultValue;
+import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
+import org.apache.druid.segment.IncrementalIndexSegment;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.QueryableIndexIndexableAdapter;
+import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.incremental.IncrementalIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexAdapter;
+import org.apache.druid.timeline.SegmentId;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MapStringStringTypeTest
+{
+  public static final int NUM_ROWS = 5;
+
+  private static final String TAG0 = "tag0";
+  private static final String TAG1 = "tag1";
+  private static final String TAG2 = "tag2";
+  private static final String TAG3 = "tag3";
+  private static final String COUNT = "count";
+
+  public static final String SINGLE_DIM = "tag0-as-single-dim";
+  public static final String MULTI_DIM = "tags";
+
+  public static final List<String> DIMENSIONS = ImmutableList.of(
+      SINGLE_DIM,
+      TAG0,
+      TAG1,
+      TAG2,
+      TAG3
+  );
+
+  private static AggregatorFactory[] INDEX_AGGS = new AggregatorFactory[]{
+      new CountAggregatorFactory(COUNT)
+  };
+
+  private static final DateTime EVENT_TIMESTAMP = DateTimes.of("2020-01-01");
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private final AggregationTestHelper groupByQueryTestHelper;
+  private final AggregationTestHelper scanQueryTestHelper;
+
+  private final IncrementalIndex incIndex1;
+  private final IncrementalIndex incIndex2;
+  private final QueryableIndex queryableIndex1;
+  private final QueryableIndex queryableIndex2;
+  private final QueryableIndex mergedQueryableIndex;
+
+  private final List<Segment> segments;
+
+  public MapStringStringTypeTest() throws Exception
+  {
+    MapStringStringDruidModule druidModule = new MapStringStringDruidModule();
+    druidModule.configure(null);
+
+    groupByQueryTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+        druidModule.getJacksonModules(),
+        new GroupByQueryConfig(),
+        tempFolder
+    );
+
+    scanQueryTestHelper = AggregationTestHelper.createScanQueryAggregationTestHelper(
+        druidModule.getJacksonModules(),
+        tempFolder
+    );
+
+    incIndex1 = makeRealtimeIndex();
+    incIndex2 = makeRealtimeIndex();
+    queryableIndex1 = TestIndex.persistRealtimeAndLoadMMapped(incIndex1);
+    queryableIndex2 = TestIndex.persistRealtimeAndLoadMMapped(incIndex2);
+
+    // Note: using tempFolder.newFolder() at this point errors out with "the temporary folder has not yet been created"
+    File someTmpFile = File.createTempFile("MapStringStringType", "test");
+    someTmpFile.delete();
+    someTmpFile.mkdirs();
+    someTmpFile.deleteOnExit();
+
+    File mergedSegmentDir = TestIndex.INDEX_MERGER.merge(
+        ImmutableList.of(
+            new IncrementalIndexAdapter(
+                Intervals.of("1970/2050"),
+                incIndex1,
+                TestIndex.INDEX_SPEC.getBitmapSerdeFactory().getBitmapFactory()
+            ),
+            new IncrementalIndexAdapter(
+                Intervals.of("1970/2050"),
+                incIndex2,
+                TestIndex.INDEX_SPEC.getBitmapSerdeFactory().getBitmapFactory()
+            ),
+            new QueryableIndexIndexableAdapter(queryableIndex1),
+            new QueryableIndexIndexableAdapter(queryableIndex2)
+        ),
+        true,
+        INDEX_AGGS,
+        someTmpFile,
+        TestIndex.INDEX_SPEC
+    );
+
+    mergedQueryableIndex = TestIndex.INDEX_IO.loadIndex(mergedSegmentDir);
+
+    segments = ImmutableList.of(
+        new IncrementalIndexSegment(incIndex1, SegmentId.dummy("test1")),
+        new IncrementalIndexSegment(incIndex1, SegmentId.dummy("test2")),
+        new QueryableIndexSegment(queryableIndex1, SegmentId.dummy("test3")),
+        new QueryableIndexSegment(queryableIndex2, SegmentId.dummy("test4")),
+        new QueryableIndexSegment(mergedQueryableIndex, SegmentId.dummy("test5"))
+    );
+  }
+
+  private static IncrementalIndex makeRealtimeIndex()
+  {
+    NullHandling.initializeForTests();
+    try {
+      List<InputRow> inputRows = Lists.newArrayListWithExpectedSize(NUM_ROWS);
+      for (int i = 0; i < NUM_ROWS; i++) {
+        String tag0Val = TAG0 + i;
+        String tag1Val = TAG1 + i;
+        String tag2Val = i % 2 == 0 ? "" : TAG2 + i;
+        String tag3Val = i % 2 == 0 ? TAG3 + i : null;
+
+        Map<String, Object> rawData = new HashMap<>();
+        rawData.put(SINGLE_DIM, tag0Val);
+        rawData.put(TAG0, tag0Val);
+        rawData.put(TAG1, tag1Val);
+        rawData.put(TAG2, tag2Val);
+        rawData.put(TAG3, tag3Val);
+        MapBasedInputRow inputRow = new MapBasedInputRow(
+            EVENT_TIMESTAMP,
+            DIMENSIONS,
+            rawData
+        );
+
+        // Note: inputRow is added twice to test rollup.
+        inputRows.add(inputRow);
+        inputRows.add(inputRow);
+      }
+
+      return AggregationTestHelper.createIncrementalIndex(
+          inputRows.iterator(),
+          new MapStringStringSelectorInputRowParser(new NoopInputRowParser(null), MULTI_DIM, Collections.singleton(SINGLE_DIM)),
+          Lists.newArrayList(StringDimensionSchema.create(SINGLE_DIM), new MapStringStringDimensionSchema(MULTI_DIM, null)),
+          INDEX_AGGS,
+          0,
+          Granularities.NONE,
+          false,
+          100,
+          true
+      );
+    }
+    catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Test
+  public void testGroupByQuery() throws Exception
+  {
+    GroupByQuery query = new GroupByQuery.Builder()
+        .setDataSource("test")
+        .setGranularity(Granularities.ALL)
+        .setInterval("1970/2050")
+        .setVirtualColumns(
+            new MapStringStringKeyVirtualColumn(MULTI_DIM, TAG0, "tag0clone"),
+            new MapStringStringKeyVirtualColumn(MULTI_DIM, TAG1, TAG1),
+            new MapStringStringKeyVirtualColumn(MULTI_DIM, TAG2, TAG2),
+            new MapStringStringKeyVirtualColumn(MULTI_DIM, TAG3, TAG3),
+            new MapStringStringKeyVirtualColumn(MULTI_DIM, "nonExistingKey", "nonExistingDim")
+        )
+        .addDimension(SINGLE_DIM)
+        .addDimension("tag0clone")
+        .addDimension(TAG1)
+        .addDimension(TAG2)
+        .addDimension(TAG3)
+        .addDimension("nonExistingDim")
+        .setAggregatorSpecs(new LongSumAggregatorFactory(COUNT, COUNT))
+        .setDimFilter(
+            new NotDimFilter(new SelectorDimFilter(TAG1, TAG1 + (NUM_ROWS - 1), null))
+        )
+        .addOrderByColumn("tag0clone")
+        .build();
+
+    // do json serialization and deserialization of query to ensure there are no serde issues
+    ObjectMapper jsonMapper = groupByQueryTestHelper.getObjectMapper();
+    query = (GroupByQuery) jsonMapper.readValue(jsonMapper.writeValueAsString(query), Query.class);
+
+    Sequence<ResultRow> seq = groupByQueryTestHelper.runQueryOnSegmentsObjs(segments, query);
+
+    List<ResultRow> rows = seq.toList();
+    Assert.assertEquals(NUM_ROWS - 1, rows.size());
+
+    for (int i = 0; i < rows.size(); i++) {
+      Map event = rows.get(i).toMap(query);
+      Assert.assertEquals(TAG0 + i, event.get(SINGLE_DIM));
+      Assert.assertEquals(TAG0 + i, event.get("tag0clone"));
+      Assert.assertEquals(TAG1 + i, event.get(TAG1));
+      Assert.assertNull(event.get("nonExistingDim"));
+      Assert.assertEquals(16L, event.get(COUNT));
+
+      if (i % 2 == 0) {
+        Assert.assertNull(event.get(TAG2));
+        Assert.assertEquals(TAG3 + i, event.get(TAG3));
+      } else {
+        Assert.assertNull(event.get(TAG3));
+        Assert.assertEquals(TAG2 + i, event.get(TAG2));
+      }
+    }
+  }
+
+  @Test
+  public void testScanQuery() throws Exception
+  {
+    ScanQuery query = Druids.newScanQueryBuilder()
+                            .dataSource("test")
+                            .columns(Collections.emptyList())
+                            .intervals(new MultipleIntervalSegmentSpec(Collections.singletonList(Intervals.of("1970/2050"))))
+                            .limit(Integer.MAX_VALUE)
+                            .legacy(false)
+                            .build();
+
+    // do json serialization and deserialization of query to ensure there are no serde issues
+    ObjectMapper jsonMapper = scanQueryTestHelper.getObjectMapper();
+    query = (ScanQuery) jsonMapper.readValue(jsonMapper.writeValueAsString(query), Query.class);
+
+    // Test IncrementalIndex segment
+    Sequence<ScanResultValue> seq = scanQueryTestHelper.runQueryOnSegmentsObjs(Collections.singletonList(new IncrementalIndexSegment(incIndex1, SegmentId.dummy("test"))), query);
+
+    List<ScanResultValue> rows = seq.toList();
+    Assert.assertEquals(1, rows.size());
+
+    ScanResultValue srv = rows.get(0);
+    List<Map> events = (List<Map>) srv.getEvents();
+    Assert.assertEquals(NUM_ROWS, events.size());
+    for (int i = 0; i < events.size(); i++) {
+      Map event = events.get(i);
+      Assert.assertEquals(EVENT_TIMESTAMP.getMillis(), event.get(ColumnHolder.TIME_COLUMN_NAME));
+      Assert.assertEquals(TAG0 + i, event.get(SINGLE_DIM));
+      Assert.assertEquals(2, event.get(COUNT));
+
+      if (i % 2 == 0) {
+        Assert.assertEquals(ImmutableMap.of(TAG0, TAG0 + i, TAG1, TAG1 + i, TAG3, TAG3 + i), event.get(MULTI_DIM));
+      } else {
+        Assert.assertEquals(ImmutableMap.of(TAG0, TAG0 + i, TAG1, TAG1 + i, TAG2, TAG2 + i), event.get(MULTI_DIM));
+      }
+    }
+
+    // Test persisted segment
+    seq = scanQueryTestHelper.runQueryOnSegmentsObjs(Collections.singletonList(new QueryableIndexSegment(queryableIndex1, SegmentId.dummy("test"))), query);
+
+    rows = seq.toList();
+    Assert.assertEquals(1, rows.size());
+
+    srv = rows.get(0);
+    events = (List<Map>) srv.getEvents();
+    Assert.assertEquals(NUM_ROWS, events.size());
+    for (int i = 0; i < events.size(); i++) {
+      Map event = events.get(i);
+      Assert.assertEquals(EVENT_TIMESTAMP.getMillis(), event.get(ColumnHolder.TIME_COLUMN_NAME));
+      Assert.assertEquals(TAG0 + i, event.get(SINGLE_DIM));
+      Assert.assertEquals(2, event.get(COUNT));
+
+      if (i % 2 == 0) {
+        Assert.assertEquals(ImmutableMap.of(TAG0, TAG0 + i, TAG1, TAG1 + i, TAG3, TAG3 + i), event.get(MULTI_DIM));
+      } else {
+        Assert.assertEquals(ImmutableMap.of(TAG0, TAG0 + i, TAG1, TAG1 + i, TAG2, TAG2 + i), event.get(MULTI_DIM));
+      }
+    }
+
+    // Test merged-and-persisted segment
+    seq = scanQueryTestHelper.runQueryOnSegmentsObjs(Collections.singletonList(new QueryableIndexSegment(mergedQueryableIndex, SegmentId.dummy("test"))), query);
+
+    rows = seq.toList();
+    Assert.assertEquals(1, rows.size());
+
+    srv = rows.get(0);
+    events = (List<Map>) srv.getEvents();
+    Assert.assertEquals(NUM_ROWS, events.size());
+    for (int i = 0; i < events.size(); i++) {
+      Map event = events.get(i);
+      Assert.assertEquals(EVENT_TIMESTAMP.getMillis(), event.get(ColumnHolder.TIME_COLUMN_NAME));
+      Assert.assertEquals(TAG0 + i, event.get(SINGLE_DIM));
+      Assert.assertEquals(8, event.get(COUNT));
+
+      if (i % 2 == 0) {
+        Assert.assertEquals(ImmutableMap.of(TAG0, TAG0 + i, TAG1, TAG1 + i, TAG3, TAG3 + i), event.get(MULTI_DIM));
+      } else {
+        Assert.assertEquals(ImmutableMap.of(TAG0, TAG0 + i, TAG1, TAG1 + i, TAG2, TAG2 + i), event.get(MULTI_DIM));
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
         <module>extensions-core/google-extensions</module>
         <module>extensions-core/druid-ranger-security</module>
         <!-- Community extensions -->
+        <module>extensions-contrib/druid-map-string-string-col</module>
         <module>extensions-contrib/influx-extensions</module>
         <module>extensions-contrib/cassandra-storage</module>
         <module>extensions-contrib/dropwizard-emitter</module>


### PR DESCRIPTION
### Description

Introduces a "mapStringString" complex type dimension column. All the code lives in an isolated contrib extension and implements relevant extensible Druid core interfaces e.g. ComplexColumn, ComplexMetricSerde, DimensionHandler, DimensionIndexer, DimensionMerger etc etc.

It allows ingestion of `Map<String,String>` column in users input data as a single `dimension` column . At query time, user can access individual keys in the map as if they were simple `string` dimension columns (see `MapStringStringKeyVirtualColumn.java` ) or column can be accessed as records of `Map<String,String>` type but that does not have much use in Druid query layer for now aside from `select` query.

User would have to implement their own `InputRowParser` to supply  `Map<String,String>` records for ingestion , we used one that was very specific to our needs.

This extension also serves as an example of how users can create their own dimension columns for the specific needs and also [indirectly] tests the dimension extensibility support introduced in #10277

Future: Now that `VirtualColumn` interface has been enhanced to support vectorization, maybe the virtual column implementation code in this extension could also be improved to support that for [potentially] better performance.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

