### PR TITLE
update syntax for golbal cached uri lookups

### DIFF
--- a/docs/development/extensions-core/lookups-cached-global.md
+++ b/docs/development/extensions-core/lookups-cached-global.md
@@ -48,9 +48,9 @@ Globally cached lookups can be specified as part of the [cluster wide config for
        "namespaceParseSpec": {
          "format": "csv",
          "columns": [
-           "key",
-           "value"
-         ]
+             "[\"key\"",
+             "\"value\"]"
+      ]
        },
        "pollPeriod": "PT5M"
      },
@@ -186,7 +186,10 @@ The remapping values for each globally cached lookup can be specified by a JSON 
   "uri": "s3://bucket/some/key/prefix/renames-0003.gz",
   "namespaceParseSpec":{
     "format":"csv",
-    "columns":["key","value"]
+    "columns":[
+        "[\"key\"",
+        "\"value\"]"
+      ]
   },
   "pollPeriod":"PT5M"
 }
@@ -199,7 +202,10 @@ The remapping values for each globally cached lookup can be specified by a JSON 
   "fileRegex":"renames-[0-9]*\\.gz",
   "namespaceParseSpec":{
     "format":"csv",
-    "columns":["key","value"]
+    "columns":[
+        "[\"key\"",
+        "\"value\"]"
+      ]
   },
   "pollPeriod":"PT5M"
 }


### PR DESCRIPTION
Fixes an issue with the syntax for columns in cached global lookups

### Description

Updates the docs to be inline with the syntax displayed in the Druid UI.


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

