### PR TITLE
Correctly handle null values in time column results

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -26,6 +26,7 @@ import com.google.inject.Inject;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -134,7 +135,7 @@ public class SqlResource
                       for (int i = 0; i < fieldList.size(); i++) {
                         final Object value;
 
-                        if (row[i] == null){
+                        if (row[i] == null) {
                           value = null;
                         } else if (timeColumns[i]) {
                           value = ISODateTimeFormat.dateTime().print(

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -26,7 +26,6 @@ import com.google.inject.Inject;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -134,7 +134,9 @@ public class SqlResource
                       for (int i = 0; i < fieldList.size(); i++) {
                         final Object value;
 
-                        if (timeColumns[i]) {
+                        if (row[i] == null){
+                          value = null;
+                        } else if (timeColumns[i]) {
                           value = ISODateTimeFormat.dateTime().print(
                               Calcites.calciteTimestampToJoda((long) row[i], timeZone)
                           );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -407,11 +407,6 @@ public class CalciteTests
           .put("m1", "6.0")
           .put("m2", "6.0")
           .put("dim1", "abc")
-          .build(),
-      ImmutableMap.<String, Object>builder()
-          .put("m1", "6.0")
-          .put("m2", "6.0")
-          .put("dim1", "abc")
           .build()
   );
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -407,6 +407,11 @@ public class CalciteTests
           .put("m1", "6.0")
           .put("m2", "6.0")
           .put("dim1", "abc")
+          .build(),
+      ImmutableMap.<String, Object>builder()
+          .put("m1", "6.0")
+          .put("m2", "6.0")
+          .put("dim1", "abc")
           .build()
   );
 

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -326,6 +326,27 @@ public class SqlResourceTest extends CalciteTestBase
   }
 
   @Test
+  public void testTimestampsInResponseWithNulls() throws Exception
+  {
+    final List<Map<String, Object>> rows = doPost(
+        new SqlQuery(
+            "SELECT MAX(__time)",
+            ResultFormat.OBJECT,
+            false,
+            null,
+            null
+        )
+    ).rhs;
+
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("__time", "2000-01-03T00:00:00.000Z")
+        ),
+        rows
+    );
+  }
+
+  @Test
   public void testFieldAliasingSelect() throws Exception
   {
     final List<Map<String, Object>> rows = doPost(

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -342,11 +342,11 @@ public class SqlResourceTest extends CalciteTestBase
         NullHandling.replaceWithDefault() ?
         ImmutableList.of(
             ImmutableMap.of("t1", "2001-01-03T00:00:00.000Z", "t2", "-292275055-05-16T16:47:04.192Z") // t2 represents Long.MIN converted to a timestamp
-        ):
+        ) :
         ImmutableList.of(
-            Maps.transformValues(ImmutableMap.of("t1", "2001-01-03T00:00:00.000Z", "t2", ""), (val) -> val.equals("") ? null : val)
-        )
-        ,rows
+            Maps.transformValues(ImmutableMap.of("t1", "2001-01-03T00:00:00.000Z", "t2", ""), (val) -> "".equals(val) ? null : val)
+        ),
+        rows
     );
   }
 


### PR DESCRIPTION
### What

This PR fixes https://github.com/apache/druid/issues/10643 by handling the case where the returned value of a query was null but was being formatted as a timestamp leading to a null pointer exception.

### How

I've added a check to see if the value for a field we're returning is null. I've considered the behaviour of this change in two cases:

1) `druid.generic.useDefaultValueForNull=true`: We never receive a null value in this case but we can get the initial value of any aggregation buffer involved with the time column, i've opened https://github.com/apache/druid/issues/10644 for this, im not sure if this is a bug or what the actual behaviour should be. In this PR the value returned from aggregation will get formatted as a timestamp

2) `druid.generic.useDefaultValueForNull=false`: In this case the value will be null and we pass it along to the output instead of attempting to format it.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->


