### PR TITLE
Fix post-aggregator computation when used with subtotals

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -712,13 +712,13 @@ public class RowBasedGrouperHelper
           return new StringInputRawSupplierColumnSelectorStrategy();
         case LONG:
           return (InputRawSupplierColumnSelectorStrategy<BaseLongColumnValueSelector>)
-              columnSelector -> columnSelector::getLong;
+              columnSelector -> () -> columnSelector.isNull() ? null : columnSelector.getLong();
         case FLOAT:
           return (InputRawSupplierColumnSelectorStrategy<BaseFloatColumnValueSelector>)
-              columnSelector -> columnSelector::getFloat;
+              columnSelector -> () -> columnSelector.isNull() ? null : columnSelector.getFloat();
         case DOUBLE:
           return (InputRawSupplierColumnSelectorStrategy<BaseDoubleColumnValueSelector>)
-              columnSelector -> columnSelector::getDouble;
+              columnSelector -> () -> columnSelector.isNull() ? null : columnSelector.getDouble();
         default:
           throw new IAE("Cannot create query type helper from invalid type [%s]", type);
       }

--- a/processing/src/main/java/org/apache/druid/query/groupby/strategy/GroupByStrategyV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/strategy/GroupByStrategyV2.java
@@ -426,7 +426,6 @@ public class GroupByStrategyV2 implements GroupByStrategy
 
         GroupByQuery subtotalQuery = baseSubtotalQuery
             .withLimitSpec(subtotalQueryLimitSpec);
-            //.withDimensionSpecs(newDimensions);
 
         final GroupByRowProcessor.ResultSupplier resultSupplierOneFinal = resultSupplierOne;
         if (Utils.isPrefix(subtotalSpec, queryDimNames)) {

--- a/processing/src/main/java/org/apache/druid/query/groupby/strategy/GroupByStrategyV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/strategy/GroupByStrategyV2.java
@@ -408,27 +408,10 @@ public class GroupByStrategyV2 implements GroupByStrategy
         // Dimension spec including dimension name and output name
         final List<DimensionSpec> subTotalDimensionSpec = new ArrayList<>(dimsInSubtotalSpec.size());
         final List<DimensionSpec> dimensions = query.getDimensions();
-        final List<DimensionSpec> newDimensions = new ArrayList<>();
 
-        for (int i = 0; i < dimensions.size(); i++) {
-          DimensionSpec dimensionSpec = dimensions.get(i);
+        for (DimensionSpec dimensionSpec : dimensions) {
           if (dimsInSubtotalSpec.contains(dimensionSpec.getOutputName())) {
-            newDimensions.add(
-                new DefaultDimensionSpec(
-                    dimensionSpec.getOutputName(),
-                    dimensionSpec.getOutputName(),
-                    dimensionSpec.getOutputType()
-                )
-            );
             subTotalDimensionSpec.add(dimensionSpec);
-          } else {
-            // Insert dummy dimension so all subtotals queries have ResultRows with the same shape.
-            // Use a field name that does not appear in the main query result, to assure the result will be null.
-            String dimName = "_" + i;
-            while (query.getResultRowSignature().indexOf(dimName) >= 0) {
-              dimName = "_" + dimName;
-            }
-            newDimensions.add(DefaultDimensionSpec.of(dimName));
           }
         }
 
@@ -442,8 +425,8 @@ public class GroupByStrategyV2 implements GroupByStrategy
         }
 
         GroupByQuery subtotalQuery = baseSubtotalQuery
-            .withLimitSpec(subtotalQueryLimitSpec)
-            .withDimensionSpecs(newDimensions);
+            .withLimitSpec(subtotalQueryLimitSpec);
+            //.withDimensionSpecs(newDimensions);
 
         final GroupByRowProcessor.ResultSupplier resultSupplierOneFinal = resultSupplierOne;
         if (Utils.isPrefix(subtotalSpec, queryDimNames)) {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -12159,23 +12159,23 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     List<Object[]> resultList;
     if (NullHandling.sqlCompatible()) {
       resultList = ImmutableList.of(
-          new Object[]{NULL_STRING, 2L, 0L, "INDIVIDUAL"},
-          new Object[]{"", 1L, 0L, "INDIVIDUAL"},
-          new Object[]{"a", 2L, 0L, "INDIVIDUAL"},
-          new Object[]{"abc", 1L, 0L, "INDIVIDUAL"},
+          new Object[]{NULL_STRING, 2L, 0L, NULL_STRING},
+          new Object[]{"", 1L, 0L, ""},
+          new Object[]{"a", 2L, 0L, "a"},
+          new Object[]{"abc", 1L, 0L, "abc"},
           new Object[]{NULL_STRING, 6L, 1L, "ALL"}
       );
     } else {
       resultList = ImmutableList.of(
-          new Object[]{"", 3L, 0L, "INDIVIDUAL"},
-          new Object[]{"a", 2L, 0L, "INDIVIDUAL"},
-          new Object[]{"abc", 1L, 0L, "INDIVIDUAL"},
+          new Object[]{"", 3L, 0L, ""},
+          new Object[]{"a", 2L, 0L, "a"},
+          new Object[]{"abc", 1L, 0L, "abc"},
           new Object[]{NULL_STRING, 6L, 1L, "ALL"}
       );
     }
     testQuery(
         "SELECT dim2, SUM(cnt), GROUPING(dim2), \n"
-        + "CASE WHEN GROUPING(dim2) = 1 THEN 'ALL' ELSE 'INDIVIDUAL' END\n"
+        + "CASE WHEN GROUPING(dim2) = 1 THEN 'ALL' ELSE dim2 END\n"
         + "FROM druid.foo\n"
         + "GROUP BY GROUPING SETS ( (dim2), () )",
         ImmutableList.of(
@@ -12200,7 +12200,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setPostAggregatorSpecs(Collections.singletonList(new ExpressionPostAggregator(
                             "p0",
-                            "case_searched((\"a1\" == 1),'ALL','INDIVIDUAL')",
+                            "case_searched((\"a1\" == 1),'ALL',\"d0\")",
                             null,
                             ExprMacroTable.nil()
                         )))


### PR DESCRIPTION
### Description

Post-aggregators, when used with subtotals, errors if the post-aggregator depends on a dimension that is absent in one of the subtotal. An example query is as follows

```
SELECT dim2, SUM(cnt), GROUPING(dim2), 
CASE WHEN GROUPING(dim2) = 1 THEN 'ALL' ELSE dim2 END
FROM druid.foo
GROUP BY GROUPING SETS ( (dim2), () )
```

The exception is 
```
java.lang.IllegalArgumentException: Missing fields [[d0]] for postAggregator [p0]

	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:148)
	at org.apache.druid.query.Queries.prepareAggregations(Queries.java:118)
	at org.apache.druid.query.groupby.GroupByQuery.<init>(GroupByQuery.java:210)
	at org.apache.druid.query.groupby.GroupByQuery.<init>(GroupByQuery.java:88)
	at org.apache.druid.query.groupby.GroupByQuery$Builder.build(GroupByQuery.java:1175)
	at org.apache.druid.query.groupby.GroupByQuery.withDimensionSpecs(GroupByQuery.java:804)
	at org.apache.druid.query.groupby.strategy.GroupByStrategyV2.processSubtotalsSpec(GroupByStrategyV2.java:446)
	at org.apache.druid.query.groupby.GroupByQueryQueryToolChest.mergeGroupByResultsWithoutPushDown(GroupByQueryQueryToolChest.java:250)
	at org.apache.druid.query.groupby.GroupByQueryQueryToolChest.mergeGroupByResults(GroupByQueryQueryToolChest.java:177)
	at org.apache.druid.query.groupby.GroupByQueryQueryToolChest.initAndMergeGroupByResults(GroupByQueryQueryToolChest.java:149)
	at org.apache.druid.query.groupby.GroupByQueryQueryToolChest.lambda$mergeResults$0(GroupByQueryQueryToolChest.java:122)
	at org.apache.druid.query.FinalizeResultsQueryRunner.run(FinalizeResultsQueryRunner.java:110)
```

I have removed the dimension renaming. We only carry over the dimensions included in the subtotal spec while generating results for any subtotal. 

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `GroupyByStrategyV2`
