### PR TITLE
Bump up jackson-databind to 2.10.5.1

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -222,7 +222,6 @@ version: 2.10.2
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core
-  - com.fasterxml.jackson.core: jackson-databind
   - com.fasterxml.jackson.dataformat: jackson-dataformat-cbor
   - com.fasterxml.jackson.dataformat: jackson-dataformat-smile
   - com.fasterxml.jackson.datatype: jackson-datatype-guava
@@ -232,6 +231,37 @@ libraries:
   - com.fasterxml.jackson.jaxrs: jackson-jaxrs-smile-provider
   - com.fasterxml.jackson.module: jackson-module-jaxb-annotations
   - com.fasterxml.jackson.module: jackson-module-guice
+notice: |
+  # Jackson JSON processor
+
+  Jackson is a high-performance, Free/Open Source JSON processing library.
+  It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+  been in development since 2007.
+  It is currently developed by a community of developers, as well as supported
+  commercially by FasterXML.com.
+
+  ## Licensing
+
+  Jackson core and extension components may licensed under different licenses.
+  To find the details that apply to this artifact see the accompanying LICENSE file.
+  For more information, including possible other licensing options, contact
+  FasterXML.com (http://fasterxml.com).
+
+  ## Credits
+
+  A list of contributors may be found from CREDITS file, which is included
+  in some artifacts (usually source distributions); but is always available
+  from the source code management (SCM) system project uses.
+
+---
+
+name: Jackson
+license_category: binary
+module: java-core
+license_name: Apache License version 2.0
+version: 2.10.5.1
+libraries:
+  - com.fasterxml.jackson.core: jackson-databind
 notice: |
   # Jackson JSON processor
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,8 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.34.v20201102</jetty.version>
         <jersey.version>1.19.3</jersey.version>
-        <jackson.version>2.10.5.1</jackson.version>
+        <jackson.version>2.10.2</jackson.version>
+        <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.8.2</log4j.version>
         <mysql.version>5.1.48</mysql.version>
@@ -451,7 +452,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.34.v20201102</jetty.version>
         <jersey.version>1.19.3</jersey.version>
-        <jackson.version>2.10.2</jackson.version>
+        <jackson.version>2.10.5.1</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.8.2</log4j.version>
         <mysql.version>5.1.48</mysql.version>


### PR DESCRIPTION
### Description

A severe security vulnerability flagged by CI (https://travis-ci.com/github/apache/druid/builds/207177055) is fixed in 2.10.5.1. This PR only changes the version of `jackson-databind` as other jackson libraries don't have the matched version. See https://nvd.nist.gov/vuln/detail/CVE-2020-25649 and https://github.com/FasterXML/jackson-databind/issues/2589 for more details.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.