### PR TITLE
Return appropriate config directory path for indexer process.

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -55,6 +55,7 @@ getConfPath() {
     _common) echo $cluster_conf_base/_common ;;
     historical) echo $cluster_conf_base/data/historical ;;
     middleManager) echo $cluster_conf_base/data/middleManager ;;
+    indexer) echo $cluster_conf_base/data/indexer ;;
     coordinator | overlord) echo $cluster_conf_base/master/coordinator-overlord ;;
     broker) echo $cluster_conf_base/query/broker ;;
     router) echo $cluster_conf_base/query/router ;;

--- a/integration-tests/docker/druid.sh
+++ b/integration-tests/docker/druid.sh
@@ -25,6 +25,7 @@ getConfPath()
     historical) echo $cluster_conf_base/data/historical ;;
     historical-for-query-retry-test) echo $cluster_conf_base/data/historical ;;
     middleManager) echo $cluster_conf_base/data/middleManager ;;
+    indexer) echo $cluster_conf_base/data/indexer ;;
     coordinator) echo $cluster_conf_base/master/coordinator ;;
     broker) echo $cluster_conf_base/query/broker ;;
     router) echo $cluster_conf_base/query/router ;;


### PR DESCRIPTION
Currently `getConfPath` function returns an empty string for `indexer` service. So the config directory path for this service is not set properly when installed using docker environment. Raising this PR to fix this.

Testing:
With this fix, now I see javaOpts being passed to jvm while starting indexer service
```java -server -Xms<xx>g -Xmx<xx>g -XX:MaxDirectMemorySize=<xx> -XX:+ExitOnOutOfMemoryError -XX:+UseG1GC -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Djava.io.tmpdir=<xx> -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Ddruid.service=druid/indexer -cp /tmp/conf/druid/cluster/_common:<xx>druid/cluster/data/indexer:lib/*: org.apache.druid.cli.Main server indexer```