### PR TITLE
fix DruidSchema incorrectly listing tables with no segments

### DIFF
--- a/integration-tests/src/test/resources/queries/broadcast_join_after_drop_metadata_queries.json
+++ b/integration-tests/src/test/resources/queries/broadcast_join_after_drop_metadata_queries.json
@@ -1,0 +1,9 @@
+[
+  {
+    "description": "query information schema to make sure datasource is joinable and broadcast",
+    "query": {
+      "query": "SELECT TABLE_NAME, IS_JOINABLE, IS_BROADCAST FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '%%JOIN_DATASOURCE%%' AND IS_JOINABLE = 'YES' AND IS_BROADCAST = 'YES' AND TABLE_SCHEMA = 'druid'"
+    },
+    "expectedResults": []
+  }
+]

--- a/integration-tests/src/test/resources/queries/broadcast_join_metadata_queries.json
+++ b/integration-tests/src/test/resources/queries/broadcast_join_metadata_queries.json
@@ -2,7 +2,7 @@
   {
     "description": "query information schema to make sure datasource is joinable and broadcast",
     "query": {
-      "query": "SELECT TABLE_NAME, IS_JOINABLE, IS_BROADCAST FROM INFORMATION_SCHEMA.TABLES WHERE IS_JOINABLE = 'YES' AND IS_BROADCAST = 'YES' AND TABLE_SCHEMA = 'druid'"
+      "query": "SELECT TABLE_NAME, IS_JOINABLE, IS_BROADCAST FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '%%JOIN_DATASOURCE%%' AND IS_JOINABLE = 'YES' AND IS_BROADCAST = 'YES' AND TABLE_SCHEMA = 'druid'"
     },
     "expectedResults": [
       {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -270,8 +270,17 @@ public class DruidSchema extends AbstractSchema
                   // Add missing segments back to the refresh list.
                   segmentsNeedingRefresh.addAll(Sets.difference(segmentsToRefresh, refreshed));
 
+                  // remove any tables which have been completely dropped before refresh
+                  Set<String> filteredDatasourcesNeedingRebuild =
+                      dataSourcesNeedingRebuild.stream()
+                                               .filter(
+                                                   table ->
+                                                       segmentMetadataInfo.containsKey(table)
+                                                       && !segmentMetadataInfo.get(table).isEmpty()
+                                               )
+                                               .collect(Collectors.toSet());
                   // Compute the list of dataSources to rebuild tables for.
-                  dataSourcesToRebuild.addAll(dataSourcesNeedingRebuild);
+                  dataSourcesToRebuild.addAll(filteredDatasourcesNeedingRebuild);
                   refreshed.forEach(segment -> dataSourcesToRebuild.add(segment.getDataSource()));
                   dataSourcesNeedingRebuild.clear();
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -271,16 +271,14 @@ public class DruidSchema extends AbstractSchema
                   segmentsNeedingRefresh.addAll(Sets.difference(segmentsToRefresh, refreshed));
 
                   // remove any tables which have been completely dropped before refresh
-                  Set<String> filteredDatasourcesNeedingRebuild =
-                      dataSourcesNeedingRebuild.stream()
-                                               .filter(
-                                                   table ->
-                                                       segmentMetadataInfo.containsKey(table)
-                                                       && !segmentMetadataInfo.get(table).isEmpty()
-                                               )
-                                               .collect(Collectors.toSet());
+                  final ImmutableSet.Builder<String> filteredDatasourcesNeedingRebuildBuilder = ImmutableSet.builder();
+                  for (String dataSource : dataSourcesNeedingRebuild) {
+                    if (segmentMetadataInfo.containsKey(dataSource) && !segmentMetadataInfo.get(dataSource).isEmpty()) {
+                      filteredDatasourcesNeedingRebuildBuilder.add(dataSource);
+                    }
+                  }
                   // Compute the list of dataSources to rebuild tables for.
-                  dataSourcesToRebuild.addAll(filteredDatasourcesNeedingRebuild);
+                  dataSourcesToRebuild.addAll(filteredDatasourcesNeedingRebuildBuilder.build());
                   refreshed.forEach(segment -> dataSourcesToRebuild.add(segment.getDataSource()));
                   dataSourcesNeedingRebuild.clear();
 


### PR DESCRIPTION
### Description
This PR fixes an issue where tables with all of their segments dropped could still incorrectly show up in the `INFORMATION_SCHEMA` tables when queries with SQL. The underlying issue was caused by a race condition between `DruidSchema.tables` being populated upon rebuilding the tables, segment removal handlers removing segments from `tables` when no other segments were left (but not `dataSourcesNeedingRebuild`), and `DruidSchema.dataSourcesNeedingRebuild` not considering if the table had been removed from `tables` due to all the segments being dropped in the time between being added to the refresh list and actually doing the refresh.

The added an additional step to the `ITBroadcastJoinQueryTest` integration test that would fail prior to the changes in `DruidSchema`, and chose this test in particular to cover the most surface area since there are segments on both the historical and the broker.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `DruidSchema`