### PR TITLE
Adding example config files for indexer process. Also added status/selfDiscovered endpoint to indexer for self discovery

### DIFF
--- a/examples/conf/druid/cluster/data/indexer/jvm.config
+++ b/examples/conf/druid/cluster/data/indexer/jvm.config
@@ -1,0 +1,9 @@
+-server
+-Xms4g
+-Xmx4g
+-XX:MaxDirectMemorySize=4g
+-XX:+ExitOnOutOfMemoryError
+-Duser.timezone=UTC
+-Dfile.encoding=UTF-8
+-Djava.io.tmpdir=var/tmp
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager

--- a/examples/conf/druid/cluster/data/indexer/main.config
+++ b/examples/conf/druid/cluster/data/indexer/main.config
@@ -1,0 +1,1 @@
+org.apache.druid.cli.Main server indexer

--- a/examples/conf/druid/cluster/data/indexer/runtime.properties
+++ b/examples/conf/druid/cluster/data/indexer/runtime.properties
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+druid.service=druid/indexer
+druid.plaintextPort=8091
+
+# Number of tasks per indexer
+druid.worker.capacity=4
+
+# Task launch parameters
+druid.indexer.task.baseTaskDir=var/druid/task
+
+# HTTP server threads
+druid.server.http.numThreads=60
+
+# Processing threads and buffers on Indexer
+druid.processing.numMergeBuffers=2
+druid.processing.buffer.sizeBytes=100MiB
+druid.processing.numThreads=4
+
+# Hadoop indexing
+druid.indexer.task.hadoopWorkingPath=var/druid/hadoop-tmp

--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -22,6 +22,7 @@ package org.apache.druid.cli;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
@@ -72,6 +73,7 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordination.ZkCoordinator;
 import org.apache.druid.server.http.HistoricalResource;
 import org.apache.druid.server.http.SegmentListerResource;
+import org.apache.druid.server.http.SelfDiscoveryResource;
 import org.apache.druid.server.initialization.jetty.CliIndexerServerModule;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.eclipse.jetty.server.Server;
@@ -168,6 +170,9 @@ public class CliIndexer extends ServerRunnable
                     )
                     .build()
             );
+
+            Jerseys.addResource(binder, SelfDiscoveryResource.class);
+            LifecycleModule.registerKey(binder, Key.get(SelfDiscoveryResource.class));
           }
 
           @Provides


### PR DESCRIPTION
In this PR I have added example config files that can be used to spin up the indexer process. And have also added the `status/selfDiscovered` endpoint to indexer. Per the [api-reference](https://druid.apache.org/docs/latest/operations/api-reference.html#common) doc, all services support `status/selfDiscovered` endpoint. So this PR would fix that expected behavior.

Code changes:
Since the SelfDiscovered endpoint is registered in the middle manager [here](https://github.com/apache/druid/blob/ee136303bb561d02dcfc8e4cd7f7b7af907e4e28/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java#L167), I followed the similar pattern in CliIndexer.java file as well

Testing
Built my own docker image, added the following in `docker-compose.yml` file
```
+  indexer:
+    image: apache/druid:harini
+    container_name: indexer
+    volumes:
+      - ./storage:/opt/data
+      - middle_var:/opt/druid/var
+    depends_on:
+      - zookeeper
+      - postgres
+      - coordinator
+    ports:
+      - "8092:8091"
+    command:
+      - indexer
+    env_file:
+      - environment
+
```

Brought all the services up
```
hrajendran@Harini-Rajendran's-MBP16 docker % docker-compose up -d
Creating network "docker_default" with the default driver
Creating postgres  ... done
Creating zookeeper ... done
Creating coordinator ... done
Creating indexer       ... done
Creating router        ... done
Creating broker        ... done
Creating historical    ... done
Creating middlemanager ... done
hrajendran@Harini-Rajendran's-MBP16 docker % docker ps
CONTAINER ID        IMAGE                 COMMAND                  CREATED             STATUS              PORTS                                    NAMES
65dc5d38b6fa        apache/druid:harini   "/druid.sh broker"       2 minutes ago       Up About a minute   0.0.0.0:8082->8082/tcp                   broker
bc4d96b16aa5        apache/druid:harini   "/druid.sh historical"   2 minutes ago       Up About a minute   0.0.0.0:8083->8083/tcp                   historical
8630096058c1        apache/druid:harini   "/druid.sh middleMan…"   2 minutes ago       Up About a minute   0.0.0.0:8091->8091/tcp                   middlemanager
61b9c89be515        apache/druid:harini   "/druid.sh indexer"      2 minutes ago       Up About a minute   0.0.0.0:8092->8091/tcp                   indexer
d3c5d2f3e3ed        apache/druid:harini   "/druid.sh router"       2 minutes ago       Up About a minute   0.0.0.0:8888->8888/tcp                   router
932a8794440b        apache/druid:harini   "/druid.sh coordinat…"   2 minutes ago       Up 2 minutes        0.0.0.0:8081->8081/tcp                   coordinator
086fe8a44b0a        postgres:latest       "docker-entrypoint.s…"   2 minutes ago       Up 2 minutes        5432/tcp                                 postgres
c3ea54ce6907        zookeeper:3.5         "/docker-entrypoint.…"   2 minutes ago       Up 2 minutes        2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp   zookeeper

```

Made `status/selfDiscovered` curl call to indexer running on port 8092 and got back 200 OK.
```
hrajendran@Harini-Rajendran's-MBP16 docker % curl -v http://localhost:8092/status/selfDiscovered
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8092 (#0)
> GET /status/selfDiscovered HTTP/1.1
> Host: localhost:8092
> User-Agent: curl/7.64.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 14 Dec 2020 20:11:58 GMT
< Content-Type: application/json
< Vary: Accept-Encoding, User-Agent
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
* Closing connection 0

```