### PR TITLE
Subtotal queries give incorrect results if query has a limit spec

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
@@ -59,6 +59,33 @@ public class ByteBufferMinMaxOffsetHeap
     this.heapIndexUpdater = heapIndexUpdater;
   }
 
+
+
+  public ByteBufferMinMaxOffsetHeap copy() {
+    LimitedBufferHashGrouper.BufferGrouperOffsetHeapIndexUpdater updater =
+        heapIndexUpdater.copy();
+
+    // deep copy buf
+    ByteBuffer buffer = ByteBuffer.allocateDirect(buf.capacity());
+
+    int bufPosition = buf.position();
+    int bufLimit = buf.limit();
+    buf.rewind();
+
+    buffer.put(buf);
+    buffer.position(bufPosition);
+    buffer.limit(bufLimit);
+
+    buf.position(bufPosition);
+    buf.limit(bufLimit);
+
+    ByteBufferMinMaxOffsetHeap retVal = new ByteBufferMinMaxOffsetHeap(buffer,this.limit,minComparator,updater);
+    retVal.heapSize = this.heapSize;
+
+    return retVal;
+  }
+
+
   public void reset()
   {
     heapSize = 0;

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
@@ -59,9 +59,8 @@ public class ByteBufferMinMaxOffsetHeap
     this.heapIndexUpdater = heapIndexUpdater;
   }
 
-
-
-  public ByteBufferMinMaxOffsetHeap copy() {
+  public ByteBufferMinMaxOffsetHeap copy()
+  {
     LimitedBufferHashGrouper.BufferGrouperOffsetHeapIndexUpdater updater =
         heapIndexUpdater.copy();
 
@@ -79,7 +78,7 @@ public class ByteBufferMinMaxOffsetHeap
     buf.position(bufPosition);
     buf.limit(bufLimit);
 
-    ByteBufferMinMaxOffsetHeap retVal = new ByteBufferMinMaxOffsetHeap(buffer,this.limit,minComparator,updater);
+    ByteBufferMinMaxOffsetHeap retVal = new ByteBufferMinMaxOffsetHeap(buffer, this.limit, minComparator, updater);
     retVal.heapSize = this.heapSize;
 
     return retVal;
@@ -482,7 +481,8 @@ public class ByteBufferMinMaxOffsetHeap
       int leftChildOffset = buf.getInt(lcIdx * Integer.BYTES);
       if (comparator.compare(offset, leftChildOffset) > 0) {
         throw new ISE("Left child val[%d] at idx[%d] is less than val[%d] at idx[%d]",
-                      leftChildOffset, lcIdx, offset, i);
+                      leftChildOffset, lcIdx, offset, i
+        );
       }
     }
 
@@ -491,7 +491,8 @@ public class ByteBufferMinMaxOffsetHeap
       int rightChildOffset = buf.getInt(rcIdx * Integer.BYTES);
       if (comparator.compare(offset, rightChildOffset) > 0) {
         throw new ISE("Right child val[%d] at idx[%d] is less than val[%d] at idx[%d]",
-                      rightChildOffset, rcIdx, offset, i);
+                      rightChildOffset, rcIdx, offset, i
+        );
       }
     }
 
@@ -500,7 +501,8 @@ public class ByteBufferMinMaxOffsetHeap
       int parentOffset = buf.getInt(parentIdx * Integer.BYTES);
       if (comparator.compare(offset, parentOffset) > 0) {
         throw new ISE("Parent val[%d] at idx[%d] is less than val[%d] at idx[%d]",
-                      parentOffset, parentIdx, offset, i);
+                      parentOffset, parentIdx, offset, i
+        );
       }
     }
 
@@ -509,7 +511,8 @@ public class ByteBufferMinMaxOffsetHeap
       int gpOffset = buf.getInt(gpIdx * Integer.BYTES);
       if (comparator.compare(gpOffset, offset) > 0) {
         throw new ISE("Grandparent val[%d] at idx[%d] is less than val[%d] at idx[%d]",
-                      gpOffset, gpIdx, offset, i);
+                      gpOffset, gpIdx, offset, i
+        );
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
@@ -25,6 +25,7 @@ import org.apache.druid.java.util.common.ISE;
 
 import java.nio.ByteBuffer;
 import java.util.Comparator;
+import java.util.Optional;
 
 /**
  * ByteBuffer-based implementation of the min-max heap developed by Atkinson, et al.
@@ -62,7 +63,10 @@ public class ByteBufferMinMaxOffsetHeap
   public ByteBufferMinMaxOffsetHeap copy()
   {
     LimitedBufferHashGrouper.BufferGrouperOffsetHeapIndexUpdater updater =
-        heapIndexUpdater.copy();
+        Optional
+            .ofNullable(heapIndexUpdater)
+            .map(LimitedBufferHashGrouper.BufferGrouperOffsetHeapIndexUpdater::copy)
+            .orElse(null);
 
     // deep copy buf
     ByteBuffer buffer = ByteBuffer.allocateDirect(buf.capacity());

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -219,10 +219,9 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
       this.indexPosition = indexPosition;
     }
 
-    public BufferGrouperOffsetHeapIndexUpdater copy() {
-
+    public BufferGrouperOffsetHeapIndexUpdater copy()
+    {
       // deep copy hashtable buffer:
-
       ByteBuffer buffer = ByteBuffer.allocateDirect(hashTableBuffer.capacity());
 
       int position = hashTableBuffer.position();
@@ -236,7 +235,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
       hashTableBuffer.position(position);
       hashTableBuffer.limit(limit);
 
-      return new BufferGrouperOffsetHeapIndexUpdater(buffer,indexPosition);
+      return new BufferGrouperOffsetHeapIndexUpdater(buffer, indexPosition);
     }
 
     public void setHashTableBuffer(ByteBuffer newTableBuffer)
@@ -358,7 +357,6 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
         final int offset = newHeap.removeMin();
         final Grouper.Entry<KeyType> entry = bucketEntryForOffset(offset);
         curr++;
-
         return entry;
       }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -53,7 +53,6 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
 
   // ByteBuffer slices used by the grouper
   private ByteBuffer totalBuffer;
-  private ByteBuffer hashTableBuffer;
   private ByteBuffer offsetHeapBuffer;
 
   // Updates the heap index field for buckets, created passed to the heap when

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouper.java
@@ -336,6 +336,7 @@ public class LimitedBufferHashGrouper<KeyType> extends AbstractBufferHashGrouper
   private CloseableIterator<Entry<KeyType>> makeHeapIterator()
   {
     final int initialHeapSize = offsetHeap.getHeapSize();
+    // Make a copy of the heap since next() below mutates it
     ByteBufferMinMaxOffsetHeap newHeap = offsetHeap.copy();
 
     return new CloseableIterator<Entry<KeyType>>()

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeapTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeapTest.java
@@ -197,7 +197,7 @@ public class ByteBufferMinMaxOffsetHeapTest
   {
     int limit = 100;
 
-    IntList values = new IntArrayList(new int[] {
+    IntList values = new IntArrayList(new int[]{
         1, 20, 1000, 2, 3, 30, 40, 10, 11, 12, 13, 300, 400, 500, 600
     });
 
@@ -230,7 +230,7 @@ public class ByteBufferMinMaxOffsetHeapTest
   {
     int limit = 100;
 
-    IntList values = new IntArrayList(new int[] {
+    IntList values = new IntArrayList(new int[]{
         1, 20, 1000, 2, 3, 30, 40, 10, 11, 12, 13, 300, 400, 500, 600, 4, 5,
         6, 7, 8, 9, 4, 5, 200, 250
     });
@@ -259,5 +259,37 @@ public class ByteBufferMinMaxOffsetHeapTest
     Assert.assertTrue(heap.isIntact());
 
     Assert.assertEquals(values, actual);
+  }
+
+
+  @Test
+  public void testCopy()
+  {
+    int limit = 100;
+    
+    IntList values = new IntArrayList(new int[]{
+        1, 20, 1000, 2, 3, 30, 40, 10, 11, 12, 13, 300, 400, 500, 600
+    });
+
+    ByteBuffer myBuffer = ByteBuffer.allocate(1000000);
+    ByteBufferMinMaxOffsetHeap heap = new ByteBufferMinMaxOffsetHeap(myBuffer, limit, Ordering.natural(), null);
+
+    for (Integer value : values) {
+      heap.addOffset(value);
+      Assert.assertTrue(heap.isIntact());
+    }
+
+    // make copy:
+    ByteBufferMinMaxOffsetHeap heapCopy = heap.copy();
+
+    // verify that original an copy are the same:
+    Assert.assertEquals(heap.getHeapSize(), heapCopy.getHeapSize());
+    for (int i = 0; i < heap.getHeapSize(); i++) {
+      Assert.assertEquals(heap.getAt(i), heapCopy.getAt(i));
+    }
+
+    // modifying the copy does not affect the original:
+    heapCopy.removeOffset(12);
+    Assert.assertEquals(heap.getHeapSize(), heapCopy.getHeapSize() + 1);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouperTest.java
@@ -198,57 +198,24 @@ public class LimitedBufferHashGrouperTest extends InitializedNullHandlingTest
   public void testIteratorIsReusable()
   {
     final int limit = 100;
-    final int keyBase = 100000;
     final TestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
-    final LimitedBufferHashGrouper<Integer> grouper = makeGrouper(columnSelectorFactory, 12120, 2, limit);
+    final LimitedBufferHashGrouper<Integer> grouper =
+        makeGrouper(columnSelectorFactory, 12120, 3, limit);
     final int numRows = 1000;
 
+    // just populate the grouper with some sample data to test reusability of its iterator...
     columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("value", 10L)));
-    for (int i = 0; i < numRows; i++) {
-      Assert.assertTrue(String.valueOf(i + keyBase), grouper.aggregate(i + keyBase).isOk());
-    }
-
-    // With minimum buffer size, after the first swap, every new key added will result in a swap
-    if (NullHandling.replaceWithDefault()) {
-      Assert.assertEquals(224, grouper.getGrowthCount());
-      Assert.assertEquals(104, grouper.getSize());
-      Assert.assertEquals(209, grouper.getBuckets());
-      Assert.assertEquals(104, grouper.getMaxSize());
-    } else {
-      Assert.assertEquals(899, grouper.getGrowthCount());
-      Assert.assertEquals(101, grouper.getSize());
-      Assert.assertEquals(202, grouper.getBuckets());
-      Assert.assertEquals(101, grouper.getMaxSize());
-    }
-    Assert.assertEquals(100, grouper.getLimit());
-
-    // Aggregate slightly different row
-    // Since these keys are smaller, they will evict the previous 100 top entries
-    // First 100 of these new rows will be the expected results.
-    columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("value", 11L)));
     for (int i = 0; i < numRows; i++) {
       Assert.assertTrue(String.valueOf(i), grouper.aggregate(i).isOk());
     }
-    if (NullHandling.replaceWithDefault()) {
-      Assert.assertEquals(474, grouper.getGrowthCount());
-      Assert.assertEquals(104, grouper.getSize());
-      Assert.assertEquals(209, grouper.getBuckets());
-      Assert.assertEquals(104, grouper.getMaxSize());
-    } else {
-      Assert.assertEquals(1899, grouper.getGrowthCount());
-      Assert.assertEquals(101, grouper.getSize());
-      Assert.assertEquals(202, grouper.getBuckets());
-      Assert.assertEquals(101, grouper.getMaxSize());
-    }
-    Assert.assertEquals(100, grouper.getLimit());
 
     final List<Grouper.Entry<Integer>> expected = new ArrayList<>();
     for (int i = 0; i < limit; i++) {
-      expected.add(new Grouper.Entry<>(i, new Object[]{11L, 1L}));
+      expected.add(new Grouper.Entry<>(i, new Object[]{10L, 1L}));
     }
 
+    // the iterator call should be reusable... just call it repeatedly a few times to validate:
     Assert.assertEquals(expected, Lists.newArrayList(grouper.iterator(true)));
-    // the iterator call should be reusable... just call it a couple more times to make sure:
     Assert.assertEquals(expected, Lists.newArrayList(grouper.iterator(true)));
     Assert.assertEquals(expected, Lists.newArrayList(grouper.iterator(true)));
   }

--- a/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
@@ -268,7 +268,7 @@ public class SqlLifecycle
     try {
       setParameters(SqlQuery.getParameterList(parameters));
       planAndAuthorize(authenticationResult);
-      result = execute(); //agt
+      result = execute();
     }
     catch (Throwable e) {
       emitLogsAndMetrics(e, null, -1);

--- a/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
@@ -268,7 +268,7 @@ public class SqlLifecycle
     try {
       setParameters(SqlQuery.getParameterList(parameters));
       planAndAuthorize(authenticationResult);
-      result = execute();
+      result = execute(); //agt
     }
     catch (Throwable e) {
       emitLogsAndMetrics(e, null, -1);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -12089,6 +12089,68 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  //agtest
+  @Test
+  public void testGroupingSetsWithLimit() throws Exception
+  {
+    // Cannot vectorize due to virtual columns.
+    cannotVectorize();
+
+    testQuery(
+        "SELECT dim2, gran, SUM(cnt)\n"
+        + "FROM (SELECT FLOOR(__time TO MONTH) AS gran, COALESCE(dim2, '') dim2, cnt FROM druid.foo) AS x\n"
+        + "GROUP BY GROUPING SETS ( (dim2, gran), (dim2), (gran), () ) LIMIT 100",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setVirtualColumns(
+                            expressionVirtualColumn(
+                                "v0",
+                                "case_searched(notnull(\"dim2\"),\"dim2\",'')",
+                                ValueType.STRING
+                            ),
+                            expressionVirtualColumn(
+                                "v1",
+                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                ValueType.LONG
+                            )
+                        )
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0"),
+                                new DefaultDimensionSpec("v1", "d1", ValueType.LONG)
+                            )
+                        )
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setSubtotalsSpec(
+                            ImmutableList.of(
+                                ImmutableList.of("d0", "d1"),
+                                ImmutableList.of("d0"),
+                                ImmutableList.of("d1"),
+                                ImmutableList.of()
+                            )
+                        )
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"", timestamp("2000-01-01"), 2L},
+            new Object[]{"", timestamp("2001-01-01"), 1L},
+            new Object[]{"a", timestamp("2000-01-01"), 1L},
+            new Object[]{"a", timestamp("2001-01-01"), 1L},
+            new Object[]{"abc", timestamp("2001-01-01"), 1L},
+            new Object[]{"", null, 3L},
+            new Object[]{"a", null, 2L},
+            new Object[]{"abc", null, 1L},
+            new Object[]{NULL_STRING, timestamp("2000-01-01"), 3L},
+            new Object[]{NULL_STRING, timestamp("2001-01-01"), 3L},
+            new Object[]{NULL_STRING, null, 6L}
+        )
+    );
+  }
+
   @Test
   public void testGroupingAggregatorDifferentOrder() throws Exception
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -12132,7 +12132,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             )
                         ).setLimitSpec(
                             new DefaultLimitSpec(
-                                ImmutableList.<OrderByColumnSpec>of(),
+                                ImmutableList.of(),
                               100)
                         )
                         .setContext(QUERY_CONTEXT_DEFAULT)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -12089,7 +12089,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
-  //agtest
   @Test
   public void testGroupingSetsWithLimit() throws Exception
   {
@@ -12131,6 +12130,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 ImmutableList.of("d1"),
                                 ImmutableList.of()
                             )
+                        ).setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.<OrderByColumnSpec>of(),
+                              100)
                         )
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()


### PR DESCRIPTION
Description
For calculating the results for a subtotal spec, we reuse the buffer iterator that was used in the base query. However, not all the implementations of such iterators are reusable. Specifically, LimitedBufferHashGrouper#iterator is one of those non-reusable iterators. This results in subtotal specs not working if there is also a limit used as part of the query. 

This PR deeps copy some shared state in the iterator `makeHeapIteratormethod` to make sure that it is reusable. It also added a unit test to verify that it can be reused now.

To summarize:
* Issue is that `makeHeapIteratormethod` copies overwrite some shared state
* Solution in this ticket is to actually copy the state so that the iterator is reusable

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage is met.


