### PR TITLE
fix integration test override config

### DIFF
--- a/integration-tests/script/docker_run_cluster.sh
+++ b/integration-tests/script/docker_run_cluster.sh
@@ -44,6 +44,12 @@ fi
     docker-compose -f ${DOCKERDIR}/docker-compose.druid-hadoop.yml up -d
   fi
 
-  # Start Druid cluster
-  docker-compose $(getComposeArgs) up -d
+  if [ -z "$DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH" ]
+  then
+    # Start Druid cluster
+    docker-compose $(getComposeArgs) up -d
+  else
+    # run druid cluster with override config
+    OVERRIDE_ENV=$DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH docker-compose $(getComposeArgs) up -d
+  fi
 }


### PR DESCRIPTION
Refactoring of docker-scripts in #10680 broke the 'override' config integration test cluster bring up due to missing environment variables. This PR changes `docker_run_cluster.sh` to check for `DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH` and it will call compose in the previous manner if set. 

`stop_cluster.sh` was also missing stopping the hadoop container, and like `docker_run_cluster.sh` will also now check for and supply the env variables for override as well when stopping the integration test cluster when the overrides are defined.