### PR TITLE
Supporting filters in the left base table for join datasources

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/IndexedTableJoinCursorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/IndexedTableJoinCursorBenchmark.java
@@ -197,6 +197,7 @@ public class IndexedTableJoinCursorBenchmark
     hashJoinSegment = closer.register(
         new HashJoinSegment(
             ReferenceCountingSegment.wrapRootGenerationSegment(baseSegment),
+            null,
             clauses,
             preAnalysis
         )

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
@@ -160,6 +160,7 @@ public class JoinAndLookupBenchmark
 
     hashJoinLookupStringKeySegment = new HashJoinSegment(
         ReferenceCountingSegment.wrapRootGenerationSegment(baseSegment),
+        null,
         joinableClausesLookupStringKey,
         preAnalysisLookupStringKey
     );
@@ -194,6 +195,7 @@ public class JoinAndLookupBenchmark
 
     hashJoinLookupLongKeySegment = new HashJoinSegment(
         ReferenceCountingSegment.wrapRootGenerationSegment(baseSegment),
+        null,
         joinableClausesLookupLongKey,
         preAnalysisLookupLongKey
     );
@@ -228,6 +230,7 @@ public class JoinAndLookupBenchmark
 
     hashJoinIndexedTableStringKeySegment = new HashJoinSegment(
         ReferenceCountingSegment.wrapRootGenerationSegment(baseSegment),
+        null,
         joinableClausesIndexedTableStringKey,
         preAnalysisIndexedStringKey
     );
@@ -262,6 +265,7 @@ public class JoinAndLookupBenchmark
 
     hashJoinIndexedTableLongKeySegment = new HashJoinSegment(
         ReferenceCountingSegment.wrapRootGenerationSegment(baseSegment),
+        null,
         joinableClausesIndexedTableLongKey,
         preAnalysisIndexedLongKey
     );

--- a/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
@@ -119,10 +119,11 @@ public class JoinDataSource implements DataSource
       final DataSource right,
       final String rightPrefix,
       final JoinConditionAnalysis conditionAnalysis,
-      final JoinType joinType
+      final JoinType joinType,
+      final DimFilter leftFilter
   )
   {
-    return new JoinDataSource(left, right, rightPrefix, conditionAnalysis, joinType, null);
+    return new JoinDataSource(left, right, rightPrefix, conditionAnalysis, joinType, leftFilter);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
@@ -60,6 +60,8 @@ public class JoinDataSource implements DataSource
   private final String rightPrefix;
   private final JoinConditionAnalysis conditionAnalysis;
   private final JoinType joinType;
+  // An optional filter on the left side if left is direct table access
+  @Nullable
   private final DimFilter leftFilter;
 
   private JoinDataSource(
@@ -68,7 +70,7 @@ public class JoinDataSource implements DataSource
       String rightPrefix,
       JoinConditionAnalysis conditionAnalysis,
       JoinType joinType,
-      DimFilter leftFilter
+      @Nullable DimFilter leftFilter
   )
   {
     this.left = Preconditions.checkNotNull(left, "left");

--- a/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
@@ -78,6 +78,7 @@ public class JoinDataSource implements DataSource
     this.rightPrefix = JoinPrefixUtils.validatePrefix(rightPrefix);
     this.conditionAnalysis = Preconditions.checkNotNull(conditionAnalysis, "conditionAnalysis");
     this.joinType = Preconditions.checkNotNull(joinType, "joinType");
+    //TODO: Add support for union data sources
     Preconditions.checkArgument(
         leftFilter == null || left instanceof TableDataSource,
         "left filter is only supported if left data source is direct table access"

--- a/processing/src/main/java/org/apache/druid/query/Queries.java
+++ b/processing/src/main/java/org/apache/druid/query/Queries.java
@@ -193,7 +193,7 @@ public class Queries
       final DataSourceAnalysis analysis = DataSourceAnalysis.forDataSource(query.getDataSource());
 
       DataSource current = newBaseDataSource;
-      DimFilter joinBaseFilter = analysis.getJoinBaseFilter().orElse(null);
+      DimFilter joinBaseFilter = analysis.getJoinBaseTableFilter().orElse(null);
 
       for (final PreJoinableClause clause : analysis.getPreJoinableClauses()) {
         current = JoinDataSource.create(

--- a/processing/src/main/java/org/apache/druid/query/Queries.java
+++ b/processing/src/main/java/org/apache/druid/query/Queries.java
@@ -181,6 +181,7 @@ public class Queries
    * Unlike the seemingly-similar {@link Query#withDataSource}, this will walk down the datasource tree and replace
    * only the base datasource (in the sense defined in {@link DataSourceAnalysis}).
    */
+  //TODO: base filter
   public static <T> Query<T> withBaseDataSource(final Query<T> query, final DataSource newBaseDataSource)
   {
     final Query<T> retVal;

--- a/processing/src/main/java/org/apache/druid/query/planning/DataSourceAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/query/planning/DataSourceAnalysis.java
@@ -82,14 +82,14 @@ public class DataSourceAnalysis
   @Nullable
   private final Query<?> baseQuery;
   @Nullable
-  private final DimFilter joinBaseFilter;
+  private final DimFilter joinBaseTableFilter;
   private final List<PreJoinableClause> preJoinableClauses;
 
   private DataSourceAnalysis(
       DataSource dataSource,
       DataSource baseDataSource,
       @Nullable Query<?> baseQuery,
-      @Nullable DimFilter joinBaseFilter,
+      @Nullable DimFilter joinBaseTableFilter,
       List<PreJoinableClause> preJoinableClauses
   )
   {
@@ -102,13 +102,13 @@ public class DataSourceAnalysis
     this.dataSource = dataSource;
     this.baseDataSource = baseDataSource;
     this.baseQuery = baseQuery;
-    this.joinBaseFilter = joinBaseFilter;
+    this.joinBaseTableFilter = joinBaseTableFilter;
     this.preJoinableClauses = preJoinableClauses;
   }
 
   public static DataSourceAnalysis forDataSource(final DataSource dataSource)
   {
-    // Strip outer queries, retaining querySegmentSpecs as we go down (lowest will become the 'baseQuerySegmentSpec').
+    // Strip outer queries, retaining querySegmentSpecs as we go down (lowest will become the 'baseQuerySegmentSpec'o).
     Query<?> baseQuery = null;
     DataSource current = dataSource;
 
@@ -148,6 +148,9 @@ public class DataSourceAnalysis
     while (current instanceof JoinDataSource) {
       final JoinDataSource joinDataSource = (JoinDataSource) current;
       current = joinDataSource.getLeft();
+      if (currentDimFilter != null) {
+        throw new IAE("Left filters are only allowed when left child is direct table access");
+      }
       currentDimFilter = joinDataSource.getLeftFilter();
       preJoinableClauses.add(
           new PreJoinableClause(
@@ -225,9 +228,9 @@ public class DataSourceAnalysis
    * If the original data source is a join data source and there is a DimFilter on the base table data source,
    * that DimFilter is returned here
    */
-  public Optional<DimFilter> getJoinBaseFilter()
+  public Optional<DimFilter> getJoinBaseTableFilter()
   {
-    return Optional.ofNullable(joinBaseFilter);
+    return Optional.ofNullable(joinBaseTableFilter);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/planning/DataSourceAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/query/planning/DataSourceAnalysis.java
@@ -108,7 +108,7 @@ public class DataSourceAnalysis
 
   public static DataSourceAnalysis forDataSource(final DataSource dataSource)
   {
-    // Strip outer queries, retaining querySegmentSpecs as we go down (lowest will become the 'baseQuerySegmentSpec'o).
+    // Strip outer queries, retaining querySegmentSpecs as we go down (lowest will become the 'baseQuerySegmentSpec').
     Query<?> baseQuery = null;
     DataSource current = dataSource;
 

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.join;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.guava.CloseQuietly;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.SegmentReference;
 import org.apache.druid.segment.StorageAdapter;
@@ -43,6 +44,7 @@ import java.util.Optional;
 public class HashJoinSegment implements SegmentReference
 {
   private final SegmentReference baseSegment;
+  private final Filter baseFilter;
   private final List<JoinableClause> clauses;
   private final JoinFilterPreAnalysis joinFilterPreAnalysis;
 
@@ -54,11 +56,13 @@ public class HashJoinSegment implements SegmentReference
    */
   public HashJoinSegment(
       SegmentReference baseSegment,
+      @Nullable Filter baseFilter,
       List<JoinableClause> clauses,
       JoinFilterPreAnalysis joinFilterPreAnalysis
   )
   {
     this.baseSegment = baseSegment;
+    this.baseFilter = baseFilter;
     this.clauses = clauses;
     this.joinFilterPreAnalysis = joinFilterPreAnalysis;
 
@@ -93,7 +97,12 @@ public class HashJoinSegment implements SegmentReference
   @Override
   public StorageAdapter asStorageAdapter()
   {
-    return new HashJoinSegmentStorageAdapter(baseSegment.asStorageAdapter(), clauses, joinFilterPreAnalysis);
+    return new HashJoinSegmentStorageAdapter(
+        baseSegment.asStorageAdapter(),
+        baseFilter,
+        clauses,
+        joinFilterPreAnalysis
+    );
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -37,7 +37,6 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
-import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysisKey;
@@ -48,7 +47,6 @@ import org.joda.time.Interval;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -261,15 +259,12 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
 
     // We merge the filter on base table specified by the user and filter on the base table that is pushed from
     // the join
-    JoinFilterSplit joinFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis);
-    Filter newBaseFilter = joinFilterSplit.getBaseTableFilter().isPresent()
-                           ? Filters.and(Arrays.asList(baseFilter, joinFilterSplit.getBaseTableFilter().get()))
-                           : baseFilter;
+    JoinFilterSplit joinFilterSplit = JoinFilterAnalyzer.splitFilter(joinFilterPreAnalysis, baseFilter);
     preJoinVirtualColumns.addAll(joinFilterSplit.getPushDownVirtualColumns());
 
 
     final Sequence<Cursor> baseCursorSequence = baseAdapter.makeCursors(
-        newBaseFilter,
+        joinFilterSplit.getBaseTableFilter().isPresent() ? joinFilterSplit.getBaseTableFilter().get() : null,
         interval,
         VirtualColumns.create(preJoinVirtualColumns),
         gran,

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinType.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinType.java
@@ -23,13 +23,13 @@ public enum JoinType
 {
   INNER {
     @Override
-    boolean isLefty()
+    public boolean isLefty()
     {
       return false;
     }
 
     @Override
-    boolean isRighty()
+    public boolean isRighty()
     {
       return false;
     }
@@ -37,13 +37,13 @@ public enum JoinType
 
   LEFT {
     @Override
-    boolean isLefty()
+    public boolean isLefty()
     {
       return true;
     }
 
     @Override
-    boolean isRighty()
+    public boolean isRighty()
     {
       return false;
     }
@@ -51,13 +51,13 @@ public enum JoinType
 
   RIGHT {
     @Override
-    boolean isLefty()
+    public boolean isLefty()
     {
       return false;
     }
 
     @Override
-    boolean isRighty()
+    public boolean isRighty()
     {
       return true;
     }
@@ -65,13 +65,13 @@ public enum JoinType
 
   FULL {
     @Override
-    boolean isLefty()
+    public boolean isLefty()
     {
       return true;
     }
 
     @Override
-    boolean isRighty()
+    public boolean isRighty()
     {
       return true;
     }
@@ -80,10 +80,10 @@ public enum JoinType
   /**
    * "Lefty" joins (LEFT or FULL) always include the full left-hand side, and can generate nulls on the right.
    */
-  abstract boolean isLefty();
+  public abstract boolean isLefty();
 
   /**
    * "Righty" joins (RIGHT or FULL) always include the full right-hand side, and can generate nulls on the left.
    */
-  abstract boolean isRighty();
+  public abstract boolean isRighty();
 }

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
@@ -106,7 +106,8 @@ public class JoinableFactoryWrapper
   }
 
   /**
-   * Compute a cache key prefix for data sources that participate in the RHS of a join. This key prefix
+   * Compute a cache key prefix for a join data source. This includes the data sources that participate in the RHS of a
+   * join as well as any query specific constructs associated with join data source such as base table filter. This key prefix
    * can be used in segment level cache or result level cache. The function can return following wrapped in an
    * Optional
    * - Non-empty byte array - If there is join datasource involved and caching is possible. The result includes
@@ -129,8 +130,8 @@ public class JoinableFactoryWrapper
 
     final CacheKeyBuilder keyBuilder;
     keyBuilder = new CacheKeyBuilder(JOIN_OPERATION);
-    if (dataSourceAnalysis.getJoinBaseFilter().isPresent()) {
-      keyBuilder.appendCacheable(dataSourceAnalysis.getJoinBaseFilter().get());
+    if (dataSourceAnalysis.getJoinBaseTableFilter().isPresent()) {
+      keyBuilder.appendCacheable(dataSourceAnalysis.getJoinBaseTableFilter().get());
     }
     for (PreJoinableClause clause : clauses) {
       Optional<byte[]> bytes = joinableFactory.computeJoinCacheKey(clause.getDataSource(), clause.getCondition());

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.cache.CacheKeyBuilder;
+import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.planning.DataSourceAnalysis;
 import org.apache.druid.query.planning.PreJoinableClause;
 import org.apache.druid.segment.SegmentReference;
@@ -69,6 +70,7 @@ public class JoinableFactoryWrapper
    *                           query from the end user.
    */
   public Function<SegmentReference, SegmentReference> createSegmentMapFn(
+      final Filter baseFilter,
       final List<PreJoinableClause> clauses,
       final AtomicLong cpuTimeAccumulator,
       final Query<?> query
@@ -94,6 +96,7 @@ public class JoinableFactoryWrapper
             return baseSegment ->
                 new HashJoinSegment(
                     baseSegment,
+                    baseFilter,
                     joinableClauses.getJoinableClauses(),
                     joinFilterPreAnalysis
                 );

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
@@ -129,6 +129,9 @@ public class JoinableFactoryWrapper
 
     final CacheKeyBuilder keyBuilder;
     keyBuilder = new CacheKeyBuilder(JOIN_OPERATION);
+    if (dataSourceAnalysis.getJoinBaseFilter().isPresent()) {
+      keyBuilder.appendCacheable(dataSourceAnalysis.getJoinBaseFilter().get());
+    }
     for (PreJoinableClause clause : clauses) {
       Optional<byte[]> bytes = joinableFactory.computeJoinCacheKey(clause.getDataSource(), clause.getCondition());
       if (!bytes.isPresent()) {

--- a/processing/src/test/java/org/apache/druid/query/QueriesTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueriesTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
 import org.apache.druid.query.aggregation.post.ConstantPostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
+import org.apache.druid.query.filter.TrueDimFilter;
 import org.apache.druid.query.spec.MultipleSpecificSegmentSpec;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
@@ -468,6 +469,80 @@ public class QueriesTest
                                               .granularity(Granularities.ALL)
                                               .build()
                                     )
+                                )
+                                .intervals("2000/3000")
+                                .granularity(Granularities.ALL)
+                                .build()
+                      )
+                  )
+                  .intervals("2000/3000")
+                  .granularity(Granularities.ALL)
+                  .build(),
+            new TableDataSource("foo")
+        )
+    );
+  }
+
+  @Test
+  public void testWithBaseDataSourcedBaseFilterWithMultiJoin()
+  {
+    Assert.assertEquals(
+        Druids.newTimeseriesQueryBuilder()
+              .dataSource(
+                  new QueryDataSource(
+                      Druids.newTimeseriesQueryBuilder()
+                            .dataSource(
+                                JoinDataSource.create(
+                                    JoinDataSource.create(
+                                        new TableDataSource("foo"),
+                                        new TableDataSource("bar"),
+                                        "j1.",
+                                        "\"foo.x\" == \"bar.x\"",
+                                        JoinType.INNER,
+                                        TrueDimFilter.instance(),
+                                        ExprMacroTable.nil()
+                                    ),
+                                    new TableDataSource("foo_outer"),
+                                    "j0.",
+                                    "\"foo_outer.x\" == \"bar.x\"",
+                                    JoinType.INNER,
+                                    null,
+                                    ExprMacroTable.nil()
+                                )
+
+                            )
+                            .intervals("2000/3000")
+                            .granularity(Granularities.ALL)
+                            .build()
+                  )
+              )
+              .intervals("2000/3000")
+              .granularity(Granularities.ALL)
+              .build(),
+        Queries.withBaseDataSource(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(
+                      new QueryDataSource(
+                          Druids.newTimeseriesQueryBuilder()
+                                .dataSource(
+                                    JoinDataSource.create(
+                                        JoinDataSource.create(
+                                            new TableDataSource("foo_inner"),
+                                            new TableDataSource("bar"),
+                                            "j1.",
+                                            "\"foo.x\" == \"bar.x\"",
+                                            JoinType.INNER,
+                                            TrueDimFilter.instance(),
+                                            ExprMacroTable.nil()
+                                        ),
+                                        new TableDataSource("foo_outer"),
+                                        "j0.",
+                                        "\"foo_outer.x\" == \"bar.x\"",
+                                        JoinType.INNER,
+                                        null,
+                                        ExprMacroTable.nil()
+                                    )
+
                                 )
                                 .intervals("2000/3000")
                                 .granularity(Granularities.ALL)

--- a/processing/src/test/java/org/apache/druid/query/QueriesTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueriesTest.java
@@ -423,6 +423,7 @@ public class QueriesTest
                                                   "j0.",
                                                   "\"foo.x\" == \"bar.x\"",
                                                   JoinType.INNER,
+                                                  null,
                                                   ExprMacroTable.nil()
                                               )
                                           )
@@ -459,6 +460,7 @@ public class QueriesTest
                                                       "j0.",
                                                       "\"foo.x\" == \"bar.x\"",
                                                       JoinType.INNER,
+                                                      null,
                                                       ExprMacroTable.nil()
                                                   )
                                               )

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
@@ -182,6 +182,7 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
     };
     hashJoinSegment = new HashJoinSegment(
         testWrapper,
+        null,
         joinableClauses,
         null
     )
@@ -210,6 +211,7 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
 
     final HashJoinSegment ignored = new HashJoinSegment(
         ReferenceCountingSegment.wrapRootGenerationSegment(baseSegment),
+        null,
         joinableClauses,
         null
     );

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
@@ -33,6 +33,8 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.TestQuery;
 import org.apache.druid.query.extraction.MapLookupExtractor;
+import org.apache.druid.query.filter.FalseDimFilter;
+import org.apache.druid.query.filter.TrueDimFilter;
 import org.apache.druid.query.planning.DataSourceAnalysis;
 import org.apache.druid.query.planning.PreJoinableClause;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
@@ -160,6 +162,7 @@ public class JoinableFactoryWrapperTest
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
     DataSource dataSource = new NoopDataSource();
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.emptyList());
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty());
     EasyMock.expect(analysis.getDataSource()).andReturn(dataSource);
     EasyMock.replay(analysis);
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
@@ -175,11 +178,11 @@ public class JoinableFactoryWrapperTest
   @Test
   public void test_computeJoinDataSourceCacheKey_noHashJoin()
   {
-
     PreJoinableClause clause1 = makeGlobalPreJoinableClause("dataSource_1", "x == \"j.x\"", "j.");
     PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_2", "x != \"h.x\"", "h.");
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Arrays.asList(clause1, clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.of(TrueDimFilter.instance())).anyTimes();
     EasyMock.replay(analysis);
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
     Optional<byte[]> cacheKey = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
@@ -195,6 +198,7 @@ public class JoinableFactoryWrapperTest
     PreJoinableClause clause2 = makePreJoinableClause(dataSource, "x == \"h.x\"", "h.", JoinType.LEFT);
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Arrays.asList(clause1, clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.of(TrueDimFilter.instance())).anyTimes();
     EasyMock.replay(analysis);
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
     Optional<byte[]> cacheKey = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
@@ -210,6 +214,7 @@ public class JoinableFactoryWrapperTest
     PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_2", "x == \"h.x\"", "h.");
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Arrays.asList(clause1, clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     EasyMock.replay(analysis);
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
     Optional<byte[]> cacheKey = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
@@ -221,6 +226,7 @@ public class JoinableFactoryWrapperTest
   public void test_computeJoinDataSourceCacheKey_keyChangesWithExpression()
   {
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
 
     PreJoinableClause clause1 = makeGlobalPreJoinableClause("dataSource_1", "y == \"j.y\"", "j.");
@@ -234,6 +240,7 @@ public class JoinableFactoryWrapperTest
     PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_1", "x == \"j.x\"", "j.");
     EasyMock.reset(analysis);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     EasyMock.replay(analysis);
     Optional<byte[]> cacheKey2 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
     Assert.assertTrue(cacheKey2.isPresent());
@@ -245,6 +252,7 @@ public class JoinableFactoryWrapperTest
   public void test_computeJoinDataSourceCacheKey_keyChangesWithJoinType()
   {
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
 
     PreJoinableClause clause1 = makeGlobalPreJoinableClause("dataSource_1", "x == \"j.x\"", "j.", JoinType.LEFT);
@@ -258,6 +266,7 @@ public class JoinableFactoryWrapperTest
     PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_1", "x == \"j.x\"", "j.", JoinType.INNER);
     EasyMock.reset(analysis);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     EasyMock.replay(analysis);
     Optional<byte[]> cacheKey2 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
     Assert.assertTrue(cacheKey2.isPresent());
@@ -269,6 +278,7 @@ public class JoinableFactoryWrapperTest
   public void test_computeJoinDataSourceCacheKey_keyChangesWithPrefix()
   {
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
 
     PreJoinableClause clause1 = makeGlobalPreJoinableClause("dataSource_1", "abc == xyz", "ab");
@@ -282,6 +292,33 @@ public class JoinableFactoryWrapperTest
     PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_1", "abc == xyz", "xy");
     EasyMock.reset(analysis);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
+    EasyMock.replay(analysis);
+    Optional<byte[]> cacheKey2 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
+    Assert.assertTrue(cacheKey2.isPresent());
+
+    Assert.assertFalse(Arrays.equals(cacheKey1.get(), cacheKey2.get()));
+  }
+
+  @Test
+  public void test_computeJoinDataSourceCacheKey_keyChangesWithBaseFilter()
+  {
+    DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.of(TrueDimFilter.instance())).anyTimes();
+    JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
+
+    PreJoinableClause clause1 = makeGlobalPreJoinableClause("dataSource_1", "abc == xyz", "ab");
+    EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause1)).anyTimes();
+    EasyMock.replay(analysis);
+
+    Optional<byte[]> cacheKey1 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
+    Assert.assertTrue(cacheKey1.isPresent());
+    Assert.assertNotEquals(0, cacheKey1.get().length);
+
+    PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_1", "abc == xyz", "ab");
+    EasyMock.reset(analysis);
+    EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.of(FalseDimFilter.instance())).anyTimes();
     EasyMock.replay(analysis);
     Optional<byte[]> cacheKey2 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
     Assert.assertTrue(cacheKey2.isPresent());
@@ -293,6 +330,7 @@ public class JoinableFactoryWrapperTest
   public void test_computeJoinDataSourceCacheKey_keyChangesWithJoinable()
   {
     DataSourceAnalysis analysis = EasyMock.mock(DataSourceAnalysis.class);
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     JoinableFactoryWrapper joinableFactoryWrapper = new JoinableFactoryWrapper(new JoinableFactoryWithCacheKey());
 
     PreJoinableClause clause1 = makeGlobalPreJoinableClause("dataSource_1", "x == \"j.x\"", "j.");
@@ -306,6 +344,8 @@ public class JoinableFactoryWrapperTest
     PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_2", "x == \"j.x\"", "j.");
     EasyMock.reset(analysis);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
+
     EasyMock.replay(analysis);
     Optional<byte[]> cacheKey2 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
     Assert.assertTrue(cacheKey2.isPresent());
@@ -321,6 +361,7 @@ public class JoinableFactoryWrapperTest
 
     PreJoinableClause clause1 = makeGlobalPreJoinableClause("dataSource_1", "x == \"j.x\"", "j.");
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause1)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     EasyMock.replay(analysis);
 
     Optional<byte[]> cacheKey1 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
@@ -330,6 +371,7 @@ public class JoinableFactoryWrapperTest
     PreJoinableClause clause2 = makeGlobalPreJoinableClause("dataSource_1", "x == \"j.x\"", "j.");
     EasyMock.reset(analysis);
     EasyMock.expect(analysis.getPreJoinableClauses()).andReturn(Collections.singletonList(clause2)).anyTimes();
+    EasyMock.expect(analysis.getJoinBaseTableFilter()).andReturn(Optional.empty()).anyTimes();
     EasyMock.replay(analysis);
     Optional<byte[]> cacheKey2 = joinableFactoryWrapper.computeJoinDataSourceCacheKey(analysis);
     Assert.assertTrue(cacheKey2.isPresent());

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
@@ -72,6 +72,7 @@ public class JoinableFactoryWrapperTest
   public void test_createSegmentMapFn_noClauses()
   {
     final Function<SegmentReference, SegmentReference> segmentMapFn = NOOP_JOINABLE_FACTORY_WRAPPER.createSegmentMapFn(
+        null,
         ImmutableList.of(),
         new AtomicLong(),
         null
@@ -95,6 +96,7 @@ public class JoinableFactoryWrapperTest
     expectedException.expectMessage("dataSource is not joinable");
 
     final Function<SegmentReference, SegmentReference> ignored = NOOP_JOINABLE_FACTORY_WRAPPER.createSegmentMapFn(
+        null,
         ImmutableList.of(clause),
         new AtomicLong(),
         null
@@ -138,6 +140,7 @@ public class JoinableFactoryWrapperTest
       }
     });
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
+        null,
         ImmutableList.of(clause),
         new AtomicLong(),
         new TestQuery(

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
@@ -172,6 +172,7 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
 
     // segmentMapFn maps each base Segment into a joined Segment if necessary.
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
+        analysis.getJoinBaseFilter().orElse(null),
         analysis.getPreJoinableClauses(),
         cpuTimeAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
@@ -59,6 +59,7 @@ import org.apache.druid.query.spec.SpecificSegmentQueryRunner;
 import org.apache.druid.query.spec.SpecificSegmentSpec;
 import org.apache.druid.segment.SegmentReference;
 import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.segment.realtime.FireHydrant;
@@ -172,7 +173,7 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
 
     // segmentMapFn maps each base Segment into a joined Segment if necessary.
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        analysis.getJoinBaseFilter().orElse(null),
+        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         cpuTimeAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
@@ -173,7 +173,7 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
 
     // segmentMapFn maps each base Segment into a joined Segment if necessary.
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
+        analysis.getJoinBaseTableFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         cpuTimeAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
@@ -95,6 +95,7 @@ public class LocalQuerySegmentWalker implements QuerySegmentWalker
     final AtomicLong cpuAccumulator = new AtomicLong(0L);
 
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
+        analysis.getJoinBaseFilter().orElse(null),
         analysis.getPreJoinableClauses(),
         cpuAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
@@ -36,6 +36,7 @@ import org.apache.druid.query.planning.DataSourceAnalysis;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.SegmentReference;
 import org.apache.druid.segment.SegmentWrangler;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.joda.time.Interval;
@@ -95,7 +96,7 @@ public class LocalQuerySegmentWalker implements QuerySegmentWalker
     final AtomicLong cpuAccumulator = new AtomicLong(0L);
 
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        analysis.getJoinBaseFilter().orElse(null),
+        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         cpuAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/LocalQuerySegmentWalker.java
@@ -96,7 +96,7 @@ public class LocalQuerySegmentWalker implements QuerySegmentWalker
     final AtomicLong cpuAccumulator = new AtomicLong(0L);
 
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
+        analysis.getJoinBaseTableFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         cpuAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
@@ -59,6 +59,7 @@ import org.apache.druid.query.spec.SpecificSegmentSpec;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.SegmentReference;
 import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.server.SegmentManager;
@@ -200,7 +201,7 @@ public class ServerManager implements QuerySegmentWalker
 
     // segmentMapFn maps each base Segment into a joined Segment if necessary.
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        analysis.getJoinBaseFilter().orElse(null),
+        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         cpuTimeAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
@@ -200,6 +200,7 @@ public class ServerManager implements QuerySegmentWalker
 
     // segmentMapFn maps each base Segment into a joined Segment if necessary.
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
+        analysis.getJoinBaseFilter().orElse(null),
         analysis.getPreJoinableClauses(),
         cpuTimeAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
@@ -201,7 +201,7 @@ public class ServerManager implements QuerySegmentWalker
 
     // segmentMapFn maps each base Segment into a joined Segment if necessary.
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
+        analysis.getJoinBaseTableFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         cpuTimeAccumulator,
         analysis.getBaseQuery().orElse(query)

--- a/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
+++ b/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
@@ -47,6 +47,7 @@ import org.apache.druid.query.spec.SpecificSegmentSpec;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentReference;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.timeline.TimelineObjectHolder;
@@ -143,7 +144,7 @@ public class TestClusterQuerySegmentWalker implements QuerySegmentWalker
     }
 
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        null,
+        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         new AtomicLong(),
         analysis.getBaseQuery().orElse(query)

--- a/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
+++ b/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
@@ -143,6 +143,7 @@ public class TestClusterQuerySegmentWalker implements QuerySegmentWalker
     }
 
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
+        null,
         analysis.getPreJoinableClauses(),
         new AtomicLong(),
         analysis.getBaseQuery().orElse(query)

--- a/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
+++ b/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
@@ -144,7 +144,7 @@ public class TestClusterQuerySegmentWalker implements QuerySegmentWalker
     }
 
     final Function<SegmentReference, SegmentReference> segmentMapFn = joinableFactoryWrapper.createSegmentMapFn(
-        analysis.getJoinBaseFilter().map(Filters::toFilter).orElse(null),
+        analysis.getJoinBaseTableFilter().map(Filters::toFilter).orElse(null),
         analysis.getPreJoinableClauses(),
         new AtomicLong(),
         analysis.getBaseQuery().orElse(query)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/Filtration.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/Filtration.java
@@ -121,19 +121,6 @@ public class Filtration
   }
 
   /**
-   * Only pulls the intervals out of any filters on time column. The intervals can be used as {@link QuerySegmentSpec}.
-   */
-  public Filtration pullIntervals()
-  {
-    return transform(
-        this,
-        ImmutableList.of(
-            MoveTimeFiltersToIntervals.instance()
-        )
-    );
-  }
-
-  /**
    * Optimize a Filtration containing only a DimFilter, avoiding pulling out intervals.
    *
    * @return equivalent Filtration

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/Filtration.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/Filtration.java
@@ -120,6 +120,19 @@ public class Filtration
     );
   }
 
+  public Filtration pullIntervals()
+  {
+    return transform(
+        this,
+        ImmutableList.of(
+            CombineAndSimplifyBounds.instance(),
+            MoveTimeFiltersToIntervals.instance(),
+            MoveMarkerFiltersToIntervals.instance(),
+            ValidateNoMarkerFiltersRemain.instance()
+        )
+    );
+  }
+
   /**
    * Optimize a Filtration containing only a DimFilter, avoiding pulling out intervals.
    *

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/Filtration.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/Filtration.java
@@ -120,15 +120,15 @@ public class Filtration
     );
   }
 
+  /**
+   * Only pulls the intervals out of any filters on time column. The intervals can be used as {@link QuerySegmentSpec}.
+   */
   public Filtration pullIntervals()
   {
     return transform(
         this,
         ImmutableList.of(
-            CombineAndSimplifyBounds.instance(),
-            MoveTimeFiltersToIntervals.instance(),
-            MoveMarkerFiltersToIntervals.instance(),
-            ValidateNoMarkerFiltersRemain.instance()
+            MoveTimeFiltersToIntervals.instance()
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -39,6 +39,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -155,6 +156,9 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
 
     if (computeLeftRequiresSubquery(leftDruidRel)) {
       leftDataSource = new QueryDataSource(leftQuery.getQuery());
+      if (leftFilter != null) {
+        throw new ISE("Filter on left table is supposed to be null if left child is a query source");
+      }
     } else {
       leftDataSource = leftQuery.getDataSource();
     }
@@ -325,7 +329,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
     return planner.getCostFactory().makeCost(cost, 0, 0);
   }
 
-  private static JoinType toDruidJoinType(JoinRelType calciteJoinType)
+  public static JoinType toDruidJoinType(JoinRelType calciteJoinType)
   {
     switch (calciteJoinType) {
       case LEFT:

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -671,6 +671,8 @@ public class DruidQuery
     if (joinDataSource.getLeftFilter() == null) {
       return Pair.of(dataSource, toFiltration(filter, virtualColumnRegistry));
     }
+    //TODO: We should avoid promoting the time filter as interval for right outer and full outer joins. This is not
+    // donw now as we apply the intervals to left base table today irrespective of the join type.
 
     // If the join is left or inner, we can pull the intervals up to the query. This is done
     // so that broker can prune the segments to query.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -672,7 +672,7 @@ public class DruidQuery
       return Pair.of(dataSource, toFiltration(filter, virtualColumnRegistry));
     }
     //TODO: We should avoid promoting the time filter as interval for right outer and full outer joins. This is not
-    // donw now as we apply the intervals to left base table today irrespective of the join type.
+    // done now as we apply the intervals to left base table today irrespective of the join type.
 
     // If the join is left or inner, we can pull the intervals up to the query. This is done
     // so that broker can prune the segments to query.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -374,7 +374,8 @@ public class BaseCalciteQueryTest extends CalciteTestBase
       DataSource right,
       String rightPrefix,
       String condition,
-      JoinType joinType
+      JoinType joinType,
+      DimFilter filter
   )
   {
     return JoinDataSource.create(
@@ -383,8 +384,20 @@ public class BaseCalciteQueryTest extends CalciteTestBase
         rightPrefix,
         condition,
         joinType,
+        filter,
         CalciteTests.createExprMacroTable()
     );
+  }
+
+  public static JoinDataSource join(
+      DataSource left,
+      DataSource right,
+      String rightPrefix,
+      String condition,
+      JoinType joinType
+  )
+  {
+    return join(left, right, rightPrefix, condition, joinType, null);
   }
 
   public static String equalsCondition(DruidExpression left, DruidExpression right)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.druid.annotations.UsedByJUnitParamsRunner;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.hll.VersionOneHyperLogLogCollector;
 import org.apache.druid.java.util.common.DateTimes;
@@ -840,5 +841,40 @@ public class BaseCalciteQueryTest extends CalciteTestBase
   protected void skipVectorize()
   {
     skipVectorize = true;
+  }
+
+  /**
+   * This is a provider of query contexts that should be used by join tests.
+   * It tests various configs that can be passed to join queries. All the configs provided by this provider should
+   * have the join query engine return the same results.
+   */
+  public static class QueryContextForJoinProvider
+  {
+    @UsedByJUnitParamsRunner
+    public static Object[] provideQueryContexts()
+    {
+      return new Object[]{
+          // default behavior
+          QUERY_CONTEXT_DEFAULT,
+          // filter value re-writes enabled
+          new ImmutableMap.Builder<String, Object>()
+              .putAll(QUERY_CONTEXT_DEFAULT)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, true)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, true)
+              .build(),
+          // rewrite values enabled but filter re-writes disabled.
+          // This should be drive the same behavior as the previous config
+          new ImmutableMap.Builder<String, Object>()
+              .putAll(QUERY_CONTEXT_DEFAULT)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, true)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, false)
+              .build(),
+          // filter re-writes disabled
+          new ImmutableMap.Builder<String, Object>()
+              .putAll(QUERY_CONTEXT_DEFAULT)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, false)
+              .build(),
+          };
+    }
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
@@ -19,49 +19,463 @@
 
 package org.apache.druid.sql.calcite;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.AllGranularity;
+import org.apache.druid.query.QueryDataSource;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
+import org.apache.druid.query.aggregation.LongMaxAggregatorFactory;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.aggregation.any.LongAnyAggregatorFactory;
+import org.apache.druid.query.aggregation.cardinality.CardinalityAggregatorFactory;
+import org.apache.druid.query.aggregation.hyperloglog.HyperUniqueFinalizingPostAggregator;
+import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
+import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.expression.TestExprMacroTable;
+import org.apache.druid.query.groupby.GroupByQuery;
+import org.apache.druid.segment.IndexBuilder;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.incremental.IncrementalIndexSchema;
+import org.apache.druid.segment.join.JoinType;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.LinearShardSpec;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(JUnitParamsRunner.class)
 public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
 {
-  @Test
-  public void testExplainCorrelatedQuery()
+  private static final IncrementalIndexSchema INDEX_SCHEMA = new IncrementalIndexSchema.Builder()
+      .withMetrics(
+          new CountAggregatorFactory("cnt")
+      )
+      .withRollup(false)
+      .withMinTimestamp(DateTimes.of("2020-12-31").getMillis())
+      .build();
+  private static final List<String> DIMENSIONS = ImmutableList.of("user", "country", "city");
+
+  @Before
+  public void setup() throws Exception
   {
+    final QueryableIndex index1 = IndexBuilder
+        .create()
+        .tmpDir(new File(temporaryFolder.newFolder(), "1"))
+        .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+        .schema(INDEX_SCHEMA)
+        .rows(getRawRows())
+        .buildMMappedIndex();
+    final DataSegment segment = DataSegment.builder()
+                                           .dataSource("visits")
+                                           .interval(index1.getDataInterval())
+                                           .version("1")
+                                           .shardSpec(new LinearShardSpec(0))
+                                           .size(0)
+                                           .build();
+    walker.add(segment, index1);
 
   }
 
   @Test
-  public void testExplainJoinWithLeftScan()
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testCorrelatedSubquery(Map<String, Object> queryContext) throws Exception
   {
+    cannotVectorize();
 
+    testQuery(
+        "select country, ANY_VALUE(\n"
+        + "        select avg(\"users\") from (\n"
+        + "            select floor(__time to day), count(distinct user) \"users\" from visits f where f.country = visits.country group by 1\n"
+        + "        )\n"
+        + "     ) as \"DAU\"\n"
+        + "from visits \n"
+        + "group by 1",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            join(
+                                new TableDataSource("visits"),
+                                new QueryDataSource(
+                                    GroupByQuery.builder()
+                                                .setDataSource(
+                                                    GroupByQuery.builder()
+                                                                .setDataSource("visits")
+                                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                                .setVirtualColumns(new ExpressionVirtualColumn(
+                                                                    "v0",
+                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    ValueType.LONG,
+                                                                    TestExprMacroTable.INSTANCE
+                                                                ))
+                                                                .setDimFilter(not(selector("country", null, null)))
+                                                                .setDimensions(
+                                                                    new DefaultDimensionSpec(
+                                                                        "v0",
+                                                                        "d0",
+                                                                        ValueType.LONG
+                                                                    ),
+                                                                    new DefaultDimensionSpec(
+                                                                        "country",
+                                                                        "d1"
+                                                                    )
+                                                                )
+                                                                .setAggregatorSpecs(new CardinalityAggregatorFactory(
+                                                                    "a0:a",
+                                                                    null,
+                                                                    Collections.singletonList(
+                                                                        new DefaultDimensionSpec(
+                                                                            "user",
+                                                                            "user"
+                                                                        )),
+                                                                    false,
+                                                                    true
+                                                                ))
+                                                                .setPostAggregatorSpecs(Collections.singletonList(new HyperUniqueFinalizingPostAggregator(
+                                                                    "a0",
+                                                                    "a0:a"
+                                                                )))
+                                                                .setContext(queryContext)
+                                                                .setGranularity(new AllGranularity())
+                                                                .build()
+                                                )
+                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                .setDimensions(new DefaultDimensionSpec("d1", "_d0"))
+                                                .setAggregatorSpecs(
+                                                    new LongSumAggregatorFactory("_a0:sum", "a0"),
+                                                    new CountAggregatorFactory("_a0:count")
+                                                )
+                                                .setPostAggregatorSpecs(Collections.singletonList(new ArithmeticPostAggregator(
+                                                    "_a0",
+                                                    "quotient",
+                                                    Arrays
+                                                        .asList(
+                                                            new FieldAccessPostAggregator(null, "_a0:sum"),
+                                                            new FieldAccessPostAggregator(null, "_a0:count")
+                                                        )
+                                                )))
+                                                .setGranularity(new AllGranularity())
+                                                .setContext(queryContext)
+                                                .build()
+                                ),
+                                "j0.",
+                                equalsCondition(
+                                    DruidExpression.fromColumn("country"),
+                                    DruidExpression.fromColumn("j0._d0")
+                                ),
+                                JoinType.LEFT
+                            )
+                        )
+                        .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                        .setDimensions(new DefaultDimensionSpec("country", "d0"))
+                        .setAggregatorSpecs(new LongAnyAggregatorFactory("a0", "j0._a0"))
+                        .setGranularity(new AllGranularity())
+                        .setContext(queryContext)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"India", 2L},
+            new Object[]{"USA", 1L},
+            new Object[]{"canada", 3L}
+        )
+    );
   }
 
   @Test
-  public void testCorrelatedTimeseriesQuery()
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testCorrelatedSubqueryWithLeftFilter(Map<String, Object> queryContext) throws Exception
   {
+    cannotVectorize();
 
+    testQuery(
+        "select country, ANY_VALUE(\n"
+        + "        select max(\"users\") from (\n"
+        + "            select floor(__time to day), count(*) \"users\" from visits f where f.country = visits.country group by 1\n"
+        + "        )\n"
+        + "     ) as \"dailyVisits\"\n"
+        + "from visits \n"
+        + " where city = 'B' and __time between '2021-01-01 01:00:00' AND '2021-01-02 23:59:59'"
+        + " group by 1",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            join(
+                                new TableDataSource("visits"),
+                                new QueryDataSource(
+                                    GroupByQuery.builder()
+                                                .setDataSource(
+                                                    GroupByQuery.builder()
+                                                                .setDataSource("visits")
+                                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                                .setVirtualColumns(new ExpressionVirtualColumn(
+                                                                    "v0",
+                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    ValueType.LONG,
+                                                                    TestExprMacroTable.INSTANCE
+                                                                ))
+                                                                .setDimFilter(not(selector("country", null, null)))
+                                                                .setDimensions(
+                                                                    new DefaultDimensionSpec(
+                                                                        "v0",
+                                                                        "d0",
+                                                                        ValueType.LONG
+                                                                    ),
+                                                                    new DefaultDimensionSpec(
+                                                                        "country",
+                                                                        "d1"
+                                                                    )
+                                                                )
+                                                                .setAggregatorSpecs(new CountAggregatorFactory("a0"))
+                                                                .setContext(queryContext)
+                                                                .setGranularity(new AllGranularity())
+                                                                .build()
+                                                )
+                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                .setDimensions(new DefaultDimensionSpec("d1", "_d0"))
+                                                .setAggregatorSpecs(
+                                                    new LongMaxAggregatorFactory("_a0", "a0")
+                                                )
+                                                .setGranularity(new AllGranularity())
+                                                .setContext(queryContext)
+                                                .build()
+                                ),
+                                "j0.",
+                                equalsCondition(
+                                    DruidExpression.fromColumn("country"),
+                                    DruidExpression.fromColumn("j0._d0")
+                                ),
+                                JoinType.LEFT,
+                                selector("city", "B", null)
+                            )
+                        )
+                        .setQuerySegmentSpec(querySegmentSpec(Intervals.of(
+                            "2021-01-01T01:00:00.000Z/2021-01-02T23:59:59.001Z")))
+                        .setDimensions(new DefaultDimensionSpec("country", "d0"))
+                        .setAggregatorSpecs(new LongAnyAggregatorFactory("a0", "j0._a0"))
+                        .setGranularity(new AllGranularity())
+                        .setContext(queryContext)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"canada", 4L}
+        )
+    );
   }
 
   @Test
-  public void testCorrelatedGroupByQuery()
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testCorrelatedSubqueryWithCorrelatedQueryFilter(Map<String, Object> queryContext) throws Exception
   {
+    cannotVectorize();
 
+    testQuery(
+        "select country, ANY_VALUE(\n"
+        + "        select max(\"users\") from (\n"
+        + "            select floor(__time to day), count(user) \"users\" from visits f where f.country = visits.country and f.city = 'A' group by 1\n"
+        + "        )\n"
+        + "     ) as \"dailyVisits\"\n"
+        + "from visits \n"
+        + " where city = 'B'"
+        + " group by 1",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            join(
+                                new TableDataSource("visits"),
+                                new QueryDataSource(
+                                    GroupByQuery.builder()
+                                                .setDataSource(
+                                                    GroupByQuery.builder()
+                                                                .setDataSource("visits")
+                                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                                .setVirtualColumns(new ExpressionVirtualColumn(
+                                                                    "v0",
+                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    ValueType.LONG,
+                                                                    TestExprMacroTable.INSTANCE
+                                                                ))
+                                                                .setDimensions(
+                                                                    new DefaultDimensionSpec(
+                                                                        "v0",
+                                                                        "d0",
+                                                                        ValueType.LONG
+                                                                    ),
+                                                                    new DefaultDimensionSpec(
+                                                                        "country",
+                                                                        "d1"
+                                                                    )
+                                                                )
+                                                                .setAggregatorSpecs(new FilteredAggregatorFactory(
+                                                                    new CountAggregatorFactory("a0"),
+                                                                    not(selector("user", null, null))
+                                                                ))
+                                                                .setDimFilter(and(
+                                                                    selector("city", "A", null),
+                                                                    not(selector("country", null, null))
+                                                                ))
+                                                                .setContext(queryContext)
+                                                                .setGranularity(new AllGranularity())
+                                                                .build()
+                                                )
+                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                .setDimensions(new DefaultDimensionSpec("d1", "_d0"))
+                                                .setAggregatorSpecs(
+                                                    new LongMaxAggregatorFactory("_a0", "a0")
+                                                )
+                                                .setGranularity(new AllGranularity())
+                                                .setContext(queryContext)
+                                                .build()
+                                ),
+                                "j0.",
+                                equalsCondition(
+                                    DruidExpression.fromColumn("country"),
+                                    DruidExpression.fromColumn("j0._d0")
+                                ),
+                                JoinType.LEFT,
+                                selector("city", "B", null)
+                            )
+                        )
+                        .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                        .setDimensions(new DefaultDimensionSpec("country", "d0"))
+                        .setAggregatorSpecs(new LongAnyAggregatorFactory("a0", "j0._a0"))
+                        .setGranularity(new AllGranularity())
+                        .setContext(queryContext)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"canada", 2L}
+        )
+    );
   }
 
   @Test
-  public void testCorrelatedTopNQuery()
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testCorrelatedSubqueryWithCorrelatedQueryFilter_Scan(Map<String, Object> queryContext) throws Exception
   {
+    cannotVectorize();
 
+    testQuery(
+        "select country, ANY_VALUE(\n"
+        + "        select max(\"users\") from (\n"
+        + "            select floor(__time to day), count(user) \"users\" from visits f where f.country = visits.country and f.city = 'A' group by 1\n"
+        + "        )\n"
+        + "     ) as \"dailyVisits\"\n"
+        + "from visits \n"
+        + " where city = 'B'"
+        + " group by 1",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            join(
+                                new TableDataSource("visits"),
+                                new QueryDataSource(
+                                    GroupByQuery.builder()
+                                                .setDataSource(
+                                                    GroupByQuery.builder()
+                                                                .setDataSource("visits")
+                                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                                .setVirtualColumns(new ExpressionVirtualColumn(
+                                                                    "v0",
+                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    ValueType.LONG,
+                                                                    TestExprMacroTable.INSTANCE
+                                                                ))
+                                                                .setDimensions(
+                                                                    new DefaultDimensionSpec(
+                                                                        "v0",
+                                                                        "d0",
+                                                                        ValueType.LONG
+                                                                    ),
+                                                                    new DefaultDimensionSpec(
+                                                                        "country",
+                                                                        "d1"
+                                                                    )
+                                                                )
+                                                                .setAggregatorSpecs(new FilteredAggregatorFactory(
+                                                                    new CountAggregatorFactory("a0"),
+                                                                    not(selector("user", null, null))
+                                                                ))
+                                                                .setDimFilter(and(
+                                                                    selector("city", "A", null),
+                                                                    not(selector("country", null, null))
+                                                                ))
+                                                                .setContext(queryContext)
+                                                                .setGranularity(new AllGranularity())
+                                                                .build()
+                                                )
+                                                .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                .setDimensions(new DefaultDimensionSpec("d1", "_d0"))
+                                                .setAggregatorSpecs(
+                                                    new LongMaxAggregatorFactory("_a0", "a0")
+                                                )
+                                                .setGranularity(new AllGranularity())
+                                                .setContext(queryContext)
+                                                .build()
+                                ),
+                                "j0.",
+                                equalsCondition(
+                                    DruidExpression.fromColumn("country"),
+                                    DruidExpression.fromColumn("j0._d0")
+                                ),
+                                JoinType.LEFT,
+                                selector("city", "B", null)
+                            )
+                        )
+                        .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                        .setDimensions(new DefaultDimensionSpec("country", "d0"))
+                        .setAggregatorSpecs(new LongAnyAggregatorFactory("a0", "j0._a0"))
+                        .setGranularity(new AllGranularity())
+                        .setContext(queryContext)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"canada", 2L}
+        )
+    );
   }
 
-  @Test
-  public void testCorrelatedScanQuery()
+  private List<InputRow> getRawRows()
   {
-
+    return ImmutableList.of(
+        toRow("2021-01-01T01:00:00Z", ImmutableMap.of("user", "alice", "country", "canada", "city", "A")),
+        toRow("2021-01-01T02:00:00Z", ImmutableMap.of("user", "alice", "country", "canada", "city", "B")),
+        toRow("2021-01-01T03:00:00Z", ImmutableMap.of("user", "bob", "country", "canada", "city", "A")),
+        toRow("2021-01-01T04:00:00Z", ImmutableMap.of("user", "alice", "country", "India", "city", "Y")),
+        toRow("2021-01-02T01:00:00Z", ImmutableMap.of("user", "alice", "country", "canada", "city", "A")),
+        toRow("2021-01-02T02:00:00Z", ImmutableMap.of("user", "bob", "country", "canada", "city", "A")),
+        toRow("2021-01-02T03:00:00Z", ImmutableMap.of("user", "foo", "country", "canada", "city", "B")),
+        toRow("2021-01-02T04:00:00Z", ImmutableMap.of("user", "bar", "country", "canada", "city", "B")),
+        toRow("2021-01-02T05:00:00Z", ImmutableMap.of("user", "alice", "country", "India", "city", "X")),
+        toRow("2021-01-02T06:00:00Z", ImmutableMap.of("user", "bob", "country", "India", "city", "X")),
+        toRow("2021-01-02T07:00:00Z", ImmutableMap.of("user", "foo", "country", "India", "city", "X")),
+        toRow("2021-01-03T01:00:00Z", ImmutableMap.of("user", "foo", "country", "USA", "city", "M"))
+    );
   }
 
-  @Test
-  public void testJoinTableLookupWithFilter()
+  private MapBasedInputRow toRow(String time, Map<String, Object> event)
   {
-
+    return new MapBasedInputRow(DateTimes.ISO_DATE_OPTIONAL_TIME.parse(time), DIMENSIONS, event);
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import org.junit.Test;
+
+public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
+{
+  @Test
+  public void testExplainCorrelatedQuery()
+  {
+
+  }
+
+  @Test
+  public void testExplainJoinWithLeftScan()
+  {
+
+  }
+
+  @Test
+  public void testCorrelatedTimeseriesQuery()
+  {
+
+  }
+
+  @Test
+  public void testCorrelatedGroupByQuery()
+  {
+
+  }
+
+  @Test
+  public void testCorrelatedTopNQuery()
+  {
+
+  }
+
+  @Test
+  public void testCorrelatedScanQuery()
+  {
+
+  }
+
+  @Test
+  public void testJoinTableLookupWithFilter()
+  {
+
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -5364,14 +5364,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .dataSource(
                       join(
                         join(
-                            new QueryDataSource(
-                                newScanQueryBuilder().dataSource(CalciteTests.DATASOURCE1)
-                                                     .intervals(querySegmentSpec(Filtration.eternity()))
-                                                     .columns("dim1", "dim2")
-                                                     .filters(selector("dim2", "a", null))
-                                                     .context(QUERY_CONTEXT_DEFAULT)
-                                                     .build()
-                            ),
+                            new TableDataSource(CalciteTests.DATASOURCE1),
                             new QueryDataSource(
                                 newScanQueryBuilder().dataSource(CalciteTests.DATASOURCE3)
                                                      .intervals(querySegmentSpec(Filtration.eternity()))
@@ -5381,7 +5374,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             "j0.",
                             "(\"dim2\" == \"j0.dim2\")",
-                            JoinType.INNER
+                            JoinType.INNER,
+                            bound("dim2", "a", "a", false, false, null, null)
                         ),
                         new QueryDataSource(
                             newScanQueryBuilder().dataSource(CalciteTests.DATASOURCE1)
@@ -16050,7 +16044,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         "j0.",
                         equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.v0")),
                         JoinType.LEFT,
-                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
+                        selector("dim1", "10.1", null)
                     )
                 )
                 .intervals(querySegmentSpec(
@@ -16099,7 +16093,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         "j0.",
                         equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
                         JoinType.LEFT,
-                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
+                        selector("dim1", "10.1", null)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
@@ -16143,7 +16137,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         "j0.",
                         equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
                         JoinType.LEFT,
-                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
+                        selector("dim1", "10.1", null)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
@@ -16187,7 +16181,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         "j0.",
                         equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
                         JoinType.INNER,
-                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
+                        selector("dim1", "10.1", null)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
@@ -16231,7 +16225,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         "j0.",
                         equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
                         JoinType.INNER,
-                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
+                        selector("dim1", "10.1", null)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
@@ -16650,31 +16644,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ).build()
     );
   }
-
-  @Test
-  public void testExplainCorrelatedQuery()
-  {
-
-  }
-
-  @Test
-  public void testExplainJoinWithLeftScan()
-  {
-
-  }
-
-  @Test
-  public void testCorrelatedQuery()
-  {
-
-  }
-
-  @Test
-  public void testJoinTableLookupWithFilter()
-  {
-
-  }
-
 
   /**
    * This is a provider of query contexts that should be used by join tests.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -8282,23 +8282,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testExplainCorrelatedSubQuery() throws Exception
-  {
-    skipVectorize();
-
-    /*testQuery(
-        "select a.dim4, count(*) from (select dim4, dim3, m1 from numfoo where dim3 = 'l') a INNER JOIN (select dim4, dim3, m1 from numfoo) b ON a.dim3 = b.dim3 group by 1",
-        ImmutableList.of(),
-        ImmutableList.of(new Object[]{""})
-    );*/
-    testQuery(
-        "SELECT dim4, count(*), AVG(select sum(m1) FROM numfoo where dim4 = \"outer\".dim4) as avg_monthyl_count FROM numfoo as \"outer\" where \"outer\".dim3 = 'l' GROUP BY 1",
-        ImmutableList.of(),
-        ImmutableList.of(new Object[]{""})
-    );
-  }
-
-  @Test
   public void testExactCountDistinctUsingSubqueryWithWherePushDown() throws Exception
   {
     testQuery(
@@ -9921,9 +9904,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     cannotVectorize();
 
     testQuery(
-        "SELECT l.k, COUNT(*)\n"
-        + "FROM foo INNER JOIN (select k, v from lookup.lookyloo where k like 'xa%') l  ON foo.dim1 = l.v\n"
-        + "GROUP BY l.k",
+        "SELECT lookyloo.v, COUNT(*)\n"
+        + "FROM foo INNER JOIN lookup.lookyloo ON foo.dim1 = lookyloo.k\n"
+        + "GROUP BY lookyloo.v",
         queryContext,
         ImmutableList.of(
             GroupByQuery.builder()
@@ -9932,13 +9915,13 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 new TableDataSource(CalciteTests.DATASOURCE1),
                                 new LookupDataSource("lookyloo"),
                                 "j0.",
-                                equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.v")),
+                                equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
                                 JoinType.INNER
                             )
                         )
                         .setInterval(querySegmentSpec(Filtration.eternity()))
                         .setGranularity(Granularities.ALL)
-                        .setDimensions(dimensions(new DefaultDimensionSpec("j0.k", "d0")))
+                        .setDimensions(dimensions(new DefaultDimensionSpec("j0.v", "d0")))
                         .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
                         .setContext(queryContext)
                         .build()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -85,7 +85,6 @@ import org.apache.druid.query.filter.BoundDimFilter;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.LikeDimFilter;
-import org.apache.druid.query.filter.NotDimFilter;
 import org.apache.druid.query.filter.RegexDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.groupby.GroupByQuery;
@@ -13227,15 +13226,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .builder()
                         .setDataSource(
                             join(
-                                new QueryDataSource(
-                                    newScanQueryBuilder()
-                                        .dataSource(CalciteTests.DATASOURCE1)
-                                        .intervals(querySegmentSpec(Intervals.of("2001-01-02T00:00:00.000Z/146140482-04-24T15:36:27.903Z")))
-                                        .columns("dim1")
-                                        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                        .context(queryContext)
-                                        .build()
-                                ),
+                                new TableDataSource(CalciteTests.DATASOURCE1),
                                 new QueryDataSource(
                                     newScanQueryBuilder()
                                         .dataSource(CalciteTests.DATASOURCE1)
@@ -13254,7 +13245,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             )
                         )
                         .setGranularity(Granularities.ALL)
-                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setInterval(querySegmentSpec(Intervals.of("2001-01-02T00:00:00.000Z/146140482-04-24T15:36:27.903Z")))
                         .setDimFilter(selector("dim1", "def", null))
                         .setDimensions(
                             dimensions(
@@ -16037,24 +16028,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             newScanQueryBuilder()
                 .dataSource(
                     join(
-                        new QueryDataSource(
-                            newScanQueryBuilder()
-                                .dataSource(CalciteTests.DATASOURCE1)
-                                .intervals(
-                                    querySegmentSpec(
-                                        Intervals.utc(
-                                            DateTimes.of("1999-01-01").getMillis(),
-                                            JodaUtils.MAX_INSTANT
-                                        )
-                                    )
-                                )
-                                .filters(new SelectorDimFilter("dim1", "10.1", null))
-                                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
-                                .columns(ImmutableList.of("__time", "v0"))
-                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(queryContext)
-                                .build()
-                        ),
+                        new TableDataSource(CalciteTests.DATASOURCE1),
                         new QueryDataSource(
                             newScanQueryBuilder()
                                 .dataSource(CalciteTests.DATASOURCE1)
@@ -16074,14 +16048,19 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.v0")),
-                        JoinType.LEFT
+                        equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.v0")),
+                        JoinType.LEFT,
+                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
                     )
                 )
-                .intervals(querySegmentSpec(Filtration.eternity()))
-                .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
-                .columns("__time", "_v0")
-                .filters(new SelectorDimFilter("v0", "10.1", null))
+                .intervals(querySegmentSpec(
+                    Intervals.utc(
+                        DateTimes.of("1999-01-01").getMillis(),
+                        JodaUtils.MAX_INSTANT
+                    )
+                ))
+                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
+                .columns("__time", "v0")
                 .context(queryContext)
                 .build()
         ),
@@ -16106,17 +16085,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             newScanQueryBuilder()
                 .dataSource(
                     join(
-                        new QueryDataSource(
-                            newScanQueryBuilder()
-                                .dataSource(CalciteTests.DATASOURCE1)
-                                .intervals(querySegmentSpec(Filtration.eternity()))
-                                .filters(new SelectorDimFilter("dim1", "10.1", null))
-                                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
-                                .columns(ImmutableList.of("__time", "v0"))
-                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(queryContext)
-                                .build()
-                        ),
+                        new TableDataSource(CalciteTests.DATASOURCE1),
                         new QueryDataSource(
                             newScanQueryBuilder()
                                 .dataSource(CalciteTests.DATASOURCE1)
@@ -16128,14 +16097,14 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
-                        JoinType.LEFT
+                        equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
+                        JoinType.LEFT,
+                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
-                .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
-                .columns("__time", "_v0")
-                .filters(new SelectorDimFilter("v0", "10.1", null))
+                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
+                .columns("__time", "v0")
                 .context(queryContext)
                 .build()
         ),
@@ -16160,17 +16129,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             newScanQueryBuilder()
                 .dataSource(
                     join(
-                        new QueryDataSource(
-                            newScanQueryBuilder()
-                                .dataSource(CalciteTests.DATASOURCE1)
-                                .intervals(querySegmentSpec(Filtration.eternity()))
-                                .filters(new SelectorDimFilter("dim1", "10.1", null))
-                                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
-                                .columns(ImmutableList.of("__time", "v0"))
-                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(queryContext)
-                                .build()
-                        ),
+                        new TableDataSource(CalciteTests.DATASOURCE1),
                         new QueryDataSource(
                             newScanQueryBuilder()
                                 .dataSource(CalciteTests.DATASOURCE1)
@@ -16182,13 +16141,14 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
-                        JoinType.LEFT
+                        equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
+                        JoinType.LEFT,
+                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
-                .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
-                .columns("__time", "_v0")
+                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
+                .columns("__time", "v0")
                 .context(queryContext)
                 .build()
         ),
@@ -16213,17 +16173,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             newScanQueryBuilder()
                 .dataSource(
                     join(
-                        new QueryDataSource(
-                            newScanQueryBuilder()
-                                .dataSource(CalciteTests.DATASOURCE1)
-                                .intervals(querySegmentSpec(Filtration.eternity()))
-                                .filters(new SelectorDimFilter("dim1", "10.1", null))
-                                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
-                                .columns(ImmutableList.of("__time", "v0"))
-                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(queryContext)
-                                .build()
-                        ),
+                        new TableDataSource(CalciteTests.DATASOURCE1),
                         new QueryDataSource(
                             newScanQueryBuilder()
                                 .dataSource(CalciteTests.DATASOURCE1)
@@ -16235,14 +16185,14 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
-                        JoinType.INNER
+                        equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
+                        JoinType.INNER,
+                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
-                .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
-                .columns("__time", "_v0")
-                .filters(new NotDimFilter(new SelectorDimFilter("v0", null, null)))
+                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
+                .columns("__time", "v0")
                 .context(queryContext)
                 .build()
         ),
@@ -16267,17 +16217,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             newScanQueryBuilder()
                 .dataSource(
                     join(
-                        new QueryDataSource(
-                            newScanQueryBuilder()
-                                .dataSource(CalciteTests.DATASOURCE1)
-                                .intervals(querySegmentSpec(Filtration.eternity()))
-                                .filters(new SelectorDimFilter("dim1", "10.1", null))
-                                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
-                                .columns(ImmutableList.of("__time", "v0"))
-                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                .context(queryContext)
-                                .build()
-                        ),
+                        new TableDataSource(CalciteTests.DATASOURCE1),
                         new QueryDataSource(
                             newScanQueryBuilder()
                                 .dataSource(CalciteTests.DATASOURCE1)
@@ -16289,13 +16229,14 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
-                        JoinType.INNER
+                        equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.dim1")),
+                        JoinType.INNER,
+                        bound("dim1", "10.1", "10.1", false, false, null, StringComparators.LEXICOGRAPHIC)
                     )
                 )
                 .intervals(querySegmentSpec(Filtration.eternity()))
-                .virtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ValueType.STRING))
-                .columns("__time", "_v0")
+                .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ValueType.STRING))
+                .columns("__time", "v0")
                 .context(queryContext)
                 .build()
         ),
@@ -16709,6 +16650,31 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ).build()
     );
   }
+
+  @Test
+  public void testExplainCorrelatedQuery()
+  {
+
+  }
+
+  @Test
+  public void testExplainJoinWithLeftScan()
+  {
+
+  }
+
+  @Test
+  public void testCorrelatedQuery()
+  {
+
+  }
+
+  @Test
+  public void testJoinTableLookupWithFilter()
+  {
+
+  }
+
 
   /**
    * This is a provider of query contexts that should be used by join tests.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.calcite.plan.RelOptPlanner;
-import org.apache.druid.annotations.UsedByJUnitParamsRunner;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
@@ -16645,38 +16644,4 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
-  /**
-   * This is a provider of query contexts that should be used by join tests.
-   * It tests various configs that can be passed to join queries. All the configs provided by this provider should
-   * have the join query engine return the same results.
-   */
-  public static class QueryContextForJoinProvider
-  {
-    @UsedByJUnitParamsRunner
-    public static Object[] provideQueryContexts()
-    {
-      return new Object[] {
-          // default behavior
-          QUERY_CONTEXT_DEFAULT,
-          // filter value re-writes enabled
-          new ImmutableMap.Builder<String, Object>()
-              .putAll(QUERY_CONTEXT_DEFAULT)
-              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, true)
-              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, true)
-              .build(),
-          // rewrite values enabled but filter re-writes disabled.
-          // This should be drive the same behavior as the previous config
-          new ImmutableMap.Builder<String, Object>()
-              .putAll(QUERY_CONTEXT_DEFAULT)
-              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, true)
-              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, false)
-              .build(),
-          // filter re-writes disabled
-          new ImmutableMap.Builder<String, Object>()
-              .putAll(QUERY_CONTEXT_DEFAULT)
-              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, false)
-              .build(),
-      };
-    }
-  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rel/DruidQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rel/DruidQueryTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rel;
+
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.JoinDataSource;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.filter.AndDimFilter;
+import org.apache.druid.query.filter.BoundDimFilter;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.query.ordering.StringComparators;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.join.JoinType;
+import org.apache.druid.sql.calcite.filtration.Filtration;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class DruidQueryTest
+{
+
+  static {
+    NullHandling.initializeForTests();
+  }
+
+  private final DimFilter selectorFilter = new SelectorDimFilter("column", "value", null);
+  private final DimFilter otherFilter = new SelectorDimFilter("column_2", "value_2", null);
+  private final DimFilter filterWithInterval = new AndDimFilter(
+      selectorFilter,
+      new BoundDimFilter("__time", "100", "200", false, true, null, null, StringComparators.NUMERIC)
+  );
+
+  @Test
+  public void test_filtration_noJoinAndInterval()
+  {
+    DataSource dataSource = new TableDataSource("test");
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        selectorFilter,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, dataSource, selectorFilter, Intervals.ETERNITY);
+  }
+
+  @Test
+  public void test_filtration_intervalInQueryFilter()
+  {
+    DataSource dataSource = new TableDataSource("test");
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        filterWithInterval,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, dataSource, selectorFilter, Intervals.utc(100, 200));
+  }
+
+  @Test
+  public void test_filtration_joinDataSource_intervalInQueryFilter()
+  {
+    DataSource dataSource = join(JoinType.INNER, otherFilter);
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        filterWithInterval,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, dataSource, selectorFilter, Intervals.utc(100, 200));
+  }
+
+  @Test
+  public void test_filtration_joinDataSource_intervalInBaseTableFilter_inner()
+  {
+    DataSource dataSource = join(JoinType.INNER, filterWithInterval);
+    DataSource expectedDataSource = join(JoinType.INNER, selectorFilter);
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        otherFilter,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
+  }
+
+  @Test
+  public void test_filtration_joinDataSource_intervalInBaseTableFilter_left()
+  {
+    DataSource dataSource = join(JoinType.LEFT, filterWithInterval);
+    DataSource expectedDataSource = join(JoinType.LEFT, selectorFilter);
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        otherFilter,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
+  }
+
+  @Test
+  public void test_filtration_joinDataSource_intervalInBaseTableFilter_right()
+  {
+    DataSource dataSource = join(JoinType.RIGHT, filterWithInterval);
+    DataSource expectedDataSource = join(JoinType.RIGHT, selectorFilter);
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        otherFilter,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
+  }
+
+  @Test
+  public void test_filtration_joinDataSource_intervalInBaseTableFilter_full()
+  {
+    DataSource dataSource = join(JoinType.FULL, filterWithInterval);
+    DataSource expectedDataSource = join(JoinType.FULL, selectorFilter);
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        otherFilter,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
+  }
+
+  @Test
+  public void test_filtration_intervalsInBothFilters()
+  {
+    DataSource dataSource = join(JoinType.INNER, filterWithInterval);
+    DataSource expectedDataSource = join(JoinType.INNER, selectorFilter);
+    DimFilter queryFilter = new AndDimFilter(
+        otherFilter,
+        new BoundDimFilter("__time", "150", "250", false, true, null, null, StringComparators.NUMERIC)
+
+    );
+    Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
+        dataSource,
+        queryFilter,
+        VirtualColumnRegistry.create(RowSignature.empty())
+    );
+    verify(pair, expectedDataSource, otherFilter, Intervals.utc(150, 200));
+  }
+
+  private JoinDataSource join(JoinType joinType, DimFilter filter)
+  {
+    return JoinDataSource.create(
+        new TableDataSource("left"),
+        new TableDataSource("right"),
+        "r.",
+        "c == \"r.c\"",
+        joinType,
+        filter,
+        ExprMacroTable.nil()
+    );
+  }
+
+  private void verify(
+      Pair<DataSource, Filtration> pair,
+      DataSource dataSource,
+      DimFilter columnFilter,
+      Interval interval
+  )
+  {
+    Assert.assertEquals(dataSource, pair.lhs);
+    Assert.assertEquals("dim-filter: " + pair.rhs.getDimFilter(), columnFilter, pair.rhs.getDimFilter());
+    Assert.assertEquals(Collections.singletonList(interval), pair.rhs.getIntervals());
+  }
+}


### PR DESCRIPTION
As of now, if the left query in the JOIN has a filter present, we plan it as the join between two query data sources even if the left source is a base table. This is of course not efficient. We had even introduced some custom calcite rules so that filters on join query are not pushed into the children tables. This issue is more significant for correlated queries since the generated physical plan is a left join with a filter on the left base table. Hence, the execution of correlation queries is not efficient. 
This PR adds the support for pushing filters into the left child. We would add the support for the right child in a different PR and also get rid of the custom calcite rules once that happens. 
What does not work
 - Partitioning pruning based on left filter of join table


<hr>

This PR has:
- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
