### PR TITLE
fix NPE when calling TaskLocation.hashCode with null host

### DIFF
--- a/core/src/main/java/org/apache/druid/indexer/TaskLocation.java
+++ b/core/src/main/java/org/apache/druid/indexer/TaskLocation.java
@@ -29,6 +29,7 @@ public class TaskLocation
 {
   private static final TaskLocation UNKNOWN = new TaskLocation(null, -1, -1);
 
+  @Nullable
   private final String host;
   private final int port;
   private final int tlsPort;
@@ -75,6 +76,16 @@ public class TaskLocation
   }
 
   @Override
+  public String toString()
+  {
+    return "TaskLocation{" +
+           "host='" + host + '\'' +
+           ", port=" + port +
+           ", tlsPort=" + tlsPort +
+           '}';
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {
@@ -83,29 +94,13 @@ public class TaskLocation
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     TaskLocation that = (TaskLocation) o;
-
-    return port == that.port && tlsPort == that.tlsPort &&
-           Objects.equals(host, that.host);
+    return port == that.port && tlsPort == that.tlsPort && Objects.equals(host, that.host);
   }
 
   @Override
   public int hashCode()
   {
-    int result = host.hashCode();
-    result = 31 * result + port;
-    result = 31 * result + tlsPort;
-    return result;
-  }
-
-  @Override
-  public String toString()
-  {
-    return "TaskLocation{" +
-           "host='" + host + '\'' +
-           ", port=" + port +
-           ", tlsPort=" + tlsPort +
-           '}';
+    return Objects.hash(host, port, tlsPort);
   }
 }

--- a/core/src/test/java/org/apache/druid/indexer/TaskLocationTest.java
+++ b/core/src/test/java/org/apache/druid/indexer/TaskLocationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexer;
+
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class TaskLocationTest
+{
+  @Test
+  public void testEqualsAndHashCode()
+  {
+    EqualsVerifier.forClass(TaskLocation.class).usingGetClass().verify();
+  }
+}


### PR DESCRIPTION
Stumbled across this issue by accident while sketching out some code, not sure if it can actually happen in a production environment, but `host` is nullable yet not treated as such in hashCode, resulting in an NPE if it gets called.
