### PR TITLE
use actual dataInterval in cache key

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
@@ -57,6 +57,7 @@ import org.apache.druid.query.spec.SpecificSegmentQueryRunner;
 import org.apache.druid.query.spec.SpecificSegmentSpec;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.SegmentReference;
+import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.server.SegmentManager;
@@ -300,10 +301,15 @@ public class ServerManager implements QuerySegmentWalker
         queryMetrics -> queryMetrics.segment(segmentIdString)
     );
 
+    StorageAdapter storageAdapter = segment.asStorageAdapter();
+    long segmentMaxTime = storageAdapter.getMaxTime().getMillis();
+    long segmentMinTime = storageAdapter.getMinTime().getMillis();
+    Interval actualDataInterval = new Interval(segmentMinTime, segmentMaxTime);
     CachingQueryRunner<T> cachingQueryRunner = new CachingQueryRunner<>(
         segmentIdString,
         cacheKeyPrefix,
         segmentDescriptor,
+        actualDataInterval,
         objectMapper,
         cache,
         toolChest,

--- a/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
@@ -413,6 +413,7 @@ public class CachingQueryRunnerTest
         CACHE_ID,
         Optional.ofNullable(cacheKeyPrefix),
         SEGMENT_DESCRIPTOR,
+        SEGMENT_DESCRIPTOR.getInterval(),
         objectMapper,
         cache,
         toolchest,


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Currently, the interval used in CachingQueryRunner by CacheUtil.computeSegmentCacheKey() is the intersection of query interval and Segment interval from segment identifier.
It's better to use the intersection of query interval and the actual dataInterval of the segment(the min/max data time in the segment, not the interval in the segment identifier).

For example, when the segment granularity is DAY and there are many partitions built by realtime tasks :
datasource_name1_2020-12-28T00:00:00.000Z_2020-12-29T00:00:00.000Z_2020-12-28T00:00:00.505Z: 
datasource_name1_2020-12-28T00:00:00.000Z_2020-12-29T00:00:00.000Z_2020-12-28T00:00:00.505Z_1: 
datasource_name1_2020-12-28T00:00:00.000Z_2020-12-29T00:00:00.000Z_2020-12-28T00:00:00.505Z_2: 

The actual min/max time in these segments are:
00:09:00 ~ 00:37:22
01:11:34 ~ 01:45:43
02:04:22 ~ 02:54:12

Currently, the first query with query interval 00:00:00/02:14:19 populates a cache with interval 00:00:00/02:14:19 in cache key.
the next query with query interval 00:00:00/02:15:19 can't reuse the cache populated by the first query due to the '00:00:00/02:14:19' used in the cache key.

For this case, the interval used in cache key should be changed to 00:09:00/00:37:22, 01:11:34/01:45:43, 02:04:22/02:14:19

This change will not break any contract, because of `Interval actualInterval = interval.overlap(dataInterval);` in `makeCursors()` in `IncrementalIndexStorageAdapter` and `QueryableIndexStorageAdapter`

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `CachingQueryRunner`
