### PR TITLE
reuse DataSegment object when a segment found on another server

### DIFF
--- a/server/src/main/java/org/apache/druid/client/BatchServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/BatchServerInventoryView.java
@@ -124,7 +124,7 @@ public class BatchServerInventoryView extends AbstractCuratorServerInventoryView
               Pair<DruidServerMetadata, DataSegment> input
           )
           {
-            return input.rhs;
+            return DataSegmentInterner.intern(input.rhs);
           }
         }
     ));

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -586,18 +586,19 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
       };
     }
 
-    private void addSegment(final DataSegment segment)
+    private void addSegment(DataSegment segment)
     {
       if (finalPredicate.apply(Pair.of(druidServer.getMetadata(), segment))) {
         if (druidServer.getSegment(segment.getId()) == null) {
-          druidServer.addDataSegment(segment);
+          DataSegment theSegment = DataSegmentInterner.intern(segment);
+          druidServer.addDataSegment(theSegment);
           runSegmentCallbacks(
               new Function<SegmentCallback, CallbackAction>()
               {
                 @Override
                 public CallbackAction apply(SegmentCallback input)
                 {
-                  return input.segmentAdded(druidServer.getMetadata(), segment);
+                  return input.segmentAdded(druidServer.getMetadata(), theSegment);
                 }
               }
           );

--- a/server/src/main/java/org/apache/druid/client/SingleServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/SingleServerInventoryView.java
@@ -81,7 +81,7 @@ public class SingleServerInventoryView extends AbstractCuratorServerInventoryVie
         Predicates.or(segmentPredicates.values())
     );
     if (predicate.apply(Pair.of(container.getMetadata(), inventory))) {
-      addSingleInventory(container, inventory);
+      addSingleInventory(container, DataSegmentInterner.intern(inventory));
     }
     return container;
   }


### PR DESCRIPTION
### Description

There is more than 1 copy of the same segment in the broker's/coordinators memory. 
This is how it happens.
1. a segment appeared in zk(BatchServerInventoryView or SingleServerInventoryView) or synced from a historical/realtime node(HttpServerInventoryView)
2. if there are more than 1 replica is configured for this segment (by load rule)
    2.1 for zk, `container.addDataSegment(inventory);`  a historical/realtime node is a `container`, the `inventory` is a segment which is deserialized from bytes from znode. For the same segment will be more than one copy stored in a different `container` when announced by different historical/realtime node
    2.2 for http, similarly, `druidServer.addDataSegment(segment)`, the same segment will be more than one copy stored in different `DruidServer`
3. #6901  handled the duplicated copy in `ServerSelector`, which is good

This PR simply uses the `DataSegmentInterner.intern(segment)` to reuse segment
<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `BatchServerInventoryView`
 * `SingleServerInventoryView`
 * `HttpServerInventoryView`
