### PR TITLE
add additional metrics for use in reliability filtering

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DirectDruidClientMetrics.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClientMetrics.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import org.apache.druid.java.util.common.Pair;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DirectDruidClientMetrics
+{
+  public static final int DEFAULT_HISTORY_LENGTH = 500;
+
+  private final AtomicInteger openConnections;
+
+  private final ConcurrentLinkedQueue<Pair<Long, HttpResponseStatus>> responseHistory;
+
+  private final AtomicInteger errorCount;
+
+  // ConcurrentLinkedDeque size method is not constant time, so maintain this
+  private final AtomicInteger historySize;
+
+  private int maxHistoryLength = DEFAULT_HISTORY_LENGTH;
+
+  public DirectDruidClientMetrics()
+  {
+    this.openConnections = new AtomicInteger();
+    this.errorCount = new AtomicInteger();
+    this.historySize = new AtomicInteger();
+    this.responseHistory = new ConcurrentLinkedQueue<>();
+  }
+
+  public int openConnection()
+  {
+    return openConnections.getAndIncrement();
+  }
+
+  public int closeConnection()
+  {
+    return openConnections.getAndDecrement();
+  }
+
+  public int getOpenConnections()
+  {
+    return openConnections.get();
+  }
+
+  public double getErrorRate()
+  {
+    int size = historySize.get();
+
+    if (size == 0) {
+      return 0;
+    }
+    
+    return ((double) errorCount.get()) / ((double) size);
+  }
+
+  public ConcurrentLinkedQueue<Pair<Long, HttpResponseStatus>> getResponseHistory()
+  {
+    return responseHistory;
+  }
+
+  public AtomicInteger getErrorCount()
+  {
+    return errorCount;
+  }
+
+  public void recordResponse(HttpResponseStatus status)
+  {
+    while (responseHistory.size() >= maxHistoryLength) {
+      if (!isSuccess(responseHistory.poll().rhs)) {
+        errorCount.decrementAndGet();
+      }
+      historySize.decrementAndGet();
+    }
+    responseHistory.add(Pair.of(System.currentTimeMillis(), status));
+    if (!isSuccess(status)) {
+      errorCount.incrementAndGet();
+    }
+    historySize.incrementAndGet();
+  }
+
+  private boolean isSuccess(HttpResponseStatus status)
+  {
+    return HttpResponseStatus.OK.equals(status) ||
+        HttpResponseStatus.CREATED.equals(status) ||
+        HttpResponseStatus.ACCEPTED.equals(status);
+  }
+
+  public int getMaxHistoryLength()
+  {
+    return maxHistoryLength;
+  }
+
+  public void setMaxHistoryLength(int maxHistoryLength)
+  {
+    this.maxHistoryLength = maxHistoryLength;
+  }
+}

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClientMetrics.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClientMetrics.java
@@ -22,7 +22,7 @@ package org.apache.druid.client;
 import org.apache.druid.java.util.common.Pair;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DirectDruidClientMetrics
@@ -31,7 +31,7 @@ public class DirectDruidClientMetrics
 
   private final AtomicInteger openConnections;
 
-  private final ConcurrentLinkedQueue<Pair<Long, HttpResponseStatus>> responseHistory;
+  private final ConcurrentLinkedDeque<Pair<Long, HttpResponseStatus>> responseHistory;
 
   private final AtomicInteger errorCount;
 
@@ -45,7 +45,7 @@ public class DirectDruidClientMetrics
     this.openConnections = new AtomicInteger();
     this.errorCount = new AtomicInteger();
     this.historySize = new AtomicInteger();
-    this.responseHistory = new ConcurrentLinkedQueue<>();
+    this.responseHistory = new ConcurrentLinkedDeque<>();
   }
 
   public int openConnection()
@@ -74,7 +74,7 @@ public class DirectDruidClientMetrics
     return ((double) errorCount.get()) / ((double) size);
   }
 
-  public ConcurrentLinkedQueue<Pair<Long, HttpResponseStatus>> getResponseHistory()
+  public ConcurrentLinkedDeque<Pair<Long, HttpResponseStatus>> getResponseHistory()
   {
     return responseHistory;
   }

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientMetricsTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientMetricsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DirectDruidClientMetricsTest
+{
+  @Test
+  public void testEmptyMetrics()
+  {
+    DirectDruidClientMetrics metrics = new DirectDruidClientMetrics();
+    Assert.assertEquals(0, metrics.getErrorRate(), 0.0001);
+  }
+
+  @Test
+  public void testFullMetrics()
+  {
+    int errorsEvery = 3;
+    double sensitivity = 0.0001;
+    int afterTestRequests = 100;
+    int afterTestErrors = 9;
+    int totalReqs = DirectDruidClientMetrics.DEFAULT_HISTORY_LENGTH;
+    DirectDruidClientMetrics metrics = new DirectDruidClientMetrics();
+
+    testMetrics(errorsEvery, sensitivity, afterTestRequests, afterTestErrors, totalReqs, metrics);
+  }
+
+  private void testMetrics(int errorsEvery, double sensitivity, int afterTestRequests, int afterTestErrors,
+      int totalReqs, DirectDruidClientMetrics metrics)
+  {
+    simulateRequests(errorsEvery, totalReqs, metrics);
+    int totalPreTestErrors = (int) Math.ceil(((double) totalReqs) / errorsEvery);
+    double errorRate = ((double) totalPreTestErrors) / totalReqs;
+    Assert.assertEquals(errorRate, metrics.getErrorRate(), sensitivity);
+    simulateRequests(afterTestErrors, afterTestRequests, metrics);
+    totalPreTestErrors -= Math.ceil((double) afterTestRequests) / errorsEvery;
+    totalPreTestErrors += (int) Math.ceil(((double) afterTestRequests) / afterTestErrors);
+    errorRate = ((double) totalPreTestErrors) / totalReqs;
+    Assert.assertEquals(errorRate, metrics.getErrorRate(), sensitivity);
+  }
+
+  private void simulateRequests(int errorsEvery, int totalReqs, DirectDruidClientMetrics metrics)
+  {
+    for (int i = 0; i < totalReqs; i++) {
+      if (i % errorsEvery == 0) {
+        metrics.recordResponse(HttpResponseStatus.SEE_OTHER);
+      } else {
+        metrics.recordResponse(HttpResponseStatus.OK);
+      }
+    }
+  }
+
+  @Test
+  public void testVariableMax()
+  {
+    int errorsEvery = 3;
+    double sensitivity = 0.0001;
+    int afterTestRequests = 100;
+    int afterTestErrors = 9;
+    int totalReqs = 100;
+    DirectDruidClientMetrics metrics = new DirectDruidClientMetrics();
+    metrics.setMaxHistoryLength(totalReqs);
+    testMetrics(errorsEvery, sensitivity, afterTestRequests, afterTestErrors, totalReqs, metrics);
+  }
+
+}


### PR DESCRIPTION
The goal of this PR is to provide additional metrics that track the reliability of clients from the broker. In another [PR](https://github.com/apache/druid/pull/10427), we have extend the ServerSelectorStrategy to filter available servers to increase success rate. This is because the CachingClusteredClient uniformly distributes queries across historicals with segment replicas, so one misbehaving server will cause the entire query to fail. This is discussed in this [issue](https://github.com/apache/druid/issues/10602)

This approach is to extend DirectDruidClient slightly to add a limited history of the HTTP Response Codes from historical and real time servers. DirectDruidClient already maintains the number of open connections and it is responsible for making requests against the query servers, so it seems like an appropriate place to add additional statistics. DirectDruidClient is available to the ServerSelectorStrategy already as the QueryRunner for the servers and the other changes can be localized to DirectDruidClient, minimizing the changes to the core Druid codebase. If statistics on the reliability of servers can be made available at the ServerSelectorStrategy level (either through an extension like this or e.g. injecting BrokerServerView) then the filtering can be added without any other core changes. 

There are a number of alternatives to collect this data. Errors can be collected with a QueryRunner that catches QueryExceptions, but successful requests are harder to capture because that information doesn't surface at the QueryRunner level. Requests could also be tracked at the CachingClusteredClient level, but that would be tracking requests issued, rather than handling the actual response. 

What do you think?

<hr>

##### Key changed/added classes in this PR
 * `DirectDruidClient`
 * `DirectDruidClientMetrics`
