### PR TITLE
javascript filter result convert to java boolean

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/JavaScriptDimFilterTest.java
@@ -117,6 +117,7 @@ public class JavaScriptDimFilterTest
   @Test
   public void testPredicateFactoryApplyObject()
   {
+    // test for return org.mozilla.javascript.NativeBoolean
     JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter(
             "dim",
             "function(id) { return ['123', '456'].includes(id); }",
@@ -126,5 +127,34 @@ public class JavaScriptDimFilterTest
     Assert.assertTrue(javaScriptDimFilter.getPredicateFactory().applyObject("123"));
     Assert.assertTrue(javaScriptDimFilter.getPredicateFactory().applyObject("456"));
     Assert.assertFalse(javaScriptDimFilter.getPredicateFactory().applyObject("789"));
+
+    // test for return java.lang.Boolean
+    JavaScriptDimFilter javaScriptDimFilter1 = new JavaScriptDimFilter(
+            "dim",
+            "function(id) { return ['123', '456'].includes(id) == true; }",
+            null,
+            JavaScriptConfig.getEnabledInstance()
+    );
+    Assert.assertTrue(javaScriptDimFilter1.getPredicateFactory().applyObject("123"));
+    Assert.assertTrue(javaScriptDimFilter1.getPredicateFactory().applyObject("456"));
+    Assert.assertFalse(javaScriptDimFilter1.getPredicateFactory().applyObject("789"));
+
+    // test for return other type
+    JavaScriptDimFilter javaScriptDimFilter2 = new JavaScriptDimFilter(
+            "dim",
+            "function(id) { return 'word'; }",
+            null,
+            JavaScriptConfig.getEnabledInstance()
+    );
+    Assert.assertTrue(javaScriptDimFilter2.getPredicateFactory().applyObject("123"));
+
+    // test for return null
+    JavaScriptDimFilter javaScriptDimFilter3 = new JavaScriptDimFilter(
+            "dim",
+            "function(id) { return null; }",
+            null,
+            JavaScriptConfig.getEnabledInstance()
+    );
+    Assert.assertFalse(javaScriptDimFilter3.getPredicateFactory().applyObject("123"));
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/JavaScriptDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/JavaScriptDimFilterTest.java
@@ -113,4 +113,18 @@ public class JavaScriptDimFilterTest
     JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter("dim", FN1, null, new JavaScriptConfig(false));
     Assert.assertEquals(javaScriptDimFilter.getRequiredColumns(), Sets.newHashSet("dim"));
   }
+
+  @Test
+  public void testPredicateFactoryApplyObject()
+  {
+    JavaScriptDimFilter javaScriptDimFilter = new JavaScriptDimFilter(
+            "dim",
+            "function(id) { return ['123', '456'].includes(id); }",
+            null,
+            JavaScriptConfig.getEnabledInstance()
+    );
+    Assert.assertTrue(javaScriptDimFilter.getPredicateFactory().applyObject("123"));
+    Assert.assertTrue(javaScriptDimFilter.getPredicateFactory().applyObject("456"));
+    Assert.assertFalse(javaScriptDimFilter.getPredicateFactory().applyObject("789"));
+  }
 }


### PR DESCRIPTION
Fixes #10719.

### Description
When javascript filter direct return js function result(like `return [1, 2, 3].includes(4);`), it seems the filter not take effect，but change it to `return [1, 2, 3].includes(4) == true;`, the result is correct.
I found the js engine(rhino)'s return type of the former usage is  `org.mozilla.javascript.NativeBoolean`, and `Context.toBoolean` will treat it as true even though the value is false! The return type of the latter is `java.lang.Boolean`, it will behave correctly.
So I add a convert js function, convert `org.mozilla.javascript.NativeBoolean` to `java.lang.Boolean`, so that `Context.toBoolean` will return the correct result.

### Another Fix Way
And there may be have another way to fix this problem, only add `context.setLanguageVersion(Context.VERSION_1_2);`.But not sure which way has lower influence.
This problem(or feature?) has described in rhino's document: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Overview#ToBoolean.
> ToBoolean
> Boolean(new Boolean(false)) is false for all versions before 1.3. It is true (and thus ECMA conformant) for version 1.3 and greater.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

<hr>

Key changed/added classes in this PR
- org.apache.druid.query.filter.JavaScriptDimFilter