### PR TITLE
fix message gap not reported when thrownAway

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorPlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorPlumber.java
@@ -153,6 +153,7 @@ public class AppenderatorPlumber implements Plumber
   {
     final SegmentIdWithShardSpec identifier = getSegmentIdentifier(row.getTimestampFromEpoch());
     if (identifier == null) {
+      metrics.reportMessageMaxTimestamp(row.getTimestampFromEpoch());
       return Plumber.THROWAWAY;
     }
 


### PR DESCRIPTION
When useEarliestOffset =true , we want to know the message gap when reading from the earliest Kafka offset while the out-dated records are being thrown away, we can use the message gap to estimate how much time left coming to the latest offset


<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
