### PR TITLE
Better error message for compaction task when it sees no segments for compaction

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -832,6 +832,9 @@ public class CompactionTask extends AbstractBatchIndexTask
 
     void checkSegments(LockGranularity lockGranularityInUse, List<DataSegment> latestSegments)
     {
+      if (latestSegments.isEmpty()) {
+        throw new ISE("No segments found for compaction. Please check that datasource name and interval are correct.");
+      }
       if (!inputSpec.validateSegments(lockGranularityInUse, latestSegments)) {
         throw new ISE(
             "Specified segments in the spec are different from the current used segments. "

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -547,6 +547,21 @@ public class CompactionTaskTest
   }
 
   @Test
+  public void testSegmentProviderFindSegmentsWithEmptySegmentsThrowException()
+  {
+    final SegmentProvider provider = new SegmentProvider(
+        "datasource",
+        new CompactionIntervalSpec(Intervals.of("2021-01-01/P1D"), null)
+    );
+
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage(
+        "No segments found for compaction. Please check that datasource name and interval are correct."
+    );
+    provider.checkSegments(LockGranularity.TIME_CHUNK, ImmutableList.of());
+  }
+
+  @Test
   public void testCreateIngestionSchema() throws IOException, SegmentLoadingException
   {
     final List<ParallelIndexIngestionSpec> ingestionSpecs = CompactionTask.createIngestionSchema(


### PR DESCRIPTION
### Description

Currently, the compaction task throws an exception like below:

```
java.lang.IllegalArgumentException: Empty list of intervals
        at org.apache.druid.java.util.common.JodaUtils.umbrellaInterval(JodaUtils.java:96) ~[druid-core-0.20.0-iap3.jar:0.20.0-iap3]
        at org.apache.druid.indexing.common.task.CompactionIntervalSpec.validateSegments(CompactionIntervalSpec.java:82) ~[druid-indexing-service-0.20.0-iap3.jar:0.20.0-iap3]
        at org.apache.druid.indexing.common.task.CompactionTask$SegmentProvider.checkSegments(CompactionTask.java:834) ~[druid-indexing-service-0.20.0-iap3.jar:0.20.0-iap3]
        at org.apache.druid.indexing.common.task.AbstractBatchIndexTask.determineLockGranularityandTryLockWithSegments(AbstractBatchIndexTask.java:308) ~[druid-indexing-service-0.20.0-iap3.jar:0.20.0-iap3]
        at org.apache.druid.indexing.common.task.CompactionTask.isReady(CompactionTask.java:314) ~[druid-indexing-service-0.20.0-iap3.jar:0.20.0-iap3]
        at org.apache.druid.indexing.overlord.TaskQueue.manage(TaskQueue.java:261) [druid-indexing-service-0.20.0-iap3.jar:0.20.0-iap3]
        at org.apache.druid.indexing.overlord.TaskQueue.access$000(TaskQueue.java:75) [druid-indexing-service-0.20.0-iap3.jar:0.20.0-iap3]
        at org.apache.druid.indexing.overlord.TaskQueue$1.run(TaskQueue.java:151) [druid-indexing-service-0.20.0-iap3.jar:0.20.0-iap3]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_262]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_262]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_262]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_262]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]
```

This PR improves the error message as the current one is not easy to understand. Even after this change, the stack trace is still printed in the overlord logs in this case, which is not user-friendly. We should propagate task failures during scheduling to users.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.