### PR TITLE
Update deps for CVE-2020-28168 and CVE-2020-28052

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -86,6 +86,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Version override to address CVE-2020-28052 -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.68</version>
+    </dependency>
+
     <!-- others -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -91,6 +91,7 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
       <version>1.68</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- others -->

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1001,7 +1001,7 @@ name: org.bouncycastle bcprov-jdk15on
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: MIT License
-version: 1.66
+version: 1.68
 libraries:
   - org.bouncycastle: bcprov-jdk15on
 
@@ -4813,7 +4813,7 @@ license_category: binary
 module: web-console
 license_name: MIT License
 copyright: Matt Zabriskie
-version: 0.19.0
+version: 0.21.1
 license_file_path: licenses/bin/axios.MIT
 
 ---

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -2412,12 +2412,18 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+        }
       }
     },
     "babel-jest": {

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -60,7 +60,7 @@
     "@blueprintjs/core": "^3.33.0",
     "@blueprintjs/datetime": "^3.19.2",
     "@blueprintjs/icons": "^3.22.0",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "brace": "^0.11.1",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.2.0",


### PR DESCRIPTION
This PR updates the axios dependency (from web-console) and a bouncy castle dependency coming in through the kubernetes extension, addressing the following CVEs that cause `mvn dependency-check:check` to fail:

https://nvd.nist.gov/vuln/detail/CVE-2020-28168
https://nvd.nist.gov/vuln/detail/CVE-2020-28052

Axios is updated to version 0.21.1.

For Bouncy Castle dependency, I couldn't find a version of the kubernetes client (https://github.com/kubernetes-client/java) that used a > 1.66 version, so I added a direct version override to use 1.68. 

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

