### PR TITLE
Web console: fix bad results if there is not native bigint

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4968,16 +4968,6 @@ license_file_path: licenses/bin/d3-time.BSD3
 
 ---
 
-name: "debug"
-license_category: binary
-module: web-console
-license_name: MIT License
-copyright: TJ Holowaychuk
-version: 3.1.0
-license_file_path: licenses/bin/debug.MIT
-
----
-
 name: "deep-equal"
 license_category: binary
 module: web-console
@@ -5051,7 +5041,7 @@ license_category: binary
 module: web-console
 license_name: MIT License
 copyright: Ruben Verborgh
-version: 1.5.10
+version: 1.13.1
 license_file_path: licenses/bin/follow-redirects.MIT
 
 ---
@@ -5146,16 +5136,6 @@ license_file_path: licenses/bin/is-arguments.MIT
 
 ---
 
-name: "is-buffer"
-license_category: binary
-module: web-console
-license_name: MIT License
-copyright: Feross Aboukhadijeh
-version: 2.0.3
-license_file_path: licenses/bin/is-buffer.MIT
-
----
-
 name: "is-date-object"
 license_category: binary
 module: web-console
@@ -5201,7 +5181,7 @@ license_category: binary
 module: web-console
 license_name: MIT License
 copyright: Vadim Ogievetsky, Andrey Sidorov
-version: 1.0.0
+version: 1.1.0
 license_file_path: licenses/bin/json-bigint-native.MIT
 
 ---
@@ -5273,16 +5253,6 @@ license_name: MIT License
 copyright: StringEpsilon
 version: 0.3.2
 license_file_path: licenses/bin/mini-create-react-context.MIT
-
----
-
-name: "ms"
-license_category: binary
-module: web-console
-license_name: MIT License
-copyright: Zeit, Inc.
-version: 2.0.0
-license_file_path: licenses/bin/ms.MIT
 
 ---
 

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -3913,6 +3913,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -5311,6 +5312,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       }
@@ -6969,7 +6971,8 @@
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -8044,9 +8047,9 @@
       "dev": true
     },
     "json-bigint-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint-native/-/json-bigint-native-1.0.0.tgz",
-      "integrity": "sha512-upUMnqV96WRGAbopHwDFHxsJbdBZRAdZW3WEJTB/WMLUseDEhJkcOQ0qr5x+JOHwIWpI9BYc6zoVJkmbL7SMLA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-bigint-native/-/json-bigint-native-1.1.0.tgz",
+      "integrity": "sha512-PPL9AlDP0ift5v8siEsR7oQsamOAIOLjn14GRaijZRUWDXsJC5rHXNlmtLPkPjK0k2i5yHK30VPqiFTZHolXaA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -8841,7 +8844,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -74,7 +74,7 @@
     "fontsource-open-sans": "^3.0.9",
     "has-own-prop": "^2.0.0",
     "hjson": "^3.2.1",
-    "json-bigint-native": "^1.0.0",
+    "json-bigint-native": "^1.1.0",
     "lodash.debounce": "^4.0.8",
     "lodash.escape": "^4.0.1",
     "memoize-one": "^5.1.1",

--- a/web-console/src/singletons/api.spec.ts
+++ b/web-console/src/singletons/api.spec.ts
@@ -23,4 +23,32 @@ describe('Api', () => {
     expect(Api.encodePath('wikipedia')).toEqual('wikipedia');
     expect(Api.encodePath(`wi%ki?pe#dia&'[]`)).toEqual('wi%25ki%3Fpe%23dia%26%27%5B%5D');
   });
+
+  describe(`with BigInt`, () => {
+    it('works as expected', () => {
+      const res = (Api.getDefaultConfig().transformResponse as any)[0](`{"x":9223372036854775799}`);
+      expect(typeof res).toEqual('object');
+      expect(typeof res.x).toEqual('bigint');
+      expect(String(res.x)).toEqual('9223372036854775799');
+    });
+  });
+
+  describe(`without BigInt`, () => {
+    const originalBigInt = (global as any).BigInt;
+
+    beforeAll(() => {
+      (global as any).BigInt = null;
+    });
+
+    afterAll(() => {
+      (global as any).BigInt = originalBigInt;
+    });
+
+    it('works as expected', () => {
+      const res = (Api.getDefaultConfig().transformResponse as any)[0](`{"x":9223372036854775799}`);
+      expect(typeof res).toEqual('object');
+      expect(typeof res.x).toEqual('number');
+      expect(String(res.x)).toEqual('9223372036854776000');
+    });
+  });
 });


### PR DESCRIPTION
This PR bumps the version of json-bigint-native to fix a bug where it would throw an error if `BigInt` was not defined (instead of doing a fallback).

This caused the results not to get parsed (due to the code in https://github.com/apache/druid/blob/master/web-console/src/singletons/api.ts#L37) and be returned as a string, which causes this madness:

![image](https://user-images.githubusercontent.com/177816/104140417-4e475780-5366-11eb-9939-73bdcc7ebf27.png)

This is on Safari 13.1 (which does not have `BigInt` yet)

Added a test to make sure there is a graceful fallback to `number`