### PR TITLE
fix limited queries with subtotals

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
@@ -63,6 +63,7 @@ public class ByteBufferMinMaxOffsetHeap
   public void reset()
   {
     heapSize = 0;
+    maxHeapSize = 0;
   }
 
   public int addOffset(int offset)

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ByteBufferMinMaxOffsetHeap.java
@@ -43,6 +43,7 @@ public class ByteBufferMinMaxOffsetHeap
   private final LimitedBufferHashGrouper.BufferGrouperOffsetHeapIndexUpdater heapIndexUpdater;
 
   private int heapSize;
+  private int maxHeapSize;
 
   public ByteBufferMinMaxOffsetHeap(
       ByteBuffer buf,
@@ -69,6 +70,9 @@ public class ByteBufferMinMaxOffsetHeap
     int pos = heapSize;
     buf.putInt(pos * Integer.BYTES, offset);
     heapSize++;
+    if (heapSize > maxHeapSize) {
+      maxHeapSize = heapSize;
+    }
 
     if (heapIndexUpdater != null) {
       heapIndexUpdater.updateHeapIndexForOffset(offset, pos);
@@ -492,7 +496,7 @@ public class ByteBufferMinMaxOffsetHeap
   @Override
   public String toString()
   {
-    if (heapSize == 0) {
+    if (heapSize == 0 && maxHeapSize == 0) {
       return "[]";
     }
 
@@ -500,6 +504,14 @@ public class ByteBufferMinMaxOffsetHeap
     for (int i = 0; i < heapSize; i++) {
       ret.append(buf.getInt(i * Integer.BYTES));
       if (i < heapSize - 1) {
+        ret.append(", ");
+      }
+    }
+
+    ret.append("] backing-array:[");
+    for (int i = 0; i < maxHeapSize; i++) {
+      ret.append(buf.getInt(i * Integer.BYTES));
+      if (i < maxHeapSize - 1) {
         ret.append(", ");
       }
     }

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouperTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.aggregation.AggregatorAdapters;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +39,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LimitedBufferHashGrouperTest
+public class LimitedBufferHashGrouperTest extends InitializedNullHandlingTest
 {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -126,6 +127,8 @@ public class LimitedBufferHashGrouperTest
     }
 
     Assert.assertEquals(expected, Lists.newArrayList(grouper.iterator(true)));
+    // iterate again, even though the min-max offset heap has been destroyed, it is replaced with a reverse sorted array
+    Assert.assertEquals(expected, Lists.newArrayList(grouper.iterator(true)));
   }
 
   @Test
@@ -191,6 +194,31 @@ public class LimitedBufferHashGrouperTest
     }
 
     Assert.assertEquals(expected, Lists.newArrayList(grouper.iterator(true)));
+    // iterate again, even though the min-max offset heap has been destroyed, it is replaced with a reverse sorted array
+    Assert.assertEquals(expected, Lists.newArrayList(grouper.iterator(true)));
+  }
+
+  @Test
+  public void testAggregateAfterIterated()
+  {
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage("attempted to add offset after grouper was iterated");
+
+    final int limit = 100;
+    final int keyBase = 100000;
+    final TestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
+    final LimitedBufferHashGrouper<Integer> grouper = makeGrouper(columnSelectorFactory, 12120, 2, limit);
+    final int numRows = 1000;
+
+    columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("value", 10L)));
+    for (int i = 0; i < numRows; i++) {
+      Assert.assertTrue(String.valueOf(i + keyBase), grouper.aggregate(i + keyBase).isOk());
+    }
+    List<Grouper.Entry<Integer>> iterated = Lists.newArrayList(grouper.iterator(true));
+    Assert.assertEquals(limit, iterated.size());
+
+    // an attempt to aggregate with a new key will explode after the grouper has been iterated
+    grouper.aggregate(keyBase + numRows + 1);
   }
 
   private static LimitedBufferHashGrouper<Integer> makeGrouper(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -16281,6 +16281,71 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @Test
+  public void testGroupingSetsWithLimit() throws Exception
+  {
+    // Cannot vectorize due to virtual columns.
+    cannotVectorize();
+
+    testQuery(
+        "SELECT dim2, gran, SUM(cnt)\n"
+        + "FROM (SELECT FLOOR(__time TO MONTH) AS gran, COALESCE(dim2, '') dim2, cnt FROM druid.foo) AS x\n"
+        + "GROUP BY GROUPING SETS ( (dim2, gran), (dim2), (gran), () ) LIMIT 100",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setVirtualColumns(
+                            expressionVirtualColumn(
+                                "v0",
+                                "case_searched(notnull(\"dim2\"),\"dim2\",'')",
+                                ValueType.STRING
+                            ),
+                            expressionVirtualColumn(
+                                "v1",
+                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                ValueType.LONG
+                            )
+                        )
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0"),
+                                new DefaultDimensionSpec("v1", "d1", ValueType.LONG)
+                            )
+                        )
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setSubtotalsSpec(
+                            ImmutableList.of(
+                                ImmutableList.of("d0", "d1"),
+                                ImmutableList.of("d0"),
+                                ImmutableList.of("d1"),
+                                ImmutableList.of()
+                            )
+                        ).setLimitSpec(
+                new DefaultLimitSpec(
+                    ImmutableList.of(),
+                    100)
+            )
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"", timestamp("2000-01-01"), 2L},
+            new Object[]{"", timestamp("2001-01-01"), 1L},
+            new Object[]{"a", timestamp("2000-01-01"), 1L},
+            new Object[]{"a", timestamp("2001-01-01"), 1L},
+            new Object[]{"abc", timestamp("2001-01-01"), 1L},
+            new Object[]{"", null, 3L},
+            new Object[]{"a", null, 2L},
+            new Object[]{"abc", null, 1L},
+            new Object[]{NULL_STRING, timestamp("2000-01-01"), 3L},
+            new Object[]{NULL_STRING, timestamp("2001-01-01"), 3L},
+            new Object[]{NULL_STRING, null, 6L}
+        )
+    );
+  }
+
   /**
    * This is a provider of query contexts that should be used by join tests.
    * It tests various configs that can be passed to join queries. All the configs provided by this provider should


### PR DESCRIPTION
### Description
This PR fixes an issue where queries with subtotals and limits can have incorrect results due to the way which `LimitedBufferHashGrouper` operates, using a min-max heap which is destroyed upon iteration, while subtotals require multiple iterations on the same grouper with different dimension sets.

To fix this, we can exploit that the min-max heap is stored as a contiguous array, and the continual removal of the min element (which is the first element of the backing array) and subsequent rebalance of the heap that follows will leave the a newly freed space at the end of the array, allowing us to write the sorted array of offsets in reverse. Subsequent iterators can then just provide the reverse ordered array.

To illustrate with an example, here is how the min-max heap normally behaves (with the data in the backing buffer included)
```
adding 1
[1] backing-array:[1]
adding 2
[1, 2] backing-array:[1, 2]
adding 3
[1, 2, 3] backing-array:[1, 2, 3]
adding 5
[1, 5, 3, 2] backing-array:[1, 5, 3, 2]
adding 8
[1, 8, 3, 2, 5] backing-array:[1, 8, 3, 2, 5]
removed min: 1
[2, 8, 3, 5] backing-array:[2, 8, 3, 5, 5]
removed min: 2
[3, 8, 5] backing-array:[3, 8, 5, 5, 5]
removed min: 3
[5, 8] backing-array:[5, 8, 5, 5, 5]
removed min: 5
[8] backing-array:[8, 8, 5, 5, 5]
removed min: 8
[] backing-array:[8, 8, 5, 5, 5]
```

Here is the same set of operations, but with back-filling the sorted array as we remove the heap:
```
adding 1
[1] backing-array:[1]
adding 2
[1, 2] backing-array:[1, 2]
adding 3
[1, 2, 3] backing-array:[1, 2, 3]
adding 5
[1, 5, 3, 2] backing-array:[1, 5, 3, 2]
adding 8
[1, 8, 3, 2, 5] backing-array:[1, 8, 3, 2, 5]
removed min: 1 set position: 4
[2, 8, 3, 5] backing-array:[2, 8, 3, 5, 1]
removed min: 2 set position: 3
[3, 8, 5] backing-array:[3, 8, 5, 2, 1]
removed min: 3 set position: 2
[5, 8] backing-array:[5, 8, 3, 2, 1]
removed min: 5 set position: 1
[8] backing-array:[8, 5, 3, 2, 1]
removed min: 8 set position: 0
[] backing-array:[8, 5, 3, 2, 1]
```

I don't believe that new offsets will be added to this heap _after_ it has been iterated, but could not definitively prove it, so I took a perhaps aggressive approach and decided that this should be an exception state. The previous behavior was likely broken, since iterating the heap is destructive, adding a new offset and then iterating again would result in an iterator which only produced the new offset. I did not want to preserve this behavior, but it would be possible if it is correct for some reason (no other grouper behaves like this afaict).

If adding new offsets does legitimately happen after iteration, when adding a new offset after the grouper has been iterated we could re-heapify from the sorted array, prior to adding the new offset to the rebuilt heap. I didn't want to add the extra code for this unless strictly necessary, so an exception will rather noisily let us know that it happens and we need to make this change, but it should be easy enough to do if necessary.


<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `LimitedBufferHashGrouper`
 * `ByteBufferMinMaxOffsetHeap`