### PR TITLE
can reset kafka Supervisor to offset by specified time

### DIFF
--- a/docs/development/extensions-core/kafka-supervisor-operations.md
+++ b/docs/development/extensions-core/kafka-supervisor-operations.md
@@ -117,6 +117,11 @@ offsets in Kafka (depending on the value of `useEarliestOffset`). After clearing
 offsets, the supervisor kills and recreates any active tasks, so that tasks begin reading 
 from valid offsets. 
 
+The `POST /druid/indexer/v1/supervisor/<supervisorId>/reset?timestamp=<timestamp in millisencond>` operation uses
+the offsets align to this timestamp, causing the supervisor to start reading offsets from
+that offsets in Kafka. After clearing stored offsets, the supervisor kills and recreates any active tasks, 
+so that tasks begin reading from valid offsets.
+
 Use care when using this operation! Resetting the supervisor may cause Kafka messages 
 to be skipped or read twice, resulting in missing or duplicate data. 
 

--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
@@ -278,6 +278,12 @@ public class MaterializedViewSupervisor implements Supervisor
   }
 
   @Override
+  public void resetToTime(long timestamp)
+  {
+    throw new UnsupportedOperationException("resetToTime() is not supported in MaterializedViewSupervisor");
+  }
+
+  @Override
   public void checkpoint(int taskGroupId, DataSourceMetadata checkpointMetadata)
   {
     // do nothing

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -628,6 +628,13 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
     throw new UnsupportedOperationException("getPosition() is not supported in Kinesis");
   }
 
+  @Nullable
+  @Override
+  public Map<String, String> getPositionFromTime(long offsetTime)
+  {
+    throw new UnsupportedOperationException("getPositionFromTime() is not supported in Kinesis");
+  }
+
   @Nonnull
   @Override
   public List<OrderedPartitionableRecord<String, String, ByteEntity>> poll(long timeout)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -220,6 +220,25 @@ public class SupervisorManager
     return true;
   }
 
+  public boolean resetSupervisorToTime(String id, long timestamp)
+  {
+    Preconditions.checkState(started, "SupervisorManager not started");
+    Preconditions.checkNotNull(id, "id");
+
+    Pair<Supervisor, SupervisorSpec> supervisor = supervisors.get(id);
+
+    if (supervisor == null) {
+      return false;
+    }
+
+    supervisor.lhs.resetToTime(timestamp);
+    SupervisorTaskAutoScaler autoscaler = autoscalers.get(id);
+    if (autoscaler != null) {
+      autoscaler.reset();
+    }
+    return true;
+  }
+
   public boolean checkPointDataSourceMetadata(
       String supervisorId,
       int taskGroupId,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -454,11 +454,14 @@ public class SupervisorResource
   @Path("/{id}/reset")
   @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(SupervisorResourceFilter.class)
-  public Response reset(@PathParam("id") final String id)
+  public Response reset(@PathParam("id") final String id, @QueryParam("timestamp") final Long timestamp)
   {
     return asLeaderWithSupervisorManager(
         manager -> {
-          if (manager.resetSupervisor(id, null)) {
+          boolean success = timestamp != null
+                            ? manager.resetSupervisorToTime(id, timestamp)
+                            : manager.resetSupervisor(id, null);
+          if (success) {
             return Response.ok(ImmutableMap.of("id", id)).build();
           } else {
             return Response.status(Response.Status.NOT_FOUND)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/RecordSupplier.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/RecordSupplier.java
@@ -27,6 +27,7 @@ import javax.validation.constraints.NotNull;
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -122,6 +123,15 @@ public interface RecordSupplier<PartitionIdType, SequenceOffsetType, RecordType 
    * @return sequence number
    */
   SequenceOffsetType getPosition(StreamPartition<PartitionIdType> partition);
+
+  /**
+   * returns the sequence number of all partitions at the specified timestamp
+   *
+   * @param offsetTime target timestamp in millisecond
+   *
+   * @return sequence number of all partitions representing this timestamp
+   */
+  Map<PartitionIdType, SequenceOffsetType> getPositionFromTime(long offsetTime);
 
   /**
    * returns the set of partitions under the given stream

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -765,7 +765,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
 
     @Override
-    public String getType() {
+    public String getType()
+    {
       return TYPE;
     }
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
@@ -1697,6 +1697,12 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
     }
 
     @Override
+    public Map<Integer, Long> getPositionFromTime(long offsetTime)
+    {
+      return null;
+    }
+
+    @Override
     public Set<Integer> getPartitionIds(String stream)
     {
       return partitions;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -1085,12 +1085,12 @@ public class SupervisorResourceTest extends EasyMockSupport
     )).andReturn(false);
     replayAll();
 
-    Response response = supervisorResource.reset("my-id");
+    Response response = supervisorResource.reset("my-id", null);
 
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
 
-    response = supervisorResource.reset("my-id-2");
+    response = supervisorResource.reset("my-id-2", null);
 
     Assert.assertEquals(404, response.getStatus());
     Assert.assertEquals("my-id", id1.getValue());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -262,6 +262,12 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
       throw new UnsupportedOperationException();
     }
 
+    @Override
+    public Map<Integer, Integer> getPositionFromTime(long offsetTime)
+    {
+      throw new UnsupportedOperationException();
+    }
+
     private long getMinRowSize()
     {
       return TIMESTAMP_STRING.length() + (NUM_COLS - 1) * STR_LEN;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -68,6 +68,12 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   }
 
   @Override
+  public boolean overrideDataSourceMetadata(String dataSource, DataSourceMetadata dataSourceMetadata)
+  {
+    return false;
+  }
+
+  @Override
   public boolean resetDataSourceMetadata(String dataSource, DataSourceMetadata dataSourceMetadata)
   {
     return false;

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -281,6 +281,16 @@ public interface IndexerMetadataStorageCoordinator
   boolean deleteDataSourceMetadata(String dataSource);
 
   /**
+   * Override dataSourceMetadata entry for 'dataSource' to the one supplied.
+   *
+   * @param dataSource         identifier
+   * @param dataSourceMetadata value to override
+   *
+   * @return true if the entry was overrided, false otherwise
+   */
+  boolean overrideDataSourceMetadata(String dataSource, DataSourceMetadata dataSourceMetadata);
+
+  /**
    * Resets dataSourceMetadata entry for 'dataSource' to the one supplied.
    *
    * @param dataSource         identifier

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
@@ -151,6 +151,11 @@ public class NoopSupervisorSpec implements SupervisorSpec
       }
 
       @Override
+      public void resetToTime(long timestamp)
+      {
+      }
+
+      @Override
       public void checkpoint(int taskGroupId, DataSourceMetadata checkpointMetadata)
       {
 

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -63,6 +63,8 @@ public interface Supervisor
 
   void reset(DataSourceMetadata dataSourceMetadata);
 
+  void resetToTime(long timestamp);
+
   /**
    * The definition of checkpoint is not very strict as currently it does not affect data or control path.
    * On this call Supervisor can potentially checkpoint data processed so far to some durable storage

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -1732,14 +1732,14 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
                   .bind("dataSource", dataSource)
                   .execute();
 
-            final DataSourceMetadataUpdateResult result = updateDataSourceMetadataWithHandle(
+            final DataStoreMetadataUpdateResult result = updateDataSourceMetadataWithHandle(
                 handle,
                 dataSource,
                 dataSourceMetadata,
                 dataSourceMetadata
             );
 
-            return result == DataSourceMetadataUpdateResult.SUCCESS;
+            return result == DataStoreMetadataUpdateResult.SUCCESS;
           }
         }
     );

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -1718,6 +1718,34 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
+  public boolean overrideDataSourceMetadata(final String dataSource, final DataSourceMetadata dataSourceMetadata)
+  {
+    return connector.retryWithHandle(
+        new HandleCallback<Boolean>()
+        {
+          @Override
+          public Boolean withHandle(Handle handle) throws Exception
+          {
+            handle.createStatement(
+                StringUtils.format("DELETE from %s WHERE dataSource = :dataSource", dbTables.getDataSourceTable())
+            )
+                  .bind("dataSource", dataSource)
+                  .execute();
+
+            final DataSourceMetadataUpdateResult result = updateDataSourceMetadataWithHandle(
+                handle,
+                dataSource,
+                dataSourceMetadata,
+                dataSourceMetadata
+            );
+
+            return result == DataSourceMetadataUpdateResult.SUCCESS;
+          }
+        }
+    );
+  }
+
+  @Override
   public boolean resetDataSourceMetadata(final String dataSource, final DataSourceMetadata dataSourceMetadata)
       throws IOException
   {


### PR DESCRIPTION
### Description

Currently, druid can only reset to earliest/latest offset, sometimes, users want to read from a specified time like the start of today

A new optional param `timestamp` is added to api `POST /druid/indexer/v1/supervisor/<supervisorId>/reset?timestamp=<timestamp in millisencond>`
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

Add `Map<PartitionIdType, SequenceOffsetType> getPositionFromTime(long offsetTime);` to get offsets from time  
Only kafka supports this feature

Add `OverrideNotice` to replace the whole DataSourceMetadata in metastore and kill tasks to let tasks restart and read starting from the new DatasourceMetadata(the same logic as ResetNotice)

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `KafkaRecordSupplier`
 * `IndexerSQLMetadataStorageCoordinator`
 * `SeekableStreamSupervisor.java`
