### PR TITLE
Web console: treat null as not defined in AutoForm

### DIFF
--- a/web-console/src/components/auto-form/auto-form.spec.tsx
+++ b/web-console/src/components/auto-form/auto-form.spec.tsx
@@ -19,6 +19,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
+import { COMPACTION_CONFIG_FIELDS } from '../../druid-models';
+
 import { AutoForm } from './auto-form';
 
 describe('AutoForm', () => {
@@ -43,5 +45,79 @@ describe('AutoForm', () => {
       />,
     );
     expect(autoForm).toMatchSnapshot();
+  });
+
+  describe('.issueWithModel', () => {
+    it('should find no issue when everything is fine', () => {
+      expect(AutoForm.issueWithModel({}, COMPACTION_CONFIG_FIELDS)).toBeUndefined();
+
+      expect(
+        AutoForm.issueWithModel(
+          {
+            dataSource: 'ds',
+            taskPriority: 25,
+            inputSegmentSizeBytes: 419430400,
+            maxRowsPerSegment: null,
+            skipOffsetFromLatest: 'P4D',
+            tuningConfig: {
+              maxRowsInMemory: null,
+              maxBytesInMemory: null,
+              maxTotalRows: null,
+              splitHintSpec: null,
+              partitionsSpec: {
+                type: 'dynamic',
+                maxRowsPerSegment: 5000000,
+                maxTotalRows: null,
+              },
+              indexSpec: null,
+              indexSpecForIntermediatePersists: null,
+              maxPendingPersists: null,
+              pushTimeout: null,
+              segmentWriteOutMediumFactory: null,
+              maxNumConcurrentSubTasks: null,
+              maxRetry: null,
+              taskStatusCheckPeriodMs: null,
+              chatHandlerTimeout: null,
+              chatHandlerNumRetries: null,
+              maxNumSegmentsToMerge: null,
+              totalNumMergeTasks: null,
+              type: 'index_parallel',
+              forceGuaranteedRollup: false,
+            },
+            taskContext: null,
+          },
+          COMPACTION_CONFIG_FIELDS,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  it('should find issue correctly', () => {
+    expect(AutoForm.issueWithModel(undefined as any, COMPACTION_CONFIG_FIELDS)).toEqual(
+      'model is undefined',
+    );
+
+    expect(
+      AutoForm.issueWithModel(
+        {
+          dataSource: 'ds',
+          taskPriority: 25,
+          inputSegmentSizeBytes: 419430400,
+          skipOffsetFromLatest: 'P4D',
+          tuningConfig: {
+            partitionsSpec: {
+              type: 'dynamic',
+              maxRowsPerSegment: 5000000,
+              maxTotalRows: null,
+            },
+            totalNumMergeTasks: 5,
+            type: 'index_parallel',
+            forceGuaranteedRollup: false,
+          },
+          taskContext: null,
+        },
+        COMPACTION_CONFIG_FIELDS,
+      ),
+    ).toEqual('field tuningConfig.totalNumMergeTasks is defined but it should not be');
   });
 });

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -122,7 +122,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
 
     for (const field of fields) {
       const fieldValue = deepGet(model, field.name);
-      const fieldValueDefined = typeof fieldValue !== 'undefined';
+      const fieldValueDefined = fieldValue != null;
       const fieldThatIsDefined = definedFields[field.name];
       if (fieldThatIsDefined) {
         if (fieldThatIsDefined === field) {


### PR DESCRIPTION
The new AutoForm based validator in the web console is a bit too strict. It treats every field that is not `undefined` as defined. This causes an issue when you set a compaction config:

After you set the initial compaction config:

![image](https://user-images.githubusercontent.com/177816/104497554-62ba6880-558f-11eb-9389-9b9ceb0c47d6.png)

The config comes back from Druid as:

```json
{
  "dataSource": "wiki-test",
  "taskPriority": 25,
  "inputSegmentSizeBytes": 419430400,
  "maxRowsPerSegment": null,
  "skipOffsetFromLatest": "P1D",
  "tuningConfig": {
    "maxRowsInMemory": null,
    "maxBytesInMemory": null,
    "maxTotalRows": null,
    "splitHintSpec": null,
    "partitionsSpec": {
      "type": "dynamic",
      "maxRowsPerSegment": 5000000,
      "maxTotalRows": null
    },
    "indexSpec": null,
    "indexSpecForIntermediatePersists": null,
    "maxPendingPersists": null,
    "pushTimeout": null,
    "segmentWriteOutMediumFactory": null,
    "maxNumConcurrentSubTasks": null,
    "maxRetry": null,
    "taskStatusCheckPeriodMs": null,
    "chatHandlerTimeout": null,
    "chatHandlerNumRetries": null,
    "maxNumSegmentsToMerge": null,
    "totalNumMergeTasks": null,
    "type": "index_parallel",
    "forceGuaranteedRollup": false
  },
  "taskContext": null
}
```

The validator complains that `"totalNumMergeTasks"` is set (to null which is not undefined) which does not make sense for the partitionsSpec.type

This is a one line change, with many tests.