### PR TITLE
VectorMatch: Disallow "copyFrom", "addAll" on self; improve tests.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/vector/VectorMatch.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/vector/VectorMatch.java
@@ -169,6 +169,8 @@ public class VectorMatch implements ReadableVectorMatch
   /**
    * Adds all rows from "other" to this object, using "scratch" as scratch space if needed. Does not modify "other".
    * Returns a reference to this object.
+   *
+   * "other" and "scratch" cannot be the same instance as each other, or as this object.
    */
   public VectorMatch addAll(final ReadableVectorMatch other, final VectorMatch scratch)
   {
@@ -176,6 +178,8 @@ public class VectorMatch implements ReadableVectorMatch
     Preconditions.checkState(this != scratch, "'scratch' must be a different instance from 'this'");
     //noinspection ObjectEquality
     Preconditions.checkState(other != scratch, "'scratch' must be a different instance from 'other'");
+    //noinspection ObjectEquality
+    Preconditions.checkState(this != other, "'other' must be a different instance from 'this'");
 
     final int[] scratchSelection = scratch.getSelection();
     final int[] otherSelection = other.getSelection();
@@ -208,19 +212,24 @@ public class VectorMatch implements ReadableVectorMatch
 
   /**
    * Copies "other" into this object, and returns a reference to this object. Does not modify "other".
+   *
+   * "other" cannot be the same instance as this object.
    */
-  public VectorMatch copyFrom(final ReadableVectorMatch other)
+  public void copyFrom(final ReadableVectorMatch other)
   {
+    //noinspection ObjectEquality
+    Preconditions.checkState(this != other, "'other' must be a different instance from 'this'");
+
     Preconditions.checkState(
         selection.length >= other.getSelectionSize(),
         "Capacity[%s] cannot fit other match's selectionSize[%s]",
         selection.length,
         other.getSelectionSize()
     );
+
     System.arraycopy(other.getSelection(), 0, selection, 0, other.getSelectionSize());
     selectionSize = other.getSelectionSize();
     assert isValid(null);
-    return this;
   }
 
   @Override


### PR DESCRIPTION
No existing code relies on being able to call these methods in this way.

The new tests exhaustively test all vectors up to size 7, and also test
the run-on-self behavior that has been adjusted by this patch.