### PR TITLE
Fix cardinality estimation

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
@@ -53,6 +53,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -269,6 +270,18 @@ class ParallelIndexTestingFactory
           SCHEMA_TIME, timestamp,
           SCHEMA_DIMENSION, dimensionValue
       ));
+    }
+    catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static String createRowFromMap(long timestamp, Map<String, Object> fields)
+  {
+    HashMap<String, Object> row = new HashMap<>(fields);
+    row.put(SCHEMA_TIME, timestamp);
+    try {
+      return NESTED_OBJECT_MAPPER.writeValueAsString(row);
     }
     catch (JsonProcessingException e) {
       throw new RuntimeException(e);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -404,7 +404,7 @@ public class PartialDimensionCardinalityTaskTest
 
     PartialDimensionCardinalityTaskBuilder withDimensions(List<String> dims)
     {
-      this.dataSchema = dataSchema.withDimensionSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims)));
+      this.dataSchema = dataSchema.withDimensionsSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims)));
       return this;
     }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -21,12 +21,14 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import org.apache.datasketches.hll.HllSketch;
 import org.apache.datasketches.memory.Memory;
 import org.apache.druid.client.indexing.NoopIndexingServiceClient;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
+import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
@@ -265,6 +267,38 @@ public class PartialDimensionCardinalityTaskTest
     }
 
     @Test
+    public void sendsCorrectReportWhenNonEmptyPartitionDimension()
+    {
+      InputSource inlineInputSource = new InlineInputSource(
+          ParallelIndexTestingFactory.createRowFromMap(0, ImmutableMap.of("dim1", "a", "dim2", "1")) + "\n" +
+          ParallelIndexTestingFactory.createRowFromMap(0, ImmutableMap.of("dim1", "a", "dim2", "2")) + "\n" +
+          ParallelIndexTestingFactory.createRowFromMap(0, ImmutableMap.of("dim1", "b", "dim2", "3")) + "\n" +
+          ParallelIndexTestingFactory.createRowFromMap(0, ImmutableMap.of("dim1", "b", "dim2", "4"))
+      );
+      HashedPartitionsSpec partitionsSpec = new HashedPartitionsSpec(null, null,
+                                                                     Collections.singletonList("dim1")
+      );
+      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
+          .partitionsSpec(partitionsSpec)
+          .build();
+
+      PartialDimensionCardinalityTaskBuilder taskBuilder = new PartialDimensionCardinalityTaskBuilder()
+          .inputSource(inlineInputSource)
+          .tuningConfig(tuningConfig)
+          .withDimensions(Arrays.asList("dim1", "dim2"));
+
+      DimensionCardinalityReport report = runTask(taskBuilder);
+
+      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Map<Interval, byte[]> intervalToCardinalities = report.getIntervalToCardinalities();
+      byte[] hllSketchBytes = Iterables.getOnlyElement(intervalToCardinalities.values());
+      HllSketch hllSketch = HllSketch.wrap(Memory.wrap(hllSketchBytes));
+      Assert.assertNotNull(hllSketch);
+      Assert.assertEquals(4L, (long) hllSketch.getEstimate());
+
+    }
+
+    @Test
     public void sendsCorrectReportWithMultipleIntervalsInData()
     {
       // Segment granularity is DAY, query granularity is HOUR
@@ -365,6 +399,12 @@ public class PartialDimensionCardinalityTaskTest
     PartialDimensionCardinalityTaskBuilder dataSchema(DataSchema dataSchema)
     {
       this.dataSchema = dataSchema;
+      return this;
+    }
+
+    PartialDimensionCardinalityTaskBuilder withDimensions(List<String> dims)
+    {
+      this.dataSchema = dataSchema.withDimensionSpec(new DimensionsSpec(DimensionsSpec.getDefaultSchemas(dims)));
       return this;
     }
 

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -300,6 +300,20 @@ public class DataSchema
     );
   }
 
+  public DataSchema withDimensionSpec(DimensionsSpec dimensionsSpec)
+  {
+    return new DataSchema(
+        dataSource,
+        timestampSpec,
+        dimensionsSpec,
+        aggregators,
+        granularitySpec,
+        transformSpec,
+        parserMap,
+        objectMapper
+    );
+  }
+
   @Override
   public String toString()
   {

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -300,7 +300,7 @@ public class DataSchema
     );
   }
 
-  public DataSchema withDimensionSpec(DimensionsSpec dimensionsSpec)
+  public DataSchema withDimensionsSpec(DimensionsSpec dimensionsSpec)
   {
     return new DataSchema(
         dataSource,

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -44,6 +44,7 @@ import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.indexing.granularity.ArbitraryGranularitySpec;
+import org.apache.druid.segment.indexing.granularity.GranularitySpec;
 import org.apache.druid.segment.transform.ExpressionTransform;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -52,6 +53,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -60,6 +63,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class DataSchemaTest extends InitializedNullHandlingTest
 {
@@ -545,5 +549,32 @@ public class DataSchemaTest extends InitializedNullHandlingTest
     Assert.assertArrayEquals(originalSchema.getAggregators(), deserialized.getAggregators());
     Assert.assertEquals(originalSchema.getTransformSpec(), deserialized.getTransformSpec());
     Assert.assertEquals(originalSchema.getParserMap(), deserialized.getParserMap());
+  }
+
+  @Test
+  public void testWithDimensionSpec()
+  {
+    TimestampSpec tsSpec = Mockito.mock(TimestampSpec.class);
+    GranularitySpec gSpec = Mockito.mock(GranularitySpec.class);
+    DimensionsSpec oldDimSpec = Mockito.mock(DimensionsSpec.class);
+    DimensionsSpec newDimSpec = Mockito.mock(DimensionsSpec.class);
+    AggregatorFactory aggFactory = Mockito.mock(AggregatorFactory.class);
+    TransformSpec transSpec = Mockito.mock(TransformSpec.class);
+    Map<String, Object> parserMap = Mockito.mock(Map.class);
+    Mockito.when(newDimSpec.withDimensionExclusions(ArgumentMatchers.any(Set.class))).thenReturn(newDimSpec);
+
+    DataSchema oldSchema = new DataSchema("dataSource", tsSpec, oldDimSpec,
+                                          new AggregatorFactory[]{aggFactory}, gSpec,
+                                          transSpec, parserMap, jsonMapper
+    );
+    DataSchema newSchema = oldSchema.withDimensionSpec(newDimSpec);
+    Assert.assertSame(oldSchema.getDataSource(), newSchema.getDataSource());
+    Assert.assertSame(oldSchema.getTimestampSpec(), newSchema.getTimestampSpec());
+    Assert.assertSame(newDimSpec, newSchema.getDimensionsSpec());
+    Assert.assertSame(oldSchema.getAggregators(), newSchema.getAggregators());
+    Assert.assertSame(oldSchema.getGranularitySpec(), newSchema.getGranularitySpec());
+    Assert.assertSame(oldSchema.getTransformSpec(), newSchema.getTransformSpec());
+    Assert.assertSame(oldSchema.getParserMap(), newSchema.getParserMap());
+
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -567,7 +567,7 @@ public class DataSchemaTest extends InitializedNullHandlingTest
                                           new AggregatorFactory[]{aggFactory}, gSpec,
                                           transSpec, parserMap, jsonMapper
     );
-    DataSchema newSchema = oldSchema.withDimensionSpec(newDimSpec);
+    DataSchema newSchema = oldSchema.withDimensionsSpec(newDimSpec);
     Assert.assertSame(oldSchema.getDataSource(), newSchema.getDataSource());
     Assert.assertSame(oldSchema.getTimestampSpec(), newSchema.getTimestampSpec());
     Assert.assertSame(newDimSpec, newSchema.getDimensionsSpec());


### PR DESCRIPTION
This PR changes the logic to compute total number of output rows when automatically calculating numShards. Currently, we estimate the unique number of hash buckets as the cardinality. Instead, we would always consider the unique number of rows irrespective of the partition dimensions. 

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.