### PR TITLE
fix task metric types in statsd emitter

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -59,15 +59,15 @@
 
   "task/success/count" : { "dimensions" : ["dataSource"], "type" : "count" },
   "task/failed/count" : { "dimensions" : ["dataSource"], "type" : "count" },
-  "task/running/count" : { "dimensions" : ["dataSource"], "type" : "count" },
-  "task/pending/count" : { "dimensions" : ["dataSource"], "type" : "count" },
-  "task/waiting/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "task/running/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "task/pending/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "task/waiting/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
 
-  "taskSlot/total/count" : { "dimensions" : [], "type" : "count" },
-  "taskSlot/idle/count" : { "dimensions" : [], "type" : "count" },
-  "taskSlot/busy/count" : { "dimensions" : [], "type" : "count" },
-  "taskSlot/lazy/count" : { "dimensions" : [], "type" : "count" },
-  "taskSlot/blacklisted/count" : { "dimensions" : [], "type" : "count" },
+  "taskSlot/total/count" : { "dimensions" : [], "type" : "gauge" },
+  "taskSlot/idle/count" : { "dimensions" : [], "type" : "gauge" },
+  "taskSlot/busy/count" : { "dimensions" : [], "type" : "gauge" },
+  "taskSlot/lazy/count" : { "dimensions" : [], "type" : "gauge" },
+  "taskSlot/blacklisted/count" : { "dimensions" : [], "type" : "gauge" },
 
   "task/run/time" : { "dimensions" : ["dataSource", "taskType"], "type" : "timer" },
   "segment/added/bytes" : { "dimensions" : ["dataSource", "taskType"], "type" : "count" },


### PR DESCRIPTION
except success and failure stats, task count metrics should all be
gauges, since they represent the current state and not some aggregate
counter over time.