### PR TITLE
Add the ability to supply client certificate to dsql command line tool.

### DIFF
--- a/examples/bin/dsql-main
+++ b/examples/bin/dsql-main
@@ -47,9 +47,9 @@ class DruidSqlException(Exception):
     f.flush()
 
 def do_query_with_args(url, sql, context, args):
-  return do_query(url, sql, context, args.timeout, args.user, args.ignore_ssl_verification, args.cafile, args.capath)
+  return do_query(url, sql, context, args.timeout, args.user, args.ignore_ssl_verification, args.cafile, args.capath, args.certchain, args.keyfile, args.keypass)
 
-def do_query(url, sql, context, timeout, user, ignore_ssl_verification, ca_file, ca_path):
+def do_query(url, sql, context, timeout, user, ignore_ssl_verification, ca_file, ca_path, cert_chain, key_file, key_pass):
   json_decoder = json.JSONDecoder(object_pairs_hook=collections.OrderedDict)
   try:
     if timeout <= 0:
@@ -63,13 +63,15 @@ def do_query(url, sql, context, timeout, user, ignore_ssl_verification, ca_file,
 
     # SSL stuff
     ssl_context = None
-    if ignore_ssl_verification or ca_file is not None or ca_path is not None:
+    if ignore_ssl_verification or ca_file is not None or ca_path is not None or cert_chain is not None:
       ssl_context = ssl.create_default_context()
       if ignore_ssl_verification:
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
-      else:
+      elif ca_path is not None:
         ssl_context.load_verify_locations(cafile=ca_file, capath=ca_path)
+      else:
+        ssl_context.load_cert_chain(certfile=cert_chain, keyfile=key_file, password=key_pass)
 
     req = urllib2.Request(url, sql_json, {'Content-Type' : 'application/json'})
 
@@ -402,6 +404,9 @@ def main():
   parser_fmt.add_argument('--tsv-delimiter', type=str, default='\t', help='Delimiter for format "tsv"')
   parser_oth.add_argument('--context-option', '-c', type=str, action='append', help='Set context option for this connection, see https://druid.apache.org/docs/latest/querying/sql.html#connection-context for options')
   parser_oth.add_argument('--execute', '-e', type=str, help='Execute single SQL query')
+  parser_cnn.add_argument('--certchain', type=str, help='Path to SSL certificate used to connect to server. See load_cert_chain() in https://docs.python.org/2/library/ssl.html#ssl.SSLContext.')
+  parser_cnn.add_argument('--keyfile', type=str, help='Path to private SSL key used to connect to server. See load_cert_chain() in https://docs.python.org/2/library/ssl.html#ssl.SSLContext.')
+  parser_cnn.add_argument('--keypass', type=str, help='Password to private SSL key file used to connect to server. See load_cert_chain() in https://docs.python.org/2/library/ssl.html#ssl.SSLContext.')
   args = parser.parse_args()
 
   # Build broker URL


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Add the ability to supply client certificate to dsql command line tool.
If the server is configured to do mutual SSL auth, there is no way of making dsql command line tool to work with Druid set up in this way. This PR adds the possibility to supply client certificate parameters, so that the appropriate cert is presented to server.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Added three new flags: `--certchain`, `--keyfile` and `--keypass`. Their values are supplied to `SSLContext`'s `load_cert_chain()` method if they're present.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
