### PR TITLE
Update PR template to include the contributing doc; suggestion to not use force push

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,7 +46,7 @@ In each section, please describe design decisions made, including:
 
 <hr>
 
-<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
+<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
 
 This PR has:
 - [ ] been self-reviewed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,4 +57,4 @@ This PR has:
 - [ ] added integration tests.
 - [ ] been tested in a test Druid cluster.
 
-Please remove this line after you read. Please avoid using force pushes and rebasing after you submit this PR since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the contributing doc](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details.
+<!-- Once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the contributing doc](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
-<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. Also please read our doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making a PR -->
+<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->
+
+<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->
 
 Fixes #XXXX.
 
@@ -56,5 +58,3 @@ This PR has:
 - [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
 - [ ] added integration tests.
 - [ ] been tested in a test Druid cluster.
-
-<!-- Once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the contributing doc](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->
+<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. Also please read our doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making a PR -->
 
 Fixes #XXXX.
 
@@ -37,6 +37,15 @@ In each section, please describe design decisions made, including:
 
 <hr>
 
+##### Key changed/added classes in this PR
+ * `MyFoo`
+ * `OurBar`
+ * `TheirBaz`
+
+<hr>
+
+<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
+
 This PR has:
 - [ ] been self-reviewed.
    - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
@@ -48,11 +57,4 @@ This PR has:
 - [ ] added integration tests.
 - [ ] been tested in a test Druid cluster.
 
-<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
-
-<hr>
-
-##### Key changed/added classes in this PR
- * `MyFoo`
- * `OurBar`
- * `TheirBaz`
+Please remove this line after you read. Please avoid using force pushes and rebasing after you submit this PR since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the contributing doc](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details.


### PR DESCRIPTION
This PR has 2 changes:

- Promoting [the contributing doc](https://github.com/apache/druid/blob/master/CONTRIBUTING.md). This change also includes a suggestion for not using force pushes and rebase after creating a PR.
- Rearrange the key changes of the PR. It seems reasonable to appear before the self-checklist.
