### PR TITLE
"druid.request.logging.type" should allow "noop" value

### DIFF
--- a/server/src/main/java/org/apache/druid/guice/QueryableModule.java
+++ b/server/src/main/java/org/apache/druid/guice/QueryableModule.java
@@ -64,6 +64,7 @@ public class QueryableModule implements DruidModule
     return Collections.singletonList(
         new SimpleModule("QueryableModule")
             .registerSubtypes(
+                NoopRequestLoggerProvider.class,
                 EmittingRequestLoggerProvider.class,
                 FileRequestLoggerProvider.class,
                 LoggingRequestLoggerProvider.class,

--- a/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerProviderTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.QueryableModule;
 import org.apache.druid.initialization.Initialization;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -68,6 +69,15 @@ public class LoggingRequestLoggerProviderTest
     final LoggingRequestLogger requestLogger = (LoggingRequestLogger) provider.get().get().get();
     Assert.assertTrue(requestLogger.isSetContextMDC());
     Assert.assertTrue(requestLogger.isSetMDC());
+  }
+
+  @Test
+  public void testNoopConfigParsing()
+  {
+    final Properties properties = new Properties();
+    properties.put(propertyPrefix + ".type", "noop");
+    provider.inject(properties, injector.getInstance(JsonConfigurator.class));
+    Assert.assertThat(provider.get().get().get(), Matchers.instanceOf(NoopRequestLogger.class));
   }
 
   private Injector makeInjector()


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

### Description

We should be able to set `druid.request.logging.type`  to `noop` as [documented](https://druid.apache.org/docs/latest/configuration/index.html#request-logging).

> Caused by: com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'noop' as a subtype of `org.apache.druid.server.log.RequestLoggerProvider`: known type ids = [composing, emitter, file, filtered, slf4j, switching]

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `QueryableModule`
