### PR TITLE
[Bug Fix] Broker will not wait for its SQL metadata view to fully initialize before starting up, even though set awaitInitializationOnStart true

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -242,7 +242,9 @@ public class DruidSchema extends AbstractSchema
                       break;
                     }
 
-                    if (isServerViewInitialized) {
+                    // lastFailure != 0L means exceptions happened before and there're some refresh work was not completed.
+                    // so that even ServerView is initialized, we can't let broker complete initialization.
+                    if (isServerViewInitialized && lastFailure == 0L) {
                       // Server view is initialized, but we don't need to do a refresh. Could happen if there are
                       // no segments in the system yet. Just mark us as initialized, then.
                       initialized.countDown();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -137,6 +137,7 @@ public class DruidSchemaTest extends CalciteTestBase
 
   private SpecificSegmentsQuerySegmentWalker walker = null;
   private DruidSchema schema = null;
+  private DruidSchema schema2 = null;
   private SegmentManager segmentManager;
   private Set<String> segmentDataSourceNames;
   private Set<String> joinableDataSourceNames;
@@ -269,6 +270,38 @@ public class DruidSchemaTest extends CalciteTestBase
       }
     };
 
+    schema2 = new DruidSchema(
+            CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
+            serverView,
+            segmentManager,
+            new MapJoinableFactory(ImmutableSet.of(globalTableJoinable), ImmutableMap.of(globalTableJoinable.getClass(), GlobalTableDataSource.class)),
+            PLANNER_CONFIG_DEFAULT,
+            new NoopViewManager(),
+            new NoopEscalator()
+    )
+    {
+
+      boolean throwException = true;
+      @Override
+      protected DruidTable buildDruidTable(String dataSource)
+      {
+        DruidTable table = super.buildDruidTable(dataSource);
+        buildTableLatch.countDown();
+        return table;
+      }
+
+      @Override
+      Set<SegmentId> refreshSegments(final Set<SegmentId> segments) throws IOException
+      {
+        if (throwException) {
+          throwException = false;
+          throw new RuntimeException("Query[xxxx] url[http://xxxx:8083/druid/v2/] timed out.");
+        } else {
+          return super.refreshSegments(segments);
+        }
+      }
+    };
+
     schema.start();
     schema.awaitInitialization();
   }
@@ -288,6 +321,19 @@ public class DruidSchemaTest extends CalciteTestBase
     final Map<String, Table> tableMap = schema.getTableMap();
     Assert.assertEquals(ImmutableSet.of("foo", "foo2"), tableMap.keySet());
   }
+
+  @Test
+  public void testSchemaInit() throws InterruptedException
+  {
+    schema2.start();
+    schema2.awaitInitialization();
+    Map<String, Table> tableMap = schema2.getTableMap();
+    Assert.assertEquals(2, tableMap.size());
+    Assert.assertTrue(tableMap.containsKey("foo"));
+    Assert.assertTrue(tableMap.containsKey("foo2"));
+    schema2.stop();
+  }
+
 
   @Test
   public void testGetTableMapFoo()


### PR DESCRIPTION
`druid.sql.planner.awaitInitializationOnStart` is used for control whether the Broker will wait for its SQL metadata view to fully initialize before starting up.

And PR https://github.com/apache/druid/pull/6765 was merge to solve the bug that `Start up DruidSchema immediately if there are no segments`

But this PR brings another bug that Broker will not wait for its SQL metadata view to fully initialize before starting up, even though set druid.sql.planner.awaitInitializationOnStart true.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

From the design view, if exceptions threw in
https://github.com/apache/druid/blob/64f97e7003ebc922e404ff49a31969993669747c/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java#L217

Broker will do retry in next loop.

Code here https://github.com/apache/druid/blob/64f97e7003ebc922e404ff49a31969993669747c/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java#L245
break this design. In next loop, `isServerViewInitialized ` is true and exit the loop directly, but there are still several refresh work need to be done.




<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Here is the full logs of this bug:
```
2021-01-19T05:02:52,921 INFO [main] org.eclipse.jetty.util.log - Logging initialized @7838ms to org.eclipse.jetty.util.log.Slf4jLog
2021-01-19T05:02:52,934 INFO [main] org.apache.druid.server.initialization.jetty.JettyServerModule - Creating http connector with port [8082]
2021-01-19T05:02:53,356 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [INIT]
2021-01-19T05:02:53,357 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [NORMAL]
2021-01-19T05:02:53,357 INFO [main] org.apache.curator.framework.imps.CuratorFrameworkImpl - Starting
2021-01-19T05:02:53,364 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:zookeeper.version=3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf, built on 03/06/2019 16:18 GMT
2021-01-19T05:02:53,364 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:host.name=druid-dev-8-broker-0.druid-dev-8-broker.druid-dev-8.svc.cluster.local
2021-01-19T05:02:53,364 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:java.version=1.8.0_221
2021-01-19T05:02:53,364 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:java.vendor=Oracle Corporation
2021-01-19T05:02:53,364 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:java.home=/usr/java/jdk1.8.0_221-amd64/jre
2021-01-19T05:02:53,364 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:java.class.path=conf/druid/_common:conf/druid/broker:lib/FastInfoset-1.2.15.jar:lib/RoaringBitmap-0.8.11.jar:lib/accessors-smart-1.2.jar:lib/aether-api-0.9.0.M2.jar:lib/aether-connector-file-0.9.0.M2.jar:lib/aether-connector-okhttp-0.0.9.jar:lib/aether-impl-0.9.0.M2.jar:lib/aether-spi-0.9.0.M2.jar:lib/aether-util-0.9.0.M2.jar:lib/aggdesigner-algorithm-6.0.jar:lib/airline-0.7.jar:lib/antlr4-runtime-4.5.1.jar:lib/aopalliance-1.0.jar:lib/asm-7.1.jar:lib/asm-analysis-7.1.jar:lib/asm-commons-7.1.jar:lib/asm-tree-7.1.jar:lib/async-http-client-2.5.3.jar:lib/async-http-client-netty-utils-2.5.3.jar:lib/audience-annotations-0.5.0.jar:lib/avatica-core-1.15.0.jar:lib/avatica-metrics-1.15.0.jar:lib/avatica-server-1.15.0.jar:lib/aws-java-sdk-core-1.11.199.jar:lib/aws-java-sdk-ec2-1.11.199.jar:lib/aws-java-sdk-kms-1.11.199.jar:lib/aws-java-sdk-s3-1.11.199.jar:lib/caffeine-2.8.0.jar:lib/calcite-core-1.21.0.jar:lib/calcite-linq4j-1.21.0.jar:lib/checker-qual-2.5.7.jar:lib/classmate-1.1.0.jar:lib/commons-beanutils-1.9.4.jar:lib/commons-codec-1.13.jar:lib/commons-collections-3.2.2.jar:lib/commons-collections4-4.2.jar:lib/commons-compiler-3.0.11.jar:lib/commons-compress-1.19.jar:lib/commons-dbcp2-2.0.1.jar:lib/commons-io-2.6.jar:lib/commons-lang-2.6.jar:lib/commons-lang3-3.8.1.jar:lib/commons-logging-1.1.1.jar:lib/commons-math3-3.6.1.jar:lib/commons-net-3.6.jar:lib/commons-pool2-2.2.jar:lib/commons-text-1.3.jar:lib/compress-lzf-1.0.4.jar:lib/config-magic-0.9.jar:lib/curator-client-4.1.0.jar:lib/curator-framework-4.1.0.jar:lib/curator-recipes-4.1.0.jar:lib/curator-x-discovery-4.1.0.jar:lib/datasketches-java-1.1.0-incubating.jar:lib/datasketches-memory-1.2.0-incubating.jar:lib/derby-10.14.2.0.jar:lib/derbyclient-10.14.2.0.jar:lib/derbynet-10.14.2.0.jar:lib/disruptor-3.3.6.jar:lib/druid-aws-common-0.17.1.jar:lib/druid-console-0.17.1.jar:lib/druid-core-0.17.1.jar:lib/druid-gcp-common-0.17.1.jar:lib/druid-hll-0.17.1.jar:lib/druid-indexing-hadoop-0.17.1.jar:lib/druid-indexing-service-0.17.1.jar:lib/druid-processing-0.17.1.jar:lib/druid-server-0.17.1.jar:lib/druid-services-0.17.1.jar:lib/druid-sql-0.17.1.jar:lib/error_prone_annotations-2.3.2.jar:lib/esri-geometry-api-2.2.0.jar:lib/extendedset-0.17.1.jar:lib/fastutil-8.2.3.jar:lib/google-api-client-1.22.0.jar:lib/google-http-client-1.22.0.jar:lib/google-http-client-jackson2-1.22.0.jar:lib/google-oauth-client-1.22.0.jar:lib/guava-16.0.1.jar:lib/guice-4.1.0.jar:lib/guice-multibindings-4.1.0.jar:lib/guice-servlet-4.1.0.jar:lib/hibernate-validator-5.2.5.Final.jar:lib/httpclient-4.5.10.jar:lib/httpcore-4.4.11.jar:lib/icu4j-55.1.jar:lib/ion-java-1.0.2.jar:lib/istack-commons-runtime-3.0.7.jar:lib/jackson-annotations-2.10.1.jar:lib/jackson-core-2.10.1.jar:lib/jackson-core-asl-1.9.13.jar:lib/jackson-databind-2.10.1.jar:lib/jackson-dataformat-cbor-2.10.1.jar:lib/jackson-dataformat-smile-2.10.1.jar:lib/jackson-datatype-guava-2.10.1.jar:lib/jackson-datatype-joda-2.10.1.jar:lib/jackson-jaxrs-base-2.10.1.jar:lib/jackson-jaxrs-json-provider-2.10.1.jar:lib/jackson-jaxrs-smile-provider-2.10.1.jar:lib/jackson-jq-0.0.10.jar:lib/jackson-mapper-asl-1.9.13.jar:lib/jackson-module-guice-2.10.1.jar:lib/jackson-module-jaxb-annotations-2.10.1.jar:lib/jakarta.activation-api-1.2.1.jar:lib/jakarta.xml.bind-api-2.3.2.jar:lib/janino-3.0.11.jar:lib/javax.activation-1.2.0.jar:lib/javax.activation-api-1.2.0.jar:lib/javax.el-3.0.0.jar:lib/javax.el-api-3.0.0.jar:lib/javax.inject-1.jar:lib/javax.servlet-api-3.1.0.jar:lib/jaxb-api-2.3.1.jar:lib/jaxb-runtime-2.3.1.jar:lib/jboss-logging-3.2.1.Final.jar:lib/jcl-over-slf4j-1.7.12.jar:lib/jcodings-1.0.43.jar:lib/jdbi-2.63.1.jar:lib/jersey-core-1.19.3.jar:lib/jersey-guice-1.19.3.jar:lib/jersey-server-1.19.3.jar:lib/jersey-servlet-1.19.3.jar:lib/jetty-client-9.4.12.v20180830.jar:lib/jetty-continuation-9.4.12.v20180830.jar:lib/jetty-http-9.4.12.v20180830.jar:lib/jetty-io-9.4.12.v20180830.jar:lib/jetty-proxy-9.4.12.v20180830.jar:lib/jetty-rewrite-9.4.12.v20180830.jar:lib/jetty-security-9.4.12.v20180830.jar:lib/jetty-server-9.4.12.v20180830.jar:lib/jetty-servlet-9.4.12.v20180830.jar:lib/jetty-servlets-9.4.12.v20180830.jar:lib/jetty-util-9.4.12.v20180830.jar:lib/jline-0.9.94.jar:lib/jmespath-java-1.11.199.jar:lib/jna-4.5.1.jar:lib/joda-time-2.10.5.jar:lib/joni-2.1.27.jar:lib/json-path-2.3.0.jar:lib/json-smart-2.3.jar:lib/jsr305-2.0.1.jar:lib/jsr311-api-1.1.1.jar:lib/jvm-attach-api-1.5.jar:lib/log4j-1.2-api-2.8.2.jar:lib/log4j-api-2.8.2.jar:lib/log4j-core-2.8.2.jar:lib/log4j-jul-2.8.2.jar:lib/log4j-slf4j-impl-2.8.2.jar:lib/lz4-java-1.6.0.jar:lib/maven-aether-provider-3.1.1.jar:lib/maven-artifact-3.6.0.jar:lib/maven-model-3.1.1.jar:lib/maven-model-builder-3.1.1.jar:lib/maven-repository-metadata-3.1.1.jar:lib/maven-settings-3.1.1.jar:lib/maven-settings-builder-3.1.1.jar:lib/metrics-core-4.0.0.jar:lib/netty-3.10.6.Final.jar:lib/netty-buffer-4.1.42.Final.jar:lib/netty-codec-4.1.42.Final.jar:lib/netty-codec-dns-4.1.42.Final.jar:lib/netty-codec-http-4.1.42.Final.jar:lib/netty-codec-socks-4.1.42.Final.jar:lib/netty-common-4.1.42.Final.jar:lib/netty-handler-4.1.42.Final.jar:lib/netty-handler-proxy-4.1.42.Final.jar:lib/netty-reactive-streams-2.0.0.jar:lib/netty-resolver-4.1.42.Final.jar:lib/netty-resolver-dns-4.1.42.Final.jar:lib/netty-transport-4.1.42.Final.jar:lib/netty-transport-native-epoll-4.1.42.Final-linux-x86_64.jar:lib/netty-transport-native-unix-common-4.1.42.Final.jar:lib/okhttp-1.0.2.jar:lib/opencsv-4.6.jar:lib/plexus-interpolation-1.19.jar:lib/plexus-utils-3.0.24.jar:lib/protobuf-java-3.11.0.jar:lib/reactive-streams-1.0.2.jar:lib/rhino-1.7.11.jar:lib/shims-0.8.11.jar:lib/sigar-1.6.5.132.jar:lib/slf4j-api-1.7.25.jar:lib/spymemcached-2.12.3.jar:lib/stax-ex-1.8.jar:lib/tesla-aether-0.0.5.jar:lib/txw2-2.3.1.jar:lib/validation-api-1.1.0.Final.jar:lib/wagon-provider-api-2.4.jar:lib/xz-1.8.jar:lib/zookeeper-3.4.14.jar:lib/zstd-jni-1.3.3-1.jar:
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:java.io.tmpdir=var/tmp
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:java.compiler=<NA>
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:os.name=Linux
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:os.arch=amd64
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:os.version=4.14.198-152.320.amzn2.x86_64
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:user.name=root
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:user.home=/root
2021-01-19T05:02:53,365 INFO [main] org.apache.zookeeper.ZooKeeper - Client environment:user.dir=/opt/apache-druid-0.17.1
2021-01-19T05:02:53,366 INFO [main] org.apache.zookeeper.ZooKeeper - Initiating client connection, connectString=druid-dev-8-zookeeper-headless:2181 sessionTimeout=30000 watcher=org.apache.curator.ConnectionState@621624b1
2021-01-19T05:02:53,381 INFO [main] org.apache.curator.framework.imps.CuratorFrameworkImpl - Default schema
2021-01-19T05:02:53,382 INFO [main] org.apache.druid.java.util.emitter.core.ComposingEmitter - Starting Composing Emitter.
2021-01-19T05:02:53,382 INFO [main] org.apache.druid.java.util.emitter.core.ComposingEmitter - Starting emitter org.apache.druid.emitter.statsd.StatsDEmitter.
2021-01-19T05:02:53,383 INFO [main] org.apache.druid.java.util.emitter.core.ComposingEmitter - Starting Composing Emitter.
2021-01-19T05:02:53,383 INFO [main] org.apache.druid.java.util.emitter.core.ComposingEmitter - Starting emitter org.apache.druid.emitter.statsd.StatsDEmitter.
2021-01-19T05:02:53,385 INFO [main-SendThread(druid-dev-8-zookeeper-headless:2181)] org.apache.zookeeper.ClientCnxn - Opening socket connection to server druid-dev-8-zookeeper-headless/10.23.37.215:2181. Will not attempt to authenticate using SASL (unknown error)
2021-01-19T05:02:53,390 INFO [main-SendThread(druid-dev-8-zookeeper-headless:2181)] org.apache.zookeeper.ClientCnxn - Socket connection established to druid-dev-8-zookeeper-headless/10.23.37.215:2181, initiating session
2021-01-19T05:02:53,398 INFO [main-SendThread(druid-dev-8-zookeeper-headless:2181)] org.apache.zookeeper.ClientCnxn - Session establishment complete on server druid-dev-8-zookeeper-headless/10.23.37.215:2181, sessionid = 0x200000192880017, negotiated timeout = 30000
2021-01-19T05:02:53,403 INFO [main-EventThread] org.apache.curator.framework.state.ConnectionStateManager - State change: CONNECTED
2021-01-19T05:02:53,435 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8104', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8104', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:53,437 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8102', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8102', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:53,438 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8103', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8103', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:53,438 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8100', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8100', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:53,439 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8101', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8101', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:53,440 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8101', hostAndPort='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8101', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:53,441 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8100', hostAndPort='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8100', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:53,441 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-historical-0.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndPort='druid-dev-8-historical-0.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndTlsPort='null', maxSize=1900000000000, tier='_default_tier', type=historical, priority=0}]
2021-01-19T05:02:53,442 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8102', hostAndPort='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8102', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:02:56,482 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - Inventory Initialized
2021-01-19T05:02:56,926 INFO [main] org.apache.druid.client.BrokerServerView - BrokerServerView initialized in [3,536] ms.
2021-01-19T05:02:56,983 INFO [main] org.apache.druid.security.basic.authentication.db.cache.CoordinatorPollingBasicAuthenticatorCacheManager - Starting CoordinatorPollingBasicAuthenticatorCacheManager.
2021-01-19T05:02:56,984 INFO [main] org.apache.druid.security.basic.authentication.db.cache.CoordinatorPollingBasicAuthenticatorCacheManager - Started CoordinatorPollingBasicAuthenticatorCacheManager.
2021-01-19T05:02:56,985 INFO [main] org.apache.druid.security.basic.authorization.db.cache.CoordinatorPollingBasicAuthorizerCacheManager - Starting CoordinatorPollingBasicAuthorizerCacheManager.
2021-01-19T05:02:56,986 INFO [main] org.apache.druid.security.basic.authorization.db.cache.CoordinatorPollingBasicAuthorizerCacheManager - Started CoordinatorPollingBasicAuthorizerCacheManager.
2021-01-19T05:02:56,988 INFO [NodeRoleWatcher[COORDINATOR]] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider$NodeRoleWatcher - Node[http://druid-dev-8-coordinator-0.druid-dev-8-coordinator.druid-dev-8.svc.cluster.local:8081] of role[coordinator] detected.
2021-01-19T05:02:56,989 INFO [NodeRoleWatcher[COORDINATOR]] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider$NodeRoleWatcher - Node watcher of role[coordinator] is now initialized.
2021-01-19T05:04:01,863 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-historical-1.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndPort='druid-dev-8-historical-1.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndTlsPort='null', maxSize=1900000000000, tier='_default_tier', type=historical, priority=0}]
2021-01-19T05:04:13,336 WARN [DruidSchema-Cache-0] org.apache.druid.server.QueryLifecycle - Exception while processing queryId [13ac5d21-6555-4353-8aa3-fb553e3dbc95] (QueryInterruptedException{msg=org.jboss.netty.channel.ChannelException: Faulty channel in resource pool, code=Unknown exception, class=java.util.concurrent.ExecutionException, host=druid-dev-8-historical-1.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083})
2021-01-19T05:04:13,336 WARN [DruidSchema-Cache-0] org.apache.druid.sql.calcite.schema.DruidSchema - Metadata refresh failed, trying again soon.
org.apache.druid.java.util.common.RE: Query[d372ab30-009d-40b4-b073-4e870e5194b4] url[http://druid-dev-8-historical-0.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083/druid/v2/] timed out.
	at org.apache.druid.client.DirectDruidClient$1.dequeue(DirectDruidClient.java:208) ~[druid-server-0.17.1.jar:0.17.1]
	at org.apache.druid.client.DirectDruidClient$1.access$800(DirectDruidClient.java:168) ~[druid-server-0.17.1.jar:0.17.1]
	at org.apache.druid.client.DirectDruidClient$1$2.nextElement(DirectDruidClient.java:287) ~[druid-server-0.17.1.jar:0.17.1]
	at org.apache.druid.client.DirectDruidClient$1$2.nextElement(DirectDruidClient.java:263) ~[druid-server-0.17.1.jar:0.17.1]
	at java.io.SequenceInputStream.nextStream(SequenceInputStream.java:110) ~[?:1.8.0_221]
	at java.io.SequenceInputStream.read(SequenceInputStream.java:211) ~[?:1.8.0_221]
	at com.fasterxml.jackson.dataformat.smile.SmileParser._loadMore(SmileParser.java:248) ~[jackson-dataformat-smile-2.10.1.jar:2.10.1]
	at com.fasterxml.jackson.dataformat.smile.SmileParser.nextToken(SmileParser.java:377) ~[jackson-dataformat-smile-2.10.1.jar:2.10.1]
	at org.apache.druid.client.JsonParserIterator.init(JsonParserIterator.java:160) ~[druid-server-0.17.1.jar:0.17.1]
	at org.apache.druid.client.JsonParserIterator.hasNext(JsonParserIterator.java:95) ~[druid-server-0.17.1.jar:0.17.1]
	at org.apache.druid.java.util.common.guava.BaseSequence.makeYielder(BaseSequence.java:89) ~[druid-core-0.17.1.jar:0.17.1]
	at org.apache.druid.java.util.common.guava.BaseSequence.toYielder(BaseSequence.java:69) ~[druid-core-0.17.1.jar:0.17.1]
	at org.apache.druid.java.util.common.guava.MappedSequence.toYielder(MappedSequence.java:49) ~[druid-core-0.17.1.jar:0.17.1]
	at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$ResultBatch.fromSequence(ParallelMergeCombiningSequence.java:847) ~[druid-core-0.17.1.jar:0.17.1]
	at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$SequenceBatcher.block(ParallelMergeCombiningSequence.java:897) ~[druid-core-0.17.1.jar:0.17.1]
	at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3313) ~[?:1.8.0_221]
	at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$SequenceBatcher.getBatchYielder(ParallelMergeCombiningSequence.java:886) ~[druid-core-0.17.1.jar:0.17.1]
	at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$YielderBatchedResultsCursor.initialize(ParallelMergeCombiningSequence.java:993) ~[druid-core-0.17.1.jar:0.17.1]
	at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$PrepareMergeCombineInputsAction.compute(ParallelMergeCombiningSequence.java:702) ~[druid-core-0.17.1.jar:0.17.1]
	at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189) ~[?:1.8.0_221]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) ~[?:1.8.0_221]
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) ~[?:1.8.0_221]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) ~[?:1.8.0_221]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157) ~[?:1.8.0_221]
	Suppressed: org.apache.druid.java.util.common.RE: Query[d372ab30-009d-40b4-b073-4e870e5194b4] url[http://druid-dev-8-historical-0.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083/druid/v2/] timed out.
		at org.apache.druid.client.DirectDruidClient$1.checkQueryTimeout(DirectDruidClient.java:415) ~[druid-server-0.17.1.jar:0.17.1]
		at org.apache.druid.client.DirectDruidClient$1.access$500(DirectDruidClient.java:168) ~[druid-server-0.17.1.jar:0.17.1]
		at org.apache.druid.client.DirectDruidClient$1$2.hasMoreElements(DirectDruidClient.java:270) ~[druid-server-0.17.1.jar:0.17.1]
		at java.io.SequenceInputStream.nextStream(SequenceInputStream.java:109) ~[?:1.8.0_221]
		at java.io.SequenceInputStream.close(SequenceInputStream.java:232) ~[?:1.8.0_221]
		at com.fasterxml.jackson.dataformat.smile.SmileParser._closeInput(SmileParser.java:309) ~[jackson-dataformat-smile-2.10.1.jar:2.10.1]
		at com.fasterxml.jackson.dataformat.smile.SmileParserBase.close(SmileParserBase.java:384) ~[jackson-dataformat-smile-2.10.1.jar:2.10.1]
		at org.apache.druid.client.JsonParserIterator.close(JsonParserIterator.java:182) ~[druid-server-0.17.1.jar:0.17.1]
		at org.apache.druid.java.util.common.guava.CloseQuietly.close(CloseQuietly.java:39) ~[druid-core-0.17.1.jar:0.17.1]
		at org.apache.druid.client.DirectDruidClient$3.cleanup(DirectDruidClient.java:504) ~[druid-server-0.17.1.jar:0.17.1]
		at org.apache.druid.client.DirectDruidClient$3.cleanup(DirectDruidClient.java:486) ~[druid-server-0.17.1.jar:0.17.1]
		at org.apache.druid.java.util.common.guava.BaseSequence.toYielder(BaseSequence.java:73) ~[druid-core-0.17.1.jar:0.17.1]
		at org.apache.druid.java.util.common.guava.MappedSequence.toYielder(MappedSequence.java:49) ~[druid-core-0.17.1.jar:0.17.1]
		at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$ResultBatch.fromSequence(ParallelMergeCombiningSequence.java:847) ~[druid-core-0.17.1.jar:0.17.1]
		at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$SequenceBatcher.block(ParallelMergeCombiningSequence.java:897) ~[druid-core-0.17.1.jar:0.17.1]
		at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3313) ~[?:1.8.0_221]
		at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$SequenceBatcher.getBatchYielder(ParallelMergeCombiningSequence.java:886) ~[druid-core-0.17.1.jar:0.17.1]
		at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$YielderBatchedResultsCursor.initialize(ParallelMergeCombiningSequence.java:993) ~[druid-core-0.17.1.jar:0.17.1]
		at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence$PrepareMergeCombineInputsAction.compute(ParallelMergeCombiningSequence.java:702) ~[druid-core-0.17.1.jar:0.17.1]
		at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189) ~[?:1.8.0_221]
		at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) ~[?:1.8.0_221]
		at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) ~[?:1.8.0_221]
		at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) ~[?:1.8.0_221]
		at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157) ~[?:1.8.0_221]

2021-01-19T05:04:13,525 INFO [main] org.apache.druid.sql.calcite.schema.DruidSchema - DruidSchema initialized in [76,537] ms.
2021-01-19T05:04:13,525 INFO [main] org.apache.druid.sql.calcite.schema.MetadataSegmentView - MetadataSegmentView Started.
2021-01-19T05:04:13,529 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8104', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8104', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,529 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-historical-1.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndPort='druid-dev-8-historical-1.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndTlsPort='null', maxSize=1900000000000, tier='_default_tier', type=historical, priority=0}]
2021-01-19T05:04:13,530 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8102', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8102', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,530 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8103', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8103', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,531 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8100', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8100', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,531 INFO [NodeRoleWatcher[OVERLORD]] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider$NodeRoleWatcher - Node[http://druid-dev-8-overlord-0.druid-dev-8-overlord.druid-dev-8.svc.cluster.local:8090] of role[overlord] detected.
2021-01-19T05:04:13,531 INFO [NodeRoleWatcher[OVERLORD]] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider$NodeRoleWatcher - Node watcher of role[overlord] is now initialized.
2021-01-19T05:04:13,532 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8101', hostAndPort='druid-dev-8-middle-manager-medium-0.druid-dev-8-middle-manager-medium.druid-dev-8.svc.cluster.local:8101', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,532 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8101', hostAndPort='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8101', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,532 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8100', hostAndPort='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8100', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,533 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-historical-0.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndPort='druid-dev-8-historical-0.druid-dev-8-historical.druid-dev-8.svc.cluster.local:8083', hostAndTlsPort='null', maxSize=1900000000000, tier='_default_tier', type=historical, priority=0}]
2021-01-19T05:04:13,533 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - New Server[DruidServerMetadata{name='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8102', hostAndPort='druid-dev-8-middle-manager-large-0.druid-dev-8-middle-manager-large.druid-dev-8.svc.cluster.local:8102', hostAndTlsPort='null', maxSize=0, tier='_default_tier', type=indexer-executor, priority=0}]
2021-01-19T05:04:13,550 INFO [main] org.apache.druid.query.lookup.LookupReferencesManager - Starting lookup lading process.
2021-01-19T05:04:13,550 INFO [main] org.apache.druid.query.lookup.LookupReferencesManager - Round of attempts #1, [5] lookups

…

```

As you can see, `DruidSchema initialized in [76,537] ms.`  DruidSchema initialized is completed immediately, even though there are exceptions which need a retry. What's worse, Broker is started but queries served by this broker will fail.

This PR add a new judgment condition to fix it.
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `DruidSchema.java`
