### PR TITLE
Web console: use new example manifest

### DIFF
--- a/web-console/console-config.js
+++ b/web-console/console-config.js
@@ -17,6 +17,6 @@
  */
 
 window.consoleConfig = {
-  "exampleManifestsUrl": "https://druid.apache.org/data/example-manifests.tsv"
+  "exampleManifestsUrl": "https://druid.apache.org/data/example-manifests-v2.tsv"
   /* future configs may go here */
 };


### PR DESCRIPTION
This is a tiny change to direct the console to use the newer example manifest file that was added here: https://github.com/apache/druid-website-src/pull/202 (please make sure that PR is merged before this one!).

The issue this solves is that https://github.com/apache/druid-website-src/blob/master/data/example-manifests.tsv had a spec that hard coded the name of the data source to `new_data_source` and the console will no longer overwrite it. This means that without this change if the user goes through the example flow and just clicks `Next` over and over (as most do) they will get a data source called `new_data_source` instead of `wikipedia` as they would have done before. This will cause needless confusion.