### PR TITLE
Bump DataSketches memory to 1.3.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3522,7 +3522,7 @@ name: DataSketches
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.2.0-incubating
+version: 1.3.0
 libraries:
   - org.apache.datasketches: datasketches-memory
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <avro.version>1.9.2</avro.version>
         <calcite.version>1.21.0</calcite.version>
         <datasketches.version>1.3.0-incubating</datasketches.version>
-        <datasketches.memory.version>1.2.0-incubating</datasketches.memory.version>
+        <datasketches.memory.version>1.3.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <guava.version>16.0.1</guava.version>


### PR DESCRIPTION
### Description

Memory 1.3.0 has a potential performance improvement (https://github.com/apache/datasketches-memory/releases/tag/1.3.0).

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->
