### PR TITLE
Run integration tests in a second stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,9 @@ install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff ${MAV
 
 stages:
   - name: test  # jobs that do not specify a stage get this default value
-    if: type != cron
+    if: type != cron && type != it
+  - name: it
+    if: type = it
   - name: cron
     if: type = cron
 
@@ -312,6 +314,7 @@ jobs:
     # START - Integration tests for Compile with Java 8 and Run with Java 8
     - &integration_batch_index
       name: "(Compile=openjdk8, Run=openjdk8) batch index integration test"
+      stage: it
       jdk: openjdk8
       services: &integration_test_services
         - docker
@@ -333,6 +336,7 @@ jobs:
 
     - &integration_input_format
       name: "(Compile=openjdk8, Run=openjdk8) input format integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=input-format' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -345,6 +349,7 @@ jobs:
 
     - &integration_input_source
       name: "(Compile=openjdk8, Run=openjdk8) input source integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=input-source' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -358,6 +363,7 @@ jobs:
     - &integration_perfect_rollup_parallel_batch_index
       name: "(Compile=openjdk8, Run=openjdk8) perfect rollup parallel batch index integration test"
       jdk: openjdk8
+      stage: it
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=perfect-rollup-parallel-batch-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
       script: *run_integration_test
@@ -369,6 +375,7 @@ jobs:
 
     - &integration_kafka_index
       name: "(Compile=openjdk8, Run=openjdk8) kafka index integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -381,6 +388,7 @@ jobs:
 
     - &integration_kafka_index_slow
       name: "(Compile=openjdk8, Run=openjdk8) kafka index integration test slow"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-index-slow' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -393,6 +401,7 @@ jobs:
 
     - &integration_kafka_transactional_index
       name: "(Compile=openjdk8, Run=openjdk8) transactional kafka index integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-transactional-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -401,6 +410,7 @@ jobs:
 
     - &integration_kafka_transactional_index_slow
       name: "(Compile=openjdk8, Run=openjdk8) transactional kafka index integration test slow"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-transactional-index-slow' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -413,6 +423,7 @@ jobs:
 
     - &integration_kafka_format_tests
       name: "(Compile=openjdk8, Run=openjdk8) Kafka index integration test with various formats"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-data-format' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -425,6 +436,7 @@ jobs:
 
     - &integration_query
       name: "(Compile=openjdk8, Run=openjdk8) query integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=query' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -433,6 +445,7 @@ jobs:
 
     - &integration_query_retry
       name: "(Compile=openjdk8, Run=openjdk8) query retry integration test for missing segments"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=query-retry' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -441,6 +454,7 @@ jobs:
 
     - &integration_security
       name: "(Compile=openjdk8, Run=openjdk8) security integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=security' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -449,6 +463,7 @@ jobs:
 
     - &integration_realtime_index
       name: "(Compile=openjdk8, Run=openjdk8) realtime index integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=realtime-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -457,6 +472,7 @@ jobs:
 
     - &integration_append_ingestion
       name: "(Compile=openjdk8, Run=openjdk8) append ingestion integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=append-ingestion' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -469,6 +485,7 @@ jobs:
 
     - &integration_compaction_tests
       name: "(Compile=openjdk8, Run=openjdk8) compaction integration test"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=compaction' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -481,6 +498,7 @@ jobs:
 
     - &integration_tests
       name: "(Compile=openjdk8, Run=openjdk8) other integration tests"
+      stage: it
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,realtime-index,security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -562,6 +580,7 @@ jobs:
 
     - &integration_batch_index_k8s
       name: "(Compile=openjdk8, Run=openjdk8, Cluster Build On K8s) ITNestedQueryPushDownTest integration test"
+      stage: it
       jdk: openjdk8
       services: &integration_test_services_k8s
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@
 
 language: java
 
-sudo: true
 dist: xenial
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ stages:
   - name: test  # jobs that do not specify a stage get this default value
     if: type != cron && type != it
   - name: it
-    if: type = it
+    if: type != cron
   - name: cron
     if: type = cron
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,8 @@ install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff ${MAV
 
 stages:
   - name: test  # jobs that do not specify a stage get this default value
-    if: type != cron && type != it
-  - name: it
     if: type != cron
+  - name: it
   - name: cron
     if: type = cron
 


### PR DESCRIPTION
### Description

Running all the tests in Travis is expensive. This PR attempts to split the tests into 2 stages so that the integration tests run only if the other tests were successful. This will allow more builds to run in parallel since the first stage tends to be faster than the integration tests (except for the intelliJ inspection check job)

This also drops `sudo` from `.travis.yml` as it has been deprecated and has no effect.
<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
