### PR TITLE
Document type inference issues with dynamic params in SQL

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -219,6 +219,18 @@ at execution time. To use dynamic parameters, replace any literal in the query w
 corresponding parameter value when you execute the query. Parameters are bound to the placeholders in the order in
 which they are passed. Parameters are supported in both the [HTTP POST](#http-post) and [JDBC](#jdbc) APIs.
 
+Please note that in certain cases, dynamic parameters used in expressions can cause type inference issues which can cause the query to fail. The following query is one such case:
+
+```sql
+SELECT * FROM druid.foo WHERE dim1 like CONCAT('%', ?, '%')
+```
+
+In these cases, the solution would be to explicitly provide the type of the dynamic parameter using the `CAST` keyword. The above example can be fixed as:
+
+```
+SELECT * FROM druid.foo WHERE dim1 like CONCAT('%', CAST (? AS VARCHAR), '%')
+```
+
 ## Data types
 
 ### Standard types

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -219,13 +219,13 @@ at execution time. To use dynamic parameters, replace any literal in the query w
 corresponding parameter value when you execute the query. Parameters are bound to the placeholders in the order in
 which they are passed. Parameters are supported in both the [HTTP POST](#http-post) and [JDBC](#jdbc) APIs.
 
-Please note that in certain cases, dynamic parameters used in expressions can cause type inference issues which can cause the query to fail. The following query is one such case:
+In certain cases, using dynamic parameters in expressions can cause type inference issues which cause your query to fail, for example:
 
 ```sql
 SELECT * FROM druid.foo WHERE dim1 like CONCAT('%', ?, '%')
 ```
 
-In these cases, the solution would be to explicitly provide the type of the dynamic parameter using the `CAST` keyword. The above example can be fixed as:
+To solve this issue, explicitly provide the type of the dynamic parameter using the `CAST` keyword. Consider the fix for the preceding example:
 
 ```
 SELECT * FROM druid.foo WHERE dim1 like CONCAT('%', CAST (? AS VARCHAR), '%')


### PR DESCRIPTION
This documentation fix attempts at clarifying type inference based query failures that happen while using dynamic parameters in a SQL query.
<hr>

This PR has:
- [x] been self-reviewed.
<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>
