### PR TITLE
Do not run integration tests in cron stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ stages:
   - name: test  # jobs that do not specify a stage get this default value
     if: type != cron
   - name: it
+    if: type != cron
   - name: cron
     if: type = cron
 


### PR DESCRIPTION
### Description

Integration tests are meant to run only as part of the test phase in travis. This PR updates the stage definition so that only the security vulnerability job is run by the cron job in travis.

I noticed this in https://travis-ci.com/github/apache/druid/builds/214984064

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
