### PR TITLE
Better stages for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,21 @@ addons:
 # output.  To compensate, use travis_wait to extend the timeout.
 install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
 
+# There are 3 stages of tests
+# 1. Tests - phase 1
+# 2. Tests - phase 2
+# 3. cron
+#
+# The cron type only runs jobs that are marked with stage cron.
+# The test type is split into 2 stages. This is done so that more PRs can run their validation
+# in parallel. The first phase is meant to include sanity test jobs. The jobs in this phase are
+# meant to be fast. The second phase is meant to run all other tests.
+# Jobs with known flaky tests should be put in the second phase since the second phase will not
+# start if there are any failures in the second stage.
 stages:
-  - name: test  # jobs that do not specify a stage get this default value
+  - name: Tests - phase 1
     if: type != cron
-  - name: it
+  - name: Tests - phase 2
     if: type != cron
   - name: cron
     if: type = cron
@@ -53,6 +64,7 @@ stages:
 jobs:
   include:
     - name: "animal sniffer checks"
+      stage: Tests - phase 1
       script: ${MVN} animal-sniffer:check --fail-at-end
 
     - name: "checkstyle"
@@ -137,15 +149,18 @@ jobs:
 
     - <<: *package
       name: "(openjdk11) packaging check"
+      stage: Tests - phase 2
       jdk: openjdk11
     
     - <<: *package
       name: "Build and test on ARM64 CPU architecture"
+      stage: Tests - phase 2
       arch: arm64
       jdk: openjdk11
 
     - &test_processing_module
       name: "(openjdk8) processing module test"
+      stage: Tests - phase 1
       env:
       - MAVEN_PROJECTS='processing'
       before_script:
@@ -206,16 +221,19 @@ jobs:
 
     - <<: *test_processing_module
       name: "(openjdk11) processing module test"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - &test_processing_module_sqlcompat
       <<: *test_processing_module
       name: "(openjdk8) processing module test (SQL Compatibility)"
+      stage: Tests - phase 1
       before_script: &setup_sqlcompat
       - export DRUID_USE_DEFAULT_VALUE_FOR_NULL=false
 
     - <<: *test_processing_module_sqlcompat
       name: "(openjdk11) processing module test (SQL Compatibility)"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - &test_indexing_module
@@ -226,15 +244,18 @@ jobs:
 
     - <<: *test_indexing_module
       name: "(openjdk11) indexing modules test"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - &test_indexing_module_sqlcompat
       <<: *test_indexing_module
       name: "(openjdk8) indexing modules test (SQL Compatibility)"
+      stage: Tests - phase 1
       before_script: *setup_sqlcompat
 
     - <<: *test_indexing_module_sqlcompat
       name: "(openjdk11) indexing modules test (SQL Compatibility)"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - &test_server_module
@@ -245,6 +266,7 @@ jobs:
 
     - <<: *test_server_module
       name: "(openjdk11) server module test"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - &test_server_module_sqlcompat
@@ -254,6 +276,7 @@ jobs:
 
     - <<: *test_server_module_sqlcompat
       name: "(openjdk11) server module test (SQL Compatibility)"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - &test_other_modules
@@ -264,6 +287,7 @@ jobs:
 
     - <<: *test_other_modules
       name: "(openjdk11) other modules test"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - &test_other_modules_sqlcompat
@@ -273,10 +297,12 @@ jobs:
 
     - <<: *test_other_modules_sqlcompat
       name: "(openjdk11) other modules test (SQL Compatibility)"
+      stage: Tests - phase 2
       jdk: openjdk11
 
     - name: "web console"
       install: skip
+      stage: Tests - phase 1
       script:
         - ${MVN} test -pl 'web-console'
       after_success:
@@ -313,7 +339,7 @@ jobs:
     # START - Integration tests for Compile with Java 8 and Run with Java 8
     - &integration_batch_index
       name: "(Compile=openjdk8, Run=openjdk8) batch index integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: &integration_test_services
         - docker
@@ -335,7 +361,7 @@ jobs:
 
     - &integration_input_format
       name: "(Compile=openjdk8, Run=openjdk8) input format integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=input-format' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -348,7 +374,7 @@ jobs:
 
     - &integration_input_source
       name: "(Compile=openjdk8, Run=openjdk8) input source integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=input-source' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -362,7 +388,7 @@ jobs:
     - &integration_perfect_rollup_parallel_batch_index
       name: "(Compile=openjdk8, Run=openjdk8) perfect rollup parallel batch index integration test"
       jdk: openjdk8
-      stage: it
+      stage: Tests - phase 2
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=perfect-rollup-parallel-batch-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
       script: *run_integration_test
@@ -374,7 +400,7 @@ jobs:
 
     - &integration_kafka_index
       name: "(Compile=openjdk8, Run=openjdk8) kafka index integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -387,7 +413,7 @@ jobs:
 
     - &integration_kafka_index_slow
       name: "(Compile=openjdk8, Run=openjdk8) kafka index integration test slow"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-index-slow' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -400,7 +426,7 @@ jobs:
 
     - &integration_kafka_transactional_index
       name: "(Compile=openjdk8, Run=openjdk8) transactional kafka index integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-transactional-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -409,7 +435,7 @@ jobs:
 
     - &integration_kafka_transactional_index_slow
       name: "(Compile=openjdk8, Run=openjdk8) transactional kafka index integration test slow"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-transactional-index-slow' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -422,7 +448,7 @@ jobs:
 
     - &integration_kafka_format_tests
       name: "(Compile=openjdk8, Run=openjdk8) Kafka index integration test with various formats"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=kafka-data-format' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -435,7 +461,7 @@ jobs:
 
     - &integration_query
       name: "(Compile=openjdk8, Run=openjdk8) query integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=query' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -444,7 +470,7 @@ jobs:
 
     - &integration_query_retry
       name: "(Compile=openjdk8, Run=openjdk8) query retry integration test for missing segments"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=query-retry' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -453,7 +479,7 @@ jobs:
 
     - &integration_security
       name: "(Compile=openjdk8, Run=openjdk8) security integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=security' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -462,7 +488,7 @@ jobs:
 
     - &integration_realtime_index
       name: "(Compile=openjdk8, Run=openjdk8) realtime index integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=realtime-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -471,7 +497,7 @@ jobs:
 
     - &integration_append_ingestion
       name: "(Compile=openjdk8, Run=openjdk8) append ingestion integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=append-ingestion' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -484,7 +510,7 @@ jobs:
 
     - &integration_compaction_tests
       name: "(Compile=openjdk8, Run=openjdk8) compaction integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-Dgroups=compaction' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -497,7 +523,7 @@ jobs:
 
     - &integration_tests
       name: "(Compile=openjdk8, Run=openjdk8) other integration tests"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
       env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,realtime-index,security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
@@ -579,7 +605,7 @@ jobs:
 
     - &integration_batch_index_k8s
       name: "(Compile=openjdk8, Run=openjdk8, Cluster Build On K8s) ITNestedQueryPushDownTest integration test"
-      stage: it
+      stage: Tests - phase 2
       jdk: openjdk8
       services: &integration_test_services_k8s
         - docker


### PR DESCRIPTION
### Description

A follow up to #10791 This PR splits the tests further. The first phase is designed to perform basic sanity tests and run fast. Tests in the first phase do not include any flaky tests so that they do not prevent all the other tests from running.

The jdk11 tests were moved to the second phase since it is very rare for them to catch a failure that's not caught by the jdk8 tests.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in https://travis-ci.com/github/suneet-s/druid/builds/215171840
