### PR TITLE
Fix unclear documentation of human readable byte

### DIFF
--- a/docs/configuration/human-readable-byte.md
+++ b/docs/configuration/human-readable-byte.md
@@ -50,7 +50,7 @@ druid.segmentCache.locations=[{"path":"/segment-cache-00","maxSize":"1t"},{"path
 ```
 
 Note: in above example, both `1t` and `1T` are acceptable since it's case-insensitive.
-Also, only integers are valid as the number part: `1200g` can not be replaced by `1.2t`.
+Also, only integers are valid as the number part. For example, you can't replace `1200g` with `1.2t`.
 
 ### Supported Units
 In the world of computer, a unit like `K` is ambiguous. It means 1000 or 1024 in different contexts, for more information please see [Here](https://en.wikipedia.org/wiki/Binary_prefix).

--- a/docs/configuration/human-readable-byte.md
+++ b/docs/configuration/human-readable-byte.md
@@ -46,10 +46,11 @@ When you have to put a large number for some configuration as above, it is easy 
 Given a disk of 1T, the configuration can be
 
 ```properties
-druid.segmentCache.locations=[{"path":"/segment-cache","maxSize":"1t"}]
+druid.segmentCache.locations=[{"path":"/segment-cache-00","maxSize":"1t"},{"path":"/segment-cache-01","maxSize":"1200g"}]
 ```
 
 Note: in above example, both `1t` and `1T` are acceptable since it's case-insensitive.
+Also, only integers are valid as the number part: `1200g` can not be replaced by `1.2t`.
 
 ### Supported Units
 In the world of computer, a unit like `K` is ambiguous. It means 1000 or 1024 in different contexts, for more information please see [Here](https://en.wikipedia.org/wiki/Binary_prefix).


### PR DESCRIPTION
Follows https://github.com/apache/druid/pull/10203; See https://github.com/apache/druid/pull/10203#issuecomment-771080634.

Area - Documentation

### Description

Based on https://github.com/apache/druid/blob/c346ce64b1497f8bbd547bee16fa98cc0d3c74f2/core/src/main/java/org/apache/druid/java/util/common/HumanReadableBytes.java#L200
Only integers are valid before the unit: `1536MiB` is valid but `1.5GiB` isn't. This PR reflects this in the documentation.

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.

Should I change the javadoc as well? The code is rather obvious.