### PR TITLE
Address CVE-2020-8570, suppress CVE-2020-8554

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>10.0.0</kubernetes.client.version>
+    <kubernetes.client.version>10.0.1</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -841,7 +841,7 @@ name: kubernetes official java client
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java
 
@@ -851,7 +851,7 @@ name: kubernetes official java client api
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java-api
 
@@ -861,7 +861,7 @@ name: kubernetes official java client extended
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java-extended
 
@@ -981,7 +981,7 @@ name: io.kubernetes client-java-proto
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java-proto
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -58,6 +58,17 @@
     <cve>CVE-2020-12691</cve>
   </suppress>
 
+
+  <suppress>
+    <!-- Not much for us to do as a user of the client lib, and no patch is available,
+     see https://github.com/kubernetes/kubernetes/issues/97076 -->
+    <notes><![CDATA[
+   file name: client-java-10.0.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.kubernetes/client\-java.*@10.0.1$</packageUrl>
+    <cve>CVE-2020-8554</cve>
+  </suppress>
+
   <!-- FIXME: These are suppressed so that CI can enforce that no new vulnerable dependencies are added. -->
   <suppress>
     <!--


### PR DESCRIPTION
The dependency check currently fails on the kubernetes extension due to the CVEs in the title.

This PR:
- Updates the Kubernetes java client to 10.0.1, to fix https://nvd.nist.gov/vuln/detail/CVE-2020-8570
- Suppresses https://nvd.nist.gov/vuln/detail/CVE-2020-8554, based on the reasoning in the comment in the suppression file

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
