### PR TITLE
Update doc for query errors and add unit tests for JsonParserIterator

### DIFF
--- a/core/src/main/java/org/apache/druid/query/QueryException.java
+++ b/core/src/main/java/org/apache/druid/query/QueryException.java
@@ -21,6 +21,7 @@ package org.apache.druid.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nullable;
 import java.net.InetAddress;
@@ -44,8 +45,9 @@ public class QueryException extends RuntimeException
     this.host = host;
   }
 
+  @VisibleForTesting
   @JsonCreator
-  protected QueryException(
+  public QueryException(
       @JsonProperty("error") @Nullable String errorCode,
       @JsonProperty("errorMessage") String errorMessage,
       @JsonProperty("errorClass") @Nullable String errorClass,

--- a/processing/src/main/java/org/apache/druid/query/ResourceLimitExceededException.java
+++ b/processing/src/main/java/org/apache/druid/query/ResourceLimitExceededException.java
@@ -35,7 +35,7 @@ public class ResourceLimitExceededException extends BadQueryException
 {
   public static final String ERROR_CODE = "Resource limit exceeded";
 
-  public static ResourceLimitExceededException withNonStrictStringFormat(String message, Object... arguments)
+  public static ResourceLimitExceededException withMessage(String message, Object... arguments)
   {
     return new ResourceLimitExceededException(StringUtils.nonStrictFormat(message, arguments));
   }

--- a/processing/src/main/java/org/apache/druid/query/ResourceLimitExceededException.java
+++ b/processing/src/main/java/org/apache/druid/query/ResourceLimitExceededException.java
@@ -21,6 +21,7 @@ package org.apache.druid.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.StringUtils;
 
 /**
  * Exception indicating that an operation failed because it exceeded some configured resource limit.
@@ -34,14 +35,19 @@ public class ResourceLimitExceededException extends BadQueryException
 {
   public static final String ERROR_CODE = "Resource limit exceeded";
 
-  public ResourceLimitExceededException(String message)
+  public static ResourceLimitExceededException withNonStrictStringFormat(String message, Object... arguments)
   {
-    this(ERROR_CODE, message, ResourceLimitExceededException.class.getName());
+    return new ResourceLimitExceededException(StringUtils.nonStrictFormat(message, arguments));
   }
 
   public ResourceLimitExceededException(String errorCode, String message, String errorClass, String host)
   {
     super(errorCode, message, errorClass, host);
+  }
+
+  public ResourceLimitExceededException(String message)
+  {
+    this(ERROR_CODE, message, ResourceLimitExceededException.class.getName());
   }
 
   @JsonCreator

--- a/processing/src/main/java/org/apache/druid/query/ResourceLimitExceededException.java
+++ b/processing/src/main/java/org/apache/druid/query/ResourceLimitExceededException.java
@@ -21,7 +21,6 @@ package org.apache.druid.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.java.util.common.StringUtils;
 
 /**
  * Exception indicating that an operation failed because it exceeded some configured resource limit.
@@ -35,9 +34,14 @@ public class ResourceLimitExceededException extends BadQueryException
 {
   public static final String ERROR_CODE = "Resource limit exceeded";
 
-  public ResourceLimitExceededException(String message, Object... arguments)
+  public ResourceLimitExceededException(String message)
   {
-    this(ERROR_CODE, StringUtils.nonStrictFormat(message, arguments), ResourceLimitExceededException.class.getName());
+    this(ERROR_CODE, message, ResourceLimitExceededException.class.getName());
+  }
+
+  public ResourceLimitExceededException(String errorCode, String message, String errorClass, String host)
+  {
+    super(errorCode, message, errorClass, host);
   }
 
   @JsonCreator
@@ -47,6 +51,6 @@ public class ResourceLimitExceededException extends BadQueryException
       @JsonProperty("errorClass") String errorClass
   )
   {
-    super(errorCode, errorMessage, errorClass, resolveHostname());
+    this(errorCode, errorMessage, errorClass, resolveHostname());
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
@@ -27,7 +27,6 @@ import org.apache.druid.collections.StableLimitingSorter;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.Pair;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
@@ -190,17 +189,15 @@ public class ScanQueryRunnerFactory implements QueryRunnerFactory<ScanResultValu
 
             return nWayMergeAndLimit(groupedRunners, queryPlus, responseContext);
           }
-          throw new ResourceLimitExceededException(
-              StringUtils.nonStrictFormat(
-                  "Time ordering is not supported for a Scan query with %,d segments per time chunk and a row limit of %,d. "
-                  + "Try reducing your query limit below maxRowsQueuedForOrdering (currently %,d), or using compaction to "
-                  + "reduce the number of segments per time chunk, or raising maxSegmentPartitionsOrderedInMemory "
-                  + "(currently %,d) above the number of segments you have per time chunk.",
-                  maxNumPartitionsInSegment,
-                  query.getScanRowsLimit(),
-                  maxRowsQueuedForOrdering,
-                  maxSegmentPartitionsOrderedInMemory
-              )
+          throw ResourceLimitExceededException.withNonStrictStringFormat(
+              "Time ordering is not supported for a Scan query with %,d segments per time chunk and a row limit of %,d. "
+              + "Try reducing your query limit below maxRowsQueuedForOrdering (currently %,d), or using compaction to "
+              + "reduce the number of segments per time chunk, or raising maxSegmentPartitionsOrderedInMemory "
+              + "(currently %,d) above the number of segments you have per time chunk.",
+              maxNumPartitionsInSegment,
+              query.getScanRowsLimit(),
+              maxRowsQueuedForOrdering,
+              maxSegmentPartitionsOrderedInMemory
           );
         }
       }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
@@ -27,6 +27,7 @@ import org.apache.druid.collections.StableLimitingSorter;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
@@ -190,14 +191,16 @@ public class ScanQueryRunnerFactory implements QueryRunnerFactory<ScanResultValu
             return nWayMergeAndLimit(groupedRunners, queryPlus, responseContext);
           }
           throw new ResourceLimitExceededException(
-              "Time ordering is not supported for a Scan query with %,d segments per time chunk and a row limit of %,d. "
-              + "Try reducing your query limit below maxRowsQueuedForOrdering (currently %,d), or using compaction to "
-              + "reduce the number of segments per time chunk, or raising maxSegmentPartitionsOrderedInMemory "
-              + "(currently %,d) above the number of segments you have per time chunk.",
-              maxNumPartitionsInSegment,
-              query.getScanRowsLimit(),
-              maxRowsQueuedForOrdering,
-              maxSegmentPartitionsOrderedInMemory
+              StringUtils.nonStrictFormat(
+                  "Time ordering is not supported for a Scan query with %,d segments per time chunk and a row limit of %,d. "
+                  + "Try reducing your query limit below maxRowsQueuedForOrdering (currently %,d), or using compaction to "
+                  + "reduce the number of segments per time chunk, or raising maxSegmentPartitionsOrderedInMemory "
+                  + "(currently %,d) above the number of segments you have per time chunk.",
+                  maxNumPartitionsInSegment,
+                  query.getScanRowsLimit(),
+                  maxRowsQueuedForOrdering,
+                  maxSegmentPartitionsOrderedInMemory
+              )
           );
         }
       }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
@@ -189,7 +189,7 @@ public class ScanQueryRunnerFactory implements QueryRunnerFactory<ScanResultValu
 
             return nWayMergeAndLimit(groupedRunners, queryPlus, responseContext);
           }
-          throw ResourceLimitExceededException.withNonStrictStringFormat(
+          throw ResourceLimitExceededException.withMessage(
               "Time ordering is not supported for a Scan query with %,d segments per time chunk and a row limit of %,d. "
               + "Try reducing your query limit below maxRowsQueuedForOrdering (currently %,d), or using compaction to "
               + "reduce the number of segments per time chunk, or raising maxSegmentPartitionsOrderedInMemory "

--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -169,7 +169,7 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
           throw timeoutQuery();
         } else {
           // TODO: NettyHttpClient should check the actual cause of the failure and set it in the future properly.
-          throw ResourceLimitExceededException.withNonStrictStringFormat(
+          throw ResourceLimitExceededException.withMessage(
               "Possibly max scatter-gather bytes limit reached while reading from url[%s].",
               url
           );

--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -170,8 +170,10 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
         } else {
           // TODO: NettyHttpClient should check the actual cause of the failure and set it in the future properly.
           throw new ResourceLimitExceededException(
-              "Possibly max scatter-gather bytes limit reached while reading from url[%s].",
-              url
+              StringUtils.nonStrictFormat(
+                  "Possibly max scatter-gather bytes limit reached while reading from url[%s].",
+                  url
+              )
           );
         }
 
@@ -187,7 +189,10 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
           );
         }
       }
-      catch (IOException | InterruptedException | ExecutionException | CancellationException e) {
+      catch (ExecutionException | CancellationException e) {
+        throw convertException(e.getCause() == null ? e : e.getCause());
+      }
+      catch (IOException | InterruptedException e) {
         throw convertException(e);
       }
       catch (TimeoutException e) {
@@ -210,7 +215,7 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
    *   based on {@link QueryException#getErrorCode()}. During conversion, {@link QueryException#host} is overridden
    *   by {@link #host}.
    */
-  private QueryException convertException(Exception cause)
+  private QueryException convertException(Throwable cause)
   {
     LOG.warn(cause, "Query [%s] to host [%s] interrupted", queryId, host);
     if (cause instanceof QueryException) {

--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -169,11 +169,9 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
           throw timeoutQuery();
         } else {
           // TODO: NettyHttpClient should check the actual cause of the failure and set it in the future properly.
-          throw new ResourceLimitExceededException(
-              StringUtils.nonStrictFormat(
-                  "Possibly max scatter-gather bytes limit reached while reading from url[%s].",
-                  url
-              )
+          throw ResourceLimitExceededException.withNonStrictStringFormat(
+              "Possibly max scatter-gather bytes limit reached while reading from url[%s].",
+              url
           );
         }
 

--- a/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
@@ -28,7 +28,6 @@ import org.apache.druid.client.DirectDruidClient;
 import org.apache.druid.client.cache.Cache;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -456,8 +455,9 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
     final int limitToUse = limit < 0 ? Integer.MAX_VALUE : limit;
 
     if (limitAccumulator.get() >= limitToUse) {
-      throw new ResourceLimitExceededException(
-          StringUtils.nonStrictFormat("Cannot issue subquery, maximum[%d] reached", limitToUse)
+      throw ResourceLimitExceededException.withNonStrictStringFormat(
+          "Cannot issue subquery, maximum[%d] reached",
+          limitToUse
       );
     }
 
@@ -469,11 +469,9 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
         resultList,
         (acc, in) -> {
           if (limitAccumulator.getAndIncrement() >= limitToUse) {
-            throw new ResourceLimitExceededException(
-                StringUtils.nonStrictFormat(
-                    "Subquery generated results beyond maximum[%d]",
-                    limitToUse
-                )
+            throw ResourceLimitExceededException.withNonStrictStringFormat(
+                "Subquery generated results beyond maximum[%d]",
+                limitToUse
             );
           }
           acc.add(in);

--- a/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
@@ -455,7 +455,7 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
     final int limitToUse = limit < 0 ? Integer.MAX_VALUE : limit;
 
     if (limitAccumulator.get() >= limitToUse) {
-      throw ResourceLimitExceededException.withNonStrictStringFormat(
+      throw ResourceLimitExceededException.withMessage(
           "Cannot issue subquery, maximum[%d] reached",
           limitToUse
       );
@@ -469,7 +469,7 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
         resultList,
         (acc, in) -> {
           if (limitAccumulator.getAndIncrement() >= limitToUse) {
-            throw ResourceLimitExceededException.withNonStrictStringFormat(
+            throw ResourceLimitExceededException.withMessage(
                 "Subquery generated results beyond maximum[%d]",
                 limitToUse
             );

--- a/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
@@ -28,6 +28,7 @@ import org.apache.druid.client.DirectDruidClient;
 import org.apache.druid.client.cache.Cache;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -455,7 +456,9 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
     final int limitToUse = limit < 0 ? Integer.MAX_VALUE : limit;
 
     if (limitAccumulator.get() >= limitToUse) {
-      throw new ResourceLimitExceededException("Cannot issue subquery, maximum[%d] reached", limitToUse);
+      throw new ResourceLimitExceededException(
+          StringUtils.nonStrictFormat("Cannot issue subquery, maximum[%d] reached", limitToUse)
+      );
     }
 
     final RowSignature signature = toolChest.resultArraySignature(query);
@@ -467,8 +470,10 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
         (acc, in) -> {
           if (limitAccumulator.getAndIncrement() >= limitToUse) {
             throw new ResourceLimitExceededException(
-                "Subquery generated results beyond maximum[%d]",
-                limitToUse
+                StringUtils.nonStrictFormat(
+                    "Subquery generated results beyond maximum[%d]",
+                    limitToUse
+                )
             );
           }
           acc.add(in);

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.query.QueryCapacityExceededException;
+import org.apache.druid.query.QueryException;
+import org.apache.druid.query.QueryInterruptedException;
+import org.apache.druid.query.QueryTimeoutException;
+import org.apache.druid.query.QueryUnsupportedException;
+import org.apache.druid.query.ResourceLimitExceededException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@RunWith(Enclosed.class)
+public class JsonParserIteratorTest
+{
+  private static final JavaType JAVA_TYPE = Mockito.mock(JavaType.class);
+  private static final String URL = "url";
+  private static final String HOST = "host";
+  private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapper();
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public static class FutureExceptionTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testConvertFutureTimeoutToQueryTimeoutException()
+    {
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateFailedFuture(
+              new QueryException(
+                  QueryTimeoutException.ERROR_CODE,
+                  "timeout exception conversion test",
+                  null,
+                  HOST
+              )
+          ),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+      expectedException.expect(QueryTimeoutException.class);
+      expectedException.expectMessage("timeout exception conversion test");
+      iterator.hasNext();
+    }
+
+    @Test
+    public void testConvertFutureCancelationToQueryInterruptedException()
+    {
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateCancelledFuture(),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+      expectedException.expect(QueryInterruptedException.class);
+      expectedException.expectMessage("Immediate cancelled future.");
+      iterator.hasNext();
+    }
+
+    @Test
+    public void testConvertFutureInterruptedToQueryInterruptedException()
+    {
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateFailedFuture(new InterruptedException("interrupted future")),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+      expectedException.expect(QueryInterruptedException.class);
+      expectedException.expectMessage("interrupted future");
+      iterator.hasNext();
+    }
+
+    @Test
+    public void testConvertIOExceptionToQueryInterruptedException() throws IOException
+    {
+      InputStream exceptionThrowingStream = Mockito.mock(InputStream.class);
+      IOException ioException = new IOException("ioexception test");
+      Mockito.when(exceptionThrowingStream.read()).thenThrow(ioException);
+      Mockito.when(exceptionThrowingStream.read(ArgumentMatchers.any())).thenThrow(ioException);
+      Mockito.when(
+          exceptionThrowingStream.read(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
+      ).thenThrow(ioException);
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateFuture(exceptionThrowingStream),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+      expectedException.expect(QueryInterruptedException.class);
+      expectedException.expectMessage("ioexception test");
+      iterator.hasNext();
+    }
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @RunWith(Parameterized.class)
+  public static class NonQueryInterruptedExceptionRestoreTest
+  {
+    @Parameters(name = "{0}")
+    public static Iterable<Object[]> constructorFeeder()
+    {
+      return ImmutableList.of(
+          new Object[]{new QueryTimeoutException()},
+          new Object[]{
+              QueryCapacityExceededException.withErrorMessageAndResolvedHost("capacity exceeded exception test")
+          },
+          new Object[]{new QueryUnsupportedException("unsupported exception test")},
+          new Object[]{new ResourceLimitExceededException("resource limit exceeded exception test")}
+      );
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final Exception exception;
+
+    public NonQueryInterruptedExceptionRestoreTest(Exception exception)
+    {
+      this.exception = exception;
+    }
+
+    @Test
+    public void testRestoreException() throws JsonProcessingException
+    {
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateFuture(mockErrorResponse(exception)),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+      expectedException.expect(exception.getClass());
+      expectedException.expectMessage(exception.getMessage());
+      iterator.hasNext();
+    }
+  }
+
+  public static class QueryInterruptedExceptionConversionTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testConvertQueryExceptionToQueryInterruptedException() throws JsonProcessingException
+    {
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateFuture(mockErrorResponse(new QueryException(null, "query exception test", null, null))),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+      expectedException.expect(QueryInterruptedException.class);
+      expectedException.expectMessage("query exception test");
+      iterator.hasNext();
+    }
+  }
+
+  private static InputStream mockErrorResponse(Exception e) throws JsonProcessingException
+  {
+    return new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(e));
+  }
+}


### PR DESCRIPTION
### Description

A follow-up of https://github.com/apache/druid/pull/10746. This PR updates the query error doc and adds unit tests for `JsonParserIterator`. Integration tests will be added in another PR.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
