### PR TITLE
Add log message when local input's filter does not match any files

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
@@ -164,11 +164,7 @@ public class LocalInputSource extends AbstractInputSource implements SplittableI
         // (by construction and non-null check of baseDir a few lines above):
         log.info("Local inputSource filter [%s] for base dir [%s] did not match any files", filter, baseDir);
       }
-      return FileUtils.iterateFiles(
-          baseDir.getAbsoluteFile(),
-          fileFilter,
-          TrueFileFilter.INSTANCE
-      );
+      return fileIterator;
     }
   }
 

--- a/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
@@ -40,6 +40,7 @@ import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.CollectionUtils;
 import org.apache.druid.utils.Streams;
 
@@ -56,6 +57,8 @@ import java.util.stream.Stream;
 
 public class LocalInputSource extends AbstractInputSource implements SplittableInputSource<List<File>>
 {
+  private static final Logger log = new Logger(LocalInputSource.class);
+
   @Nullable
   private final File baseDir;
   @Nullable
@@ -150,6 +153,16 @@ public class LocalInputSource extends AbstractInputSource implements SplittableI
                 new NameFileFilter(files.stream().map(File::getName).collect(Collectors.toList()), IOCase.SENSITIVE)
             )
         );
+      }
+      Iterator<File> fileIterator = FileUtils.iterateFiles(
+          baseDir.getAbsoluteFile(),
+          fileFilter,
+          TrueFileFilter.INSTANCE
+      );
+      if (!fileIterator.hasNext()) {
+        // base dir & filter are guaranteed to be non-null here
+        // (by construction and non-null check of baseDir a few lines above):
+        log.info("Local inputSource filter [%s] for base dir [%s] did not match any files", filter, baseDir);
       }
       return FileUtils.iterateFiles(
           baseDir.getAbsoluteFile(),


### PR DESCRIPTION
### Provide information in the log when the filter for local inputSource does not match any files

### Expected behavior

When the filter for local inputSource does not match any file a log message should be output at `INFO` level indicating that "no files matched the filter expression:.

### Actual behavior

When the filter for local inputSource does not match any file there is no log message, the task report simply indicates that no rows were parsed.

### Key changes:
Added a logger & log message to class `LocalInputSource.java` to match the expected behavior as outlined above.