### PR TITLE
HTTP inputSource should deny all domains by default

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSourceConfig.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSourceConfig.java
@@ -22,13 +22,17 @@ package org.apache.druid.data.input.impl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 
 public class HttpInputSourceConfig
 {
+  private static final List<String> DENY_ALL_ALLOW_LIST_DOMAINS = ImmutableList.of();
+
   @JsonProperty
   private final List<String> allowListDomains;
   @JsonProperty
@@ -36,11 +40,13 @@ public class HttpInputSourceConfig
 
   @JsonCreator
   public HttpInputSourceConfig(
-      @JsonProperty("allowListDomains") List<String> allowListDomains,
-      @JsonProperty("denyListDomains") List<String> denyListDomains
+      @JsonProperty("allowListDomains") @Nullable List<String> allowListDomains,
+      @JsonProperty("denyListDomains") @Nullable List<String> denyListDomains
   )
   {
-    this.allowListDomains = allowListDomains;
+    this.allowListDomains = (allowListDomains == null && denyListDomains == null)
+                            ? DENY_ALL_ALLOW_LIST_DOMAINS
+                            : allowListDomains;
     this.denyListDomains = denyListDomains;
     Preconditions.checkArgument(
         this.denyListDomains == null || this.allowListDomains == null,

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -514,6 +514,15 @@ This deep storage is used to interface with Cassandra.  Note that the `druid-cas
 |`druid.storage.host`|Cassandra host.|none|
 |`druid.storage.keyspace`|Cassandra key space.|none|
 
+### Ingestion Security Configuration
+
+You can optionally configure following properties to control what domains native batch tasks can access to using
+the [HTTP input source](../ingestion/native-batch.md#http-input-source).
+
+|Property|Possible Values|Description|Default|
+|--------|---------------|-----------|-------|
+|`druid.ingestion.http.allowListDomains`|List of domains|Allowed domains from which ingestion will be allowed. This property is defaulted to an empty list, which means all domains are _NOT_ allowed by default. Only one of `allowListDomains` or `denyListDomains` can be set.|Empty list|
+|`druid.ingestion.http.denyListDomains`|List of domains|Blacklisted domains from which ingestion will not be allowed. Set this property to an empty list to allow all domains. Only one of `allowListDomains` or `denyListDomains` can be set.|null|
 
 ### Task Logging
 
@@ -1354,15 +1363,6 @@ The amount of direct memory needed by Druid is at least
 `druid.processing.buffer.sizeBytes * (druid.processing.numMergeBuffers + druid.processing.numThreads + 1)`. You can
 ensure at least this amount of direct memory is available by providing `-XX:MaxDirectMemorySize=<VALUE>` at the command
 line.
-
-#### Indexer Security Configuration
-You can optionally configure following additional configs to restrict druid ingestion
- 
-|Property|Possible Values|Description|Default|
-|--------|---------------|-----------|-------|
-|`druid.ingestion.http.allowListDomains`|List of domains|Allowed domains from which ingestion will be allowed. Only one of allowList or denyList can be set.|empty list|
-|`druid.ingestion.http.denyListDomains`|List of domains|Blacklisted domains from which ingestion will NOT be allowed. Only one of allowList or denyList can be set. |empty list|
-
 
 #### Query Configurations
 

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -1133,8 +1133,11 @@ the [S3 input source](#s3-input-source) or the [Google Cloud Storage input sourc
 
 ### HTTP Input Source
 
-The HTTP input source is to support reading files directly
-from remote sites via HTTP.
+The HTTP input source is to support reading files directly from remote sites via HTTP.
+
+The HTTP input source is set to _deny accesses to all hosts_ by default. You need to configure [Ingestion security properties](../configuration/index.md#ingestion-security-configuration)
+to use the HTTP input source.
+
 The HTTP input source is _splittable_ and can be used by the [Parallel task](#parallel-task),
 where each worker task of `index_parallel` will read only one file. This input source does not support Split Hint Spec.
 

--- a/examples/conf/druid/single-server/large/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/large/_common/common.runtime.properties
@@ -143,3 +143,8 @@ druid.sql.enable=true
 # Lookups
 #
 druid.lookup.enableLookupSyncOnStartup=false
+
+#
+# HTTP inputSource
+#
+druid.ingestion.http.denyListDomains=[]

--- a/examples/conf/druid/single-server/medium/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/medium/_common/common.runtime.properties
@@ -143,3 +143,8 @@ druid.sql.enable=true
 # Lookups
 #
 druid.lookup.enableLookupSyncOnStartup=false
+
+#
+# HTTP inputSource
+#
+druid.ingestion.http.denyListDomains=[]

--- a/examples/conf/druid/single-server/micro-quickstart/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/micro-quickstart/_common/common.runtime.properties
@@ -143,3 +143,8 @@ druid.sql.enable=true
 # Lookups
 #
 druid.lookup.enableLookupSyncOnStartup=false
+
+#
+# HTTP inputSource
+#
+druid.ingestion.http.denyListDomains=[]

--- a/examples/conf/druid/single-server/nano-quickstart/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/nano-quickstart/_common/common.runtime.properties
@@ -143,3 +143,8 @@ druid.sql.enable=true
 # Lookups
 #
 druid.lookup.enableLookupSyncOnStartup=false
+
+#
+# HTTP inputSource
+#
+druid.ingestion.http.denyListDomains=[]

--- a/examples/conf/druid/single-server/small/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/small/_common/common.runtime.properties
@@ -143,3 +143,8 @@ druid.sql.enable=true
 # Lookups
 #
 druid.lookup.enableLookupSyncOnStartup=false
+
+#
+# HTTP inputSource
+#
+druid.ingestion.http.denyListDomains=[]

--- a/examples/conf/druid/single-server/xlarge/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/xlarge/_common/common.runtime.properties
@@ -143,3 +143,8 @@ druid.sql.enable=true
 # Lookups
 #
 druid.lookup.enableLookupSyncOnStartup=false
+
+#
+# HTTP inputSource
+#
+druid.ingestion.http.denyListDomains=[]


### PR DESCRIPTION
### Description

In the current Druid security model, the people who can ingest data are usually system administrators or trusted users because they will get the same privilege as what the Overlord has. However, when ingest permission is granted to a non-trusted user for some reason, it could be problematic if that user can ingest from any domains using HTTP inputSource. This PR changes HTTP inputSource to deny access to all domains by default. This can be a good practice for system admins to think about what domains they want to allow before using HTTP inputSource.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.