### PR TITLE
Build distribution after all other modules are installed on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ addons:
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
-install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
+install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
 stages:
   - name: test  # jobs that do not specify a stage get this default value


### PR DESCRIPTION
Some jobs have been flaky recently on Travis. One of them is the `license check` test. I don't have a link of failed tests at handy, but the log was something like below:

```
08:28:20.303 [main] ERROR org.apache.druid.cli.PullDependencies - Unable to resolve artifacts for [org.apache.druid.extensions:druid-ranger-security:jar:0.22.0-SNAPSHOT (runtime) -> [] < [ (https://repo1.maven.org/maven2/, releases+snapshots)]].
org.eclipse.aether.resolution.DependencyResolutionException: Could not find artifact org.apache.druid.extensions:druid-ranger-security:jar:0.22.0-SNAPSHOT in  (https://repo1.maven.org/maven2/)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies(DefaultRepositorySystem.java:384) ~[aether-impl-0.9.0.M2.jar:?]
	at io.tesla.aether.internal.DefaultTeslaAether.resolveArtifacts(DefaultTeslaAether.java:289) ~[tesla-aether-0.0.5.jar:0.0.5]
	at org.apache.druid.cli.PullDependencies.downloadExtension(PullDependencies.java:404) [druid-services-0.22.0-SNAPSHOT.jar:0.22.0-SNAPSHOT]
	at org.apache.druid.cli.PullDependencies.downloadExtension(PullDependencies.java:362) [druid-services-0.22.0-SNAPSHOT.jar:0.22.0-SNAPSHOT]
	at org.apache.druid.cli.PullDependencies.run(PullDependencies.java:308) [druid-services-0.22.0-SNAPSHOT.jar:0.22.0-SNAPSHOT]
	at org.apache.druid.cli.Main.main(Main.java:113) [druid-services-0.22.0-SNAPSHOT.jar:0.22.0-SNAPSHOT]
```

I'm unsure why the license check was pulling extension dependencies. However, the issue seems like a race as the maven build uses 2 threads to build modules. The `druid-ranger-security` module is the second last one that maven builds, and thus it might not be installed yet when maven builds the last module, `distribution`. This PR changes to the `install` command to build all other modules first before building the `distribution`.