### PR TITLE
Fix a kind of nested groupBy sql will caused the infinite loop by removing SortRemoveRule.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
@@ -62,7 +62,6 @@ import org.apache.calcite.rel.rules.ReduceExpressionsRule;
 import org.apache.calcite.rel.rules.SortJoinTransposeRule;
 import org.apache.calcite.rel.rules.SortProjectTransposeRule;
 import org.apache.calcite.rel.rules.SortRemoveConstantKeysRule;
-import org.apache.calcite.rel.rules.SortRemoveRule;
 import org.apache.calcite.rel.rules.SortUnionTransposeRule;
 import org.apache.calcite.rel.rules.TableScanRule;
 import org.apache.calcite.rel.rules.UnionPullUpConstantsRule;
@@ -185,6 +184,7 @@ public class Rules
   // 4) FilterJoinRule.FILTER_ON_JOIN and FilterJoinRule.JOIN
   //    Removed by https://github.com/apache/druid/pull/9773 due to issue in https://github.com/apache/druid/issues/9843
   //    TODO: Re-enable when https://github.com/apache/druid/issues/9843 is fixed
+  // 5) SortRemoveRule (it cause testNestedGroupBy2 infinite loop)
   private static final List<RelOptRule> ABSTRACT_RELATIONAL_RULES =
       ImmutableList.of(
           AbstractConverter.ExpandConversionRule.INSTANCE,
@@ -193,8 +193,7 @@ public class Rules
           ProjectRemoveRule.INSTANCE,
           AggregateJoinTransposeRule.INSTANCE,
           AggregateProjectMergeRule.INSTANCE,
-          CalcRemoveRule.INSTANCE,
-          SortRemoveRule.INSTANCE
+          CalcRemoveRule.INSTANCE
       );
 
   private Rules()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -7357,6 +7357,65 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testNestedGroupBy2() throws Exception
+  {
+    testQuery(
+        "SELECT dim2, dim1, SUM(inner_sum) AS sum_m1\n"
+        + "   FROM (\n"
+        + "     SELECT dim2, dim1, SUM(m1) AS inner_sum\n"
+        + "     FROM foo\n"
+        + "     GROUP BY dim2, dim1\n"
+        + "   )\n"
+        + "   GROUP BY dim2, dim1\n"
+        + "   ORDER BY dim2, dim1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            CalciteTests.DATASOURCE1
+                        )
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(dimensions(
+                            new DefaultDimensionSpec("dim2", "d0", ValueType.STRING),
+                            new DefaultDimensionSpec("dim1", "d1", ValueType.STRING)
+                        ))
+                        .setAggregatorSpecs(
+                            aggregators(
+                                new DoubleSumAggregatorFactory("a0", "m1")
+                            )
+                        )
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec(
+                                        "d0",
+                                        OrderByColumnSpec.Direction.ASCENDING,
+                                        StringComparators.LEXICOGRAPHIC
+                                    ),
+                                    new OrderByColumnSpec(
+                                        "d1",
+                                        OrderByColumnSpec.Direction.ASCENDING,
+                                        StringComparators.LEXICOGRAPHIC
+                                    )
+                                ),
+                                Integer.MAX_VALUE
+                            )
+                        )
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"", "10.1", 2.0},
+            new Object[]{"", "2", 3.0},
+            new Object[]{"", "abc", 6.0},
+            new Object[]{"a", "", 1.0},
+            new Object[]{"a", "1", 4.0},
+            new Object[]{"abc", "def", 5.0}
+        )
+    );
+  }
+
+  @Test
   public void testDoubleNestedGroupBy() throws Exception
   {
     testQuery(
@@ -13901,7 +13960,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                       )
                   )
                   .postAggregators(
-                      expressionPostAgg("p0", "(\"a0\" + \"a1\")")
+                      expressionPostAgg("s0", "(\"a0\" + \"a1\")")
                   )
                   .descending(true)
                   .context(getTimeseriesContextWithFloorTime(TIMESERIES_CONTEXT_DEFAULT, "d0"))


### PR DESCRIPTION
Fixes #10842.

### Description

The root cause is the sql described in #10842 will go to infinite loop by these rules.

- `AggregateRemoveRule`
- `AggregateProjectMergeRule` 
- `SortRemoveRule` 
- `SortProjectTransposeRule`

Removing any of above rules which can avoid infinite loop. This patch remove `SortRemoveRule ` to resolve it.