### PR TITLE
Fix the leadership integration test with Java 11

### DIFF
--- a/integration-tests/docker/docker-compose.high-availability.yml
+++ b/integration-tests/docker/docker-compose.high-availability.yml
@@ -132,7 +132,7 @@ services:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
       - DRUID_SERVICE=custom-node-role
       - DRUID_LOG_PATH=/shared/logs/custom-node-role.log
-      - SERVICE_DRUID_JAVA_OPTS=-server -Xmx32m -Xms32m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5011
+      - SERVICE_DRUID_JAVA_OPTS=-server -Xmx64m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5011
       - druid_host=druid-custom-node-role
       - druid_auth_basic_common_cacheDirectory=/tmp/authCache/custom_node_role
       - druid_server_https_crlPath=/tls/revocations.crl


### PR DESCRIPTION
### Description

The leadership integration test starts failing with Java 11 such as in [here](https://travis-ci.com/github/apache/druid/jobs/479868850). It is because of the custom node failed with OOM.

```2021-02-03T19:40:52,852 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [ANNOUNCEMENTS]
java.lang.OutOfMemoryError: Java heap space
Dumping heap to /tmp/java_pid906.hprof ...
Heap dump file created [46020040 bytes in 0.143 secs]
Terminating due to java.lang.OutOfMemoryError: Java heap space
```

This PR increases the heap from 32m to 64m.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.