### PR TITLE
Suppress CVE-2020-9492 for hadoop-mapreduce-client-core

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -287,5 +287,6 @@
      ]]></notes>
      <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop/hadoop\-.*@.*$</packageUrl>
      <cve>CVE-2018-11765</cve>
+     <cve>CVE-2020-9492</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Suppress CVE-2020-9492(https://nvd.nist.gov/vuln/detail/CVE-2020-9492) as it seems to apply only to the `WebHDFS` client.