### PR TITLE
[WIP] Import jdk11 tests and checks from separate config

### DIFF
--- a/.travis-jdk11.yml
+++ b/.travis-jdk11.yml
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+jobs:
+  include:
+    - <<: *package
+      name: "(openjdk11) packaging check"
+      jdk: openjdk11
+    
+    - <<: *package
+      name: "Build and test on ARM64 CPU architecture"
+      arch: arm64
+      jdk: openjdk11
+
+    - <<: *test_processing_module
+      name: "(openjdk11) processing module test"
+      jdk: openjdk11
+
+    - <<: *test_processing_module_sqlcompat
+      name: "(openjdk11) processing module test (SQL Compatibility)"
+      jdk: openjdk11
+
+    - <<: *test_indexing_module
+      name: "(openjdk11) indexing modules test"
+      jdk: openjdk11
+
+    - <<: *test_indexing_module_sqlcompat
+      name: "(openjdk11) indexing modules test (SQL Compatibility)"
+      jdk: openjdk11
+
+    - <<: *test_server_module
+      name: "(openjdk11) server module test"
+      jdk: openjdk11
+
+    - <<: *test_server_module_sqlcompat
+      name: "(openjdk11) server module test (SQL Compatibility)"
+      jdk: openjdk11
+
+    - <<: *test_other_modules
+      name: "(openjdk11) other modules test"
+      jdk: openjdk11
+
+    - <<: *test_other_modules_sqlcompat
+      name: "(openjdk11) other modules test (SQL Compatibility)"
+      jdk: openjdk11
+
+    # Integration tests Java Compile version is set by the machine environment jdk (set by the jdk key)
+    # Integration tests Java Runtime version is set by the JVM_RUNTIME env property (set env key to -Djvm.runtime=<JVM_RUNTIME_VERSION>)
+    # Integration tests will either use MiddleManagers or Indexers
+
+    # START - Integration tests for Compile with Java 8 and Run with Java 11
+    - <<: *integration_batch_index
+      name: "(Compile=openjdk8, Run=openjdk11) batch index integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=batch-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_input_format
+      name: "(Compile=openjdk8, Run=openjdk11) input format integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=input-format' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_input_source
+      name: "(Compile=openjdk8, Run=openjdk11) input source integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=input-source' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_perfect_rollup_parallel_batch_index
+      name: "(Compile=openjdk8, Run=openjdk11) perfect rollup parallel batch index integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=perfect-rollup-parallel-batch-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_query
+      name: "(Compile=openjdk8, Run=openjdk11) query integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=query' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_query_retry
+      name: "(Compile=openjdk8, Run=openjdk11) query retry integration test for missing segments"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=query-retry' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_security
+      name: "(Compile=openjdk8, Run=openjdk11) security integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=security' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_realtime_index
+      name: "(Compile=openjdk8, Run=openjdk11) realtime index integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=realtime-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_append_ingestion
+      name: "(Compile=openjdk8, Run=openjdk11) append ingestion integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=append-ingestion' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_compaction_tests
+      name: "(Compile=openjdk8, Run=openjdk11) compaction integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=compaction' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_tests
+      name: "(Compile=openjdk8, Run=openjdk11) other integration test"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,realtime-index,security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    - <<: *integration_tests
+      name: "(Compile=openjdk8, Run=openjdk11) leadership and high availability integration tests"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=high-availability' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+
+    # Subset of integration tests to run with ZooKeeper 3.4.x for backwards compatibility
+    - <<: *integration_tests
+      name: "(Compile=openjdk8, Run=openjdk11, ZK=3.4) leadership and high availability integration tests"
+      jdk: openjdk8
+      env: TESTNG_GROUPS='-Dgroups=high-availability' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager' ZK_VERSION=3.4
+
+    # END - Integration tests for Compile with Java 8 and Run with Java 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -526,75 +526,6 @@ jobs:
 
     # END - Integration tests for Compile with Java 8 and Run with Java 8
 
-    # START - Integration tests for Compile with Java 8 and Run with Java 11
-    - <<: *integration_batch_index
-      name: "(Compile=openjdk8, Run=openjdk11) batch index integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=batch-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_input_format
-      name: "(Compile=openjdk8, Run=openjdk11) input format integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=input-format' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_input_source
-      name: "(Compile=openjdk8, Run=openjdk11) input source integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=input-source' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_perfect_rollup_parallel_batch_index
-      name: "(Compile=openjdk8, Run=openjdk11) perfect rollup parallel batch index integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=perfect-rollup-parallel-batch-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_query
-      name: "(Compile=openjdk8, Run=openjdk11) query integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=query' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_query_retry
-      name: "(Compile=openjdk8, Run=openjdk11) query retry integration test for missing segments"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=query-retry' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_security
-      name: "(Compile=openjdk8, Run=openjdk11) security integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=security' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_realtime_index
-      name: "(Compile=openjdk8, Run=openjdk11) realtime index integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=realtime-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_append_ingestion
-      name: "(Compile=openjdk8, Run=openjdk11) append ingestion integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=append-ingestion' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_compaction_tests
-      name: "(Compile=openjdk8, Run=openjdk11) compaction integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=compaction' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_tests
-      name: "(Compile=openjdk8, Run=openjdk11) other integration test"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,realtime-index,security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    - <<: *integration_tests
-      name: "(Compile=openjdk8, Run=openjdk11) leadership and high availability integration tests"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=high-availability' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
-
-    # Subset of integration tests to run with ZooKeeper 3.4.x for backwards compatibility
-    - <<: *integration_tests
-      name: "(Compile=openjdk8, Run=openjdk11, ZK=3.4) leadership and high availability integration tests"
-      jdk: openjdk8
-      env: TESTNG_GROUPS='-Dgroups=high-availability' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager' ZK_VERSION=3.4
-
-    # END - Integration tests for Compile with Java 8 and Run with Java 11
-
     - &integration_batch_index_k8s
       name: "(Compile=openjdk8, Run=openjdk8, Cluster Build On K8s) ITNestedQueryPushDownTest integration test"
       stage: it
@@ -621,6 +552,13 @@ jobs:
         information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).
 
         " && false; }
+
+# START - Integration tests for Compile with Java 8 and Run with Java 11
+
+import:
+  - source: .travis-jdk11.yml
+
+# END - Integration tests for Compile with Java 8 and Run with Java 11
 
 # Travis CI only supports per build (and not per-job notifications): https://github.com/travis-ci/travis-ci/issues/9888
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -516,6 +516,7 @@ jobs:
 
 import:
   - source: .travis-jdk11.yml
+    mode: deep_merge_prepend
 
 # END - Integration tests for Compile with Java 8 and Run with Java 11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,15 +136,6 @@ jobs:
         MAVEN_OPTS='-Xmx3000m' ${MVN} clean install -Prat -Pdist -Pbundle-contrib-exts --fail-at-end
         -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Ddruid.console.skip=false -T1C
 
-    - <<: *package
-      name: "(openjdk11) packaging check"
-      jdk: openjdk11
-    
-    - <<: *package
-      name: "Build and test on ARM64 CPU architecture"
-      arch: arm64
-      jdk: openjdk11
-
     - &test_processing_module
       name: "(openjdk8) processing module test"
       env:
@@ -205,19 +196,11 @@ jobs:
         - travis_retry curl -o codecov.sh -s https://codecov.io/bash
         - travis_retry bash codecov.sh -X gcov
 
-    - <<: *test_processing_module
-      name: "(openjdk11) processing module test"
-      jdk: openjdk11
-
     - &test_processing_module_sqlcompat
       <<: *test_processing_module
       name: "(openjdk8) processing module test (SQL Compatibility)"
       before_script: &setup_sqlcompat
       - export DRUID_USE_DEFAULT_VALUE_FOR_NULL=false
-
-    - <<: *test_processing_module_sqlcompat
-      name: "(openjdk11) processing module test (SQL Compatibility)"
-      jdk: openjdk11
 
     - &test_indexing_module
       <<: *test_processing_module
@@ -225,18 +208,10 @@ jobs:
       env:
       - MAVEN_PROJECTS='indexing-hadoop,indexing-service,extensions-core/kafka-indexing-service,extensions-core/kinesis-indexing-service'
 
-    - <<: *test_indexing_module
-      name: "(openjdk11) indexing modules test"
-      jdk: openjdk11
-
     - &test_indexing_module_sqlcompat
       <<: *test_indexing_module
       name: "(openjdk8) indexing modules test (SQL Compatibility)"
       before_script: *setup_sqlcompat
-
-    - <<: *test_indexing_module_sqlcompat
-      name: "(openjdk11) indexing modules test (SQL Compatibility)"
-      jdk: openjdk11
 
     - &test_server_module
       <<: *test_processing_module
@@ -244,18 +219,10 @@ jobs:
       env:
         - MAVEN_PROJECTS='server'
 
-    - <<: *test_server_module
-      name: "(openjdk11) server module test"
-      jdk: openjdk11
-
     - &test_server_module_sqlcompat
       <<: *test_server_module
       name: "(openjdk8) server module test (SQL Compatibility)"
       before_script: *setup_sqlcompat
-
-    - <<: *test_server_module_sqlcompat
-      name: "(openjdk11) server module test (SQL Compatibility)"
-      jdk: openjdk11
 
     - &test_other_modules
       <<: *test_processing_module
@@ -263,18 +230,10 @@ jobs:
       env:
         - MAVEN_PROJECTS='!processing,!indexing-hadoop,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-core/kinesis-indexing-service,!server,!web-console,!integration-tests'
 
-    - <<: *test_other_modules
-      name: "(openjdk11) other modules test"
-      jdk: openjdk11
-
     - &test_other_modules_sqlcompat
       <<: *test_other_modules
       name: "(openjdk8) other modules test (SQL Compatibility)"
       before_script: *setup_sqlcompat
-
-    - <<: *test_other_modules_sqlcompat
-      name: "(openjdk11) other modules test (SQL Compatibility)"
-      jdk: openjdk11
 
     - name: "web console"
       install: skip


### PR DESCRIPTION
This change would allow in the future to add conditional imports so that JDK11 tests can be entirely disabled for some environments and branches. 