### PR TITLE
Add a new iterator policy for coordinator auto CompactionTask

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -305,6 +305,12 @@ public class CompactionTask extends AbstractBatchIndexTask
   }
 
   @Override
+  public boolean isWaitingToRun()
+  {
+    return false;
+  }
+
+  @Override
   public int getPriority()
   {
     return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_MERGE_TASK_PRIORITY);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -123,6 +123,11 @@ public interface Task
    */
   String getType();
 
+  default boolean isWaitingToRun()
+  {
+    return true;
+  }
+
   /**
    * Get the nodeType for if/when this task publishes on zookeeper.
    *

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -202,6 +202,29 @@ public class OverlordResource
   }
 
   @GET
+  @Path("/getNonLockIntervals/{dataSource}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getNonLockIntervals(
+      @PathParam("dataSource") String dataSource,
+      @QueryParam("interval") String intervalStr,
+      @Context HttpServletRequest request
+  )
+  {
+    log.info("Search unLocked intervals conditions: searchDataSource[%s],searchInterval[%s]", dataSource, intervalStr);
+    return asLeaderWith(
+        taskMaster.getTaskQueue(),
+        new Function<TaskQueue, Response>()
+        {
+          @Override
+          public Response apply(TaskQueue taskQueue)
+          {
+            return Response.ok(taskQueue.getNonLockIntervalSnapshots(dataSource, Intervals.of(intervalStr))).build();
+          }
+        }
+    );
+  }
+
+  @GET
   @Path("/leader")
   @ResourceFilters(StateResourceFilter.class)
   @Produces(MediaType.APPLICATION_JSON)

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -328,7 +328,10 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
         null,
         null,
         null,
+        null,
+        null,
         skipOffsetFromLatest,
+        null,
         new UserCompactionTaskQueryTuningConfig(
             null,
             null,

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
@@ -65,4 +65,9 @@ public interface IndexingServiceClient
   TaskPayloadResponse getTaskPayload(String taskId);
 
   SamplerResponse sample(SamplerSpec samplerSpec);
+
+  /**
+   * Gets all unLocked intervals from interval.
+   */
+  List<Interval> getNonLockIntervals(String dataSource, Interval interval);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -27,6 +27,10 @@ import org.skife.config.Default;
  */
 public abstract class DruidCoordinatorConfig
 {
+  public static final String AUTO_COMPACT_POLICY_NEWEST = "newest";
+  public static final String AUTO_COMPACT_POLICY_HIGH_SCORE = "score";
+  static final String DEFAULT_AUTO_COMPACT_POLICY = AUTO_COMPACT_POLICY_NEWEST;
+
   @Config("druid.coordinator.startDelay")
   @Default("PT300s")
   public abstract Duration getCoordinatorStartDelay();
@@ -38,6 +42,18 @@ public abstract class DruidCoordinatorConfig
   @Config("druid.coordinator.period.indexingPeriod")
   @Default("PT1800s")
   public abstract Duration getCoordinatorIndexingPeriod();
+
+  @Config("druid.coordinator.period.autoCompactionPeriod")
+  public Duration getCoordinatorAutoCompactionPeriod()
+  {
+    return Duration.millis(30 * 60 * 1000);
+  }
+
+  @Config("druid.coordinator.autoCompactionPolicy")
+  public String getAutoCompactionPolicy()
+  {
+    return DEFAULT_AUTO_COMPACT_POLICY;
+  }
 
   @Config("druid.coordinator.kill.period")
   @Default("P1D")

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactionSegmentIterator.java
@@ -19,26 +19,55 @@
 
 package org.apache.druid.server.coordinator.duty;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
+import org.apache.druid.client.indexing.IndexingServiceClient;
+import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.server.coordinator.CompactionStatistics;
+import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
+import org.joda.time.Interval;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Segments in the lists which are the elements of this iterator are sorted according to the natural segment order
  * (see {@link DataSegment#compareTo}).
  */
-public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
+public abstract class CompactionSegmentIterator<T> implements Iterator<T>
 {
+  private static final Logger log = new Logger(CompactionSegmentIterator.class);
+  final Map<String, CompactionStatistics> compactedSegments = new HashMap<>();
+  final Map<String, CompactionStatistics> skippedSegments = new HashMap<>();
+
+  private final ObjectMapper objectMapper;
+
+  public CompactionSegmentIterator(ObjectMapper objectMapper)
+  {
+    this.objectMapper = objectMapper;
+  }
+
   /**
    * Return a map of dataSourceName to CompactionStatistics.
    * This method returns the aggregated statistics of segments that was already compacted and does not need to be compacted
    * again. Hence, segment that were not returned by the {@link Iterator#next()} becuase it does not needs compaction.
    * Note that the aggregations returned by this method is only up to the current point of the iterator being iterated.
    */
-  Map<String, CompactionStatistics> totalCompactedStatistics();
+  Map<String, CompactionStatistics> totalCompactedStatistics()
+  {
+    return compactedSegments;
+  }
 
   /**
    * Return a map of dataSourceName to CompactionStatistics.
@@ -46,6 +75,174 @@ public interface CompactionSegmentIterator extends Iterator<List<DataSegment>>
    * Hence, segment that were not returned by the {@link Iterator#next()} becuase it cannot be compacted.
    * Note that the aggregations returned by this method is only up to the current point of the iterator being iterated.
    */
-  Map<String, CompactionStatistics> totalSkippedStatistics();
+  Map<String, CompactionStatistics> totalSkippedStatistics()
+  {
+    return skippedSegments;
+  }
 
+  void collectSegmentStatistics(
+      Map<String, CompactionStatistics> statisticsMap,
+      String dataSourceName,
+      SegmentsToCompact segments
+  )
+  {
+    CompactionStatistics statistics = statisticsMap.computeIfAbsent(
+        dataSourceName,
+        v -> CompactionStatistics.initializeCompactionStatistics()
+    );
+    statistics.incrementCompactedByte(segments.getTotalSize());
+    statistics.incrementCompactedIntervals(segments.getNumberOfIntervals());
+    statistics.incrementCompactedSegments(segments.getNumberOfSegments());
+  }
+
+  /**
+   * compaction iterator reset
+   */
+  abstract void reset(Map<String, List<Interval>> skipIntervals, IndexingServiceClient indexingServiceClient);
+
+  /**
+   * compaction iterator skip elements,
+   * skip latest compaction task failure count
+   *
+   * @param dataSource
+   * @param skipCount
+   */
+  abstract void skip(String dataSource, int skipCount);
+
+  void setCompactType(boolean isMajor)
+  {
+  }
+
+  /**
+   * Need compaction common conditions
+   *
+   * @param tuningConfig
+   * @param candidates
+   *
+   * @return
+   */
+  boolean needsCompaction(ClientCompactionTaskQueryTuningConfig tuningConfig, SegmentsToCompact candidates)
+  {
+    Preconditions.checkState(!candidates.isEmpty(), "Empty candidates");
+
+    final PartitionsSpec partitionsSpecFromConfig = findPartitinosSpecFromConfig(tuningConfig);
+    final CompactionState lastCompactionState = candidates.segments.get(0).getLastCompactionState();
+    if (lastCompactionState == null) {
+      log.info("Candidate segment[%s] is not compacted yet. Needs compaction.", candidates.segments.get(0).getId());
+      return true;
+    }
+
+    final boolean allCandidatesHaveSameLastCompactionState = candidates
+        .segments
+        .stream()
+        .allMatch(segment -> lastCompactionState.equals(segment.getLastCompactionState()));
+
+    if (!allCandidatesHaveSameLastCompactionState) {
+      log.info(
+          "[%s] Candidate segments were compacted with different partitions spec. Needs compaction.",
+          candidates.segments.size()
+      );
+      log.debugSegments(
+          candidates.segments,
+          "Candidate segments compacted with different partiton spec"
+      );
+
+      return true;
+    }
+
+    final PartitionsSpec segmentPartitionsSpec = lastCompactionState.getPartitionsSpec();
+    final IndexSpec segmentIndexSpec = objectMapper.convertValue(lastCompactionState.getIndexSpec(), IndexSpec.class);
+    final IndexSpec configuredIndexSpec;
+    if (tuningConfig.getIndexSpec() == null) {
+      configuredIndexSpec = new IndexSpec();
+    } else {
+      configuredIndexSpec = tuningConfig.getIndexSpec();
+    }
+    boolean needsCompaction = false;
+    if (!Objects.equals(partitionsSpecFromConfig, segmentPartitionsSpec)) {
+      log.info(
+          "Configured partitionsSpec[%s] is differenet from "
+          + "the partitionsSpec[%s] of segments. Needs compaction.",
+          partitionsSpecFromConfig,
+          segmentPartitionsSpec
+      );
+      needsCompaction = true;
+    }
+    // segmentIndexSpec cannot be null.
+    if (!segmentIndexSpec.equals(configuredIndexSpec)) {
+      log.info(
+          "Configured indexSpec[%s] is different from the one[%s] of segments. Needs compaction",
+          configuredIndexSpec,
+          segmentIndexSpec
+      );
+      needsCompaction = true;
+    }
+
+    return needsCompaction;
+  }
+
+  @VisibleForTesting
+  static PartitionsSpec findPartitinosSpecFromConfig(ClientCompactionTaskQueryTuningConfig tuningConfig)
+  {
+    final PartitionsSpec partitionsSpecFromTuningConfig = tuningConfig.getPartitionsSpec();
+    if (partitionsSpecFromTuningConfig instanceof DynamicPartitionsSpec) {
+      return new DynamicPartitionsSpec(
+          partitionsSpecFromTuningConfig.getMaxRowsPerSegment(),
+          ((DynamicPartitionsSpec) partitionsSpecFromTuningConfig).getMaxTotalRowsOr(Long.MAX_VALUE)
+      );
+    } else {
+      final long maxTotalRows = tuningConfig.getMaxTotalRows() != null
+                                ? tuningConfig.getMaxTotalRows()
+                                : Long.MAX_VALUE;
+      return partitionsSpecFromTuningConfig == null
+             ? new DynamicPartitionsSpec(tuningConfig.getMaxRowsPerSegment(), maxTotalRows)
+             : partitionsSpecFromTuningConfig;
+    }
+  }
+
+  static class SegmentsToCompact
+  {
+    final List<DataSegment> segments;
+    final long totalSize;
+
+    public SegmentsToCompact()
+    {
+      this(Collections.emptyList());
+    }
+
+    public SegmentsToCompact(List<DataSegment> segments)
+    {
+      this.segments = segments;
+      this.totalSize = segments.stream().mapToLong(DataSegment::getSize).sum();
+    }
+
+    public boolean isEmpty()
+    {
+      return segments.isEmpty();
+    }
+
+    public long getTotalSize()
+    {
+      return totalSize;
+    }
+
+    public long getNumberOfSegments()
+    {
+      return segments.size();
+    }
+
+    public long getNumberOfIntervals()
+    {
+      return segments.stream().map(DataSegment::getInterval).distinct().count();
+    }
+
+    @Override
+    public String toString()
+    {
+      return "SegmentsToCompact{" +
+             "segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
+             ", totalSize=" + totalSize +
+             '}';
+    }
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/HighScoreSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/HighScoreSegmentFirstIterator.java
@@ -345,8 +345,8 @@ public class HighScoreSegmentFirstIterator
    */
   static class CompactibleTimelineObjectHolderCursor implements Iterator<Tuple2<Float, List<DataSegment>>>
   {
-    private final float timeWeightForRecentDays = DataSourceCompactionConfig.DEFAULT_COMPACTION_TIME_WEIGHT_FOR_RECENT_DAYS;
-    private final float smallFileNumWeight = DataSourceCompactionConfig.DEFAULT_COMPACTION_SEGMENT_NUM_WEIGHT;
+    private static final float TIME_WEIGHT_FOR_RECENT_DAYS = DataSourceCompactionConfig.DEFAULT_COMPACTION_TIME_WEIGHT_FOR_RECENT_DAYS;
+    private static final float SMALLFILE_NUM_WEIGHT = DataSourceCompactionConfig.DEFAULT_COMPACTION_SEGMENT_NUM_WEIGHT;
     private final Period recentDays;
     private volatile List<Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> minorHolders;
     private volatile List<Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> majorHolders;
@@ -368,7 +368,7 @@ public class HighScoreSegmentFirstIterator
           )
           .collect(Collectors.toList());
       // compute score--timeline
-      minorHolders = computeTimelineScore(holders, timeWeightForRecentDays, recentDays, smallFileNumWeight);
+      minorHolders = computeTimelineScore(holders, TIME_WEIGHT_FOR_RECENT_DAYS, recentDays, SMALLFILE_NUM_WEIGHT);
     }
 
     public void compareAndUpdateCompactIterator(boolean isMajorNew)
@@ -378,14 +378,16 @@ public class HighScoreSegmentFirstIterator
           // update major from minor iterator
           log.info("Update major iterator from minor.");
           majorHolders = computeTimelineScore(minorHolders.stream().map(t -> t._2).collect(Collectors.toList()),
-                                              timeWeightForRecentDays * MAJOR_COMPACTION_IGNORE_TIME_LEVEL, recentDays,
-                                              smallFileNumWeight
+                                              TIME_WEIGHT_FOR_RECENT_DAYS * MAJOR_COMPACTION_IGNORE_TIME_LEVEL,
+                                              recentDays,
+                                              SMALLFILE_NUM_WEIGHT
           );
         } else {
           log.info("Update minor iterator from major.");
           minorHolders = computeTimelineScore(majorHolders.stream().map(t -> t._2).collect(Collectors.toList()),
-                                              timeWeightForRecentDays * MAJOR_COMPACTION_IGNORE_TIME_LEVEL, recentDays,
-                                              smallFileNumWeight
+                                              TIME_WEIGHT_FOR_RECENT_DAYS * MAJOR_COMPACTION_IGNORE_TIME_LEVEL,
+                                              recentDays,
+                                              SMALLFILE_NUM_WEIGHT
           );
         }
         this.curIsMajor = isMajorNew;

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/HighScoreSegmentFirstPolicy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/HighScoreSegmentFirstPolicy.java
@@ -26,32 +26,34 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
 /**
- * This policy searches segments for compaction from the newest one to oldest one.
+ * This policy searches segments for compaction from the high score to the low score.
  */
-public class NewestSegmentFirstPolicy implements CompactionSegmentSearchPolicy
+public class HighScoreSegmentFirstPolicy implements CompactionSegmentSearchPolicy
 {
   private final ObjectMapper objectMapper;
   private final IndexingServiceClient indexingServiceClient;
 
-  public NewestSegmentFirstPolicy(ObjectMapper objectMapper, @Nullable IndexingServiceClient indexingServiceClient)
+  public HighScoreSegmentFirstPolicy(
+      ObjectMapper objectMapper,
+      IndexingServiceClient indexingServiceClient
+  )
   {
     this.objectMapper = objectMapper;
     this.indexingServiceClient = indexingServiceClient;
   }
 
   @Override
-  public CompactionSegmentIterator reset(
+  public CompactionSegmentIterator<HighScoreSegmentFirstIterator.Tuple2<Float, List<DataSegment>>> reset(
       Map<String, DataSourceCompactionConfig> compactionConfigs,
       Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources,
       Map<String, List<Interval>> skipIntervals
   )
   {
-    return new NewestSegmentFirstIterator(
+    return new HighScoreSegmentFirstIterator(
         objectMapper,
         compactionConfigs,
         dataSources,

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
@@ -73,6 +73,7 @@ public class CoordinatorCompactionConfigsResource
   @Consumes(MediaType.APPLICATION_JSON)
   public Response setCompactionTaskLimit(
       @QueryParam("ratio") Double compactionTaskSlotRatio,
+      @QueryParam("majorRatioInAvailableCompact") Double majorRatioInAvailableCompact,
       @QueryParam("max") Integer maxCompactionTaskSlots,
       @HeaderParam(AuditManager.X_DRUID_AUTHOR) @DefaultValue("") final String author,
       @HeaderParam(AuditManager.X_DRUID_COMMENT) @DefaultValue("") final String comment,
@@ -84,6 +85,7 @@ public class CoordinatorCompactionConfigsResource
     final CoordinatorCompactionConfig newCompactionConfig = CoordinatorCompactionConfig.from(
         current,
         compactionTaskSlotRatio,
+        majorRatioInAvailableCompact,
         maxCompactionTaskSlots
     );
 

--- a/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
@@ -110,4 +110,10 @@ public class NoopIndexingServiceClient implements IndexingServiceClient
   {
     return new SamplerResponse(0, 0, Collections.emptyList());
   }
+
+  @Override
+  public List<Interval> getNonLockIntervals(String dataSource, Interval interval)
+  {
+    return null;
+  }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
@@ -54,7 +54,10 @@ public class DataSourceCompactionConfigTest
         null,
         500L,
         null,
+        null,
+        null,
         new Period(3600),
+        true,
         null,
         ImmutableMap.of("key", "val")
     );
@@ -77,8 +80,11 @@ public class DataSourceCompactionConfigTest
         "dataSource",
         null,
         500L,
+        null,
+        null,
         30,
         new Period(3600),
+        null,
         null,
         ImmutableMap.of("key", "val")
     );
@@ -102,7 +108,10 @@ public class DataSourceCompactionConfigTest
         null,
         500L,
         null,
+        null,
+        null,
         new Period(3600),
+        null,
         new UserCompactionTaskQueryTuningConfig(
             null,
             null,
@@ -143,8 +152,11 @@ public class DataSourceCompactionConfigTest
         "dataSource",
         null,
         500L,
+        null,
+        null,
         10000,
         new Period(3600),
+        null,
         new UserCompactionTaskQueryTuningConfig(
             null,
             null,

--- a/server/src/test/java/org/apache/druid/server/coordinator/TestDruidCoordinatorConfig.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/TestDruidCoordinatorConfig.java
@@ -32,6 +32,8 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   private final Duration coordinatorKillDurationToRetain;
   private final Duration getLoadQueuePeonRepeatDelay;
   private final int coordinatorKillMaxSegments;
+  private final String autoCompactPolicy;
+  private final Duration autoCheckOrSubmitPeriod;
 
   public TestDruidCoordinatorConfig(
       Duration coordinatorStartDelay,
@@ -44,6 +46,33 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
       Duration getLoadQueuePeonRepeatDelay
   )
   {
+    this(
+        coordinatorStartDelay,
+        coordinatorPeriod,
+        coordinatorIndexingPeriod,
+        loadTimeoutDelay,
+        coordinatorKillPeriod,
+        coordinatorKillDurationToRetain,
+        coordinatorKillMaxSegments,
+        getLoadQueuePeonRepeatDelay,
+        null,
+        null
+    );
+  }
+
+  public TestDruidCoordinatorConfig(
+      Duration coordinatorStartDelay,
+      Duration coordinatorPeriod,
+      Duration coordinatorIndexingPeriod,
+      Duration loadTimeoutDelay,
+      Duration coordinatorKillPeriod,
+      Duration coordinatorKillDurationToRetain,
+      int coordinatorKillMaxSegments,
+      Duration getLoadQueuePeonRepeatDelay,
+      String autoCompactPolicy,
+      Duration autoCheckOrSubmitPeriod
+  )
+  {
     this.coordinatorStartDelay = coordinatorStartDelay;
     this.coordinatorPeriod = coordinatorPeriod;
     this.coordinatorIndexingPeriod = coordinatorIndexingPeriod;
@@ -52,6 +81,8 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
     this.coordinatorKillDurationToRetain = coordinatorKillDurationToRetain;
     this.coordinatorKillMaxSegments = coordinatorKillMaxSegments;
     this.getLoadQueuePeonRepeatDelay = getLoadQueuePeonRepeatDelay;
+    this.autoCompactPolicy = autoCompactPolicy;
+    this.autoCheckOrSubmitPeriod = autoCheckOrSubmitPeriod;
   }
 
   @Override
@@ -94,6 +125,24 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   public Duration getLoadTimeoutDelay()
   {
     return loadTimeoutDelay == null ? super.getLoadTimeoutDelay() : loadTimeoutDelay;
+  }
+
+  @Override
+  public Duration getCoordinatorAutoCompactionPeriod()
+  {
+    if (autoCheckOrSubmitPeriod == null) {
+      return super.getCoordinatorAutoCompactionPeriod();
+    }
+    return autoCheckOrSubmitPeriod;
+  }
+
+  @Override
+  public String getAutoCompactionPolicy()
+  {
+    if (autoCompactPolicy == null) {
+      return super.getAutoCompactionPolicy();
+    }
+    return autoCompactPolicy;
   }
 
   @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/HighScoreSegmentFirstIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/HighScoreSegmentFirstIteratorTest.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.TimelineObjectHolder;
+import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.joda.time.Interval;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HighScoreSegmentFirstIteratorTest
+{
+  private final float timeWeight = DataSourceCompactionConfig.DEFAULT_COMPACTION_TIME_WEIGHT_FOR_RECENT_DAYS;
+  private final Period recentDaysForTimeWeight = DataSourceCompactionConfig.DEFAULT_COMPACTION_RECENT_DAYS;
+  private final float segmentsNumWeight = DataSourceCompactionConfig.DEFAULT_COMPACTION_SEGMENT_NUM_WEIGHT;
+
+  @Test
+  public void testFilterSkipIntervals()
+  {
+    final Interval totalInterval = Intervals.of("2018-01-01/2019-01-01");
+    final List<Interval> expectedSkipIntervals = ImmutableList.of(
+        Intervals.of("2018-01-15/2018-03-02"),
+        Intervals.of("2018-07-23/2018-10-01"),
+        Intervals.of("2018-10-02/2018-12-25"),
+        Intervals.of("2018-12-31/2019-01-01")
+    );
+    final List<Interval> skipIntervals = NewestSegmentFirstIterator.filterSkipIntervals(
+        totalInterval,
+        Lists.newArrayList(
+            Intervals.of("2017-12-01/2018-01-15"),
+            Intervals.of("2018-03-02/2018-07-23"),
+            Intervals.of("2018-10-01/2018-10-02"),
+            Intervals.of("2018-12-25/2018-12-31")
+        )
+    );
+
+    Assert.assertEquals(expectedSkipIntervals, skipIntervals);
+  }
+
+  @Test
+  public void testAddSkipIntervalFromLatestAndSort()
+  {
+    final List<Interval> expectedIntervals = ImmutableList.of(
+        Intervals.of("2018-12-24/2018-12-25"),
+        Intervals.of("2018-12-29/2019-01-01")
+    );
+    final List<Interval> fullSkipIntervals = NewestSegmentFirstIterator.sortAndAddSkipIntervalFromLatest(
+        DateTimes.of("2019-01-01"),
+        new Period(72, 0, 0, 0),
+        ImmutableList.of(
+            Intervals.of("2018-12-30/2018-12-31"),
+            Intervals.of("2018-12-24/2018-12-25")
+        )
+    );
+
+    Assert.assertEquals(expectedIntervals, fullSkipIntervals);
+  }
+
+  @Test
+  public void testHighScoreForNewTimeFirst()
+  {
+    final long inputSegmentSizeBytes = 8000000;
+    final VersionedIntervalTimeline<String, DataSegment> timeline = NewestSegmentFirstPolicyTest.createTimeline(
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-01T00:00:00/2021-01-02T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 2,
+            2
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-03T00:00:00/2021-01-04T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 2,
+            2
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-05T00:00:00/2021-01-06T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 2, // first
+            2
+        )
+    );
+    List<Interval> searchInterval = new ArrayList<>();
+    searchInterval.add(Intervals.of("2021-01-01/2021-02-01"));
+    List<TimelineObjectHolder<String, DataSegment>> holders = searchInterval
+        .stream()
+        .flatMap(interval -> timeline
+            .lookup(interval)
+            .stream()
+            // 过滤掉interval下所有segment大小全为0的interval.
+            .filter(holder -> HighScoreSegmentFirstIterator.isCompactibleHolder(interval, holder))
+        )
+        .collect(Collectors.toList());
+
+    List<Interval> computIntervals = new ArrayList<>();
+    final List<HighScoreSegmentFirstIterator.Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> tuple2s
+        = HighScoreSegmentFirstIterator.computeTimelineScore(
+        holders,
+        timeWeight,
+        recentDaysForTimeWeight,
+        segmentsNumWeight
+    );
+    tuple2s.forEach(t -> System.out.println(t._1 + "," + t._2.getInterval()));
+    tuple2s.forEach(t -> computIntervals.add(t._2.getInterval()));
+
+    Assert.assertEquals(ImmutableList.of(
+        Intervals.of("2021-01-01T00:00:00.000Z/2021-01-02T00:00:00.000Z"),
+        Intervals.of("2021-01-03T00:00:00.000Z/2021-01-04T00:00:00.000Z"),
+        Intervals.of("2021-01-05T00:00:00.000Z/2021-01-06T00:00:00.000Z")
+    ), computIntervals);
+  }
+
+  @Test
+  public void testHighScoreForSmallSizeFirst()
+  {
+    final long inputSegmentSizeBytes = 8000000;
+    final VersionedIntervalTimeline<String, DataSegment> timeline = NewestSegmentFirstPolicyTest.createTimeline(
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-01T00:00:00/2021-01-02T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 2,
+            2
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-03T00:00:00/2021-01-04T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 50, // first
+            4
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-05T00:00:00/2021-01-06T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 2 + 1,
+            2
+        )
+    );
+    List<Interval> searchInterval = new ArrayList<>();
+    searchInterval.add(Intervals.of("2021-01-01/2021-02-01"));
+    List<TimelineObjectHolder<String, DataSegment>> holders = searchInterval
+        .stream()
+        .flatMap(interval -> timeline
+            .lookup(interval)
+            .stream()
+            // 过滤掉interval下所有segment大小全为0的interval.
+            .filter(holder -> HighScoreSegmentFirstIterator.isCompactibleHolder(interval, holder))
+        )
+        .collect(Collectors.toList());
+
+    List<Interval> computIntervals = new ArrayList<>();
+    final List<HighScoreSegmentFirstIterator.Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> tuple2s
+        = HighScoreSegmentFirstIterator.computeTimelineScore(
+        holders,
+        timeWeight,
+        recentDaysForTimeWeight,
+        segmentsNumWeight
+    );
+    tuple2s.forEach(t -> System.out.println(t._1 + "," + t._2.getInterval()));
+
+    tuple2s.forEach(t -> computIntervals.add(t._2.getInterval()));
+
+    Assert.assertEquals(ImmutableList.of(
+        Intervals.of("2021-01-01T00:00:00.000Z/2021-01-02T00:00:00.000Z"),
+        Intervals.of("2021-01-05T00:00:00.000Z/2021-01-06T00:00:00.000Z"),
+        Intervals.of("2021-01-03T00:00:00.000Z/2021-01-04T00:00:00.000Z")
+    ), computIntervals);
+  }
+
+  @Test
+  public void testHighScoreForMaxSegmentNumShardFirst()
+  {
+    final long inputSegmentSizeBytes = 8000000;
+    final VersionedIntervalTimeline<String, DataSegment> timeline = NewestSegmentFirstPolicyTest.createTimeline(
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-01T00:00:00/2021-01-02T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 2 + 1,
+            2
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-03T00:00:00/2021-01-04T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 10, // first
+            10
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-05T00:00:00/2021-01-06T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 2,
+            2
+        )
+    );
+    List<Interval> searchInterval = new ArrayList<>();
+    searchInterval.add(Intervals.of("2021-01-01/2021-02-01"));
+    List<TimelineObjectHolder<String, DataSegment>> holders = searchInterval
+        .stream()
+        .flatMap(interval -> timeline
+            .lookup(interval)
+            .stream()
+            // 过滤掉interval下所有segment大小全为0的interval.
+            .filter(holder -> HighScoreSegmentFirstIterator.isCompactibleHolder(interval, holder))
+        )
+        .collect(Collectors.toList());
+
+    List<Interval> computIntervals = new ArrayList<>();
+    final List<HighScoreSegmentFirstIterator.Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> tuple2s
+        = HighScoreSegmentFirstIterator.computeTimelineScore(
+        holders,
+        timeWeight,
+        recentDaysForTimeWeight,
+        segmentsNumWeight
+    );
+    tuple2s.forEach(t -> System.out.println(t._1 + "," + t._2.getInterval()));
+
+    tuple2s.forEach(t -> computIntervals.add(t._2.getInterval()));
+
+    Assert.assertEquals(ImmutableList.of(
+        Intervals.of("2021-01-01T00:00:00.000Z/2021-01-02T00:00:00.000Z"),
+        Intervals.of("2021-01-05T00:00:00.000Z/2021-01-06T00:00:00.000Z"),
+        Intervals.of("2021-01-03T00:00:00.000Z/2021-01-04T00:00:00.000Z")
+    ), computIntervals);
+  }
+
+
+  @Test
+  public void testIntervalScoreForMinorAndMajorCompaction()
+  {
+    final long inputSegmentSizeBytes = 8000000;
+    final VersionedIntervalTimeline<String, DataSegment> timeline = NewestSegmentFirstPolicyTest.createTimeline(
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2000-01-01T00:00:00/2000-01-02T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 10 + 1, // minor last
+            30
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2020-10-01T00:00:00/2020-10-02T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 10 + 1,
+            25
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-01T00:00:00/2021-01-02T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 8, // major first
+            25
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-03T00:00:00/2021-01-04T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 10 + 3,
+            2
+        )
+    );
+
+    List<Interval> searchInterval = new ArrayList<>();
+    searchInterval.add(Intervals.of("2000-01-01/2021-02-01"));
+    List<TimelineObjectHolder<String, DataSegment>> holders = searchInterval
+        .stream()
+        .flatMap(interval -> timeline
+            .lookup(interval)
+            .stream()
+            // 过滤掉interval下所有segment大小全为0的interval.
+            .filter(holder -> HighScoreSegmentFirstIterator.isCompactibleHolder(interval, holder))
+        )
+        .collect(Collectors.toList());
+
+    // minor compaction
+    List<Interval> computIntervals = new ArrayList<>();
+    final List<HighScoreSegmentFirstIterator.Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> tuple2s
+        = HighScoreSegmentFirstIterator.computeTimelineScore(
+        holders,
+        timeWeight,
+        recentDaysForTimeWeight,
+        segmentsNumWeight
+    );
+    tuple2s.forEach(t -> System.out.println(t._1 + "," + t._2.getInterval()));
+
+    tuple2s.forEach(t -> computIntervals.add(t._2.getInterval()));
+
+    Assert.assertEquals(Intervals.of("2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z"), computIntervals.get(0));
+
+    // major compaction
+    float majorTimeWeight = timeWeight * HighScoreSegmentFirstIterator.MAJOR_COMPACTION_IGNORE_TIME_LEVEL;
+    List<Interval> computIntervals2 = new ArrayList<>();
+    final List<HighScoreSegmentFirstIterator.Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> tuple2s2
+        = HighScoreSegmentFirstIterator.computeTimelineScore(
+        holders,
+        majorTimeWeight,
+        recentDaysForTimeWeight,
+        segmentsNumWeight
+    );
+    tuple2s2.forEach(t -> System.out.println(t._1 + "," + t._2.getInterval()));
+
+    tuple2s2.forEach(t -> computIntervals2.add(t._2.getInterval()));
+
+    Assert.assertEquals(Intervals.of("2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z"), computIntervals2.get(0));
+    Assert.assertEquals(
+        Intervals.of("2021-01-01T00:00:00.000Z/2021-01-02T00:00:00.000Z"),
+        computIntervals2.get(computIntervals2.size() - 1)
+    );
+  }
+
+  @Test
+  public void testHighScoreForLowTimePriority()
+  {
+    final float timeWeight = 0.1f;
+    List<Interval> computIntervals = computeIntervalList(timeWeight);
+
+    Assert.assertEquals(ImmutableList.of(
+        Intervals.of("2021-01-03T00:00:00.000Z/2021-01-04T00:00:00.000Z"),
+        Intervals.of("2021-01-02T00:00:00.000Z/2021-01-03T00:00:00.000Z"),
+        Intervals.of("2021-01-01T00:00:00.000Z/2021-01-02T00:00:00.000Z")
+    ), computIntervals);
+  }
+
+  @Test
+  public void testHighScoreForHighTimePriority()
+  {
+    final float timeWeight = 1f;
+    List<Interval> computIntervals = computeIntervalList(timeWeight);
+
+    Assert.assertEquals(ImmutableList.of(
+        Intervals.of("2021-01-01T00:00:00.000Z/2021-01-02T00:00:00.000Z"),
+        Intervals.of("2021-01-02T00:00:00.000Z/2021-01-03T00:00:00.000Z"),
+        Intervals.of("2021-01-03T00:00:00.000Z/2021-01-04T00:00:00.000Z")
+    ), computIntervals);
+  }
+
+  private List<Interval> computeIntervalList(float timeWeight)
+  {
+    final long inputSegmentSizeBytes = 8000000;
+    final VersionedIntervalTimeline<String, DataSegment> timeline = NewestSegmentFirstPolicyTest.createTimeline(
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-01T00:00:00/2021-01-02T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 10 + 1000,
+            20
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-02T00:00:00/2021-01-03T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 10 + 2000, // first
+            12
+        ),
+        new NewestSegmentFirstPolicyTest.SegmentGenerateSpec(
+            Intervals.of("2021-01-03T00:00:00/2021-01-04T00:00:00"),
+            new Period("P1D"),
+            inputSegmentSizeBytes / 10 + 3000,
+            2
+        )
+    );
+    List<Interval> searchInterval = new ArrayList<>();
+    searchInterval.add(Intervals.of("2021-01-01/2021-02-01"));
+    List<TimelineObjectHolder<String, DataSegment>> holders = searchInterval
+        .stream()
+        .flatMap(interval -> timeline
+            .lookup(interval)
+            .stream()
+            // 过滤掉interval下所有segment大小全为0的interval.
+            .filter(holder -> HighScoreSegmentFirstIterator.isCompactibleHolder(interval, holder))
+        )
+        .collect(Collectors.toList());
+
+    List<Interval> computIntervals = new ArrayList<>();
+    final List<HighScoreSegmentFirstIterator.Tuple2<Float, TimelineObjectHolder<String, DataSegment>>> tuple2s
+        = HighScoreSegmentFirstIterator.computeTimelineScore(
+        holders,
+        timeWeight,
+        recentDaysForTimeWeight,
+        segmentsNumWeight
+    );
+    tuple2s.forEach(t -> System.out.println(t._1 + "," + t._2.getInterval()));
+
+    tuple2s.forEach(t -> computIntervals.add(t._2.getInterval()));
+    return computIntervals;
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIteratorTest.java
@@ -90,11 +90,14 @@ public class NewestSegmentFirstIteratorTest
         null,
         null,
         null,
+        null,
+        true,
+        null,
         null
     );
     Assert.assertEquals(
         new DynamicPartitionsSpec(null, Long.MAX_VALUE),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -109,6 +112,9 @@ public class NewestSegmentFirstIteratorTest
         null,
         null,
         null,
+        null,
+        null,
+        true,
         new UserCompactionTaskQueryTuningConfig(
             null,
             null,
@@ -132,7 +138,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new DynamicPartitionsSpec(null, Long.MAX_VALUE),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -147,6 +153,9 @@ public class NewestSegmentFirstIteratorTest
         null,
         null,
         null,
+        null,
+        null,
+        true,
         new UserCompactionTaskQueryTuningConfig(
             null,
             null,
@@ -170,7 +179,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new DynamicPartitionsSpec(null, 1000L),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -181,6 +190,9 @@ public class NewestSegmentFirstIteratorTest
   {
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "datasource",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -208,7 +220,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new DynamicPartitionsSpec(100, 1000L),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -221,7 +233,10 @@ public class NewestSegmentFirstIteratorTest
         "datasource",
         null,
         null,
+        null,
+        null,
         100,
+        null,
         null,
         new UserCompactionTaskQueryTuningConfig(
             null,
@@ -246,7 +261,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new DynamicPartitionsSpec(100, 1000L),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -259,7 +274,10 @@ public class NewestSegmentFirstIteratorTest
         "datasource",
         null,
         null,
+        null,
+        null,
         100,
+        null,
         null,
         new UserCompactionTaskQueryTuningConfig(
             null,
@@ -284,7 +302,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new DynamicPartitionsSpec(null, Long.MAX_VALUE),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -295,6 +313,9 @@ public class NewestSegmentFirstIteratorTest
   {
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "datasource",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -322,7 +343,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new DynamicPartitionsSpec(null, Long.MAX_VALUE),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -333,6 +354,9 @@ public class NewestSegmentFirstIteratorTest
   {
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "datasource",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -360,7 +384,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new HashedPartitionsSpec(null, 10, ImmutableList.of("dim")),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );
@@ -371,6 +395,9 @@ public class NewestSegmentFirstIteratorTest
   {
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "datasource",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -398,7 +425,7 @@ public class NewestSegmentFirstIteratorTest
     );
     Assert.assertEquals(
         new SingleDimensionPartitionsSpec(10000, null, "dim", false),
-        NewestSegmentFirstIterator.findPartitinosSpecFromConfig(
+        CompactionSegmentIterator.findPartitinosSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment())
         )
     );


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
This PR mainly fixes scenes where delayed data reaches a relatively serious level, and the efficiency of auto-compact task is low. The details are as follows:
1. If a segment is smaller than `inputSegmentSizeBytes`, the segment size will be compact.In fact, we are more concerned with compact with multiple small files.
2. The coordinator timer resubmits compact from the latest interval every time. There may be a situation that the old interval cannot do compact all the time due to insufficient slots.
3. The Coordinator's timer submits in order from the latest interval to the oldest. Intervals submitted by the Coordinator may be blocked by a lock, and the Compact task that only applies the latest interval is more likely to block or fail and occupy a slot, we need to set `skipOffsetFromLatest` big enough, and it will waste recent many small files without compaction.
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Main change list:
1.add new policy for auto compaction.
[score](https://github.com/liuxiaohui1221/algorithm/blob/master/Codes/scorePolicy.png)
2.compactionTask not waiting.
3.compaction taskId changed
4.filter locked interval before submitted.
5.add some configuration parameters.

#### Renamed the class ...
#### Added a forbidden-apis entry ...
Added dynamic configuration parameters:
| dynamic configuration              | detail                                                       | default value |
| -------------------------- | ------------------------------------------------------------ | ------------- |
| enableFilterLockedInterval | whether or not filter locked interval before submitted,`false`/`true` | `false`       |
| minInputSegmentNum         | Compaction min input segments num                            | `1`           |
| minorCompactRecentDays     | minor compaction are first search recent days segments to compact. | `P5D`         |



Added coordination configuration parameters:
| coordinator configuration                     | detail                                                       | default value |
| --------------------------------------------- | ------------------------------------------------------------ | ------------- |
| druid.coordinator.period.autoCompactionPeriod | coordinator submit compactionTask period,it must smaller or equal than `druid.coordinator.period.indexingPeriod` | `PT30M`       |
| druid.coordinator.autoCompactionPolicy        | coordinator auto compaction iterator policy,`newest` or `score` | `newest`      |

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
