### PR TITLE
Allow for empty keys in hash map

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractionFnSerDeTest.java
+++ b/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractionFnSerDeTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.extraction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
 import org.junit.Assert;
@@ -39,7 +40,8 @@ public class MapLookupExtractionFnSerDeTest
   private static ObjectMapper mapper;
   private static final Map<String, String> RENAMES = ImmutableMap.of(
       "foo", "bar",
-      "bar", "baz"
+      "bar", "baz",
+      "", "empty"
   );
 
   @BeforeClass
@@ -51,6 +53,7 @@ public class MapLookupExtractionFnSerDeTest
   @Test
   public void testDeserialization() throws IOException
   {
+    NullHandling.initializeForTests();
     final DimExtractionFn fn = mapper.readerFor(DimExtractionFn.class).readValue(
         StringUtils.format(
             "{\"type\":\"lookup\",\"lookup\":{\"type\":\"map\", \"map\":%s}}",

--- a/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractionFnSerDeTest.java
+++ b/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractionFnSerDeTest.java
@@ -21,11 +21,8 @@ package org.apache.druid.query.extraction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import org.apache.druid.guice.GuiceInjectors;
-import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -48,8 +45,7 @@ public class MapLookupExtractionFnSerDeTest
   @BeforeClass
   public static void setup()
   {
-    Injector defaultInjector = GuiceInjectors.makeStartupInjector();
-    mapper = defaultInjector.getInstance(Key.get(ObjectMapper.class, Json.class));
+    mapper = TestHelper.makeJsonMapper();
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #10859.

There is also an alternate implementation as follows where we add following method to `GuiceAnnotationIntrospector` and remove `#findPropertyIgnorals`
```
  @Override
  public boolean hasIgnoreMarker(AnnotatedMember annotated)
  {
    return annotated.hasAnnotation(JacksonInject.class);
  }
```
Though, it will throw an exception if the user tries to pass input with values for properties that were annotated with JacksonInject. As opposed to the current world, where such erroneous input is silently ignored. 

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
