### PR TITLE
Exclude redundant jars from integration-tests build

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -90,6 +90,16 @@
             <artifactId>druid-orc-extensions</artifactId>
             <version>${project.parent.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.druid.extensions</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -92,10 +92,6 @@
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>com.squareup.okhttp</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>


### PR DESCRIPTION
Currently, we have multiple versions of `servlet-api` jars in the docker build and services can fail to come up depending on which version is picked first. 