### PR TITLE
Update dependency-check plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -639,7 +639,7 @@ jobs:
       stage: cron
       install: skip
       script: |-
-        ${MVN} dependency-check:aggregate || { echo "
+        ${MVN} dependency-check:aggregate -pl '!integration-tests' || { echo "
 
         The OWASP dependency check has found security vulnerabilities. Please use a newer version
         of the dependency that does not have vulnerabilities. To see a report run

--- a/.travis.yml
+++ b/.travis.yml
@@ -639,10 +639,12 @@ jobs:
       stage: cron
       install: skip
       script: |-
-        ${MVN} dependency-check:check || { echo "
+        ${MVN} dependency-check:aggregate || { echo "
 
         The OWASP dependency check has found security vulnerabilities. Please use a newer version
-        of the dependency that does not have vulnerabilities. If the analysis has false positives,
+        of the dependency that does not have vulnerabilities. To see a report run
+        `mvn dependency-check:check`
+        If the analysis has false positives,
         they can be suppressed by adding entries to owasp-dependency-check-suppressions.xml (for more
         information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).
 

--- a/pom.xml
+++ b/pom.xml
@@ -1570,9 +1570,8 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.3.2</version>
+                <version>6.0.3</version>
                 <configuration>
-                    <cveValidForHours>24</cveValidForHours>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
@@ -1580,9 +1579,13 @@
                     <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>  <!-- plugin author (jeremylong) recommends to disable, since this analyzer is retired -->
                     <nodeAuditSkipDevDependencies>true</nodeAuditSkipDevDependencies>
                     <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
+                    <inherited>false</inherited>
                 </configuration>
                 <executions>
                     <execution>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
                         <phase>none</phase>  <!-- TODO: Consider enabling so part of dev flow instead of just CI -->
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1571,6 +1571,7 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>6.0.3</version>
+                <inherited>false</inherited>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
@@ -1579,7 +1580,6 @@
                     <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>  <!-- plugin author (jeremylong) recommends to disable, since this analyzer is retired -->
                     <nodeAuditSkipDevDependencies>true</nodeAuditSkipDevDependencies>
                     <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
-                    <inherited>false</inherited>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
### Description

This PR aims to make the dependency-check job less flaky. It addresses intermittent failures with error messages like

`Failed to request component-reports`

This was inspired by the workaround suggested in https://github.com/jeremylong/DependencyCheck/issues/1908
Local testing appears to support the workaround mentioned in this issue.

The drawback of this approach is that the job will no longer produce a dependency vulnerability report - so if the job fails, devs need to run `mvn dependency-check:check` locally to see which project the vulnerability is reported from.

This PR also updates the version to the latest. The upgrade from 5.x to 6.x is a breaking change for some use cases, but AFAICT nothing was needed as part of the version upgrade.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.