### PR TITLE
Web console: remove namespace prop that does not exist from JDBC lookup

### DIFF
--- a/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
@@ -225,25 +225,6 @@ exports[`LookupEditDialog matches snapshot 1`] = `
           },
           Object {
             "defined": [Function],
-            "info": <React.Fragment>
-              <p>
-                The namespace value in the SQL query:
-              </p>
-              <p>
-                SELECT keyColumn, valueColumn, tsColumn? FROM 
-                <strong>
-                  namespace
-                </strong>
-                .table WHERE filter
-              </p>
-            </React.Fragment>,
-            "name": "extractionNamespace.namespace",
-            "placeholder": "some_lookup",
-            "required": true,
-            "type": "string",
-          },
-          Object {
-            "defined": [Function],
             "info": "Defines the connectURI value on the The connector config to used",
             "label": "Connect URI",
             "name": "extractionNamespace.connectorConfig.connectURI",

--- a/web-console/src/druid-models/lookup-spec.spec.ts
+++ b/web-console/src/druid-models/lookup-spec.spec.ts
@@ -235,36 +235,12 @@ describe('lookup-spec', () => {
     });
 
     describe('ExtractionNamespace type JDBC', () => {
-      it('No namespace', () => {
-        expect(
-          isLookupInvalid('lookup', 'v1', '__default', {
-            type: 'cachedNamespace',
-            extractionNamespace: {
-              type: 'jdbc',
-              namespace: undefined,
-              connectorConfig: {
-                createTables: true,
-                connectURI: 'jdbc:mysql://localhost:3306/druid',
-                user: 'druid',
-                password: 'diurd',
-              },
-              table: 'some_lookup_table',
-              keyColumn: 'the_old_dim_value',
-              valueColumn: 'the_new_dim_value',
-              tsColumn: 'timestamp_column',
-              pollPeriod: 600000,
-            },
-          }),
-        ).toBe(true);
-      });
-
       it('No connectorConfig', () => {
         expect(
           isLookupInvalid('lookup', 'v1', '__default', {
             type: 'cachedNamespace',
             extractionNamespace: {
               type: 'jdbc',
-              namespace: 'some_lookup',
               connectorConfig: undefined,
               table: 'some_lookup_table',
               keyColumn: 'the_old_dim_value',
@@ -282,7 +258,6 @@ describe('lookup-spec', () => {
             type: 'cachedNamespace',
             extractionNamespace: {
               type: 'jdbc',
-              namespace: 'some_lookup',
               connectorConfig: {
                 createTables: true,
                 connectURI: 'jdbc:mysql://localhost:3306/druid',
@@ -305,7 +280,6 @@ describe('lookup-spec', () => {
             type: 'cachedNamespace',
             extractionNamespace: {
               type: 'jdbc',
-              namespace: 'some_lookup',
               connectorConfig: {
                 createTables: true,
                 connectURI: 'jdbc:mysql://localhost:3306/druid',
@@ -322,13 +296,12 @@ describe('lookup-spec', () => {
         ).toBe(true);
       });
 
-      it('No keyColumn', () => {
+      it('No valueColumn', () => {
         expect(
           isLookupInvalid('lookup', 'v1', '__default', {
             type: 'cachedNamespace',
             extractionNamespace: {
               type: 'jdbc',
-              namespace: 'some_lookup',
               connectorConfig: {
                 createTables: true,
                 connectURI: 'jdbc:mysql://localhost:3306/druid',
@@ -428,13 +401,12 @@ describe('lookup-spec', () => {
     });
 
     describe('ExtractionNamespace type JDBC', () => {
-      it('No namespace', () => {
+      it('All good', () => {
         expect(
           isLookupInvalid('lookup', 'v1', '__default', {
             type: 'cachedNamespace',
             extractionNamespace: {
               type: 'jdbc',
-              namespace: 'lookup',
               connectorConfig: {
                 createTables: true,
                 connectURI: 'jdbc:mysql://localhost:3306/druid',

--- a/web-console/src/druid-models/lookup-spec.tsx
+++ b/web-console/src/druid-models/lookup-spec.tsx
@@ -28,7 +28,6 @@ export interface ExtractionNamespaceSpec {
   uriPrefix?: string;
   fileRegex?: string;
   namespaceParseSpec?: NamespaceParseSpec;
-  namespace?: string;
   connectorConfig?: {
     createTables: boolean;
     connectURI: string;
@@ -268,22 +267,6 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
   },
 
   // JDBC stuff
-  {
-    name: 'extractionNamespace.namespace',
-    type: 'string',
-    placeholder: 'some_lookup',
-    defined: (model: LookupSpec) => deepGet(model, 'extractionNamespace.type') === 'jdbc',
-    required: true,
-    info: (
-      <>
-        <p>The namespace value in the SQL query:</p>
-        <p>
-          SELECT keyColumn, valueColumn, tsColumn? FROM <strong>namespace</strong>.table WHERE
-          filter
-        </p>
-      </>
-    ),
-  },
   {
     name: 'extractionNamespace.connectorConfig.connectURI',
     label: 'Connect URI',


### PR DESCRIPTION
Turns out there is no `namespace` property in JDBC lookups. https://github.com/apache/druid/blob/753bce324bdf8c7c5b2b602f89c720749bfa6e22/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java#L41

Removing it to make the UI more accurate.