### PR TITLE
Fix maxBytesInMemory for heap overhead of all sinks and hydrants check

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -332,6 +332,51 @@ public class AppenderatorImpl implements Appenderator
       if (allowIncrementalPersists) {
         // persistAll clears rowsCurrentlyInMemory, no need to update it.
         log.info("Flushing in-memory data to disk because %s.", String.join(",", persistReasons));
+
+        long bytesInMemoryBeforePersist = bytesCurrentlyInMemory.get();
+        long bytesPersisted = 0L;
+        for (Map.Entry<SegmentIdWithShardSpec, Sink> entry : sinks.entrySet()) {
+          final Sink currentSink = entry.getValue();
+          if (currentSink != null) {
+            bytesPersisted += currentSink.getBytesInMemory();
+            if (currentSink.swappable()) {
+              // After swapping the sink, we use memory mapped segment instead. However, the memory mapped segment still consumes memory.
+              // These memory mapped segments are held in memory throughout the ingestion phase and permanently add to the bytesCurrentlyInMemory
+              int memoryStillInUse = calculateMMappedHydrantMemoryInUsed(currentSink.getCurrHydrant());
+              bytesInMemoryBeforePersist += memoryStillInUse;
+            }
+          }
+        }
+
+        log.info("bytesInMemoryBeforePersist=" + bytesInMemoryBeforePersist + " bytesPersisted=" + bytesPersisted);
+        // bytesCurrentlyInMemory can change while persisting due to concurrent ingestion.
+        // Hence, we use bytesInMemoryBeforePersist to determine the change of this persist
+        if (!skipBytesInMemoryOverheadCheck && bytesInMemoryBeforePersist - bytesPersisted > maxBytesTuningConfig) {
+          // We are still over maxBytesTuningConfig even after persisting.
+          // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
+          final String alertMessage = StringUtils.format(
+              "Task has exceeded safe estimated heap usage limits, failing "
+              + "(numSinks: [%d] numHydrantsAcrossAllSinks: [%d] totalRows: [%d])",
+              sinks.size(),
+              sinks.values().stream().mapToInt(Iterables::size).sum(),
+              getTotalRowCount()
+          );
+          final String errorMessage = StringUtils.format(
+              "%s.\nThis can occur when the overhead from too many intermediary segment persists becomes to "
+              + "great to have enough space to process additional input rows. This check, along with metering the overhead "
+              + "of these objects to factor into the 'maxBytesInMemory' computation, can be disabled by setting "
+              + "'skipBytesInMemoryOverheadCheck' to 'true' (note that doing so might allow the task to naturally encounter "
+              + "a 'java.lang.OutOfMemoryError'). Alternatively, 'maxBytesInMemory' can be increased which will cause an "
+              + "increase in heap footprint, but will allow for more intermediary segment persists to occur before "
+              + "reaching this condition.",
+              alertMessage
+          );
+          log.makeAlert(alertMessage)
+             .addData("dataSource", schema.getDataSource())
+             .emit();
+          throw new RuntimeException(errorMessage);
+        }
+
         Futures.addCallback(
             persistAll(committerSupplier == null ? null : committerSupplier.get()),
             new FutureCallback<Object>()
@@ -513,7 +558,6 @@ public class AppenderatorImpl implements Appenderator
   public ListenableFuture<Object> persistAll(@Nullable final Committer committer)
   {
     throwPersistErrorIfExists();
-    long bytesInMemoryBeforePersist = bytesCurrentlyInMemory.get();
     final Map<String, Integer> currentHydrants = new HashMap<>();
     final List<Pair<FireHydrant, SegmentIdWithShardSpec>> indexesToPersist = new ArrayList<>();
     int numPersistedRows = 0;
@@ -543,9 +587,7 @@ public class AppenderatorImpl implements Appenderator
         // These memory mapped segments are held in memory throughout the ingestion phase and permanently add to the bytesCurrentlyInMemory
         int memoryStillInUse = calculateMMappedHydrantMemoryInUsed(sink.getCurrHydrant());
         bytesCurrentlyInMemory.addAndGet(memoryStillInUse);
-
         indexesToPersist.add(Pair.of(sink.swap(), identifier));
-
       }
     }
 
@@ -638,33 +680,6 @@ public class AppenderatorImpl implements Appenderator
 
     log.info("Persisted rows[%,d] and bytes[%,d]", numPersistedRows, bytesPersisted);
 
-    // bytesCurrentlyInMemory can change while persisting due to concurrent ingestion.
-    // Hence, we use bytesInMemoryBeforePersist to determine the change of this persist
-    if (!skipBytesInMemoryOverheadCheck && bytesInMemoryBeforePersist - bytesPersisted > maxBytesTuningConfig) {
-      // We are still over maxBytesTuningConfig even after persisting.
-      // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
-      final String alertMessage = StringUtils.format(
-          "Task has exceeded safe estimated heap usage limits, failing "
-          + "(numSinks: [%d] numHydrantsAcrossAllSinks: [%d] totalRows: [%d])",
-          sinks.size(),
-          sinks.values().stream().mapToInt(Iterables::size).sum(),
-          getTotalRowCount()
-      );
-      final String errorMessage = StringUtils.format(
-          "%s.\nThis can occur when the overhead from too many intermediary segment persists becomes to "
-          + "great to have enough space to process additional input rows. This check, along with metering the overhead "
-          + "of these objects to factor into the 'maxBytesInMemory' computation, can be disabled by setting "
-          + "'skipBytesInMemoryOverheadCheck' to 'true' (note that doing so might allow the task to naturally encounter "
-          + "a 'java.lang.OutOfMemoryError'). Alternatively, 'maxBytesInMemory' can be increased which will cause an "
-          + "increase in heap footprint, but will allow for more intermediary segment persists to occur before "
-          + "reaching this condition.",
-          alertMessage
-      );
-      log.makeAlert(alertMessage)
-         .addData("dataSource", schema.getDataSource())
-         .emit();
-      throw new RuntimeException(errorMessage);
-    }
     return future;
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -332,6 +332,47 @@ public class AppenderatorImpl implements Appenderator
       if (allowIncrementalPersists) {
         // persistAll clears rowsCurrentlyInMemory, no need to update it.
         log.info("Flushing in-memory data to disk because %s.", String.join(",", persistReasons));
+
+        long bytesPersisted = 0L;
+        for (Map.Entry<SegmentIdWithShardSpec, Sink> entry : sinks.entrySet()) {
+          final Sink sinkEntry = entry.getValue();
+          if (sinkEntry != null) {
+            bytesPersisted += sinkEntry.getBytesInMemory();
+            if (sinkEntry.swappable()) {
+              // After swapping the sink, we use memory mapped segment instead. However, the memory mapped segment still consumes memory.
+              // These memory mapped segments are held in memory throughout the ingestion phase and permanently add to the bytesCurrentlyInMemory
+              int memoryStillInUse = calculateMMappedHydrantMemoryInUsed(sink.getCurrHydrant());
+              bytesCurrentlyInMemory.addAndGet(memoryStillInUse);
+            }
+          }
+        }
+
+        if (!skipBytesInMemoryOverheadCheck && bytesCurrentlyInMemory.get() - bytesPersisted > maxBytesTuningConfig) {
+          // We are still over maxBytesTuningConfig even after persisting.
+          // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
+          final String alertMessage = StringUtils.format(
+              "Task has exceeded safe estimated heap usage limits, failing "
+              + "(numSinks: [%d] numHydrantsAcrossAllSinks: [%d] totalRows: [%d])",
+              sinks.size(),
+              sinks.values().stream().mapToInt(Iterables::size).sum(),
+              getTotalRowCount()
+          );
+          final String errorMessage = StringUtils.format(
+              "%s.\nThis can occur when the overhead from too many intermediary segment persists becomes to "
+              + "great to have enough space to process additional input rows. This check, along with metering the overhead "
+              + "of these objects to factor into the 'maxBytesInMemory' computation, can be disabled by setting "
+              + "'skipBytesInMemoryOverheadCheck' to 'true' (note that doing so might allow the task to naturally encounter "
+              + "a 'java.lang.OutOfMemoryError'). Alternatively, 'maxBytesInMemory' can be increased which will cause an "
+              + "increase in heap footprint, but will allow for more intermediary segment persists to occur before "
+              + "reaching this condition.",
+              alertMessage
+          );
+          log.makeAlert(alertMessage)
+             .addData("dataSource", schema.getDataSource())
+             .emit();
+          throw new RuntimeException(errorMessage);
+        }
+
         Futures.addCallback(
             persistAll(committerSupplier == null ? null : committerSupplier.get()),
             new FutureCallback<Object>()
@@ -513,7 +554,6 @@ public class AppenderatorImpl implements Appenderator
   public ListenableFuture<Object> persistAll(@Nullable final Committer committer)
   {
     throwPersistErrorIfExists();
-    long bytesInMemoryBeforePersist = bytesCurrentlyInMemory.get();
     final Map<String, Integer> currentHydrants = new HashMap<>();
     final List<Pair<FireHydrant, SegmentIdWithShardSpec>> indexesToPersist = new ArrayList<>();
     int numPersistedRows = 0;
@@ -539,44 +579,9 @@ public class AppenderatorImpl implements Appenderator
       }
 
       if (sink.swappable()) {
-        // After swapping the sink, we use memory mapped segment instead. However, the memory mapped segment still consumes memory.
-        // These memory mapped segments are held in memory throughout the ingestion phase and permanently add to the bytesCurrentlyInMemory
-        int memoryStillInUse = calculateMMappedHydrantMemoryInUsed(sink.getCurrHydrant());
-        bytesCurrentlyInMemory.addAndGet(memoryStillInUse);
-        bytesInMemoryBeforePersist += memoryStillInUse;
         indexesToPersist.add(Pair.of(sink.swap(), identifier));
       }
     }
-
-    log.info("bytesInMemoryBeforePersist=" + bytesInMemoryBeforePersist + " bytesPersisted=" + bytesPersisted);
-    // bytesCurrentlyInMemory can change while persisting due to concurrent ingestion.
-    // Hence, we use bytesInMemoryBeforePersist to determine the change of this persist
-    if (!skipBytesInMemoryOverheadCheck && bytesInMemoryBeforePersist - bytesPersisted > maxBytesTuningConfig) {
-      // We are still over maxBytesTuningConfig even after persisting.
-      // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
-      final String alertMessage = StringUtils.format(
-          "Task has exceeded safe estimated heap usage limits, failing "
-          + "(numSinks: [%d] numHydrantsAcrossAllSinks: [%d] totalRows: [%d])",
-          sinks.size(),
-          sinks.values().stream().mapToInt(Iterables::size).sum(),
-          getTotalRowCount()
-      );
-      final String errorMessage = StringUtils.format(
-          "%s.\nThis can occur when the overhead from too many intermediary segment persists becomes to "
-          + "great to have enough space to process additional input rows. This check, along with metering the overhead "
-          + "of these objects to factor into the 'maxBytesInMemory' computation, can be disabled by setting "
-          + "'skipBytesInMemoryOverheadCheck' to 'true' (note that doing so might allow the task to naturally encounter "
-          + "a 'java.lang.OutOfMemoryError'). Alternatively, 'maxBytesInMemory' can be increased which will cause an "
-          + "increase in heap footprint, but will allow for more intermediary segment persists to occur before "
-          + "reaching this condition.",
-          alertMessage
-      );
-      log.makeAlert(alertMessage)
-         .addData("dataSource", schema.getDataSource())
-         .emit();
-      throw new RuntimeException(errorMessage);
-    }
-
     log.debug("Submitting persist runnable for dataSource[%s]", schema.getDataSource());
 
     final Object commitMetadata = committer == null ? null : committer.getMetadata();

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -332,51 +332,6 @@ public class AppenderatorImpl implements Appenderator
       if (allowIncrementalPersists) {
         // persistAll clears rowsCurrentlyInMemory, no need to update it.
         log.info("Flushing in-memory data to disk because %s.", String.join(",", persistReasons));
-
-        long bytesInMemoryBeforePersist = bytesCurrentlyInMemory.get();
-        long bytesPersisted = 0L;
-        for (Map.Entry<SegmentIdWithShardSpec, Sink> entry : sinks.entrySet()) {
-          final Sink currentSink = entry.getValue();
-          if (currentSink != null) {
-            bytesPersisted += currentSink.getBytesInMemory();
-            if (currentSink.swappable()) {
-              // After swapping the sink, we use memory mapped segment instead. However, the memory mapped segment still consumes memory.
-              // These memory mapped segments are held in memory throughout the ingestion phase and permanently add to the bytesCurrentlyInMemory
-              int memoryStillInUse = calculateMMappedHydrantMemoryInUsed(currentSink.getCurrHydrant());
-              bytesInMemoryBeforePersist += memoryStillInUse;
-            }
-          }
-        }
-
-        log.info("bytesInMemoryBeforePersist=" + bytesInMemoryBeforePersist + " bytesPersisted=" + bytesPersisted);
-        // bytesCurrentlyInMemory can change while persisting due to concurrent ingestion.
-        // Hence, we use bytesInMemoryBeforePersist to determine the change of this persist
-        if (!skipBytesInMemoryOverheadCheck && bytesInMemoryBeforePersist - bytesPersisted > maxBytesTuningConfig) {
-          // We are still over maxBytesTuningConfig even after persisting.
-          // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
-          final String alertMessage = StringUtils.format(
-              "Task has exceeded safe estimated heap usage limits, failing "
-              + "(numSinks: [%d] numHydrantsAcrossAllSinks: [%d] totalRows: [%d])",
-              sinks.size(),
-              sinks.values().stream().mapToInt(Iterables::size).sum(),
-              getTotalRowCount()
-          );
-          final String errorMessage = StringUtils.format(
-              "%s.\nThis can occur when the overhead from too many intermediary segment persists becomes to "
-              + "great to have enough space to process additional input rows. This check, along with metering the overhead "
-              + "of these objects to factor into the 'maxBytesInMemory' computation, can be disabled by setting "
-              + "'skipBytesInMemoryOverheadCheck' to 'true' (note that doing so might allow the task to naturally encounter "
-              + "a 'java.lang.OutOfMemoryError'). Alternatively, 'maxBytesInMemory' can be increased which will cause an "
-              + "increase in heap footprint, but will allow for more intermediary segment persists to occur before "
-              + "reaching this condition.",
-              alertMessage
-          );
-          log.makeAlert(alertMessage)
-             .addData("dataSource", schema.getDataSource())
-             .emit();
-          throw new RuntimeException(errorMessage);
-        }
-
         Futures.addCallback(
             persistAll(committerSupplier == null ? null : committerSupplier.get()),
             new FutureCallback<Object>()
@@ -558,6 +513,7 @@ public class AppenderatorImpl implements Appenderator
   public ListenableFuture<Object> persistAll(@Nullable final Committer committer)
   {
     throwPersistErrorIfExists();
+    long bytesInMemoryBeforePersist = bytesCurrentlyInMemory.get();
     final Map<String, Integer> currentHydrants = new HashMap<>();
     final List<Pair<FireHydrant, SegmentIdWithShardSpec>> indexesToPersist = new ArrayList<>();
     int numPersistedRows = 0;
@@ -587,8 +543,38 @@ public class AppenderatorImpl implements Appenderator
         // These memory mapped segments are held in memory throughout the ingestion phase and permanently add to the bytesCurrentlyInMemory
         int memoryStillInUse = calculateMMappedHydrantMemoryInUsed(sink.getCurrHydrant());
         bytesCurrentlyInMemory.addAndGet(memoryStillInUse);
+        bytesInMemoryBeforePersist += memoryStillInUse;
         indexesToPersist.add(Pair.of(sink.swap(), identifier));
       }
+    }
+
+    log.info("bytesInMemoryBeforePersist=" + bytesInMemoryBeforePersist + " bytesPersisted=" + bytesPersisted);
+    // bytesCurrentlyInMemory can change while persisting due to concurrent ingestion.
+    // Hence, we use bytesInMemoryBeforePersist to determine the change of this persist
+    if (!skipBytesInMemoryOverheadCheck && bytesInMemoryBeforePersist - bytesPersisted > maxBytesTuningConfig) {
+      // We are still over maxBytesTuningConfig even after persisting.
+      // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
+      final String alertMessage = StringUtils.format(
+          "Task has exceeded safe estimated heap usage limits, failing "
+          + "(numSinks: [%d] numHydrantsAcrossAllSinks: [%d] totalRows: [%d])",
+          sinks.size(),
+          sinks.values().stream().mapToInt(Iterables::size).sum(),
+          getTotalRowCount()
+      );
+      final String errorMessage = StringUtils.format(
+          "%s.\nThis can occur when the overhead from too many intermediary segment persists becomes to "
+          + "great to have enough space to process additional input rows. This check, along with metering the overhead "
+          + "of these objects to factor into the 'maxBytesInMemory' computation, can be disabled by setting "
+          + "'skipBytesInMemoryOverheadCheck' to 'true' (note that doing so might allow the task to naturally encounter "
+          + "a 'java.lang.OutOfMemoryError'). Alternatively, 'maxBytesInMemory' can be increased which will cause an "
+          + "increase in heap footprint, but will allow for more intermediary segment persists to occur before "
+          + "reaching this condition.",
+          alertMessage
+      );
+      log.makeAlert(alertMessage)
+         .addData("dataSource", schema.getDataSource())
+         .emit();
+      throw new RuntimeException(errorMessage);
     }
 
     log.debug("Submitting persist runnable for dataSource[%s]", schema.getDataSource());

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTest.java
@@ -257,7 +257,7 @@ public class AppenderatorTest extends InitializedNullHandlingTest
   @Test
   public void testMaxBytesInMemory() throws Exception
   {
-    try (final AppenderatorTester tester = new AppenderatorTester(100, 10000, true)) {
+    try (final AppenderatorTester tester = new AppenderatorTester(100, 15000, true)) {
       final Appenderator appenderator = tester.getAppenderator();
       final AtomicInteger eventCount = new AtomicInteger(0);
       final Supplier<Committer> committerSupplier = () -> {
@@ -297,7 +297,7 @@ public class AppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the same sink to cause persist.
-      for (int i = 0; i < 26; i++) {
+      for (int i = 0; i < 53; i++) {
         appenderator.add(IDENTIFIERS.get(0), ir("2000", "bar_" + i, 1), committerSupplier);
       }
       sinkSizeOverhead = 1 * AppenderatorImpl.ROUGH_OVERHEAD_PER_SINK;
@@ -333,7 +333,7 @@ public class AppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the same sink to cause persist.
-      for (int i = 0; i < 5; i++) {
+      for (int i = 0; i < 31; i++) {
         appenderator.add(IDENTIFIERS.get(0), ir("2000", "bar_" + i, 1), committerSupplier);
       }
       // currHydrant size is 0 since we just persist all indexes to disk.
@@ -363,7 +363,7 @@ public class AppenderatorTest extends InitializedNullHandlingTest
   @Test(expected = RuntimeException.class)
   public void testTaskFailAsPersistCannotFreeAnyMoreMemory() throws Exception
   {
-    try (final AppenderatorTester tester = new AppenderatorTester(100, 10, true)) {
+    try (final AppenderatorTester tester = new AppenderatorTester(100, 5180, true)) {
       final Appenderator appenderator = tester.getAppenderator();
       final AtomicInteger eventCount = new AtomicInteger(0);
       final Supplier<Committer> committerSupplier = () -> {


### PR DESCRIPTION
Fix maxBytesInMemory for heap overhead of sinks and hydrants check

### Description

There is currently two bugs with maxBytesInMemory for heap overhead of sinks and hydrants check.
The first bug is that the check for maxBytesInMemory for heap overhead of sinks and hydrants check is currently done instead the `persistAll` method. The `persistAll` method is done in the background and while the `persistAll` method is running, there could already be another concurrent in-memory ingestion. The new in-memory ingestion would use the old value of `bytesCurrentlyInMemory` without accounting for the heap overhead of sinks and hydrants from the latest persist (since we only calculate the heap overhead of sinks and hydrants in the `persistAll` method.
The second bug is that the memory overhead of sinks and hydrants check lags by one persist iteration. In each persist iteration the heap overhead of sinks and hydrants is calculated and store in a variable called bytesCurrentlyInMemory. However, bytesCurrentlyInMemory is only check against the limit in the next iteration of persist. This is because, in the current iteration we check against `bytesInMemoryBeforePersist` which is a copy of `bytesCurrentlyInMemory` at the start of the persist (not accounting for the heap overhead of sinks and hydrants in the current persist). Basically we will only fails the task one persist iteration after we have already reached the limit. Most of the time this is fine as our limit is below the real JVM memory capacity. However, for JVM memory that is set very low, this bug can results in OOM.  

This PR fixes both problem by moving the heap overhead of sinks and hydrants check outside of the `persistAll` method. It is now done before the background task `persistAll` method. This also eliminates the needs of `bytesInMemoryBeforePersist` variable. Hence, we can adds the heap overhead of sinks and hydrants to `bytesCurrentlyInMemory` and checks `bytesCurrentlyInMemory` before calling `persistAll` 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

