### PR TITLE
Web console: fix service view actions when grouping

### DIFF
--- a/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
+++ b/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
@@ -196,6 +196,7 @@ exports[`services view action services view 1`] = `
           "width": 400,
         },
         Object {
+          "Aggregated": [Function],
           "Cell": [Function],
           "Header": "Actions",
           "accessor": [Function],

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -552,12 +552,14 @@ ORDER BY "rank" DESC, "service" DESC`;
             width: ACTION_COLUMN_WIDTH,
             accessor: row => row.worker,
             filterable: false,
-            Cell: ({ value }) => {
+            Cell: ({ value, aggregated }) => {
+              if (aggregated) return '';
               if (!value) return null;
               const disabled = value.version === '';
               const workerActions = this.getWorkerActions(value.host, disabled);
               return <ActionCell actions={workerActions} />;
             },
+            Aggregated: () => '',
           },
         ]}
       />


### PR DESCRIPTION
Right now the service view crashes when you try to group services by Type or Tier.

This bug was introduced in https://github.com/apache/druid/pull/7770

![image](https://user-images.githubusercontent.com/177816/108290724-d7ac2f80-7145-11eb-99a4-2cf9a40a6837.png)

This fixes it by not trying to render the actions button for aggregated rows

![image](https://user-images.githubusercontent.com/177816/108290786-f4486780-7145-11eb-9031-83eaf5773c77.png)


