### PR TITLE
fix ClassCastException when finalize hyperUnique metric in sql

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
@@ -39,8 +39,8 @@ import java.util.Set;
  */
 public class HyperUniqueFinalizingPostAggregator implements PostAggregator
 {
-  private static final Comparator<Double> DOUBLE_COMPARATOR =
-      Ordering.from((Comparator<Double>) (lhs, rhs) -> Double.compare(lhs, rhs)).nullsFirst();
+  private static final Comparator<Number> NUMBER_COMPARATOR =
+      Ordering.from((Comparator<Number>) (lhs, rhs) -> Double.compare(lhs.doubleValue(), rhs.doubleValue())).nullsFirst();
 
   private final String name;
   private final String fieldName;
@@ -76,9 +76,9 @@ public class HyperUniqueFinalizingPostAggregator implements PostAggregator
   }
 
   @Override
-  public Comparator<Double> getComparator()
+  public Comparator<Number> getComparator()
   {
-    return DOUBLE_COMPARATOR;
+    return NUMBER_COMPARATOR;
   }
 
   @Override


### PR DESCRIPTION
### Description

for a sql like this
```sql
select count(1) as totalData
from  (
   select count(distinct unique_user_id) as uv
   from a_table
   group by city_name
   order by uv
) t
```
unique_user_id is hyperUnique metric.

java.lang.ClassCastException is thrown as
> java.lang.Long cannot be cast to java.lang.Double

The reason is that  `count(distinct unique_user_id)` is Long in row signature, but the comparator in `HyperUniqueFinalizingPostAggregator` is Double

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `HyperUniqueFinalizingPostAggregator`
