### PR TITLE
BoundDimFilter: Simplify the various DruidLongPredicates.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/BoundDimFilter.java
@@ -615,93 +615,25 @@ public class BoundDimFilter extends AbstractOptimizableDimFilter implements DimF
   {
     if (hasLowerLongBound && hasUpperLongBound) {
       if (upperStrict && lowerStrict) {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int lowerComparing = Long.compare(input, lowerLongBound);
-            final int upperComparing = Long.compare(upperLongBound, input);
-            return ((lowerComparing > 0)) && (upperComparing > 0);
-          }
-        };
+        return input -> input > lowerLongBound && input < upperLongBound;
       } else if (lowerStrict) {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int lowerComparing = Long.compare(input, lowerLongBound);
-            final int upperComparing = Long.compare(upperLongBound, input);
-            return (lowerComparing > 0) && (upperComparing >= 0);
-          }
-        };
+        return input -> input > lowerLongBound && input <= upperLongBound;
       } else if (upperStrict) {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int lowerComparing = Long.compare(input, lowerLongBound);
-            final int upperComparing = Long.compare(upperLongBound, input);
-            return (lowerComparing >= 0) && (upperComparing > 0);
-          }
-        };
+        return input -> input >= lowerLongBound && input < upperLongBound;
       } else {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int lowerComparing = Long.compare(input, lowerLongBound);
-            final int upperComparing = Long.compare(upperLongBound, input);
-            return (lowerComparing >= 0) && (upperComparing >= 0);
-          }
-        };
+        return input -> input >= lowerLongBound && input <= upperLongBound;
       }
     } else if (hasUpperLongBound) {
       if (upperStrict) {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int upperComparing = Long.compare(upperLongBound, input);
-            return upperComparing > 0;
-          }
-        };
+        return input -> input < upperLongBound;
       } else {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int upperComparing = Long.compare(upperLongBound, input);
-            return upperComparing >= 0;
-          }
-        };
+        return input -> input <= upperLongBound;
       }
     } else if (hasLowerLongBound) {
       if (lowerStrict) {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int lowerComparing = Long.compare(input, lowerLongBound);
-            return lowerComparing > 0;
-          }
-        };
+        return input -> input > lowerLongBound;
       } else {
-        return new DruidLongPredicate()
-        {
-          @Override
-          public boolean applyLong(long input)
-          {
-            final int lowerComparing = Long.compare(input, lowerLongBound);
-            return lowerComparing >= 0;
-          }
-        };
+        return input -> input >= lowerLongBound;
       }
     } else {
       return DruidLongPredicate.ALWAYS_TRUE;


### PR DESCRIPTION
They all use Long.compare, but they don't need to. Changing to
regular comparisons simplifies the code and also removes branches.
(Internally, Long.compare has two branches.)

I tried benchmarking before/after using query 6 of SqlBenchmark, and
the results were inconclusive as to whether removing the branches makes
a noticeable performance improvement. But, if nothing else, at least the
code is nicer.

```
master

Benchmark              (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt   Score   Error  Units
SqlBenchmark.querySql        6           1000000        force  avgt   15  25.176 ± 0.762  ms/op

patch

Benchmark              (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt   Score   Error  Units
SqlBenchmark.querySql        6           1000000        force  avgt   15  24.862 ± 0.610  ms/op
```