### PR TITLE
fix 'is not null' is invalid for array-type in druid-sql

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
@@ -241,7 +241,7 @@ public class Calcites
         -1
     );
 
-    return  typeFactory.createTypeWithNullability(dataType, nullable);
+    return typeFactory.createTypeWithNullability(dataType, nullable);
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
@@ -241,7 +241,7 @@ public class Calcites
         -1
     );
 
-    return dataType;
+    return  typeFactory.createTypeWithNullability(dataType, nullable);
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #10525 


### Description
Fix the bug : incorrect results (including nulls) when querying string-array column(let's say it's `col`) with col <> '' and col is not null 

Reason: When we use `is not null`  filter in SQL, Calcite will treat it  as `truefilter` through call stack as beflow:
`DruidPlanner.plan(final String sql) -> PlannerImpl.rel(SqlNode sql) ->SqlToRelConverter.convertQuery(SqlNode query, boolean needsValidation, boolean top) ->SqlToRelConverter.convertQueryRecursive(SqlNode query, boolean top, RelDataType targetRowType)->SqlToRelConverter.convertSelect(SqlSelect select, boolean top) -> SqlToRelConverter.convertSelectImpl(SqlToRelConverter.Blackboard bb, SqlSelect select) -> SqlToRelConverter.convertWhere(SqlToRelConverter.Blackboard bb, SqlNode where) -> RexCall.isAlwaysTrue()-> AbstractSqlType.isNullable()`

The last method `AbstractSqlType.isNullable()` will return false in our arrayColumnType. Because in the method `Calcites.createSqlArrayTypeWithNullability()`, we only specify `nullable` praram for elementType in arrayColumnType,
however, `typeFactory.createArrayType()` will invoke ` new ArraySqlType(elementType, false)` to return  a new RelDataType.
Thus, we will got  incorrect results (including nulls) when use `is not null`

Solution: support specify  `nullable` praram for  arrayColumnType

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.sql.calcite.planner.Calcites`
