### PR TITLE
Upgrade jetty to latest version

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1975,6 +1975,7 @@ libraries:
   - org.eclipse.jetty: jetty-servlet
   - org.eclipse.jetty: jetty-servlets
   - org.eclipse.jetty: jetty-util
+  - org.eclipse.jetty: jetty-util-ajax
 notice: |
   ==============================================================
    Jetty Web Container

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1962,7 +1962,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.34.v20201102
+version: 9.4.38.v20210224
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <jersey.version>1.19.3</jersey.version>
         <jackson.version>2.10.2</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>


### PR DESCRIPTION
Bumping up jetty to 9.4.38 which addresses the security vulnerability [CVE-2020-27223 ](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27223)