### PR TITLE
Add javadoc and test for Granularity configs in Compaction / Auto Compaction

### DIFF
--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskGranularitySpec.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionTaskGranularitySpec.java
@@ -22,9 +22,20 @@ package org.apache.druid.client.indexing;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.segment.indexing.granularity.GranularitySpec;
 
 import java.util.Objects;
 
+/**
+ * Spec containing Granularity configs for Compaction Task.
+ * This class mimics JSON field names for fields supported in compaction task with
+ * the corresponding fields in {@link GranularitySpec}.
+ * This is done for end-user ease of use. Basically, end-user will use the same syntax / JSON structure to set
+ * Granularity configs for Compaction task as they would for any other ingestion task.
+ * Note that this class is not the same as {@link GranularitySpec}. This class simply holds Granularity configs
+ * and use it to generate index task specs (Compaction task internally creates index task).
+ * This class does not do bucketing, group events or knows how to partition data.
+ */
 public class ClientCompactionTaskGranularitySpec
 {
   private final Granularity segmentGranularity;

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -333,11 +333,11 @@ public class AppenderatorImpl implements Appenderator
         // persistAll clears rowsCurrentlyInMemory, no need to update it.
         log.info("Flushing in-memory data to disk because %s.", String.join(",", persistReasons));
 
-        long bytesPersisted = 0L;
+        long bytesToBePersisted = 0L;
         for (Map.Entry<SegmentIdWithShardSpec, Sink> entry : sinks.entrySet()) {
           final Sink sinkEntry = entry.getValue();
           if (sinkEntry != null) {
-            bytesPersisted += sinkEntry.getBytesInMemory();
+            bytesToBePersisted += sinkEntry.getBytesInMemory();
             if (sinkEntry.swappable()) {
               // After swapping the sink, we use memory mapped segment instead. However, the memory mapped segment still consumes memory.
               // These memory mapped segments are held in memory throughout the ingestion phase and permanently add to the bytesCurrentlyInMemory
@@ -347,7 +347,7 @@ public class AppenderatorImpl implements Appenderator
           }
         }
 
-        if (!skipBytesInMemoryOverheadCheck && bytesCurrentlyInMemory.get() - bytesPersisted > maxBytesTuningConfig) {
+        if (!skipBytesInMemoryOverheadCheck && bytesCurrentlyInMemory.get() - bytesToBePersisted > maxBytesTuningConfig) {
           // We are still over maxBytesTuningConfig even after persisting.
           // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
           final String alertMessage = StringUtils.format(

--- a/server/src/main/java/org/apache/druid/server/coordinator/UserCompactionTaskGranularityConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/UserCompactionTaskGranularityConfig.java
@@ -22,9 +22,19 @@ package org.apache.druid.server.coordinator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.segment.indexing.granularity.GranularitySpec;
 
 import java.util.Objects;
 
+/**
+ * Spec containing Granularity configs for Auto Compaction.
+ * This class mimics JSON field names for fields supported in auto compaction with
+ * the corresponding fields in {@link GranularitySpec}.
+ * This is done for end-user ease of use. Basically, end-user will use the same syntax / JSON structure to set
+ * Granularity configs for Auto Compaction as they would for any other ingestion task.
+ * Note that this class is not the same as {@link GranularitySpec}. This class simply holds Granularity configs
+ * and pass it to compaction task spec. This class does not do bucketing, group events or knows how to partition data.
+ */
 public class UserCompactionTaskGranularityConfig
 {
   private final Granularity segmentGranularity;


### PR DESCRIPTION
Add javadoc and test for Granularity configs in Compaction / Auto Compaction

### Description

This is a followup to https://github.com/apache/druid/pull/10900
- Add javadocs
- Add tests
- Rename variables

Note that there is no functionality change in this PR

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [ ] been tested in a test Druid cluster.
