### PR TITLE
If ingested data has sparse columns, the ingested data with forceGuaranteedRollup=true can result in imperfect rollup and final dimension ordering can be different from dimensionSpec ordering in the ingestionSpec

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -609,7 +609,7 @@ public class IndexGeneratorJob implements Jobby
     {
       boolean rollup = config.getSchema().getDataSchema().getGranularitySpec().isRollup();
       return HadoopDruidIndexerConfig.INDEX_MERGER_V9
-          .mergeQueryableIndex(indexes, rollup, aggs, file, config.getIndexSpec(), progressIndicator, null, -1);
+          .mergeQueryableIndex(indexes, rollup, aggs, null, file, config.getIndexSpec(), progressIndicator, null, -1);
     }
 
     @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
@@ -329,7 +329,7 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec, P extends PartitionL
         });
       }
       if (maxNumSegmentsToMerge >= indexes.size()) {
-        dimensionNames = IndexMerger.getMergedDimensionsFromQueryableIndexes(indexesToMerge);
+        dimensionNames = IndexMerger.getMergedDimensionsFromQueryableIndexes(indexesToMerge, dataSchema.getDimensionsSpec());
       }
       final File outDir = new File(baseOutDir, StringUtils.format("merged_%d", suffix++));
       mergedFiles.add(

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
@@ -101,6 +101,20 @@ public abstract class AbstractIndexerTest
     unloadAndKillData(dataSource, first, last);
   }
 
+  protected void loadData(String indexTask, final String fullDatasourceName) throws Exception
+  {
+    String taskSpec = getResourceAsString(indexTask);
+    taskSpec = StringUtils.replace(taskSpec, "%%DATASOURCE%%", fullDatasourceName);
+    final String taskID = indexer.submitTask(taskSpec);
+    LOG.info("TaskID for loading index task %s", taskID);
+    indexer.waitUntilTaskCompletes(taskID);
+
+    ITRetryUtil.retryUntilTrue(
+        () -> coordinator.areSegmentsLoaded(fullDatasourceName),
+        "Segment Load"
+    );
+  }
+
   private void unloadAndKillData(final String dataSource, String start, String end)
   {
     // Wait for any existing index tasks to complete before disabling the datasource otherwise

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionSparseColumnTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionSparseColumnTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.tests.indexer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import org.apache.commons.io.IOUtils;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.testing.IntegrationTestingConfig;
+import org.apache.druid.testing.guice.DruidTestModuleFactory;
+import org.apache.druid.testing.utils.ITRetryUtil;
+import org.apache.druid.tests.TestNGGroup;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Test(groups = {TestNGGroup.COMPACTION, TestNGGroup.QUICKSTART_COMPATIBLE})
+@Guice(moduleFactory = DruidTestModuleFactory.class)
+public class ITCompactionSparseColumnTest extends AbstractIndexerTest
+{
+  private static final Logger LOG = new Logger(ITCompactionTaskTest.class);
+  private static final String INDEX_DATASOURCE = "sparse_column_index_test";
+
+  private static final String INDEX_TASK = "/indexer/sparse_column_index_task.json";
+  private static final String COMPACTION_QUERIES_RESOURCE = "/indexer/sparse_column_index_queries.json";
+
+  private static final String COMPACTION_TASK_WITHOUT_DIMENSION = "/indexer/sparse_column_without_dim_compaction_task.json";
+  private static final String COMPACTION_TASK_WITH_DIMENSION = "/indexer/sparse_column_with_dim_compaction_task.json";
+
+  @Inject
+  private IntegrationTestingConfig config;
+
+  private String fullDatasourceName;
+
+  @BeforeMethod
+  public void setFullDatasourceName(Method method)
+  {
+    fullDatasourceName = INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix() + "-" + method.getName();
+  }
+
+  @Test
+  public void testCompactionPerfectRollUpWithoutDimensionSpec() throws Exception
+  {
+    try (final Closeable ignored = unloader(fullDatasourceName)) {
+      // Load and verify initial data
+      loadAndVerifyDataWithSparseColumn(fullDatasourceName);
+      // Compaction with perfect roll up. Rolls with "X", "H" (for the first and second columns respectively) should be roll up
+      String template = getResourceAsString(COMPACTION_TASK_WITHOUT_DIMENSION);
+      template = StringUtils.replace(template, "%%DATASOURCE%%", fullDatasourceName);
+      final String taskID = indexer.submitTask(template);
+      indexer.waitUntilTaskCompletes(taskID);
+      ITRetryUtil.retryUntilTrue(
+          () -> coordinator.areSegmentsLoaded(fullDatasourceName),
+          "Segment Compaction"
+      );
+      // Verify compacted data
+      verifyCompactedData();
+    }
+  }
+
+  @Test
+  public void testCompactionPerfectRollUpWithLexicographicDimensionSpec() throws Exception
+  {
+    try (final Closeable ignored = unloader(fullDatasourceName)) {
+      // Load and verify initial data
+      loadAndVerifyDataWithSparseColumn(fullDatasourceName);
+      // Compaction with perfect roll up. Rolls with "X", "H" (for the first and second columns respectively) should be roll up
+      String template = getResourceAsString(COMPACTION_TASK_WITH_DIMENSION);
+      template = StringUtils.replace(template, "%%DATASOURCE%%", fullDatasourceName);
+      //
+      List<String> dimensionsOrder = ImmutableList.of("dimA", "dimB", "dimC");
+      template = StringUtils.replace(
+          template,
+          "%%DIMENSION_NAMES%%",
+          jsonMapper.writeValueAsString(dimensionsOrder)
+      );
+      final String taskID = indexer.submitTask(template);
+      indexer.waitUntilTaskCompletes(taskID);
+      ITRetryUtil.retryUntilTrue(
+          () -> coordinator.areSegmentsLoaded(fullDatasourceName),
+          "Segment Compaction"
+      );
+      // Verify compacted data
+      verifyCompactedData();
+    }
+  }
+
+  @Test
+  public void testCompactionPerfectRollUpWithNonLexicographicDimensionSpec() throws Exception
+  {
+    try (final Closeable ignored = unloader(fullDatasourceName)) {
+      // Load and verify initial data
+      loadAndVerifyDataWithSparseColumn(fullDatasourceName);
+      // Compaction with perfect roll up. Rolls with "X", "H" (for the first and second columns respectively) should be roll up
+      String template = getResourceAsString(COMPACTION_TASK_WITH_DIMENSION);
+      template = StringUtils.replace(template, "%%DATASOURCE%%", fullDatasourceName);
+      //
+      List<String> dimensionsOrder = ImmutableList.of("dimC", "dimB", "dimA");
+      template = StringUtils.replace(
+          template,
+          "%%DIMENSION_NAMES%%",
+          jsonMapper.writeValueAsString(dimensionsOrder)
+      );
+      final String taskID = indexer.submitTask(template);
+      indexer.waitUntilTaskCompletes(taskID);
+      ITRetryUtil.retryUntilTrue(
+          () -> coordinator.areSegmentsLoaded(fullDatasourceName),
+          "Segment Compaction"
+      );
+      // Verify compacted data
+      verifyCompactedData();
+    }
+  }
+
+  private void loadAndVerifyDataWithSparseColumn(String fullDatasourceName) throws Exception
+  {
+    loadData(INDEX_TASK, fullDatasourceName);
+    List<Map<String, List<List<Object>>>> expectedResultBeforeCompaction = new ArrayList<>();
+    // First segments have the following rows:
+    List<List<Object>> segment1Rows = ImmutableList.of(
+        ImmutableList.of(1442016000000L,"F","C",1,1),
+        ImmutableList.of(1442016000000L,"J","C",1,1),
+        ImmutableList.of(1442016000000L,"X","H",1,1)
+    );
+    expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment1Rows));
+    // Second segments have the following rows:
+    List<List<Object>> segment2Rows = ImmutableList.of(
+        ImmutableList.of(1442016000000L,"S","Z",1,1),
+        ImmutableList.of(1442016000000L,"X","H",1,1),
+        ImmutableList.of(1442016000000L,"Z","H",1,1)
+    );
+    expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment2Rows));
+    // Third segments have the following rows:
+    List<List<Object>> segment3Rows = ImmutableList.of(
+        ImmutableList.of(1442016000000L,"R","J",1,1),
+        ImmutableList.of(1442016000000L,"T","H",1,1),
+        ImmutableList.of(1442016000000L,"X","H",1,1)
+    );
+    expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment3Rows));
+    // Fourth segments have the following rows:
+    List<List<Object>> segment4Rows = ImmutableList.of(
+        ImmutableList.of(1442016000000L,"X","A",1,1)
+    );
+    expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment4Rows));
+    verifyQueryResult(expectedResultBeforeCompaction, 10, 10, 1);
+  }
+
+  private void verifyCompactedData() throws Exception
+  {
+    List<Map<String, List<List<Object>>>> expectedResultAfterCompaction = new ArrayList<>();
+    // Compacted data only have one segments. First segment have the following rows:
+    List<List<Object>> segment1Rows = ImmutableList.of(
+        Arrays.asList(1442016000000L, null, "X", "A", 1, 1),
+        Arrays.asList(1442016000000L, "C", "F", null, 1, 1),
+        Arrays.asList(1442016000000L, "C", "J", null, 1, 1),
+        Arrays.asList(1442016000000L, "H", "T", null, 1, 1),
+        Arrays.asList(1442016000000L, "H", "X", null, 3, 3),
+        Arrays.asList(1442016000000L, "H", "Z", null, 1, 1),
+        Arrays.asList(1442016000000L, "J", "R", null, 1, 1),
+        Arrays.asList(1442016000000L, "Z", "S", null, 1, 1)
+    );
+    expectedResultAfterCompaction.add(ImmutableMap.of("events", segment1Rows));
+    verifyQueryResult(expectedResultAfterCompaction, 8, 10, 0.8);
+  }
+
+  private void verifyQueryResult(
+      List<Map<String, List<List<Object>>>> expectedScanResult,
+      int expectedNumRoll,
+      int expectedSumCount,
+      double expectedRollupRatio
+  ) throws Exception
+  {
+    InputStream is = AbstractITBatchIndexTest.class.getResourceAsStream(COMPACTION_QUERIES_RESOURCE);
+    String queryResponseTemplate = IOUtils.toString(is, StandardCharsets.UTF_8);
+    queryResponseTemplate = StringUtils.replace(
+        queryResponseTemplate,
+        "%%DATASOURCE%%",
+        fullDatasourceName
+    );
+    queryResponseTemplate = StringUtils.replace(
+        queryResponseTemplate,
+        "%%EXPECTED_SCAN_RESULT%%",
+        jsonMapper.writeValueAsString(expectedScanResult)
+    );
+    queryResponseTemplate = StringUtils.replace(
+        queryResponseTemplate,
+        "%%EXPECTED_SUM_COUNT%%",
+        jsonMapper.writeValueAsString(expectedSumCount)
+    );
+    queryResponseTemplate = StringUtils.replace(
+        queryResponseTemplate,
+        "%%EXPECTED_ROLLUP_RATIO%%",
+        jsonMapper.writeValueAsString(expectedRollupRatio)
+    );
+    queryResponseTemplate = StringUtils.replace(
+        queryResponseTemplate,
+        "%%EXPECTED_NUM_ROW%%",
+        jsonMapper.writeValueAsString(expectedNumRoll)
+    );
+    queryHelper.testQueriesFromString(queryResponseTemplate);
+  }
+}

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionSparseColumnTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionSparseColumnTest.java
@@ -146,28 +146,28 @@ public class ITCompactionSparseColumnTest extends AbstractIndexerTest
     List<Map<String, List<List<Object>>>> expectedResultBeforeCompaction = new ArrayList<>();
     // First segments have the following rows:
     List<List<Object>> segment1Rows = ImmutableList.of(
-        ImmutableList.of(1442016000000L,"F","C",1,1),
-        ImmutableList.of(1442016000000L,"J","C",1,1),
-        ImmutableList.of(1442016000000L,"X","H",1,1)
+        ImmutableList.of(1442016000000L, "F", "C", 1, 1),
+        ImmutableList.of(1442016000000L, "J", "C", 1, 1),
+        ImmutableList.of(1442016000000L, "X", "H", 1, 1)
     );
     expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment1Rows));
     // Second segments have the following rows:
     List<List<Object>> segment2Rows = ImmutableList.of(
-        ImmutableList.of(1442016000000L,"S","Z",1,1),
-        ImmutableList.of(1442016000000L,"X","H",1,1),
-        ImmutableList.of(1442016000000L,"Z","H",1,1)
+        ImmutableList.of(1442016000000L, "S", "Z", 1, 1),
+        ImmutableList.of(1442016000000L, "X", "H", 1, 1),
+        ImmutableList.of(1442016000000L, "Z", "H", 1, 1)
     );
     expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment2Rows));
     // Third segments have the following rows:
     List<List<Object>> segment3Rows = ImmutableList.of(
-        ImmutableList.of(1442016000000L,"R","J",1,1),
-        ImmutableList.of(1442016000000L,"T","H",1,1),
-        ImmutableList.of(1442016000000L,"X","H",1,1)
+        ImmutableList.of(1442016000000L, "R", "J", 1, 1),
+        ImmutableList.of(1442016000000L, "T", "H", 1, 1),
+        ImmutableList.of(1442016000000L, "X", "H", 1, 1)
     );
     expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment3Rows));
     // Fourth segments have the following rows:
     List<List<Object>> segment4Rows = ImmutableList.of(
-        ImmutableList.of(1442016000000L,"X","A",1,1)
+        ImmutableList.of(1442016000000L, "X", "A", 1, 1)
     );
     expectedResultBeforeCompaction.add(ImmutableMap.of("events", segment4Rows));
     verifyQueryResult(expectedResultBeforeCompaction, 10, 10, 1);

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionSparseColumnTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionSparseColumnTest.java
@@ -82,7 +82,20 @@ public class ITCompactionSparseColumnTest extends AbstractIndexerTest
           "Segment Compaction"
       );
       // Verify compacted data
-      verifyCompactedData();
+      // Compacted data only have one segments. First segment have the following rows:
+      // The ordering of the columns will be "dimB", "dimA", "dimC" (This is the same as the ordering in the initial
+      // ingestion task)
+      List<List<Object>> segmentRows = ImmutableList.of(
+          Arrays.asList(1442016000000L, "F", null, "C", 1, 1),
+          Arrays.asList(1442016000000L, "J", null, "C", 1, 1),
+          Arrays.asList(1442016000000L, "R", null, "J", 1, 1),
+          Arrays.asList(1442016000000L, "S", null, "Z", 1, 1),
+          Arrays.asList(1442016000000L, "T", null, "H", 1, 1),
+          Arrays.asList(1442016000000L, "X", null, "H", 3, 3),
+          Arrays.asList(1442016000000L, "X", "A", null, 1, 1),
+          Arrays.asList(1442016000000L, "Z", null, "H", 1, 1)
+      );
+      verifyCompactedData(segmentRows);
     }
   }
 
@@ -109,7 +122,19 @@ public class ITCompactionSparseColumnTest extends AbstractIndexerTest
           "Segment Compaction"
       );
       // Verify compacted data
-      verifyCompactedData();
+      // Compacted data only have one segments. First segment have the following rows:
+      // The ordering of the columns will be "dimA", "dimB", "dimC"
+      List<List<Object>> segmentRows = ImmutableList.of(
+          Arrays.asList(1442016000000L, null, "X", "A", 1, 1),
+          Arrays.asList(1442016000000L, "C", "F", null, 1, 1),
+          Arrays.asList(1442016000000L, "C", "J", null, 1, 1),
+          Arrays.asList(1442016000000L, "H", "T", null, 1, 1),
+          Arrays.asList(1442016000000L, "H", "X", null, 3, 3),
+          Arrays.asList(1442016000000L, "H", "Z", null, 1, 1),
+          Arrays.asList(1442016000000L, "J", "R", null, 1, 1),
+          Arrays.asList(1442016000000L, "Z", "S", null, 1, 1)
+      );
+      verifyCompactedData(segmentRows);
     }
   }
 
@@ -136,7 +161,19 @@ public class ITCompactionSparseColumnTest extends AbstractIndexerTest
           "Segment Compaction"
       );
       // Verify compacted data
-      verifyCompactedData();
+      // Compacted data only have one segments. First segment have the following rows:
+      // The ordering of the columns will be "dimC", "dimB", "dimA"
+      List<List<Object>> segment1Rows = ImmutableList.of(
+          Arrays.asList(1442016000000L, null, "F", "C", 1, 1),
+          Arrays.asList(1442016000000L, null, "J", "C", 1, 1),
+          Arrays.asList(1442016000000L, null, "R", "J", 1, 1),
+          Arrays.asList(1442016000000L, null, "S", "Z", 1, 1),
+          Arrays.asList(1442016000000L, null, "T", "H", 1, 1),
+          Arrays.asList(1442016000000L, null, "X", "H", 3, 3),
+          Arrays.asList(1442016000000L, null, "Z", "H", 1, 1),
+          Arrays.asList(1442016000000L, "A", "X", null, 1, 1)
+      );
+      verifyCompactedData(segment1Rows);
     }
   }
 
@@ -173,21 +210,10 @@ public class ITCompactionSparseColumnTest extends AbstractIndexerTest
     verifyQueryResult(expectedResultBeforeCompaction, 10, 10, 1);
   }
 
-  private void verifyCompactedData() throws Exception
+  private void verifyCompactedData(List<List<Object>> segmentRows) throws Exception
   {
     List<Map<String, List<List<Object>>>> expectedResultAfterCompaction = new ArrayList<>();
-    // Compacted data only have one segments. First segment have the following rows:
-    List<List<Object>> segment1Rows = ImmutableList.of(
-        Arrays.asList(1442016000000L, null, "X", "A", 1, 1),
-        Arrays.asList(1442016000000L, "C", "F", null, 1, 1),
-        Arrays.asList(1442016000000L, "C", "J", null, 1, 1),
-        Arrays.asList(1442016000000L, "H", "T", null, 1, 1),
-        Arrays.asList(1442016000000L, "H", "X", null, 3, 3),
-        Arrays.asList(1442016000000L, "H", "Z", null, 1, 1),
-        Arrays.asList(1442016000000L, "J", "R", null, 1, 1),
-        Arrays.asList(1442016000000L, "Z", "S", null, 1, 1)
-    );
-    expectedResultAfterCompaction.add(ImmutableMap.of("events", segment1Rows));
+    expectedResultAfterCompaction.add(ImmutableMap.of("events", segmentRows));
     verifyQueryResult(expectedResultAfterCompaction, 8, 10, 0.8);
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
@@ -101,7 +101,7 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
   public void testCompactionWithQueryGranularityInGranularitySpec() throws Exception
   {
     try (final Closeable ignored = unloader(fullDatasourceName)) {
-      loadData(INDEX_TASK);
+      loadData(INDEX_TASK, fullDatasourceName);
       // 4 segments across 2 days
       checkNumberOfSegments(4);
       List<String> expectedIntervalAfterCompaction = coordinator.getSegmentIntervals(fullDatasourceName);
@@ -140,7 +140,7 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
   public void testCompactionWithSegmentGranularityAndQueryGranularityInGranularitySpec() throws Exception
   {
     try (final Closeable ignored = unloader(fullDatasourceName)) {
-      loadData(INDEX_TASK);
+      loadData(INDEX_TASK, fullDatasourceName);
       // 4 segments across 2 days
       checkNumberOfSegments(4);
       List<String> expectedIntervalAfterCompaction = coordinator.getSegmentIntervals(fullDatasourceName);
@@ -182,7 +182,7 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
   ) throws Exception
   {
     try (final Closeable ignored = unloader(fullDatasourceName)) {
-      loadData(indexTask);
+      loadData(indexTask, fullDatasourceName);
       // 4 segments across 2 days
       checkNumberOfSegments(4);
       List<String> expectedIntervalAfterCompaction = coordinator.getSegmentIntervals(fullDatasourceName);
@@ -209,20 +209,6 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
       }
       checkCompactionIntervals(expectedIntervalAfterCompaction);
     }
-  }
-
-  private void loadData(String indexTask) throws Exception
-  {
-    String taskSpec = getResourceAsString(indexTask);
-    taskSpec = StringUtils.replace(taskSpec, "%%DATASOURCE%%", fullDatasourceName);
-    final String taskID = indexer.submitTask(taskSpec);
-    LOG.info("TaskID for loading index task %s", taskID);
-    indexer.waitUntilTaskCompletes(taskID);
-
-    ITRetryUtil.retryUntilTrue(
-        () -> coordinator.areSegmentsLoaded(fullDatasourceName),
-        "Segment Load"
-    );
   }
 
   private void compactData(String compactionResource, GranularityType newSegmentGranularity, GranularityType newQueryGranularity) throws Exception

--- a/integration-tests/src/test/resources/indexer/sparse_column_index_queries.json
+++ b/integration-tests/src/test/resources/indexer/sparse_column_index_queries.json
@@ -1,0 +1,80 @@
+[
+  {
+    "description": "timeseries, 1 agg, all",
+    "query":{
+      "queryType" : "timeBoundary",
+      "dataSource": "%%DATASOURCE%%"
+    },
+    "expectedResults":[
+      {
+        "timestamp" : "2015-09-12T00:00:00.000Z",
+        "result" : {
+          "minTime" : "2015-09-12T00:00:00.000Z",
+          "maxTime" : "2015-09-12T00:00:00.000Z"
+        }
+      }
+    ]
+  },
+  {
+    "description": "scan, all",
+    "query": {
+      "queryType": "scan",
+      "dataSource": "%%DATASOURCE%%",
+      "intervals": [
+        "2013-01-01/2020-01-02"
+      ],
+      "resultFormat":"compactedList"
+    },
+    "expectedResults": %%EXPECTED_SCAN_RESULT%%,
+    "fieldsToTest": ["events"]
+  },
+  {
+    "description": "roll up ratio",
+    "query": {
+      "queryType":"timeseries",
+      "dataSource":{
+        "type":"table",
+        "name":"%%DATASOURCE%%"
+      },
+      "intervals":{
+        "type":"intervals",
+        "intervals":[
+          "2013-01-01/2020-01-02"
+        ]
+      },
+      "granularity":{
+        "type":"all"
+      },
+      "aggregations":[
+        {
+          "type":"count",
+          "name":"a0"
+        },
+        {
+          "type":"longSum",
+          "name":"a1",
+          "fieldName":"count",
+          "expression":null
+        }
+      ],
+      "postAggregations":[
+        {
+          "type":"expression",
+          "name":"p0",
+          "expression":"((\"a0\" * 1.00) / \"a1\")",
+          "ordering":null
+        }
+      ]
+    },
+    "expectedResults": [
+      {
+        "timestamp" : "2015-09-12T00:00:00.000Z",
+        "result" : {
+          "a1" : %%EXPECTED_SUM_COUNT%%,
+          "p0" : %%EXPECTED_ROLLUP_RATIO%%,
+          "a0" : %%EXPECTED_NUM_ROW%%
+        }
+      }
+    ]
+  }
+]

--- a/integration-tests/src/test/resources/indexer/sparse_column_index_task.json
+++ b/integration-tests/src/test/resources/indexer/sparse_column_index_task.json
@@ -1,0 +1,57 @@
+{
+  "type": "index_parallel",
+  "spec": {
+    "ioConfig": {
+      "type": "index_parallel",
+      "inputSource": {
+        "type": "inline",
+        "data": "{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"C\",\"dimB\":\"F\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"C\",\"dimB\":\"J\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"H\",\"dimB\":\"X\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"Z\",\"dimB\":\"S\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"H\",\"dimB\":\"X\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"H\",\"dimB\":\"Z\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"J\",\"dimB\":\"R\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"H\",\"dimB\":\"T\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimA\":\"H\",\"dimB\":\"X\",\"metA\":1}\n{\"time\":\"2015-09-12T00:46:58.771Z\",\"dimC\":\"A\",\"dimB\":\"X\",\"metA\":1}\n"
+      },
+      "inputFormat": {
+        "type": "json"
+      }
+    },
+    "tuningConfig": {
+      "type": "index_parallel",
+      "partitionsSpec": {
+        "type": "dynamic",
+        "maxRowsPerSegment": 3,
+        "maxTotalRows": 3
+      },
+      "maxRowsInMemory": 3
+    },
+    "dataSchema": {
+      "dataSource": "%%DATASOURCE%%",
+      "timestampSpec": {
+        "column": "time",
+        "format": "iso"
+      },
+      "dimensionsSpec": {
+        "dimensions": [
+          "dimB",
+          "dimA",
+          "dimC",
+          "dimD",
+          "dimE",
+          "dimF"
+        ]
+      },
+      "granularitySpec": {
+        "queryGranularity": "hour",
+        "rollup": true,
+        "segmentGranularity": "hour"
+      },
+      "metricsSpec": [
+        {
+          "name": "count",
+          "type": "count"
+        },
+        {
+          "name": "sum_metA",
+          "type": "longSum",
+          "fieldName": "metA"
+        }
+      ]
+    }
+  }
+}

--- a/integration-tests/src/test/resources/indexer/sparse_column_with_dim_compaction_task.json
+++ b/integration-tests/src/test/resources/indexer/sparse_column_with_dim_compaction_task.json
@@ -1,0 +1,19 @@
+{
+  "type": "compact",
+  "dataSource": "%%DATASOURCE%%",
+  "dimensionsSpec": {
+    "dimensions": %%DIMENSION_NAMES%%
+  },
+  "interval": "2010-10-29T05:00:00Z/2030-10-29T06:00:00Z",
+  "tuningConfig": {
+    "type": "index_parallel",
+    "maxRowsPerSegment": 3,
+    "maxRowsInMemory": 3,
+    "maxNumConcurrentSubTasks": 2,
+    "partitionsSpec": {
+      "type": "hashed",
+      "numShards": 1
+    },
+    "forceGuaranteedRollup": true
+  }
+}

--- a/integration-tests/src/test/resources/indexer/sparse_column_without_dim_compaction_task.json
+++ b/integration-tests/src/test/resources/indexer/sparse_column_without_dim_compaction_task.json
@@ -1,0 +1,16 @@
+{
+  "type": "compact",
+  "dataSource": "%%DATASOURCE%%",
+  "interval": "2010-10-29T05:00:00Z/2030-10-29T06:00:00Z",
+  "tuningConfig": {
+    "type": "index_parallel",
+    "maxRowsPerSegment": 3,
+    "maxRowsInMemory": 3,
+    "maxNumConcurrentSubTasks": 2,
+    "partitionsSpec": {
+      "type": "hashed",
+      "numShards": 1
+    },
+    "forceGuaranteedRollup": true
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
@@ -127,7 +127,7 @@ public interface IndexMerger
         log.info("Cannot fall back on dimension ordering from ingestionSpec as it does not exist");
         return null;
       }
-      List<String> candidate = dimensionsSpec.getDimensionNames();
+      List<String> candidate = new ArrayList<>(dimensionsSpec.getDimensionNames());
       // Remove all dimensions that does not exist within the indexes from the candidate
       Set<String> allValidDimensions = indexes.stream()
                                          .flatMap(indexableAdapter -> indexableAdapter.getDimensionNames().stream())

--- a/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
@@ -26,8 +26,10 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.PeekingIterator;
 import com.google.inject.ImplementedBy;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.utils.SerializerUtils;
+import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.java.util.common.ByteBufferUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
@@ -65,9 +67,12 @@ public interface IndexMerger
   int INVALID_ROW = -1;
   int UNLIMITED_MAX_COLUMNS_TO_MERGE = -1;
 
-  static List<String> getMergedDimensionsFromQueryableIndexes(List<QueryableIndex> indexes)
+  static List<String> getMergedDimensionsFromQueryableIndexes(
+      List<QueryableIndex> indexes,
+      @Nullable DimensionsSpec dimensionsSpec
+  )
   {
-    return getMergedDimensions(toIndexableAdapters(indexes));
+    return getMergedDimensions(toIndexableAdapters(indexes), dimensionsSpec);
   }
 
   static List<IndexableAdapter> toIndexableAdapters(List<QueryableIndex> indexes)
@@ -75,14 +80,18 @@ public interface IndexMerger
     return indexes.stream().map(QueryableIndexIndexableAdapter::new).collect(Collectors.toList());
   }
 
-  static List<String> getMergedDimensions(List<IndexableAdapter> indexes)
+  static List<String> getMergedDimensions(
+      List<IndexableAdapter> indexes,
+      @Nullable DimensionsSpec dimensionsSpec
+  )
   {
     if (indexes.size() == 0) {
       return ImmutableList.of();
     }
-    List<String> commonDimOrder = getLongestSharedDimOrder(indexes);
+    List<String> commonDimOrder = getLongestSharedDimOrder(indexes, dimensionsSpec);
     if (commonDimOrder == null) {
-      log.warn("Indexes have incompatible dimension orders, using lexicographic order.");
+      log.warn("Indexes have incompatible dimension orders and there is no valid dimension ordering"
+               + " in the ingestionSpec, using lexicographic order.");
       return getLexicographicMergedDimensions(indexes);
     } else {
       return commonDimOrder;
@@ -90,7 +99,10 @@ public interface IndexMerger
   }
 
   @Nullable
-  static List<String> getLongestSharedDimOrder(List<IndexableAdapter> indexes)
+  static List<String> getLongestSharedDimOrder(
+      List<IndexableAdapter> indexes,
+      @Nullable DimensionsSpec dimensionsSpec
+  )
   {
     int maxSize = 0;
     Iterable<String> orderingCandidate = null;
@@ -106,6 +118,41 @@ public interface IndexMerger
       return null;
     }
 
+    if (isDimensionOrderingValid(indexes, orderingCandidate)) {
+      return ImmutableList.copyOf(orderingCandidate);
+    } else {
+      log.info("Indexes have incompatible dimension orders, try falling back on dimension ordering from ingestionSpec");
+      // Check if there is a valid dimension ordering in the ingestionSpec to fall back on
+      if (dimensionsSpec == null || CollectionUtils.isEmpty(dimensionsSpec.getDimensionNames())) {
+        log.info("Cannot fall back on dimension ordering from ingestionSpec as it does not exist");
+        return null;
+      }
+        List<String> candidate = dimensionsSpec.getDimensionNames();
+        // Remove all dimensions that does not exist within the indexes from the candidate
+        Set<String> allValidDimensions = indexes.stream()
+                                           .flatMap(indexableAdapter -> indexableAdapter.getDimensionNames().stream())
+                                           .collect(Collectors.toSet());
+        candidate.retainAll(allValidDimensions);
+        // Sanity check that there is no extra/missing columns
+        if (candidate.size() != allValidDimensions.size()) {
+          log.error("Dimension mismatched between ingestionSpec and indexes. ingestionSpec[%s] indexes[%s]",
+                    candidate,
+                    allValidDimensions);
+          return null;
+        }
+
+        // Sanity check that all indexes dimension ordering is the same as the ordering in candidate
+        if (!isDimensionOrderingValid(indexes, candidate)) {
+          log.error("Dimension from ingestionSpec has invalid ordering");
+          return null;
+        }
+        log.info("Dimension ordering from ingestionSpec is valid. Fall back on dimension ordering [%s]", candidate);
+        return candidate;
+    }
+  }
+
+  static boolean isDimensionOrderingValid(List<IndexableAdapter> indexes, Iterable<String> orderingCandidate)
+  {
     for (IndexableAdapter index : indexes) {
       Iterator<String> candidateIter = orderingCandidate.iterator();
       for (String matchDim : index.getDimensionNames()) {
@@ -118,11 +165,11 @@ public interface IndexMerger
           }
         }
         if (!matched) {
-          return null;
+          return false;
         }
       }
     }
-    return ImmutableList.copyOf(orderingCandidate);
+    return true;
   }
 
   static List<String> getLexicographicMergedDimensions(List<IndexableAdapter> indexes)
@@ -205,6 +252,18 @@ public interface IndexMerger
       List<QueryableIndex> indexes,
       boolean rollup,
       AggregatorFactory[] metricAggs,
+      @Nullable DimensionsSpec dimensionsSpec,
+      File outDir,
+      IndexSpec indexSpec,
+      @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+      int maxColumnsToMerge
+  ) throws IOException;
+
+  File mergeQueryableIndex(
+      List<QueryableIndex> indexes,
+      boolean rollup,
+      AggregatorFactory[] metricAggs,
+      @Nullable DimensionsSpec dimensionsSpec,
       File outDir,
       IndexSpec indexSpec,
       ProgressIndicator progress,

--- a/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
@@ -127,27 +127,27 @@ public interface IndexMerger
         log.info("Cannot fall back on dimension ordering from ingestionSpec as it does not exist");
         return null;
       }
-        List<String> candidate = dimensionsSpec.getDimensionNames();
-        // Remove all dimensions that does not exist within the indexes from the candidate
-        Set<String> allValidDimensions = indexes.stream()
-                                           .flatMap(indexableAdapter -> indexableAdapter.getDimensionNames().stream())
-                                           .collect(Collectors.toSet());
-        candidate.retainAll(allValidDimensions);
-        // Sanity check that there is no extra/missing columns
-        if (candidate.size() != allValidDimensions.size()) {
-          log.error("Dimension mismatched between ingestionSpec and indexes. ingestionSpec[%s] indexes[%s]",
-                    candidate,
-                    allValidDimensions);
-          return null;
-        }
+      List<String> candidate = dimensionsSpec.getDimensionNames();
+      // Remove all dimensions that does not exist within the indexes from the candidate
+      Set<String> allValidDimensions = indexes.stream()
+                                         .flatMap(indexableAdapter -> indexableAdapter.getDimensionNames().stream())
+                                         .collect(Collectors.toSet());
+      candidate.retainAll(allValidDimensions);
+      // Sanity check that there is no extra/missing columns
+      if (candidate.size() != allValidDimensions.size()) {
+        log.error("Dimension mismatched between ingestionSpec and indexes. ingestionSpec[%s] indexes[%s]",
+                  candidate,
+                  allValidDimensions);
+        return null;
+      }
 
-        // Sanity check that all indexes dimension ordering is the same as the ordering in candidate
-        if (!isDimensionOrderingValid(indexes, candidate)) {
-          log.error("Dimension from ingestionSpec has invalid ordering");
-          return null;
-        }
-        log.info("Dimension ordering from ingestionSpec is valid. Fall back on dimension ordering [%s]", candidate);
-        return candidate;
+      // Sanity check that all indexes dimension ordering is the same as the ordering in candidate
+      if (!isDimensionOrderingValid(indexes, candidate)) {
+        log.error("Dimension from ingestionSpec has invalid ordering");
+        return null;
+      }
+      log.info("Dimension ordering from ingestionSpec is valid. Fall back on dimension ordering [%s]", candidate);
+      return candidate;
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.PeekingIterator;
 import com.google.inject.ImplementedBy;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.utils.SerializerUtils;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -40,6 +39,7 @@ import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -123,7 +123,7 @@ public interface IndexMerger
     } else {
       log.info("Indexes have incompatible dimension orders, try falling back on dimension ordering from ingestionSpec");
       // Check if there is a valid dimension ordering in the ingestionSpec to fall back on
-      if (dimensionsSpec == null || CollectionUtils.isEmpty(dimensionsSpec.getDimensionNames())) {
+      if (dimensionsSpec == null || CollectionUtils.isNullOrEmpty(dimensionsSpec.getDimensionNames())) {
         log.info("Cannot fall back on dimension ordering from ingestionSpec as it does not exist");
         return null;
       }

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
@@ -24,10 +24,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.ListIndexed;
 import org.joda.time.Interval;
+import org.joda.time.chrono.ISOChronology;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,7 +57,7 @@ public class IndexMergerLongestSharedDimOrderTest
   BitmapFactory mockBitmapFactory;
 
   @Before
-  public void setUp() throws Exception
+  public void setUp()
   {
     when(mockSupplier.get()).thenReturn(mockColumnHolder);
     // This value does not matter
@@ -160,7 +162,7 @@ public class IndexMergerLongestSharedDimOrderTest
   {
     return new QueryableIndexIndexableAdapter(
         new SimpleQueryableIndex(
-            new Interval("2012-01-01/2012-01-02"),
+            new Interval("2012-01-01/2012-01-02", ISOChronology.getInstance(DateTimes.inferTzFromString("America/Los_Angeles"))),
             new ListIndexed<>(dimensions),
             mockBitmapFactory,
             ImmutableMap.of(ColumnHolder.TIME_COLUMN_NAME, mockSupplier),

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.data.ListIndexed;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IndexMergerLongestSharedDimOrderTest
+{
+  @Mock
+  Supplier<ColumnHolder> mockSupplier;
+
+  @Mock
+  ColumnHolder mockColumnHolder;
+
+  @Mock
+  SmooshedFileMapper mockSmooshedFileMapper;
+
+  @Mock
+  BitmapFactory mockBitmapFactory;
+
+  @Before
+  public void setUp() throws Exception
+  {
+      when(mockSupplier.get()).thenReturn(mockColumnHolder);
+      // This value does not matter
+      when(mockColumnHolder.getLength()).thenReturn(1);
+  }
+
+  @Test
+  public void testGetLongestSharedDimOrderWithNullDimensionSpecAndEmptyIndex()
+  {
+    List<String> actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(), null);
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void testGetLongestSharedDimOrderWithNullDimensionSpecAndValidOrdering()
+  {
+    QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
+    QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("b", "c"));
+    List<String> actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), null);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(ImmutableList.of("a", "b", "c"), actual);
+
+    //  Valid ordering as although second index has gap, it is still same ordering
+    index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
+    index2 = makeIndexWithDimensionList(ImmutableList.of("a", "c"));
+    actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), null);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(ImmutableList.of("a", "b", "c"), actual);
+  }
+
+  @Test
+  public void testGetLongestSharedDimOrderWithNullDimensionSpecAndNoValidOrdering()
+  {
+    // No valid ordering as no index as all three dimensions
+    QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b"));
+    QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("b", "c"));
+    List<String> actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), null);
+    Assert.assertNull(actual);
+
+    //  No valid ordering as ordering is not the same in all indexes
+    index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
+    index2 = makeIndexWithDimensionList(ImmutableList.of("c", "b"));
+    actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), null);
+    Assert.assertNull(actual);
+  }
+
+
+  @Test
+  public void testGetLongestSharedDimOrderWithSchemalessDimensionSpecAndNoValidOrdering()
+  {
+    DimensionsSpec empty = new DimensionsSpec(ImmutableList.of());
+    // No valid ordering as no index as all three dimensions
+    QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b"));
+    QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("b", "c"));
+    List<String> actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), empty);
+    Assert.assertNull(actual);
+
+    //  No valid ordering as ordering is not the same in all indexes
+    index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
+    index2 = makeIndexWithDimensionList(ImmutableList.of("c", "b"));
+    actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), empty);
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void testGetLongestSharedDimOrderWithValidSchemaDimensionSpecAndNoValidOrdering()
+  {
+    DimensionsSpec valid = new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("a", "b", "c")));
+    // No valid ordering as no index has all three dimensions
+    QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b"));
+    QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("b", "c"));
+    List<String> actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), valid);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(ImmutableList.of("a", "b", "c"), actual);
+  }
+
+  @Test
+  public void testGetLongestSharedDimOrderWithInvalidSchemaDimensionSpecAndNoValidOrdering()
+  {
+    DimensionsSpec valid = new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("a", "b", "c")));
+    //  No valid ordering as ordering is not the same in all indexes
+    QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
+    QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("c", "b"));
+    List<String>  actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), valid);
+    // Since ordering of index2 is not the same as the ordering of the schema in DimensionSpec
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void testGetLongestSharedDimOrderWithValidSchemaDimensionSpecAndInvalidOrdering()
+  {
+    DimensionsSpec valid = new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("a", "b", "c")));
+    //  No valid ordering as ordering is not the same in all indexes
+    QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
+    QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("c", "b", "e"));
+    List<String>  actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), valid);
+    // Since index2 has dimension that is not in the schema in DimensionSpec. This should not be possible.
+    Assert.assertNull(actual);
+  }
+
+  private QueryableIndexIndexableAdapter makeIndexWithDimensionList(List<String> dimensions) {
+    return new QueryableIndexIndexableAdapter(
+        new SimpleQueryableIndex(
+            new Interval("2012-01-01/2012-01-02"),
+            new ListIndexed<>(dimensions),
+            mockBitmapFactory,
+            ImmutableMap.of(ColumnHolder.TIME_COLUMN_NAME, mockSupplier),
+            mockSmooshedFileMapper,
+            null,
+            true
+        )
+    );
+  }
+}
+
+

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
@@ -57,9 +57,9 @@ public class IndexMergerLongestSharedDimOrderTest
   @Before
   public void setUp() throws Exception
   {
-      when(mockSupplier.get()).thenReturn(mockColumnHolder);
-      // This value does not matter
-      when(mockColumnHolder.getLength()).thenReturn(1);
+    when(mockSupplier.get()).thenReturn(mockColumnHolder);
+    // This value does not matter
+    when(mockColumnHolder.getLength()).thenReturn(1);
   }
 
   @Test
@@ -139,7 +139,7 @@ public class IndexMergerLongestSharedDimOrderTest
     //  No valid ordering as ordering is not the same in all indexes
     QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
     QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("c", "b"));
-    List<String>  actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), valid);
+    List<String> actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), valid);
     // Since ordering of index2 is not the same as the ordering of the schema in DimensionSpec
     Assert.assertNull(actual);
   }
@@ -151,12 +151,13 @@ public class IndexMergerLongestSharedDimOrderTest
     //  No valid ordering as ordering is not the same in all indexes
     QueryableIndexIndexableAdapter index1 = makeIndexWithDimensionList(ImmutableList.of("a", "b", "c"));
     QueryableIndexIndexableAdapter index2 = makeIndexWithDimensionList(ImmutableList.of("c", "b", "e"));
-    List<String>  actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), valid);
+    List<String> actual = IndexMerger.getLongestSharedDimOrder(ImmutableList.of(index1, index2), valid);
     // Since index2 has dimension that is not in the schema in DimensionSpec. This should not be possible.
     Assert.assertNull(actual);
   }
 
-  private QueryableIndexIndexableAdapter makeIndexWithDimensionList(List<String> dimensions) {
+  private QueryableIndexIndexableAdapter makeIndexWithDimensionList(List<String> dimensions)
+  {
     return new QueryableIndexIndexableAdapter(
         new SimpleQueryableIndex(
             new Interval("2012-01-01/2012-01-02"),

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -824,6 +824,7 @@ public class AppenderatorImpl implements Appenderator
             indexes,
             schema.getGranularitySpec().isRollup(),
             schema.getAggregators(),
+            schema.getDimensionsSpec(),
             mergedTarget,
             tuningConfig.getIndexSpec(),
             tuningConfig.getSegmentWriteOutMediumFactory(),
@@ -848,7 +849,7 @@ public class AppenderatorImpl implements Appenderator
           // semantics.
           () -> dataSegmentPusher.push(
               mergedFile,
-              sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes)),
+              sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes, schema.getDimensionsSpec())),
               useUniquePath
           ),
           exception -> exception instanceof Exception,

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
@@ -30,6 +30,7 @@ import com.google.inject.Provider;
 import org.apache.druid.client.cache.Cache;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.client.cache.CachePopulatorStats;
+import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.guice.annotations.Processing;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
@@ -656,6 +657,22 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
         List<QueryableIndex> indexes,
         boolean rollup,
         AggregatorFactory[] metricAggs,
+        File outDir,
+        IndexSpec indexSpec,
+        ProgressIndicator progress,
+        @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+        int maxColumnsToMerge
+    )
+    {
+      throw new UOE(ERROR_MSG);
+    }
+
+    @Override
+    public File mergeQueryableIndex(
+        List<QueryableIndex> indexes,
+        boolean rollup,
+        AggregatorFactory[] metricAggs,
+        DimensionsSpec dimensionsSpec,
         File outDir,
         IndexSpec indexSpec,
         ProgressIndicator progress,

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
@@ -657,9 +657,9 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
         List<QueryableIndex> indexes,
         boolean rollup,
         AggregatorFactory[] metricAggs,
+        @Nullable DimensionsSpec dimensionsSpec,
         File outDir,
         IndexSpec indexSpec,
-        ProgressIndicator progress,
         @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
         int maxColumnsToMerge
     )
@@ -672,7 +672,7 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
         List<QueryableIndex> indexes,
         boolean rollup,
         AggregatorFactory[] metricAggs,
-        DimensionsSpec dimensionsSpec,
+        @Nullable DimensionsSpec dimensionsSpec,
         File outDir,
         IndexSpec indexSpec,
         ProgressIndicator progress,

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
@@ -522,6 +522,30 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
         int maxColumnsToMerge
     )
     {
+      return mergeQueryableIndex(
+          indexes,
+          rollup,
+          metricAggs,
+          null,
+          outDir,
+          indexSpec,
+          segmentWriteOutMediumFactory,
+          maxColumnsToMerge
+      );
+    }
+
+    @Override
+    public File mergeQueryableIndex(
+        List<QueryableIndex> indexes,
+        boolean rollup,
+        AggregatorFactory[] metricAggs,
+        @Nullable DimensionsSpec dimensionsSpec,
+        File outDir,
+        IndexSpec indexSpec,
+        @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+        int maxColumnsToMerge
+    )
+    {
       ListenableFuture<File> mergeFuture = mergeExecutor.submit(
           new Callable<File>()
           {
@@ -533,6 +557,7 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
                     indexes,
                     rollup,
                     metricAggs,
+                    dimensionsSpec,
                     outDir,
                     indexSpec,
                     segmentWriteOutMediumFactory,
@@ -647,21 +672,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
         IndexSpec indexSpec,
         ProgressIndicator progress,
         @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
-    )
-    {
-      throw new UOE(ERROR_MSG);
-    }
-
-    @Override
-    public File mergeQueryableIndex(
-        List<QueryableIndex> indexes,
-        boolean rollup,
-        AggregatorFactory[] metricAggs,
-        @Nullable DimensionsSpec dimensionsSpec,
-        File outDir,
-        IndexSpec indexSpec,
-        @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
-        int maxColumnsToMerge
     )
     {
       throw new UOE(ERROR_MSG);

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -456,7 +456,7 @@ public class RealtimePlumber implements Plumber
 
               DataSegment segment = dataSegmentPusher.push(
                   mergedFile,
-                  sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes)),
+                  sink.getSegment().withDimensions(IndexMerger.getMergedDimensionsFromQueryableIndexes(indexes, schema.getDimensionsSpec())),
                   false
               );
               log.info("Inserting [%s] to the metadata store", sink.getSegment().getId());


### PR DESCRIPTION
If ingested data has sparse columns, the ingested data with forceGuaranteedRollup=true can result in imperfect rollup and final dimension ordering can be different from dimensionSpec ordering in the ingestionSpec

### Description

**When does this problem happens:**

This can happens when we have sparse columns in the input data and a dimensionsSpec with dimension ordering that is not lexicographic. Note that this isn’t limited to Compaction but can also occurs in initial batch ingestion of data (index task).

**Root cause:**

This bug occurs when all the dimensions in the intermediate segments does not have a common shared dimension ordering. 

For example, if the dimensions of my data are “dimA”, “dimB” and “dimC”, where both “dimA” and “dimC” are sparse. During ingestion, the following intermediate segments are created:

intermediate segment 1 has column “dimA” and “dimB”. It does not have “dimC” since “dimC” is sparse and does not exist in any rows of intermediate segment 1.

intermediate segment 2 has column “dimB” and “dimC”. It does not have “dimA” since “dimA” is sparse and does not exist in any rows of intermediate segment 2.

When we try to merge all the intermediate segments, we will not be able to find a shared common dimensions across all the intermediate segments (there is no intermediate segment with all “dimA”, “dimB” and “dimC” in it’s index. The current behavior would then fall back into merging all the intermediate segments with a lexicographic ordering of all the dimensions. The final merged segment will have the lexicographic ordering. This can be different than the dimension specified in the ingestionSpec if the dimension specified is not lexicographic ordering.

**How this impact user:**

**Impact 1: Segment size.** When a user specify a dimenionsSpec with ordering of dimension in the ingestionSpec, the ingestion task should creates segments with that ordering. The ordering matters as it impacts the segment size. Since this bug will results in a final segment with lexicographic ordering despite a dimenionsSpec (with ordering of dimension) in the ingestionSpec. 

**Impact 2: Roll up**. When a user specify forceGuaranteedRollup=true (with hash or single dim partitioning), the user expects perfect rollup. If a dimenionsSpec (with ordering of dimension) in the ingestionSpec is specified, that ordering is used to create the intermediate segments. However, because of this bug, the merging of all the intermediate segments would be done with a different ordering (lexicographic) assuming that the ordering in dimenionsSpec is not also lexicographic. This would result in imperfect roll up.

**More detailed example + walkthrough of how the bug occurs:**

Let’s say this is our input data

```
{"time":"2015-09-12T00:46:58.771Z","dimA":"C","dimB":"F","metA":1}
{"time":"2015-09-12T00:46:58.771Z","dimA":"C","dimB":"J","metA":1}
{"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"X","metA":1} **
{"time":"2015-09-12T00:46:58.771Z","dimA":"Z","dimB":"S","metA":1}
{"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"X","metA":1} **
{"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"Z","metA":1}
{"time":"2015-09-12T00:46:58.771Z","dimA":"J","dimB":"R","metA":1}
{"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"T","metA":1}
{"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"X","metA":1} **
{"time":"2015-09-12T00:46:58.771Z","dimC":"A","dimB":"X","metA":1}
```
The `**` denotes row that should be roll up together.

Now we will ingest/compact this with `dimB, dimA, dimC` order in the dimensionsSpec. 

Now lets say that the intermediate segments generated are:  

```
Segment 1: {"time":"2015-09-12T00:46:58.771Z","dimA":"C","dimB":"F","metA":1}
Segment 1: {"time":"2015-09-12T00:46:58.771Z","dimA":"C","dimB":"J","metA":1}
Segment 1: {"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"X","metA":1}

Segment 2: {"time":"2015-09-12T00:46:58.771Z","dimA":"Z","dimB":"S","metA":1}
Segment 2: {"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"X","metA":1}
Segment 2: {"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"Z","metA":1}

Segment 3: {"time":"2015-09-12T00:46:58.771Z","dimA":"J","dimB":"R","metA":1}
Segment 3: {"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"T","metA":1}
Segment 3: {"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"X","metA":1}

Segment 4: {"time":"2015-09-12T00:46:58.771Z","dimC":"A","dimB":"X","metA":1}
```
and the indexes for these intermediate segments are:  

Note that the ordering of dimensions here are important and that the ordering here follow the ordering of the dimension in the dimensionsSpec of the ingestionSpec (`dimB, dimA, dimC`)

intermediate segments 1: dimB, dimA
intermediate segments 2: dimB, dimA
intermediate segments 3: dimB, dimA
intermediate segments 4: dimB, dimC

The generated intermediate segments rows are sorted by dimension in the ordering of the  dimensionsSpec of the ingestionSpec (`dimB, dimA, dimC`). 

At merging of the intermediate segments, `getLongestSharedDimOrder` returns `null` as there is no common shared dimension ordering across all 4 intermediate segments (none of the index have all dimA, dimB, and dimC). This causes the merging to be done with lexicographic ordering (`dimA, dimB, and dimC`). 

Merging of the intermediate segments iterates through all the indexes in like a BFS way. Basically, it would try to get everything for a given (time, dims) tuple from across all segments before moving to the next tuple. When it moved to the next tuple, it would assume that we are now on a different time, dims tuple. Hence, it is important that the intermediate segments are sorted with the dimension ordering that is used for merging.

Back to our example, since we are now merging with lexicographic ordering (dimA, dimB, and dimC), the first row to be pulled is 

`{"time":"2015-09-12T00:46:58.771Z","dimC":"A","dimB":"X","metA":1}`

since it first looks for the smallest value in dimA, follow by dimB, follow by dimC where null is treated as smallest across all the first rows of all the intermediate segments.

then it move on to 

` {"time":"2015-09-12T00:46:58.771Z","dimA":"C","dimB":"F","metA":1}` (from intermediate segment 1) then

`{"time":"2015-09-12T00:46:58.771Z","dimA":"C","dimB":"J","metA":1}` (from intermediate segment 1) then

`{"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"X","metA":1}` (from intermediate segment 1) then

So far nothing is roll up as we haven’t gotten any (time, dims) tuple that are the same. We have now iterated through all the rows in intermediate segments 4 (first iteration) and intermediate segments 1 (second to fourth iterations). 

Now the next row to be iterate is either the first row of intermediate segments 2 (`{"time":"2015-09-12T00:46:58.771Z","dimA":"Z","dimB":"S","metA":1}`) or the first row of intermediate segment 3 (`{"time":"2015-09-12T00:46:58.771Z","dimA":"J","dimB":"R","metA":1}`). The problem here is that it should have iterate through the rows with `"dimA":"H","dimB":"X"` in intermediate segment 2 and 3 first to be able to combine with the `"dimA":"H","dimB":"X"` already iterated from intermediate segment 1. Just to complete the example, we then iterates `{"time":"2015-09-12T00:46:58.771Z","dimA":"J","dimB":"R","metA":1} `(from intermediate segments 3) first since dimA value of J is smaller than dimA value of Z (from intermediate segments 2). Then we iterate the `{"time":"2015-09-12T00:46:58.771Z","dimA":"H","dimB":"T","metA":1} `(from intermediate segments 3) since dimA value of H is smaller than dimA value of Z (from intermediate segments 2). However, we can no longer roll up the row (from intermediate segments 3) with the previously iterated row from intermediate segments 1 since there was the` {"time":"2015-09-12T00:46:58.771Z","dimA":"J","dimB":"R","metA":1}` in between which has dimA  != H and dimB != X values.

**Purpose Fix:**

High level: 
We will make the dimension names given in the ingest spec available to getLongestShardeDimOrder (As an additional argument). 

We should pass the `schema.getDimensionsSpec().getDimensionNames()` (which is the DimensionNames from the ingestionSpec) from within the `AppendetaorImpl#mergeAndPush` to `indexMerger.mergeQueryableIndex(...)` method. Which would then pass the DimensionNames to the `IndexMergerV9.merge` method. `IndexMergerV9.merge` would pass DimensionNames to the `IndexMerger.getMergedDimensions(indexes)` and finally, we pass it to `getLongestSharedDimOrder(...);`

In `getLongestSharedDimOrder(indexes, specDimensionNames)`, we would then try to find the LongestSharedDim as usually. However, if we cannot find the LongestSharedDim, before returning null, we will do the following in sequence:

1. check if `specDimensionNames` is not null and not empty. → if null or empty, we return null
2. get the `specDimensionNames` and remove all dimensions that does not exist within the `indexes` dimension names. 
3. check if `specDimensionNames` does not have extra / missing columns from the set of all `indexes` dimension names. → if it has extra/missing columns, we return null
4. check that all `indexes` dimension name ordering is the same as the ordering in `specDimensionNames`. → if any index dimension name have a different ordering than `specDimensionNames` we return null.  For example, if `specDimensionNames` is A, B, C and one of the index dimension name is A, C then this is valid, however if one of the index dimension name is C, A then this is invalid and we return null 
5. return specDimensionNames

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
