### PR TITLE
Fix classCastException when inputs to union are join

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidUnionDataSourceRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidUnionDataSourceRule.java
@@ -69,8 +69,7 @@ public class DruidUnionDataSourceRule extends RelOptRule
     final DruidRel<?> firstDruidRel = call.rel(1);
     final DruidQueryRel secondDruidRel = call.rel(2);
 
-    // Can only do UNION ALL of inputs that have compatible schemas (or schema mappings).
-    return unionRel.all && isUnionCompatible(firstDruidRel, secondDruidRel);
+    return isCompatible(unionRel, firstDruidRel, secondDruidRel);
   }
 
   @Override
@@ -109,6 +108,17 @@ public class DruidUnionDataSourceRule extends RelOptRule
           )
       );
     }
+  }
+
+  // Can only do UNION ALL of inputs that have compatible schemas (or schema mappings) and right side
+  // is a simple table scan
+  public static boolean isCompatible(final Union unionRel, final DruidRel<?> first, final DruidRel<?> second)
+  {
+    if (!(second instanceof DruidQueryRel)) {
+      return false;
+    }
+
+    return unionRel.all && isUnionCompatible(first, second);
   }
 
   private static boolean isUnionCompatible(final DruidRel<?> first, final DruidRel<?> second)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidUnionRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidUnionRule.java
@@ -55,7 +55,10 @@ public class DruidUnionRule extends RelOptRule
   public boolean matches(RelOptRuleCall call)
   {
     // Make DruidUnionRule and DruidUnionDataSourceRule mutually exclusive.
-    return !DruidUnionDataSourceRule.instance().matches(call);
+    final Union unionRel = call.rel(0);
+    final DruidRel<?> firstDruidRel = call.rel(1);
+    final DruidRel<?> secondDruidRel = call.rel(2);
+    return !DruidUnionDataSourceRule.isCompatible(unionRel, firstDruidRel, secondDruidRel);
   }
 
   @Override


### PR DESCRIPTION
Fixes a `ClassCastException` bug when the second input to `UNION ALL` is a join query and we try to cast `DruidJoinQueryRel` to `DruidQueryRel`. 