### PR TITLE
Show leader nodes in Services Tab

### DIFF
--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -114,6 +114,7 @@ interface ServiceQueryResultRow {
   service: string;
   service_type: string;
   tier: string;
+  is_leader: number;
   curr_size: number;
   host: string;
   max_size: number;
@@ -164,7 +165,7 @@ export class ServicesView extends React.PureComponent<ServicesViewProps, Service
   //   peon => 1
 
   static SERVICE_SQL = `SELECT
-  "server" AS "service", "server_type" AS "service_type", "tier", "host", "plaintext_port", "tls_port", "curr_size", "max_size",
+  "server" AS "service", "server_type" AS "service_type", "tier", "host", "plaintext_port", "tls_port", "curr_size", "max_size", "is_leader",
   (
     CASE "server_type"
     WHEN 'coordinator' THEN 8
@@ -484,7 +485,7 @@ ORDER BY "rank" DESC, "service" DESC`;
           },
           {
             Header: 'Detail',
-            show: capabilities.hasCoordinatorAccess() && hiddenColumns.exists('Detail'),
+            show: hiddenColumns.exists('Detail'),
             id: 'queue',
             width: 400,
             filterable: false,
@@ -500,6 +501,8 @@ ORDER BY "rank" DESC, "service" DESC`;
                   details.push(`Blacklisted until: ${row.blacklistedUntil}`);
                 }
                 return details.join(' ');
+              } else if (oneOf(row.service_type, 'coordinator', 'overlord')) {
+                return (row.is_leader || 0) === 1 ? 'leader' : '';
               } else {
                 return (row.segmentsToLoad || 0) + (row.segmentsToDrop || 0);
               }
@@ -524,6 +527,10 @@ ORDER BY "rank" DESC, "service" DESC`;
 
                 case 'indexer':
                 case 'middle_manager':
+                  return row.value;
+
+                case 'coordinator':
+                case 'overlord':
                   return row.value;
 
                 default:


### PR DESCRIPTION
This PR is a replacement for #10418 . 

The core changes at the server side in #10418 has been implemented in #10680, and based on that implementation,  a `is_leader` column is added to 'servers' table which means user could know which nodes are playing in a role of leader by querying 'servers' table.

This PR provides a more convenient, intuitive way for users to get leader information - by showing the information in 'Details' column under 'Services' tab. 

![image](https://user-images.githubusercontent.com/6525742/110099907-cbc69b80-7ddc-11eb-8670-d681afc646be.png)


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
