### PR TITLE
Remove flaky arm64 test job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,12 +153,6 @@ jobs:
       stage: Tests - phase 2
       jdk: openjdk11
     
-    - <<: *package
-      name: "Build and test on ARM64 CPU architecture"
-      stage: Tests - phase 2
-      arch: arm64
-      jdk: openjdk11
-
     - &test_processing_module
       name: "(openjdk8) processing module test"
       stage: Tests - phase 1


### PR DESCRIPTION
This removes a flaky test job that was added in #10562 

The travis job was added to test building Druid on Arm64 architecture. No tests are actually run as part of the job. 

However this job appears to fail around half of the time. My limited googling has not yielded any promising results. Since this impacts dev productivity, I propose we remove this job until we find out why this test fails so often and fix it appropriately.