### PR TITLE
[Minor]Add metadata-related logs and missing UT for kill tasks.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -84,7 +84,7 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8.0_221" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -84,7 +84,7 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8.0_221" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -1296,7 +1296,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   {
     String segmentsTable = dbTables.getSegmentsTable();
     String segmentId = segment.getId().toString();
-    log.info("Removing segment [%s] [%s] from Metadata Storage [%s]!", segmentId, segment.getDataSource(), segmentsTable);
+    log.debug("Removing segment [%s] [%s] from Metadata Storage [%s]!", segmentId, segment.getDataSource(), segmentsTable);
     handle.createStatement(StringUtils.format("DELETE from %s WHERE id = :id", segmentsTable))
             .bind("id", segmentId)
             .execute();

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -1284,7 +1284,8 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
               dataSource = segment.getDataSource();
               deleteSegment(handle, segment);
             }
-            log.info("Removed [%d] segments'metadata for dataSource [%s]!", segmentSize, dataSource);
+            log.debugSegments(segments, "Delete the metadata of segments");
+            log.info("Removed [%d] segments from metadata storage for dataSource [%s]!", segmentSize, dataSource);
 
             return null;
           }
@@ -1294,12 +1295,9 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
   private void deleteSegment(final Handle handle, final DataSegment segment)
   {
-    String segmentsTable = dbTables.getSegmentsTable();
-    String segmentId = segment.getId().toString();
-    log.debug("Removing segment [%s] [%s] from Metadata Storage [%s]!", segmentId, segment.getDataSource(), segmentsTable);
-    handle.createStatement(StringUtils.format("DELETE from %s WHERE id = :id", segmentsTable))
-            .bind("id", segmentId)
-            .execute();
+    handle.createStatement(StringUtils.format("DELETE from %s WHERE id = :id", dbTables.getSegmentsTable()))
+          .bind("id", segment.getId().toString())
+          .execute();
   }
 
   private void updatePayload(final Handle handle, final DataSegment segment) throws IOException

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -1278,9 +1278,13 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
           @Override
           public Void inTransaction(Handle handle, TransactionStatus transactionStatus)
           {
+            int segmentSize = segments.size();
+            String dataSource = "";
             for (final DataSegment segment : segments) {
+              dataSource = segment.getDataSource();
               deleteSegment(handle, segment);
             }
+            log.info("Removed [%d] segments'metadata for dataSource [%s]!", segmentSize, dataSource);
 
             return null;
           }
@@ -1290,9 +1294,12 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
   private void deleteSegment(final Handle handle, final DataSegment segment)
   {
-    handle.createStatement(StringUtils.format("DELETE from %s WHERE id = :id", dbTables.getSegmentsTable()))
-          .bind("id", segment.getId().toString())
-          .execute();
+    String segmentsTable = dbTables.getSegmentsTable();
+    String segmentId = segment.getId().toString();
+    log.info("Removing segment [%s] [%s] from Metadata Storage [%s]!", segmentId, segment.getDataSource(), segmentsTable);
+    handle.createStatement(StringUtils.format("DELETE from %s WHERE id = :id", segmentsTable))
+            .bind("id", segmentId)
+            .execute();
   }
 
   private void updatePayload(final Handle handle, final DataSegment segment) throws IOException

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -849,22 +849,33 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   }
 
   @Test
-  public void testDeleteSegments()
+  public void testDeleteSegmentsInMetaDataStorage() throws IOException
   {
-    Exception e = null;
-    try {
-      coordinator.deleteSegments(SEGMENTS);
-    }
-    catch (Exception ex) {
-      e = ex;
-    }
-    Assert.assertNull(e);
+    // Published segments to MetaDataStorage
+    coordinator.announceHistoricalSegments(SEGMENTS);
+
+    // check segments Published
+    Assert.assertEquals(
+            SEGMENTS,
+            ImmutableSet.copyOf(
+                    coordinator.retrieveUsedSegmentsForInterval(
+                            defaultSegment.getDataSource(),
+                            defaultSegment.getInterval(),
+                            Segments.ONLY_VISIBLE
+                    )
+            )
+    );
+    // remove segments in MetaDataStorage
+    coordinator.deleteSegments(SEGMENTS);
+
+    // check segments removed
     Assert.assertEquals(
             0,
             ImmutableSet.copyOf(
-                    coordinator.retrieveUnusedSegmentsForInterval(
+                    coordinator.retrieveUsedSegmentsForInterval(
                             defaultSegment.getDataSource(),
-                            defaultSegment.getInterval()
+                            defaultSegment.getInterval(),
+                            Segments.ONLY_VISIBLE
                     )
             ).size()
     );

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -849,6 +849,28 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   }
 
   @Test
+  public void testDeleteSegments()
+  {
+    Exception e = null;
+    try {
+      coordinator.deleteSegments(SEGMENTS);
+    }
+    catch (Exception ex) {
+      e = ex;
+    }
+    Assert.assertNull(e);
+    Assert.assertEquals(
+            0,
+            ImmutableSet.copyOf(
+                    coordinator.retrieveUnusedSegmentsForInterval(
+                            defaultSegment.getDataSource(),
+                            defaultSegment.getInterval()
+                    )
+            ).size()
+    );
+  }
+
+  @Test
   public void testSingleAdditionalNumberedShardWithNoCorePartitions() throws IOException
   {
     additionalNumberedShardTest(ImmutableSet.of(numberedSegment0of0));


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes https://github.com/apache/druid/issues/10423.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Logs more info for metadata deletion in overlord:
1. This would help users to more clearly understand what delete actions have been done by the kill task including metadata and data.
2. This would help in debugging metadata related issues.


P.S.
Kill task is divided into two stages:
1. Overlord deletes meta infos.
2. Peon deletes DeepStorage files.

So that we can only add meta-related logs in overlord.


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
