### PR TITLE
Don't fail on invalid views in InformationSchema

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/InformationSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/InformationSchema.java
@@ -46,6 +46,7 @@ import org.apache.calcite.schema.TableMacro;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.server.security.AuthenticationResult;
@@ -64,6 +65,8 @@ import java.util.Set;
 
 public class InformationSchema extends AbstractSchema
 {
+  private static final EmittingLogger log = new EmittingLogger(InformationSchema.class);
+
   private static final String CATALOG_NAME = "druid";
   private static final String SCHEMATA_TABLE = "SCHEMATA";
   private static final String TABLES_TABLE = "TABLES";
@@ -357,12 +360,18 @@ public class InformationSchema extends AbstractSchema
                                         return null;
                                       }
 
-                                      return generateColumnMetadata(
-                                          schemaName,
-                                          functionName,
-                                          viewMacro.apply(ImmutableList.of()),
-                                          typeFactory
-                                      );
+                                      try {
+                                        return generateColumnMetadata(
+                                            schemaName,
+                                            functionName,
+                                            viewMacro.apply(ImmutableList.of()),
+                                            typeFactory
+                                        );
+                                      }
+                                      catch (Exception e) {
+                                        log.error(e, "Encountered exception while handling view[%s].", functionName);
+                                        return null;
+                                      }
                                     }
                                   }
                               )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -830,6 +830,12 @@ public class BaseCalciteQueryTest extends CalciteTestBase
         "restrictedView",
         "SELECT __time, dim1, dim2, m1 FROM druid.forbiddenDatasource WHERE dim2 = 'a'"
     );
+
+    viewManager.createView(
+        plannerFactory,
+        "invalidView",
+        "SELECT __time, dim1, dim2, m1 FROM druid.invalidDatasource WHERE dim2 = 'a'"
+    );
     return sqlLifecycleFactory;
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -888,6 +888,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             .add(new Object[]{"view", "bview", "VIEW", "NO", "NO"})
             .add(new Object[]{"view", "cview", "VIEW", "NO", "NO"})
             .add(new Object[]{"view", "dview", "VIEW", "NO", "NO"})
+            .add(new Object[]{"view", "invalidView", "VIEW", "NO", "NO"})
             .add(new Object[]{"view", "restrictedView", "VIEW", "NO", "NO"})
             .build()
     );
@@ -923,6 +924,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             .add(new Object[]{"view", "cview", "VIEW", "NO", "NO"})
             .add(new Object[]{"view", "dview", "VIEW", "NO", "NO"})
             .add(new Object[]{"view", "forbiddenView", "VIEW", "NO", "NO"})
+            .add(new Object[]{"view", "invalidView", "VIEW", "NO", "NO"})
             .add(new Object[]{"view", "restrictedView", "VIEW", "NO", "NO"})
             .build()
     );


### PR DESCRIPTION
This PR fixes an issue where INFORMATION_SCHEMA queries would fail if an invalid view (e.g., view on a non-existent datasource) is defined.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
