### PR TITLE
fix SQL issue for group by queries with time filter that gets optimized to false

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -67,7 +67,6 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
-import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -345,6 +344,8 @@ public class GroupByQuery extends BaseQuery<ResultRow>
 
   /**
    * If this query has a single universal timestamp, return it. Otherwise return null.
+   *
+   * If {@link #getIntervals()} is empty, there are no results (or timestamps) so this method returns null.
    *
    * This method will return a nonnull timestamp in the following two cases:
    *
@@ -717,7 +718,7 @@ public class GroupByQuery extends BaseQuery<ResultRow>
       return DateTimes.utc(Long.parseLong(timestampStringFromContext));
     } else if (Granularities.ALL.equals(granularity)) {
       final List<Interval> intervals = getIntervals();
-      if (CollectionUtils.isNullOrEmpty(intervals)) {
+      if (intervals.isEmpty()) {
         // null, the "universal timestamp" of nothing
         return null;
       }

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -718,6 +718,7 @@ public class GroupByQuery extends BaseQuery<ResultRow>
     } else if (Granularities.ALL.equals(granularity)) {
       final List<Interval> intervals = getIntervals();
       if (CollectionUtils.isNullOrEmpty(intervals)) {
+        // null, the "universal timestamp" of nothing
         return null;
       }
       final DateTime timeStart = intervals.get(0).getStart();

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -67,6 +67,7 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -715,7 +716,11 @@ public class GroupByQuery extends BaseQuery<ResultRow>
     if (!timestampStringFromContext.isEmpty()) {
       return DateTimes.utc(Long.parseLong(timestampStringFromContext));
     } else if (Granularities.ALL.equals(granularity)) {
-      final DateTime timeStart = getIntervals().get(0).getStart();
+      final List<Interval> intervals = getIntervals();
+      if (CollectionUtils.isNullOrEmpty(intervals)) {
+        return null;
+      }
+      final DateTime timeStart = intervals.get(0).getStart();
       return granularity.getIterable(new Interval(timeStart, timeStart.plus(1))).iterator().next().getStart();
     } else {
       return null;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
@@ -134,7 +134,7 @@ public class CombineAndSimplifyBounds extends BottomUpTransform
     // Group Bound filters by dimension, extractionFn, and comparator and compute a RangeSet for each one.
     final Map<BoundRefKey, List<BoundDimFilter>> bounds = new HashMap<>();
 
-    boolean allFalse = true;
+    boolean allFalse = newChildren.size() > 0;
     for (final DimFilter child : newChildren) {
       if (child instanceof BoundDimFilter) {
         final BoundDimFilter bound = (BoundDimFilter) child;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.filter.AndDimFilter;
 import org.apache.druid.query.filter.BoundDimFilter;
 import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.FalseDimFilter;
 import org.apache.druid.query.filter.NotDimFilter;
 import org.apache.druid.query.filter.OrDimFilter;
 
@@ -52,7 +53,10 @@ public class CombineAndSimplifyBounds extends BottomUpTransform
   @Override
   public DimFilter process(DimFilter filter)
   {
-    if (filter instanceof AndDimFilter) {
+    if (filter instanceof FalseDimFilter) {
+      // we might sometimes come into here with just a false from optimizing impossible conditions
+      return filter;
+    } else if (filter instanceof AndDimFilter) {
       final List<DimFilter> children = getAndFilterChildren((AndDimFilter) filter);
       final DimFilter one = doSimplifyAnd(children);
       final DimFilter two = negate(doSimplifyOr(negateAll(children)));
@@ -130,13 +134,22 @@ public class CombineAndSimplifyBounds extends BottomUpTransform
     // Group Bound filters by dimension, extractionFn, and comparator and compute a RangeSet for each one.
     final Map<BoundRefKey, List<BoundDimFilter>> bounds = new HashMap<>();
 
+    boolean allFalse = true;
     for (final DimFilter child : newChildren) {
       if (child instanceof BoundDimFilter) {
         final BoundDimFilter bound = (BoundDimFilter) child;
         final BoundRefKey boundRefKey = BoundRefKey.from(bound);
         final List<BoundDimFilter> filterList = bounds.computeIfAbsent(boundRefKey, k -> new ArrayList<>());
         filterList.add(bound);
+        allFalse = false;
+      } else {
+        allFalse &= child instanceof FalseDimFilter;
       }
+    }
+
+    // short circuit if can never be true
+    if (allFalse) {
+      return Filtration.matchNothing();
     }
 
     // Try to simplify filters within each group.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
@@ -110,13 +110,11 @@ public class CombineAndSimplifyBounds extends BottomUpTransform
 
   private static DimFilter doSimplifyAnd(final List<DimFilter> children)
   {
-    Preconditions.checkArgument(!children.isEmpty(), "And filter has no operands, how can this be?");
     return doSimplify(children, false);
   }
 
   private static DimFilter doSimplifyOr(final List<DimFilter> children)
   {
-    Preconditions.checkArgument(!children.isEmpty(), "Or filter has no operands, how can this be?");
     return doSimplify(children, true);
   }
 
@@ -136,6 +134,7 @@ public class CombineAndSimplifyBounds extends BottomUpTransform
     // Group Bound filters by dimension, extractionFn, and comparator and compute a RangeSet for each one.
     final Map<BoundRefKey, List<BoundDimFilter>> bounds = new HashMap<>();
 
+    // all and/or filters have at least 1 child
     boolean allFalse = true;
     for (final DimFilter child : newChildren) {
       if (child instanceof BoundDimFilter) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBounds.java
@@ -110,11 +110,13 @@ public class CombineAndSimplifyBounds extends BottomUpTransform
 
   private static DimFilter doSimplifyAnd(final List<DimFilter> children)
   {
+    Preconditions.checkArgument(!children.isEmpty(), "And filter has no operands, how can this be?");
     return doSimplify(children, false);
   }
 
   private static DimFilter doSimplifyOr(final List<DimFilter> children)
   {
+    Preconditions.checkArgument(!children.isEmpty(), "Or filter has no operands, how can this be?");
     return doSimplify(children, true);
   }
 
@@ -134,7 +136,7 @@ public class CombineAndSimplifyBounds extends BottomUpTransform
     // Group Bound filters by dimension, extractionFn, and comparator and compute a RangeSet for each one.
     final Map<BoundRefKey, List<BoundDimFilter>> bounds = new HashMap<>();
 
-    boolean allFalse = newChildren.size() > 0;
+    boolean allFalse = true;
     for (final DimFilter child : newChildren) {
       if (child instanceof BoundDimFilter) {
         final BoundDimFilter bound = (BoundDimFilter) child;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -95,6 +95,7 @@ import org.apache.druid.query.groupby.orderby.OrderByColumnSpec.Direction;
 import org.apache.druid.query.lookup.RegisteredLookupExtractionFn;
 import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.query.scan.ScanQuery;
+import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.topn.DimensionTopNMetricSpec;
 import org.apache.druid.query.topn.InvertedTopNMetricSpec;
 import org.apache.druid.query.topn.NumericTopNMetricSpec;
@@ -5206,6 +5207,29 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .aggregators(aggregators(new CountAggregatorFactory("a0")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
                   .build()
+        ),
+        ImmutableList.of()
+    );
+  }
+
+  @Test
+  public void testGroupByWithImpossibleTimeFilter() throws Exception
+  {
+    // this gets optimized into 'false'
+    testQuery(
+        "SELECT dim1, COUNT(*) FROM druid.foo\n"
+        + "WHERE FLOOR(__time TO DAY) = TIMESTAMP '2000-01-02 01:00:00'\n"
+        + "OR FLOOR(__time TO DAY) = TIMESTAMP '2000-01-02 02:00:00'\n"
+        + "GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of()))
+                        .setDimensions(dimensions(new DefaultDimensionSpec("dim1", "d0")))
+                        .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
+                        .setGranularity(Granularities.ALL)
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
         ),
         ImmutableList.of()
     );
@@ -16757,5 +16781,4 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ).build()
     );
   }
-
 }


### PR DESCRIPTION
### Description
This PR fixes an issue where during SQL planning we optimize the time filter to false or some combination of all false filters in an "and" or "or" filter, resulting in the filtration for the query in the planner making a `GroupByQuery` with an empty interval, but this explodes in the constructor because `computeUniversalTimestamp` doesn't handle this case and expects there to be a start timestamp. This results in an unfriendly 

```
java.lang.IndexOutOfBoundsException: index (0) must be less than size (0)

	at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:313)
	at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:295)
	at com.google.common.collect.RegularImmutableList.get(RegularImmutableList.java:65)
	at java.util.Collections$UnmodifiableList.get(Collections.java:1311)
	at org.apache.druid.query.groupby.GroupByQuery.computeUniversalTimestamp(GroupByQuery.java:723)
	at org.apache.druid.query.groupby.GroupByQuery.<init>(GroupByQuery.java:221)
	at org.apache.druid.query.groupby.GroupByQuery.<init>(GroupByQuery.java:89)
	at org.apache.druid.query.groupby.GroupByQuery$Builder.build(GroupByQuery.java:1180)
...
```
instead of returning empty results. 

I also added some additional short circuits for always false conditions in `CombineAndSimplifyBounds` based on observations in debugger while testing this issue.

<hr>


This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
