### PR TITLE
Fix Kinesis should not increment throwAway count on EOS record

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -2645,7 +2645,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     // Check metrics
     Assert.assertEquals(3, task.getRunner().getRowIngestionMeters().getProcessed());
     Assert.assertEquals(0, task.getRunner().getRowIngestionMeters().getUnparseable());
-    Assert.assertEquals(1, task.getRunner().getRowIngestionMeters().getThrownAway()); // EOS marker
+    Assert.assertEquals(0, task.getRunner().getRowIngestionMeters().getThrownAway());
 
     // Check published metadata and segments in deep storage
     assertEqualsExceptVersion(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -624,7 +624,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
             );
 
             if (shouldProcess) {
-              final List<InputRow> rows = parser.parse(record.getData());
+              final List<InputRow> rows = parser.parse(record.getData(), isEndOfShard(record.getSequenceNumber()));
               boolean isPersistRequired = false;
 
               final SequenceMetadata<PartitionIdType, SequenceOffsetType> sequenceToUse = sequences

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/StreamChunkParser.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/StreamChunkParser.java
@@ -90,10 +90,14 @@ class StreamChunkParser<RecordType extends ByteEntity>
     this.parseExceptionHandler = parseExceptionHandler;
   }
 
-  List<InputRow> parse(@Nullable List<RecordType> streamChunk) throws IOException
+  List<InputRow> parse(@Nullable List<RecordType> streamChunk, boolean isEndOfShard) throws IOException
   {
     if (streamChunk == null || streamChunk.isEmpty()) {
-      rowIngestionMeters.incrementThrownAway();
+      if (!isEndOfShard) {
+        // We do not count end of shard record as thrown away event since this is a record created by Druid
+        // Note that this only applies to Kinesis
+        rowIngestionMeters.incrementThrownAway();
+      }
       return Collections.emptyList();
     } else {
       if (byteEntityReader != null) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkParserTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkParserTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.seekablestream;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntityReader;
@@ -34,6 +35,7 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.segment.incremental.NoopRowIngestionMeters;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
@@ -43,6 +45,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -52,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+@RunWith(MockitoJUnitRunner.class)
 public class StreamChunkParserTest
 {
   private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec(null, null, null);
@@ -163,10 +169,56 @@ public class StreamChunkParserTest
     Assert.assertTrue(inputFormat.props.used);
   }
 
+  @Test
+  public void parseEmptyNotEndOfShard() throws IOException
+  {
+    final TrackingJsonInputFormat inputFormat = new TrackingJsonInputFormat(
+        JSONPathSpec.DEFAULT,
+        Collections.emptyMap()
+    );
+    RowIngestionMeters mockRowIngestionMeters = Mockito.mock(RowIngestionMeters.class);
+    final StreamChunkParser<ByteEntity> chunkParser = new StreamChunkParser<>(
+        null,
+        inputFormat,
+        new InputRowSchema(TIMESTAMP_SPEC, DimensionsSpec.EMPTY, Collections.emptyList()),
+        TransformSpec.NONE,
+        temporaryFolder.newFolder(),
+        row -> true,
+        mockRowIngestionMeters,
+        parseExceptionHandler
+    );
+    List<InputRow> parsedRows = chunkParser.parse(ImmutableList.of(), false);
+    Assert.assertEquals(0, parsedRows.size());
+    Mockito.verify(mockRowIngestionMeters).incrementThrownAway();
+  }
+
+  @Test
+  public void parseEmptyEndOfShard() throws IOException
+  {
+    final TrackingJsonInputFormat inputFormat = new TrackingJsonInputFormat(
+        JSONPathSpec.DEFAULT,
+        Collections.emptyMap()
+    );
+    RowIngestionMeters mockRowIngestionMeters = Mockito.mock(RowIngestionMeters.class);
+    final StreamChunkParser<ByteEntity> chunkParser = new StreamChunkParser<>(
+        null,
+        inputFormat,
+        new InputRowSchema(TIMESTAMP_SPEC, DimensionsSpec.EMPTY, Collections.emptyList()),
+        TransformSpec.NONE,
+        temporaryFolder.newFolder(),
+        row -> true,
+        mockRowIngestionMeters,
+        parseExceptionHandler
+    );
+    List<InputRow> parsedRows = chunkParser.parse(ImmutableList.of(), true);
+    Assert.assertEquals(0, parsedRows.size());
+    Mockito.verifyNoInteractions(mockRowIngestionMeters);
+  }
+
   private void parseAndAssertResult(StreamChunkParser<ByteEntity> chunkParser) throws IOException
   {
     final String json = "{\"timestamp\": \"2020-01-01\", \"dim\": \"val\", \"met\": \"val2\"}";
-    List<InputRow> parsedRows = chunkParser.parse(Collections.singletonList(new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))));
+    List<InputRow> parsedRows = chunkParser.parse(Collections.singletonList(new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))), false);
     Assert.assertEquals(1, parsedRows.size());
     InputRow row = parsedRows.get(0);
     Assert.assertEquals(DateTimes.of("2020-01-01"), row.getTimestamp());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkParserTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkParserTest.java
@@ -35,7 +35,6 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.segment.incremental.NoopRowIngestionMeters;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/OverlordResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/OverlordResourceTestClient.java
@@ -38,6 +38,7 @@ import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.StatusResponseHandler;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
+import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.guice.TestClient;
 import org.apache.druid.testing.utils.ITRetryUtil;
@@ -208,18 +209,37 @@ public class OverlordResourceTestClient
 
   public String getTaskErrorMessage(String taskId)
   {
+    return ((IngestionStatsAndErrorsTaskReportData) getTaskReport(taskId).get("ingestionStatsAndErrors").getPayload()).getErrorMsg();
+  }
+
+  public RowIngestionMetersTotals getTaskStats(String taskId)
+  {
+    return (RowIngestionMetersTotals) ((IngestionStatsAndErrorsTaskReportData) getTaskReport(taskId).get("ingestionStatsAndErrors").getPayload()).getRowStats().get("buildSegments");
+  }
+
+  private Map<String, IngestionStatsAndErrorsTaskReport> getTaskReport(String taskId)
+  {
     try {
       StatusResponseHolder response = makeRequest(
           HttpMethod.GET,
-          StringUtils.format("%s%s", getIndexerURL(), StringUtils.format("task/%s/reports", StringUtils.urlEncode(taskId)))
+          StringUtils.format(
+              "%s%s",
+              getIndexerURL(),
+              StringUtils.format("task/%s/reports", StringUtils.urlEncode(taskId))
+          )
       );
-      Map<String, IngestionStatsAndErrorsTaskReport> x = jsonMapper.readValue(response.getContent(), new TypeReference<Map<String, IngestionStatsAndErrorsTaskReport>>() {});
-      return ((IngestionStatsAndErrorsTaskReportData) x.get("ingestionStatsAndErrors").getPayload()).getErrorMsg();
+      return jsonMapper.readValue(
+          response.getContent(),
+          new TypeReference<Map<String, IngestionStatsAndErrorsTaskReport>>()
+          {
+          }
+      );
     }
     catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
+
 
   public void waitUntilTaskCompletes(final String taskID)
   {

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/OverlordResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/OverlordResourceTestClient.java
@@ -225,35 +225,25 @@ public class OverlordResourceTestClient
 
   private Map<String, IngestionStatsAndErrorsTaskReport> getTaskReport(String taskId)
   {
-    return ITRetryUtil.retryUntilNoException(
-        new Callable<Map<String, IngestionStatsAndErrorsTaskReport>>()
-        {
-          @Override
-          public Map<String, IngestionStatsAndErrorsTaskReport> call()
+    try {
+      StatusResponseHolder response = makeRequest(
+          HttpMethod.GET,
+          StringUtils.format(
+              "%s%s",
+              getIndexerURL(),
+              StringUtils.format("task/%s/reports", StringUtils.urlEncode(taskId))
+          )
+      );
+      return jsonMapper.readValue(
+          response.getContent(),
+          new TypeReference<Map<String, IngestionStatsAndErrorsTaskReport>>()
           {
-            try {
-              StatusResponseHolder response = makeRequest(
-                  HttpMethod.GET,
-                  StringUtils.format(
-                      "%s%s",
-                      getIndexerURL(),
-                      StringUtils.format("task/%s/reports", StringUtils.urlEncode(taskId))
-                  )
-              );
-              return jsonMapper.readValue(
-                  response.getContent(),
-                  new TypeReference<Map<String, IngestionStatsAndErrorsTaskReport>>()
-                  {
-                  }
-              );
-            }
-            catch (Exception e) {
-              throw new RuntimeException(e);
-            }
           }
-        },
-        "Getting task report for task id=" + taskId
-    );
+      );
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public void waitUntilTaskCompletes(final String taskID)

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
@@ -72,4 +72,44 @@ public class ITRetryUtil
     }
   }
 
+  public static <E> E retryUntilNoException(
+      Callable<E> callable,
+      String taskMessage
+  )
+  {
+    return retryUntilNoException(callable, DEFAULT_RETRY_SLEEP, DEFAULT_RETRY_COUNT, taskMessage);
+  }
+
+  public static <E> E retryUntilNoException(
+      Callable<E> callable,
+      long delayInMillis,
+      int retryCount,
+      String taskMessage
+  )
+  {
+    try {
+      int currentTry = 0;
+      while (true) {
+        try {
+          return callable.call();
+        }
+        catch (Exception e) {
+          LOG.info(
+              "Ignoring exception to retry. Attempt[%d]: Task %s still not complete. Next retry in %d ms",
+              currentTry, taskMessage, delayInMillis
+          );
+        }
+        if (currentTry > retryCount) {
+          throw new ISE("Max number of retries[%d] exceeded for Task[%s]. Failing.", retryCount, taskMessage);
+        }
+        Thread.sleep(delayInMillis);
+
+        currentTry++;
+      }
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
 }

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
@@ -72,44 +72,4 @@ public class ITRetryUtil
     }
   }
 
-  public static <E> E retryUntilNoException(
-      Callable<E> callable,
-      String taskMessage
-  )
-  {
-    return retryUntilNoException(callable, DEFAULT_RETRY_SLEEP, DEFAULT_RETRY_COUNT, taskMessage);
-  }
-
-  public static <E> E retryUntilNoException(
-      Callable<E> callable,
-      long delayInMillis,
-      int retryCount,
-      String taskMessage
-  )
-  {
-    try {
-      int currentTry = 0;
-      while (true) {
-        try {
-          return callable.call();
-        }
-        catch (Exception e) {
-          LOG.info(
-              "Ignoring exception to retry. Attempt[%d]: Task %s still not complete. Next retry in %d ms",
-              currentTry, taskMessage, delayInMillis
-          );
-        }
-        if (currentTry > retryCount) {
-          throw new ISE("Max number of retries[%d] exceeded for Task[%s]. Failing.", retryCount, taskMessage);
-        }
-        Thread.sleep(delayInMillis);
-
-        currentTry++;
-      }
-    }
-    catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
@@ -188,7 +188,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
         EVENTS_PER_SECOND,
         CYCLE_PADDING_MS
     );
-    final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(parserType, getResourceAsString(specPath), true);
+    final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(parserType, getResourceAsString(specPath));
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
         final StreamEventWriter streamEventWriter = createStreamEventWriter(config, transactionEnabled)
@@ -241,8 +241,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
         INPUT_FORMAT,
-        getResourceAsString(JSON_INPUT_FORMAT_PATH),
-        true
+        getResourceAsString(JSON_INPUT_FORMAT_PATH)
     );
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -305,8 +304,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
             INPUT_FORMAT,
-            getResourceAsString(JSON_INPUT_FORMAT_PATH),
-            true
+            getResourceAsString(JSON_INPUT_FORMAT_PATH)
     );
     try (
             final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -386,8 +384,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
         INPUT_FORMAT,
-        getResourceAsString(JSON_INPUT_FORMAT_PATH),
-        true
+        getResourceAsString(JSON_INPUT_FORMAT_PATH)
     );
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -464,9 +461,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
         INPUT_FORMAT,
-        getResourceAsString(JSON_INPUT_FORMAT_PATH),
-        // getTaskStats does not work when datasource name has special characters
-        false
+        getResourceAsString(JSON_INPUT_FORMAT_PATH)
     );
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -552,8 +547,10 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
     // Verify that event thrown away count was not incremented by the reshard
     List<TaskResponseObject> completedTasks = indexer.getCompleteTasksForDataSource(generatedTestConfig.getFullDatasourceName());
     for (TaskResponseObject task : completedTasks) {
-      RowIngestionMetersTotals stats = indexer.getTaskStats(task.getId());
-      Assert.assertEquals(0L, stats.getThrownAway());
+      if (task.getStatus().isSuccess()) {
+        RowIngestionMetersTotals stats = indexer.getTaskStats(task.getId());
+        Assert.assertEquals(0L, stats.getThrownAway());
+      }
     }
   }
 
@@ -651,7 +648,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
     private Function<String, String> streamIngestionPropsTransform;
     private Function<String, String> streamQueryPropsTransform;
 
-    GeneratedTestConfig(String parserType, String parserOrInputFormat, boolean useExtraDatasourceNameSuffix) throws Exception
+    GeneratedTestConfig(String parserType, String parserOrInputFormat) throws Exception
     {
       streamName = getTestNamePrefix() + "_index_test_" + UUID.randomUUID();
       String datasource = getTestNamePrefix() + "_indexing_service_test_" + UUID.randomUUID();
@@ -667,11 +664,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
           30,
           "Wait for stream active"
       );
-      if (useExtraDatasourceNameSuffix) {
-        fullDatasourceName = datasource + config.getExtraDatasourceNameSuffix();
-      } else {
-        fullDatasourceName = datasource;
-      }
+      fullDatasourceName = datasource + config.getExtraDatasourceNameSuffix();
       streamIngestionPropsTransform = generateStreamIngestionPropsTransform(
           streamName,
           fullDatasourceName,

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.clients.TaskResponseObject;
 import org.apache.druid.testing.utils.DruidClusterAdminClient;
@@ -43,6 +44,7 @@ import org.apache.druid.testing.utils.WikipediaStreamEventStreamGenerator;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.testng.Assert;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -541,6 +543,12 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
       );
       // Verify that supervisor can catch up with the stream
       verifyIngestedData(generatedTestConfig, numWritten);
+    }
+    // Verify that event thrown away count was not incremented by the reshard
+    List<TaskResponseObject> completedTasks = indexer.getCompleteTasksForDataSource(generatedTestConfig.getFullDatasourceName());
+    for (TaskResponseObject task : completedTasks) {
+      RowIngestionMetersTotals stats = indexer.getTaskStats(task.getId());
+      Assert.assertEquals(0L, stats.getThrownAway());
     }
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
@@ -547,9 +547,15 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
     // Verify that event thrown away count was not incremented by the reshard
     List<TaskResponseObject> completedTasks = indexer.getCompleteTasksForDataSource(generatedTestConfig.getFullDatasourceName());
     for (TaskResponseObject task : completedTasks) {
-      if (task.getStatus().isSuccess()) {
+      try {
         RowIngestionMetersTotals stats = indexer.getTaskStats(task.getId());
         Assert.assertEquals(0L, stats.getThrownAway());
+      }
+      catch (Exception e) {
+        // Failed task may not have a task stats report. We can ignore it as the task did not consume any data
+        if (!task.getStatus().isFailure()) {
+          throw e;
+        }
       }
     }
   }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractStreamIndexingTest.java
@@ -188,7 +188,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
         EVENTS_PER_SECOND,
         CYCLE_PADDING_MS
     );
-    final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(parserType, getResourceAsString(specPath));
+    final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(parserType, getResourceAsString(specPath), true);
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
         final StreamEventWriter streamEventWriter = createStreamEventWriter(config, transactionEnabled)
@@ -241,7 +241,8 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
         INPUT_FORMAT,
-        getResourceAsString(JSON_INPUT_FORMAT_PATH)
+        getResourceAsString(JSON_INPUT_FORMAT_PATH),
+        true
     );
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -304,7 +305,8 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
             INPUT_FORMAT,
-            getResourceAsString(JSON_INPUT_FORMAT_PATH)
+            getResourceAsString(JSON_INPUT_FORMAT_PATH),
+            true
     );
     try (
             final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -384,7 +386,8 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
         INPUT_FORMAT,
-        getResourceAsString(JSON_INPUT_FORMAT_PATH)
+        getResourceAsString(JSON_INPUT_FORMAT_PATH),
+        true
     );
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -461,7 +464,9 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
   {
     final GeneratedTestConfig generatedTestConfig = new GeneratedTestConfig(
         INPUT_FORMAT,
-        getResourceAsString(JSON_INPUT_FORMAT_PATH)
+        getResourceAsString(JSON_INPUT_FORMAT_PATH),
+        // getTaskStats does not work when datasource name has special characters
+        false
     );
     try (
         final Closeable closer = createResourceCloser(generatedTestConfig);
@@ -646,7 +651,7 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
     private Function<String, String> streamIngestionPropsTransform;
     private Function<String, String> streamQueryPropsTransform;
 
-    GeneratedTestConfig(String parserType, String parserOrInputFormat) throws Exception
+    GeneratedTestConfig(String parserType, String parserOrInputFormat, boolean useExtraDatasourceNameSuffix) throws Exception
     {
       streamName = getTestNamePrefix() + "_index_test_" + UUID.randomUUID();
       String datasource = getTestNamePrefix() + "_indexing_service_test_" + UUID.randomUUID();
@@ -662,7 +667,11 @@ public abstract class AbstractStreamIndexingTest extends AbstractIndexerTest
           30,
           "Wait for stream active"
       );
-      fullDatasourceName = datasource + config.getExtraDatasourceNameSuffix();
+      if (useExtraDatasourceNameSuffix) {
+        fullDatasourceName = datasource + config.getExtraDatasourceNameSuffix();
+      } else {
+        fullDatasourceName = datasource;
+      }
       streamIngestionPropsTransform = generateStreamIngestionPropsTransform(
           streamName,
           fullDatasourceName,


### PR DESCRIPTION
Fix Kinesis should not increment throwAway count on EOS record

### Description

Druid writes a record with the sequence number "EOS" to Kinesis stream when Kinesis stream is re-shard (i.e. number of shard increased). Druid then consume this record (with the sequence number "EOS") and see that it is empty and increment the "throwAway" count. We should not increment the "throwAway" count as the record was generated by Druid and incrementing the "throwAway" count makes it very difficult to determine if any data was actually lost during a resharding event.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
