### PR TITLE
use maven enforcer to check maven version

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -30,10 +30,6 @@
     <version>0.22.0-SNAPSHOT</version>
   </parent>
 
-  <prerequisites>
-    <maven>3.0</maven>
-  </prerequisites>
-
   <dependencies>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1475,7 +1475,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>
@@ -1484,6 +1484,9 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.0</version>
+                                </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>1.8.0</version>
                                 </requireJavaVersion>


### PR DESCRIPTION
* removes a warning about prerequisites only being allowed for plugins
* update maven enforcer plugin to the latest version (3.0.0-M3)