### PR TITLE
update code check plugins for Java 15 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1357,13 +1357,13 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.12</version>
+                <version>4.2.0</version>
                 <dependencies>
                     <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs</artifactId>
-                        <version>3.1.12</version>
+                        <version>4.2.2</version>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -1373,7 +1373,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.8</version>
+                <version>3.14.0</version>
                 <configuration>
                     <printFailingErrors>true</printFailingErrors>
                     <rulesets>
@@ -1396,7 +1396,7 @@
             <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
-                <version>2.6</version>
+                <version>3.1</version>
                 <configuration>
                     <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
                     <bundledSignatures>

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
@@ -43,7 +43,9 @@ public class FinalizingFieldAccessPostAggregator implements PostAggregator
   // prior to usage (and is currently done so in the query constructors of all queries which can have post-aggs)
   @Nullable
   private final ValueType finalizedType;
+  @Nullable
   private final Comparator<Object> comparator;
+  @Nullable
   private final Function<Object, Object> finalizer;
 
   @JsonCreator
@@ -59,8 +61,8 @@ public class FinalizingFieldAccessPostAggregator implements PostAggregator
       final String name,
       final String fieldName,
       @Nullable final ValueType finalizedType,
-      final Comparator<Object> comparator,
-      final Function<Object, Object> finalizer
+      @Nullable final Comparator<Object> comparator,
+      @Nullable final Function<Object, Object> finalizer
   )
   {
     this.name = name;

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -784,7 +784,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     }
   }
 
-  private ColumnCapabilitiesImpl makeDefaultCapabilitiesFromValueType(ValueType type, String typeName)
+  private ColumnCapabilitiesImpl makeDefaultCapabilitiesFromValueType(ValueType type, @Nullable String typeName)
   {
     switch (type) {
       case STRING:

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexColumnPartSerde.java
@@ -34,10 +34,11 @@ public class ComplexColumnPartSerde implements ColumnPartSerde
   private final String typeName;
   @Nullable
   private final ComplexMetricSerde serde;
+  @Nullable
   private final Serializer serializer;
   private static final Logger log = new Logger(ComplexColumnPartSerde.class);
 
-  private ComplexColumnPartSerde(String typeName, Serializer serializer)
+  private ComplexColumnPartSerde(String typeName, @Nullable Serializer serializer)
   {
     this.typeName = typeName;
     this.serde = ComplexMetrics.getSerdeForType(typeName);

--- a/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
@@ -116,7 +116,7 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
   private DictionaryEncodedColumnPartSerde(
       ByteOrder byteOrder,
       BitmapSerdeFactory bitmapSerdeFactory,
-      Serializer serializer
+      @Nullable Serializer serializer
   )
   {
     this.byteOrder = byteOrder;

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -70,6 +70,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
 
   private final TaskInfoMapper<EntryType, StatusType> taskInfoMapper;
 
+  @SuppressWarnings("PMD.UnnecessaryFullyQualifiedName")
   public SQLMetadataStorageActionHandler(
       final SQLMetadataConnector connector,
       final ObjectMapper jsonMapper,


### PR DESCRIPTION
* update maven-forbidden-api plugin to 3.1
* update maven-pmd-plugin to 3.14
* update spotbugs to 4.2.2
* fixes validation failures newly caught by those updates
  - fix SpotBugs NP_NONNULL_PARAM_VIOLATION
  - fix PMD UnnecessaryFullyQualifiedName
