### PR TITLE
Apache archive mirror

### DIFF
--- a/examples/quickstart/tutorial/hadoop/docker/Dockerfile
+++ b/examples/quickstart/tutorial/hadoop/docker/Dockerfile
@@ -45,7 +45,8 @@ ENV JAVA_HOME /usr/lib/jvm/zulu-8
 ENV PATH $PATH:$JAVA_HOME/bin
 
 # hadoop
-RUN curl -s https://archive.apache.org/dist/hadoop/core/hadoop-2.8.5/hadoop-2.8.5.tar.gz | tar -xz -C /usr/local/
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
+RUN curl -s ${APACHE_ARCHIVE_MIRROR_HOST}/dist/hadoop/core/hadoop-2.8.5/hadoop-2.8.5.tar.gz | tar -xz -C /usr/local/
 RUN cd /usr/local && ln -s ./hadoop-2.8.5 hadoop
 
 ENV HADOOP_PREFIX /usr/local/hadoop

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -46,6 +46,12 @@ environment variable to localhost on your system, as follows:
 export DOCKER_IP=127.0.0.1
 ```
 
+Optionally, you can also set `APACHE_ARCHIVE_MIRROR_HOST` to override `https://archive.apache.org` host. This host is used to download archives such as hadoop and kafka during building docker images:
+
+```
+export APACHE_ARCHIVE_MIRROR_HOST=https://example.com/remote-generic-repo
+```
+
 ## Running tests
 
 To run all tests from a test group using docker and mvn run the following command: 

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -19,8 +19,8 @@ FROM openjdk:$JDK_VERSION as druidbase
 # Bundle everything into one script so cleanup can reduce image size.
 # Otherwise docker's layered images mean that things are not actually deleted.
 
-COPY base-setup.sh /root/base-setup.sh
-RUN /root/base-setup.sh && rm -f /root/base-setup.sh
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
+RUN APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh
 
 FROM druidbase
 ARG MYSQL_VERSION

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -19,6 +19,7 @@ FROM openjdk:$JDK_VERSION as druidbase
 # Bundle everything into one script so cleanup can reduce image size.
 # Otherwise docker's layered images mean that things are not actually deleted.
 
+COPY base-setup.sh /root/base-setup.sh
 ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
 RUN APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh
 

--- a/integration-tests/docker/base-setup.sh
+++ b/integration-tests/docker/base-setup.sh
@@ -18,6 +18,7 @@ set -e
 set -u
 
 export DEBIAN_FRONTEND=noninteractive
+APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST:-https://archive.apache.org}
 
 apt-get update
 
@@ -33,7 +34,7 @@ apt-get install -y supervisor
 # Zookeeper
 
 install_zk() {
-  wget -q -O /tmp/$ZK_TAR.tar.gz "https://archive.apache.org/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
+  wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
   tar -xzf /tmp/$ZK_TAR.tar.gz -C /usr/local
   cp /usr/local/$ZK_TAR/conf/zoo_sample.cfg /usr/local/$ZK_TAR/conf/zoo.cfg
   rm /tmp/$ZK_TAR.tar.gz
@@ -52,7 +53,7 @@ ln -s /usr/local/$ZK_TAR /usr/local/zookeeper-3.5
 # Kafka
 # Match the version to the Kafka client used by KafkaSupervisor
 KAFKA_VERSION=2.7.0
-wget -q -O /tmp/kafka_2.13-$KAFKA_VERSION.tgz "https://apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.13-$KAFKA_VERSION.tgz"
+wget -q -O /tmp/kafka_2.13-$KAFKA_VERSION.tgz "$APACHE_ARCHIVE_MIRROR_HOST/dist/kafka/$KAFKA_VERSION/kafka_2.13-$KAFKA_VERSION.tgz"
 tar -xzf /tmp/kafka_2.13-$KAFKA_VERSION.tgz -C /usr/local
 ln -s /usr/local/kafka_2.13-$KAFKA_VERSION /usr/local/kafka
 rm /tmp/kafka_2.13-$KAFKA_VERSION.tgz

--- a/integration-tests/script/docker_build_containers.sh
+++ b/integration-tests/script/docker_build_containers.sh
@@ -28,11 +28,11 @@ else
   case "${DRUID_INTEGRATION_TEST_JVM_RUNTIME}" in
   8)
     echo "Build druid-cluster with Java 8"
-    docker build -t druid/cluster --build-arg JDK_VERSION=8-slim --build-arg MYSQL_VERSION $SHARED_DIR/docker
+    docker build -t druid/cluster --build-arg JDK_VERSION=8-slim --build-arg MYSQL_VERSION --build-arg APACHE_ARCHIVE_MIRROR_HOST $SHARED_DIR/docker
     ;;
   11)
     echo "Build druid-cluster with Java 11"
-    docker build -t druid/cluster --build-arg JDK_VERSION=11-slim --build-arg MYSQL_VERSION $SHARED_DIR/docker
+    docker build -t druid/cluster --build-arg JDK_VERSION=11-slim --build-arg MYSQL_VERSION --build-arg APACHE_ARCHIVE_MIRROR_HOST $SHARED_DIR/docker
     ;;
   *)
     echo "Invalid JVM Runtime given. Stopping"
@@ -44,5 +44,5 @@ fi
 # Build Hadoop docker if needed
 if [ -n "$DRUID_INTEGRATION_TEST_BUILD_HADOOP_DOCKER" ] && [ "$DRUID_INTEGRATION_TEST_BUILD_HADOOP_DOCKER" == true ]
 then
-  docker build -t druid-it/hadoop:2.8.5 $HADOOP_DOCKER_DIR
+  docker build -t druid-it/hadoop:2.8.5  --build-arg APACHE_ARCHIVE_MIRROR_HOST $HADOOP_DOCKER_DIR
 fi


### PR DESCRIPTION
Fixes the issue of builds were failed cause apache.org bandwitch limits

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

There were intermittent downloading issues during massive integration tests outside travis such as:

```
[2021-03-09T21:27:53.027Z] Step 13/53 : RUN curl -s https://archive.apache.org/dist/hadoop/core/hadoop-2.8.5/hadoop-2.8.5.tar.gz | tar -xz -C /usr/local/
[2021-03-09T21:27:53.027Z]  ---> Running in e1bebb15f9ac
[2021-03-09T21:27:53.600Z] 
[2021-03-09T21:27:53.600Z] gzip: stdin: not in gzip format
[2021-03-09T21:27:53.600Z] tar: Child returned status 1
[2021-03-09T21:27:53.600Z] tar: Error is not recoverable: exiting now
```

or 

```
[2021-03-09T22:19:00.605Z] The command '/bin/sh -c /root/base-setup.sh && rm -f /root/base-setup.sh' returned a non-zero code: 8
[2021-03-09T22:19:00.605Z] [ERROR] Command execution failed.
[2021-03-09T22:19:00.605Z] org.apache.commons.exec.ExecuteException: Process exited with an error: 8 (Exit value: 8)
[2021-03-09T22:19:00.605Z]     at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
[2021-03-09T22:19:00.605Z]     at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
``` 

These are because `archive.apache.org` isn't available by bandwitch limits
The solution is to use mirror of this host, such as artifactory generic remote repository which points to https://archive.apache.org/

### Changes:

Added `ARG` instructions to the following dockerfiles `examples/quickstart/tutorial/hadoop/docker/Dockerfile` and `integration-tests/docker/Dockerfile`, changed `integration-tests/docker/base-setup.sh` to support `APACHE_ARCHIVE_MIRROR_HOST` variable and added optional `--build-arg` arguments to `integration-tests/script/docker_build_containers.sh`

Added a tip in documentation: `integration-tests/README.md` about how to override `archive.apache.org`

`archive.apache.org` host is still used by default

### Labels:

`Area - Testing`
