### PR TITLE
Fix Smile encoding for HTTP response

### DIFF
--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/AbstractQueryResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/AbstractQueryResourceTestClient.java
@@ -80,7 +80,7 @@ public abstract class AbstractQueryResourceTestClient<QueryType>
   }
 
   /**
-   * A encoder/decoder encodes/decods request/response based on value of Content-Type
+   * A encoder/decoder that encodes/decodes requests/responses based on Content-Type.
    */
   interface EncoderDecoder<QueryType>
   {

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/QueryResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/QueryResourceTestClient.java
@@ -29,6 +29,9 @@ import org.apache.druid.query.Query;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.guice.TestClient;
 
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MediaType;
+
 public class QueryResourceTestClient extends AbstractQueryResourceTestClient<Query>
 {
 
@@ -40,17 +43,19 @@ public class QueryResourceTestClient extends AbstractQueryResourceTestClient<Que
       IntegrationTestingConfig config
   )
   {
-    super(jsonMapper, smileMapper, httpClient, config.getRouterUrl());
+    this(jsonMapper, smileMapper, httpClient, config.getRouterUrl(), MediaType.APPLICATION_JSON, null);
   }
 
   private QueryResourceTestClient(
       ObjectMapper jsonMapper,
       @Smile ObjectMapper smileMapper,
       @TestClient HttpClient httpClient,
-      String routerUrl
+      String routerUrl,
+      String contentType,
+      String accept
   )
   {
-    super(jsonMapper, smileMapper, httpClient, routerUrl);
+    super(jsonMapper, smileMapper, httpClient, routerUrl, contentType, accept);
   }
 
   @Override
@@ -69,16 +74,15 @@ public class QueryResourceTestClient extends AbstractQueryResourceTestClient<Que
    * @param contentType Content-Type header of request. Cannot be NULL. Both application/json and application/x-jackson-smile are allowed
    * @param accept      Accept header of request. Both application/json and application/x-jackson-smile are allowed
    */
-  public QueryResourceTestClient withEncoding(String contentType, String accept)
+  public QueryResourceTestClient withEncoding(String contentType, @Nullable String accept)
   {
-    QueryResourceTestClient client = new QueryResourceTestClient(
+    return new QueryResourceTestClient(
         this.jsonMapper,
         this.smileMapper,
         this.httpClient,
-        this.routerUrl
+        this.routerUrl,
+        contentType,
+        accept
     );
-    client.setContentTypeHeader(contentType);
-    client.setAcceptHeader(accept);
-    return client;
   }
 }

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/QueryResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/QueryResourceTestClient.java
@@ -22,6 +22,7 @@ package org.apache.druid.testing.clients;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
+import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.query.Query;
@@ -34,11 +35,22 @@ public class QueryResourceTestClient extends AbstractQueryResourceTestClient<Que
   @Inject
   QueryResourceTestClient(
       ObjectMapper jsonMapper,
+      @Smile ObjectMapper smileMapper,
       @TestClient HttpClient httpClient,
       IntegrationTestingConfig config
   )
   {
-    super(jsonMapper, httpClient, config);
+    super(jsonMapper, smileMapper, httpClient, config.getRouterUrl());
+  }
+
+  private QueryResourceTestClient(
+      ObjectMapper jsonMapper,
+      @Smile ObjectMapper smileMapper,
+      @TestClient HttpClient httpClient,
+      String routerUrl
+  )
+  {
+    super(jsonMapper, smileMapper, httpClient, routerUrl);
   }
 
   @Override
@@ -50,4 +62,11 @@ public class QueryResourceTestClient extends AbstractQueryResourceTestClient<Que
     );
   }
 
+  public QueryResourceTestClient withEncoding(boolean requestSmileEncoding, boolean responseSmileEncoding)
+  {
+    QueryResourceTestClient client = new QueryResourceTestClient(this.jsonMapper, this.smileMapper, this.httpClient, this.routerUrl);
+    client.requestSmileEncoding = requestSmileEncoding;
+    client.responseSmileEncoding = responseSmileEncoding;
+    return client;
+  }
 }

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/QueryResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/QueryResourceTestClient.java
@@ -62,11 +62,23 @@ public class QueryResourceTestClient extends AbstractQueryResourceTestClient<Que
     );
   }
 
-  public QueryResourceTestClient withEncoding(boolean requestSmileEncoding, boolean responseSmileEncoding)
+  /**
+   * clone a new instance of current object with given encoding.
+   * Note: For {@link AbstractQueryResourceTestClient#queryAsync(String, Object)} operation, contentType could only be application/json
+   *
+   * @param contentType Content-Type header of request. Cannot be NULL. Both application/json and application/x-jackson-smile are allowed
+   * @param accept      Accept header of request. Both application/json and application/x-jackson-smile are allowed
+   */
+  public QueryResourceTestClient withEncoding(String contentType, String accept)
   {
-    QueryResourceTestClient client = new QueryResourceTestClient(this.jsonMapper, this.smileMapper, this.httpClient, this.routerUrl);
-    client.requestSmileEncoding = requestSmileEncoding;
-    client.responseSmileEncoding = responseSmileEncoding;
+    QueryResourceTestClient client = new QueryResourceTestClient(
+        this.jsonMapper,
+        this.smileMapper,
+        this.httpClient,
+        this.routerUrl
+    );
+    client.setContentTypeHeader(contentType);
+    client.setAcceptHeader(accept);
     return client;
   }
 }

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/SqlResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/SqlResourceTestClient.java
@@ -37,7 +37,9 @@ public class SqlResourceTestClient extends AbstractQueryResourceTestClient<SqlQu
       IntegrationTestingConfig config
   )
   {
-    super(jsonMapper, httpClient, config);
+    // currently smile encoding is not supported on SQL endpoint
+    // so no need to pass smile ObjectMapper
+    super(jsonMapper, null, httpClient, config.getRouterUrl());
   }
 
   @Override

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/SqlResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/SqlResourceTestClient.java
@@ -27,6 +27,8 @@ import org.apache.druid.sql.http.SqlQuery;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.guice.TestClient;
 
+import javax.ws.rs.core.MediaType;
+
 public class SqlResourceTestClient extends AbstractQueryResourceTestClient<SqlQuery>
 {
 
@@ -39,7 +41,7 @@ public class SqlResourceTestClient extends AbstractQueryResourceTestClient<SqlQu
   {
     // currently smile encoding is not supported on SQL endpoint
     // so no need to pass smile ObjectMapper
-    super(jsonMapper, null, httpClient, config.getRouterUrl());
+    super(jsonMapper, null, httpClient, config.getRouterUrl(), MediaType.APPLICATION_JSON, null);
   }
 
   @Override

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/AbstractTestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/AbstractTestQueryHelper.java
@@ -43,8 +43,8 @@ public abstract class AbstractTestQueryHelper<QueryResultType extends AbstractQu
 
   public static final Logger LOG = new Logger(TestQueryHelper.class);
 
-  private final AbstractQueryResourceTestClient queryClient;
-  private final ObjectMapper jsonMapper;
+  protected final AbstractQueryResourceTestClient queryClient;
+  protected final ObjectMapper jsonMapper;
   protected final String broker;
   protected final String brokerTLS;
   protected final String router;
@@ -57,12 +57,31 @@ public abstract class AbstractTestQueryHelper<QueryResultType extends AbstractQu
       IntegrationTestingConfig config
   )
   {
+    this(
+        jsonMapper,
+        queryClient,
+        config.getBrokerUrl(),
+        config.getBrokerTLSUrl(),
+        config.getRouterUrl(),
+        config.getRouterTLSUrl()
+    );
+  }
+
+  AbstractTestQueryHelper(
+      ObjectMapper jsonMapper,
+      AbstractQueryResourceTestClient queryClient,
+      String broker,
+      String brokerTLS,
+      String router,
+      String routerTLS
+  )
+  {
     this.jsonMapper = jsonMapper;
     this.queryClient = queryClient;
-    this.broker = config.getBrokerUrl();
-    this.brokerTLS = config.getBrokerTLSUrl();
-    this.router = config.getRouterUrl();
-    this.routerTLS = config.getRouterTLSUrl();
+    this.broker = broker;
+    this.brokerTLS = brokerTLS;
+    this.router = router;
+    this.routerTLS = routerTLS;
   }
 
   public abstract String getQueryURL(String schemeAndHost);

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/TestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/TestQueryHelper.java
@@ -38,10 +38,40 @@ public class TestQueryHelper extends AbstractTestQueryHelper<QueryWithResults>
     super(jsonMapper, queryClient, config);
   }
 
+  private TestQueryHelper(
+      ObjectMapper jsonMapper,
+      QueryResourceTestClient queryResourceTestClient,
+      String broker,
+      String brokerTLS,
+      String router,
+      String routerTLS
+  )
+  {
+    super(
+        jsonMapper,
+        queryResourceTestClient,
+        broker,
+        brokerTLS,
+        router,
+        routerTLS
+    );
+  }
+
   @Override
   public String getQueryURL(String schemeAndHost)
   {
     return StringUtils.format("%s/druid/v2?pretty", schemeAndHost);
   }
 
+  public TestQueryHelper withEncoding(boolean requestSmileEncoding, boolean responseSmileEncoding)
+  {
+    return new TestQueryHelper(
+        this.jsonMapper,
+        ((QueryResourceTestClient) this.queryClient).withEncoding(requestSmileEncoding, responseSmileEncoding),
+        this.broker,
+        this.brokerTLS,
+        this.router,
+        this.routerTLS
+    );
+  }
 }

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/TestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/TestQueryHelper.java
@@ -25,6 +25,9 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.clients.QueryResourceTestClient;
 
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
 public class TestQueryHelper extends AbstractTestQueryHelper<QueryWithResults>
 {
 
@@ -63,11 +66,17 @@ public class TestQueryHelper extends AbstractTestQueryHelper<QueryWithResults>
     return StringUtils.format("%s/druid/v2?pretty", schemeAndHost);
   }
 
-  public TestQueryHelper withEncoding(boolean requestSmileEncoding, boolean responseSmileEncoding)
+  /**
+   * clone a new instance of current object with given encoding
+   *
+   * @param contentType Content-Type header of request. Cannot be NULL. Both application/json and application/x-jackson-smile are allowed
+   * @param accept      Accept header of request. Both application/json and application/x-jackson-smile are allowed
+   */
+  public TestQueryHelper withEncoding(@NotNull String contentType, @Nullable String accept)
   {
     return new TestQueryHelper(
         this.jsonMapper,
-        ((QueryResourceTestClient) this.queryClient).withEncoding(requestSmileEncoding, responseSmileEncoding),
+        ((QueryResourceTestClient) this.queryClient).withEncoding(contentType, accept),
         this.broker,
         this.brokerTLS,
         this.router,

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITWikipediaQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITWikipediaQueryTest.java
@@ -36,6 +36,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Guice;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -79,6 +80,22 @@ public class ITWikipediaQueryTest
   @Test
   public void testWikipediaQueriesFromFile() throws Exception
   {
+    queryHelper.testQueriesFromFile(WIKIPEDIA_QUERIES_RESOURCE);
+  }
+
+  @Test
+  @Parameters(
+      {
+          "true, true",
+          "true, false",
+          "false, true",
+          "false, false",
+      }
+  )
+  public void testWikipediaQueriesFromFileWithSmileEncoding(boolean requestSmileEncoding, boolean responseSmileEncoding)
+      throws Exception
+  {
+    TestQueryHelper queryHelper = this.queryHelper.withEncoding(requestSmileEncoding, responseSmileEncoding);
     queryHelper.testQueriesFromFile(WIKIPEDIA_QUERIES_RESOURCE);
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITWikipediaQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITWikipediaQueryTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.tests.query;
 
+import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
@@ -35,10 +36,11 @@ import org.apache.druid.tests.TestNGGroup;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Guice;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -77,25 +79,32 @@ public class ITWikipediaQueryTest
     }
   }
 
-  @Test
-  public void testWikipediaQueriesFromFile() throws Exception
+  /**
+   * A combination of request Content-Type and Accept HTTP header
+   * The first is Content-Type which can not be null while the 2nd is Accept which could be null
+   * <p>
+   * When Accept is null, its value defaults to value of Content-Type
+   */
+  @DataProvider
+  public static Object[][] encodingCombination()
   {
-    queryHelper.testQueriesFromFile(WIKIPEDIA_QUERIES_RESOURCE);
+    return new Object[][]{
+        {MediaType.APPLICATION_JSON, null},
+        {MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON},
+        {MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE},
+        {SmileMediaTypes.APPLICATION_JACKSON_SMILE, null},
+        {SmileMediaTypes.APPLICATION_JACKSON_SMILE, MediaType.APPLICATION_JSON},
+        {SmileMediaTypes.APPLICATION_JACKSON_SMILE, SmileMediaTypes.APPLICATION_JACKSON_SMILE},
+        };
   }
 
-  @Test
-  @Parameters(
-      {
-          "true, true",
-          "true, false",
-          "false, true",
-          "false, false",
-      }
-  )
-  public void testWikipediaQueriesFromFileWithSmileEncoding(boolean requestSmileEncoding, boolean responseSmileEncoding)
+  @Test(dataProvider = "encodingCombination")
+  public void testWikipediaQueriesFromFile(String contentType, String accept)
       throws Exception
   {
-    TestQueryHelper queryHelper = this.queryHelper.withEncoding(requestSmileEncoding, responseSmileEncoding);
+    // run tests on a new query helper
+    TestQueryHelper queryHelper = this.queryHelper.withEncoding(contentType, accept);
+
     queryHelper.testQueriesFromFile(WIKIPEDIA_QUERIES_RESOURCE);
   }
 

--- a/server/src/main/java/org/apache/druid/server/BrokerQueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/BrokerQueryResource.java
@@ -91,11 +91,10 @@ public class BrokerQueryResource extends QueryResource
       @Context final HttpServletRequest req
   ) throws IOException
   {
-    final ResourceIOReaderWriter ioReaderWriter =
-        createResourceIOReaderWriter(req.getContentType(), pretty != null);
+    final ResourceIOReaderWriter ioReaderWriter = createResourceIOReaderWriter(req, pretty != null);
     try {
-      Query<?> query = ioReaderWriter.getInputMapper().readValue(in, Query.class);
-      return ioReaderWriter.ok(
+      Query<?> query = ioReaderWriter.getRequestMapper().readValue(in, Query.class);
+      return ioReaderWriter.getResponseWriter().ok(
           ServerViewUtil.getTargetLocations(
               brokerServerView,
               query.getDataSource(),
@@ -105,7 +104,7 @@ public class BrokerQueryResource extends QueryResource
       );
     }
     catch (Exception e) {
-      return ioReaderWriter.gotError(e);
+      return ioReaderWriter.getResponseWriter().gotError(e);
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -183,13 +183,7 @@ public class QueryResource implements QueryCountStatsProvider
     final QueryLifecycle queryLifecycle = queryLifecycleFactory.factorize();
     Query<?> query = null;
 
-    String acceptHeader = req.getHeader("Accept");
-    if (Strings.isNullOrEmpty(acceptHeader)) {
-      //default to content-type
-      acceptHeader = req.getContentType();
-    }
-
-    final ResourceIOReaderWriter ioReaderWriter = createResourceIOReaderWriter(acceptHeader, pretty != null);
+    final ResourceIOReaderWriter ioReaderWriter = createResourceIOReaderWriter(req, pretty != null);
 
     final String currThreadName = Thread.currentThread().getName();
     try {
@@ -235,7 +229,7 @@ public class QueryResource implements QueryCountStatsProvider
             QueryContexts.isSerializeDateTimeAsLong(query, false)
             || (!shouldFinalize && QueryContexts.isSerializeDateTimeAsLongInner(query, false));
 
-        final ObjectWriter jsonWriter = ioReaderWriter.newOutputWriter(
+        final ObjectWriter jsonWriter = ioReaderWriter.getResponseWriter().newOutputWriter(
             queryLifecycle.getToolChest(),
             queryLifecycle.getQuery(),
             serializeDateTimeAsLong
@@ -276,7 +270,7 @@ public class QueryResource implements QueryCountStatsProvider
                     }
                   }
                 },
-                ioReaderWriter.getContentType()
+                ioReaderWriter.getResponseWriter().getRequestType()
             )
             .header("X-Druid-Query-Id", queryId);
 
@@ -337,27 +331,27 @@ public class QueryResource implements QueryCountStatsProvider
     catch (QueryInterruptedException e) {
       interruptedQueryCount.incrementAndGet();
       queryLifecycle.emitLogsAndMetrics(e, req.getRemoteAddr(), -1);
-      return ioReaderWriter.gotError(e);
+      return ioReaderWriter.getResponseWriter().gotError(e);
     }
     catch (QueryTimeoutException timeout) {
       timedOutQueryCount.incrementAndGet();
       queryLifecycle.emitLogsAndMetrics(timeout, req.getRemoteAddr(), -1);
-      return ioReaderWriter.gotTimeout(timeout);
+      return ioReaderWriter.getResponseWriter().gotTimeout(timeout);
     }
     catch (QueryCapacityExceededException cap) {
       failedQueryCount.incrementAndGet();
       queryLifecycle.emitLogsAndMetrics(cap, req.getRemoteAddr(), -1);
-      return ioReaderWriter.gotLimited(cap);
+      return ioReaderWriter.getResponseWriter().gotLimited(cap);
     }
     catch (QueryUnsupportedException unsupported) {
       failedQueryCount.incrementAndGet();
       queryLifecycle.emitLogsAndMetrics(unsupported, req.getRemoteAddr(), -1);
-      return ioReaderWriter.gotUnsupported(unsupported);
+      return ioReaderWriter.getResponseWriter().gotUnsupported(unsupported);
     }
     catch (BadJsonQueryException | ResourceLimitExceededException e) {
       interruptedQueryCount.incrementAndGet();
       queryLifecycle.emitLogsAndMetrics(e, req.getRemoteAddr(), -1);
-      return ioReaderWriter.gotBadQuery(e);
+      return ioReaderWriter.getResponseWriter().gotBadQuery(e);
     }
     catch (ForbiddenException e) {
       // don't do anything for an authorization failure, ForbiddenExceptionMapper will catch this later and
@@ -374,7 +368,7 @@ public class QueryResource implements QueryCountStatsProvider
          .addData("peer", req.getRemoteAddr())
          .emit();
 
-      return ioReaderWriter.gotError(e);
+      return ioReaderWriter.getResponseWriter().gotError(e);
     }
     finally {
       Thread.currentThread().setName(currThreadName);
@@ -389,7 +383,7 @@ public class QueryResource implements QueryCountStatsProvider
   {
     Query baseQuery;
     try {
-      baseQuery = ioReaderWriter.getInputMapper().readValue(in, Query.class);
+      baseQuery = ioReaderWriter.getRequestMapper().readValue(in, Query.class);
     }
     catch (JsonParseException e) {
       throw new BadJsonQueryException(e);
@@ -415,47 +409,71 @@ public class QueryResource implements QueryCountStatsProvider
     return mapper.copy().registerModule(new SimpleModule().addSerializer(DateTime.class, new DateTimeSerializer()));
   }
 
-  protected ResourceIOReaderWriter createResourceIOReaderWriter(String requestType, boolean pretty)
+  protected ResourceIOReaderWriter createResourceIOReaderWriter(HttpServletRequest req, boolean pretty)
   {
-    boolean isSmile = SmileMediaTypes.APPLICATION_JACKSON_SMILE.equals(requestType) ||
-                      APPLICATION_SMILE.equals(requestType);
-    String contentType = isSmile ? SmileMediaTypes.APPLICATION_JACKSON_SMILE : MediaType.APPLICATION_JSON;
+    String requestType = req.getContentType();
+    String acceptHeader = req.getHeader("Accept");
+
+    // response type defaults to Content-Type if no 'Accept' header provided
+    String responseType = Strings.isNullOrEmpty(acceptHeader) ? requestType : acceptHeader;
+
+    boolean isRequestSmile = SmileMediaTypes.APPLICATION_JACKSON_SMILE.equals(requestType) || APPLICATION_SMILE.equals(requestType);
+    boolean isResponseSmile = SmileMediaTypes.APPLICATION_JACKSON_SMILE.equals(responseType) || APPLICATION_SMILE.equals(responseType);
+
     return new ResourceIOReaderWriter(
-        contentType,
-        isSmile ? smileMapper : jsonMapper,
-        isSmile ? serializeDateTimeAsLongSmileMapper : serializeDateTimeAsLongJsonMapper,
-        pretty
-    );
+        isRequestSmile ? smileMapper : jsonMapper,
+        new ResourceIOWriter(isResponseSmile ? SmileMediaTypes.APPLICATION_JACKSON_SMILE : MediaType.APPLICATION_JSON,
+                             isResponseSmile ? smileMapper : jsonMapper,
+                             isResponseSmile ? serializeDateTimeAsLongSmileMapper : serializeDateTimeAsLongJsonMapper,
+                             pretty
+    ));
   }
 
   protected static class ResourceIOReaderWriter
   {
-    private final String contentType;
+    private final ObjectMapper requestMapper;
+    private final ResourceIOWriter writer;
+
+    public ResourceIOReaderWriter(ObjectMapper requestMapper, ResourceIOWriter writer)
+    {
+      this.requestMapper = requestMapper;
+      this.writer = writer;
+    }
+
+    public ObjectMapper getRequestMapper()
+    {
+      return requestMapper;
+    }
+
+    public ResourceIOWriter getResponseWriter()
+    {
+      return writer;
+    }
+  }
+
+  protected static class ResourceIOWriter
+  {
+    private final String responseType;
     private final ObjectMapper inputMapper;
     private final ObjectMapper serializeDateTimeAsLongInputMapper;
     private final boolean isPretty;
 
-    ResourceIOReaderWriter(
-        String contentType,
+    ResourceIOWriter(
+        String responseType,
         ObjectMapper inputMapper,
         ObjectMapper serializeDateTimeAsLongInputMapper,
         boolean isPretty
     )
     {
-      this.contentType = contentType;
+      this.responseType = responseType;
       this.inputMapper = inputMapper;
       this.serializeDateTimeAsLongInputMapper = serializeDateTimeAsLongInputMapper;
       this.isPretty = isPretty;
     }
 
-    String getContentType()
+    String getRequestType()
     {
-      return contentType;
-    }
-
-    ObjectMapper getInputMapper()
-    {
-      return inputMapper;
+      return responseType;
     }
 
     ObjectWriter newOutputWriter(
@@ -476,7 +494,7 @@ public class QueryResource implements QueryCountStatsProvider
 
     Response ok(Object object) throws IOException
     {
-      return Response.ok(newOutputWriter(null, null, false).writeValueAsString(object), contentType).build();
+      return Response.ok(newOutputWriter(null, null, false).writeValueAsString(object), responseType).build();
     }
 
     Response gotError(Exception e) throws IOException
@@ -510,7 +528,7 @@ public class QueryResource implements QueryCountStatsProvider
     Response buildNonOkResponse(int status, Exception e) throws JsonProcessingException
     {
       return Response.status(status)
-                     .type(contentType)
+                     .type(responseType)
                      .entity(newOutputWriter(null, null, false).writeValueAsBytes(e))
                      .build();
     }

--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -270,7 +270,7 @@ public class QueryResource implements QueryCountStatsProvider
                     }
                   }
                 },
-                ioReaderWriter.getResponseWriter().getRequestType()
+                ioReaderWriter.getResponseWriter().getResponseType()
             )
             .header("X-Druid-Query-Id", queryId);
 
@@ -414,7 +414,7 @@ public class QueryResource implements QueryCountStatsProvider
     String requestType = req.getContentType();
     String acceptHeader = req.getHeader("Accept");
 
-    // response type defaults to Content-Type if no 'Accept' header provided
+    // response type defaults to Content-Type if 'Accept' header not provided
     String responseType = Strings.isNullOrEmpty(acceptHeader) ? requestType : acceptHeader;
 
     boolean isRequestSmile = SmileMediaTypes.APPLICATION_JACKSON_SMILE.equals(requestType) || APPLICATION_SMILE.equals(requestType);
@@ -471,7 +471,7 @@ public class QueryResource implements QueryCountStatsProvider
       this.isPretty = isPretty;
     }
 
-    String getRequestType()
+    String getResponseType()
     {
       return responseType;
     }

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -28,6 +28,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import org.apache.druid.guice.GuiceInjectors;
+import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.guava.LazySequence;
@@ -96,7 +100,6 @@ import java.util.function.Consumer;
 public class QueryResourceTest
 {
   private static final QueryToolChestWarehouse WAREHOUSE = new MapQueryToolChestWarehouse(ImmutableMap.of());
-  private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
   private static final AuthenticationResult AUTHENTICATION_RESULT =
       new AuthenticationResult("druid", "druid", null, null);
 
@@ -178,6 +181,8 @@ public class QueryResourceTest
       false
   );
 
+  private ObjectMapper jsonMapper;
+  private ObjectMapper smileMapper;
   private QueryResource queryResource;
   private QueryScheduler queryScheduler;
   private TestRequestLogger testRequestLogger;
@@ -191,6 +196,10 @@ public class QueryResourceTest
   @Before
   public void setup()
   {
+    Injector injector = GuiceInjectors.makeStartupInjector();
+    jsonMapper = injector.getInstance(ObjectMapper.class);
+    smileMapper = injector.getInstance(Key.get(ObjectMapper.class, Smile.class));
+
     EasyMock.expect(testServletRequest.getContentType()).andReturn(MediaType.APPLICATION_JSON).anyTimes();
     EasyMock.expect(testServletRequest.getHeader("Accept")).andReturn(MediaType.APPLICATION_JSON).anyTimes();
     EasyMock.expect(testServletRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
@@ -213,8 +222,8 @@ public class QueryResourceTest
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
             Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        smileMapper,
         queryScheduler,
         new AuthConfig(),
         null,
@@ -259,8 +268,8 @@ public class QueryResourceTest
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
             Suppliers.ofInstance(overrideConfig)
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        smileMapper,
         queryScheduler,
         new AuthConfig(),
         null,
@@ -279,7 +288,7 @@ public class QueryResourceTest
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ((StreamingOutput) response.getEntity()).write(baos);
-    final List<Result<TimeBoundaryResultValue>> responses = JSON_MAPPER.readValue(
+    final List<Result<TimeBoundaryResultValue>> responses = jsonMapper.readValue(
         baos.toByteArray(),
         new TypeReference<List<Result<TimeBoundaryResultValue>>>() {}
     );
@@ -311,8 +320,8 @@ public class QueryResourceTest
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
             Suppliers.ofInstance(overrideConfig)
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        smileMapper,
         queryScheduler,
         new AuthConfig(),
         null,
@@ -332,7 +341,7 @@ public class QueryResourceTest
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ((StreamingOutput) response.getEntity()).write(baos);
-    final List<Result<TimeBoundaryResultValue>> responses = JSON_MAPPER.readValue(
+    final List<Result<TimeBoundaryResultValue>> responses = jsonMapper.readValue(
         baos.toByteArray(),
         new TypeReference<List<Result<TimeBoundaryResultValue>>>() {}
     );
@@ -367,7 +376,7 @@ public class QueryResourceTest
     ).toString();
     Assert.assertEquals(
         expectedException,
-        JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryInterruptedException.class).toString()
+        jsonMapper.readValue((byte[]) response.getEntity(), QueryInterruptedException.class).toString()
     );
   }
 
@@ -457,7 +466,7 @@ public class QueryResourceTest
   }
 
   @Test
-  public void testGoodQueryWithSmileAcceptHeader() throws IOException
+  public void testGoodQueryWithJsonRequestAndSmileAcceptHeader() throws IOException
   {
     //Doing a replay of testServletRequest for teardown to succeed.
     //We dont use testServletRequest in this testcase
@@ -466,6 +475,8 @@ public class QueryResourceTest
     //Creating our own Smile Servlet request, as to not disturb the remaining tests.
     // else refactoring required for this class. i know this kinda makes the class somewhat Dirty.
     final HttpServletRequest smileRequest = EasyMock.createMock(HttpServletRequest.class);
+
+    // Set Content-Type to JSON
     EasyMock.expect(smileRequest.getContentType()).andReturn(MediaType.APPLICATION_JSON).anyTimes();
 
     EasyMock.expect(smileRequest.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED))
@@ -479,6 +490,7 @@ public class QueryResourceTest
 
     smileRequest.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
 
+    // Set Accept to Smile
     EasyMock.expect(smileRequest.getHeader("Accept")).andReturn(SmileMediaTypes.APPLICATION_JACKSON_SMILE).anyTimes();
     EasyMock.expect(smileRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
     EasyMock.expect(smileRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
@@ -490,6 +502,98 @@ public class QueryResourceTest
         smileRequest
     );
     Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+
+    // Content-Type in response should be Smile
+    Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, (response.getMetadata().get("Content-Type").get(0)).toString());
+    Assert.assertNotNull(response);
+    EasyMock.verify(smileRequest);
+  }
+
+  @Test
+  public void testGoodQueryWithSmileRequestAndSmileAcceptHeader() throws IOException
+  {
+    //Doing a replay of testServletRequest for teardown to succeed.
+    //We dont use testServletRequest in this testcase
+    EasyMock.replay(testServletRequest);
+
+    //Creating our own Smile Servlet request, as to not disturb the remaining tests.
+    // else refactoring required for this class. i know this kinda makes the class somewhat Dirty.
+    final HttpServletRequest smileRequest = EasyMock.createMock(HttpServletRequest.class);
+
+    // Set Content-Type to Smile
+    EasyMock.expect(smileRequest.getContentType()).andReturn(SmileMediaTypes.APPLICATION_JACKSON_SMILE).anyTimes();
+
+    EasyMock.expect(smileRequest.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED))
+            .andReturn(null)
+            .anyTimes();
+    EasyMock.expect(smileRequest.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).anyTimes();
+
+    EasyMock.expect(smileRequest.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+            .andReturn(AUTHENTICATION_RESULT)
+            .anyTimes();
+
+    smileRequest.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+
+    // Set Accept to Smile
+    EasyMock.expect(smileRequest.getHeader("Accept")).andReturn(SmileMediaTypes.APPLICATION_JACKSON_SMILE).anyTimes();
+    EasyMock.expect(smileRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(smileRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
+
+    EasyMock.replay(smileRequest);
+    Response response = queryResource.doPost(
+        // Write input in Smile encoding
+        new ByteArrayInputStream(smileMapper.writeValueAsBytes(jsonMapper.readTree(SIMPLE_TIMESERIES_QUERY))),
+        null /*pretty*/,
+        smileRequest
+    );
+    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+
+    // Content-Type in response should be Smile
+    Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, (response.getMetadata().get("Content-Type").get(0)).toString());
+    Assert.assertNotNull(response);
+    EasyMock.verify(smileRequest);
+  }
+
+  @Test
+  public void testGoodQueryWithSmileRequestNoSmileAcceptHeader() throws IOException
+  {
+    //Doing a replay of testServletRequest for teardown to succeed.
+    //We dont use testServletRequest in this testcase
+    EasyMock.replay(testServletRequest);
+
+    //Creating our own Smile Servlet request, as to not disturb the remaining tests.
+    // else refactoring required for this class. i know this kinda makes the class somewhat Dirty.
+    final HttpServletRequest smileRequest = EasyMock.createMock(HttpServletRequest.class);
+
+    // Set Content-Type to Smile
+    EasyMock.expect(smileRequest.getContentType()).andReturn(SmileMediaTypes.APPLICATION_JACKSON_SMILE).anyTimes();
+
+    EasyMock.expect(smileRequest.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED))
+            .andReturn(null)
+            .anyTimes();
+    EasyMock.expect(smileRequest.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).anyTimes();
+
+    EasyMock.expect(smileRequest.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+            .andReturn(AUTHENTICATION_RESULT)
+            .anyTimes();
+
+    smileRequest.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+
+    // DO NOT set Accept to Smile, Content-Type in response will be default to Content-Type in request
+    EasyMock.expect(smileRequest.getHeader("Accept")).andReturn(null).anyTimes();
+    EasyMock.expect(smileRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(smileRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
+
+    EasyMock.replay(smileRequest);
+    Response response = queryResource.doPost(
+        // Write input in Smile encoding
+        new ByteArrayInputStream(smileMapper.writeValueAsBytes(jsonMapper.readTree(SIMPLE_TIMESERIES_QUERY))),
+        null /*pretty*/,
+        smileRequest
+    );
+    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+
+    // Content-Type in response will be default to Content-Type in request
     Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, (response.getMetadata().get("Content-Type").get(0)).toString());
     Assert.assertNotNull(response);
     EasyMock.verify(smileRequest);
@@ -506,7 +610,7 @@ public class QueryResourceTest
     );
     Assert.assertNotNull(response);
     Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    QueryException e = JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryException.class);
+    QueryException e = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
     Assert.assertEquals(BadJsonQueryException.ERROR_CODE, e.getErrorCode());
     Assert.assertEquals(BadJsonQueryException.ERROR_CLASS, e.getErrorClass());
   }
@@ -525,7 +629,7 @@ public class QueryResourceTest
     );
     Assert.assertNotNull(response);
     Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    QueryException e = JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryException.class);
+    QueryException e = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
     Assert.assertEquals(ResourceLimitExceededException.ERROR_CODE, e.getErrorCode());
     Assert.assertEquals(ResourceLimitExceededException.class.getName(), e.getErrorClass());
   }
@@ -546,7 +650,7 @@ public class QueryResourceTest
     );
     Assert.assertNotNull(response);
     Assert.assertEquals(QueryUnsupportedException.STATUS_CODE, response.getStatus());
-    QueryException ex = JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryException.class);
+    QueryException ex = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
     Assert.assertEquals(errorMessage, ex.getMessage());
     Assert.assertEquals(QueryUnsupportedException.ERROR_CODE, ex.getErrorCode());
   }
@@ -603,8 +707,8 @@ public class QueryResourceTest
             authMapper,
             Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        smileMapper,
         queryScheduler,
         new AuthConfig(),
         authMapper,
@@ -632,7 +736,7 @@ public class QueryResourceTest
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ((StreamingOutput) response.getEntity()).write(baos);
-    final List<Result<TimeBoundaryResultValue>> responses = JSON_MAPPER.readValue(
+    final List<Result<TimeBoundaryResultValue>> responses = jsonMapper.readValue(
         baos.toByteArray(),
         new TypeReference<List<Result<TimeBoundaryResultValue>>>() {}
     );
@@ -679,8 +783,8 @@ public class QueryResourceTest
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
             Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        jsonMapper,
         queryScheduler,
         new AuthConfig(),
         null,
@@ -697,7 +801,7 @@ public class QueryResourceTest
     Assert.assertEquals(QueryTimeoutException.STATUS_CODE, response.getStatus());
     QueryTimeoutException ex;
     try {
-      ex = JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryTimeoutException.class);
+      ex = jsonMapper.readValue((byte[]) response.getEntity(), QueryTimeoutException.class);
     }
     catch (IOException e) {
       throw new RuntimeException(e);
@@ -777,8 +881,8 @@ public class QueryResourceTest
             authMapper,
             Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        smileMapper,
         queryScheduler,
         new AuthConfig(),
         authMapper,
@@ -901,8 +1005,8 @@ public class QueryResourceTest
             authMapper,
             Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        smileMapper,
         queryScheduler,
         new AuthConfig(),
         authMapper,
@@ -995,7 +1099,7 @@ public class QueryResourceTest
           Assert.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
           QueryCapacityExceededException ex;
           try {
-            ex = JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryCapacityExceededException.class);
+            ex = jsonMapper.readValue((byte[]) response.getEntity(), QueryCapacityExceededException.class);
           }
           catch (IOException e) {
             throw new RuntimeException(e);
@@ -1036,7 +1140,7 @@ public class QueryResourceTest
           Assert.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
           QueryCapacityExceededException ex;
           try {
-            ex = JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryCapacityExceededException.class);
+            ex = jsonMapper.readValue((byte[]) response.getEntity(), QueryCapacityExceededException.class);
           }
           catch (IOException e) {
             throw new RuntimeException(e);
@@ -1088,7 +1192,7 @@ public class QueryResourceTest
           Assert.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
           QueryCapacityExceededException ex;
           try {
-            ex = JSON_MAPPER.readValue((byte[]) response.getEntity(), QueryCapacityExceededException.class);
+            ex = jsonMapper.readValue((byte[]) response.getEntity(), QueryCapacityExceededException.class);
           }
           catch (IOException e) {
             throw new RuntimeException(e);
@@ -1160,8 +1264,8 @@ public class QueryResourceTest
             AuthTestUtils.TEST_AUTHORIZER_MAPPER,
             Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
         ),
-        JSON_MAPPER,
-        JSON_MAPPER,
+        jsonMapper,
+        smileMapper,
         scheduler,
         new AuthConfig(),
         null,


### PR DESCRIPTION
This PR fixes #10945

### Description

/druid/v2 endpoint supports jackson smile encoding both for request and response. But there's a bug there when processing a request with 'Accept:application/x-jackson-smile' header.

Current implementation takes 'Accept' parameter, which indicates server that smile encoding is accepted by client to decode the HTTP response, to decode a JSON request. According to HTTP protocol on 'Content-Type' and 'Accept', server should alway decode the body according to 'Content-Type' header, while encode response by 'Accept' header( if not provided, 'Accept' defaults to 'Content-Type')

The reason why current unit tests fails to detect this bug is because test cases in `QueryResourceTest` wrongly inject a Json ObjectMapper instead of Smile ObjectMapper for Smile decoding. All related test cases are fixed in this PR too.

### Smile encoding test

I have never heard of Smile encoding before, and there's little doc in Druid to describe if we should exploit it. So I also make some investigation how it saves response sizes in Druid to see if this feature could be used in our environment.

### Test data

Wikipedia data shipped by Druid

### Tests

Sending following scan query by CURL with following parameters
- `limit` parameter range in [100,200,300,400,500]
- Accept:application/x-jackson-smile turned on and off
- Content-Encoding:gzip turned on and off

observe 'size_download' for each response outputted by CURL 

```
{
  "queryType": "scan",
  "dataSource": {
    "type": "table",
    "name": "wikipedia"
  },
  "intervals": {
    "type": "intervals",
    "intervals": [
      "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
    ]
  },
  "virtualColumns": [],
  "batchSize": 20480,
  "limit": 100,
  "legacy": false,
  "descending": false,
  "granularity": {
    "type": "all"
  }
}
```

#### Result

Limit |Response Bytes in JSON(GZip) | Response Bytes in JSON(No-GZip) | Response Bytes in Smile(GZip) | Response Bytes in Smile(No-GZip)
-- | -- | -- | -- | --
100 | 6753 | 43084 | 6550 | 17874
200 | 12485 | 86427 | 11646 | 35781
300 | 18879 | 129798 | 17316 | 53797
400 | 24494 | 172290 | 22208 | 70896
500 | 30886 | 215331 | 27920 | 88595

The tests above do not cover all queries in druid, but the data in the table generally reflects advantages of Smile encoding in one aspect.

From the table we can see that:
- when gzip is not enabled in response, Smile encoding(column 5) takes about only 41% space over JSON(column 3)
- when gzip is enabled, Smile encoding performs a little improvement(column 4 vs columns 2)

In contrast to gzip which requires more resources on server side, Smile saves serialization time compared to JSON according to [some tests](http://www.theotherian.com/2013/12/kryo-vs-smile-vs-json-shootout-part-1.html). And there's no too much work to do expect replacing default object mapper to smile object mapper which usually is one line of work in many dependency injection system, I think Smile encoding is worthy to try.

### Note

SQL endpoint does not support Smile encoding yet(#10931), this PR does not add Smile encoding to SQL endpoint. I think we could have a discussion. Based on the tests shown above, IMO, it's reasonable to provide such support because SQL query is more popular than native query, at least in our environment.

<hr>

##### Key changed/added classes in this PR
 * `ResourceIOWriter` is extracted from `ResourceIOReaderWriter` to hold response content-type and right ObjectMapper while original ResourceIOReaderWriter holds right ObjectMapper to deserialize input request.

<hr>


This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
