### PR TITLE
Caching parsed expressions in sql planner

### DIFF
--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -15,8 +15,6 @@
 
 grammar Expr;
 
-start : expr EOF ;
-
 expr : NULL                                                         # null
      | ('-'|'!') expr                                               # unaryOpExpr
      |<assoc=right> expr '^' expr                                   # powOpExpr

--- a/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
+++ b/core/src/main/antlr4/org/apache/druid/math/expr/antlr/Expr.g4
@@ -15,6 +15,8 @@
 
 grammar Expr;
 
+start : expr EOF ;
+
 expr : NULL                                                         # null
      | ('-'|'!') expr                                               # unaryOpExpr
      |<assoc=right> expr '^' expr                                   # powOpExpr

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1680,6 +1680,7 @@ The Druid SQL server is configured through the following properties on the Broke
 |`druid.sql.planner.sqlTimeZone`|Sets the default time zone for the server, which will affect how time functions and timestamp literals behave. Should be a time zone name like "America/Los_Angeles" or offset like "-08:00".|UTC|
 |`druid.sql.planner.metadataSegmentCacheEnable`|Whether to keep a cache of published segments in broker. If true, broker polls coordinator in background to get segments from metadata store and maintains a local cache. If false, coordinator's REST API will be invoked when broker needs published segments info.|false|
 |`druid.sql.planner.metadataSegmentPollPeriod`|How often to poll coordinator for published segments list if `druid.sql.planner.metadataSegmentCacheEnable` is set to true. Poll period is in milliseconds. |60000|
+|`druid.sql.planner.useParsedExprCache`|Whether to use a cache for parsed expressions. This cache is created per query and stored on heap memory. Enabling cache can be useful when planning time takes long.|false|
 
 > Previous versions of Druid had properties named `druid.sql.planner.maxQueryCount` and `druid.sql.planner.maxSemiJoinRowsInMemory`.
 > These properties are no longer available. Since Druid 0.18.0, you can use `druid.server.http.maxSubqueryRows` to control the maximum

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -1008,6 +1008,7 @@ Connection context can be specified as JDBC connection properties or as a "conte
 |`sqlTimeZone`|Sets the time zone for this connection, which will affect how time functions and timestamp literals behave. Should be a time zone name like "America/Los_Angeles" or offset like "-08:00".|druid.sql.planner.sqlTimeZone on the Broker (default: UTC)|
 |`useApproximateCountDistinct`|Whether to use an approximate cardinality algorithm for `COUNT(DISTINCT foo)`.|druid.sql.planner.useApproximateCountDistinct on the Broker (default: true)|
 |`useApproximateTopN`|Whether to use approximate [TopN queries](topnquery.md) when a SQL query could be expressed as such. If false, exact [GroupBy queries](groupbyquery.md) will be used instead.|druid.sql.planner.useApproximateTopN on the Broker (default: true)|
+|`useParsedExprCache`|Whether to use a cache for parsed expressions. This cache is created per query and stored on heap memory. Enabling cache can be useful when planning time takes long.|druid.sql.planner.useParsedExprCache on the Broker (default: false)|
 
 ## Metadata tables
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -1008,7 +1008,7 @@ Connection context can be specified as JDBC connection properties or as a "conte
 |`sqlTimeZone`|Sets the time zone for this connection, which will affect how time functions and timestamp literals behave. Should be a time zone name like "America/Los_Angeles" or offset like "-08:00".|druid.sql.planner.sqlTimeZone on the Broker (default: UTC)|
 |`useApproximateCountDistinct`|Whether to use an approximate cardinality algorithm for `COUNT(DISTINCT foo)`.|druid.sql.planner.useApproximateCountDistinct on the Broker (default: true)|
 |`useApproximateTopN`|Whether to use approximate [TopN queries](topnquery.md) when a SQL query could be expressed as such. If false, exact [GroupBy queries](groupbyquery.md) will be used instead.|druid.sql.planner.useApproximateTopN on the Broker (default: true)|
-|`useParsedExprCache`|Whether to use a cache for parsed expressions. This cache is created per query and stored on heap memory. Enabling cache can be useful when planning time takes long.|druid.sql.planner.useParsedExprCache on the Broker (default: false)|
+|`useParsedExprCache`|Whether to use a cache for parsed expressions. This cache is created per query and stored on heap memory. Enabling cache can be useful when planning time takes long.|`druid.sql.planner.useParsedExprCache` on the Broker (default: false)|
 
 ## Metadata tables
 

--- a/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.segment.join.JoinConditionAnalysis;
@@ -108,6 +110,30 @@ public class JoinDataSource implements DataSource
             Preconditions.checkNotNull(condition, "condition"),
             StringUtils.nullToEmptyNonDruidDataString(rightPrefix),
             macroTable
+        ),
+        joinType,
+        leftFilter
+    );
+  }
+
+  public static JoinDataSource create(
+      DataSource left,
+      DataSource right,
+      String rightPrefix,
+      String condition,
+      JoinType joinType,
+      DimFilter leftFilter,
+      Supplier<Expr> conditionExprSupplier
+  )
+  {
+    return new JoinDataSource(
+        left,
+        right,
+        StringUtils.nullToEmptyNonDruidDataString(rightPrefix),
+        JoinConditionAnalysis.forExpression(
+            Preconditions.checkNotNull(condition, "condition"),
+            StringUtils.nullToEmptyNonDruidDataString(rightPrefix),
+            conditionExprSupplier
         ),
         joinType,
         leftFilter

--- a/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
@@ -24,11 +24,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.segment.join.JoinConditionAnalysis;
 import org.apache.druid.segment.join.JoinPrefixUtils;
@@ -102,17 +104,14 @@ public class JoinDataSource implements DataSource
       @JacksonInject ExprMacroTable macroTable
   )
   {
-    return new JoinDataSource(
+    return create(
         left,
         right,
-        StringUtils.nullToEmptyNonDruidDataString(rightPrefix),
-        JoinConditionAnalysis.forExpression(
-            Preconditions.checkNotNull(condition, "condition"),
-            StringUtils.nullToEmptyNonDruidDataString(rightPrefix),
-            macroTable
-        ),
+        rightPrefix,
+        condition,
         joinType,
-        leftFilter
+        leftFilter,
+        Suppliers.memoize(() -> Parser.parse(condition, macroTable))
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMaxAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseDoubleColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class DoubleMaxAggregatorFactory extends SimpleDoubleAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public DoubleMaxAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public DoubleMaxAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMinAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseDoubleColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class DoubleMinAggregatorFactory extends SimpleDoubleAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public DoubleMinAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public DoubleMinAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleSumAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseDoubleColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class DoubleSumAggregatorFactory extends SimpleDoubleAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public DoubleSumAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public DoubleSumAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class FloatMaxAggregatorFactory extends SimpleFloatAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public FloatMaxAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public FloatMaxAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class FloatMinAggregatorFactory extends SimpleFloatAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public FloatMinAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public FloatMinAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class FloatSumAggregatorFactory extends SimpleFloatAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public FloatSumAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public FloatSumAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class LongMaxAggregatorFactory extends SimpleLongAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public LongMaxAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public LongMaxAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class LongMinAggregatorFactory extends SimpleLongAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public LongMinAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public LongMinAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregatorFactory.java
@@ -22,7 +22,9 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -46,6 +48,17 @@ public class LongSumAggregatorFactory extends SimpleLongAggregatorFactory
   )
   {
     super(macroTable, name, fieldName, expression);
+  }
+
+  public LongSumAggregatorFactory(
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier,
+      ExprMacroTable macroTable
+  )
+  {
+    super(macroTable, name, fieldName, expression, expressionSupplier);
   }
 
   public LongSumAggregatorFactory(String name, String fieldName)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
@@ -67,12 +67,29 @@ public abstract class SimpleDoubleAggregatorFactory extends NullableNumericAggre
       @Nullable String expression
   )
   {
+    this(
+        macroTable,
+        name,
+        fieldName,
+        expression,
+        Suppliers.memoize(() -> expression == null ? null : Parser.parse(expression, macroTable))
+    );
+  }
+
+  public SimpleDoubleAggregatorFactory(
+      ExprMacroTable macroTable,
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier
+  )
+  {
     this.macroTable = macroTable;
     this.name = name;
     this.fieldName = fieldName;
     this.expression = expression;
     this.storeDoubleAsFloat = ColumnHolder.storeDoubleAsFloat();
-    this.fieldExpression = Suppliers.memoize(() -> expression == null ? null : Parser.parse(expression, macroTable));
+    this.fieldExpression = expressionSupplier;
     Preconditions.checkNotNull(name, "Must have a valid, non-null aggregator name");
     Preconditions.checkArgument(
         fieldName == null ^ expression == null,

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
@@ -59,11 +59,28 @@ public abstract class SimpleFloatAggregatorFactory extends NullableNumericAggreg
       @Nullable String expression
   )
   {
+    this(
+        macroTable,
+        name,
+        fieldName,
+        expression,
+        Suppliers.memoize(() -> expression == null ? null : Parser.parse(expression, macroTable))
+    );
+  }
+
+  public SimpleFloatAggregatorFactory(
+      ExprMacroTable macroTable,
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier
+  )
+  {
     this.macroTable = macroTable;
     this.name = name;
     this.fieldName = fieldName;
     this.expression = expression;
-    this.fieldExpression = Suppliers.memoize(() -> expression == null ? null : Parser.parse(expression, macroTable));
+    this.fieldExpression = expressionSupplier;
     Preconditions.checkNotNull(name, "Must have a valid, non-null aggregator name");
     Preconditions.checkArgument(
         fieldName == null ^ expression == null,

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
@@ -65,11 +65,28 @@ public abstract class SimpleLongAggregatorFactory extends NullableNumericAggrega
       @Nullable String expression
   )
   {
+    this(
+        macroTable,
+        name,
+        fieldName,
+        expression,
+        Suppliers.memoize(() -> expression == null ? null : Parser.parse(expression, macroTable))
+    );
+  }
+
+  public SimpleLongAggregatorFactory(
+      ExprMacroTable macroTable,
+      String name,
+      String fieldName,
+      @Nullable String expression,
+      Supplier<Expr> expressionSupplier
+  )
+  {
     this.macroTable = macroTable;
     this.name = name;
     this.fieldName = fieldName;
     this.expression = expression;
-    this.fieldExpression = Suppliers.memoize(() -> expression == null ? null : Parser.parse(expression, macroTable));
+    this.fieldExpression = expressionSupplier;
     Preconditions.checkNotNull(name, "Must have a valid, non-null aggregator name");
     Preconditions.checkArgument(
         fieldName == null ^ expression == null,

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/ExpressionPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/ExpressionPostAggregator.java
@@ -96,6 +96,26 @@ public class ExpressionPostAggregator implements PostAggregator
     );
   }
 
+  public ExpressionPostAggregator(
+      final String name,
+      final String expression,
+      @Nullable final String ordering,
+      final ExprMacroTable macroTable,
+      final Supplier<Expr> parsed
+  )
+  {
+    this(
+        name,
+        expression,
+        ordering,
+        null, // in the future this will be computed by decorate
+        macroTable,
+        ImmutableMap.of(),
+        parsed,
+        Suppliers.memoize(() -> parsed.get().analyzeInputs().getRequiredBindings())
+    );
+  }
+
   private ExpressionPostAggregator(
       final String name,
       final String expression,

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/ExpressionPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/ExpressionPostAggregator.java
@@ -101,26 +101,6 @@ public class ExpressionPostAggregator implements PostAggregator
       final String expression,
       @Nullable final String ordering,
       final ExprMacroTable macroTable,
-      final Supplier<Expr> parsed
-  )
-  {
-    this(
-        name,
-        expression,
-        ordering,
-        null, // in the future this will be computed by decorate
-        macroTable,
-        ImmutableMap.of(),
-        parsed,
-        Suppliers.memoize(() -> parsed.get().analyzeInputs().getRequiredBindings())
-    );
-  }
-
-  private ExpressionPostAggregator(
-      final String name,
-      final String expression,
-      @Nullable final String ordering,
-      final ExprMacroTable macroTable,
       final Map<String, Function<Object, Object>> finalizers,
       final Supplier<Expr> parsed
   )

--- a/processing/src/main/java/org/apache/druid/query/filter/ExpressionDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/ExpressionDimFilter.java
@@ -56,6 +56,13 @@ public class ExpressionDimFilter extends AbstractOptimizableDimFilter implements
     this.parsed = Suppliers.memoize(() -> Parser.parse(expression, macroTable));
   }
 
+  public ExpressionDimFilter(final String expression, final Supplier<Expr> exprSupplier)
+  {
+    this.expression = expression;
+    this.filterTuning = null;
+    this.parsed = exprSupplier;
+  }
+
   @VisibleForTesting
   public ExpressionDimFilter(final String expression, ExprMacroTable macroTable)
   {

--- a/processing/src/main/java/org/apache/druid/query/filter/ExpressionDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/ExpressionDimFilter.java
@@ -51,15 +51,17 @@ public class ExpressionDimFilter extends AbstractOptimizableDimFilter implements
       @JacksonInject ExprMacroTable macroTable
   )
   {
-    this.expression = expression;
-    this.filterTuning = filterTuning;
-    this.parsed = Suppliers.memoize(() -> Parser.parse(expression, macroTable));
+    this(expression, filterTuning, Suppliers.memoize(() -> Parser.parse(expression, macroTable)));
   }
 
-  public ExpressionDimFilter(final String expression, final Supplier<Expr> exprSupplier)
+  public ExpressionDimFilter(
+      final String expression,
+      @Nullable final FilterTuning filterTuning,
+      final Supplier<Expr> exprSupplier
+  )
   {
     this.expression = expression;
-    this.filterTuning = null;
+    this.filterTuning = filterTuning;
     this.parsed = exprSupplier;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
@@ -109,7 +109,7 @@ public class JoinConditionAnalysis
       final String condition,
       final String rightPrefix,
       final Supplier<Expr> exprSupplier
-      )
+  )
   {
     final Expr conditionExpr = exprSupplier.get();
     final List<Equality> equiConditions = new ArrayList<>();

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionVirtualColumn.java
@@ -69,10 +69,20 @@ public class ExpressionVirtualColumn implements VirtualColumn
       @JacksonInject ExprMacroTable macroTable
   )
   {
+    this(name, expression, outputType, Suppliers.memoize(() -> Parser.parse(expression, macroTable)));
+  }
+
+  public ExpressionVirtualColumn(
+      String name,
+      String expression,
+      @Nullable ValueType outputType,
+      Supplier<Expr> exprSupplier
+  )
+  {
     this.name = Preconditions.checkNotNull(name, "name");
     this.expression = Preconditions.checkNotNull(expression, "expression");
     this.outputType = outputType;
-    this.parsedExpression = Suppliers.memoize(() -> Parser.parse(expression, macroTable));
+    this.parsedExpression = exprSupplier;
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
@@ -103,6 +103,7 @@ public class AvgSqlAggregator implements SqlAggregator
     final String sumName = Calcites.makePrefixedName(name, "sum");
     final String countName = Calcites.makePrefixedName(name, "count");
     final AggregatorFactory sum = SumSqlAggregator.createSumAggregatorFactory(
+        plannerContext,
         sumType,
         sumName,
         fieldName,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/MaxSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/MaxSqlAggregator.java
@@ -31,6 +31,7 @@ import org.apache.druid.query.aggregation.LongMaxAggregatorFactory;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class MaxSqlAggregator extends SimpleSqlAggregator
 {
@@ -42,6 +43,7 @@ public class MaxSqlAggregator extends SimpleSqlAggregator
 
   @Override
   Aggregation getAggregation(
+      final PlannerContext plannerContext,
       final String name,
       final AggregateCall aggregateCall,
       final ExprMacroTable macroTable,
@@ -50,10 +52,18 @@ public class MaxSqlAggregator extends SimpleSqlAggregator
   )
   {
     final ValueType valueType = Calcites.getValueTypeForRelDataType(aggregateCall.getType());
-    return Aggregation.create(createMaxAggregatorFactory(valueType, name, fieldName, expression, macroTable));
+    return Aggregation.create(createMaxAggregatorFactory(
+        plannerContext,
+        valueType,
+        name,
+        fieldName,
+        expression,
+        macroTable
+    ));
   }
 
   private static AggregatorFactory createMaxAggregatorFactory(
+      final PlannerContext plannerContext,
       final ValueType aggregationType,
       final String name,
       final String fieldName,
@@ -63,11 +73,29 @@ public class MaxSqlAggregator extends SimpleSqlAggregator
   {
     switch (aggregationType) {
       case LONG:
-        return new LongMaxAggregatorFactory(name, fieldName, expression, macroTable);
+        return new LongMaxAggregatorFactory(
+            name,
+            fieldName,
+            expression,
+            plannerContext.getCachingExprParser().lazyParse(expression),
+            macroTable
+        );
       case FLOAT:
-        return new FloatMaxAggregatorFactory(name, fieldName, expression, macroTable);
+        return new FloatMaxAggregatorFactory(
+            name,
+            fieldName,
+            expression,
+            plannerContext.getCachingExprParser().lazyParse(expression),
+            macroTable
+        );
       case DOUBLE:
-        return new DoubleMaxAggregatorFactory(name, fieldName, expression, macroTable);
+        return new DoubleMaxAggregatorFactory(
+            name,
+            fieldName,
+            expression,
+            plannerContext.getCachingExprParser().lazyParse(expression),
+            macroTable
+        );
       default:
         throw new ISE("Cannot create aggregator factory for type[%s]", aggregationType);
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/MinSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/MinSqlAggregator.java
@@ -31,6 +31,7 @@ import org.apache.druid.query.aggregation.LongMinAggregatorFactory;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class MinSqlAggregator extends SimpleSqlAggregator
 {
@@ -42,6 +43,7 @@ public class MinSqlAggregator extends SimpleSqlAggregator
 
   @Override
   Aggregation getAggregation(
+      final PlannerContext plannerContext,
       final String name,
       final AggregateCall aggregateCall,
       final ExprMacroTable macroTable,
@@ -50,10 +52,18 @@ public class MinSqlAggregator extends SimpleSqlAggregator
   )
   {
     final ValueType valueType = Calcites.getValueTypeForRelDataType(aggregateCall.getType());
-    return Aggregation.create(createMinAggregatorFactory(valueType, name, fieldName, expression, macroTable));
+    return Aggregation.create(createMinAggregatorFactory(
+        plannerContext,
+        valueType,
+        name,
+        fieldName,
+        expression,
+        macroTable
+    ));
   }
 
   private static AggregatorFactory createMinAggregatorFactory(
+      final PlannerContext plannerContext,
       final ValueType aggregationType,
       final String name,
       final String fieldName,
@@ -63,11 +73,29 @@ public class MinSqlAggregator extends SimpleSqlAggregator
   {
     switch (aggregationType) {
       case LONG:
-        return new LongMinAggregatorFactory(name, fieldName, expression, macroTable);
+        return new LongMinAggregatorFactory(
+            name,
+            fieldName,
+            expression,
+            plannerContext.getCachingExprParser().lazyParse(expression),
+            macroTable
+        );
       case FLOAT:
-        return new FloatMinAggregatorFactory(name, fieldName, expression, macroTable);
+        return new FloatMinAggregatorFactory(
+            name,
+            fieldName,
+            expression,
+            plannerContext.getCachingExprParser().lazyParse(expression),
+            macroTable
+        );
       case DOUBLE:
-        return new DoubleMinAggregatorFactory(name, fieldName, expression, macroTable);
+        return new DoubleMinAggregatorFactory(
+            name,
+            fieldName,
+            expression,
+            plannerContext.getCachingExprParser().lazyParse(expression),
+            macroTable
+        );
       default:
         throw new ISE("Cannot create aggregator factory for type[%s]", aggregationType);
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SimpleSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SimpleSqlAggregator.java
@@ -88,10 +88,11 @@ public abstract class SimpleSqlAggregator implements SqlAggregator
       expression = arg.getExpression();
     }
 
-    return getAggregation(name, aggregateCall, macroTable, fieldName, expression);
+    return getAggregation(plannerContext, name, aggregateCall, macroTable, fieldName, expression);
   }
 
   abstract Aggregation getAggregation(
+      PlannerContext plannerContext,
       String name,
       AggregateCall aggregateCall,
       ExprMacroTable macroTable,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
@@ -23,11 +23,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Chars;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.math.expr.Expr;
-import org.apache.druid.math.expr.ExprMacroTable;
-import org.apache.druid.math.expr.Parser;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import java.util.Arrays;
 import java.util.List;
@@ -153,23 +151,23 @@ public class DruidExpression
     return simpleExtraction != null;
   }
 
-  public Expr parse(final ExprMacroTable macroTable)
-  {
-    return Parser.parse(expression, macroTable);
-  }
-
   public SimpleExtraction getSimpleExtraction()
   {
     return Preconditions.checkNotNull(simpleExtraction);
   }
 
   public ExpressionVirtualColumn toVirtualColumn(
+      final PlannerContext plannerContext,
       final String name,
-      final ValueType outputType,
-      final ExprMacroTable macroTable
+      final ValueType outputType
   )
   {
-    return new ExpressionVirtualColumn(name, expression, outputType, macroTable);
+    return new ExpressionVirtualColumn(
+        name,
+        expression,
+        outputType,
+        plannerContext.getCachingExprParser().lazyParse(expression)
+    );
   }
 
   public DruidExpression map(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
@@ -660,6 +660,7 @@ public class Expressions
     if (druidExpression != null) {
       return new ExpressionDimFilter(
           druidExpression.getExpression(),
+          null,
           plannerContext.getCachingExprParser().lazyParse(druidExpression.getExpression())
       );
     } else {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
@@ -27,7 +27,6 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
-import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.filter.AndDimFilter;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.segment.column.RowSignature;
@@ -93,7 +92,7 @@ public class ArrayContainsOperatorConversion extends BaseExpressionDimFilterOper
     final DruidExpression rightExpr = druidExpressions.get(1);
 
     if (leftExpr.isSimpleExtraction()) {
-      Expr expr = Parser.parse(rightExpr.getExpression(), plannerContext.getExprMacroTable());
+      Expr expr = plannerContext.getCachingExprParser().parse(rightExpr.getExpression());
       // To convert this expression filter into an And of Selector filters, we need to extract all array elements.
       // For now, we can optimize only when rightExpr is a literal because there is no way to extract the array elements
       // by traversing the Expr. Note that all implementations of Expr are defined as package-private classes in a

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
@@ -28,7 +28,6 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
-import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.segment.column.RowSignature;
@@ -105,7 +104,7 @@ public class ArrayOverlapOperatorConversion extends BaseExpressionDimFilterOpera
       return toExpressionFilter(plannerContext, getDruidFunctionName(), druidExpressions);
     }
 
-    Expr expr = Parser.parse(complexExpr.getExpression(), plannerContext.getExprMacroTable());
+    Expr expr = plannerContext.getCachingExprParser().parse(complexExpr.getExpression());
     if (expr.isLiteral()) {
       // Evaluate the expression to take out the array elements.
       // We can safely pass null if the expression is literal.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BaseExpressionDimFilterOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BaseExpressionDimFilterOperatorConversion.java
@@ -50,6 +50,7 @@ public abstract class BaseExpressionDimFilterOperatorConversion extends DirectOp
 
     return new ExpressionDimFilter(
         filterExpr,
+        null,
         plannerContext.getCachingExprParser().lazyParse(filterExpr)
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BaseExpressionDimFilterOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BaseExpressionDimFilterOperatorConversion.java
@@ -50,7 +50,7 @@ public abstract class BaseExpressionDimFilterOperatorConversion extends DirectOp
 
     return new ExpressionDimFilter(
         filterExpr,
-        plannerContext.getExprMacroTable()
+        plannerContext.getCachingExprParser().lazyParse(filterExpr)
     );
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -133,9 +133,9 @@ public class CastOperatorConversion implements SqlOperatorConversion
       if (toType == SqlTypeName.DATE) {
         // Floor to day when casting to DATE.
         return TimeFloorOperatorConversion.applyTimestampFloor(
+            plannerContext,
             typeCastExpression,
-            new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone()),
-            plannerContext.getExprMacroTable()
+            new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone())
         );
       } else {
         return typeCastExpression;
@@ -161,9 +161,9 @@ public class CastOperatorConversion implements SqlOperatorConversion
 
     if (toType == SqlTypeName.DATE) {
       return TimeFloorOperatorConversion.applyTimestampFloor(
+          plannerContext,
           timestampExpression,
-          new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone()),
-          plannerContext.getExprMacroTable()
+          new PeriodGranularity(Period.days(1), null, plannerContext.getTimeZone())
       );
     } else if (toType == SqlTypeName.TIMESTAMP) {
       return timestampExpression;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DateTruncOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DateTruncOperatorConversion.java
@@ -30,7 +30,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
-import org.apache.druid.math.expr.Parser;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
@@ -90,9 +89,8 @@ public class DateTruncOperatorConversion implements SqlOperatorConversion
         rexNode,
         inputExpressions -> {
           final DruidExpression arg = inputExpressions.get(1);
-          final Expr truncTypeExpr = Parser.parse(
-              inputExpressions.get(0).getExpression(),
-              plannerContext.getExprMacroTable()
+          final Expr truncTypeExpr = plannerContext.getCachingExprParser().parse(
+              inputExpressions.get(0).getExpression()
           );
 
           if (!truncTypeExpr.isLiteral()) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
@@ -72,7 +72,9 @@ public class QueryLookupOperatorConversion implements SqlOperatorConversion
         StringUtils.toLowerCase(calciteOperator().getName()),
         inputExpressions -> {
           final DruidExpression arg = inputExpressions.get(0);
-          final Expr lookupNameExpr = inputExpressions.get(1).parse(plannerContext.getExprMacroTable());
+          final Expr lookupNameExpr = plannerContext.getCachingExprParser().parse(
+              inputExpressions.get(1).getExpression()
+          );
 
           if (arg.isSimpleExtraction() && lookupNameExpr.isLiteral()) {
             return arg.getSimpleExtraction().cascade(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpExtractOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpExtractOperatorConversion.java
@@ -66,9 +66,9 @@ public class RegexpExtractOperatorConversion implements SqlOperatorConversion
         StringUtils.toLowerCase(calciteOperator().getName()),
         inputExpressions -> {
           final DruidExpression arg = inputExpressions.get(0);
-          final Expr patternExpr = inputExpressions.get(1).parse(plannerContext.getExprMacroTable());
+          final Expr patternExpr = plannerContext.getCachingExprParser().parse(inputExpressions.get(1).getExpression());
           final Expr indexExpr = inputExpressions.size() > 2
-                                 ? inputExpressions.get(2).parse(plannerContext.getExprMacroTable())
+                                 ? plannerContext.getCachingExprParser().parse(inputExpressions.get(2).getExpression())
                                  : null;
 
           if (arg.isSimpleExtraction() && patternExpr.isLiteral() && (indexExpr == null || indexExpr.isLiteral())) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
@@ -32,7 +32,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
-import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.expression.TimestampFloorExprMacro;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
@@ -66,9 +65,9 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
    * it's responsible for generating "timestamp_floor" calls.
    */
   public static DruidExpression applyTimestampFloor(
+      final PlannerContext plannerContext,
       final DruidExpression input,
-      final PeriodGranularity granularity,
-      final ExprMacroTable macroTable
+      final PeriodGranularity granularity
   )
   {
     Preconditions.checkNotNull(input, "input");
@@ -77,8 +76,8 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
     // Collapse floor chains if possible. Useful for constructs like CAST(FLOOR(__time TO QUARTER) AS DATE).
     if (granularity.getPeriod().equals(Period.days(1))) {
       final TimestampFloorExprMacro.TimestampFloorExpr floorExpr = Expressions.asTimestampFloorExpr(
-          input,
-          macroTable
+          plannerContext,
+          input
       );
 
       if (floorExpr != null) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TruncateOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TruncateOperatorConversion.java
@@ -62,7 +62,7 @@ public class TruncateOperatorConversion implements SqlOperatorConversion
         inputExpressions -> {
           final DruidExpression arg = inputExpressions.get(0);
           final Expr digitsExpr = inputExpressions.size() > 1
-                                  ? inputExpressions.get(1).parse(plannerContext.getExprMacroTable())
+                                  ? plannerContext.getCachingExprParser().parse(inputExpressions.get(1).getExpression())
                                   : null;
 
           final String factorString;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/BottomUpTransform.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/BottomUpTransform.java
@@ -36,7 +36,8 @@ public abstract class BottomUpTransform implements Function<Filtration, Filtrati
   private DimFilter checkedProcess(final DimFilter filter)
   {
     final DimFilter retVal = process(Preconditions.checkNotNull(filter, "filter"));
-    return Preconditions.checkNotNull(retVal, "process(filter) result in %s", getClass().getSimpleName());
+    assert retVal != null;
+    return retVal;
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/BottomUpTransform.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/BottomUpTransform.java
@@ -36,8 +36,7 @@ public abstract class BottomUpTransform implements Function<Filtration, Filtrati
   private DimFilter checkedProcess(final DimFilter filter)
   {
     final DimFilter retVal = process(Preconditions.checkNotNull(filter, "filter"));
-    assert retVal != null;
-    return retVal;
+    return Preconditions.checkNotNull(retVal, "process(filter) result in %s", getClass().getSimpleName());
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CachingExprParser.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CachingExprParser.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.planner;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.Parser;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An expression parser that caches expressions in memory.
+ * This parser is created per SQL query and used by {@link DruidPlanner}.
+ */
+public class CachingExprParser
+{
+  private final ExprMacroTable macroTable;
+  private final boolean enabled;
+  private final Map<String, Expr> exprCache = new HashMap<>();
+
+  public CachingExprParser(ExprMacroTable macroTable, PlannerConfig plannerConfig)
+  {
+    this.macroTable = macroTable;
+    this.enabled = plannerConfig.isUseParsedExprCache();
+  }
+
+  /**
+   * Parses the given expression and caches the result if caching is enabled.
+   * Returns null only when the given expression is null.
+   */
+  @Nullable
+  public Expr parse(@Nullable String expression)
+  {
+    if (expression == null) {
+      return null;
+    }
+    if (enabled) {
+      return exprCache.computeIfAbsent(expression, k -> Parser.parse(k, macroTable));
+    } else {
+      return Parser.parse(expression, macroTable);
+    }
+  }
+
+  /**
+   * Returns an {@link Expr} supplier that lazily parses the given expression.
+   * The supplier can return null if the given expression is null.
+   */
+  public Supplier<Expr> lazyParse(@Nullable String expression)
+  {
+    return () -> parse(expression);
+  }
+
+  @VisibleForTesting
+  public Map<String, Expr> getExprCache()
+  {
+    return exprCache;
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModule.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.sql.calcite.planner;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -28,10 +29,13 @@ import org.apache.druid.guice.JsonConfigProvider;
  */
 public class CalcitePlannerModule implements Module
 {
+  @VisibleForTesting
+  static final String PLANNER_CONFIG_PREFIX = "druid.sql.planner";
+
   @Override
   public void configure(Binder binder)
   {
-    JsonConfigProvider.bind(binder, "druid.sql.planner", PlannerConfig.class);
+    JsonConfigProvider.bind(binder, PLANNER_CONFIG_PREFIX, PlannerConfig.class);
     binder.bind(PlannerFactory.class);
     binder.bind(DruidOperatorTable.class);
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
@@ -29,7 +29,6 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprType;
-import org.apache.druid.math.expr.Parser;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
@@ -71,7 +70,7 @@ public class DruidRexExecutor implements RexExecutor
         reducedValues.add(constExp);
       } else {
         final SqlTypeName sqlTypeName = constExp.getType().getSqlTypeName();
-        final Expr expr = Parser.parse(druidExpression.getExpression(), plannerContext.getExprMacroTable());
+        final Expr expr = plannerContext.getCachingExprParser().parse(druidExpression.getExpression());
 
         final ExprEval exprResult = expr.eval(
             name -> {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerConfig.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerConfig.java
@@ -31,6 +31,7 @@ public class PlannerConfig
 {
   public static final String CTX_KEY_USE_APPROXIMATE_COUNT_DISTINCT = "useApproximateCountDistinct";
   public static final String CTX_KEY_USE_APPROXIMATE_TOPN = "useApproximateTopN";
+  public static final String CTX_KEY_USE_PARSED_EXPR_CACHE = "useParsedExprCache";
 
   @JsonProperty
   private Period metadataRefreshPeriod = new Period("PT1M");
@@ -58,6 +59,9 @@ public class PlannerConfig
 
   @JsonProperty
   private long metadataSegmentPollPeriod = 60000;
+
+  @JsonProperty
+  private boolean useParsedExprCache = false;
 
   public long getMetadataSegmentPollPeriod()
   {
@@ -111,6 +115,11 @@ public class PlannerConfig
     return serializeComplexValues;
   }
 
+  public boolean isUseParsedExprCache()
+  {
+    return useParsedExprCache;
+  }
+
   public PlannerConfig withOverrides(final Map<String, Object> context)
   {
     if (context == null) {
@@ -136,6 +145,11 @@ public class PlannerConfig
     newConfig.metadataSegmentCacheEnable = isMetadataSegmentCacheEnable();
     newConfig.metadataSegmentPollPeriod = getMetadataSegmentPollPeriod();
     newConfig.serializeComplexValues = shouldSerializeComplexValues();
+    newConfig.useParsedExprCache = getContextBoolean(
+        context,
+        CTX_KEY_USE_PARSED_EXPR_CACHE,
+        isUseParsedExprCache()
+    );
     return newConfig;
   }
 
@@ -174,6 +188,7 @@ public class PlannerConfig
            awaitInitializationOnStart == that.awaitInitializationOnStart &&
            metadataSegmentCacheEnable == that.metadataSegmentCacheEnable &&
            metadataSegmentPollPeriod == that.metadataSegmentPollPeriod &&
+           useParsedExprCache == that.useParsedExprCache &&
            serializeComplexValues == that.serializeComplexValues &&
            Objects.equals(metadataRefreshPeriod, that.metadataRefreshPeriod) &&
            Objects.equals(sqlTimeZone, that.sqlTimeZone);
@@ -182,7 +197,6 @@ public class PlannerConfig
   @Override
   public int hashCode()
   {
-
     return Objects.hash(
         metadataRefreshPeriod,
         maxTopNLimit,
@@ -193,6 +207,7 @@ public class PlannerConfig
         sqlTimeZone,
         metadataSegmentCacheEnable,
         metadataSegmentPollPeriod,
+        useParsedExprCache,
         serializeComplexValues
     );
   }
@@ -207,9 +222,10 @@ public class PlannerConfig
            ", useApproximateTopN=" + useApproximateTopN +
            ", requireTimeCondition=" + requireTimeCondition +
            ", awaitInitializationOnStart=" + awaitInitializationOnStart +
+           ", sqlTimeZone=" + sqlTimeZone +
            ", metadataSegmentCacheEnable=" + metadataSegmentCacheEnable +
            ", metadataSegmentPollPeriod=" + metadataSegmentPollPeriod +
-           ", sqlTimeZone=" + sqlTimeZone +
+           ", useParsedExprCache=" + useParsedExprCache +
            ", serializeComplexValues=" + serializeComplexValues +
            '}';
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -68,6 +68,7 @@ public class PlannerContext
   private final DateTime localNow;
   private final Map<String, Object> queryContext;
   private final String sqlQueryId;
+  private final CachingExprParser cachingExprParser;
   private final List<String> nativeQueryIds = new CopyOnWriteArrayList<>();
   // bindings for dynamic parameters to bind during planning
   private List<TypedValue> parameters = Collections.emptyList();
@@ -98,6 +99,7 @@ public class PlannerContext
       sqlQueryId = UUID.randomUUID().toString();
     }
     this.sqlQueryId = sqlQueryId;
+    this.cachingExprParser = new CachingExprParser(macroTable, plannerConfig);
   }
 
   public static PlannerContext create(
@@ -281,5 +283,10 @@ public class PlannerContext
   public void setResources(Set<Resource> resources)
   {
     this.resources = Preconditions.checkNotNull(resources, "resources");
+  }
+
+  public CachingExprParser getCachingExprParser()
+  {
+    return cachingExprParser;
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -192,7 +192,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
             condition.getExpression(),
             toDruidJoinType(joinRel.getJoinType()),
             getDimFilter(getPlannerContext(), leftSignature, leftFilter),
-            getPlannerContext().getExprMacroTable()
+            getPlannerContext().getCachingExprParser().lazyParse(condition.getExpression())
         ),
         prefixSignaturePair.rhs,
         getPlannerContext(),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -792,8 +792,8 @@ public class DruidQuery
     } else if (grouping.getDimensions().size() == 1) {
       final DimensionExpression dimensionExpression = Iterables.getOnlyElement(grouping.getDimensions());
       queryGranularity = Expressions.toQueryGranularity(
-          dimensionExpression.getDruidExpression(),
-          plannerContext.getExprMacroTable()
+          plannerContext,
+          dimensionExpression.getDruidExpression()
       );
 
       if (queryGranularity == null) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
@@ -27,7 +27,7 @@ import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.math.expr.Parser;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.dimension.DimensionSpec;
@@ -190,8 +190,8 @@ public class Grouping
 
     for (int i = 0; i < dimensions.size(); i++) {
       final DimensionExpression dimension = dimensions.get(i);
-      if (Parser.parse(dimension.getDruidExpression().getExpression(), plannerContext.getExprMacroTable())
-                .isLiteral() && !aggregateProjectBits.get(i)) {
+      final Expr parsed = plannerContext.getCachingExprParser().parse(dimension.getDruidExpression().getExpression());
+      if (parsed.isLiteral() && !aggregateProjectBits.get(i)) {
         newDimIndexes[i] = -1;
       } else {
         newDimIndexes[i] = newDimensions.size();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Projection.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Projection.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite.rel;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
@@ -185,6 +186,7 @@ public class Projection
           postAggregatorExpression.getExpression(),
           null,
           plannerContext.getExprMacroTable(),
+          ImmutableMap.of(),
           plannerContext.getCachingExprParser().lazyParse(postAggregatorExpression.getExpression())
       );
       postAggregatorVisitor.addPostAgg(postAggregator);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Projection.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Projection.java
@@ -184,7 +184,8 @@ public class Projection
           postAggregatorVisitor.getOutputNamePrefix() + postAggregatorVisitor.getAndIncrementCounter(),
           postAggregatorExpression.getExpression(),
           null,
-          plannerContext.getExprMacroTable()
+          plannerContext.getExprMacroTable(),
+          plannerContext.getCachingExprParser().lazyParse(postAggregatorExpression.getExpression())
       );
       postAggregatorVisitor.addPostAgg(postAggregator);
       rowOrder.add(postAggregator.getName());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
@@ -86,9 +86,9 @@ public class VirtualColumnRegistry
     if (!virtualColumnsByExpression.containsKey(expression.getExpression())) {
       final String virtualColumnName = virtualColumnPrefix + virtualColumnCounter++;
       final VirtualColumn virtualColumn = expression.toVirtualColumn(
+          plannerContext,
           virtualColumnName,
-          valueType,
-          plannerContext.getExprMacroTable()
+          valueType
       );
       virtualColumnsByExpression.put(
           expression.getExpression(),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlPlannerExprCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlPlannerExprCacheTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.calcite.tools.RelConversionException;
+import org.apache.druid.sql.SqlLifecycle;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.util.CalciteTests;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class SqlPlannerExprCacheTest extends BaseCalciteQueryTest
+{
+  private static final PlannerConfig CACHE_DISABLING_CONFIG = new PlannerConfig();
+  private static final PlannerConfig CACHE_ENABLING_CONFIG = new PlannerConfig().withOverrides(
+      ImmutableMap.of(PlannerConfig.CTX_KEY_USE_PARSED_EXPR_CACHE, true)
+  );
+  private static final String DEFAULT_SQL =
+      "SELECT CAST(__time AS BIGINT), m1, ANY_VALUE(dim3, 100) FROM foo\n"
+      + "WHERE (CAST(TIME_FLOOR(__time, 'PT1H') AS BIGINT), m1) IN\n"
+      + "   (\n"
+      + "     SELECT CAST(TIME_FLOOR(__time, 'PT1H') AS BIGINT) + 0 AS t1, MIN(m1) AS t2\n"
+      + "     FROM foo\n"
+      + "     WHERE dim3 = 'b' AND __time BETWEEN '1994-04-29 00:00:00' AND '2020-01-11 00:00:00'\n"
+      + "     GROUP BY 1\n"
+      + "   )\n"
+      + "GROUP BY 1, 2\n";
+
+  @Test
+  public void testEnableCacheViaConfig() throws RelConversionException
+  {
+    final PlannerContext context = plan(CACHE_ENABLING_CONFIG, DEFAULT_SQL, ImmutableMap.of());
+    Assert.assertEquals(
+        ImmutableSet.of(
+            "100",
+            "\"dim3\"",
+            "timestamp_parse('2020-01-11 00:00:00',null,'UTC')",
+            "timestamp_floor(\"__time\",'PT1H',null,'UTC')",
+            "(timestamp_floor(\"__time\",'PT1H',null,'UTC') + 0)",
+            "\"__time\"",
+            "timestamp_parse('1994-04-29 00:00:00',null,'UTC')"
+        ),
+        context.getCachingExprParser().getExprCache().keySet()
+    );
+  }
+
+  @Test
+  public void testEnableCacheViaQueryContext() throws RelConversionException
+  {
+    final PlannerContext context = plan(
+        CACHE_DISABLING_CONFIG,
+        DEFAULT_SQL,
+        ImmutableMap.of(PlannerConfig.CTX_KEY_USE_PARSED_EXPR_CACHE, true)
+    );
+    Assert.assertEquals(
+        ImmutableSet.of(
+            "100",
+            "\"dim3\"",
+            "timestamp_parse('2020-01-11 00:00:00',null,'UTC')",
+            "timestamp_floor(\"__time\",'PT1H',null,'UTC')",
+            "(timestamp_floor(\"__time\",'PT1H',null,'UTC') + 0)",
+            "\"__time\"",
+            "timestamp_parse('1994-04-29 00:00:00',null,'UTC')"
+        ),
+        context.getCachingExprParser().getExprCache().keySet()
+    );
+  }
+
+  @Test
+  public void testDisableCacheViaConfig() throws RelConversionException
+  {
+    final PlannerContext context = plan(CACHE_DISABLING_CONFIG, DEFAULT_SQL, ImmutableMap.of());
+    Assert.assertTrue(context.getCachingExprParser().getExprCache().isEmpty());
+  }
+
+  @Test
+  public void testDisableCacheViaQueryContext() throws RelConversionException
+  {
+    final PlannerContext context = plan(
+        CACHE_ENABLING_CONFIG,
+        DEFAULT_SQL,
+        ImmutableMap.of(PlannerConfig.CTX_KEY_USE_PARSED_EXPR_CACHE, false)
+    );
+    Assert.assertTrue(context.getCachingExprParser().getExprCache().isEmpty());
+  }
+
+  private PlannerContext plan(PlannerConfig plannerConfig, String sql, Map<String, Object> queryContext)
+      throws RelConversionException
+  {
+    final SqlLifecycle lifecycle = getSqlLifecycleFactory(
+        plannerConfig,
+        CalciteTests.createOperatorTable(),
+        CalciteTests.createExprMacroTable(),
+        CalciteTests.TEST_AUTHORIZER_MAPPER,
+        CalciteTests.getJsonMapper()
+    ).factorize();
+    lifecycle.initialize(sql, queryContext);
+    lifecycle.validateAndAuthorize(CalciteTests.REGULAR_USER_AUTH_RESULT);
+    return lifecycle.plan();
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/CachingExprParserTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/CachingExprParserTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.planner;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CachingExprParserTest extends InitializedNullHandlingTest
+{
+  private static final ExprMacroTable MACRO_TABLE = ExprMacroTable.nil();
+  private static final PlannerConfig CACHE_DISABLING_CONFIG = new PlannerConfig();
+  private static final PlannerConfig CACHE_ENABLING_CONFIG = new PlannerConfig().withOverrides(
+      ImmutableMap.of(PlannerConfig.CTX_KEY_USE_PARSED_EXPR_CACHE, true)
+  );
+
+  @Test
+  public void testParseNullReturnNull()
+  {
+    CachingExprParser parser = new CachingExprParser(MACRO_TABLE, CACHE_DISABLING_CONFIG);
+    Assert.assertNull(parser.parse(null));
+    Assert.assertTrue(parser.getExprCache().isEmpty());
+
+    parser = new CachingExprParser(MACRO_TABLE, CACHE_ENABLING_CONFIG);
+    Assert.assertNull(parser.parse(null));
+    Assert.assertTrue(parser.getExprCache().isEmpty());
+  }
+
+  @Test
+  public void testLazyParseNullReturnSupplierOfNull()
+  {
+    CachingExprParser parser = new CachingExprParser(MACRO_TABLE, CACHE_DISABLING_CONFIG);
+    Supplier<Expr> exprSupplier = parser.lazyParse(null);
+    Assert.assertNull(exprSupplier.get());
+    Assert.assertTrue(parser.getExprCache().isEmpty());
+
+    parser = new CachingExprParser(MACRO_TABLE, CACHE_ENABLING_CONFIG);
+    exprSupplier = parser.lazyParse(null);
+    Assert.assertNull(exprSupplier.get());
+    Assert.assertTrue(parser.getExprCache().isEmpty());
+  }
+
+  @Test
+  public void testParseWithCacheEnabled()
+  {
+    final CachingExprParser parser = new CachingExprParser(MACRO_TABLE, CACHE_ENABLING_CONFIG);
+    final String strExpr = "x + y";
+    final Expr expr = parser.parse(strExpr);
+    Assert.assertNotNull(expr);
+    Assert.assertSame(expr, parser.parse(strExpr));
+    Assert.assertSame(expr, parser.getExprCache().get(strExpr));
+  }
+
+  @Test
+  public void testParseWithCacheDisabled()
+  {
+    final CachingExprParser parser = new CachingExprParser(MACRO_TABLE, CACHE_DISABLING_CONFIG);
+    final String strExpr = "x + y";
+    final Expr expr = parser.parse(strExpr);
+    Assert.assertNotNull(expr);
+    Assert.assertNotSame(expr, parser.parse(strExpr));
+    Assert.assertTrue(parser.getExprCache().isEmpty());
+  }
+
+  @Test
+  public void testLazyParseWithCacheEnabled()
+  {
+    final CachingExprParser parser = new CachingExprParser(MACRO_TABLE, CACHE_ENABLING_CONFIG);
+    final String strExpr = "x + y";
+    final Supplier<Expr> exprSupplier = parser.lazyParse(strExpr);
+    Assert.assertSame(exprSupplier.get(), parser.parse(strExpr));
+    Assert.assertSame(exprSupplier.get(), parser.getExprCache().get(strExpr));
+  }
+
+  @Test
+  public void testLazyParseWithCacheDisabled()
+  {
+    final CachingExprParser parser = new CachingExprParser(MACRO_TABLE, CACHE_DISABLING_CONFIG);
+    final String strExpr = "x + y";
+    final Supplier<Expr> exprSupplier = parser.lazyParse(strExpr);
+    Assert.assertNotSame(exprSupplier.get(), parser.parse(strExpr));
+    Assert.assertTrue(parser.getExprCache().isEmpty());
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
@@ -29,6 +29,7 @@ import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.jackson.JacksonModule;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.server.QueryLifecycleFactory;
@@ -161,7 +162,7 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
     properties.setProperty(getPlannerConfigKey("useApproximateTopN"), "false");
     properties.setProperty(getPlannerConfigKey("requireTimeCondition"), "true");
     properties.setProperty(getPlannerConfigKey("awaitInitializationOnStart"), "false");
-    properties.setProperty(getPlannerConfigKey("sqlTimeZone"), DateTimeZone.forID("Asia/Seoul").toString());
+    properties.setProperty(getPlannerConfigKey("sqlTimeZone"), DateTimes.inferTzFromString("Asia/Seoul").toString());
     properties.setProperty(getPlannerConfigKey("metadataSegmentCacheEnable"), "true");
     properties.setProperty(getPlannerConfigKey("metadataSegmentPollPeriod"), "20");
     properties.setProperty(getPlannerConfigKey("useParsedExprCache"), "true");
@@ -173,7 +174,7 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
     Assert.assertFalse(plannerConfig.isUseApproximateTopN());
     Assert.assertTrue(plannerConfig.isRequireTimeCondition());
     Assert.assertFalse(plannerConfig.isAwaitInitializationOnStart());
-    Assert.assertEquals(DateTimeZone.forID("Asia/Seoul"), plannerConfig.getSqlTimeZone());
+    Assert.assertEquals(DateTimes.inferTzFromString("Asia/Seoul"), plannerConfig.getSqlTimeZone());
     Assert.assertTrue(plannerConfig.isMetadataSegmentCacheEnable());
     Assert.assertEquals(20, plannerConfig.getMetadataSegmentPollPeriod());
     Assert.assertTrue(plannerConfig.isUseParsedExprCache());

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
@@ -29,6 +29,7 @@ import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.jackson.JacksonModule;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.server.QueryLifecycleFactory;
 import org.apache.druid.server.security.AuthorizerMapper;
@@ -40,6 +41,8 @@ import org.apache.druid.sql.calcite.util.CalciteTestBase;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +50,7 @@ import org.junit.runner.RunWith;
 
 import javax.validation.Validation;
 import javax.validation.Validator;
+import java.util.Properties;
 import java.util.Set;
 
 @RunWith(EasyMockRunner.class)
@@ -78,6 +82,7 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
   private Set<NamedSchema> calciteSchemas;
 
   private CalcitePlannerModule target;
+  private Properties properties;
   private Injector injector;
 
   @Before
@@ -92,6 +97,7 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
     aggregators = ImmutableSet.of();
     operatorConversions = ImmutableSet.of();
     target = new CalcitePlannerModule();
+    properties = new Properties();
     injector = Guice.createInjector(
         new JacksonModule(),
         binder -> {
@@ -105,6 +111,7 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
           binder.bind(Key.get(new TypeLiteral<Set<SqlAggregator>>(){})).toInstance(aggregators);
           binder.bind(Key.get(new TypeLiteral<Set<SqlOperatorConversion>>(){})).toInstance(operatorConversions);
           binder.bind(SchemaPlus.class).toInstance(rootSchema);
+          binder.bind(Properties.class).toInstance(properties);
         },
         target
     );
@@ -129,9 +136,51 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
   }
 
   @Test
-  public void testPlannerConfigIsInjected()
+  public void testDefaultPlannerConfigIsInjected()
   {
     PlannerConfig plannerConfig = injector.getInstance(PlannerConfig.class);
     Assert.assertNotNull(plannerConfig);
+    Assert.assertEquals(new Period("PT1M"), plannerConfig.getMetadataRefreshPeriod());
+    Assert.assertEquals(100000, plannerConfig.getMaxTopNLimit());
+    Assert.assertTrue(plannerConfig.isUseApproximateCountDistinct());
+    Assert.assertTrue(plannerConfig.isUseApproximateTopN());
+    Assert.assertFalse(plannerConfig.isRequireTimeCondition());
+    Assert.assertTrue(plannerConfig.isAwaitInitializationOnStart());
+    Assert.assertEquals(DateTimeZone.UTC, plannerConfig.getSqlTimeZone());
+    Assert.assertFalse(plannerConfig.isMetadataSegmentCacheEnable());
+    Assert.assertEquals(60000, plannerConfig.getMetadataSegmentPollPeriod());
+    Assert.assertFalse(plannerConfig.isUseParsedExprCache());
+  }
+
+  @Test
+  public void testInjectPlannerConfigWithCustomProperties()
+  {
+    properties.setProperty(getPlannerConfigKey("metadataRefreshPeriod"), "PT10M");
+    properties.setProperty(getPlannerConfigKey("maxTopNLimit"), "10");
+    properties.setProperty(getPlannerConfigKey("useApproximateCountDistinct"), "false");
+    properties.setProperty(getPlannerConfigKey("useApproximateTopN"), "false");
+    properties.setProperty(getPlannerConfigKey("requireTimeCondition"), "true");
+    properties.setProperty(getPlannerConfigKey("awaitInitializationOnStart"), "false");
+    properties.setProperty(getPlannerConfigKey("sqlTimeZone"), DateTimeZone.forID("Asia/Seoul").toString());
+    properties.setProperty(getPlannerConfigKey("metadataSegmentCacheEnable"), "true");
+    properties.setProperty(getPlannerConfigKey("metadataSegmentPollPeriod"), "20");
+    properties.setProperty(getPlannerConfigKey("useParsedExprCache"), "true");
+    PlannerConfig plannerConfig = injector.getInstance(PlannerConfig.class);
+    Assert.assertNotNull(plannerConfig);
+    Assert.assertEquals(new Period("PT10M"), plannerConfig.getMetadataRefreshPeriod());
+    Assert.assertEquals(10, plannerConfig.getMaxTopNLimit());
+    Assert.assertFalse(plannerConfig.isUseApproximateCountDistinct());
+    Assert.assertFalse(plannerConfig.isUseApproximateTopN());
+    Assert.assertTrue(plannerConfig.isRequireTimeCondition());
+    Assert.assertFalse(plannerConfig.isAwaitInitializationOnStart());
+    Assert.assertEquals(DateTimeZone.forID("Asia/Seoul"), plannerConfig.getSqlTimeZone());
+    Assert.assertTrue(plannerConfig.isMetadataSegmentCacheEnable());
+    Assert.assertEquals(20, plannerConfig.getMetadataSegmentPollPeriod());
+    Assert.assertTrue(plannerConfig.isUseParsedExprCache());
+  }
+
+  private static String getPlannerConfigKey(String suffix)
+  {
+    return StringUtils.format("%s.%s", CalcitePlannerModule.PLANNER_CONFIG_PREFIX, suffix);
   }
 }


### PR DESCRIPTION
### Description

Druid can parse the same expressions over again while it explores the search space of candidate plans. This PR adds caching parsed expressions per query. This could also be useful when the search space is large. Caching is disabled by default.

`SqlBenchmark.planSql()` results after applying this and https://github.com/apache/druid/pull/11041. Only the query 19 (the giant union query) shows a noticeable improvement (total ~25%, ~7% for only caching). However, in my testing after I quadrupled the query 19, the gain in planning time was smaller (~11%) than with the original query. This was because of too many candidate plans to explore. I think parallelizing query planning can help in this case, but didn't investigate that idea much because it should be done in Calcite.

```
master

Benchmark             (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score   Error  Units
SqlBenchmark.planSql        0                 5        false  avgt   15    0.563 ± 0.005  ms/op
SqlBenchmark.planSql        1                 5        false  avgt   15    0.603 ± 0.004  ms/op
SqlBenchmark.planSql        2                 5        false  avgt   15    0.662 ± 0.007  ms/op
SqlBenchmark.planSql        3                 5        false  avgt   15    0.808 ± 0.009  ms/op
SqlBenchmark.planSql        4                 5        false  avgt   15    1.156 ± 0.014  ms/op
SqlBenchmark.planSql        5                 5        false  avgt   15    1.291 ± 0.011  ms/op
SqlBenchmark.planSql        6                 5        false  avgt   15    1.504 ± 0.011  ms/op
SqlBenchmark.planSql        7                 5        false  avgt   15    1.270 ± 0.013  ms/op
SqlBenchmark.planSql        8                 5        false  avgt   15    2.044 ± 0.013  ms/op
SqlBenchmark.planSql        9                 5        false  avgt   15    1.982 ± 0.022  ms/op
SqlBenchmark.planSql       10                 5        false  avgt   15    0.707 ± 0.005  ms/op
SqlBenchmark.planSql       11                 5        false  avgt   15    0.741 ± 0.002  ms/op
SqlBenchmark.planSql       12                 5        false  avgt   15    0.624 ± 0.006  ms/op
SqlBenchmark.planSql       13                 5        false  avgt   15    0.874 ± 0.007  ms/op
SqlBenchmark.planSql       14                 5        false  avgt   15    0.980 ± 0.008  ms/op
SqlBenchmark.planSql       15                 5        false  avgt   15    0.628 ± 0.007  ms/op
SqlBenchmark.planSql       16                 5        false  avgt   15    0.745 ± 0.005  ms/op
SqlBenchmark.planSql       17                 5        false  avgt   15    0.956 ± 0.009  ms/op
SqlBenchmark.planSql       18                 5        false  avgt   15    1.078 ± 0.011  ms/op
SqlBenchmark.planSql       19                 5        false  avgt   15  129.221 ± 0.725  ms/op

patch

Benchmark             (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt   Score   Error  Units
SqlBenchmark.planSql        0                 5        false  avgt   15   0.541 ± 0.003  ms/op
SqlBenchmark.planSql        1                 5        false  avgt   15   0.608 ± 0.004  ms/op
SqlBenchmark.planSql        2                 5        false  avgt   15   0.650 ± 0.003  ms/op
SqlBenchmark.planSql        3                 5        false  avgt   15   0.700 ± 0.008  ms/op
SqlBenchmark.planSql        4                 5        false  avgt   15   1.131 ± 0.007  ms/op
SqlBenchmark.planSql        5                 5        false  avgt   15   1.121 ± 0.004  ms/op
SqlBenchmark.planSql        6                 5        false  avgt   15   1.315 ± 0.015  ms/op
SqlBenchmark.planSql        7                 5        false  avgt   15   1.166 ± 0.011  ms/op
SqlBenchmark.planSql        8                 5        false  avgt   15   1.769 ± 0.014  ms/op
SqlBenchmark.planSql        9                 5        false  avgt   15   1.587 ± 0.017  ms/op
SqlBenchmark.planSql       10                 5        false  avgt   15   0.710 ± 0.003  ms/op
SqlBenchmark.planSql       11                 5        false  avgt   15   0.732 ± 0.005  ms/op
SqlBenchmark.planSql       12                 5        false  avgt   15   0.584 ± 0.005  ms/op
SqlBenchmark.planSql       13                 5        false  avgt   15   0.801 ± 0.005  ms/op
SqlBenchmark.planSql       14                 5        false  avgt   15   0.894 ± 0.005  ms/op
SqlBenchmark.planSql       15                 5        false  avgt   15   0.583 ± 0.007  ms/op
SqlBenchmark.planSql       16                 5        false  avgt   15   0.691 ± 0.003  ms/op
SqlBenchmark.planSql       17                 5        false  avgt   15   0.820 ± 0.005  ms/op
SqlBenchmark.planSql       18                 5        false  avgt   15   0.937 ± 0.007  ms/op
SqlBenchmark.planSql       19                 5        false  avgt   15  97.453 ± 0.540  ms/op
```

<hr>

##### Key changed/added classes in this PR
 * `CachingExprParser`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
