### PR TITLE
CompactionTask throws exception on conflicting segmentGranularity

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -61,6 +61,7 @@ import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervi
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.indexing.input.DruidInputSource;
 import org.apache.druid.indexing.overlord.Segments;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
@@ -207,6 +208,16 @@ public class CompactionTask extends AbstractBatchIndexTask
     this.dimensionsSpec = dimensionsSpec == null ? dimensions : dimensionsSpec;
     this.metricsSpec = metricsSpec;
     this.segmentGranularity = segmentGranularity;
+    if (granularitySpec != null
+        && segmentGranularity != null
+        && !segmentGranularity.equals(granularitySpec.getSegmentGranularity())) {
+      throw new IAE(StringUtils.format(
+          "Conflicting segment granularities found %s(segmentGranularity) and %s(granularitySpec.segmentGranularity).\n"
+          + "Remove `segmentGranularity` and set the `granularitySpec.segmentGranularity` to the expected granularity",
+          segmentGranularity,
+          granularitySpec.getSegmentGranularity()
+      ));
+    }
     if (granularitySpec == null && segmentGranularity != null) {
       this.granularitySpec = new ClientCompactionTaskGranularitySpec(segmentGranularity, null);
     } else {
@@ -544,7 +555,9 @@ public class CompactionTask extends AbstractBatchIndexTask
             segmentsToCompact,
             dimensionsSpec,
             metricsSpec,
-            granularitySpec == null ? new ClientCompactionTaskGranularitySpec(segmentGranularityToUse, null) : granularitySpec.withSegmentGranularity(segmentGranularityToUse)
+            granularitySpec == null
+            ? new ClientCompactionTaskGranularitySpec(segmentGranularityToUse, null)
+            : granularitySpec.withSegmentGranularity(segmentGranularityToUse)
         );
 
         specs.add(
@@ -658,7 +671,10 @@ public class CompactionTask extends AbstractBatchIndexTask
       log.info("Generate compaction task spec with segments original query granularity [%s]", queryGranularityToUse);
     } else {
       queryGranularityToUse = granularitySpec.getQueryGranularity();
-      log.info("Generate compaction task spec with new query granularity overrided from input [%s]", queryGranularityToUse);
+      log.info(
+          "Generate compaction task spec with new query granularity overrided from input [%s]",
+          queryGranularityToUse
+      );
     }
 
     final GranularitySpec uniformGranularitySpec = new UniformGranularitySpec(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -208,6 +208,10 @@ public class CompactionTask extends AbstractBatchIndexTask
     this.dimensionsSpec = dimensionsSpec == null ? dimensions : dimensionsSpec;
     this.metricsSpec = metricsSpec;
     this.segmentGranularity = segmentGranularity;
+    // Prior to apache/druid#10843 users could specify segmentGranularity using `segmentGranularity`
+    // Now users should prefer to use `granularitySpec`
+    // In case users accidentally specify both, and they are conflicting, warn the user instead of proceeding
+    // by picking one or another.
     if (granularitySpec != null
         && segmentGranularity != null
         && !segmentGranularity.equals(granularitySpec.getSegmentGranularity())) {


### PR DESCRIPTION
### Description

A follow up to #10843 

Since there are 2 ways for a user to specify segmentGranularity - this change makes throws an exception if a user accidentally submits a compaction task with conflicting segmentGranularities - by using the old way and the new way at the same time.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
