### PR TITLE
suppress CVE check for security fix

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -307,4 +307,12 @@
      ]]></notes>
     <cve>CVE-2017-15288</cve>
   </suppress>
+
+  <suppress>
+    <!-- (avro, parquet, integration-tests) we don't allow velocity templates to be uploaded by untrusted users -->
+    <notes><![CDATA[
+     file name: velocity-engine-core-2.2.jar:
+     ]]></notes>
+    <cve>CVE-2020-13936</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppresses https://nvd.nist.gov/vuln/detail/CVE-2020-13936 which gets triggered by the security check, caused by `velocity-engine-core-2.2.jar` which is a dependency of Avro and Parquet extensions.

Based on the description:
```
Applications using Apache Velocity that allow untrusted users to
upload templates should upgrade to version 2.3.  This version adds
additional default restrictions on what methods/properties can be
accessed in a template.
```

I don't believe we should be impacted.