### PR TITLE
vectorize 'auto' long decoding

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
@@ -93,7 +93,12 @@ public class BaseColumnarLongsBenchmark
         filter.set(rowToAccess);
         bitmap.add(rowToAccess);
       }
-      vectorOffset = new BitmapVectorOffset(VECTOR_SIZE, new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()), 0, rows);
+      vectorOffset = new BitmapVectorOffset(
+          VECTOR_SIZE,
+          new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
+          0,
+          rows
+      );
     } else {
       vectorOffset = new NoFilterVectorOffset(VECTOR_SIZE, 0, rows);
     }
@@ -174,7 +179,6 @@ public class BaseColumnarLongsBenchmark
   // for testing encodings: validate that all encoders read the same values
   // noinspection unused
   static void checkSanity(Map<String, ColumnarLongs> encoders, List<String> encodings, int rows)
-      throws Exception
   {
     for (int i = 0; i < rows; i++) {
       checkRowSanity(encoders, encodings, i);

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import org.apache.druid.collections.bitmap.WrappedImmutableRoaringBitmap;
+import org.apache.druid.segment.data.ColumnarLongs;
+import org.apache.druid.segment.data.ColumnarLongsSerializer;
+import org.apache.druid.segment.data.CompressedColumnarLongsSupplier;
+import org.apache.druid.segment.data.CompressionFactory;
+import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.vector.BitmapVectorOffset;
+import org.apache.druid.segment.vector.NoFilterVectorOffset;
+import org.apache.druid.segment.vector.VectorOffset;
+import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+@State(Scope.Benchmark)
+public class BaseColumnarLongsBenchmark
+{
+  static final int VECTOR_SIZE = 512;
+
+  @Param({
+      "lz4-longs",
+      "lz4-auto"
+  })
+  String encoding;
+
+  Random rand = new Random(0);
+
+  long[] vals;
+
+  long minValue;
+  long maxValue;
+
+  @Nullable
+  BitSet filter;
+
+  VectorOffset vectorOffset;
+
+  void setupFilters(int rows, double filteredRowCountPercentage)
+  {
+    // todo: filter set distributions to simulate different select patterns?
+    //  (because benchmarks don't take long enough already..)
+    filter = null;
+    final int filteredRowCount = (int) Math.floor(rows * filteredRowCountPercentage);
+
+    if (filteredRowCount < rows) {
+      // setup bitset filter
+      filter = new BitSet();
+      MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+      for (int i = 0; i < filteredRowCount; i++) {
+        int rowToAccess = rand.nextInt(rows);
+        // Skip already selected rows if any
+        while (filter.get(rowToAccess)) {
+          rowToAccess = rand.nextInt(rows);
+        }
+        filter.set(rowToAccess);
+        bitmap.add(rowToAccess);
+      }
+      vectorOffset = new BitmapVectorOffset(VECTOR_SIZE, new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()), 0, rows);
+    } else {
+      vectorOffset = new NoFilterVectorOffset(VECTOR_SIZE, 0, rows);
+    }
+  }
+
+  static int encodeToFile(long[] vals, String encoding, FileChannel output)throws IOException
+  {
+    SegmentWriteOutMedium writeOutMedium = new OnHeapMemorySegmentWriteOutMedium();
+
+    ColumnarLongsSerializer serializer;
+    switch (encoding) {
+      case "lz4-longs":
+        serializer = CompressionFactory.getLongSerializer(
+            encoding,
+            writeOutMedium,
+            "lz4-longs",
+            ByteOrder.LITTLE_ENDIAN,
+            CompressionFactory.LongEncodingStrategy.LONGS,
+            CompressionStrategy.LZ4
+        );
+        break;
+      case "lz4-auto":
+        serializer = CompressionFactory.getLongSerializer(
+            encoding,
+            writeOutMedium,
+            "lz4-auto",
+            ByteOrder.LITTLE_ENDIAN,
+            CompressionFactory.LongEncodingStrategy.AUTO,
+            CompressionStrategy.LZ4
+        );
+        break;
+      case "none-longs":
+        serializer = CompressionFactory.getLongSerializer(
+            encoding,
+            writeOutMedium,
+            "none-longs",
+            ByteOrder.LITTLE_ENDIAN,
+            CompressionFactory.LongEncodingStrategy.LONGS,
+            CompressionStrategy.NONE
+        );
+        break;
+      case "none-auto":
+        serializer = CompressionFactory.getLongSerializer(
+            encoding,
+            writeOutMedium,
+            "none-auto",
+            ByteOrder.LITTLE_ENDIAN,
+            CompressionFactory.LongEncodingStrategy.AUTO,
+            CompressionStrategy.NONE
+        );
+        break;
+      default:
+        throw new RuntimeException("unknown encoding");
+    }
+
+    serializer.open();
+    for (long val : vals) {
+      serializer.add(val);
+    }
+    serializer.writeTo(output, null);
+    return (int) serializer.getSerializedSize();
+  }
+
+  static ColumnarLongs createColumnarLongs(String encoding, ByteBuffer buffer)
+  {
+    switch (encoding) {
+      case "lz4-longs":
+      case "lz4-auto":
+      case "none-auto":
+      case "none-longs":
+        return CompressedColumnarLongsSupplier.fromByteBuffer(buffer, ByteOrder.LITTLE_ENDIAN).get();
+    }
+
+    throw new IllegalArgumentException("unknown encoding");
+  }
+
+
+  // for debugging: validate that all encoders read the same values
+  static void checkSanity(Map<String, ColumnarLongs> encoders, List<String> encodings, int rows)
+      throws Exception
+  {
+    for (int i = 0; i < rows; i++) {
+      checkRowSanity(encoders, encodings, i);
+    }
+  }
+
+  static void checkRowSanity(Map<String, ColumnarLongs> encoders, List<String> encodings, int row)
+      throws Exception
+  {
+    if (encodings.size() > 1) {
+      for (int i = 0; i < encodings.size() - 1; i++) {
+        String currentKey = encodings.get(i);
+        String nextKey = encodings.get(i + 1);
+        ColumnarLongs current = encoders.get(currentKey);
+        ColumnarLongs next = encoders.get(nextKey);
+        long vCurrent = current.get(row);
+        long vNext = next.get(row);
+        if (vCurrent != vNext) {
+          throw new Exception("values do not match at row "
+                              + row
+                              + " - "
+                              + currentKey
+                              + ":"
+                              + vCurrent
+                              + " "
+                              + nextKey
+                              + ":"
+                              + vNext);
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
@@ -20,6 +20,7 @@
 package org.apache.druid.benchmark.compression;
 
 import org.apache.druid.collections.bitmap.WrappedImmutableRoaringBitmap;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.segment.data.ColumnarLongs;
 import org.apache.druid.segment.data.ColumnarLongsSerializer;
 import org.apache.druid.segment.data.CompressedColumnarLongsSupplier;
@@ -50,6 +51,10 @@ public class BaseColumnarLongsBenchmark
 {
   static final int VECTOR_SIZE = 512;
 
+  /**
+   * Name of the long encoding strategy. For longs, this is a composite of both byte level block compression and
+   * encoding of values within the block.
+   */
   @Param({
       "lz4-longs",
       "lz4-auto"
@@ -166,7 +171,8 @@ public class BaseColumnarLongsBenchmark
   }
 
 
-  // for debugging: validate that all encoders read the same values
+  // for testing encodings: validate that all encoders read the same values
+  // noinspection unused
   static void checkSanity(Map<String, ColumnarLongs> encoders, List<String> encodings, int rows)
       throws Exception
   {
@@ -176,7 +182,6 @@ public class BaseColumnarLongsBenchmark
   }
 
   static void checkRowSanity(Map<String, ColumnarLongs> encoders, List<String> encodings, int row)
-      throws Exception
   {
     if (encodings.size() > 1) {
       for (int i = 0; i < encodings.size() - 1; i++) {
@@ -187,16 +192,14 @@ public class BaseColumnarLongsBenchmark
         long vCurrent = current.get(row);
         long vNext = next.get(row);
         if (vCurrent != vNext) {
-          throw new Exception("values do not match at row "
-                              + row
-                              + " - "
-                              + currentKey
-                              + ":"
-                              + vCurrent
-                              + " "
-                              + nextKey
-                              + ":"
-                              + vNext);
+          throw new RE(
+              "values do not match at row %s - %s:%s %s:%s",
+              row,
+              currentKey,
+              vCurrent,
+              nextKey,
+              vNext
+          );
         }
       }
     }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromGeneratorBenchmark.java
@@ -1,0 +1,425 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.generator.ColumnValueGenerator;
+import org.apache.druid.segment.generator.GeneratorColumnSchema;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+@State(Scope.Benchmark)
+public class BaseColumnarLongsFromGeneratorBenchmark extends BaseColumnarLongsBenchmark
+{
+  static int SEED = 1;
+
+  @Param({
+      "0.0",
+//      "0.5",
+//      "0.95"
+  })
+  double zeroProbability;
+
+  @Param({"5000000"})
+  int rows;
+
+  @Param({
+//      "enumerated-0-1",
+//      "enumerated-full",
+//      "normal",
+//      "sequential-1000",
+//      "sequential-unique",
+      "uniform-1",
+      "uniform-2",
+//      "uniform-3",
+      "uniform-4",
+      "uniform-8",
+      "uniform-12",
+      "uniform-16",
+      "uniform-20",
+      "uniform-24",
+      "uinform-32",
+      "uniform-40",
+      "uniform-48",
+      "uniform-56",
+      "uniform-64",
+//      "zipf-low-100",
+//      "zipf-low-100000",
+//      "zipf-low-32-bit",
+//      "zipf-high-100",
+//      "zipf-high-100000",
+//      "zipf-high-32-bit"
+  })
+  String distribution;
+
+  void initializeValues() throws IOException
+  {
+    vals = new long[rows];
+    final String filename = getGeneratorValueFilename(distribution, rows, zeroProbability);
+    File dir = getTmpDir();
+    File dataFile = new File(dir, filename);
+
+    if (dataFile.exists()) {
+      System.out.println("Data files already exist, re-using");
+      try (BufferedReader br = Files.newBufferedReader(dataFile.toPath(), StandardCharsets.UTF_8)) {
+        int lineNum = 0;
+        String line;
+        while ((line = br.readLine()) != null) {
+          vals[lineNum] = Long.parseLong(line);
+          if (vals[lineNum] < minValue) {
+            minValue = vals[lineNum];
+          }
+          if (vals[lineNum] > maxValue) {
+            maxValue = vals[lineNum];
+          }
+          lineNum++;
+        }
+      }
+    } else {
+      try (Writer writer = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8)) {
+        ColumnValueGenerator valueGenerator = makeGenerator(distribution, rows, zeroProbability);
+
+        for (int i = 0; i < rows; i++) {
+          long value;
+          Object rowValue = valueGenerator.generateRowValue();
+          value = rowValue != null ? (long) rowValue : 0;
+          vals[i] = value;
+          if (vals[i] < minValue) {
+            minValue = vals[i];
+          }
+          if (vals[i] > maxValue) {
+            maxValue = vals[i];
+          }
+          writer.write(vals[i] + "\n");
+        }
+      }
+    }
+  }
+
+  static ColumnValueGenerator makeGenerator(
+      String distribution,
+      int rows,
+      double zeroProbability
+  )
+  {
+    List<Object> enumerated;
+    List<Double> probability;
+    switch (distribution) {
+      case "enumerated-0-1":
+        enumerated = ImmutableList.of(0, 1);
+        probability = ImmutableList.of(0.6, 0.4);
+        return GeneratorColumnSchema.makeEnumerated(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            enumerated,
+            probability
+        ).makeGenerator(SEED);
+      case "enumerated-full":
+        enumerated = ImmutableList.of(
+            0,
+            1,
+            Long.MAX_VALUE - 1,
+            Long.MIN_VALUE + 1,
+            Long.MIN_VALUE / 2,
+            Long.MAX_VALUE / 2
+        );
+        probability = ImmutableList.of(0.4, 0.2, 0.1, 0.1, 0.1, 0.1);
+        return GeneratorColumnSchema.makeEnumerated(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            enumerated,
+            probability
+        ).makeGenerator(SEED);
+      case "normal":
+        return GeneratorColumnSchema.makeNormal(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            1.0,
+            (double) Integer.MAX_VALUE,
+            true
+        ).makeGenerator(SEED);
+      case "sequential-1000":
+        return GeneratorColumnSchema.makeSequential(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            Integer.MAX_VALUE - 1001,
+            Integer.MAX_VALUE - 1
+        ).makeGenerator(SEED);
+      case "sequential-unique":
+        return GeneratorColumnSchema.makeSequential(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            rows
+        ).makeGenerator(SEED);
+      case "uniform-1":
+        return GeneratorColumnSchema.makeDiscreteUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            1
+        ).makeGenerator(SEED);
+      case "uniform-2":
+        return GeneratorColumnSchema.makeDiscreteUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            4
+        ).makeGenerator(SEED);
+      case "uniform-3":
+        return GeneratorColumnSchema.makeDiscreteUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            1000000,
+            1000008
+        ).makeGenerator(SEED);
+      case "uniform-4":
+        return GeneratorColumnSchema.makeDiscreteUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            1 << 4
+        ).makeGenerator(SEED);
+      case "uniform-8":
+        return GeneratorColumnSchema.makeDiscreteUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            1 << 8
+        ).makeGenerator(SEED);
+      case "uniform-12":
+        return GeneratorColumnSchema.makeDiscreteUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            1 << 12
+        ).makeGenerator(SEED);
+      case "uniform-16":
+        return GeneratorColumnSchema.makeDiscreteUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            1 << 16
+        ).makeGenerator(SEED);
+      case "uniform-20":
+        return GeneratorColumnSchema.makeContinuousUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            1 << 20
+        ).makeGenerator(SEED);
+      case "uniform-24":
+        return GeneratorColumnSchema.makeContinuousUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            (1 << 24) - 1
+        ).makeGenerator(SEED);
+      case "uinform-32":
+        return GeneratorColumnSchema.makeContinuousUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            Integer.MAX_VALUE - 1
+        ).makeGenerator(SEED);
+      case "uniform-40":
+        return GeneratorColumnSchema.makeContinuousUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0L,
+            (1L << 40) - 1
+        ).makeGenerator(SEED);
+      case "uniform-48":
+        return GeneratorColumnSchema.makeContinuousUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            (1L << 48) - 1
+        ).makeGenerator(SEED);
+      case "uniform-56":
+        return GeneratorColumnSchema.makeContinuousUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            (1L << 56 - 1)
+        ).makeGenerator(SEED);
+      case "uniform-64":
+        return GeneratorColumnSchema.makeContinuousUniform(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            Long.MAX_VALUE - 1
+        ).makeGenerator(SEED);
+      case "zipf-low-100":
+        return GeneratorColumnSchema.makeLazyZipf(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            100,
+            1d
+        ).makeGenerator(SEED);
+      case "zipf-low-100000":
+        return GeneratorColumnSchema.makeLazyZipf(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            -50000,
+            50000,
+            1d
+        ).makeGenerator(SEED);
+      case "zipf-low-32-bit":
+        return GeneratorColumnSchema.makeLazyZipf(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            0d,
+            0,
+            Integer.MAX_VALUE,
+            1d
+        ).makeGenerator(SEED);
+      case "zipf-high-100":
+        return GeneratorColumnSchema.makeLazyZipf(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            0,
+            100,
+            3d
+        ).makeGenerator(SEED);
+      case "zipf-high-100000":
+        return GeneratorColumnSchema.makeLazyZipf(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            zeroProbability,
+            -50000,
+            50000,
+            3d
+        ).makeGenerator(SEED);
+      case "zipf-high-32-bit":
+        return GeneratorColumnSchema.makeLazyZipf(
+            distribution,
+            ValueType.LONG,
+            true,
+            1,
+            0d,
+            0,
+            Integer.MAX_VALUE,
+            3d
+        ).makeGenerator(SEED);
+    }
+    throw new IllegalArgumentException("unknown distribution");
+  }
+
+  static String getGeneratorValueFilename(String distribution, int rows, double nullProbability)
+  {
+    return StringUtils.format("values-%s-%s-%s.bin", distribution, rows, nullProbability);
+  }
+
+  static String getGeneratorEncodedFilename(String encoding, String distribution, int rows, double nullProbability)
+  {
+    return StringUtils.format("%s-%s-%s-%s.bin", encoding, distribution, rows, nullProbability);
+  }
+
+  static File getTmpDir()
+  {
+    final String dirPath = "tmp/encoding/longs/";
+    File dir = new File(dirPath);
+    dir.mkdirs();
+    return dir;
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromSegmentsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromSegmentsBenchmark.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.Lists;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.IndexIO;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.LongsColumn;
+import org.apache.druid.segment.column.ValueType;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Set;
+
+@State(Scope.Benchmark)
+public class BaseColumnarLongsFromSegmentsBenchmark extends BaseColumnarLongsBenchmark
+{
+  //CHECKSTYLE.OFF: Regexp
+  // twitter-ticker
+  @Param({
+      "__time",
+      "followers",
+      "friends",
+      "max_followers",
+      "max_retweets",
+      "max_statuses",
+      "retweets",
+      "statuses",
+      "tweets"
+  })
+  String columnName;
+
+  @Param({"3259585"})
+  int rows;
+
+
+  @Param({"tmp/segments/twitter-ticker-1/"})
+  String segmentPath;
+
+  @Param({"twitter-ticker"})
+  String segmentName;
+
+
+  //CHECKSTYLE.ON: Regexp
+
+  private static IndexIO INDEX_IO;
+  public static ObjectMapper JSON_MAPPER;
+
+  void initializeValues() throws IOException
+  {
+    initializeSegmentValueIntermediaryFile();
+    File dir = getTmpDir();
+    File dataFile = new File(dir, getColumnDataFileName(segmentName, columnName));
+
+    ArrayList<Long> values = Lists.newArrayList();
+    try (BufferedReader br = Files.newBufferedReader(dataFile.toPath(), StandardCharsets.UTF_8)) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        long value = Long.parseLong(line);
+        if (value < minValue) {
+          minValue = value;
+        }
+        if (value > maxValue) {
+          maxValue = value;
+        }
+        values.add(value);
+        rows++;
+      }
+    }
+
+    vals = values.stream().mapToLong(i -> i).toArray();
+  }
+
+
+  String getColumnDataFileName(String segmentName, String columnName)
+  {
+    return StringUtils.format("%s-longs-%s.txt", segmentName, columnName);
+  }
+
+  String getColumnEncodedFileName(String encoding, String segmentName, String columnName)
+  {
+    return StringUtils.format("%s-%s-longs-%s.bin", encoding, segmentName, columnName);
+  }
+
+  File getTmpDir()
+  {
+    final String dirPath = StringUtils.format("tmp/encoding/%s", segmentName);
+    File dir = new File(dirPath);
+    dir.mkdirs();
+    return dir;
+  }
+
+  /**
+   * writes column values to text file, 1 per line
+   *
+   * @throws IOException
+   */
+  void initializeSegmentValueIntermediaryFile() throws IOException
+  {
+    File dir = getTmpDir();
+    File dataFile = new File(dir, getColumnDataFileName(segmentName, columnName));
+
+    if (!dataFile.exists()) {
+      JSON_MAPPER = new DefaultObjectMapper();
+      INDEX_IO = new IndexIO(
+          JSON_MAPPER,
+          () -> 0
+      );
+      try (final QueryableIndex index = INDEX_IO.loadIndex(new File(segmentPath))) {
+        final Set<String> columnNames = Sets.newLinkedHashSet();
+        columnNames.add(ColumnHolder.TIME_COLUMN_NAME);
+        Iterables.addAll(columnNames, index.getColumnNames());
+        final ColumnHolder column = index.getColumnHolder(columnName);
+        final ColumnCapabilities capabilities = column.getCapabilities();
+        final ValueType columnType = capabilities.getType();
+        try (Writer writer = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8)) {
+          if (columnType != ValueType.LONG) {
+            throw new RuntimeException("Invalid column type, expected 'Long'");
+          }
+          LongsColumn theColumn = (LongsColumn) column.getColumn();
+
+
+          for (int i = 0; i < theColumn.length(); i++) {
+            long value = theColumn.getLongSingleValueRow(i);
+            writer.write(value + "\n");
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromSegmentsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromSegmentsBenchmark.java
@@ -59,6 +59,9 @@ public class BaseColumnarLongsFromSegmentsBenchmark extends BaseColumnarLongsBen
   /**
    * Path to a segment file to read long columns from. This shouldn't really be used as a parameter, but is nice to
    * be included in the output measurements.
+   *
+   * This is BYO segment, as this file doesn't probably exist for you, replace it and other parameters with the segment
+   * to test.
    */
   @Param({"tmp/segments/twitter-ticker-1/"})
   String segmentPath;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromGeneratorBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 2)
+public class ColumnarLongsEncodeDataFromGeneratorBenchmark extends BaseColumnarLongsFromGeneratorBenchmark
+{
+  @Setup
+  public void setup() throws Exception
+  {
+    initializeValues();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void encodeColumn(Blackhole blackhole) throws IOException
+  {
+    File dir = getTmpDir();
+    File columnDataFile = new File(dir, getGeneratorEncodedFilename(encoding, distribution, rows, zeroProbability));
+    columnDataFile.delete();
+    FileChannel output =
+        FileChannel.open(columnDataFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+    int size = encodeToFile(vals, encoding, output);
+    EncodingSizeProfiler.encodedSize = size;
+    blackhole.consume(size);
+    output.close();
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(ColumnarLongsEncodeDataFromGeneratorBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-longs-encode-speed.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
@@ -21,7 +21,6 @@ package org.apache.druid.benchmark.compression;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.IndexIO;
@@ -56,6 +55,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -123,7 +123,7 @@ public class ColumnarLongsEncodeDataFromSegmentBenchmark extends BaseColumnarLon
           () -> 0
       );
       try (final QueryableIndex index = INDEX_IO.loadIndex(new File(segmentPath))) {
-        final Set<String> columnNames = Sets.newLinkedHashSet();
+        final Set<String> columnNames = new LinkedHashSet<>();
         columnNames.add(ColumnHolder.TIME_COLUMN_NAME);
         Iterables.addAll(columnNames, index.getColumnNames());
         final ColumnHolder column = index.getColumnHolder(columnName);

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.benchmark.compression;
 
-import com.google.api.client.util.Lists;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 1)
+public class ColumnarLongsEncodeDataFromSegmentBenchmark extends BaseColumnarLongsFromSegmentsBenchmark
+{
+  @Setup
+  public void setup() throws Exception
+  {
+    initializeValues();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void encodeColumn(Blackhole blackhole) throws IOException
+  {
+    File dir = getTmpDir();
+    File columnDataFile = new File(dir, getColumnEncodedFileName(encoding, segmentName, columnName));
+    columnDataFile.delete();
+    FileChannel output =
+        FileChannel.open(columnDataFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+    int size = BaseColumnarLongsBenchmark.encodeToFile(vals, encoding, output);
+    EncodingSizeProfiler.encodedSize = size;
+    blackhole.consume(size);
+    output.close();
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    System.out.println("main happened");
+    Options opt = new OptionsBuilder()
+        .include(ColumnarLongsEncodeDataFromSegmentBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-longs-encode-speed-segments.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsEncodeDataFromSegmentBenchmark.java
@@ -20,7 +20,6 @@
 package org.apache.druid.benchmark.compression;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.IndexIO;
@@ -56,6 +55,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -72,7 +72,7 @@ public class ColumnarLongsEncodeDataFromSegmentBenchmark extends BaseColumnarLon
     File dir = getTmpDir();
     File dataFile = new File(dir, getColumnDataFileName(segmentName, columnName));
 
-    ArrayList<Long> values = Lists.newArrayList();
+    List<Long> values = new ArrayList<>();
     try (BufferedReader br = Files.newBufferedReader(dataFile.toPath(), StandardCharsets.UTF_8)) {
       String line;
       while ((line = br.readLine()) != null) {
@@ -118,11 +118,11 @@ public class ColumnarLongsEncodeDataFromSegmentBenchmark extends BaseColumnarLon
     File dataFile = new File(dir, getColumnDataFileName(segmentName, columnName));
 
     if (!dataFile.exists()) {
-      IndexIO INDEX_IO = new IndexIO(
+      final IndexIO indexIO = new IndexIO(
           new DefaultObjectMapper(),
           () -> 0
       );
-      try (final QueryableIndex index = INDEX_IO.loadIndex(new File(segmentPath))) {
+      try (final QueryableIndex index = indexIO.loadIndex(new File(segmentPath))) {
         final Set<String> columnNames = new LinkedHashSet<>();
         columnNames.add(ColumnHolder.TIME_COLUMN_NAME);
         Iterables.addAll(columnNames, index.getColumnNames());

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
@@ -71,7 +71,7 @@ public class ColumnarLongsSelectRowsFromGeneratorBenchmark extends BaseColumnarL
   private double filteredRowCountPercentage;
 
   @Setup
-  public void setup() throws Exception
+  public void setup() throws IOException
   {
     decoders = Maps.newHashMap();
     encodedSize = Maps.newHashMap();
@@ -93,7 +93,7 @@ public class ColumnarLongsSelectRowsFromGeneratorBenchmark extends BaseColumnarL
   }
 
   @TearDown
-  public void teardown() throws Exception
+  public void teardown()
   {
     for (ColumnarLongs longs : decoders.values()) {
       longs.close();

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import com.google.common.collect.Maps;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.segment.data.ColumnarLongs;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+public class ColumnarLongsSelectRowsFromGeneratorBenchmark extends BaseColumnarLongsFromGeneratorBenchmark
+{
+  private Map<String, ColumnarLongs> decoders;
+  private Map<String, Integer> encodedSize;
+
+  // Number of rows to read, the test will read random rows
+//  @Param({"0.1", "0.05", "0.95", "1.0"})
+  @Param({
+//      "0.1",
+//      "0.5",
+//      "0.95",
+      "1.0"
+  })
+  private double filteredRowCountPercentage;
+
+  @Setup
+  public void setup() throws Exception
+  {
+    decoders = Maps.newHashMap();
+    encodedSize = Maps.newHashMap();
+
+    setupFromFile(encoding);
+    setupFilters(rows, filteredRowCountPercentage);
+
+    // uncomment me to load multiple encoded files for sanity check
+    //CHECKSTYLE.OFF: Regexp
+//    ImmutableList<String> all = ImmutableList.of("lz4-longs", "lz4-auto");
+//    for (String _enc : all) {
+//      if (!_enc.equalsIgnoreCase(encoding)) {
+//        setupFromFile(_enc);
+//      }
+//    }
+//
+//    checkSanity(decoders, all, rows);
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  @TearDown
+  public void teardown() throws Exception
+  {
+    for (ColumnarLongs longs : decoders.values()) {
+      longs.close();
+    }
+  }
+
+  private void setupFromFile(String encoding) throws IOException
+  {
+    File dir = getTmpDir();
+    File compFile = new File(dir, getGeneratorEncodedFilename(encoding, distribution, rows, zeroProbability));
+    ByteBuffer buffer = FileUtils.map(compFile).get();
+
+    int size = (int) compFile.length();
+    encodedSize.put(encoding, size);
+    ColumnarLongs data = createColumnarLongs(encoding, buffer);
+    decoders.put(encoding, data);
+  }
+
+//  @Benchmark
+//  @BenchmarkMode(Mode.AverageTime)
+//  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+//  public void selectRows(Blackhole blackhole)
+//  {
+//    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+//    ColumnarLongs encoder = decoders.get(encoding);
+//    if (filter == null) {
+//      for (int i = 0; i < rows; i++) {
+//        blackhole.consume(encoder.get(i));
+//      }
+//    } else {
+//      for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
+//        blackhole.consume(encoder.get(i));
+//      }
+//    }
+//  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void selectRowsVectorized(Blackhole blackhole)
+  {
+    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+    ColumnarLongs columnDecoder = decoders.get(encoding);
+    long[] vector = new long[VECTOR_SIZE];
+    while (!vectorOffset.isDone()) {
+      if (vectorOffset.isContiguous()) {
+        columnDecoder.get(vector, vectorOffset.getStartOffset(), vectorOffset.getCurrentVectorSize());
+      } else {
+        columnDecoder.get(vector, vectorOffset.getOffsets(), vectorOffset.getCurrentVectorSize());
+      }
+      for (int i = 0 ; i < vectorOffset.getCurrentVectorSize(); i++) {
+        blackhole.consume(vector[i]);
+      }
+      vectorOffset.advance();
+    }
+    blackhole.consume(vector);
+    blackhole.consume(vectorOffset);
+    vectorOffset.reset();
+    columnDecoder.close();
+  }
+
+//  @Benchmark
+//  @BenchmarkMode(Mode.AverageTime)
+//  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+//  public void readVectorizedSequential(Blackhole bh)
+//  {
+//    long[] vector = new long[QueryableIndexStorageAdapter.DEFAULT_VECTOR_SIZE];
+//    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+//    ColumnarLongs columnDecoder = decoders.get(encoding);
+//    int count = columnDecoder.size();
+//    for (int i = 0; i < count; i++) {
+//      if (i % vector.length == 0) {
+//        columnDecoder.get(vector, i, Math.min(vector.length, count - i));
+//      }
+//      bh.consume(vector[i % vector.length]);
+//    }
+//    columnDecoder.close();
+//  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(ColumnarLongsSelectRowsFromGeneratorBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-longs-select-speed.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
@@ -144,7 +144,7 @@ public class ColumnarLongsSelectRowsFromGeneratorBenchmark extends BaseColumnarL
       } else {
         columnDecoder.get(vector, vectorOffset.getOffsets(), vectorOffset.getCurrentVectorSize());
       }
-      for (int i = 0 ; i < vectorOffset.getCurrentVectorSize(); i++) {
+      for (int i = 0; i < vectorOffset.getCurrentVectorSize(); i++) {
         blackhole.consume(vector[i]);
       }
       vectorOffset.advance();

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromGeneratorBenchmark.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.benchmark.compression;
 
-import com.google.common.collect.Maps;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.segment.data.ColumnarLongs;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -44,6 +43,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -73,8 +73,8 @@ public class ColumnarLongsSelectRowsFromGeneratorBenchmark extends BaseColumnarL
   @Setup
   public void setup() throws IOException
   {
-    decoders = Maps.newHashMap();
-    encodedSize = Maps.newHashMap();
+    decoders = new HashMap<>();
+    encodedSize = new HashMap<>();
 
     setupFromFile(encoding);
     setupFilters(rows, filteredRowCountPercentage);

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
@@ -138,7 +138,7 @@ public class ColumnarLongsSelectRowsFromSegmentBenchmark extends BaseColumnarLon
       } else {
         columnDecoder.get(vector, vectorOffset.getOffsets(), vectorOffset.getCurrentVectorSize());
       }
-      for (int i = 0 ; i < vectorOffset.getCurrentVectorSize(); i++) {
+      for (int i = 0; i < vectorOffset.getCurrentVectorSize(); i++) {
         blackhole.consume(vector[i]);
       }
       vectorOffset.advance();

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import org.apache.druid.segment.data.ColumnarLongs;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 1)
+public class ColumnarLongsSelectRowsFromSegmentBenchmark extends BaseColumnarLongsFromSegmentsBenchmark
+{
+  private Map<String, ColumnarLongs> decoders;
+  private Map<String, Integer> encodedSize;
+
+  // Number of rows to read, the test will read random rows
+//  @Param({"0.01", "0.1", "0.33", "0.66", "0.95", "1.0"})
+  @Param({"1.0"})
+  private double filteredRowCountPercentage;
+
+  @Setup
+  public void setup() throws Exception
+  {
+    decoders = Maps.newHashMap();
+    encodedSize = Maps.newHashMap();
+    setupFilters(rows, filteredRowCountPercentage);
+
+    setupFromFile(encoding);
+
+
+    // uncomment me to load some encoding files to cross reference values for sanity check
+    //CHECKSTYLE.OFF: Regexp
+    List<String> all = ImmutableList.of("lz4-longs", "lz4-auto");
+    for (String _enc : all) {
+      if (!_enc.equals(encoding)) {
+        setupFromFile(_enc);
+      }
+    }
+
+    checkSanity(decoders, all, rows);
+  }
+
+  @TearDown
+  public void teardown()
+  {
+    for (ColumnarLongs longs : decoders.values()) {
+      longs.close();
+    }
+  }
+
+  private void setupFromFile(String encoding) throws IOException
+  {
+    File dir = getTmpDir();
+    File compFile = new File(dir, getColumnEncodedFileName(encoding, segmentName, columnName));
+    ByteBuffer buffer = Files.map(compFile);
+
+    int size = (int) compFile.length();
+    encodedSize.put(encoding, size);
+    ColumnarLongs data = BaseColumnarLongsBenchmark.createColumnarLongs(encoding, buffer);
+    decoders.put(encoding, data);
+  }
+
+//  @Benchmark
+//  @BenchmarkMode(Mode.AverageTime)
+//  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+//  public void selectRows(Blackhole blackhole)
+//  {
+//    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+//    ColumnarLongs encoder = decoders.get(encoding);
+//    if (filter == null) {
+//      for (int i = 0; i < rows; i++) {
+//        blackhole.consume(encoder.get(i));
+//      }
+//    } else {
+//      for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
+//        blackhole.consume(encoder.get(i));
+//      }
+//    }
+//  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void selectRowsVectorized(Blackhole blackhole)
+  {
+    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+    ColumnarLongs columnDecoder = decoders.get(encoding);
+    long[] vector = new long[VECTOR_SIZE];
+    while (!vectorOffset.isDone()) {
+      if (vectorOffset.isContiguous()) {
+        columnDecoder.get(vector, vectorOffset.getStartOffset(), vectorOffset.getCurrentVectorSize());
+      } else {
+        columnDecoder.get(vector, vectorOffset.getOffsets(), vectorOffset.getCurrentVectorSize());
+      }
+      for (int i = 0 ; i < vectorOffset.getCurrentVectorSize(); i++) {
+        blackhole.consume(vector[i]);
+      }
+      vectorOffset.advance();
+    }
+    blackhole.consume(vector);
+    blackhole.consume(vectorOffset);
+    vectorOffset.reset();
+    columnDecoder.close();
+  }
+
+
+  public static void main(String[] args) throws RunnerException
+  {
+    System.out.println("main happened");
+    Options opt = new OptionsBuilder()
+        .include(ColumnarLongsSelectRowsFromSegmentBenchmark.class.getSimpleName())
+        .addProfiler(EncodingSizeProfiler.class)
+        .resultFormat(ResultFormatType.CSV)
+        .result("column-longs-select-speed-segments.csv")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.benchmark.compression;
 
-import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.druid.segment.data.ColumnarLongs;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -44,6 +43,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -66,8 +66,8 @@ public class ColumnarLongsSelectRowsFromSegmentBenchmark extends BaseColumnarLon
   @Setup
   public void setup() throws Exception
   {
-    decoders = Maps.newHashMap();
-    encodedSize = Maps.newHashMap();
+    decoders = new HashMap<>();
+    encodedSize = new HashMap<>();
     setupFilters(rows, filteredRowCountPercentage);
 
     setupFromFile(encoding);

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/CompressedVSizeColumnarMultiIntsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/CompressedVSizeColumnarMultiIntsBenchmark.java
@@ -17,16 +17,19 @@
  * under the License.
  */
 
-package org.apache.druid.benchmark;
+package org.apache.druid.benchmark.compression;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.segment.data.ColumnarInts;
-import org.apache.druid.segment.data.CompressedVSizeColumnarIntsSupplier;
+import org.apache.druid.segment.data.ColumnarMultiInts;
+import org.apache.druid.segment.data.CompressedVSizeColumnarMultiIntsSupplier;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.data.VSizeColumnarInts;
+import org.apache.druid.segment.data.VSizeColumnarMultiInts;
 import org.apache.druid.segment.data.WritableSupplier;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -42,23 +45,28 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
-public class CompressedColumnarIntsBenchmark
+public class CompressedVSizeColumnarMultiIntsBenchmark
 {
   static {
     NullHandling.initializeForTests();
   }
 
-  private IndexedInts uncompressed;
-  private IndexedInts compressed;
+  private ColumnarMultiInts uncompressed;
+  private ColumnarMultiInts compressed;
 
   @Param({"1", "2", "3", "4"})
   int bytes;
+
+  @Param({"5", "10", "100", "1000"})
+  int valuesPerRowBound;
 
   // Number of rows to read, the test will read random rows
   @Param({"1000", "10000", "100000", "1000000", "1000000"})
@@ -70,42 +78,49 @@ public class CompressedColumnarIntsBenchmark
   public void setup() throws IOException
   {
     Random rand = ThreadLocalRandom.current();
-    int[] vals = new int[0x100000];
+    List<int[]> rows = new ArrayList<>();
     final int bound = 1 << bytes;
-    for (int i = 0; i < vals.length; ++i) {
-      vals[i] = rand.nextInt(bound);
+    for (int i = 0; i < 0x100000; i++) {
+      int count = rand.nextInt(valuesPerRowBound) + 1;
+      int[] row = new int[rand.nextInt(count)];
+      for (int j = 0; j < row.length; j++) {
+        row[j] = rand.nextInt(bound);
+      }
+      rows.add(row);
     }
+
     final ByteBuffer bufferCompressed = serialize(
-        CompressedVSizeColumnarIntsSupplier.fromList(
-            IntArrayList.wrap(vals),
+        CompressedVSizeColumnarMultiIntsSupplier.fromIterable(
+            Iterables.transform(rows, (Function<int[], ColumnarInts>) input -> VSizeColumnarInts.fromArray(input, 20)),
             bound - 1,
-            CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForBytes(bytes),
             ByteOrder.nativeOrder(),
             CompressionStrategy.LZ4,
             Closer.create()
         )
     );
-    this.compressed = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
+    this.compressed = CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
         bufferCompressed,
         ByteOrder.nativeOrder()
     ).get();
 
-    final ByteBuffer bufferUncompressed = serialize(VSizeColumnarInts.fromArray(vals));
-    this.uncompressed = VSizeColumnarInts.readFromByteBuffer(bufferUncompressed);
+    final ByteBuffer bufferUncompressed = serialize(
+        VSizeColumnarMultiInts.fromIterable(Iterables.transform(rows, input -> VSizeColumnarInts.fromArray(input, 20)))
+    );
+    this.uncompressed = VSizeColumnarMultiInts.readFromByteBuffer(bufferUncompressed);
 
     filter = new BitSet();
     for (int i = 0; i < filteredRowCount; i++) {
-      int rowToAccess = rand.nextInt(vals.length);
+      int rowToAccess = rand.nextInt(rows.size());
       // Skip already selected rows if any
       while (filter.get(rowToAccess)) {
-        rowToAccess = (rowToAccess + 1) % vals.length;
+        rowToAccess = (rowToAccess + 1) % rows.size();
       }
       filter.set(rowToAccess);
     }
-
   }
 
-  private static ByteBuffer serialize(WritableSupplier<ColumnarInts> writableSupplier) throws IOException
+  private static ByteBuffer serialize(WritableSupplier<ColumnarMultiInts> writableSupplier)
+      throws IOException
   {
     final ByteBuffer buffer = ByteBuffer.allocateDirect((int) writableSupplier.getSerializedSize());
 
@@ -142,7 +157,10 @@ public class CompressedColumnarIntsBenchmark
   public void uncompressed(Blackhole blackhole)
   {
     for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
-      blackhole.consume(uncompressed.get(i));
+      IndexedInts row = uncompressed.get(i);
+      for (int j = 0, rowSize = row.size(); j < rowSize; j++) {
+        blackhole.consume(row.get(j));
+      }
     }
   }
 
@@ -152,7 +170,10 @@ public class CompressedColumnarIntsBenchmark
   public void compressed(Blackhole blackhole)
   {
     for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
-      blackhole.consume(compressed.get(i));
+      IndexedInts row = compressed.get(i);
+      for (int j = 0, rowSize = row.size(); j < rowSize; j++) {
+        blackhole.consume(row.get(j));
+      }
     }
   }
 }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/EncodingSizeProfiler.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/EncodingSizeProfiler.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.compression;
+
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ScalarResult;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class EncodingSizeProfiler implements InternalProfiler
+{
+  public static int encodedSize;
+
+  @Override
+  public void beforeIteration(
+      BenchmarkParams benchmarkParams,
+      IterationParams iterationParams
+  )
+  {
+  }
+
+  @Override
+  public Collection<? extends Result> afterIteration(
+      BenchmarkParams benchmarkParams,
+      IterationParams iterationParams,
+      IterationResult result
+  )
+  {
+    return Collections.singletonList(
+        new ScalarResult("encoded size", encodedSize, "bytes", AggregationPolicy.MAX)
+    );
+  }
+
+  @Override
+  public String getDescription()
+  {
+    return "super janky encoding size result collector";
+  }
+}

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/EncodingSizeProfiler.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/EncodingSizeProfiler.java
@@ -20,6 +20,7 @@
 package org.apache.druid.benchmark.compression;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.infra.IterationParams;
 import org.openjdk.jmh.profile.InternalProfiler;
 import org.openjdk.jmh.results.AggregationPolicy;
@@ -30,6 +31,19 @@ import org.openjdk.jmh.results.ScalarResult;
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+ * Crude jmh 'profiler' that allows calling benchmark methods to set this static value in a benchmark run, and if
+ * this profiler to the run and have this additional measurement show up in the results.
+ *
+ * This allows 2 measurements to be collected for the result set, timing of the test, and size in bytes set here.
+ *
+ * @see ColumnarLongsSelectRowsFromGeneratorBenchmark#selectRows(Blackhole)
+ * @see ColumnarLongsSelectRowsFromGeneratorBenchmark#selectRowsVectorized(Blackhole)
+ * @see ColumnarLongsEncodeDataFromGeneratorBenchmark#encodeColumn(Blackhole)
+ * @see ColumnarLongsSelectRowsFromSegmentBenchmark#selectRows(Blackhole)
+ * @see ColumnarLongsSelectRowsFromSegmentBenchmark#selectRowsVectorized(Blackhole)
+ * @see ColumnarLongsEncodeDataFromSegmentBenchmark#encodeColumn(Blackhole)
+ */
 public class EncodingSizeProfiler implements InternalProfiler
 {
   public static int encodedSize;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/LongCompressionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/LongCompressionBenchmark.java
@@ -43,6 +43,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -92,19 +93,30 @@ public class LongCompressionBenchmark
     bufferHandler.close();
   }
 
-//  @Benchmark
-//  public void readContinuous(Blackhole bh)
-//  {
-//    ColumnarLongs columnarLongs = supplier.get();
-//    int count = columnarLongs.size();
-//    for (int i = 0; i < count; i++) {
-//      bh.consume(columnarLongs.get(i));
-//    }
-//    columnarLongs.close();
-//  }
+  @Benchmark
+  public void readContinuous(Blackhole bh)
+  {
+    ColumnarLongs columnarLongs = supplier.get();
+    int count = columnarLongs.size();
+    for (int i = 0; i < count; i++) {
+      bh.consume(columnarLongs.get(i));
+    }
+    columnarLongs.close();
+  }
 
   @Benchmark
-  public void readVectorizedSequential(Blackhole bh)
+  public void readSkipping(Blackhole bh)
+  {
+    ColumnarLongs columnarLongs = supplier.get();
+    int count = columnarLongs.size();
+    for (int i = 0; i < count; i += ThreadLocalRandom.current().nextInt(2000)) {
+      bh.consume(columnarLongs.get(i));
+    }
+    columnarLongs.close();
+  }
+
+  @Benchmark
+  public void readVectorizedContinuous(Blackhole bh)
   {
     long[] vector = new long[QueryableIndexStorageAdapter.DEFAULT_VECTOR_SIZE];
     ColumnarLongs columnarLongs = supplier.get();
@@ -117,16 +129,4 @@ public class LongCompressionBenchmark
     }
     columnarLongs.close();
   }
-
-//  @Benchmark
-//  public void readSkipping(Blackhole bh)
-//  {
-//    ColumnarLongs columnarLongs = supplier.get();
-//    int count = columnarLongs.size();
-//    for (int i = 0; i < count; i += ThreadLocalRandom.current().nextInt(2000)) {
-//      bh.consume(columnarLongs.get(i));
-//    }
-//    columnarLongs.close();
-//  }
-
 }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/LongCompressionBenchmarkFileGenerator.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/LongCompressionBenchmarkFileGenerator.java
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-package org.apache.druid.benchmark;
+package org.apache.druid.benchmark.compression;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.column.ValueType;
-import org.apache.druid.segment.data.ColumnarFloatsSerializer;
+import org.apache.druid.segment.data.ColumnarLongsSerializer;
 import org.apache.druid.segment.data.CompressionFactory;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.generator.ColumnValueGenerator;
@@ -43,21 +43,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class FloatCompressionBenchmarkFileGenerator
+public class LongCompressionBenchmarkFileGenerator
 {
   static {
     NullHandling.initializeForTests();
   }
 
-  private static final Logger log = new Logger(FloatCompressionBenchmarkFileGenerator.class);
+  private static final Logger log = new Logger(LongCompressionBenchmarkFileGenerator.class);
   public static final int ROW_NUM = 5000000;
   public static final List<CompressionStrategy> COMPRESSIONS =
       ImmutableList.of(
           CompressionStrategy.LZ4,
-          CompressionStrategy.NONE
-      );
+          CompressionStrategy.NONE);
+  public static final List<CompressionFactory.LongEncodingStrategy> ENCODINGS =
+      ImmutableList.of(CompressionFactory.LongEncodingStrategy.AUTO, CompressionFactory.LongEncodingStrategy.LONGS);
 
-  private static String dirPath = "floatCompress/";
+  private static String dirPath = "longCompress/";
 
   public static void main(String[] args) throws IOException
   {
@@ -67,16 +68,16 @@ public class FloatCompressionBenchmarkFileGenerator
 
     GeneratorColumnSchema enumeratedSchema = GeneratorColumnSchema.makeEnumerated(
         "",
-        ValueType.FLOAT,
+        ValueType.LONG,
         true,
         1,
         0d,
         ImmutableList.of(
-            0f,
-            1.1f,
-            2.2f,
-            3.3f,
-            4.4f
+            0,
+            1,
+            2,
+            3,
+            4
         ),
         ImmutableList.of(
             0.95,
@@ -86,19 +87,10 @@ public class FloatCompressionBenchmarkFileGenerator
             0.0001
         )
     );
-    GeneratorColumnSchema zipfLowSchema = GeneratorColumnSchema.makeZipf(
-        "",
-        ValueType.FLOAT,
-        true,
-        1,
-        0d,
-        -1,
-        1000,
-        1d
-    );
+    GeneratorColumnSchema zipfLowSchema = GeneratorColumnSchema.makeZipf("", ValueType.LONG, true, 1, 0d, -1, 1000, 1d);
     GeneratorColumnSchema zipfHighSchema = GeneratorColumnSchema.makeZipf(
         "",
-        ValueType.FLOAT,
+        ValueType.LONG,
         true,
         1,
         0d,
@@ -108,16 +100,16 @@ public class FloatCompressionBenchmarkFileGenerator
     );
     GeneratorColumnSchema sequentialSchema = GeneratorColumnSchema.makeSequential(
         "",
-        ValueType.FLOAT,
+        ValueType.LONG,
         true,
         1,
         0d,
         1470187671,
         2000000000
     );
-    GeneratorColumnSchema uniformSchema = GeneratorColumnSchema.makeContinuousUniform(
+    GeneratorColumnSchema uniformSchema = GeneratorColumnSchema.makeDiscreteUniform(
         "",
-        ValueType.FLOAT,
+        ValueType.LONG,
         true,
         1,
         0d,
@@ -141,40 +133,43 @@ public class FloatCompressionBenchmarkFileGenerator
       dataFile.delete();
       try (Writer writer = Files.newBufferedWriter(dataFile.toPath(), StandardCharsets.UTF_8)) {
         for (int i = 0; i < ROW_NUM; i++) {
-          writer.write((Float) entry.getValue().generateRowValue() + "\n");
+          writer.write((long) entry.getValue().generateRowValue() + "\n");
         }
       }
     }
 
-    // create compressed files using all combinations of CompressionStrategy and FloatEncoding provided
+    // create compressed files using all combinations of CompressionStrategy and LongEncoding provided
     for (Map.Entry<String, ColumnValueGenerator> entry : generators.entrySet()) {
       for (CompressionStrategy compression : COMPRESSIONS) {
-        String name = entry.getKey() + "-" + compression;
-        log.info("%s: ", name);
-        File compFile = new File(dir, name);
-        compFile.delete();
-        File dataFile = new File(dir, entry.getKey());
+        for (CompressionFactory.LongEncodingStrategy encoding : ENCODINGS) {
+          String name = entry.getKey() + "-" + compression + "-" + encoding;
+          log.info("%s: ", name);
+          File compFile = new File(dir, name);
+          compFile.delete();
+          File dataFile = new File(dir, entry.getKey());
 
-        ColumnarFloatsSerializer writer = CompressionFactory.getFloatSerializer(
-            "float-benchmark",
-            new OffHeapMemorySegmentWriteOutMedium(),
-            "float",
-            ByteOrder.nativeOrder(),
-            compression
-        );
-        try (
-            BufferedReader br = Files.newBufferedReader(dataFile.toPath(), StandardCharsets.UTF_8);
-            FileChannel output =
-                FileChannel.open(compFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
-        ) {
-          writer.open();
-          String line;
-          while ((line = br.readLine()) != null) {
-            writer.add(Float.parseFloat(line));
+          ColumnarLongsSerializer writer = CompressionFactory.getLongSerializer(
+              "long-benchmark",
+              new OffHeapMemorySegmentWriteOutMedium(),
+              "long",
+              ByteOrder.nativeOrder(),
+              encoding,
+              compression
+          );
+          try (
+              BufferedReader br = Files.newBufferedReader(dataFile.toPath(), StandardCharsets.UTF_8);
+              FileChannel output =
+                  FileChannel.open(compFile.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
+          ) {
+            writer.open();
+            String line;
+            while ((line = br.readLine()) != null) {
+              writer.add(Long.parseLong(line));
+            }
+            writer.writeTo(output, null);
           }
-          writer.writeTo(output, null);
+          log.info("%d", compFile.length() / 1024);
         }
-        log.info("%d", compFile.length() / 1024);
       }
     }
   }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/VSizeSerdeBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/VSizeSerdeBenchmark.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.druid.benchmark;
+package org.apache.druid.benchmark.compression;
 
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.FileUtils;

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressionFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressionFactory.java
@@ -283,26 +283,9 @@ public class CompressionFactory
 
     long read(int index);
 
-    default void read(long[] out, int outPosition, int startIndex, int length)
-    {
-      for (int i = 0; i < length; i++) {
-        out[outPosition + i] = read(startIndex + i);
-      }
-    }
+    void read(long[] out, int outPosition, int startIndex, int length);
 
-    default int read(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
-    {
-      for (int i = 0; i < length; i++) {
-        int index = indexes[outPosition + i] - indexOffset;
-        if (index >= limit) {
-          return i;
-        }
-
-        out[outPosition + i] = read(index);
-      }
-
-      return length;
-    }
+    int read(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit);
 
     LongEncodingReader duplicate();
   }

--- a/processing/src/main/java/org/apache/druid/segment/data/DeltaLongEncodingReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/DeltaLongEncodingReader.java
@@ -66,6 +66,28 @@ public class DeltaLongEncodingReader implements CompressionFactory.LongEncodingR
   }
 
   @Override
+  public void read(long[] out, int outPosition, int startIndex, int length)
+  {
+    deserializer.get(out, outPosition, startIndex, length);
+
+    for (int i = 0; i < length; i++) {
+      out[outPosition + i] += base;
+    }
+  }
+
+  @Override
+  public int read(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
+  {
+    final int len = deserializer.get(out, outPosition, indexes, length, indexOffset, limit);
+
+    for (int i = 0; i < len; i++) {
+      out[outPosition + i] += base;
+    }
+
+    return len;
+  }
+
+  @Override
   public CompressionFactory.LongEncodingReader duplicate()
   {
     return new DeltaLongEncodingReader(buffer.duplicate(), base, bitsPerValue);

--- a/processing/src/main/java/org/apache/druid/segment/data/DeltaLongEncodingReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/DeltaLongEncodingReader.java
@@ -68,23 +68,13 @@ public class DeltaLongEncodingReader implements CompressionFactory.LongEncodingR
   @Override
   public void read(long[] out, int outPosition, int startIndex, int length)
   {
-    deserializer.get(out, outPosition, startIndex, length);
-
-    for (int i = 0; i < length; i++) {
-      out[outPosition + i] += base;
-    }
+    deserializer.getDelta(out, outPosition, startIndex, length, base);
   }
 
   @Override
   public int read(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
   {
-    final int len = deserializer.get(out, outPosition, indexes, length, indexOffset, limit);
-
-    for (int i = 0; i < len; i++) {
-      out[outPosition + i] += base;
-    }
-
-    return len;
+    return deserializer.getDelta(out, outPosition, indexes, length, indexOffset, limit, base);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/data/TableLongEncodingReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/TableLongEncodingReader.java
@@ -72,6 +72,28 @@ public class TableLongEncodingReader implements CompressionFactory.LongEncodingR
   }
 
   @Override
+  public void read(long[] out, int outPosition, int startIndex, int length)
+  {
+    deserializer.get(out, outPosition, startIndex, length);
+
+    for (int i = 0; i < length; i++) {
+      out[outPosition + i] = table[(int) out[outPosition + i]];
+    }
+  }
+
+  @Override
+  public int read(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
+  {
+    final int len = deserializer.get(out, outPosition, indexes, length, indexOffset, limit);
+
+    for (int i = 0; i < len; i++) {
+      out[outPosition + i] = table[(int) out[outPosition + i]];
+    }
+
+    return len;
+  }
+
+  @Override
   public CompressionFactory.LongEncodingReader duplicate()
   {
     return new TableLongEncodingReader(buffer.duplicate(), table, bitsPerValue);

--- a/processing/src/main/java/org/apache/druid/segment/data/TableLongEncodingReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/TableLongEncodingReader.java
@@ -74,23 +74,13 @@ public class TableLongEncodingReader implements CompressionFactory.LongEncodingR
   @Override
   public void read(long[] out, int outPosition, int startIndex, int length)
   {
-    deserializer.get(out, outPosition, startIndex, length);
-
-    for (int i = 0; i < length; i++) {
-      out[outPosition + i] = table[(int) out[outPosition + i]];
-    }
+    deserializer.getTable(out, outPosition, startIndex, length, table);
   }
 
   @Override
   public int read(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
   {
-    final int len = deserializer.get(out, outPosition, indexes, length, indexOffset, limit);
-
-    for (int i = 0; i < len; i++) {
-      out[outPosition + i] = table[(int) out[outPosition + i]];
-    }
-
-    return len;
+    return deserializer.getTable(out, outPosition, indexes, length, indexOffset, limit, table);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -557,13 +557,6 @@ public class VSizeLongSerde
       while ((index & 0x3) != 0 && i < length) {
         out[outPosition + i++] = delta + get(index++);
       }
-//      for ( ; i + 4 < length; index += 4) {
-//        final byte unpack = buffer.get(offset + (index >> 2));
-//        out[outPosition + i++] = delta + (unpack >> 6) & 3;
-//        out[outPosition + i++] = delta + (unpack >> 4) & 3;
-//        out[outPosition + i++] = delta + (unpack >> 2) & 3;
-//        out[outPosition + i++] = delta + unpack & 3;
-//      }
       for ( ; i + 8 < length; index += 8) {
         final short unpack = buffer.getShort(offset + (index >> 2));
         out[outPosition + i++] = delta + (unpack >> 14) & 3;
@@ -590,13 +583,6 @@ public class VSizeLongSerde
       while ((index & 0x3) != 0 && i < length) {
         out[outPosition + i++] = table[(int) get(index++)];
       }
-//      for ( ; i + 4 < length; index += 4) {
-//        final byte unpack = buffer.get(offset + (index >> 2));
-//        out[outPosition + i++] = table[(unpack >> 6) & 3];
-//        out[outPosition + i++] = table[(unpack >> 4) & 3];
-//        out[outPosition + i++] = table[(unpack >> 2) & 3];
-//        out[outPosition + i++] = table[unpack & 3];
-//      }
       for ( ; i + 8 < length; index += 8) {
         final short unpack = buffer.getShort(offset + (index >> 2));
         out[outPosition + i++] = table[(unpack >> 14) & 3];
@@ -642,11 +628,6 @@ public class VSizeLongSerde
       while ((index & 0x1) != 0 && i < length) {
         out[outPosition + i++] = delta + get(index++) & 0xF;
       }
-//      for ( ; i + 2 < length; index += 2) {
-//        final byte unpack = buffer.get(offset + (index >> 1));
-//        out[outPosition + i++] = delta + (unpack >> 4) & 0xF;
-//        out[outPosition + i++] = delta + unpack & 0xF;
-//      }
       for ( ; i + 8 < length; index += 8) {
         final int unpack = buffer.getInt(offset + (index >> 1));
         out[outPosition + i++] = delta + (unpack >> 28) & 0xF;
@@ -673,11 +654,6 @@ public class VSizeLongSerde
       while ((index & 0x1) != 0 && i < length) {
         out[outPosition + i++] = table[(int) get(index++)];
       }
-//      for ( ; i + 2 < length; index += 2) {
-//        final byte unpack = buffer.get(offset + (index >> 1));
-//        out[outPosition + i++] = table[(unpack >> 4) & 0xF];
-//        out[outPosition + i++] = table[unpack & 0xF];
-//      }
       for ( ; i + 8 < length; index += 8) {
         final int unpack = buffer.getInt(offset + (index >> 1));
         out[outPosition + i++] = table[(unpack >> 28) & 0xF];
@@ -718,22 +694,6 @@ public class VSizeLongSerde
       for (int i = 0, indexOffset = startIndex; i < length; i++, indexOffset++) {
         out[outPosition + i] = delta + buffer.get(offset + indexOffset) & 0xFF;
       }
-//      int i = 0;
-//      for (int indexOffset = startIndex; i + 8 < length; indexOffset += 8) {
-//        final long unpack = buffer.getLong(indexOffset);
-//        out[outPosition + i++] = delta + ((unpack >>> 56) & 0xFF);
-//        out[outPosition + i++] = delta + ((unpack >>> 48) & 0xFF);
-//        out[outPosition + i++] = delta + ((unpack >>> 40) & 0xFF);
-//        out[outPosition + i++] = delta + ((unpack >>> 32) & 0xFF);
-//        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFF);
-//        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFF);
-//        out[outPosition + i++] = delta + ((unpack >>> 8) & 0xFF);
-//        out[outPosition + i++] = delta + (unpack & 0xFF);
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = delta + (int) get(startIndex + i);
-//        i++;
-//      }
     }
 
     @Override
@@ -757,21 +717,6 @@ public class VSizeLongSerde
       for (int i = 0, indexOffset = startIndex; i < length; i++, indexOffset++) {
         out[outPosition + i] = table[buffer.get(offset + indexOffset) & 0xFF];
       }
-//      int i = 0;
-//      for (int indexOffset = startIndex; i + 8 < length; indexOffset += 8) {
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset) & 0xFF];
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 1) & 0xFF];
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 2) & 0xFF];
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 3) & 0xFF];
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 4) & 0xFF];
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 5) & 0xFF];
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 6) & 0xFF];
-//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 7) & 0xFF];
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = table[(int) get(startIndex + i)];
-//        i++;
-//      }
     }
 
     @Override
@@ -828,7 +773,7 @@ public class VSizeLongSerde
         out[outPosition + i++] = delta + ((unpack >> 28) & 0xFFF);
         out[outPosition + i++] = delta + ((unpack >> 16) & 0xFFF);
         out[outPosition + i++] = delta + ((unpack >> 4) & 0xFFF);
-        out[outPosition + i++] = delta + (((unpack & 0xF) << 8) | ((unpack2 >> 24) & 0xFF));
+        out[outPosition + i++] = delta + (((unpack & 0xF) << 8) | ((unpack2 >>> 24) & 0xFF));
         out[outPosition + i++] = delta + ((unpack2 >> 12) & 0xFFF);
         out[outPosition + i++] = delta + (unpack2 & 0xFFF);
       }
@@ -862,32 +807,6 @@ public class VSizeLongSerde
       for (int i = 0, indexOffset = (startIndex << 1); i < length; i++, indexOffset += Short.BYTES) {
         out[outPosition + i] = delta + buffer.getShort(offset + indexOffset) & 0xFFFF;
       }
-//      int i = 0;
-//      final int unpackSize = 8 * Short.BYTES;
-//      for (int indexOffset = startIndex << 1; i + 8 < length; indexOffset += unpackSize) {
-////        final long unpack = buffer.getLong(indexOffset);
-////        final long unpack2 = buffer.getLong(indexOffset + Long.BYTES);
-////        out[outPosition + i++] = delta + ((unpack >> 48) & 0xFFFF);
-////        out[outPosition + i++] = delta + ((unpack >> 32) & 0xFFFF);
-////        out[outPosition + i++] = delta + ((unpack >> 16) & 0xFFFF);
-////        out[outPosition + i++] = delta + (unpack & 0xFFFF);
-////        out[outPosition + i++] = delta + ((unpack2 >> 48) & 0xFFFF);
-////        out[outPosition + i++] = delta + ((unpack2 >> 32) & 0xFFFF);
-////        out[outPosition + i++] = delta + ((unpack2 >> 16) & 0xFFFF);
-////        out[outPosition + i++] = delta + (unpack2 & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset) & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 2) & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 4) & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 6) & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 8) & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 10) & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 12) & 0xFFFF);
-//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 14) & 0xFFFF);
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = delta + (int) get(startIndex + i);
-//        i++;
-//      }
     }
 
     @Override
@@ -962,12 +881,12 @@ public class VSizeLongSerde
         final long unpack = buffer.getLong(offset + indexOffset);
         final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
         final int unpack3 = buffer.getInt(offset + indexOffset + Long.BYTES + Long.BYTES);
-        out[outPosition + i++] = delta + ((unpack >>> 44) & 0xFFFFF);
-        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFFFFF);
-        out[outPosition + i++] = delta + ((unpack >>> 4) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack >> 44) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack >> 24) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack >> 4) & 0xFFFFF);
         out[outPosition + i++] = delta + (((unpack & 0xF) << 16) | ((unpack2 >>> 48) & 0xFFFF));
-        out[outPosition + i++] = delta + ((unpack2 >>> 28) & 0xFFFFF);
-        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack2 >> 28) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack2 >> 8) & 0xFFFFF);
         out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 12) | ((unpack3 >>> 20) & 0xFFF));
         out[outPosition + i++] = delta + (unpack3 & 0xFFFFF);
       }
@@ -1004,13 +923,13 @@ public class VSizeLongSerde
         final long unpack = buffer.getLong(offset + indexOffset);
         final long unpack2 = buffer.getLong(offset +indexOffset + Long.BYTES);
         final long unpack3 = buffer.getLong(offset + indexOffset + Long.BYTES + Long.BYTES);
-        out[outPosition + i++] = delta + ((unpack >>> 40) & 0xFFFFFF);
-        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFFFFFF);
+        out[outPosition + i++] = delta + ((unpack >> 40) & 0xFFFFFF);
+        out[outPosition + i++] = delta + ((unpack >> 16) & 0xFFFFFF);
         out[outPosition + i++] = delta + (((unpack & 0xFFFF) << 8) | ((unpack2 >>> 56) & 0xFF));
-        out[outPosition + i++] = delta + ((unpack2 >>> 32) & 0xFFFFFF);
-        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFFF);
+        out[outPosition + i++] = delta + ((unpack2 >> 32) & 0xFFFFFF);
+        out[outPosition + i++] = delta + ((unpack2 >> 8) & 0xFFFFFF);
         out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 16) | ((unpack3 >>> 48) & 0xFFFF));
-        out[outPosition + i++] = delta + ((unpack3 >>> 24) & 0xFFFFFF);
+        out[outPosition + i++] = delta + ((unpack3 >> 24) & 0xFFFFFF);
         out[outPosition + i++] = delta + (unpack3 & 0xFFFFFF);
       }
       while (i < length) {
@@ -1043,22 +962,6 @@ public class VSizeLongSerde
       for (int i = 0, indexOffset = (startIndex << 2); i < length; i++, indexOffset += Integer.BYTES) {
         out[outPosition + i] = delta + buffer.getInt(offset + indexOffset) & 0xFFFFFFFFL;
       }
-//      int i = 0;
-//      final int unpackSize = 8 * Integer.BYTES;
-//      for (int indexOffset = startIndex << 2; i + 8 < length; indexOffset += unpackSize) {
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset) & 0xFFFFFFFFL);
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 4) & 0xFFFFFFFFL);
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 8) & 0xFFFFFFFFL);
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 12) & 0xFFFFFFFFL);
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 16) & 0xFFFFFFFFL);
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 20) & 0xFFFFFFFFL);
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 24) & 0xFFFFFFFFL);
-//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 28) & 0xFFFFFFFFL);
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = delta + (int) get(startIndex + i);
-//        i++;
-//      }
     }
   }
 
@@ -1079,31 +982,31 @@ public class VSizeLongSerde
       return buffer.getLong(offset + (index * 5)) >>> 24;
     }
 
-//    @Override
-//    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
-//    {
-//      int i = 0;
-//      final int unpackSize = 5 * Long.BYTES;
-//      for (int indexOffset = startIndex * 5; i + 8 < length; indexOffset += unpackSize) {
-//        final long unpack = buffer.getLong(offset + indexOffset);
-//        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
-//        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
-//        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
-//        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
-//        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFFFFFFFFFFL);
-//        out[outPosition + i++] = delta + (((unpack & 0xFFFFFFL) << 16) | ((unpack2 >>> 48) & 0xFFFFL));
-//        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFFFFFFFL);
-//        out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 32) | ((unpack3 >>> 32) & 0xFFFFFFFFL));
-//        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFFFL) << 32) | ((unpack4 >>> 56 ) & 0xFF));
-//        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFL);
-//        out[outPosition + i++] = delta + (((unpack4 & 0xFFFF) << 24) | ((unpack5 >>> 40) & 0xFFFFFF));
-//        out[outPosition + i++] = delta + (unpack5 & 0xFFFFFFFFFFL);
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = delta + (int) get(startIndex + i);
-//        i++;
-//      }
-//    }
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int i = 0;
+      final int unpackSize = 5 * Long.BYTES;
+      for (int indexOffset = startIndex * 5; i + 8 < length; indexOffset += unpackSize) {
+        final long unpack = buffer.getLong(offset + indexOffset);
+        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
+        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
+        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
+        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
+        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFFFFFFFFFFL);
+        out[outPosition + i++] = delta + (((unpack & 0xFFFFFFL) << 16) | ((unpack2 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFFFFFFFL);
+        out[outPosition + i++] = delta + (((unpack2 & 0xFFL) << 32) | ((unpack3 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFFFL) << 8) | ((unpack4 >>> 56 ) & 0xFFL));
+        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFL);
+        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
+        out[outPosition + i++] = delta + (unpack5 & 0xFFFFFFFFFFL);
+      }
+      while (i < length) {
+        out[outPosition + i] = delta + get(startIndex + i);
+        i++;
+      }
+    }
   }
 
   private static final class Size48Des implements LongDeserializer
@@ -1123,32 +1026,32 @@ public class VSizeLongSerde
       return buffer.getLong(offset + (index * 6)) >>> 16;
     }
 
-//    @Override
-//    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
-//    {
-//      int i = 0;
-//      final int unpackSize = 6 * Long.BYTES;
-//      for (int indexOffset = startIndex * 6; i + 8 < length; indexOffset += unpackSize) {
-//        final long unpack = buffer.getLong(offset + indexOffset);
-//        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
-//        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
-//        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
-//        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
-//        final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
-//        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFFFFFFFFFFFFL);
-//        out[outPosition + i++] = delta + (((unpack & 0xFFFFL) << 32) | ((unpack2 >>> 32) & 0xFFFFFFFFL));
-//        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFFFFFL) << 32) | ((unpack3 >>> 48) & 0xFFFFL));
-//        out[outPosition + i++] = delta + (unpack3 & 0xFFFFFFFFFFFFL);
-//        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFFFL);
-//        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFL) << 32) | ((unpack5 >>> 32) & 0xFFFFFFFFL));
-//        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFL) << 32) | ((unpack6 >>> 48) & 0xFFFFL));
-//        out[outPosition + i++] = delta + (unpack6 & 0xFFFFFFFFFFFFL);
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = delta + (int) get(startIndex + i);
-//        i++;
-//      }
-//    }
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int i = 0;
+      final int unpackSize = 6 * Long.BYTES;
+      for (int indexOffset = startIndex * 6; i + 8 < length; indexOffset += unpackSize) {
+        final long unpack = buffer.getLong(offset + indexOffset);
+        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
+        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
+        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
+        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
+        final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
+        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFFFFFFFFFFFFL);
+        out[outPosition + i++] = delta + (((unpack & 0xFFFFL) << 32) | ((unpack2 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFFFFFL) << 16) | ((unpack3 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = delta + (unpack3 & 0xFFFFFFFFFFFFL);
+        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFFFL);
+        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFL) << 32) | ((unpack5 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = delta + (unpack6 & 0xFFFFFFFFFFFFL);
+      }
+      while (i < length) {
+        out[outPosition + i] = delta + get(startIndex + i);
+        i++;
+      }
+    }
   }
 
   private static final class Size56Des implements LongDeserializer
@@ -1168,33 +1071,33 @@ public class VSizeLongSerde
       return buffer.getLong(offset + (index * 7)) >>> 8;
     }
 
-//    @Override
-//    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
-//    {
-//      int i = 0;
-//      final int unpackSize = 7 * Long.BYTES;
-//      for (int indexOffset = startIndex * 7; i + 8 < length; indexOffset += unpackSize) {
-//        final long unpack = buffer.getLong(offset + indexOffset);
-//        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
-//        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
-//        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
-//        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
-//        final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
-//        final long unpack7 = buffer.getLong(offset + indexOffset + (6 * Long.BYTES));
-//        out[outPosition + i++] = delta + ((unpack >>> 8) & 0xFFFFFFFFFFFFFFL);
-//        out[outPosition + i++] = delta + (((unpack & 0xFFL) << 48) | ((unpack2 >>> 16) & 0xFFFFFFFFFFFFL));
-//        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFL) << 40) | ((unpack3 >>> 24) & 0xFFFFFFFFFFL));
-//        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFL) << 32) | ((unpack4 >>> 32) & 0xFFFFFFFFL));
-//        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
-//        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
-//        out[outPosition + i++] = delta + (((unpack6 & 0xFFFFFFFFFFFFL) << 8) | ((unpack7 >>> 56) & 0xFFL));
-//        out[outPosition + i++] = delta + (unpack7 & 0xFFFFFFFFFFFFFFL);
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = delta + (int) get(startIndex + i);
-//        i++;
-//      }
-//    }
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int i = 0;
+      final int unpackSize = 7 * Long.BYTES;
+      for (int indexOffset = startIndex * 7; i + 8 < length; indexOffset += unpackSize) {
+        final long unpack = buffer.getLong(offset + indexOffset);
+        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
+        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
+        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
+        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
+        final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
+        final long unpack7 = buffer.getLong(offset + indexOffset + (6 * Long.BYTES));
+        out[outPosition + i++] = delta + ((unpack >>> 8) & 0xFFFFFFFFFFFFFFL);
+        out[outPosition + i++] = delta + (((unpack & 0xFFL) << 48) | ((unpack2 >>> 16) & 0xFFFFFFFFFFFFL));
+        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFL) << 40) | ((unpack3 >>> 24) & 0xFFFFFFFFFFL));
+        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFL) << 32) | ((unpack4 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
+        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = delta + (((unpack6 & 0xFFFFFFFFFFFFL) << 8) | ((unpack7 >>> 56) & 0xFFL));
+        out[outPosition + i++] = delta + (unpack7 & 0xFFFFFFFFFFFFFFL);
+      }
+      while (i < length) {
+        out[outPosition + i] = delta + get(startIndex + i);
+        i++;
+      }
+    }
   }
 
   private static final class Size64Des implements LongDeserializer
@@ -1220,22 +1123,6 @@ public class VSizeLongSerde
       for (int i = 0, indexOffset = (startIndex << 3); i < length; i++, indexOffset += Long.BYTES) {
         out[outPosition + i] = delta + buffer.getLong(offset + indexOffset);
       }
-//      int i = 0;
-//      final int unpackSize = 8 * Long.BYTES;
-//      for (int indexOffset = (startIndex << 3); i + 8 < length; indexOffset += unpackSize) {
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset);
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 8);
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 16);
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 24);
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 32);
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 40);
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 48);
-//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 56);
-//      }
-//      while (i < length) {
-//        out[outPosition + i] = delta + (int) get(startIndex + i);
-//        i++;
-//      }
     }
 
     @Override
@@ -1246,10 +1133,8 @@ public class VSizeLongSerde
         if (index >= limit) {
           return i;
         }
-
         out[outPosition + i] = base + buffer.getLong(offset + (index << 3));
       }
-
       return length;
     }
   }

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -929,7 +929,7 @@ public class VSizeLongSerde
       final int unpackSize = 3 * Long.BYTES;
       for (int indexOffset = startIndex * 3; i + 8 < length; indexOffset += unpackSize) {
         final long unpack = buffer.getLong(offset + indexOffset);
-        final long unpack2 = buffer.getLong(offset +indexOffset + Long.BYTES);
+        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
         final long unpack3 = buffer.getLong(offset + indexOffset + Long.BYTES + Long.BYTES);
         out[outPosition + i++] = base + ((unpack >> 40) & 0xFFFFFF);
         out[outPosition + i++] = base + ((unpack >> 16) & 0xFFFFFF);
@@ -1005,7 +1005,7 @@ public class VSizeLongSerde
         out[outPosition + i++] = base + (((unpack & 0xFFFFFFL) << 16) | ((unpack2 >>> 48) & 0xFFFFL));
         out[outPosition + i++] = base + ((unpack2 >>> 8) & 0xFFFFFFFFFFL);
         out[outPosition + i++] = base + (((unpack2 & 0xFFL) << 32) | ((unpack3 >>> 32) & 0xFFFFFFFFL));
-        out[outPosition + i++] = base + (((unpack3 & 0xFFFFFFFFL) << 8) | ((unpack4 >>> 56 ) & 0xFFL));
+        out[outPosition + i++] = base + (((unpack3 & 0xFFFFFFFFL) << 8) | ((unpack4 >>> 56) & 0xFFL));
         out[outPosition + i++] = base + ((unpack4 >>> 16) & 0xFFFFFFFFFFL);
         out[outPosition + i++] = base + (((unpack4 & 0xFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
         out[outPosition + i++] = base + (unpack5 & 0xFFFFFFFFFFL);

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.data;
 
+import com.google.common.base.Preconditions;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.UOE;
 
@@ -213,6 +214,7 @@ public class VSizeLongSerde
     @Override
     public void write(long value) throws IOException
     {
+      Preconditions.checkArgument(value >= 0);
       if (count == 8) {
         buffer.put(curByte);
         count = 0;
@@ -267,6 +269,7 @@ public class VSizeLongSerde
     @Override
     public void write(long value) throws IOException
     {
+      Preconditions.checkArgument(value >= 0);
       if (count == 8) {
         buffer.put(curByte);
         count = 0;
@@ -324,6 +327,7 @@ public class VSizeLongSerde
     @Override
     public void write(long value) throws IOException
     {
+      Preconditions.checkArgument(value >= 0);
       int shift = 0;
       if (first) {
         shift = 4;
@@ -388,6 +392,7 @@ public class VSizeLongSerde
     @Override
     public void write(long value) throws IOException
     {
+      Preconditions.checkArgument(value >= 0);
       for (int i = numBytes - 1; i >= 0; i--) {
         buffer.put((byte) (value >>> (i * 8)));
         if (output != null) {

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.segment.data;
 
-import org.apache.datasketches.memory.Memory;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.UOE;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -330,7 +330,7 @@ public class VSizeLongSerde
         curByte = (byte) value;
         first = false;
       } else {
-        curByte = (byte) ((curByte << 4) | ((value >> (numBytes << 3)) & 0xF));
+        curByte = (byte) ((curByte << 4) | ((value >>> (numBytes << 3)) & 0xF));
         buffer.put(curByte);
         first = true;
       }
@@ -417,14 +417,14 @@ public class VSizeLongSerde
   {
     long get(int index);
 
-    default void get(long[] out, int outPosition, int startIndex, int length)
+    default void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
     {
       for (int i = 0; i < length; i++) {
-        out[outPosition + i] = get(startIndex + i);
+        out[outPosition + i] = delta + get(startIndex + i);
       }
     }
 
-    default int get(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
+    default int getDelta(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long delta)
     {
       for (int i = 0; i < length; i++) {
         int index = indexes[outPosition + i] - indexOffset;
@@ -432,7 +432,26 @@ public class VSizeLongSerde
           return i;
         }
 
-        out[outPosition + i] = get(index);
+        out[outPosition + i] = delta + get(index);
+      }
+
+      return length;
+    }
+
+    default void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
+    {
+      throw new UOE("Table decoding not supported for %s", this.getClass().getSimpleName());
+    }
+
+    default int getTable(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long[] table)
+    {
+      for (int i = 0; i < length; i++) {
+        int index = indexes[outPosition + i] - indexOffset;
+        if (index >= limit) {
+          return i;
+        }
+
+        out[outPosition + i] = table[(int) get(index)];
       }
 
       return length;
@@ -441,89 +460,284 @@ public class VSizeLongSerde
 
   private static final class Size1Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size1Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
       int shift = 7 - (index & 7);
-      return (buffer.getByte((index >> 3)) >> shift) & 1;
+      return (buffer.get(offset + (index >> 3)) >> shift) & 1;
+    }
+
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int index = startIndex;
+      int i = 0;
+
+      // byte align
+      while ((index & 0x7) != 0 && i < length) {
+        out[outPosition + i++] = delta + get(index++);
+      }
+      for ( ; i + Byte.SIZE < length; index += Byte.SIZE) {
+        final byte unpack = buffer.get(offset + (index >> 3));
+        out[outPosition + i++] = delta + (unpack >> 7) & 1;
+        out[outPosition + i++] = delta + (unpack >> 6) & 1;
+        out[outPosition + i++] = delta + (unpack >> 5) & 1;
+        out[outPosition + i++] = delta + (unpack >> 4) & 1;
+        out[outPosition + i++] = delta + (unpack >> 3) & 1;
+        out[outPosition + i++] = delta + (unpack >> 2) & 1;
+        out[outPosition + i++] = delta + (unpack >> 1) & 1;
+        out[outPosition + i++] = delta + unpack & 1;
+      }
+      while (i < length) {
+        out[outPosition + i++] = delta + get(index++);
+      }
+    }
+
+    @Override
+    public void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
+    {
+      int index = startIndex;
+      int i = 0;
+
+      // byte align
+      while ((index & 0x7) != 0 && i < length) {
+        out[outPosition + i++] = table[(int) get(index++)];
+      }
+      for ( ; i + Byte.SIZE < length; index += Byte.SIZE) {
+        final byte unpack = buffer.get(offset + (index >> 3));
+        out[outPosition + i++] = table[(unpack >> 7) & 1];
+        out[outPosition + i++] = table[(unpack >> 6) & 1];
+        out[outPosition + i++] = table[(unpack >> 5) & 1];
+        out[outPosition + i++] = table[(unpack >> 4) & 1];
+        out[outPosition + i++] = table[(unpack >> 3) & 1];
+        out[outPosition + i++] = table[(unpack >> 2) & 1];
+        out[outPosition + i++] = table[(unpack >> 1) & 1];
+        out[outPosition + i++] = table[unpack & 1];
+      }
+      while (i < length) {
+        out[outPosition + i++] = table[(int) get(index++)];
+      }
     }
   }
 
   private static final class Size2Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size2Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
       int shift = 6 - ((index & 3) << 1);
-      return (buffer.getByte((index >> 2)) >> shift) & 3;
+      return (buffer.get(offset + (index >> 2)) >> shift) & 3;
+    }
+
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int index = startIndex;
+      int i = 0;
+
+      // byte align
+      while ((index & 0x3) != 0 && i < length) {
+        out[outPosition + i++] = delta + get(index++);
+      }
+//      for ( ; i + 4 < length; index += 4) {
+//        final byte unpack = buffer.get(offset + (index >> 2));
+//        out[outPosition + i++] = delta + (unpack >> 6) & 3;
+//        out[outPosition + i++] = delta + (unpack >> 4) & 3;
+//        out[outPosition + i++] = delta + (unpack >> 2) & 3;
+//        out[outPosition + i++] = delta + unpack & 3;
+//      }
+      for ( ; i + 8 < length; index += 8) {
+        final short unpack = buffer.getShort(offset + (index >> 2));
+        out[outPosition + i++] = delta + (unpack >> 14) & 3;
+        out[outPosition + i++] = delta + (unpack >> 12) & 3;
+        out[outPosition + i++] = delta + (unpack >> 10) & 3;
+        out[outPosition + i++] = delta + (unpack >> 8) & 3;
+        out[outPosition + i++] = delta + (unpack >> 6) & 3;
+        out[outPosition + i++] = delta + (unpack >> 4) & 3;
+        out[outPosition + i++] = delta + (unpack >> 2) & 3;
+        out[outPosition + i++] = delta + unpack & 3;
+      }
+      while (i < length) {
+        out[outPosition + i++] = delta + get(index++);
+      }
+    }
+
+    @Override
+    public void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
+    {
+      int index = startIndex;
+      int i = 0;
+
+      // byte align
+      while ((index & 0x3) != 0 && i < length) {
+        out[outPosition + i++] = table[(int) get(index++)];
+      }
+//      for ( ; i + 4 < length; index += 4) {
+//        final byte unpack = buffer.get(offset + (index >> 2));
+//        out[outPosition + i++] = table[(unpack >> 6) & 3];
+//        out[outPosition + i++] = table[(unpack >> 4) & 3];
+//        out[outPosition + i++] = table[(unpack >> 2) & 3];
+//        out[outPosition + i++] = table[unpack & 3];
+//      }
+      for ( ; i + 8 < length; index += 8) {
+        final short unpack = buffer.getShort(offset + (index >> 2));
+        out[outPosition + i++] = table[(unpack >> 14) & 3];
+        out[outPosition + i++] = table[(unpack >> 12) & 3];
+        out[outPosition + i++] = table[(unpack >> 10) & 3];
+        out[outPosition + i++] = table[(unpack >> 8) & 3];
+        out[outPosition + i++] = table[(unpack >> 6) & 3];
+        out[outPosition + i++] = table[(unpack >> 4) & 3];
+        out[outPosition + i++] = table[(unpack >> 2) & 3];
+        out[outPosition + i++] = table[unpack & 3];
+      }
+      while (i < length) {
+        out[outPosition + i++] = table[(int) get(index++)];
+      }
     }
   }
 
   private static final class Size4Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size4Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
       int shift = ((index + 1) & 1) << 2;
-      return (buffer.getByte((index >> 1)) >> shift) & 0xF;
+      return (buffer.get(offset + (index >> 1)) >> shift) & 0xF;
+    }
+
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int index = startIndex;
+      int i = 0;
+
+      // byte align
+      while ((index & 0x1) != 0 && i < length) {
+        out[outPosition + i++] = delta + get(index++) & 0xF;
+      }
+//      for ( ; i + 2 < length; index += 2) {
+//        final byte unpack = buffer.get(offset + (index >> 1));
+//        out[outPosition + i++] = delta + (unpack >> 4) & 0xF;
+//        out[outPosition + i++] = delta + unpack & 0xF;
+//      }
+      for ( ; i + 8 < length; index += 8) {
+        final int unpack = buffer.getInt(offset + (index >> 1));
+        out[outPosition + i++] = delta + (unpack >> 28) & 0xF;
+        out[outPosition + i++] = delta + (unpack >> 24) & 0xF;
+        out[outPosition + i++] = delta + (unpack >> 20) & 0xF;
+        out[outPosition + i++] = delta + (unpack >> 16) & 0xF;
+        out[outPosition + i++] = delta + (unpack >> 12) & 0xF;
+        out[outPosition + i++] = delta + (unpack >> 8) & 0xF;
+        out[outPosition + i++] = delta + (unpack >> 4) & 0xF;
+        out[outPosition + i++] = delta + unpack & 0xF;
+      }
+      while (i < length) {
+        out[outPosition + i++] = delta + get(index++);
+      }
+    }
+
+    @Override
+    public void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
+    {
+      int index = startIndex;
+      int i = 0;
+
+      // byte align
+      while ((index & 0x1) != 0 && i < length) {
+        out[outPosition + i++] = table[(int) get(index++)];
+      }
+//      for ( ; i + 2 < length; index += 2) {
+//        final byte unpack = buffer.get(offset + (index >> 1));
+//        out[outPosition + i++] = table[(unpack >> 4) & 0xF];
+//        out[outPosition + i++] = table[unpack & 0xF];
+//      }
+      for ( ; i + 8 < length; index += 8) {
+        final int unpack = buffer.getInt(offset + (index >> 1));
+        out[outPosition + i++] = table[(unpack >> 28) & 0xF];
+        out[outPosition + i++] = table[(unpack >> 24) & 0xF];
+        out[outPosition + i++] = table[(unpack >> 20) & 0xF];
+        out[outPosition + i++] = table[(unpack >> 16) & 0xF];
+        out[outPosition + i++] = table[(unpack >> 12) & 0xF];
+        out[outPosition + i++] = table[(unpack >> 8) & 0xF];
+        out[outPosition + i++] = table[(unpack >> 4) & 0xF];
+        out[outPosition + i++] = table[unpack & 0xF];
+      }
+      while (i < length) {
+        out[outPosition + i++] = table[(int) get(index++)];
+      }
     }
   }
 
   private static final class Size8Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size8Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getByte(index) & 0xFF;
+      return buffer.get(offset + index) & 0xFF;
     }
 
     @Override
-    public void get(long[] out, int outPosition, int startIndex, int length)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
     {
-      long pos = startIndex;
-      for (int i = 0; i < length; i++, pos += 1) {
-        out[outPosition + i] = buffer.getByte(pos) & 0xFF;
+      for (int i = 0, indexOffset = startIndex; i < length; i++, indexOffset++) {
+        out[outPosition + i] = delta + buffer.get(offset + indexOffset) & 0xFF;
       }
+//      int i = 0;
+//      for (int indexOffset = startIndex; i + 8 < length; indexOffset += 8) {
+//        final long unpack = buffer.getLong(indexOffset);
+//        out[outPosition + i++] = delta + ((unpack >>> 56) & 0xFF);
+//        out[outPosition + i++] = delta + ((unpack >>> 48) & 0xFF);
+//        out[outPosition + i++] = delta + ((unpack >>> 40) & 0xFF);
+//        out[outPosition + i++] = delta + ((unpack >>> 32) & 0xFF);
+//        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFF);
+//        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFF);
+//        out[outPosition + i++] = delta + ((unpack >>> 8) & 0xFF);
+//        out[outPosition + i++] = delta + (unpack & 0xFF);
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = delta + (int) get(startIndex + i);
+//        i++;
+//      }
     }
 
     @Override
-    public int get(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
+    public int getDelta(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long base)
     {
       for (int i = 0; i < length; i++) {
         int index = indexes[outPosition + i] - indexOffset;
@@ -531,7 +745,45 @@ public class VSizeLongSerde
           return i;
         }
 
-        out[outPosition + i] = buffer.getByte(index) & 0xFF;
+        out[outPosition + i] = base + (buffer.get(offset + index) & 0xFF);
+      }
+
+      return length;
+    }
+
+    @Override
+    public void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
+    {
+      for (int i = 0, indexOffset = startIndex; i < length; i++, indexOffset++) {
+        out[outPosition + i] = table[buffer.get(offset + indexOffset) & 0xFF];
+      }
+//      int i = 0;
+//      for (int indexOffset = startIndex; i + 8 < length; indexOffset += 8) {
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset) & 0xFF];
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 1) & 0xFF];
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 2) & 0xFF];
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 3) & 0xFF];
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 4) & 0xFF];
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 5) & 0xFF];
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 6) & 0xFF];
+//        out[outPosition + i++] = table[buffer.getByte(indexOffset + 7) & 0xFF];
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = table[(int) get(startIndex + i)];
+//        i++;
+//      }
+    }
+
+    @Override
+    public int getTable(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long[] table)
+    {
+      for (int i = 0; i < length; i++) {
+        int index = indexes[outPosition + i] - indexOffset;
+        if (index >= limit) {
+          return i;
+        }
+
+        out[outPosition + i] = table[buffer.get(offset + index) & 0xFF];
       }
 
       return length;
@@ -540,52 +792,106 @@ public class VSizeLongSerde
 
   private static final class Size12Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size12Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
       int shift = ((index + 1) & 1) << 2;
-      int offset = (index * 3) >> 1;
-      return (buffer.getShort(offset) >> shift) & 0xFFF;
+      int indexOffset = (index * 3) >> 1;
+      return (buffer.getShort(offset + indexOffset) >> shift) & 0xFFF;
+    }
+
+
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int i = 0;
+      int index = startIndex;
+      // every other value is byte aligned
+      if ((index & 0x1) != 0) {
+        out[outPosition + i++] = get(index++);
+      }
+      final int unpackSize = Long.BYTES + Integer.BYTES;
+      for (int indexOffset = (index * 3) >> 1; i + 8 < length; indexOffset += unpackSize) {
+        final long unpack = buffer.getLong(offset + indexOffset);
+        final int unpack2 = buffer.getInt(offset + indexOffset + Long.BYTES);
+        out[outPosition + i++] = delta + ((unpack >> 52) & 0xFFF);
+        out[outPosition + i++] = delta + ((unpack >> 40) & 0xFFF);
+        out[outPosition + i++] = delta + ((unpack >> 28) & 0xFFF);
+        out[outPosition + i++] = delta + ((unpack >> 16) & 0xFFF);
+        out[outPosition + i++] = delta + ((unpack >> 4) & 0xFFF);
+        out[outPosition + i++] = delta + (((unpack & 0xF) << 8) | ((unpack2 >> 24) & 0xFF));
+        out[outPosition + i++] = delta + ((unpack2 >> 12) & 0xFFF);
+        out[outPosition + i++] = delta + (unpack2 & 0xFFF);
+      }
+      while (i < length) {
+        out[outPosition + i] = delta + (int) get(startIndex + i);
+        i++;
+      }
     }
   }
 
   private static final class Size16Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size16Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getShort((long) index << 1) & 0xFFFF;
+      return buffer.getShort(offset + (index << 1)) & 0xFFFF;
     }
 
     @Override
-    public void get(long[] out, int outPosition, int startIndex, int length)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
     {
-      long pos = (long) startIndex << 1;
-      for (int i = 0; i < length; i++, pos += Short.BYTES) {
-        out[outPosition + i] = buffer.getShort(pos) & 0xFFFF;
+      for (int i = 0, indexOffset = (startIndex << 1); i < length; i++, indexOffset += Short.BYTES) {
+        out[outPosition + i] = delta + buffer.getShort(offset + indexOffset) & 0xFFFF;
       }
+//      int i = 0;
+//      final int unpackSize = 8 * Short.BYTES;
+//      for (int indexOffset = startIndex << 1; i + 8 < length; indexOffset += unpackSize) {
+////        final long unpack = buffer.getLong(indexOffset);
+////        final long unpack2 = buffer.getLong(indexOffset + Long.BYTES);
+////        out[outPosition + i++] = delta + ((unpack >> 48) & 0xFFFF);
+////        out[outPosition + i++] = delta + ((unpack >> 32) & 0xFFFF);
+////        out[outPosition + i++] = delta + ((unpack >> 16) & 0xFFFF);
+////        out[outPosition + i++] = delta + (unpack & 0xFFFF);
+////        out[outPosition + i++] = delta + ((unpack2 >> 48) & 0xFFFF);
+////        out[outPosition + i++] = delta + ((unpack2 >> 32) & 0xFFFF);
+////        out[outPosition + i++] = delta + ((unpack2 >> 16) & 0xFFFF);
+////        out[outPosition + i++] = delta + (unpack2 & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset) & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 2) & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 4) & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 6) & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 8) & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 10) & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 12) & 0xFFFF);
+//        out[outPosition + i++] = delta + (buffer.getShort(indexOffset + 14) & 0xFFFF);
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = delta + (int) get(startIndex + i);
+//        i++;
+//      }
     }
 
     @Override
-    public int get(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
+    public int getDelta(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long base)
     {
       for (int i = 0; i < length; i++) {
         int index = indexes[outPosition + i] - indexOffset;
@@ -593,7 +899,30 @@ public class VSizeLongSerde
           return i;
         }
 
-        out[outPosition + i] = buffer.getShort((long) index << 1) & 0xFFFF;
+        out[outPosition + i] = base + buffer.getShort(offset + (index << 1)) & 0xFFFF;
+      }
+
+      return length;
+
+    }
+    @Override
+    public void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
+    {
+      for (int i = 0, indexOffset = (startIndex << 1); i < length; i++, indexOffset += Short.BYTES) {
+        out[outPosition + i] = table[buffer.getShort(offset + indexOffset) & 0xFFFF];
+      }
+    }
+
+    @Override
+    public int getTable(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long[] table)
+    {
+      for (int i = 0; i < length; i++) {
+        int index = indexes[outPosition + i] - indexOffset;
+        if (index >= limit) {
+          return i;
+        }
+
+        out[outPosition + i] = table[buffer.getShort(offset + (index << 1)) & 0xFFFF];
       }
 
       return length;
@@ -602,139 +931,315 @@ public class VSizeLongSerde
 
   private static final class Size20Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size20Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
       int shift = (((index + 1) & 1) << 2) + 8;
-      int offset = (index * 5) >> 1;
-      return (buffer.getInt(offset) >> shift) & 0xFFFFF;
+      int indexOffset = (index * 5) >> 1;
+      return (buffer.getInt(offset + indexOffset) >> shift) & 0xFFFFF;
+    }
+
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int i = 0;
+      int index = startIndex;
+      // every other value is byte aligned
+      if ((index & 0x1) != 0) {
+        out[outPosition + i++] = get(index++);
+      }
+      final int unpackSize = Long.BYTES + Long.BYTES + Integer.BYTES;
+      for (int indexOffset = (index * 5) >> 1; i + 8 < length; indexOffset += unpackSize) {
+        final long unpack = buffer.getLong(offset + indexOffset);
+        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
+        final int unpack3 = buffer.getInt(offset + indexOffset + Long.BYTES + Long.BYTES);
+        out[outPosition + i++] = delta + ((unpack >>> 44) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack >>> 4) & 0xFFFFF);
+        out[outPosition + i++] = delta + (((unpack & 0xF) << 16) | ((unpack2 >>> 48) & 0xFFFF));
+        out[outPosition + i++] = delta + ((unpack2 >>> 28) & 0xFFFFF);
+        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFF);
+        out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 12) | ((unpack3 >>> 20) & 0xFFF));
+        out[outPosition + i++] = delta + (unpack3 & 0xFFFFF);
+      }
+      while (i < length) {
+        out[outPosition + i] = delta + (int) get(startIndex + i);
+        i++;
+      }
     }
   }
 
   private static final class Size24Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size24Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getInt(index * 3L) >>> 8;
+      return buffer.getInt(offset + (index * 3)) >>> 8;
+    }
+
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      int i = 0;
+      final int unpackSize = 3 * Long.BYTES;
+      for (int indexOffset = startIndex * 3; i + 8 < length; indexOffset += unpackSize) {
+        final long unpack = buffer.getLong(offset + indexOffset);
+        final long unpack2 = buffer.getLong(offset +indexOffset + Long.BYTES);
+        final long unpack3 = buffer.getLong(offset + indexOffset + Long.BYTES + Long.BYTES);
+        out[outPosition + i++] = delta + ((unpack >>> 40) & 0xFFFFFF);
+        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFFFFFF);
+        out[outPosition + i++] = delta + (((unpack & 0xFFFF) << 8) | ((unpack2 >>> 56) & 0xFF));
+        out[outPosition + i++] = delta + ((unpack2 >>> 32) & 0xFFFFFF);
+        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFFF);
+        out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 16) | ((unpack3 >>> 48) & 0xFFFF));
+        out[outPosition + i++] = delta + ((unpack3 >>> 24) & 0xFFFFFF);
+        out[outPosition + i++] = delta + (unpack3 & 0xFFFFFF);
+      }
+      while (i < length) {
+        out[outPosition + i] = delta + (int) get(startIndex + i);
+        i++;
+      }
     }
   }
 
   private static final class Size32Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size32Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getInt(((long) index << 2)) & 0xFFFFFFFFL;
+      return buffer.getInt((offset + (index << 2))) & 0xFFFFFFFFL;
+    }
+
+    @Override
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    {
+      for (int i = 0, indexOffset = (startIndex << 2); i < length; i++, indexOffset += Integer.BYTES) {
+        out[outPosition + i] = delta + buffer.getInt(offset + indexOffset) & 0xFFFFFFFFL;
+      }
+//      int i = 0;
+//      final int unpackSize = 8 * Integer.BYTES;
+//      for (int indexOffset = startIndex << 2; i + 8 < length; indexOffset += unpackSize) {
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset) & 0xFFFFFFFFL);
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 4) & 0xFFFFFFFFL);
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 8) & 0xFFFFFFFFL);
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 12) & 0xFFFFFFFFL);
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 16) & 0xFFFFFFFFL);
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 20) & 0xFFFFFFFFL);
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 24) & 0xFFFFFFFFL);
+//        out[outPosition + i++] = delta + (buffer.getInt(offset + indexOffset + 28) & 0xFFFFFFFFL);
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = delta + (int) get(startIndex + i);
+//        i++;
+//      }
     }
   }
 
   private static final class Size40Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size40Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getLong(index * 5L) >>> 24;
+      return buffer.getLong(offset + (index * 5)) >>> 24;
     }
+
+//    @Override
+//    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+//    {
+//      int i = 0;
+//      final int unpackSize = 5 * Long.BYTES;
+//      for (int indexOffset = startIndex * 5; i + 8 < length; indexOffset += unpackSize) {
+//        final long unpack = buffer.getLong(offset + indexOffset);
+//        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
+//        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
+//        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
+//        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
+//        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFFFFFFFFFFL);
+//        out[outPosition + i++] = delta + (((unpack & 0xFFFFFFL) << 16) | ((unpack2 >>> 48) & 0xFFFFL));
+//        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFFFFFFFL);
+//        out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 32) | ((unpack3 >>> 32) & 0xFFFFFFFFL));
+//        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFFFL) << 32) | ((unpack4 >>> 56 ) & 0xFF));
+//        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFL);
+//        out[outPosition + i++] = delta + (((unpack4 & 0xFFFF) << 24) | ((unpack5 >>> 40) & 0xFFFFFF));
+//        out[outPosition + i++] = delta + (unpack5 & 0xFFFFFFFFFFL);
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = delta + (int) get(startIndex + i);
+//        i++;
+//      }
+//    }
   }
 
   private static final class Size48Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size48Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getLong(index * 6L) >>> 16;
+      return buffer.getLong(offset + (index * 6)) >>> 16;
     }
+
+//    @Override
+//    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+//    {
+//      int i = 0;
+//      final int unpackSize = 6 * Long.BYTES;
+//      for (int indexOffset = startIndex * 6; i + 8 < length; indexOffset += unpackSize) {
+//        final long unpack = buffer.getLong(offset + indexOffset);
+//        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
+//        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
+//        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
+//        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
+//        final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
+//        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFFFFFFFFFFFFL);
+//        out[outPosition + i++] = delta + (((unpack & 0xFFFFL) << 32) | ((unpack2 >>> 32) & 0xFFFFFFFFL));
+//        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFFFFFL) << 32) | ((unpack3 >>> 48) & 0xFFFFL));
+//        out[outPosition + i++] = delta + (unpack3 & 0xFFFFFFFFFFFFL);
+//        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFFFL);
+//        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFL) << 32) | ((unpack5 >>> 32) & 0xFFFFFFFFL));
+//        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFL) << 32) | ((unpack6 >>> 48) & 0xFFFFL));
+//        out[outPosition + i++] = delta + (unpack6 & 0xFFFFFFFFFFFFL);
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = delta + (int) get(startIndex + i);
+//        i++;
+//      }
+//    }
   }
 
   private static final class Size56Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size56Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getLong(index * 7L) >>> 8;
+      return buffer.getLong(offset + (index * 7)) >>> 8;
     }
+
+//    @Override
+//    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+//    {
+//      int i = 0;
+//      final int unpackSize = 7 * Long.BYTES;
+//      for (int indexOffset = startIndex * 7; i + 8 < length; indexOffset += unpackSize) {
+//        final long unpack = buffer.getLong(offset + indexOffset);
+//        final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
+//        final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
+//        final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
+//        final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
+//        final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
+//        final long unpack7 = buffer.getLong(offset + indexOffset + (6 * Long.BYTES));
+//        out[outPosition + i++] = delta + ((unpack >>> 8) & 0xFFFFFFFFFFFFFFL);
+//        out[outPosition + i++] = delta + (((unpack & 0xFFL) << 48) | ((unpack2 >>> 16) & 0xFFFFFFFFFFFFL));
+//        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFL) << 40) | ((unpack3 >>> 24) & 0xFFFFFFFFFFL));
+//        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFL) << 32) | ((unpack4 >>> 32) & 0xFFFFFFFFL));
+//        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
+//        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
+//        out[outPosition + i++] = delta + (((unpack6 & 0xFFFFFFFFFFFFL) << 8) | ((unpack7 >>> 56) & 0xFFL));
+//        out[outPosition + i++] = delta + (unpack7 & 0xFFFFFFFFFFFFFFL);
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = delta + (int) get(startIndex + i);
+//        i++;
+//      }
+//    }
   }
 
   private static final class Size64Des implements LongDeserializer
   {
-    final Memory buffer;
+    final ByteBuffer buffer;
+    final int offset;
 
     public Size64Des(ByteBuffer buffer, int bufferOffset)
     {
-      final ByteBuffer dup = buffer.duplicate();
-      dup.position(bufferOffset);
-      this.buffer = Memory.wrap(dup.slice(), buffer.order());
+      this.buffer = buffer;
+      this.offset = bufferOffset;
     }
 
     @Override
     public long get(int index)
     {
-      return buffer.getLong((long) index << 3);
+      return buffer.getLong(offset + (index << 3));
     }
 
     @Override
-    public void get(long[] out, int outPosition, int startIndex, int length)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
     {
-      buffer.getLongArray((long) startIndex << 3, out, outPosition, length);
+      for (int i = 0, indexOffset = (startIndex << 3); i < length; i++, indexOffset += Long.BYTES) {
+        out[outPosition + i] = delta + buffer.getLong(offset + indexOffset);
+      }
+//      int i = 0;
+//      final int unpackSize = 8 * Long.BYTES;
+//      for (int indexOffset = (startIndex << 3); i + 8 < length; indexOffset += unpackSize) {
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset);
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 8);
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 16);
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 24);
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 32);
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 40);
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 48);
+//        out[outPosition + i++] = delta + buffer.getLong(offset + indexOffset + 56);
+//      }
+//      while (i < length) {
+//        out[outPosition + i] = delta + (int) get(startIndex + i);
+//        i++;
+//      }
     }
 
     @Override
-    public int get(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit)
+    public int getDelta(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long base)
     {
       for (int i = 0; i < length; i++) {
         int index = indexes[outPosition + i] - indexOffset;
@@ -742,7 +1247,7 @@ public class VSizeLongSerde
           return i;
         }
 
-        out[outPosition + i] = buffer.getLong((long) index << 3);
+        out[outPosition + i] = base + buffer.getLong(offset + (index << 3));
       }
 
       return length;

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -809,7 +809,7 @@ public class VSizeLongSerde
         out[outPosition + i++] = base + (unpack2 & 0xFFF);
       }
       while (i < length) {
-        out[outPosition + i] = base + (int) get(startIndex + i);
+        out[outPosition + i] = base + get(startIndex + i);
         i++;
       }
     }
@@ -899,7 +899,7 @@ public class VSizeLongSerde
         out[outPosition + i++] = base + (unpack3 & 0xFFFFF);
       }
       while (i < length) {
-        out[outPosition + i] = base + (int) get(startIndex + i);
+        out[outPosition + i] = base + get(startIndex + i);
         i++;
       }
     }
@@ -941,7 +941,7 @@ public class VSizeLongSerde
         out[outPosition + i++] = base + (unpack3 & 0xFFFFFF);
       }
       while (i < length) {
-        out[outPosition + i] = base + (int) get(startIndex + i);
+        out[outPosition + i] = base + get(startIndex + i);
         i++;
       }
     }

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -392,7 +392,10 @@ public class VSizeLongSerde
     @Override
     public void write(long value) throws IOException
     {
-      Preconditions.checkArgument(value >= 0);
+      if (numBytes != 8) {
+        // if the value is not stored in a full long, ensure it is zero or positive
+        Preconditions.checkArgument(value >= 0);
+      }
       for (int i = numBytes - 1; i >= 0; i--) {
         buffer.put((byte) (value >>> (i * 8)));
         if (output != null) {

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -20,7 +20,6 @@
 package org.apache.druid.segment.data;
 
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.UOE;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -413,18 +412,32 @@ public class VSizeLongSerde
     }
   }
 
+  /**
+   * Unpack bitpacked long values from an underlying contiguous memory block
+   */
   public interface LongDeserializer
   {
+    /**
+     * Unpack long value at the specified row index
+     */
     long get(int index);
 
-    default void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    /**
+     * Unpack a contiguous vector of long values at the specified start index of length and adjust them by the supplied
+     * delta base value.
+     */
+    default void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       for (int i = 0; i < length; i++) {
-        out[outPosition + i] = delta + get(startIndex + i);
+        out[outPosition + i] = base + get(startIndex + i);
       }
     }
 
-    default int getDelta(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long delta)
+    /**
+     * Unpack a non-contiguous vector of long values at the specified indexes and adjust them by the supplied delta base
+     * value.
+     */
+    default int getDelta(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long base)
     {
       for (int i = 0; i < length; i++) {
         int index = indexes[outPosition + i] - indexOffset;
@@ -432,18 +445,36 @@ public class VSizeLongSerde
           return i;
         }
 
-        out[outPosition + i] = delta + get(index);
+        out[outPosition + i] = base + get(index);
       }
 
       return length;
     }
 
+    /**
+     * Unpack a contiguous vector of long values at the specified start index of length and lookup and replace stored
+     * values based on their index in the supplied value lookup 'table'
+     */
     default void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
     {
-      throw new UOE("Table decoding not supported for %s", this.getClass().getSimpleName());
+      for (int i = 0; i < length; i++) {
+        out[outPosition + i] = table[(int) get(startIndex + i)];
+      }
     }
 
-    default int getTable(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long[] table)
+    /**
+     * Unpack a contiguous vector of long values at the specified indexes and lookup and replace stored values based on
+     * their index in the supplied value lookup 'table'
+     */
+    default int getTable(
+        long[] out,
+        int outPosition,
+        int[] indexes,
+        int length,
+        int indexOffset,
+        int limit,
+        long[] table
+    )
     {
       for (int i = 0; i < length; i++) {
         int index = indexes[outPosition + i] - indexOffset;
@@ -477,28 +508,28 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int index = startIndex;
       int i = 0;
 
       // byte align
       while ((index & 0x7) != 0 && i < length) {
-        out[outPosition + i++] = delta + get(index++);
+        out[outPosition + i++] = base + get(index++);
       }
       for ( ; i + Byte.SIZE < length; index += Byte.SIZE) {
         final byte unpack = buffer.get(offset + (index >> 3));
-        out[outPosition + i++] = delta + (unpack >> 7) & 1;
-        out[outPosition + i++] = delta + (unpack >> 6) & 1;
-        out[outPosition + i++] = delta + (unpack >> 5) & 1;
-        out[outPosition + i++] = delta + (unpack >> 4) & 1;
-        out[outPosition + i++] = delta + (unpack >> 3) & 1;
-        out[outPosition + i++] = delta + (unpack >> 2) & 1;
-        out[outPosition + i++] = delta + (unpack >> 1) & 1;
-        out[outPosition + i++] = delta + unpack & 1;
+        out[outPosition + i++] = base + (unpack >> 7) & 1;
+        out[outPosition + i++] = base + (unpack >> 6) & 1;
+        out[outPosition + i++] = base + (unpack >> 5) & 1;
+        out[outPosition + i++] = base + (unpack >> 4) & 1;
+        out[outPosition + i++] = base + (unpack >> 3) & 1;
+        out[outPosition + i++] = base + (unpack >> 2) & 1;
+        out[outPosition + i++] = base + (unpack >> 1) & 1;
+        out[outPosition + i++] = base + unpack & 1;
       }
       while (i < length) {
-        out[outPosition + i++] = delta + get(index++);
+        out[outPosition + i++] = base + get(index++);
       }
     }
 
@@ -548,28 +579,28 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int index = startIndex;
       int i = 0;
 
       // byte align
       while ((index & 0x3) != 0 && i < length) {
-        out[outPosition + i++] = delta + get(index++);
+        out[outPosition + i++] = base + get(index++);
       }
       for ( ; i + 8 < length; index += 8) {
         final short unpack = buffer.getShort(offset + (index >> 2));
-        out[outPosition + i++] = delta + (unpack >> 14) & 3;
-        out[outPosition + i++] = delta + (unpack >> 12) & 3;
-        out[outPosition + i++] = delta + (unpack >> 10) & 3;
-        out[outPosition + i++] = delta + (unpack >> 8) & 3;
-        out[outPosition + i++] = delta + (unpack >> 6) & 3;
-        out[outPosition + i++] = delta + (unpack >> 4) & 3;
-        out[outPosition + i++] = delta + (unpack >> 2) & 3;
-        out[outPosition + i++] = delta + unpack & 3;
+        out[outPosition + i++] = base + (unpack >> 14) & 3;
+        out[outPosition + i++] = base + (unpack >> 12) & 3;
+        out[outPosition + i++] = base + (unpack >> 10) & 3;
+        out[outPosition + i++] = base + (unpack >> 8) & 3;
+        out[outPosition + i++] = base + (unpack >> 6) & 3;
+        out[outPosition + i++] = base + (unpack >> 4) & 3;
+        out[outPosition + i++] = base + (unpack >> 2) & 3;
+        out[outPosition + i++] = base + unpack & 3;
       }
       while (i < length) {
-        out[outPosition + i++] = delta + get(index++);
+        out[outPosition + i++] = base + get(index++);
       }
     }
 
@@ -619,28 +650,28 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int index = startIndex;
       int i = 0;
 
       // byte align
       while ((index & 0x1) != 0 && i < length) {
-        out[outPosition + i++] = delta + get(index++) & 0xF;
+        out[outPosition + i++] = base + get(index++) & 0xF;
       }
       for ( ; i + 8 < length; index += 8) {
         final int unpack = buffer.getInt(offset + (index >> 1));
-        out[outPosition + i++] = delta + (unpack >> 28) & 0xF;
-        out[outPosition + i++] = delta + (unpack >> 24) & 0xF;
-        out[outPosition + i++] = delta + (unpack >> 20) & 0xF;
-        out[outPosition + i++] = delta + (unpack >> 16) & 0xF;
-        out[outPosition + i++] = delta + (unpack >> 12) & 0xF;
-        out[outPosition + i++] = delta + (unpack >> 8) & 0xF;
-        out[outPosition + i++] = delta + (unpack >> 4) & 0xF;
-        out[outPosition + i++] = delta + unpack & 0xF;
+        out[outPosition + i++] = base + (unpack >> 28) & 0xF;
+        out[outPosition + i++] = base + (unpack >> 24) & 0xF;
+        out[outPosition + i++] = base + (unpack >> 20) & 0xF;
+        out[outPosition + i++] = base + (unpack >> 16) & 0xF;
+        out[outPosition + i++] = base + (unpack >> 12) & 0xF;
+        out[outPosition + i++] = base + (unpack >> 8) & 0xF;
+        out[outPosition + i++] = base + (unpack >> 4) & 0xF;
+        out[outPosition + i++] = base + unpack & 0xF;
       }
       while (i < length) {
-        out[outPosition + i++] = delta + get(index++);
+        out[outPosition + i++] = base + get(index++);
       }
     }
 
@@ -689,10 +720,10 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       for (int i = 0, indexOffset = startIndex; i < length; i++, indexOffset++) {
-        out[outPosition + i] = delta + buffer.get(offset + indexOffset) & 0xFF;
+        out[outPosition + i] = base + buffer.get(offset + indexOffset) & 0xFF;
       }
     }
 
@@ -756,7 +787,7 @@ public class VSizeLongSerde
 
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int i = 0;
       int index = startIndex;
@@ -768,17 +799,17 @@ public class VSizeLongSerde
       for (int indexOffset = (index * 3) >> 1; i + 8 < length; indexOffset += unpackSize) {
         final long unpack = buffer.getLong(offset + indexOffset);
         final int unpack2 = buffer.getInt(offset + indexOffset + Long.BYTES);
-        out[outPosition + i++] = delta + ((unpack >> 52) & 0xFFF);
-        out[outPosition + i++] = delta + ((unpack >> 40) & 0xFFF);
-        out[outPosition + i++] = delta + ((unpack >> 28) & 0xFFF);
-        out[outPosition + i++] = delta + ((unpack >> 16) & 0xFFF);
-        out[outPosition + i++] = delta + ((unpack >> 4) & 0xFFF);
-        out[outPosition + i++] = delta + (((unpack & 0xF) << 8) | ((unpack2 >>> 24) & 0xFF));
-        out[outPosition + i++] = delta + ((unpack2 >> 12) & 0xFFF);
-        out[outPosition + i++] = delta + (unpack2 & 0xFFF);
+        out[outPosition + i++] = base + ((unpack >> 52) & 0xFFF);
+        out[outPosition + i++] = base + ((unpack >> 40) & 0xFFF);
+        out[outPosition + i++] = base + ((unpack >> 28) & 0xFFF);
+        out[outPosition + i++] = base + ((unpack >> 16) & 0xFFF);
+        out[outPosition + i++] = base + ((unpack >> 4) & 0xFFF);
+        out[outPosition + i++] = base + (((unpack & 0xF) << 8) | ((unpack2 >>> 24) & 0xFF));
+        out[outPosition + i++] = base + ((unpack2 >> 12) & 0xFFF);
+        out[outPosition + i++] = base + (unpack2 & 0xFFF);
       }
       while (i < length) {
-        out[outPosition + i] = delta + (int) get(startIndex + i);
+        out[outPosition + i] = base + (int) get(startIndex + i);
         i++;
       }
     }
@@ -802,10 +833,10 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       for (int i = 0, indexOffset = (startIndex << 1); i < length; i++, indexOffset += Short.BYTES) {
-        out[outPosition + i] = delta + buffer.getShort(offset + indexOffset) & 0xFFFF;
+        out[outPosition + i] = base + buffer.getShort(offset + indexOffset) & 0xFFFF;
       }
     }
 
@@ -819,29 +850,6 @@ public class VSizeLongSerde
         }
 
         out[outPosition + i] = base + buffer.getShort(offset + (index << 1)) & 0xFFFF;
-      }
-
-      return length;
-
-    }
-    @Override
-    public void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
-    {
-      for (int i = 0, indexOffset = (startIndex << 1); i < length; i++, indexOffset += Short.BYTES) {
-        out[outPosition + i] = table[buffer.getShort(offset + indexOffset) & 0xFFFF];
-      }
-    }
-
-    @Override
-    public int getTable(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit, long[] table)
-    {
-      for (int i = 0; i < length; i++) {
-        int index = indexes[outPosition + i] - indexOffset;
-        if (index >= limit) {
-          return i;
-        }
-
-        out[outPosition + i] = table[buffer.getShort(offset + (index << 1)) & 0xFFFF];
       }
 
       return length;
@@ -868,7 +876,7 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int i = 0;
       int index = startIndex;
@@ -881,17 +889,17 @@ public class VSizeLongSerde
         final long unpack = buffer.getLong(offset + indexOffset);
         final long unpack2 = buffer.getLong(offset + indexOffset + Long.BYTES);
         final int unpack3 = buffer.getInt(offset + indexOffset + Long.BYTES + Long.BYTES);
-        out[outPosition + i++] = delta + ((unpack >> 44) & 0xFFFFF);
-        out[outPosition + i++] = delta + ((unpack >> 24) & 0xFFFFF);
-        out[outPosition + i++] = delta + ((unpack >> 4) & 0xFFFFF);
-        out[outPosition + i++] = delta + (((unpack & 0xF) << 16) | ((unpack2 >>> 48) & 0xFFFF));
-        out[outPosition + i++] = delta + ((unpack2 >> 28) & 0xFFFFF);
-        out[outPosition + i++] = delta + ((unpack2 >> 8) & 0xFFFFF);
-        out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 12) | ((unpack3 >>> 20) & 0xFFF));
-        out[outPosition + i++] = delta + (unpack3 & 0xFFFFF);
+        out[outPosition + i++] = base + ((unpack >> 44) & 0xFFFFF);
+        out[outPosition + i++] = base + ((unpack >> 24) & 0xFFFFF);
+        out[outPosition + i++] = base + ((unpack >> 4) & 0xFFFFF);
+        out[outPosition + i++] = base + (((unpack & 0xF) << 16) | ((unpack2 >>> 48) & 0xFFFF));
+        out[outPosition + i++] = base + ((unpack2 >> 28) & 0xFFFFF);
+        out[outPosition + i++] = base + ((unpack2 >> 8) & 0xFFFFF);
+        out[outPosition + i++] = base + (((unpack2 & 0xFF) << 12) | ((unpack3 >>> 20) & 0xFFF));
+        out[outPosition + i++] = base + (unpack3 & 0xFFFFF);
       }
       while (i < length) {
-        out[outPosition + i] = delta + (int) get(startIndex + i);
+        out[outPosition + i] = base + (int) get(startIndex + i);
         i++;
       }
     }
@@ -915,7 +923,7 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int i = 0;
       final int unpackSize = 3 * Long.BYTES;
@@ -923,17 +931,17 @@ public class VSizeLongSerde
         final long unpack = buffer.getLong(offset + indexOffset);
         final long unpack2 = buffer.getLong(offset +indexOffset + Long.BYTES);
         final long unpack3 = buffer.getLong(offset + indexOffset + Long.BYTES + Long.BYTES);
-        out[outPosition + i++] = delta + ((unpack >> 40) & 0xFFFFFF);
-        out[outPosition + i++] = delta + ((unpack >> 16) & 0xFFFFFF);
-        out[outPosition + i++] = delta + (((unpack & 0xFFFF) << 8) | ((unpack2 >>> 56) & 0xFF));
-        out[outPosition + i++] = delta + ((unpack2 >> 32) & 0xFFFFFF);
-        out[outPosition + i++] = delta + ((unpack2 >> 8) & 0xFFFFFF);
-        out[outPosition + i++] = delta + (((unpack2 & 0xFF) << 16) | ((unpack3 >>> 48) & 0xFFFF));
-        out[outPosition + i++] = delta + ((unpack3 >> 24) & 0xFFFFFF);
-        out[outPosition + i++] = delta + (unpack3 & 0xFFFFFF);
+        out[outPosition + i++] = base + ((unpack >> 40) & 0xFFFFFF);
+        out[outPosition + i++] = base + ((unpack >> 16) & 0xFFFFFF);
+        out[outPosition + i++] = base + (((unpack & 0xFFFF) << 8) | ((unpack2 >>> 56) & 0xFF));
+        out[outPosition + i++] = base + ((unpack2 >> 32) & 0xFFFFFF);
+        out[outPosition + i++] = base + ((unpack2 >> 8) & 0xFFFFFF);
+        out[outPosition + i++] = base + (((unpack2 & 0xFF) << 16) | ((unpack3 >>> 48) & 0xFFFF));
+        out[outPosition + i++] = base + ((unpack3 >> 24) & 0xFFFFFF);
+        out[outPosition + i++] = base + (unpack3 & 0xFFFFFF);
       }
       while (i < length) {
-        out[outPosition + i] = delta + (int) get(startIndex + i);
+        out[outPosition + i] = base + (int) get(startIndex + i);
         i++;
       }
     }
@@ -957,10 +965,10 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       for (int i = 0, indexOffset = (startIndex << 2); i < length; i++, indexOffset += Integer.BYTES) {
-        out[outPosition + i] = delta + buffer.getInt(offset + indexOffset) & 0xFFFFFFFFL;
+        out[outPosition + i] = base + buffer.getInt(offset + indexOffset) & 0xFFFFFFFFL;
       }
     }
   }
@@ -983,7 +991,7 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int i = 0;
       final int unpackSize = 5 * Long.BYTES;
@@ -993,17 +1001,17 @@ public class VSizeLongSerde
         final long unpack3 = buffer.getLong(offset + indexOffset + (2 * Long.BYTES));
         final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
         final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
-        out[outPosition + i++] = delta + ((unpack >>> 24) & 0xFFFFFFFFFFL);
-        out[outPosition + i++] = delta + (((unpack & 0xFFFFFFL) << 16) | ((unpack2 >>> 48) & 0xFFFFL));
-        out[outPosition + i++] = delta + ((unpack2 >>> 8) & 0xFFFFFFFFFFL);
-        out[outPosition + i++] = delta + (((unpack2 & 0xFFL) << 32) | ((unpack3 >>> 32) & 0xFFFFFFFFL));
-        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFFFL) << 8) | ((unpack4 >>> 56 ) & 0xFFL));
-        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFL);
-        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
-        out[outPosition + i++] = delta + (unpack5 & 0xFFFFFFFFFFL);
+        out[outPosition + i++] = base + ((unpack >>> 24) & 0xFFFFFFFFFFL);
+        out[outPosition + i++] = base + (((unpack & 0xFFFFFFL) << 16) | ((unpack2 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = base + ((unpack2 >>> 8) & 0xFFFFFFFFFFL);
+        out[outPosition + i++] = base + (((unpack2 & 0xFFL) << 32) | ((unpack3 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = base + (((unpack3 & 0xFFFFFFFFL) << 8) | ((unpack4 >>> 56 ) & 0xFFL));
+        out[outPosition + i++] = base + ((unpack4 >>> 16) & 0xFFFFFFFFFFL);
+        out[outPosition + i++] = base + (((unpack4 & 0xFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
+        out[outPosition + i++] = base + (unpack5 & 0xFFFFFFFFFFL);
       }
       while (i < length) {
-        out[outPosition + i] = delta + get(startIndex + i);
+        out[outPosition + i] = base + get(startIndex + i);
         i++;
       }
     }
@@ -1027,7 +1035,7 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int i = 0;
       final int unpackSize = 6 * Long.BYTES;
@@ -1038,17 +1046,17 @@ public class VSizeLongSerde
         final long unpack4 = buffer.getLong(offset + indexOffset + (3 * Long.BYTES));
         final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
         final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
-        out[outPosition + i++] = delta + ((unpack >>> 16) & 0xFFFFFFFFFFFFL);
-        out[outPosition + i++] = delta + (((unpack & 0xFFFFL) << 32) | ((unpack2 >>> 32) & 0xFFFFFFFFL));
-        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFFFFFL) << 16) | ((unpack3 >>> 48) & 0xFFFFL));
-        out[outPosition + i++] = delta + (unpack3 & 0xFFFFFFFFFFFFL);
-        out[outPosition + i++] = delta + ((unpack4 >>> 16) & 0xFFFFFFFFFFFFL);
-        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFL) << 32) | ((unpack5 >>> 32) & 0xFFFFFFFFL));
-        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
-        out[outPosition + i++] = delta + (unpack6 & 0xFFFFFFFFFFFFL);
+        out[outPosition + i++] = base + ((unpack >>> 16) & 0xFFFFFFFFFFFFL);
+        out[outPosition + i++] = base + (((unpack & 0xFFFFL) << 32) | ((unpack2 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = base + (((unpack2 & 0xFFFFFFFFL) << 16) | ((unpack3 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = base + (unpack3 & 0xFFFFFFFFFFFFL);
+        out[outPosition + i++] = base + ((unpack4 >>> 16) & 0xFFFFFFFFFFFFL);
+        out[outPosition + i++] = base + (((unpack4 & 0xFFFFL) << 32) | ((unpack5 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = base + (((unpack5 & 0xFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = base + (unpack6 & 0xFFFFFFFFFFFFL);
       }
       while (i < length) {
-        out[outPosition + i] = delta + get(startIndex + i);
+        out[outPosition + i] = base + get(startIndex + i);
         i++;
       }
     }
@@ -1072,7 +1080,7 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       int i = 0;
       final int unpackSize = 7 * Long.BYTES;
@@ -1084,17 +1092,17 @@ public class VSizeLongSerde
         final long unpack5 = buffer.getLong(offset + indexOffset + (4 * Long.BYTES));
         final long unpack6 = buffer.getLong(offset + indexOffset + (5 * Long.BYTES));
         final long unpack7 = buffer.getLong(offset + indexOffset + (6 * Long.BYTES));
-        out[outPosition + i++] = delta + ((unpack >>> 8) & 0xFFFFFFFFFFFFFFL);
-        out[outPosition + i++] = delta + (((unpack & 0xFFL) << 48) | ((unpack2 >>> 16) & 0xFFFFFFFFFFFFL));
-        out[outPosition + i++] = delta + (((unpack2 & 0xFFFFL) << 40) | ((unpack3 >>> 24) & 0xFFFFFFFFFFL));
-        out[outPosition + i++] = delta + (((unpack3 & 0xFFFFFFL) << 32) | ((unpack4 >>> 32) & 0xFFFFFFFFL));
-        out[outPosition + i++] = delta + (((unpack4 & 0xFFFFFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
-        out[outPosition + i++] = delta + (((unpack5 & 0xFFFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
-        out[outPosition + i++] = delta + (((unpack6 & 0xFFFFFFFFFFFFL) << 8) | ((unpack7 >>> 56) & 0xFFL));
-        out[outPosition + i++] = delta + (unpack7 & 0xFFFFFFFFFFFFFFL);
+        out[outPosition + i++] = base + ((unpack >>> 8) & 0xFFFFFFFFFFFFFFL);
+        out[outPosition + i++] = base + (((unpack & 0xFFL) << 48) | ((unpack2 >>> 16) & 0xFFFFFFFFFFFFL));
+        out[outPosition + i++] = base + (((unpack2 & 0xFFFFL) << 40) | ((unpack3 >>> 24) & 0xFFFFFFFFFFL));
+        out[outPosition + i++] = base + (((unpack3 & 0xFFFFFFL) << 32) | ((unpack4 >>> 32) & 0xFFFFFFFFL));
+        out[outPosition + i++] = base + (((unpack4 & 0xFFFFFFFFL) << 24) | ((unpack5 >>> 40) & 0xFFFFFFL));
+        out[outPosition + i++] = base + (((unpack5 & 0xFFFFFFFFFFL) << 16) | ((unpack6 >>> 48) & 0xFFFFL));
+        out[outPosition + i++] = base + (((unpack6 & 0xFFFFFFFFFFFFL) << 8) | ((unpack7 >>> 56) & 0xFFL));
+        out[outPosition + i++] = base + (unpack7 & 0xFFFFFFFFFFFFFFL);
       }
       while (i < length) {
-        out[outPosition + i] = delta + get(startIndex + i);
+        out[outPosition + i] = base + get(startIndex + i);
         i++;
       }
     }
@@ -1118,10 +1126,10 @@ public class VSizeLongSerde
     }
 
     @Override
-    public void getDelta(long[] out, int outPosition, int startIndex, int length, long delta)
+    public void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
     {
       for (int i = 0, indexOffset = (startIndex << 3); i < length; i++, indexOffset += Long.BYTES) {
-        out[outPosition + i] = delta + buffer.getLong(offset + indexOffset);
+        out[outPosition + i] = base + buffer.getLong(offset + indexOffset);
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/VSizeLongSerde.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.data;
 
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.UOE;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -329,7 +330,7 @@ public class VSizeLongSerde
         curByte = (byte) value;
         first = false;
       } else {
-        curByte = (byte) ((curByte << 4) | ((value >>> (numBytes << 3)) & 0xF));
+        curByte = (byte) ((curByte << 4) | ((value >> (numBytes << 3)) & 0xF));
         buffer.put(curByte);
         first = true;
       }
@@ -426,12 +427,7 @@ public class VSizeLongSerde
      * Unpack a contiguous vector of long values at the specified start index of length and adjust them by the supplied
      * delta base value.
      */
-    default void getDelta(long[] out, int outPosition, int startIndex, int length, long base)
-    {
-      for (int i = 0; i < length; i++) {
-        out[outPosition + i] = base + get(startIndex + i);
-      }
-    }
+    void getDelta(long[] out, int outPosition, int startIndex, int length, long base);
 
     /**
      * Unpack a non-contiguous vector of long values at the specified indexes and adjust them by the supplied delta base
@@ -457,9 +453,7 @@ public class VSizeLongSerde
      */
     default void getTable(long[] out, int outPosition, int startIndex, int length, long[] table)
     {
-      for (int i = 0; i < length; i++) {
-        out[outPosition + i] = table[(int) get(startIndex + i)];
-      }
+      throw new UOE("Table decoding not supported for %s", this.getClass().getSimpleName());
     }
 
     /**

--- a/processing/src/main/java/org/apache/druid/segment/generator/ColumnValueGenerator.java
+++ b/processing/src/main/java/org/apache/druid/segment/generator/ColumnValueGenerator.java
@@ -33,8 +33,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.function.Supplier;
 
-public class ColumnValueGenerator
+public class ColumnValueGenerator implements Supplier<Object>
 {
   private final GeneratorColumnSchema schema;
   private final long seed;
@@ -223,5 +224,11 @@ public class ColumnValueGenerator
     } else {
       ((EnumeratedDistribution) distribution).reseedRandomGenerator(seed);
     }
+  }
+
+  @Override
+  public Object get()
+  {
+    return generateRowValue();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
@@ -224,11 +224,17 @@ public class CompressedLongsSerdeTest
     Assert.assertEquals(vals.length, indexed.size());
 
     // sequential access
+    long[] vector = new long[256];
     int[] indices = new int[vals.length];
     for (int i = 0; i < indexed.size(); ++i) {
+      if (i % 256 == 0) {
+        indexed.get(vector, i, Math.min(256, indexed.size() - i));
+      }
       Assert.assertEquals(vals[i], indexed.get(i));
+      Assert.assertEquals(vals[i], vector[i % 256]);
       indices[i] = i;
     }
+
 
     // random access, limited to 1000 elements for large lists (every element would take too long)
     IntArrays.shuffle(indices, ThreadLocalRandom.current());

--- a/processing/src/test/java/org/apache/druid/segment/data/VSizeLongSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/VSizeLongSerdeTest.java
@@ -20,91 +20,161 @@
 package org.apache.druid.segment.data;
 
 
+import com.google.common.primitives.Ints;
+import org.apache.druid.java.util.common.StringUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
+@RunWith(Enclosed.class)
 public class VSizeLongSerdeTest
 {
-  private ByteBuffer buffer;
-  private ByteArrayOutputStream outStream;
-  private ByteBuffer outBuffer;
-  private final long[] values0 = {0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1};
-  private final long[] values1 = {0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1};
-  private final long[] values2 = {12, 5, 2, 9, 3, 2, 5, 1, 0, 6, 13, 10, 15};
-  private final long[] values3 = {1, 1, 1, 1, 1, 11, 11, 11, 11};
-  private final long[] values4 = {200, 200, 200, 401, 200, 301, 200, 200, 200, 404, 200, 200, 200, 200};
-  private final long[] values5 = {123, 632, 12, 39, 536, 0, 1023, 52, 777, 526, 214, 562, 823, 346};
-  private final long[] values6 = {1000000, 1000001, 1000002, 1000003, 1000004, 1000005, 1000006, 1000007, 1000008};
-
-  @Before
-  public void setUp()
+  @RunWith(Parameterized.class)
+  public static class EveryLittleBitTest
   {
-    outStream = new ByteArrayOutputStream();
-    outBuffer = ByteBuffer.allocate(500000);
-  }
+    private final int numBits;
 
-  @Test
-  public void testGetBitsForMax()
-  {
-    Assert.assertEquals(1, VSizeLongSerde.getBitsForMax(1));
-    Assert.assertEquals(1, VSizeLongSerde.getBitsForMax(2));
-    Assert.assertEquals(2, VSizeLongSerde.getBitsForMax(3));
-    Assert.assertEquals(4, VSizeLongSerde.getBitsForMax(16));
-    Assert.assertEquals(8, VSizeLongSerde.getBitsForMax(200));
-    Assert.assertEquals(12, VSizeLongSerde.getBitsForMax(999));
-    Assert.assertEquals(24, VSizeLongSerde.getBitsForMax(12345678));
-    Assert.assertEquals(32, VSizeLongSerde.getBitsForMax(Integer.MAX_VALUE));
-    Assert.assertEquals(64, VSizeLongSerde.getBitsForMax(Long.MAX_VALUE));
-  }
+    public EveryLittleBitTest(int numBits)
+    {
+      this.numBits = numBits;
+    }
 
-  @Test
-  public void testSerdeValues() throws IOException
-  {
-    for (int i : VSizeLongSerde.SUPPORTED_SIZES) {
-      testSerde(i, values0);
-      if (i >= 1) {
-        testSerde(i, values1);
+    @Parameterized.Parameters(name = "numBits={0}")
+    public static Collection<Object[]> data()
+    {
+      return Arrays.stream(VSizeLongSerde.SUPPORTED_SIZES)
+                   .mapToObj(value -> new Object[]{value})
+                   .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testEveryPowerOfTwo() throws IOException
+    {
+      // Test every long that has a single bit set.
+
+      final int numLongs = Math.min(64, numBits);
+      final long[] longs = new long[numLongs];
+
+      for (int bit = 0; bit < numLongs; bit++) {
+        longs[bit] = 1L << bit;
       }
-      if (i >= 4) {
-        testSerde(i, values2);
-        testSerde(i, values3);
+
+      testSerde(numBits, longs);
+    }
+
+    @Test
+    public void testEveryPowerOfTwoMinusOne() throws IOException
+    {
+      // Test every long with runs of low bits set.
+
+      final int numLongs = Math.min(64, numBits + 1);
+      final long[] longs = new long[numLongs];
+
+      for (int bit = 0; bit < numLongs; bit++) {
+        longs[bit] = (1L << bit) - 1;
       }
-      if (i >= 9) {
-        testSerde(i, values4);
-      }
-      if (i >= 10) {
-        testSerde(i, values5);
-      }
-      if (i >= 20) {
-        testSerde(i, values6);
-      }
+
+      testSerde(numBits, longs);
     }
   }
 
-  @Test
-  public void testSerdeLoop() throws IOException
+  public static class SpecificValuesTest
   {
-    for (int i : VSizeLongSerde.SUPPORTED_SIZES) {
-      if (i >= 8) {
-        testSerdeIncLoop(i, 0, 256);
+    private final long[] values0 = {0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1};
+    private final long[] values1 = {0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1};
+    private final long[] values2 = {12, 5, 2, 9, 3, 2, 5, 1, 0, 6, 13, 10, 15};
+    private final long[] values3 = {1, 1, 1, 1, 1, 11, 11, 11, 11};
+    private final long[] values4 = {200, 200, 200, 401, 200, 301, 200, 200, 200, 404, 200, 200, 200, 200};
+    private final long[] values5 = {123, 632, 12, 39, 536, 0, 1023, 52, 777, 526, 214, 562, 823, 346};
+    private final long[] values6 = {1000000, 1000001, 1000002, 1000003, 1000004, 1000005, 1000006, 1000007, 1000008};
+
+    @Test
+    public void testGetBitsForMax()
+    {
+      Assert.assertEquals(1, VSizeLongSerde.getBitsForMax(1));
+      Assert.assertEquals(1, VSizeLongSerde.getBitsForMax(2));
+      Assert.assertEquals(2, VSizeLongSerde.getBitsForMax(3));
+      Assert.assertEquals(4, VSizeLongSerde.getBitsForMax(16));
+      Assert.assertEquals(8, VSizeLongSerde.getBitsForMax(200));
+      Assert.assertEquals(12, VSizeLongSerde.getBitsForMax(999));
+      Assert.assertEquals(24, VSizeLongSerde.getBitsForMax(12345678));
+      Assert.assertEquals(32, VSizeLongSerde.getBitsForMax(Integer.MAX_VALUE));
+      Assert.assertEquals(64, VSizeLongSerde.getBitsForMax(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testSerdeValues() throws IOException
+    {
+      for (int i : VSizeLongSerde.SUPPORTED_SIZES) {
+        testSerde(i, values0);
+        if (i >= 1) {
+          testSerde(i, values1);
+        }
+        if (i >= 4) {
+          testSerde(i, values2);
+          testSerde(i, values3);
+        }
+        if (i >= 9) {
+          testSerde(i, values4);
+        }
+        if (i >= 10) {
+          testSerde(i, values5);
+        }
+        if (i >= 20) {
+          testSerde(i, values6);
+        }
       }
-      if (i >= 16) {
-        testSerdeIncLoop(i, 0, 50000);
+    }
+
+    @Test
+    public void testSerdeLoop() throws IOException
+    {
+      final long[] zeroTo256 = generateSequentialLongs(0, 256);
+      final long[] zeroTo50000 = generateSequentialLongs(0, 50000);
+
+      for (int i : VSizeLongSerde.SUPPORTED_SIZES) {
+        if (i >= 8) {
+          testSerde(i, zeroTo256);
+        }
+        if (i >= 16) {
+          testSerde(i, zeroTo50000);
+        }
       }
+    }
+
+    private long[] generateSequentialLongs(final long start, final long end)
+    {
+      final long[] values = new long[Ints.checkedCast(end - start)];
+
+      for (int i = 0; i < values.length; i++) {
+        values[i] = start + i;
+      }
+
+      return values;
     }
   }
 
-  public void testSerde(int longSize, long[] values) throws IOException
+  public static void testSerde(int numBits, long[] values) throws IOException
   {
-    outBuffer.rewind();
-    outStream.reset();
-    VSizeLongSerde.LongSerializer streamSer = VSizeLongSerde.getSerializer(longSize, outStream);
-    VSizeLongSerde.LongSerializer bufferSer = VSizeLongSerde.getSerializer(longSize, outBuffer, 0);
+    final int bufferOffset = 1;
+    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    outStream.write(0xAF); // Dummy byte so the real stuff starts at bufferOffset
+
+    final ByteBuffer buffer =
+        ByteBuffer.allocate(VSizeLongSerde.getSerializedSize(numBits, values.length) + bufferOffset);
+    buffer.rewind();
+    buffer.put(0, (byte) 0xAF); // Dummy byte again.
+    VSizeLongSerde.LongSerializer streamSer = VSizeLongSerde.getSerializer(numBits, outStream);
+    VSizeLongSerde.LongSerializer bufferSer = VSizeLongSerde.getSerializer(numBits, buffer, bufferOffset);
     for (long value : values) {
       streamSer.write(value);
       bufferSer.write(value);
@@ -112,40 +182,189 @@ public class VSizeLongSerdeTest
     streamSer.close();
     bufferSer.close();
 
-    buffer = ByteBuffer.wrap(outStream.toByteArray());
-    Assert.assertEquals(VSizeLongSerde.getSerializedSize(longSize, values.length), buffer.capacity());
-    Assert.assertEquals(VSizeLongSerde.getSerializedSize(longSize, values.length), outBuffer.position());
-    VSizeLongSerde.LongDeserializer streamDes = VSizeLongSerde.getDeserializer(longSize, buffer, 0);
-    VSizeLongSerde.LongDeserializer bufferDes = VSizeLongSerde.getDeserializer(longSize, outBuffer, 0);
-    for (int i = 0; i < values.length; i++) {
-      Assert.assertEquals(values[i], streamDes.get(i));
-      Assert.assertEquals(values[i], bufferDes.get(i));
-    }
+    // Verify serialized sizes.
+    final ByteBuffer bufferFromStream = ByteBuffer.wrap(outStream.toByteArray());
+    Assert.assertEquals(
+        StringUtils.format("Serialized size (stream, numBits = %d)", numBits),
+        VSizeLongSerde.getSerializedSize(numBits, values.length),
+        bufferFromStream.capacity() - bufferOffset
+    );
+    Assert.assertEquals(
+        StringUtils.format("Serialized size (buffer, numBits = %d)", numBits),
+        VSizeLongSerde.getSerializedSize(numBits, values.length),
+        buffer.position() - bufferOffset
+    );
+
+    // Verify the actual serialized contents.
+    Assert.assertArrayEquals(
+        StringUtils.format("Stream and buffer serialized images are equal (numBits = %d)", numBits),
+        bufferFromStream.array(),
+        buffer.array()
+    );
+
+    // Verify deserialization. We know the two serialized buffers are equal, so from this point on, just use one.
+    VSizeLongSerde.LongDeserializer deserializer = VSizeLongSerde.getDeserializer(numBits, buffer, bufferOffset);
+
+    testGetSingleRow(deserializer, numBits, values);
+    testContiguousGetSingleRow(deserializer, numBits, values);
+    testContiguousGetWholeRegion(deserializer, numBits, values);
+    testNoncontiguousGetSingleRow(deserializer, numBits, values);
+    testNoncontiguousGetEveryOtherValue(deserializer, numBits, values);
+    testNoncontiguousGetEveryOtherValueWithLimit(deserializer, numBits, values);
   }
 
-  public void testSerdeIncLoop(int longSize, long start, long end) throws IOException
+  private static void testGetSingleRow(
+      final VSizeLongSerde.LongDeserializer deserializer,
+      final int numBits,
+      final long[] values
+  )
   {
-    outBuffer.rewind();
-    outStream.reset();
-    VSizeLongSerde.LongSerializer streamSer = VSizeLongSerde.getSerializer(longSize, outStream);
-    VSizeLongSerde.LongSerializer bufferSer = VSizeLongSerde.getSerializer(longSize, outBuffer, 0);
-    for (long i = start; i < end; i++) {
-      streamSer.write(i);
-      bufferSer.write(i);
-    }
-    streamSer.close();
-    bufferSer.close();
-
-    buffer = ByteBuffer.wrap(outStream.toByteArray());
-    Assert.assertEquals(VSizeLongSerde.getSerializedSize(longSize, (int) (end - start)), buffer.capacity());
-    Assert.assertEquals(VSizeLongSerde.getSerializedSize(longSize, (int) (end - start)), outBuffer.position());
-    VSizeLongSerde.LongDeserializer streamDes = VSizeLongSerde.getDeserializer(longSize, buffer, 0);
-    VSizeLongSerde.LongDeserializer bufferDes = VSizeLongSerde.getDeserializer(longSize, outBuffer, 0);
-    for (int i = 0; i < end - start; i++) {
-      Assert.assertEquals(start + i, streamDes.get(i));
-      Assert.assertEquals(start + i, bufferDes.get(i));
+    for (int i = 0; i < values.length; i++) {
+      Assert.assertEquals(
+          StringUtils.format("Deserializer (testGetSingleRow, numBits = %d, position = %d)", numBits, i),
+          values[i],
+          deserializer.get(i)
+      );
     }
   }
 
+  private static void testContiguousGetSingleRow(
+      final VSizeLongSerde.LongDeserializer deserializer,
+      final int numBits,
+      final long[] values
+  )
+  {
+    final int outPosition = 1;
+    final long[] out = new long[values.length + outPosition];
 
+    for (int i = 0; i < values.length; i++) {
+      Arrays.fill(out, -1);
+      deserializer.get(out, outPosition, i, 1);
+
+      Assert.assertEquals(
+          StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+          values[i],
+          out[outPosition]
+      );
+    }
+  }
+
+  private static void testContiguousGetWholeRegion(
+      final VSizeLongSerde.LongDeserializer deserializer,
+      final int numBits,
+      final long[] values
+  )
+  {
+    final int outPosition = 1;
+    final long[] out = new long[values.length + outPosition];
+    Arrays.fill(out, -1);
+    deserializer.get(out, outPosition, 0, values.length);
+
+    Assert.assertArrayEquals(
+        StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits),
+        values,
+        Arrays.stream(out).skip(outPosition).toArray()
+    );
+  }
+
+  private static void testNoncontiguousGetSingleRow(
+      final VSizeLongSerde.LongDeserializer deserializer,
+      final int numBits,
+      final long[] values
+  )
+  {
+    final int indexOffset = 1;
+    final int outPosition = 1;
+    final long[] out = new long[values.length + outPosition];
+    final int[] indexes = new int[values.length + outPosition];
+
+    for (int i = 0; i < values.length; i++) {
+      Arrays.fill(out, -1);
+      Arrays.fill(indexes, -1);
+      indexes[outPosition] = i + indexOffset;
+
+      deserializer.get(out, outPosition, indexes, 1, indexOffset, values.length);
+
+      Assert.assertEquals(
+          StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+          values[i],
+          out[outPosition]
+      );
+    }
+  }
+
+  private static void testNoncontiguousGetEveryOtherValue(
+      final VSizeLongSerde.LongDeserializer deserializer,
+      final int numBits,
+      final long[] values
+  )
+  {
+    final int indexOffset = 1;
+    final int outPosition = 1;
+    final long[] out = new long[values.length + outPosition];
+    final long[] expectedOut = new long[values.length + outPosition];
+    final int[] indexes = new int[values.length + outPosition];
+
+    Arrays.fill(out, -1);
+    Arrays.fill(expectedOut, -1);
+    Arrays.fill(indexes, -1);
+
+    int cnt = 0;
+    for (int i = 0; i < values.length; i++) {
+      if (i % 2 == 0) {
+        indexes[outPosition + i / 2] = i + indexOffset;
+        expectedOut[outPosition + i / 2] = values[i];
+        cnt++;
+      }
+    }
+
+    deserializer.get(out, outPosition, indexes, cnt, indexOffset, values.length);
+
+    Assert.assertArrayEquals(
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+        expectedOut,
+        out
+    );
+  }
+
+  private static void testNoncontiguousGetEveryOtherValueWithLimit(
+      final VSizeLongSerde.LongDeserializer deserializer,
+      final int numBits,
+      final long[] values
+  )
+  {
+    final int indexOffset = 1;
+    final int outPosition = 1;
+    final long[] out = new long[values.length + outPosition];
+    final long[] expectedOut = new long[values.length + outPosition];
+    final int[] indexes = new int[values.length + outPosition];
+    final int limit = values.length - 2; // Don't do the last value
+
+    Arrays.fill(out, -1);
+    Arrays.fill(expectedOut, -1);
+    Arrays.fill(indexes, -1);
+
+    int cnt = 0;
+    for (int i = 0; i < values.length; i++) {
+      if (i % 2 == 0) {
+        indexes[outPosition + i / 2] = i + indexOffset;
+
+        if (i < limit) {
+          expectedOut[outPosition + i / 2] = values[i];
+        }
+
+        cnt++;
+      }
+    }
+
+    final int ret = deserializer.get(out, outPosition, indexes, cnt, indexOffset, limit);
+
+    Assert.assertArrayEquals(
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+        expectedOut,
+        out
+    );
+
+    Assert.assertEquals(Math.max(0, cnt - 1), ret);
+  }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/VSizeLongSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/VSizeLongSerdeTest.java
@@ -238,8 +238,9 @@ public class VSizeLongSerdeTest
     final long[] out = new long[values.length + outPosition];
 
     for (int i = 0; i < values.length; i++) {
+
       Arrays.fill(out, -1);
-      deserializer.get(out, outPosition, i, 1);
+      deserializer.getDelta(out, outPosition, i, 1, 0);
 
       Assert.assertEquals(
           StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
@@ -258,7 +259,7 @@ public class VSizeLongSerdeTest
     final int outPosition = 1;
     final long[] out = new long[values.length + outPosition];
     Arrays.fill(out, -1);
-    deserializer.get(out, outPosition, 0, values.length);
+    deserializer.getDelta(out, outPosition, 0, values.length, 0);
 
     Assert.assertArrayEquals(
         StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits),
@@ -283,7 +284,7 @@ public class VSizeLongSerdeTest
       Arrays.fill(indexes, -1);
       indexes[outPosition] = i + indexOffset;
 
-      deserializer.get(out, outPosition, indexes, 1, indexOffset, values.length);
+      deserializer.getDelta(out, outPosition, indexes, 1, indexOffset, values.length, 0);
 
       Assert.assertEquals(
           StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
@@ -318,7 +319,7 @@ public class VSizeLongSerdeTest
       }
     }
 
-    deserializer.get(out, outPosition, indexes, cnt, indexOffset, values.length);
+    deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, values.length, 0);
 
     Assert.assertArrayEquals(
         StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
@@ -357,7 +358,7 @@ public class VSizeLongSerdeTest
       }
     }
 
-    final int ret = deserializer.get(out, outPosition, indexes, cnt, indexOffset, limit);
+    final int ret = deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, limit, 0);
 
     Assert.assertArrayEquals(
         StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),


### PR DESCRIPTION
### Description
This PR specializes `LongDeserializer` implementations with `getDelta` and `getTable` methods to push down unpacking bits, delta encoding adjustment, and table lookups for vectors of data as far as possible and work more efficiently with vectorized query engines, primarily focusing on contiguous reads.

It works by unrolling value reads to line up with `ByteBuffer` get methods to eliminate overlapping reads where possible, reading blocks of 8 values at a time for un-aligned values (1, 2, 4, 12, 20, 24, 40, 48, 56). `ByteBuffer` aligned bit-packing widths (8, 16, 32, 64) actually performed worse when this same unrolling was performed, so instead they utilize a traditional for loop with the aligned get methods.

Most of the improvement is on the small end since it has the most redundant/overlapping memory accesses, but is pretty decent improvement there.

### Full column scans before/after on uniform distribution columns of varying bits to cover the entire set of value decoders
before:

```
Benchmark                                                                           (distribution)  (encoding)  (filteredRowCountPercentage)   (rows)  (zeroProbability)  Mode  Cnt         Score      Error  Units
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-1    lz4-auto                           1.0  5000000                0.0  avgt    5     23862.994 ± 1944.514  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-2    lz4-auto                           1.0  5000000                0.0  avgt    5     23567.778 ±  757.632  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-4    lz4-auto                           1.0  5000000                0.0  avgt    5     28826.685 ± 3260.379  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-8    lz4-auto                           1.0  5000000                0.0  avgt    5     19829.688 ±  923.047  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-12    lz4-auto                           1.0  5000000                0.0  avgt    5     32419.941 ± 1486.951  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-16    lz4-auto                           1.0  5000000                0.0  avgt    5     22460.206 ± 4207.942  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-20    lz4-auto                           1.0  5000000                0.0  avgt    5     31415.040 ± 3867.699  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-24    lz4-auto                           1.0  5000000                0.0  avgt    5     24444.519 ± 2472.537  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uinform-32    lz4-auto                           1.0  5000000                0.0  avgt    5     18031.908 ± 1471.220  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-40    lz4-auto                           1.0  5000000                0.0  avgt    5     22442.611 ± 1778.178  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-48    lz4-auto                           1.0  5000000                0.0  avgt    5     24733.015 ± 3076.896  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-56    lz4-auto                           1.0  5000000                0.0  avgt    5     23201.264 ± 1578.009  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-64    lz4-auto                           1.0  5000000                0.0  avgt    5     20581.399 ± 1269.190  us/op
```

after:
```
Benchmark                                                                           (distribution)  (encoding)  (filteredRowCountPercentage)   (rows)
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-1    lz4-auto                           1.0  5000000                0.0  avgt    5     17892.362 ±  102.776  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-2    lz4-auto                           1.0  5000000                0.0  avgt    5     17796.103 ±  417.847  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-4    lz4-auto                           1.0  5000000                0.0  avgt    5     17879.496 ±  237.066  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                       uniform-8    lz4-auto                           1.0  5000000                0.0  avgt    5     17508.260 ±  560.856  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-12    lz4-auto                           1.0  5000000                0.0  avgt    5     18272.440 ±   71.751  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-16    lz4-auto                           1.0  5000000                0.0  avgt    5     19042.292 ±  595.685  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-20    lz4-auto                           1.0  5000000                0.0  avgt    5     18782.746 ±  248.738  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-24    lz4-auto                           1.0  5000000                0.0  avgt    5     19048.354 ±  160.025  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uinform-32    lz4-auto                           1.0  5000000                0.0  avgt    5     17984.778 ±  633.691  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-40    lz4-auto                           1.0  5000000                0.0  avgt    5     22070.007 ±  166.035  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-48    lz4-auto                           1.0  5000000                0.0  avgt    5     22052.517 ± 2168.763  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-56    lz4-auto                           1.0  5000000                0.0  avgt    5     25001.739 ±  259.184  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                      uniform-64    lz4-auto                           1.0  5000000                0.0  avgt    5     20325.369 ±   60.724  us/op
```

### Full column scans on other value distribution before/after comparison
before:
```
Benchmark                                                                           (distribution)  (encoding)  (filteredRowCountPercentage)   (rows)  (zeroProbability)  Mode  Cnt         Score      Error  Units
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                  enumerated-0-1    lz4-auto                           1.0  5000000                0.0  avgt    5     24186.788 ± 1440.692  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 enumerated-full    lz4-auto                           1.0  5000000                0.0  avgt    5     27220.865 ± 2221.740  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                     normal-1-32    lz4-auto                           1.0  5000000                0.0  avgt    5     19490.250 ± 1231.429  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                  normal-40-1000    lz4-auto                           1.0  5000000                0.0  avgt    5     20701.792 ± 1898.845  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 sequential-1000    lz4-auto                           1.0  5000000                0.0  avgt    5     28977.482 ±  878.240  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized               sequential-unique    lz4-auto                           1.0  5000000                0.0  avgt    5     22856.419 ±  247.786  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                    zipf-low-100    lz4-auto                           1.0  5000000                0.0  avgt    5     19135.244 ±  437.260  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 zipf-low-100000    lz4-auto                           1.0  5000000                0.0  avgt    5     31696.149 ± 2933.263  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 zipf-low-32-bit    lz4-auto                           1.0  5000000                0.0  avgt    5     25815.759 ± 2073.480  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   zipf-high-100    lz4-auto                           1.0  5000000                0.0  avgt    5     20582.544 ± 1726.414  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                zipf-high-100000    lz4-auto                           1.0  5000000                0.0  avgt    5     18996.105 ± 1412.307  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                zipf-high-32-bit    lz4-auto                           1.0  5000000                0.0  avgt    5     18628.002 ±  450.125  us/op
```

after:
```
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                  enumerated-0-1    lz4-auto                           1.0  5000000                0.0  avgt    5     19250.882 ± 1221.067  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 enumerated-full    lz4-auto                           1.0  5000000                0.0  avgt    5     19853.160 ±  780.701  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                     normal-1-32    lz4-auto                           1.0  5000000                0.0  avgt    5     18414.646 ± 1705.926  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                  normal-40-1000    lz4-auto                           1.0  5000000                0.0  avgt    5     20054.183 ± 2539.912  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 sequential-1000    lz4-auto                           1.0  5000000                0.0  avgt    5     18585.123 ± 1524.581  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized               sequential-unique    lz4-auto                           1.0  5000000                0.0  avgt    5     19304.239 ±  808.152  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                    zipf-low-100    lz4-auto                           1.0  5000000                0.0  avgt    5     19248.088 ±  470.994  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 zipf-low-100000    lz4-auto                           1.0  5000000                0.0  avgt    5     23815.318 ± 4413.581  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                 zipf-low-32-bit    lz4-auto                           1.0  5000000                0.0  avgt    5     26111.974 ± 4594.582  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   zipf-high-100    lz4-auto                           1.0  5000000                0.0  avgt    5     20144.349 ±  489.978  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                zipf-high-100000    lz4-auto                           1.0  5000000                0.0  avgt    5     18956.415 ±  796.136  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                zipf-high-32-bit    lz4-auto                           1.0  5000000                0.0  avgt    5     18666.583 ±  385.407  us/op
```

### Full benchmarks on column scan value selects with simulated filters (up to full scan) 
For the top line graph, the x axis is percent of rows selected by column scan (offset analog) and goes up to 1.0/contiguous scan. The y axis is the amount of time it took to select that many values. The numbers are kind of noisy because i didn't spend the multiple days necessary to do it proper, but it gives a decent idea. Nearly all of the improvement is on the full scan end of the spectrum (last datapoint), because the underlying `BitmapVectorOffset` will never call the contiguous vectorized get methods (which I will fix in a follow-up PR) and the contiguous gets were the primary area of improvement in this PR. The bottom bar chart is the size of the column in bytes as it would be stored in a segment (encoded and/or compressed).

![before-after](https://user-images.githubusercontent.com/1577461/111410582-3d80ce00-8696-11eb-8f6c-c57230ba0849.gif)

In a follow-up PR i will probably argue for making this the default long encoding since it does pretty well with the vectorized engine, compared to lz4 longs.

<hr>

### Unpacking
I uh, drew pictures to help me get the shifts and masking correct, so I'll add them here in case they are any help to reviewers. Imagine each diagram for the bit width is the number of values to unpack (8) per loop, where each color is a separate value, and each box is 4 bits.

<img width="1058" alt="PNG image-9F52520DEE1D-1" src="https://user-images.githubusercontent.com/1577461/111421585-7d51b080-86aa-11eb-8360-933e60274e3c.png">
<img width="1036" alt="PNG image-BA4F111C2B53-1" src="https://user-images.githubusercontent.com/1577461/111421614-86db1880-86aa-11eb-9651-cc750878125a.png">
<img width="958" alt="PNG image-F37823656142-1" src="https://user-images.githubusercontent.com/1577461/111421645-94909e00-86aa-11eb-9127-8f37c403e727.png">
<img width="974" alt="PNG image-8754DDE6B474-1" src="https://user-images.githubusercontent.com/1577461/111421668-9ce8d900-86aa-11eb-963f-79b5521ab92e.png">
<img width="1022" alt="PNG image-D07C1140D960-1" src="https://user-images.githubusercontent.com/1577461/111421682-a3775080-86aa-11eb-85d2-e84ab0e12885.png">


<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.

