### PR TITLE
[BUG FIX]Kinesis lag keep increasing when there is no more new data for kinesis stream

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -84,7 +84,7 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8.0_221" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -84,7 +84,7 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8.0_221" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -863,19 +863,34 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
         iteratorType = ShardIteratorType.AT_SEQUENCE_NUMBER.toString();
         offsetToUse = offset;
       }
-      String shardIterator = kinesis.getShardIterator(
-          partition.getStream(),
-          partition.getPartitionId(),
-          iteratorType,
-          offsetToUse
-      ).getShardIterator();
 
-      GetRecordsResult recordsResult = kinesis.getRecords(
-          new GetRecordsRequest().withShardIterator(shardIterator).withLimit(1)
-      );
+      GetRecordsResult recordsResult = getRecords(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString(), offsetToUse, partition);
+
+      // If no more new data after offsetToUse, it means there is no lag for now.
+      // So report lag points as 0L.
+      if (recordsResult.getRecords().size() == 0) {
+        return 0L;
+      } else {
+        recordsResult = getRecords(iteratorType, offsetToUse, partition);
+      }
 
       return recordsResult.getMillisBehindLatest();
     });
+  }
+
+  private GetRecordsResult getRecords(String iteratorType, String offsetToUse, StreamPartition<String> partition)
+  {
+    String shardIterator = kinesis.getShardIterator(
+            partition.getStream(),
+            partition.getPartitionId(),
+            iteratorType,
+            offsetToUse
+    ).getShardIterator();
+
+    GetRecordsResult recordsResult = kinesis.getRecords(
+            new GetRecordsRequest().withShardIterator(shardIterator).withLimit(1)
+    );
+    return recordsResult;
   }
 
   /**

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -864,21 +864,21 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
         offsetToUse = offset;
       }
 
-      GetRecordsResult recordsResult = getRecords(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString(), offsetToUse, partition);
+      GetRecordsResult recordsResult = getRecordsForLag(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString(), offsetToUse, partition);
 
       // If no more new data after offsetToUse, it means there is no lag for now.
       // So report lag points as 0L.
       if (recordsResult.getRecords().size() == 0) {
         return 0L;
       } else {
-        recordsResult = getRecords(iteratorType, offsetToUse, partition);
+        recordsResult = getRecordsForLag(iteratorType, offsetToUse, partition);
       }
 
       return recordsResult.getMillisBehindLatest();
     });
   }
 
-  private GetRecordsResult getRecords(String iteratorType, String offsetToUse, StreamPartition<String> partition)
+  private GetRecordsResult getRecordsForLag(String iteratorType, String offsetToUse, StreamPartition<String> partition)
   {
     String shardIterator = kinesis.getShardIterator(
             partition.getStream(),

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
@@ -70,17 +70,19 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   private static final String SHARD_ID0 = "0";
   private static final String SHARD1_ITERATOR = "1";
   private static final String SHARD0_ITERATOR = "0";
-  private static final String SHARD2_ITERATOR = "2";
 
   private static final Long SHARD0_LAG_MILLIS = 100L;
   private static final Long SHARD1_LAG_MILLIS = 200L;
+  private static final Long SHARD1_LAG_MILLIS_EMPTY = 0L;
   private static Map<String, Long> SHARDS_LAG_MILLIS =
       ImmutableMap.of(SHARD_ID0, SHARD0_LAG_MILLIS, SHARD_ID1, SHARD1_LAG_MILLIS);
+  private static Map<String, Long> SHARDS_LAG_MILLIS_EMPTY =
+          ImmutableMap.of(SHARD_ID0, SHARD0_LAG_MILLIS, SHARD_ID1, SHARD1_LAG_MILLIS_EMPTY);
   private static final List<Record> SHARD0_RECORDS = ImmutableList.of(
       new Record().withData(jb("2008", "a", "y", "10", "20.0", "1.0")).withSequenceNumber("0"),
       new Record().withData(jb("2009", "b", "y", "10", "20.0", "1.0")).withSequenceNumber("1")
   );
-  private static final List<Record> SHARD2_RECORDS = ImmutableList.of(new Record());
+  private static final List<Record> SHARD1_RECORDS_EMPTY = ImmutableList.of();
   private static final List<Record> SHARD1_RECORDS = ImmutableList.of(
       new Record().withData(jb("2011", "d", "y", "10", "20.0", "1.0")).withSequenceNumber("0"),
       new Record().withData(jb("2011", "e", "y", "10", "20.0", "1.0")).withSequenceNumber("1"),
@@ -148,9 +150,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   private static DescribeStreamResult describeStreamResult1;
   private static GetShardIteratorResult getShardIteratorResult0;
   private static GetShardIteratorResult getShardIteratorResult1;
-  private static GetShardIteratorResult getShardIteratorResult2;
   private static GetRecordsResult getRecordsResult0;
-  private static GetRecordsResult getRecordsResult2;
   private static GetRecordsResult getRecordsResult1;
   private static StreamDescription streamDescription0;
   private static StreamDescription streamDescription1;
@@ -166,9 +166,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     describeStreamResult1 = createMock(DescribeStreamResult.class);
     getShardIteratorResult0 = createMock(GetShardIteratorResult.class);
     getShardIteratorResult1 = createMock(GetShardIteratorResult.class);
-    getShardIteratorResult2 = createMock(GetShardIteratorResult.class);
     getRecordsResult0 = createMock(GetRecordsResult.class);
-    getRecordsResult2 = createMock(GetRecordsResult.class);
     getRecordsResult1 = createMock(GetRecordsResult.class);
     streamDescription0 = createMock(StreamDescription.class);
     streamDescription1 = createMock(StreamDescription.class);
@@ -939,34 +937,43 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
             EasyMock.eq(SHARD_ID0),
             EasyMock.eq(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString()),
             EasyMock.matches("\\d+")
-    )).andReturn(getShardIteratorResult2).anyTimes();
+    )).andReturn(getShardIteratorResult0).anyTimes();
 
     EasyMock.expect(kinesis.getShardIterator(
-        EasyMock.anyObject(),
-        EasyMock.eq(SHARD_ID1),
-        EasyMock.anyString(),
-        EasyMock.or(EasyMock.matches("\\d+"), EasyMock.isNull())
+            EasyMock.anyObject(),
+            EasyMock.eq(SHARD_ID1),
+            EasyMock.eq(ShardIteratorType.TRIM_HORIZON.toString()),
+            EasyMock.or(EasyMock.matches("\\d+"), EasyMock.isNull())
+    )).andReturn(getShardIteratorResult1).anyTimes();
+
+    EasyMock.expect(kinesis.getShardIterator(
+            EasyMock.anyObject(),
+            EasyMock.eq(SHARD_ID1),
+            EasyMock.eq(ShardIteratorType.AT_SEQUENCE_NUMBER.toString()),
+            EasyMock.matches("\\d+")
+    )).andReturn(getShardIteratorResult1).anyTimes();
+
+    EasyMock.expect(kinesis.getShardIterator(
+            EasyMock.anyObject(),
+            EasyMock.eq(SHARD_ID1),
+            EasyMock.eq(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString()),
+            EasyMock.matches("\\d+")
     )).andReturn(getShardIteratorResult1).anyTimes();
 
     EasyMock.expect(getShardIteratorResult0.getShardIterator()).andReturn(SHARD0_ITERATOR).anyTimes();
-    EasyMock.expect(getShardIteratorResult2.getShardIterator()).andReturn(SHARD2_ITERATOR).anyTimes();
     EasyMock.expect(getShardIteratorResult1.getShardIterator()).andReturn(SHARD1_ITERATOR).anyTimes();
     EasyMock.expect(kinesis.getRecords(generateGetRecordsReq(SHARD0_ITERATOR, recordsPerFetch)))
             .andReturn(getRecordsResult0)
             .anyTimes();
-    EasyMock.expect(kinesis.getRecords(generateGetRecordsReq(SHARD2_ITERATOR, recordsPerFetch)))
-            .andReturn(getRecordsResult2)
-            .anyTimes();
     EasyMock.expect(kinesis.getRecords(generateGetRecordsReq(SHARD1_ITERATOR, recordsPerFetch)))
             .andReturn(getRecordsResult1)
             .anyTimes();
-    EasyMock.expect(getRecordsResult0.getRecords()).andReturn(SHARD0_RECORDS).once();
-    EasyMock.expect(getRecordsResult2.getRecords()).andReturn(SHARD2_RECORDS).once();
-    EasyMock.expect(getRecordsResult1.getRecords()).andReturn(SHARD1_RECORDS).times(2);
+    EasyMock.expect(getRecordsResult0.getRecords()).andReturn(SHARD0_RECORDS).times(2);
+    EasyMock.expect(getRecordsResult1.getRecords()).andReturn(SHARD1_RECORDS_EMPTY).times(2);
     EasyMock.expect(getRecordsResult0.getNextShardIterator()).andReturn(null).anyTimes();
     EasyMock.expect(getRecordsResult1.getNextShardIterator()).andReturn(null).anyTimes();
     EasyMock.expect(getRecordsResult0.getMillisBehindLatest()).andReturn(SHARD0_LAG_MILLIS).times(2);
-    EasyMock.expect(getRecordsResult1.getMillisBehindLatest()).andReturn(SHARD1_LAG_MILLIS).times(2);
+    EasyMock.expect(getRecordsResult1.getMillisBehindLatest()).andReturn(SHARD1_LAG_MILLIS_EMPTY).once();
 
     replayAll();
 
@@ -1001,14 +1008,14 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
 
 
     Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertEquals(SHARDS_LAG_MILLIS, timeLag);
+    Assert.assertEquals(SHARDS_LAG_MILLIS_EMPTY, timeLag);
 
     Map<String, String> offsets = ImmutableMap.of(
         SHARD_ID1, SHARD1_RECORDS.get(0).getSequenceNumber(),
         SHARD_ID0, SHARD0_RECORDS.get(0).getSequenceNumber()
     );
     Map<String, Long> independentTimeLag = recordSupplier.getPartitionsTimeLag(STREAM, offsets);
-    Assert.assertEquals(SHARDS_LAG_MILLIS, independentTimeLag);
+    Assert.assertEquals(SHARDS_LAG_MILLIS_EMPTY, independentTimeLag);
 
     // Verify that kinesis apis are not called for custom sequence numbers
     for (String sequenceNum : Arrays.asList(NO_END_SEQUENCE_NUMBER, END_OF_SHARD_MARKER, EXPIRED_MARKER)) {

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
@@ -70,6 +70,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   private static final String SHARD_ID0 = "0";
   private static final String SHARD1_ITERATOR = "1";
   private static final String SHARD0_ITERATOR = "0";
+  private static final String SHARD2_ITERATOR = "2";
 
   private static final Long SHARD0_LAG_MILLIS = 100L;
   private static final Long SHARD1_LAG_MILLIS = 200L;
@@ -79,6 +80,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
       new Record().withData(jb("2008", "a", "y", "10", "20.0", "1.0")).withSequenceNumber("0"),
       new Record().withData(jb("2009", "b", "y", "10", "20.0", "1.0")).withSequenceNumber("1")
   );
+  private static final List<Record> SHARD2_RECORDS = ImmutableList.of(new Record());
   private static final List<Record> SHARD1_RECORDS = ImmutableList.of(
       new Record().withData(jb("2011", "d", "y", "10", "20.0", "1.0")).withSequenceNumber("0"),
       new Record().withData(jb("2011", "e", "y", "10", "20.0", "1.0")).withSequenceNumber("1"),
@@ -146,7 +148,9 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   private static DescribeStreamResult describeStreamResult1;
   private static GetShardIteratorResult getShardIteratorResult0;
   private static GetShardIteratorResult getShardIteratorResult1;
+  private static GetShardIteratorResult getShardIteratorResult2;
   private static GetRecordsResult getRecordsResult0;
+  private static GetRecordsResult getRecordsResult2;
   private static GetRecordsResult getRecordsResult1;
   private static StreamDescription streamDescription0;
   private static StreamDescription streamDescription1;
@@ -162,7 +166,9 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     describeStreamResult1 = createMock(DescribeStreamResult.class);
     getShardIteratorResult0 = createMock(GetShardIteratorResult.class);
     getShardIteratorResult1 = createMock(GetShardIteratorResult.class);
+    getShardIteratorResult2 = createMock(GetShardIteratorResult.class);
     getRecordsResult0 = createMock(GetRecordsResult.class);
+    getRecordsResult2 = createMock(GetRecordsResult.class);
     getRecordsResult1 = createMock(GetRecordsResult.class);
     streamDescription0 = createMock(StreamDescription.class);
     streamDescription1 = createMock(StreamDescription.class);
@@ -917,9 +923,23 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     EasyMock.expect(kinesis.getShardIterator(
         EasyMock.anyObject(),
         EasyMock.eq(SHARD_ID0),
-        EasyMock.anyString(),
-        EasyMock.or(EasyMock.matches("\\d+"), EasyMock.isNull())
+            EasyMock.eq(ShardIteratorType.TRIM_HORIZON.toString()),
+            EasyMock.or(EasyMock.matches("\\d+"), EasyMock.isNull())
     )).andReturn(getShardIteratorResult0).anyTimes();
+
+    EasyMock.expect(kinesis.getShardIterator(
+            EasyMock.anyObject(),
+            EasyMock.eq(SHARD_ID0),
+            EasyMock.eq(ShardIteratorType.AT_SEQUENCE_NUMBER.toString()),
+            EasyMock.matches("\\d+")
+    )).andReturn(getShardIteratorResult0).anyTimes();
+
+    EasyMock.expect(kinesis.getShardIterator(
+            EasyMock.anyObject(),
+            EasyMock.eq(SHARD_ID0),
+            EasyMock.eq(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString()),
+            EasyMock.matches("\\d+")
+    )).andReturn(getShardIteratorResult2).anyTimes();
 
     EasyMock.expect(kinesis.getShardIterator(
         EasyMock.anyObject(),
@@ -929,15 +949,20 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     )).andReturn(getShardIteratorResult1).anyTimes();
 
     EasyMock.expect(getShardIteratorResult0.getShardIterator()).andReturn(SHARD0_ITERATOR).anyTimes();
+    EasyMock.expect(getShardIteratorResult2.getShardIterator()).andReturn(SHARD2_ITERATOR).anyTimes();
     EasyMock.expect(getShardIteratorResult1.getShardIterator()).andReturn(SHARD1_ITERATOR).anyTimes();
     EasyMock.expect(kinesis.getRecords(generateGetRecordsReq(SHARD0_ITERATOR, recordsPerFetch)))
             .andReturn(getRecordsResult0)
+            .anyTimes();
+    EasyMock.expect(kinesis.getRecords(generateGetRecordsReq(SHARD2_ITERATOR, recordsPerFetch)))
+            .andReturn(getRecordsResult2)
             .anyTimes();
     EasyMock.expect(kinesis.getRecords(generateGetRecordsReq(SHARD1_ITERATOR, recordsPerFetch)))
             .andReturn(getRecordsResult1)
             .anyTimes();
     EasyMock.expect(getRecordsResult0.getRecords()).andReturn(SHARD0_RECORDS).once();
-    EasyMock.expect(getRecordsResult1.getRecords()).andReturn(SHARD1_RECORDS).once();
+    EasyMock.expect(getRecordsResult2.getRecords()).andReturn(SHARD2_RECORDS).once();
+    EasyMock.expect(getRecordsResult1.getRecords()).andReturn(SHARD1_RECORDS).times(2);
     EasyMock.expect(getRecordsResult0.getNextShardIterator()).andReturn(null).anyTimes();
     EasyMock.expect(getRecordsResult1.getNextShardIterator()).andReturn(null).anyTimes();
     EasyMock.expect(getRecordsResult0.getMillisBehindLatest()).andReturn(SHARD0_LAG_MILLIS).times(2);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes https://github.com/apache/druid/issues/11005.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
check the value of `AFTER_SEQUENCE_NUMBER`. If empty it means there is no more new data for current stream. So just return 0L here.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `KinesisRecordSupplier.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
