### PR TITLE
Improve performance of queries against SYSTEM.SEGMENT table.

### DIFF
--- a/server/src/main/java/org/apache/druid/server/security/AuthorizationUtils.java
+++ b/server/src/main/java/org/apache/druid/server/security/AuthorizationUtils.java
@@ -263,6 +263,10 @@ public class AuthorizationUtils
       throw new ISE("No authorizer found with name: [%s].", authenticationResult.getAuthorizerName());
     }
 
+    if (authorizer instanceof AllowAllAuthorizer) {
+      return resources;
+    }
+
     final Map<ResourceAction, Access> resultCache = new HashMap<>();
     final Iterable<ResType> filteredResources = Iterables.filter(
         resources,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -702,13 +702,14 @@ public class DruidSchema extends AbstractSchema
 
   Map<SegmentId, AvailableSegmentMetadata> getSegmentMetadataSnapshot()
   {
-    final Map<SegmentId, AvailableSegmentMetadata> segmentMetadata = new HashMap<>();
     synchronized (lock) {
+      final Map<SegmentId, AvailableSegmentMetadata> segmentMetadata = Maps.newHashMapWithExpectedSize(
+          segmentMetadataInfo.values().stream().mapToInt(v -> v.size()).sum());
       for (TreeMap<SegmentId, AvailableSegmentMetadata> val : segmentMetadataInfo.values()) {
         segmentMetadata.putAll(val);
       }
+      return segmentMetadata;
     }
-    return segmentMetadata;
   }
 
   int getTotalSegments()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -29,6 +29,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.inject.Inject;
@@ -90,7 +91,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -287,7 +287,7 @@ public class SystemSchema extends AbstractSchema
       // Coordinator.
       final Iterator<SegmentWithOvershadowedStatus> metadataStoreSegments = metadataView.getPublishedSegments();
 
-      final Set<SegmentId> segmentsAlreadySeen = new HashSet<>();
+      final Set<SegmentId> segmentsAlreadySeen = Sets.newHashSetWithExpectedSize(druidSchema.getTotalSegments());
 
       final FluentIterable<Object[]> publishedSegments = FluentIterable
           .from(() -> getAuthorizedPublishedSegments(metadataStoreSegments, root))


### PR DESCRIPTION
Fixes #11007 .

After hooking up Yourkit against the broker instance running the queries mentioned in the above issue, it turns out that a lot of time is being spent in resizing HashMap and HashSet that have been created with the default constructor. Also, a lot of CPU cycles are wasted unnecessarily looping through and authorizing resources even though the authorizer configured is AllowAllAuthorizer. 

After making these changes, on my test cluster, I see that the query times went down from ~12seconds to ~7seconds. 


This PR has:
- [X] been self-reviewed.
   - [X] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [X ] been tested in a test Druid cluster.
