### PR TITLE
Fix subquery with order by

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -134,11 +134,12 @@ public class DruidPlanner implements Closeable
       explain = (SqlExplain) parsed;
       parsed = explain.getExplicandum();
     }
-    final Pair<SqlNode, RelDataType> validated = planner.validateAndGetType(parsed);
-    RelRoot root = planner.rel(validated.getKey());
+    final SqlNode validated = planner.validate(parsed);
+    RelRoot root = planner.rel(validated);
     RelDataType rowType = root.validatedRowType;
 
-    RelDataType parameterTypes = validated.getValue();
+    SqlValidator validator = getValidator();
+    RelDataType parameterTypes = validator.getParameterRowType(validator.validate(validated));
 
     if (explain != null) {
       final RelDataTypeFactory typeFactory = root.rel.getCluster().getTypeFactory();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -134,12 +134,11 @@ public class DruidPlanner implements Closeable
       explain = (SqlExplain) parsed;
       parsed = explain.getExplicandum();
     }
-    final SqlNode validated = planner.validate(parsed);
-    RelRoot root = planner.rel(validated);
+    final Pair<SqlNode, RelDataType> validated = planner.validateAndGetType(parsed);
+    RelRoot root = planner.rel(validated.getKey());
     RelDataType rowType = root.validatedRowType;
 
-    SqlValidator validator = getValidator();
-    RelDataType parameterTypes = validator.getParameterRowType(validator.validate(parsed));
+    RelDataType parameterTypes = validated.getValue();
 
     if (explain != null) {
       final RelDataTypeFactory typeFactory = root.rel.getCluster().getTypeFactory();

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidStatementTest.java
@@ -151,6 +151,34 @@ public class DruidStatementTest extends CalciteTestBase
   }
 
   @Test
+  public void testSubQueryWithOrderBy()
+  {
+    final String sql = "select T20.F13 as F22  from (SELECT DISTINCT dim1 as F13 FROM druid.foo T10) T20 order by T20.F13 ASC";
+    final DruidStatement statement = new DruidStatement("", 0, null, sqlLifecycleFactory.factorize(), () -> {
+    }).prepare(sql, -1, AllowAllAuthenticator.ALLOW_ALL_RESULT);
+    // First frame, ask for all rows.
+    Meta.Frame frame = statement.execute(Collections.emptyList()).nextFrame(DruidStatement.START_OFFSET, 6);
+    Assert.assertEquals(
+        Meta.Frame.create(
+            0,
+            true,
+            Lists.newArrayList(
+                new Object[]{""},
+                new Object[]{
+                    "1"
+                },
+                new Object[]{"10.1"},
+                new Object[]{"2"},
+                new Object[]{"abc"},
+                new Object[]{"def"}
+            )
+        ),
+        frame
+    );
+    Assert.assertTrue(statement.isDone());
+  }
+
+  @Test
   public void testSelectAllInFirstFrame()
   {
     final String sql = "SELECT __time, cnt, dim1, dim2, m1 FROM druid.foo";


### PR DESCRIPTION
Fixes #9871

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Problem:
In the jdbc connection, it is invalid to use subquery with `order by`  clause . It will throw excepiton with msg: `Table 'xxx' not found`

Reason:
The exception was thrown in `DruidPlanner.prepare()`, let 's see  the orginal code:
```
  public PrepareResult prepare(final String sql) throws SqlParseException, ValidationException, RelConversionException
  {
    reset();
    SqlNode parsed = planner.parse(sql);
    SqlExplain explain = null;
    if (parsed.getKind() == SqlKind.EXPLAIN) {
      explain = (SqlExplain) parsed;
      parsed = explain.getExplicandum();
    }
    final SqlNode validated = planner.validate(parsed);
    RelRoot root = planner.rel(validated);
    RelDataType rowType = root.validatedRowType;

    SqlValidator validator = getValidator();
    RelDataType parameterTypes = validator.getParameterRowType(validator.validate(parsed));

    if (explain != null) {
      final RelDataTypeFactory typeFactory = root.rel.getCluster().getTypeFactory();
      return new PrepareResult(getExplainStructType(typeFactory), parameterTypes);
    }
    return new PrepareResult(rowType, parameterTypes);
  }
```
The problem should focus on `validator.validate(parsed)`, we try to validate `parsed` sqlnode to get parameterTypes, However, when we use order by clause, the `order by` item will be pushed down into `sqlSelect` node through the method invoke chain
` SqlNode validated = planner.validate(parsed);` -> `PlannerImpl.validate(SqlNode sqlNode) ` ->`SqlValidatorImpl.validateScopedExpression` ->`SqlValidatorImpl.performUnconditionalRewrites` -> ` SqlSelect.setOrderBy(orderBy.orderList);`,  Therefore, the variable `parsed` was change in the first validation in the 
following code fragment:
```

        // Don't clobber existing ORDER BY.  It may be needed for
        // an order-sensitive function like RANK.
        if (select.getOrderList() == null) {
          // push ORDER BY into existing select
          select.setOrderBy(orderBy.orderList);
          select.setOffset(orderBy.offset);
          select.setFetch(orderBy.fetch);
          return select;
        }
      }
```
 When we validate it sencondly ,  in the same method `SqlValidatorImpl.performUnconditionalRewrites`,  the `select.getOrderList()` is not null , and  it finally build a sqlSelect node similar to `select * `, which leads to the excepiton with msg :`Table 'xxx' not found`


Solution:
1. we can validate for variable `validated` which is the result for first validation and it  is similar to the api `PlannerImpl.validateAndGetType(SqlNode sqlNode)`



<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.sql.calcite.planner.DruidPlanner`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
