### PR TITLE
add protobuf inputformat

### DIFF
--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -295,8 +295,7 @@ The `inputFormat` to load data of Protobuf format. An example is:
           "expr": "$.someRecord.subInt"
         }
       ]
-    },
-    "binaryAsString": false
+    }
   },
   ...
 }
@@ -304,9 +303,9 @@ The `inputFormat` to load data of Protobuf format. An example is:
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
-|type| String| This should be set to `protobuf` to read Protobuf file| yes |
+|type| String| This should be set to `protobuf` to read Protobuf serialized data| yes |
 |flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Protobuf record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
-|protoBytesDecoder| JSON Object |Specifies how to decode bytes to Protobuf record. | yes |
+|`protoBytesDecoder`| JSON Object |Specifies how to decode bytes to Protobuf record. | yes |
 
 ### FlattenSpec
 
@@ -1102,7 +1101,7 @@ This parser is for [stream ingestion](./index.md#streaming) and reads Protocol b
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
 | type | String | This should say `protobuf`. | yes |
-| protoBytesDecoder | JSON Object | Specifies how to decode bytes to Protobuf record. | yes |
+| `protoBytesDecoder` | JSON Object | Specifies how to decode bytes to Protobuf record. | yes |
 | parseSpec | JSON Object | Specifies the timestamp and dimensions of the data.  The format must be JSON. See [JSON ParseSpec](./index.md) for more configuration options.  Note that timeAndDims parseSpec is no longer supported. | yes |
 
 Sample spec:
@@ -1144,7 +1143,7 @@ more details and examples.
 
 #### Protobuf Bytes Decoder
 
-If `type` is not included, the avroBytesDecoder defaults to `schema_registry`.
+If `type` is not included, the `protoBytesDecoder` defaults to `schema_registry`.
 
 ##### File-based Protobuf Bytes Decoder
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -265,9 +265,16 @@ The `inputFormat` to load data of Avro OCF format. An example is:
 }
 ```
 
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+|type| String| This should be set to `avro_ocf` to read Avro OCF file| yes |
+|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Avro records. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
+|schema| JSON Object |Define a reader schema to be used when parsing Avro records, this is useful when parsing multiple versions of Avro OCF file data | no (default will decode using the writer schema contained in the OCF file) |
+| binaryAsString | Boolean | Specifies if the bytes parquet column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
+
 ### Protobuf
 
-> You need to include the [`druid-avro-extensions`](../development/extensions-core/protobuf.md) as an extension to use the Avro OCF input format.
+> You need to include the [`druid-protobuf-extensions`](../development/extensions-core/protobuf.md) as an extension to use the Protobuf input format.
 
 The `inputFormat` to load data of Protobuf format. An example is:
 ```json
@@ -297,10 +304,9 @@ The `inputFormat` to load data of Protobuf format. An example is:
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
-|type| String| This should be set to `avro_ocf` to read Avro OCF file| yes |
-|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Avro records. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
-|schema| JSON Object |Define a reader schema to be used when parsing Avro records, this is useful when parsing multiple versions of Avro OCF file data | no (default will decode using the writer schema contained in the OCF file) |
-| binaryAsString | Boolean | Specifies if the bytes parquet column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
+|type| String| This should be set to `protobuf` to read Protobuf file| yes |
+|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Protobuf record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
+|protoBytesDecoder| JSON Object |Specifies how to decode bytes to Protobuf record. | yes |
 
 ### FlattenSpec
 

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -137,6 +137,10 @@
       <version>2.0.1</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -158,6 +158,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
@@ -149,7 +149,8 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
 
     FileBasedProtobufBytesDecoder that = (FileBasedProtobufBytesDecoder) o;
 
-    return Objects.equals(descriptorFilePath, that.descriptorFilePath);
+    return Objects.equals(descriptorFilePath, that.descriptorFilePath) &&
+        Objects.equals(protoMessageType, that.protoMessageType);
   }
 
   @Override

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
@@ -152,4 +152,10 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
     return Objects.equals(descriptorFilePath, that.descriptorFilePath);
   }
 
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(descriptorFilePath, protoMessageType);
+  }
+
 }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.Set;
 
 public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
@@ -52,6 +53,18 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
     this.descriptorFilePath = descriptorFilePath;
     this.protoMessageType = protoMessageType;
     initDescriptor();
+  }
+
+  @JsonProperty
+  public String getDescriptor()
+  {
+    return descriptorFilePath;
+  }
+
+  @JsonProperty
+  public String getProtoMessageType()
+  {
+    return protoMessageType;
   }
 
   @VisibleForTesting
@@ -123,4 +136,20 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
     }
     return desc;
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FileBasedProtobufBytesDecoder that = (FileBasedProtobufBytesDecoder) o;
+
+    return Objects.equals(descriptorFilePath, that.descriptorFilePath);
+  }
+
 }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufExtensionsModule.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufExtensionsModule.java
@@ -38,7 +38,7 @@ public class ProtobufExtensionsModule implements DruidModule
         new SimpleModule("ProtobufInputRowParserModule")
             .registerSubtypes(
                 new NamedType(ProtobufInputRowParser.class, "protobuf"),
-                new NamedType(ProtobufInputFormat.class, "protobuf_format")
+                new NamedType(ProtobufInputFormat.class, "protobuf")
             )
     );
   }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufExtensionsModule.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufExtensionsModule.java
@@ -37,7 +37,8 @@ public class ProtobufExtensionsModule implements DruidModule
     return Collections.singletonList(
         new SimpleModule("ProtobufInputRowParserModule")
             .registerSubtypes(
-                new NamedType(ProtobufInputRowParser.class, "protobuf")
+                new NamedType(ProtobufInputRowParser.class, "protobuf"),
+                new NamedType(ProtobufInputFormat.class, "protobuf_format")
             )
     );
   }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputFormat.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputFormat.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.protobuf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.data.input.InputEntity;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.NestedInputFormat;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+
+public class ProtobufInputFormat extends NestedInputFormat
+{
+  private final ProtobufBytesDecoder protobufBytesDecoder;
+
+  @JsonCreator
+  public ProtobufInputFormat(
+      @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
+      @JsonProperty("protoBytesDecoder") ProtobufBytesDecoder protobufBytesDecoder
+  )
+  {
+    super(flattenSpec);
+    this.protobufBytesDecoder = protobufBytesDecoder;
+  }
+
+  @Override
+  public boolean isSplittable()
+  {
+    return false;
+  }
+
+  @Override
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  {
+    return new ProtobufReader(
+        inputRowSchema,
+        source,
+        protobufBytesDecoder,
+        getFlattenSpec()
+    );
+  }
+}

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputFormat.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputFormat.java
@@ -82,4 +82,11 @@ public class ProtobufInputFormat extends NestedInputFormat
     return Objects.equals(getFlattenSpec(), that.getFlattenSpec()) &&
         Objects.equals(protobufBytesDecoder, that.protobufBytesDecoder);
   }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(protobufBytesDecoder, getFlattenSpec());
+  }
+
 }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputFormat.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufInputFormat.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import javax.annotation.Nullable;
 
 import java.io.File;
+import java.util.Objects;
 
 public class ProtobufInputFormat extends NestedInputFormat
 {
@@ -43,6 +44,12 @@ public class ProtobufInputFormat extends NestedInputFormat
   {
     super(flattenSpec);
     this.protobufBytesDecoder = protobufBytesDecoder;
+  }
+
+  @JsonProperty
+  public ProtobufBytesDecoder getProtoBytesDecoder()
+  {
+    return protobufBytesDecoder;
   }
 
   @Override
@@ -60,5 +67,19 @@ public class ProtobufInputFormat extends NestedInputFormat
         protobufBytesDecoder,
         getFlattenSpec()
     );
+  }
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProtobufInputFormat that = (ProtobufInputFormat) o;
+    return Objects.equals(getFlattenSpec(), that.getFlattenSpec()) &&
+        Objects.equals(protobufBytesDecoder, that.protobufBytesDecoder);
   }
 }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.protobuf;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterators;
+import com.google.protobuf.util.JsonFormat;
+import org.apache.commons.io.IOUtils;
+import org.apache.druid.data.input.InputEntity;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.IntermediateRowParsingReader;
+import org.apache.druid.data.input.impl.MapInputRowParser;
+import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.JSONFlattenerMaker;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.common.parsers.ObjectFlattener;
+import org.apache.druid.java.util.common.parsers.ObjectFlatteners;
+import org.apache.druid.java.util.common.parsers.ParseException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ProtobufReader extends IntermediateRowParsingReader<String>
+{
+  private final InputRowSchema inputRowSchema;
+  private final InputEntity source;
+  private final ObjectFlattener<JsonNode> recordFlattener;
+  private final ProtobufBytesDecoder protobufBytesDecoder;
+
+  ProtobufReader(
+      InputRowSchema inputRowSchema,
+      InputEntity source,
+      ProtobufBytesDecoder protobufBytesDecoder,
+      JSONPathSpec flattenSpec
+  )
+  {
+    this.inputRowSchema = inputRowSchema;
+    this.source = source;
+    this.protobufBytesDecoder = protobufBytesDecoder;
+    this.recordFlattener = ObjectFlatteners.create(flattenSpec, new JSONFlattenerMaker(true));
+  }
+
+  @Override
+  protected CloseableIterator<String> intermediateRowIterator() throws IOException
+  {
+    return CloseableIterators.withEmptyBaggage(
+        Iterators.singletonIterator(JsonFormat.printer().print(protobufBytesDecoder.parse(ByteBuffer.wrap(IOUtils.toByteArray(source.open())))
+        )));
+  }
+
+  @Override
+  protected List<InputRow> parseInputRows(String intermediateRow) throws ParseException, JsonProcessingException
+  {
+    JsonNode document = new ObjectMapper().readValue(intermediateRow, JsonNode.class);
+    final Map<String, Object> flattened = recordFlattener.flatten(document);
+    return Collections.singletonList(MapInputRowParser.parse(inputRowSchema, flattened));
+  }
+
+  @Override
+  protected List<Map<String, Object>> toMap(String intermediateRow) throws JsonProcessingException
+  {
+    return Collections.singletonList(new ObjectMapper().readValue(intermediateRow, Map.class));
+  }
+}

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
@@ -73,8 +73,8 @@ public class ProtobufReader extends IntermediateRowParsingReader<DynamicMessage>
   protected CloseableIterator<DynamicMessage> intermediateRowIterator() throws IOException
   {
     return CloseableIterators.withEmptyBaggage(
-        Iterators.singletonIterator(protobufBytesDecoder.parse(ByteBuffer.wrap(IOUtils.toByteArray(source.open())
-        ))));
+        Iterators.singletonIterator(protobufBytesDecoder.parse(ByteBuffer.wrap(IOUtils.toByteArray(source.open()))))
+    );
   }
 
   @Override

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -98,6 +98,20 @@ public class ProtobufInputFormatTest
   }
 
   @Test
+  public void testSerdeForSchemaRegistry() throws IOException
+  {
+    ProtobufInputFormat inputFormat = new ProtobufInputFormat(
+        flattenSpec,
+        new SchemaRegistryBasedProtobufBytesDecoder("http://test:8081", 100, null, null, null)
+    );
+    NestedInputFormat inputFormat2 = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(inputFormat),
+        NestedInputFormat.class
+    );
+    Assert.assertEquals(inputFormat, inputFormat2);
+  }
+
+  @Test
   public void testParseNestedData() throws Exception
   {
     //configure parser with desc file

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -19,13 +19,17 @@
 
 package org.apache.druid.data.input.protobuf;
 
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.NestedInputFormat;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
@@ -38,6 +42,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -50,6 +55,8 @@ public class ProtobufInputFormatTest
   private DimensionsSpec dimensionsSpec;
   private JSONPathSpec flattenSpec;
   private FileBasedProtobufBytesDecoder decoder;
+
+  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
 
   @Before
   public void setUp()
@@ -70,6 +77,24 @@ public class ProtobufInputFormatTest
         )
     );
     decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent");
+    for (Module jacksonModule : new ProtobufExtensionsModule().getJacksonModules()) {
+      jsonMapper.registerModule(jacksonModule);
+    }
+  }
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    ProtobufInputFormat inputFormat = new ProtobufInputFormat(
+        flattenSpec,
+        decoder
+    );
+    NestedInputFormat inputFormat2 = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(inputFormat),
+        NestedInputFormat.class
+    );
+
+    Assert.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -39,7 +39,6 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 
 public class ProtobufInputFormatTest
@@ -107,7 +106,7 @@ public class ProtobufInputFormatTest
 
     final ByteEntity entity = new ByteEntity(ByteBuffer.wrap(out.toByteArray()));
 
-    InputRow row = protobufInputFormat.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, Collections.emptyList()), entity, null).read().next();
+    InputRow row = protobufInputFormat.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, null), entity, null).read().next();
 
     Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
 
@@ -151,7 +150,7 @@ public class ProtobufInputFormatTest
 
     final ByteEntity entity = new ByteEntity(ByteBuffer.wrap(out.toByteArray()));
 
-    InputRow row = protobufInputFormat.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, Collections.emptyList()), entity, null).read().next();
+    InputRow row = protobufInputFormat.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, null), entity, null).read().next();
 
     System.out.println(row);
 

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.protobuf;
+
+import com.google.common.collect.Lists;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+public class ProtobufInputFormatTest
+{
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private TimestampSpec timestampSpec;
+  private DimensionsSpec dimensionsSpec;
+  private JSONPathSpec flattenSpec;
+  private FileBasedProtobufBytesDecoder decoder;
+
+  @Before
+  public void setUp()
+  {
+    timestampSpec = new TimestampSpec("timestamp", "iso", null);
+    dimensionsSpec = new DimensionsSpec(Lists.newArrayList(
+        new StringDimensionSchema("event"),
+        new StringDimensionSchema("id"),
+        new StringDimensionSchema("someOtherId"),
+        new StringDimensionSchema("isValid")
+    ), null, null);
+    flattenSpec = new JSONPathSpec(
+        true,
+        Lists.newArrayList(
+            new JSONPathFieldSpec(JSONPathFieldType.ROOT, "eventType", "eventType"),
+            new JSONPathFieldSpec(JSONPathFieldType.PATH, "foobar", "$.foo.bar"),
+            new JSONPathFieldSpec(JSONPathFieldType.PATH, "bar0", "$.bar[0].bar")
+        )
+    );
+    decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent");
+  }
+
+  @Test
+  public void testParseNestedData() throws Exception
+  {
+    //configure parser with desc file
+    ProtobufInputFormat protobufInputFormat = new ProtobufInputFormat(flattenSpec, decoder);
+
+    //create binary of proto test event
+    DateTime dateTime = new DateTime(2012, 7, 12, 9, 30, ISOChronology.getInstanceUTC());
+    ProtoTestEventWrapper.ProtoTestEvent event = ProtoTestEventWrapper.ProtoTestEvent.newBuilder()
+        .setDescription("description")
+        .setEventType(ProtoTestEventWrapper.ProtoTestEvent.EventCategory.CATEGORY_ONE)
+        .setId(4711L)
+        .setIsValid(true)
+        .setSomeOtherId(4712)
+        .setTimestamp(dateTime.toString())
+        .setSomeFloatColumn(47.11F)
+        .setSomeIntColumn(815)
+        .setSomeLongColumn(816L)
+        .setFoo(ProtoTestEventWrapper.ProtoTestEvent.Foo
+            .newBuilder()
+            .setBar("baz"))
+        .addBar(ProtoTestEventWrapper.ProtoTestEvent.Foo
+            .newBuilder()
+            .setBar("bar0"))
+        .addBar(ProtoTestEventWrapper.ProtoTestEvent.Foo
+            .newBuilder()
+            .setBar("bar1"))
+        .build();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    event.writeTo(out);
+
+    final ByteEntity entity = new ByteEntity(ByteBuffer.wrap(out.toByteArray()));
+
+    InputRow row = protobufInputFormat.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, Collections.emptyList()), entity, null).read().next();
+
+    Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+
+    assertDimensionEquals(row, "id", "4711");
+    assertDimensionEquals(row, "isValid", "true");
+    assertDimensionEquals(row, "someOtherId", "4712");
+    assertDimensionEquals(row, "description", "description");
+
+    assertDimensionEquals(row, "eventType", ProtoTestEventWrapper.ProtoTestEvent.EventCategory.CATEGORY_ONE.name());
+    assertDimensionEquals(row, "foobar", "baz");
+    assertDimensionEquals(row, "bar0", "bar0");
+
+
+    Assert.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
+    Assert.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
+    Assert.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
+  }
+
+  @Test
+  public void testParseFlatData() throws Exception
+  {
+    //configure parser with desc file
+    ProtobufInputFormat protobufInputFormat = new ProtobufInputFormat(null, decoder);
+
+    //create binary of proto test event
+    DateTime dateTime = new DateTime(2012, 7, 12, 9, 30, ISOChronology.getInstanceUTC());
+    ProtoTestEventWrapper.ProtoTestEvent event = ProtoTestEventWrapper.ProtoTestEvent.newBuilder()
+        .setDescription("description")
+        .setEventType(ProtoTestEventWrapper.ProtoTestEvent.EventCategory.CATEGORY_ONE)
+        .setId(4711L)
+        .setIsValid(true)
+        .setSomeOtherId(4712)
+        .setTimestamp(dateTime.toString())
+        .setSomeFloatColumn(47.11F)
+        .setSomeIntColumn(815)
+        .setSomeLongColumn(816L)
+        .build();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    event.writeTo(out);
+
+    final ByteEntity entity = new ByteEntity(ByteBuffer.wrap(out.toByteArray()));
+
+    InputRow row = protobufInputFormat.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, Collections.emptyList()), entity, null).read().next();
+
+    System.out.println(row);
+
+    Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+
+    assertDimensionEquals(row, "id", "4711");
+    assertDimensionEquals(row, "isValid", "true");
+    assertDimensionEquals(row, "someOtherId", "4712");
+    assertDimensionEquals(row, "description", "description");
+
+
+    Assert.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
+    Assert.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
+    Assert.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
+  }
+
+  private void assertDimensionEquals(InputRow row, String dimension, Object expected)
+  {
+    List<String> values = row.getDimension(dimension);
+    Assert.assertEquals(1, values.size());
+    Assert.assertEquals(expected, values.get(0));
+  }
+}

--- a/website/.spelling
+++ b/website/.spelling
@@ -630,6 +630,7 @@ Avro-1124
 SchemaRepo
 avro
 avroBytesDecoder
+protoBytesDecoder
 flattenSpec
 jq
 org.apache.druid.extensions


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->
Because of deprecated of parseSpec, I develop ProtobufInputFormat for new interface, which supports stream ingestion for data encoded by Protobuf.
<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
