### PR TITLE
Add missing coordinator dynamic config in web console

### DIFF
--- a/web-console/src/dialogs/coordinator-dynamic-config-dialog/__snapshots__/coordinator-dynamic-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/coordinator-dynamic-config-dialog/__snapshots__/coordinator-dynamic-config-dialog.spec.tsx.snap
@@ -183,6 +183,14 @@ exports[`coordinator dynamic config matches snapshot 1`] = `
           "name": "pauseCoordination",
           "type": "boolean",
         },
+        Object {
+          "defaultValue": false,
+          "info": <React.Fragment>
+            Boolean flag for whether or not additional replication is needed for segments that have failed to load due to the expiry of coordinator load timeout. If this is set to true, the coordinator will attempt to replicate the failed segment on a different historical server.
+          </React.Fragment>,
+          "name": "replicateAfterLoadTimeout",
+          "type": "boolean",
+        },
       ]
     }
     model={Object {}}

--- a/web-console/src/druid-models/coordinator-dynamic-config.tsx
+++ b/web-console/src/druid-models/coordinator-dynamic-config.tsx
@@ -222,4 +222,16 @@ export const COORDINATOR_DYNAMIC_CONFIG_FIELDS: Field<CoordinatorDynamicConfig>[
       </>
     ),
   },
+  {
+    name: 'replicateAfterLoadTimeout',
+    type: 'boolean',
+    defaultValue: false,
+    info: (
+      <>
+        Boolean flag for whether or not additional replication is needed for segments that have
+        failed to load due to the expiry of coordinator load timeout. If this is set to true, the
+        coordinator will attempt to replicate the failed segment on a different historical server.
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
The dynamic config property: `replicateAfterLoadTimeout` was recently added but it is missing from the Coordinator Dynamic Config dialog in the web console. This PR fixes this issue. 

<img width="496" alt="Screen Shot 2021-03-22 at 9 15 50 AM" src="https://user-images.githubusercontent.com/4603202/112004509-ddec4d80-8aef-11eb-97b3-f5db4f2f8a5b.png">


This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
