### PR TITLE
allow multiple ldap bootstrap files for integration tests

### DIFF
--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -60,7 +60,7 @@ services:
     image: druid/cluster
     container_name: druid-metadata-storage
     ports:
-      - 3306:3306
+      - 13306:3306
     networks:
       druid-it-net:
         ipv4_address: 172.172.172.3
@@ -371,7 +371,7 @@ services:
       - 8636:636
     privileged: true
     volumes:
-      - ./ldap-configs/bootstrap.ldif:/container/service/slapd/assets/config/bootstrap/ldif/bootstrap.ldif
+      - ./ldap-configs:/container/service/slapd/assets/config/bootstrap/ldif/custom
       - ${HOME}/shared:/shared
     env_file:
       - ./environment-configs/common


### PR DESCRIPTION
### Description

This PR allows the LDAP integration tests to read multiple bootstrap files so that you can add more configuration files for testing your custom extensions. It also changes the host port bound for metadata store as it can conflict when you have mysql running.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
