### PR TITLE
Suppress CVEs for Solr and org.codehaus.jackson

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -317,6 +317,7 @@
   </suppress>
 
   <suppress>
+     <!-- (ranger, ambari, and aliyun-oss) these vulnerabilities are legit, but their latest releases still use the vulnerable jackson version -->
      <notes><![CDATA[
      file name: jackson-xc-1.9.x.jar or jackson-jaxrs-1.9.x.jar
      ]]></notes>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -315,4 +315,24 @@
      ]]></notes>
     <cve>CVE-2020-13936</cve>
   </suppress>
+
+  <suppress>
+     <notes><![CDATA[
+     file name: jackson-xc-1.9.x.jar or jackson-jaxrs-1.9.x.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson-(xc|jaxrs)@1.9.*$</packageUrl>
+     <cve>CVE-2018-14718</cve>
+     <cve>CVE-2018-7489</cve>
+  </suppress>
+
+  <suppress>
+     <notes><![CDATA[
+     file name: solr-solrj-7.7.1.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.apache\.solr/solr-solrj@7.7.1$</packageUrl>
+     <cve>CVE-2020-13957</cve>
+     <cve>CVE-2019-17558</cve>
+     <cve>CVE-2019-0193</cve>
+     <cve>CVE-2020-13941</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Description

The security vulnerability check CI is failing against master with the below error (https://travis-ci.com/github/apache/druid/builds/221003723):

```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:6.0.3:aggregate (default-cli) on project druid: 
[ERROR] 
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
[ERROR] 
[ERROR] jackson-xc-1.9.13.jar: CVE-2018-14718, CVE-2018-7489
[ERROR] jackson-xc-1.9.2.jar: CVE-2018-14718, CVE-2018-7489
[ERROR] libthrift-0.13.0.jar: CVE-2020-13949
[ERROR] solr-solrj-7.7.1.jar: CVE-2020-13957, CVE-2019-0193, CVE-2019-17558, CVE-2020-13941
```

This PR suppresses all these CVEs except for CVE-2020-13949 which should be addressed in https://github.com/apache/druid/issues/11028.

Analysis of CVEs:

- CVEs for Solr 7.7.1 ([CVE-2020-13957](https://nvd.nist.gov/vuln/detail/CVE-2020-13957), CVE-2019-0193, CVE-2019-17558, [CVE-2020-13941](https://nvd.nist.gov/vuln/detail/CVE-2020-13941)): The ranger-security extension has a dependency on `ranger-plugins-audit` which supports [SolrAuditProvider](https://github.com/apache/ranger/blob/release-ranger-2.1.0/agents-audit/src/main/java/org/apache/ranger/audit/provider/solr/SolrAuditProvider.java). These CVEs seem exploitable on the server side only.
- CVEs for jackson-xc and jackson-jaxrs (CVE-2018-14718, CVE-2018-7489): These are used in the ranger-security, ambari-metrics-emitter, and aliyun-oss extensions. I think these vulnerabilities are legitimate at least for the aliyun-oss extension and so created https://github.com/apache/druid/issues/11029. For other extensions, I assume they are legit as well as I'm not 100% sure how they are using jackson. However, their latest releases still use the same vulnerable version of 1.9.x, so I would suggest suppressing them until they release a new version that has the fix.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
