### PR TITLE
improve bitmap vector offset to report contiguous groups

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
@@ -21,11 +21,14 @@ package org.apache.druid.benchmark.compression;
 
 import org.apache.druid.collections.bitmap.WrappedImmutableRoaringBitmap;
 import org.apache.druid.java.util.common.RE;
+import org.apache.druid.segment.BitmapOffset;
+import org.apache.druid.segment.SimpleAscendingOffset;
 import org.apache.druid.segment.data.ColumnarLongs;
 import org.apache.druid.segment.data.ColumnarLongsSerializer;
 import org.apache.druid.segment.data.CompressedColumnarLongsSupplier;
 import org.apache.druid.segment.data.CompressionFactory;
 import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.data.Offset;
 import org.apache.druid.segment.vector.BitmapVectorOffset;
 import org.apache.druid.segment.vector.NoFilterVectorOffset;
 import org.apache.druid.segment.vector.VectorOffset;
@@ -34,14 +37,14 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
-import java.util.BitSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -51,6 +54,8 @@ public class BaseColumnarLongsBenchmark
 {
   static final int VECTOR_SIZE = 512;
 
+  Map<String, ColumnarLongs> decoders = new HashMap<>();
+  Map<String, Integer> encodedSize = new HashMap<>();
   /**
    * Name of the long encoding strategy. For longs, this is a composite of both byte level block compression and
    * encoding of values within the block.
@@ -68,40 +73,156 @@ public class BaseColumnarLongsBenchmark
   long minValue;
   long maxValue;
 
-  @Nullable
-  BitSet filter;
-
+  Offset offset;
   VectorOffset vectorOffset;
 
-  void setupFilters(int rows, double filteredRowCountPercentage)
+
+  void scan(Blackhole blackhole)
   {
-    // todo: filter set distributions to simulate different select patterns?
-    //  (because benchmarks don't take long enough already..)
-    filter = null;
+    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+    ColumnarLongs encoder = decoders.get(encoding);
+    while(offset.withinBounds()) {
+      blackhole.consume(encoder.get(offset.getOffset()));
+      offset.increment();
+    }
+    offset.reset();
+    blackhole.consume(offset);
+  }
+
+  void scanVectorized(Blackhole blackhole)
+  {
+    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
+    ColumnarLongs columnDecoder = decoders.get(encoding);
+    long[] vector = new long[VECTOR_SIZE];
+    while (!vectorOffset.isDone()) {
+      if (vectorOffset.isContiguous()) {
+        columnDecoder.get(vector, vectorOffset.getStartOffset(), vectorOffset.getCurrentVectorSize());
+      } else {
+        columnDecoder.get(vector, vectorOffset.getOffsets(), vectorOffset.getCurrentVectorSize());
+      }
+      for (int i = 0; i < vectorOffset.getCurrentVectorSize(); i++) {
+        blackhole.consume(vector[i]);
+      }
+      vectorOffset.advance();
+    }
+    blackhole.consume(vector);
+    blackhole.consume(vectorOffset);
+    vectorOffset.reset();
+    columnDecoder.close();
+  }
+
+  void setupFilters(int rows, double filteredRowCountPercentage, String filterDistribution)
+  {
     final int filteredRowCount = (int) Math.floor(rows * filteredRowCountPercentage);
 
+
     if (filteredRowCount < rows) {
-      // setup bitset filter
-      filter = new BitSet();
-      MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
-      for (int i = 0; i < filteredRowCount; i++) {
-        int rowToAccess = rand.nextInt(rows);
-        // Skip already selected rows if any
-        while (filter.get(rowToAccess)) {
-          rowToAccess = rand.nextInt(rows);
-        }
-        filter.set(rowToAccess);
-        bitmap.add(rowToAccess);
+      switch (filterDistribution) {
+        case "random":
+          setupRandomFilter(rows, filteredRowCount);
+          break;
+        case "contiguous-start":
+          offset = new SimpleAscendingOffset(rows);
+          vectorOffset = new NoFilterVectorOffset(VECTOR_SIZE, 0, filteredRowCount);
+          break;
+        case "contiguous-end":
+          offset = new SimpleAscendingOffset(rows);
+          vectorOffset = new NoFilterVectorOffset(VECTOR_SIZE, rows - filteredRowCount, rows);
+          break;
+        case "contiguous-bitmap-start":
+          setupContiguousBitmapFilter(rows, filteredRowCount, 0);
+          break;
+        case "contiguous-bitmap-end":
+          setupContiguousBitmapFilter(rows, filteredRowCount, rows - filteredRowCount);
+          break;
+        case "chunky-1000":
+          setupChunkyFilter(rows, filteredRowCount, 1000);
+          break;
+        case "chunky-10000":
+          setupChunkyFilter(rows, filteredRowCount, 10000);
+          break;
+        default:
+          throw new IllegalArgumentException("unknown filter distribution");
       }
-      vectorOffset = new BitmapVectorOffset(
-          VECTOR_SIZE,
-          new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
-          0,
-          rows
-      );
     } else {
+      offset = new SimpleAscendingOffset(rows);
       vectorOffset = new NoFilterVectorOffset(VECTOR_SIZE, 0, rows);
     }
+  }
+
+  private void setupRandomFilter(int rows, int filteredRowCount)
+  {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    for (int i = 0; i < filteredRowCount; i++) {
+      int rowToAccess = rand.nextInt(rows);
+      // Skip already selected rows if any
+      while (bitmap.contains(rowToAccess)) {
+        rowToAccess = rand.nextInt(rows);
+      }
+      bitmap.add(rowToAccess);
+    }
+    offset = BitmapOffset.of(
+        new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
+        false,
+        rows
+    );
+    vectorOffset = new BitmapVectorOffset(
+        VECTOR_SIZE,
+        new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
+        0,
+        rows
+    );
+  }
+
+  private void setupContiguousBitmapFilter(int rows, int filterRowCount, int startOffset)
+  {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    for (int i = startOffset; i < filterRowCount; i++) {
+      bitmap.add(i);
+    }
+    offset = BitmapOffset.of(
+        new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
+        false,
+        rows
+    );
+    vectorOffset = new BitmapVectorOffset(
+        VECTOR_SIZE,
+        new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
+        startOffset,
+        rows
+    );
+  }
+
+  private void setupChunkyFilter(int rows, int filteredRowCount, int chunkSize)
+  {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    for (int count = 0; count < filteredRowCount; ) {
+      int chunkOffset = rand.nextInt(rows - chunkSize);
+      // Skip already selected rows if any
+      while (bitmap.contains(chunkOffset)) {
+        chunkOffset = rand.nextInt(rows - chunkSize);
+      }
+      int numAdded = 0;
+      for (; numAdded < chunkSize && count + numAdded < filteredRowCount; numAdded++) {
+        // break if we run into an existing contiguous section
+        if (bitmap.contains(numAdded)) {
+          break;
+        }
+        bitmap.add(chunkOffset + numAdded);
+      }
+      count += numAdded;
+    }
+    offset = BitmapOffset.of(
+        new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
+        false,
+        rows
+    );
+    vectorOffset = new BitmapVectorOffset(
+        VECTOR_SIZE,
+        new WrappedImmutableRoaringBitmap(bitmap.toImmutableRoaringBitmap()),
+        0,
+        rows
+    );
   }
 
   static int encodeToFile(long[] vals, String encoding, FileChannel output)throws IOException

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
@@ -81,7 +81,7 @@ public class BaseColumnarLongsBenchmark
   {
     EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
     ColumnarLongs encoder = decoders.get(encoding);
-    while(offset.withinBounds()) {
+    while (offset.withinBounds()) {
       blackhole.consume(encoder.get(offset.getOffset()));
       offset.increment();
     }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/ColumnarLongsSelectRowsFromSegmentBenchmark.java
@@ -54,21 +54,38 @@ import java.util.concurrent.TimeUnit;
 public class ColumnarLongsSelectRowsFromSegmentBenchmark extends BaseColumnarLongsFromSegmentsBenchmark
 {
   private Map<String, ColumnarLongs> decoders;
-  private Map<String, Integer> encodedSize;
 
   /**
    * Number of rows to read, the test will randomly set positions in a simulated offset of the specified density in
-   * {@link #setupFilters(int, double)}
+   * {@link #setupFilters(int, double, String)}
    */
-  @Param({"0.01", "0.1", "0.33", "0.66", "0.95", "1.0"})
+  @Param({
+      "0.1",
+      "0.25",
+      "0.5",
+      "0.75",
+      "0.9",
+      "1.0"
+  })
   private double filteredRowCountPercentage;
+
+  @Param({
+      "random",
+      "contiguous-start",
+      "contiguous-end",
+      "contiguous-bitmap-start",
+      "contiguous-bitmap-end",
+      "chunky-1000",
+      "chunky-10000"
+  })
+  private String filterDistribution;
 
   @Setup
   public void setup() throws Exception
   {
     decoders = new HashMap<>();
     encodedSize = new HashMap<>();
-    setupFilters(rows, filteredRowCountPercentage);
+    setupFilters(rows, filteredRowCountPercentage, filterDistribution);
 
     setupFromFile(encoding);
 
@@ -111,17 +128,7 @@ public class ColumnarLongsSelectRowsFromSegmentBenchmark extends BaseColumnarLon
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public void selectRows(Blackhole blackhole)
   {
-    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
-    ColumnarLongs encoder = decoders.get(encoding);
-    if (filter == null) {
-      for (int i = 0; i < rows; i++) {
-        blackhole.consume(encoder.get(i));
-      }
-    } else {
-      for (int i = filter.nextSetBit(0); i >= 0; i = filter.nextSetBit(i + 1)) {
-        blackhole.consume(encoder.get(i));
-      }
-    }
+    scan(blackhole);
   }
 
   @Benchmark
@@ -129,24 +136,7 @@ public class ColumnarLongsSelectRowsFromSegmentBenchmark extends BaseColumnarLon
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public void selectRowsVectorized(Blackhole blackhole)
   {
-    EncodingSizeProfiler.encodedSize = encodedSize.get(encoding);
-    ColumnarLongs columnDecoder = decoders.get(encoding);
-    long[] vector = new long[VECTOR_SIZE];
-    while (!vectorOffset.isDone()) {
-      if (vectorOffset.isContiguous()) {
-        columnDecoder.get(vector, vectorOffset.getStartOffset(), vectorOffset.getCurrentVectorSize());
-      } else {
-        columnDecoder.get(vector, vectorOffset.getOffsets(), vectorOffset.getCurrentVectorSize());
-      }
-      for (int i = 0; i < vectorOffset.getCurrentVectorSize(); i++) {
-        blackhole.consume(vector[i]);
-      }
-      vectorOffset.advance();
-    }
-    blackhole.consume(vector);
-    blackhole.consume(vectorOffset);
-    vectorOffset.reset();
-    columnDecoder.close();
+    scanVectorized(blackhole);
   }
 
 

--- a/processing/src/main/java/org/apache/druid/segment/vector/BitmapVectorOffset.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/BitmapVectorOffset.java
@@ -133,6 +133,9 @@ public class BitmapVectorOffset implements VectorOffset
   @Override
   public int[] getOffsets()
   {
+    if (isContiguous) {
+      throw new UnsupportedOperationException("is contiguous");
+    }
     return offsets;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/vector/BitmapVectorOffset.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/BitmapVectorOffset.java
@@ -33,6 +33,7 @@ public class BitmapVectorOffset implements VectorOffset
   private BatchIterator iterator;
   private boolean pastEnd;
   private int currentVectorSize;
+  private boolean isContiguous;
 
   public BitmapVectorOffset(
       final int vectorSize,
@@ -60,6 +61,7 @@ public class BitmapVectorOffset implements VectorOffset
   public void advance()
   {
     currentVectorSize = 0;
+    isContiguous = false;
 
     if (pastEnd) {
       return;
@@ -85,6 +87,14 @@ public class BitmapVectorOffset implements VectorOffset
 
       currentVectorSize = to;
     }
+
+    if (currentVectorSize > 1) {
+      final int adjusted = currentVectorSize - 1;
+      // for example:
+      //  [300, 301, 302, 303]: 4 - 1 == 3 == 303 - 300
+      //  [300, 301, 303, 304]: 4 - 1 == 3 != 304 - 300
+      isContiguous = offsets[adjusted] - offsets[0] == adjusted;
+    }
   }
 
   @Override
@@ -96,7 +106,7 @@ public class BitmapVectorOffset implements VectorOffset
   @Override
   public boolean isContiguous()
   {
-    return false;
+    return isContiguous;
   }
 
   @Override
@@ -114,6 +124,9 @@ public class BitmapVectorOffset implements VectorOffset
   @Override
   public int getStartOffset()
   {
+    if (isContiguous) {
+      return offsets[0];
+    }
     throw new UnsupportedOperationException("not contiguous");
   }
 
@@ -129,6 +142,7 @@ public class BitmapVectorOffset implements VectorOffset
     iterator = bitmap.batchIterator();
     currentVectorSize = 0;
     pastEnd = false;
+    isContiguous = false;
     advance();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/vector/BitmapVectorOffsetTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/vector/BitmapVectorOffsetTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.vector;
+
+import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.collections.bitmap.WrappedImmutableRoaringBitmap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class BitmapVectorOffsetTest
+{
+  private static final int VECTOR_SIZE = 128;
+  private static final int ROWS = VECTOR_SIZE * VECTOR_SIZE;
+
+  @Test
+  public void testContiguous()
+  {
+    // every bit is set, start from every offset and ensure all batches are contiguous
+    MutableRoaringBitmap wrapped = new MutableRoaringBitmap();
+    for (int i = 0; i < ROWS; i++) {
+      wrapped.add(i);
+    }
+
+    ImmutableBitmap bitmap = new WrappedImmutableRoaringBitmap(wrapped.toImmutableRoaringBitmap());
+    for (int startOffset = 0; startOffset < ROWS; startOffset++) {
+      BitmapVectorOffset offset = new BitmapVectorOffset(VECTOR_SIZE, bitmap, startOffset, ROWS);
+
+      while (!offset.isDone()) {
+        if (offset.getCurrentVectorSize() > 1) {
+          Assert.assertTrue(offset.isContiguous());
+        }
+        offset.advance();
+      }
+    }
+  }
+
+  @Test
+  public void testNeverContiguous()
+  {
+    MutableRoaringBitmap wrapped = new MutableRoaringBitmap();
+    for (int i = 0; i < ROWS; i++) {
+      if (i % 2 != 0) {
+        wrapped.add(i);
+      }
+    }
+
+    ImmutableBitmap bitmap = new WrappedImmutableRoaringBitmap(wrapped.toImmutableRoaringBitmap());
+    for (int startOffset = 0; startOffset < ROWS; startOffset++) {
+      BitmapVectorOffset offset = new BitmapVectorOffset(VECTOR_SIZE, bitmap, startOffset, ROWS);
+      while (!offset.isDone()) {
+        Assert.assertFalse(offset.isContiguous());
+        offset.advance();
+      }
+    }
+  }
+
+  @Test
+  public void testSometimesContiguous()
+  {
+    // this test is sort of vague
+    // set a lot of the rows so that there will be some contiguous and always at least 1 non-contiguous group
+    // (i imagine this is somewhat dependent on underlying bitmap iterator implementation)
+    MutableRoaringBitmap wrapped = new MutableRoaringBitmap();
+    for (int i = 0; i < ROWS - VECTOR_SIZE + 1; i++) {
+      int set = ThreadLocalRandom.current().nextInt(0, ROWS);
+      while (wrapped.contains(set)) {
+        set = ThreadLocalRandom.current().nextInt(0, ROWS);
+      }
+      wrapped.add(set);
+    }
+
+    ImmutableBitmap bitmap = new WrappedImmutableRoaringBitmap(wrapped.toImmutableRoaringBitmap());
+
+    int contiguousCount = 0;
+    int nonContiguousCount = 0;
+    int noContiguous = 0;
+    int allContiguous = 0;
+    for (int startOffset = 0; startOffset < ROWS; startOffset++) {
+      BitmapVectorOffset offset = new BitmapVectorOffset(VECTOR_SIZE, bitmap, startOffset, ROWS);
+
+      boolean none = true;
+      boolean all = true;
+      while (!offset.isDone()) {
+        if (offset.isContiguous()) {
+          contiguousCount++;
+          none = false;
+        } else {
+          nonContiguousCount++;
+          all = false;
+        }
+        offset.advance();
+      }
+      if (none) {
+        noContiguous++;
+      }
+      if (all) {
+        allContiguous++;
+      }
+    }
+
+    Assert.assertTrue(contiguousCount > 0);
+    Assert.assertTrue(nonContiguousCount > 0);
+    // depending on the distribution of set bits and starting offset, there are some which are never contiguous
+    Assert.assertTrue(noContiguous > 0);
+    Assert.assertEquals(0, allContiguous);
+  }
+}


### PR DESCRIPTION
### Description
This PR is a follow-up to #11004, which improves `BitmapVectorOffset` to report the current set of offsets as "contiguous" when they are, in order to take advantage of any optimizations available when processing contiguous vectorized gets. 

In #11004, I noticed the improvements to vectorized decoding of long values in my column scan benchmarks only seemed to impact a full scan. Looking closer, it was due to how the benchmark uses a `BitmapVectorOffset` to simulate filtering rows, which prior to this pr would _never_ report the current set of offsets as contiguous, even if it was. Since #11004 primarily improved performance of contiguous vectorized gets, when using a `BitmapVectorOffset` we were missing out on these improvements entirely.

To help measure the improvements of allowing contiguous blocks to be processed with the contiguous get methods, I improved the benchmarks added in #11004 to now have several different filter "distributions" to simulate different filtering patterns, instead of previously only using a random distribution. These include:
- random: `BitmapVectorOffset`, bitmap is set randomly for desired number of rows
- contiguous-start: `NoFilterVectorOffset` from starting offset 0 to desired number of rows
- contiguous-end: opposite end of column as 'contiguous-start'
- contiguous-bitmap-start: `BitmapVectorOffset`, bitmap set from 0 to desired number of rows
- contiguous-bitmap-end: opposite end of column as `contiguous-bitmap-start`
- chunky-1000: `BitmapVectorOffset`, position chosen randomly and up to 1000 contiguous values set until chosen number of rows is set
- chunky-10000: 'chunky-1000' but with chunks of 10k contiguous values

The results of this change is a pretty decent improvement to vectorized column read speed when there are contiguous vectors to read:

![before-after-bitmaps](https://user-images.githubusercontent.com/1577461/112883932-b9f6b200-9083-11eb-8688-1ffb1a827bcb.gif)


before:
```
Benchmark                                                                        (distribution)  (encoding)     (filterDistribution)  (filteredRowCountPercentage)   (rows)  (zeroProbability)  Mode  Cnt        Score      Error  Units
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.1  5000000                0.0  avgt   10     3096.136 ±   20.732  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                          0.25  5000000                0.0  avgt   10     8142.492 ±  124.247  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.5  5000000                0.0  avgt   10    16204.635 ±  101.374  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.6  5000000                0.0  avgt   10    19377.004 ±  109.489  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                          0.75  5000000                0.0  avgt   10    25621.704 ± 1544.863  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.8  5000000                0.0  avgt   10    26393.053 ±  190.878  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.9  5000000                0.0  avgt   10    29200.991 ±  493.996  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                          0.95  5000000                0.0  avgt   10    30702.206 ±  198.864  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           1.0  5000000                0.0  avgt   10    17997.131 ±  127.793  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.1  5000000                0.0  avgt   10     3881.268 ±   19.018  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                          0.25  5000000                0.0  avgt   10     8097.172 ±  284.560  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.5  5000000                0.0  avgt   10    14498.809 ±   77.822  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.6  5000000                0.0  avgt   10    18387.397 ±   96.425  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                          0.75  5000000                0.0  avgt   10    21986.742 ±   89.077  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.8  5000000                0.0  avgt   10    23239.459 ±  290.921  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.9  5000000                0.0  avgt   10    25199.260 ±  162.413  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                          0.95  5000000                0.0  avgt   10    27449.210 ± 1688.145  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           1.0  5000000                0.0  avgt   10    17981.037 ±   63.957  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.1  5000000                0.0  avgt   10     5120.464 ±  193.518  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                          0.25  5000000                0.0  avgt   10    10236.347 ±  307.603  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.5  5000000                0.0  avgt   10    19979.496 ±  566.214  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.6  5000000                0.0  avgt   10    23576.997 ±  438.873  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                          0.75  5000000                0.0  avgt   10    29285.756 ±  986.723  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.8  5000000                0.0  avgt   10    29974.530 ± 1441.189  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.9  5000000                0.0  avgt   10    33905.473 ± 2021.488  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                          0.95  5000000                0.0  avgt   10    33024.158 ±  389.507  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           1.0  5000000                0.0  avgt   10    18252.778 ±  211.648  us/op
```


after:
```
Benchmark                                                                        (distribution)  (encoding)     (filterDistribution)  (filteredRowCountPercentage)   (rows)  (zeroProbability)  Mode  Cnt        Score     Error  Units
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.1  5000000                0.0  avgt   10     2396.812 ±   59.423  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                          0.25  5000000                0.0  avgt   10     5941.108 ±  206.432  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.5  5000000                0.0  avgt   10    10904.502 ±  248.979  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.6  5000000                0.0  avgt   10    13237.317 ±  175.817  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                          0.75  5000000                0.0  avgt   10    17216.386 ±  934.780  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.8  5000000                0.0  avgt   10    17088.263 ±  116.899  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           0.9  5000000                0.0  avgt   10    20996.326 ±   81.832  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                          0.95  5000000                0.0  avgt   10    20735.792 ±   71.165  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto  contiguous-bitmap-start                           1.0  5000000                0.0  avgt   10    17992.744 ±   87.609  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.1  5000000                0.0  avgt   10     3226.460 ±   16.228  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                          0.25  5000000                0.0  avgt   10     6771.234 ±  127.713  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.5  5000000                0.0  avgt   10    12587.962 ±   50.479  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.6  5000000                0.0  avgt   10    15874.411 ±   72.437  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                          0.75  5000000                0.0  avgt   10    18694.264 ±   34.897  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.8  5000000                0.0  avgt   10    20658.982 ±  214.946  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           0.9  5000000                0.0  avgt   10    21208.258 ±   73.285  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                          0.95  5000000                0.0  avgt   10    23644.473 ±  968.966  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto              chunky-1000                           1.0  5000000                0.0  avgt   10    17980.515 ±   95.417  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.1  5000000                0.0  avgt   10     5174.737 ±  237.912  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                          0.25  5000000                0.0  avgt   10     9280.395 ±  334.380  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.5  5000000                0.0  avgt   10    18088.591 ±  467.872  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.6  5000000                0.0  avgt   10    21431.135 ±  217.091  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                          0.75  5000000                0.0  avgt   10    25727.534 ± 1334.654  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.8  5000000                0.0  avgt   10    27875.558 ±  209.684  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           0.9  5000000                0.0  avgt   10    28871.937 ±  203.491  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                          0.95  5000000                0.0  avgt   10    32956.537 ±  524.990  us/op
ColumnarLongsSelectRowsFromGeneratorBenchmark.selectRowsVectorized                   uniform-12    lz4-auto                   random                           1.0  5000000                0.0  avgt   10    18136.036 ±  151.741  us/op
```

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
