### PR TITLE
Bump Aliyun OSS SDK to 3.11.3

### DIFF
--- a/extensions-contrib/aliyun-oss-extensions/pom.xml
+++ b/extensions-contrib/aliyun-oss-extensions/pom.xml
@@ -42,7 +42,7 @@
         <dependency> <!-- aliyun oss -->
             <groupId>com.aliyun.oss</groupId>
             <artifactId>aliyun-sdk-oss</artifactId>
-            <version>3.3.0</version>
+            <version>3.11.3</version>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
Fixes #11029

### Description

This PR updates Alibaba Cloud Storage SDK used by 'aliyun-oss-extension' from 3.3.0 to the latest 3.11.3 to eliminate security vulnerabilities which are reported in its dependency.

This PR has:
- [X] been self-reviewed.
- [X] been tested in a test Druid cluster.
