### PR TITLE
Allow list for JDBC connection properties to address CVE-2021-26919

### DIFF
--- a/core/src/main/java/org/apache/druid/utils/ConnectionUriUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/ConnectionUriUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.utils;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Set;
+
+public final class ConnectionUriUtils
+{
+  // Note: MySQL JDBC connector 8 supports 7 other protocols than just `jdbc:mysql:`
+  // (https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html).
+  // We should consider either expanding recognized mysql protocols or restricting allowed protocols to
+  // just a basic one.
+  public static final String MYSQL_PREFIX = "jdbc:mysql:";
+  public static final String POSTGRES_PREFIX = "jdbc:postgresql:";
+
+  /**
+   * This method checks {@param actualProperties} against {@param allowedProperties} if they are not system properties.
+   * A property is regarded as a system property if its name starts with a prefix in {@param systemPropertyPrefixes}.
+   * See org.apache.druid.server.initialization.JDBCAccessSecurityConfig for more details.
+   *
+   * If a non-system property that is not allowed is found, this method throws an {@link IllegalArgumentException}.
+   */
+  public static void throwIfPropertiesAreNotAllowed(
+      Set<String> actualProperties,
+      Set<String> systemPropertyPrefixes,
+      Set<String> allowedProperties
+  )
+  {
+    for (String property : actualProperties) {
+      if (systemPropertyPrefixes.stream().noneMatch(property::startsWith)) {
+        Preconditions.checkArgument(
+            allowedProperties.contains(property),
+            "The property [%s] is not in the allowed list %s",
+            property,
+            allowedProperties
+        );
+      }
+    }
+  }
+
+  private ConnectionUriUtils()
+  {
+  }
+}

--- a/core/src/main/java/org/apache/druid/utils/Throwables.java
+++ b/core/src/main/java/org/apache/druid/utils/Throwables.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.utils;
+
+public final class Throwables
+{
+  public static boolean isThrowable(Throwable t, Class<? extends Throwable> searchFor)
+  {
+    if (t.getClass().isAssignableFrom(searchFor)) {
+      return true;
+    } else {
+      if (t.getCause() != null) {
+        return isThrowable(t.getCause(), searchFor);
+      } else {
+        return false;
+      }
+    }
+  }
+
+  private Throwables()
+  {
+  }
+}

--- a/core/src/test/java/org/apache/druid/utils/ConnectionUriUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/utils/ConnectionUriUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.utils;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+@RunWith(Enclosed.class)
+public class ConnectionUriUtilsTest
+{
+  public static class ThrowIfURLHasNotAllowedPropertiesTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testEmptyActualProperties()
+    {
+      ConnectionUriUtils.throwIfPropertiesAreNotAllowed(
+          ImmutableSet.of(),
+          ImmutableSet.of("valid_key1", "valid_key2"),
+          ImmutableSet.of("system_key1", "system_key2")
+      );
+    }
+
+    @Test
+    public void testThrowForNonAllowedProperties()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("The property [invalid_key] is not in the allowed list [valid_key1, valid_key2]");
+
+      ConnectionUriUtils.throwIfPropertiesAreNotAllowed(
+          ImmutableSet.of("valid_key1", "invalid_key"),
+          ImmutableSet.of("system_key1", "system_key2"),
+          ImmutableSet.of("valid_key1", "valid_key2")
+      );
+    }
+
+    @Test
+    public void testAllowedProperties()
+    {
+      ConnectionUriUtils.throwIfPropertiesAreNotAllowed(
+          ImmutableSet.of("valid_key2"),
+          ImmutableSet.of("system_key1", "system_key2"),
+          ImmutableSet.of("valid_key1", "valid_key2")
+      );
+    }
+
+    @Test
+    public void testAllowSystemProperties()
+    {
+      ConnectionUriUtils.throwIfPropertiesAreNotAllowed(
+          ImmutableSet.of("system_key1", "valid_key2"),
+          ImmutableSet.of("system_key1", "system_key2"),
+          ImmutableSet.of("valid_key1", "valid_key2")
+      );
+    }
+
+    @Test
+    public void testMatchSystemProperties()
+    {
+      ConnectionUriUtils.throwIfPropertiesAreNotAllowed(
+          ImmutableSet.of("system_key1.1", "system_key1.5", "system_key11.11", "valid_key2"),
+          ImmutableSet.of("system_key1", "system_key2"),
+          ImmutableSet.of("valid_key1", "valid_key2")
+      );
+    }
+  }
+}

--- a/core/src/test/java/org/apache/druid/utils/ThrowablesTest.java
+++ b/core/src/test/java/org/apache/druid/utils/ThrowablesTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ThrowablesTest
+{
+  @Test
+  public void testIsThrowableItself()
+  {
+    Assert.assertTrue(Throwables.isThrowable(new NoClassDefFoundError(), NoClassDefFoundError.class));
+  }
+
+  @Test
+  public void testIsThrowableNestedThrowable()
+  {
+    Assert.assertTrue(
+        Throwables.isThrowable(new RuntimeException(new NoClassDefFoundError()), NoClassDefFoundError.class)
+    );
+  }
+
+  @Test
+  public void testIsThrowableNonTarget()
+  {
+    Assert.assertFalse(
+        Throwables.isThrowable(new RuntimeException(new ClassNotFoundException()), NoClassDefFoundError.class)
+    );
+  }
+}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -537,6 +537,25 @@ the [HTTP input source](../ingestion/native-batch.md#http-input-source) and the 
 |`druid.ingestion.http.allowedProtocols`|List of protocols|Allowed protocols for the HTTP input source and HTTP firehose.|["http", "https"]|
 
 
+### Ingestion Security Configuration
+
+#### JDBC Connections to External Databases
+
+You can use the following properties to specify permissible JDBC options for:
+- [SQL input source](../ingestion/native-batch.md#sql-input-source)
+- [SQL firehose](../ingestion/native-batch.md#sqlfirehose),
+- [globally cached JDBC lookups](../development/extensions-core/lookups-cached-global.md#jdbc-lookup)
+- [JDBC Data Fetcher for per-lookup caching](../development/extensions-core/druid-lookups.md#data-fetcher-layer).
+
+These properties do not apply to metadata storage connections.
+
+|Property|Possible Values|Description|Default|
+|--------|---------------|-----------|-------|
+|`druid.access.jdbc.enforceAllowedProperties`|Boolean|When true, Druid applies `druid.access.jdbc.allowedProperties` to JDBC connections starting with `jdbc:postgresql:` or `jdbc:mysql:`. When false, Druid allows any kind of JDBC connections without JDBC property validation. This config is deprecated and will be removed in a future release.|false|
+|`druid.access.jdbc.allowedProperties`|List of JDBC properties|Defines a list of allowed JDBC properties. Druid always enforces the list for all JDBC connections starting with `jdbc:postgresql:` or `jdbc:mysql:` if `druid.access.jdbc.enforceAllowedProperties` is set to true.<br/><br/>This option is tested against MySQL connector 5.1.48 and PostgreSQL connector 42.2.14. Other connector versions might not work.|["useSSL", "requireSSL", "ssl", "sslmode"]|
+|`druid.access.jdbc.allowUnknownJdbcUrlFormat`|Boolean|When false, Druid only accepts JDBC connections starting with `jdbc:postgresql:` or `jdbc:mysql:`. When true, Druid allows JDBC connections to any kind of database, but only enforces `druid.access.jdbc.allowedProperties` for PostgreSQL and MySQL.|true|
+
+
 ### Task Logging
 
 If you are running the indexing service in remote mode, the task logs must be stored in S3, Azure Blob Store, Google Cloud Storage or HDFS.

--- a/docs/development/extensions-core/druid-lookups.md
+++ b/docs/development/extensions-core/druid-lookups.md
@@ -72,7 +72,7 @@ Same for Loading cache, developer can implement a new type of loading cache by i
 
 |Field|Type|Description|Required|default|
 |-----|----|-----------|--------|-------|
-|dataFetcher|JSON object|Specifies the lookup data fetcher type  to use in order to fetch data|yes|null|
+|dataFetcher|JSON object|Specifies the lookup data fetcher type for fetching data|yes|null|
 |cacheFactory|JSON Object|Cache factory implementation|no |onHeapPolling|
 |pollPeriod|Period|polling period |no |null (poll once)|
 
@@ -129,7 +129,7 @@ Guava cache configuration spec.
    "type":"loadingLookup",
    "dataFetcher":{ "type":"jdbcDataFetcher", "connectorConfig":"jdbc://mysql://localhost:3306/my_data_base", "table":"lookup_table_name", "keyColumn":"key_column_name", "valueColumn": "value_column_name"},
    "loadingCacheSpec":{"type":"guava"},
-   "reverseLoadingCacheSpec":{"type":"guava", "maximumSize":500000, "expireAfterAccess":100000, "expireAfterAccess":10000}
+   "reverseLoadingCacheSpec":{"type":"guava", "maximumSize":500000, "expireAfterAccess":100000, "expireAfterWrite":10000}
 }
 ```
 
@@ -150,6 +150,16 @@ Off heap cache is backed by [MapDB](http://www.mapdb.org/) implementation. MapDB
    "type":"loadingLookup",
    "dataFetcher":{ "type":"jdbcDataFetcher", "connectorConfig":"jdbc://mysql://localhost:3306/my_data_base", "table":"lookup_table_name", "keyColumn":"key_column_name", "valueColumn": "value_column_name"},
    "loadingCacheSpec":{"type":"mapDb", "maxEntriesSize":100000},
-   "reverseLoadingCacheSpec":{"type":"mapDb", "maxStoreSize":5, "expireAfterAccess":100000, "expireAfterAccess":10000}
+   "reverseLoadingCacheSpec":{"type":"mapDb", "maxStoreSize":5, "expireAfterAccess":100000, "expireAfterWrite":10000}
 }
 ```
+
+### JDBC Data Fetcher
+
+|Field|Type|Description|Required|default|
+|-----|----|-----------|--------|-------|
+|`connectorConfig`|JSON object|Specifies the database connection details. You can set `connectURI`, `user` and `password`. You can selectively allow JDBC properties in `connectURI`. See [JDBC connections security config](../../configuration/index.md#jdbc-connections-to-external-databases) for more details.|yes||
+|`table`|string|The table name to read from.|yes||
+|`keyColumn`|string|The column name that contains the lookup key.|yes||
+|`valueColumn`|string|The column name that contains the lookup value.|yes||
+|`streamingFetchSize`|int|Fetch size used in JDBC connections.|no|1000|

--- a/docs/development/extensions-core/lookups-cached-global.md
+++ b/docs/development/extensions-core/lookups-cached-global.md
@@ -64,7 +64,6 @@ Globally cached lookups can be specified as part of the [cluster wide config for
     "extractionNamespace": {
        "type": "jdbc",
        "connectorConfig": {
-         "createTables": true,
          "connectURI": "jdbc:mysql:\/\/localhost:3306\/druid",
          "user": "druid",
          "password": "diurd"
@@ -107,7 +106,6 @@ In a simple case where only one [tier](../../querying/lookups.md#dynamic-configu
         "extractionNamespace": {
           "type": "jdbc",
           "connectorConfig": {
-            "createTables": true,
             "connectURI": "jdbc:mysql:\/\/localhost:3306\/druid",
             "user": "druid",
             "password": "diurd"
@@ -136,7 +134,6 @@ Where the Coordinator endpoint `/druid/coordinator/v1/lookups/realtime_customer2
     "extractionNamespace": {
       "type": "jdbc",
       "connectorConfig": {
-        "createTables": true,
         "connectURI": "jdbc:mysql://localhost:3306/druid",
         "user": "druid",
         "password": "diurd"
@@ -347,7 +344,7 @@ The JDBC lookups will poll a database to populate its local cache. If the `tsCol
 
 |Parameter|Description|Required|Default|
 |---------|-----------|--------|-------|
-|`connectorConfig`|The connector config to use|Yes||
+|`connectorConfig`|The connector config to use. You can set `connectURI`, `user` and `password`. You can selectively allow JDBC properties in `connectURI`. See [JDBC connections security config](../../configuration/index.md#jdbc-connections-to-external-databases) for more details.|Yes||
 |`table`|The table which contains the key value pairs|Yes||
 |`keyColumn`|The column in `table` which contains the keys|Yes||
 |`valueColumn`|The column in `table` which contains the values|Yes||
@@ -359,7 +356,6 @@ The JDBC lookups will poll a database to populate its local cache. If the `tsCol
 {
   "type":"jdbc",
   "connectorConfig":{
-    "createTables":true,
     "connectURI":"jdbc:mysql://localhost:3306/druid",
     "user":"druid",
     "password":"diurd"

--- a/docs/development/extensions-core/mysql.md
+++ b/docs/development/extensions-core/mysql.md
@@ -105,7 +105,6 @@ Copy or symlink this file to `extensions/mysql-metadata-storage` under the distr
 |`druid.metadata.mysql.ssl.enabledSSLCipherSuites`|Overrides the existing cipher suites with these cipher suites.|none|no|
 |`druid.metadata.mysql.ssl.enabledTLSProtocols`|Overrides the TLS protocols with these protocols.|none|no|
 
-
 ### MySQL Firehose
 
 The MySQL extension provides an implementation of an [SqlFirehose](../../ingestion/native-batch.md#firehoses-deprecated) which can be used to ingest data into Druid from a MySQL database.

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -1380,7 +1380,7 @@ Please refer to the Recommended practices section below before using this input 
 |property|description|required?|
 |--------|-----------|---------|
 |type|This should be "sql".|Yes|
-|database|Specifies the database connection details. The database type corresponds to the extension that supplies the `connectorConfig` support and this extension must be loaded into Druid. For database types `mysql` and `postgresql`, the `connectorConfig` support is provided by [mysql-metadata-storage](../development/extensions-core/mysql.md) and [postgresql-metadata-storage](../development/extensions-core/postgresql.md) extensions respectively.|Yes|
+|database|Specifies the database connection details. The database type corresponds to the extension that supplies the `connectorConfig` support. The specified extension must be loaded into Druid:<br/><br/><ul><li>[mysql-metadata-storage](../development/extensions-core/mysql.md) for `mysql`</li><li> [postgresql-metadata-storage](../development/extensions-core/postgresql.md) extension for `postgresql`.</li></ul><br/><br/>You can selectively allow JDBC properties in `connectURI`. See [JDBC connections security config](../configuration/index.md#jdbc-connections-to-external-databases) for more details.|Yes|
 |foldCase|Toggle case folding of database column names. This may be enabled in cases where the database returns case insensitive column names in query results.|No|
 |sqls|List of SQL queries where each SQL query would retrieve the data to be indexed.|Yes|
 
@@ -1734,7 +1734,7 @@ Requires one of the following extensions:
 |property|description|default|required?|
 |--------|-----------|-------|---------|
 |type|This should be "sql".||Yes|
-|database|Specifies the database connection details.||Yes|
+|database|Specifies the database connection details. The database type corresponds to the extension that supplies the `connectorConfig` support. The specified extension must be loaded into Druid:<br/><br/><ul><li>[mysql-metadata-storage](../development/extensions-core/mysql.md) for `mysql`</li><li> [postgresql-metadata-storage](../development/extensions-core/postgresql.md) extension for `postgresql`.</li></ul><br/><br/>You can selectively allow JDBC properties in `connectURI`. See [JDBC connections security config](../configuration/index.md#jdbc-connections-to-external-databases) for more details.||Yes|
 |maxCacheCapacityBytes|Maximum size of the cache space in bytes. 0 means disabling cache. Cached files are not removed until the ingestion task completes.|1073741824|No|
 |maxFetchCapacityBytes|Maximum size of the fetch space in bytes. 0 means disabling prefetch. Prefetched files are removed immediately once they are read.|1073741824|No|
 |prefetchTriggerBytes|Threshold to trigger prefetching SQL result objects.|maxFetchCapacityBytes / 2|No|

--- a/extensions-core/lookups-cached-global/pom.xml
+++ b/extensions-core/lookups-cached-global/pom.xml
@@ -110,12 +110,15 @@
       <artifactId>jsr311-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <!-- Included to improve the out-of-the-box experience for supported JDBC connectors -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${mysql.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <!-- Tests -->

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespaceUrlCheckTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespaceUrlCheckTest.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.lookup.namespace;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.joda.time.Period;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+
+@RunWith(Enclosed.class)
+public class JdbcExtractionNamespaceUrlCheckTest
+{
+  private static final String TABLE_NAME = "abstractDbRenameTest";
+  private static final String KEY_NAME = "keyName";
+  private static final String VAL_NAME = "valName";
+  private static final String TS_COLUMN = "tsColumn";
+
+  public static class MySqlTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
+    {
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testThrowWhenUrlHasNonAllowedPropertiesWhenEnforcingAllowedProperties()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenUrlHasNonAllowedPropertiesWhenNotEnforcingAllowedProperties()
+    {
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return false;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenInvalidUrlFormat()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Invalid URL format [jdbc:mysql:/invalid-url::3006]");
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql:/invalid-url::3006";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+
+  public static class PostgreSqlTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
+    {
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testThrowWhenUrlHasNonAllowedPropertiesWhenEnforcingAllowedProperties()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenUrlHasNonAllowedPropertiesWhenNotEnforcingAllowedProperties()
+    {
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return false;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenInvalidUrlFormat()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Invalid URL format [jdbc:postgresql://invalid-url::3006]");
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://invalid-url::3006";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+
+  public static class UnknownSchemeTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testThrowWhenUnknownFormatIsNotAllowed()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Unknown JDBC connection scheme: mydb");
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isAllowUnknownJdbcUrlFormat()
+            {
+              return false;
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testSkipUrlParsingWhenUnknownFormatIsAllowed()
+    {
+      new JdbcExtractionNamespace(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_NAME,
+          VAL_NAME,
+          TS_COLUMN,
+          "some filter",
+          new Period(10),
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isAllowUnknownJdbcUrlFormat()
+            {
+              return true;
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+}

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.query.lookup.namespace.JdbcExtractionNamespace;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
 import org.apache.druid.server.lookup.namespace.cache.CacheScheduler;
 import org.apache.druid.server.lookup.namespace.cache.OnHeapNamespaceExtractionCacheManager;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
@@ -42,7 +43,7 @@ import java.util.Collections;
 public class JdbcCacheGeneratorTest
 {
   private static final MetadataStorageConnectorConfig MISSING_METADATA_STORAGE_CONNECTOR_CONFIG =
-      createMetadataStorageConnectorConfig("postgresql");
+      createMetadataStorageConnectorConfig("mydb");
 
   private static final CacheScheduler.EntryImpl<JdbcExtractionNamespace> KEY =
       EasyMock.mock(CacheScheduler.EntryImpl.class);
@@ -127,7 +128,8 @@ public class JdbcCacheGeneratorTest
         "valueColumn",
         tsColumn,
         "filter",
-        Period.ZERO
+        Period.ZERO,
+        new JdbcAccessSecurityConfig()
     );
   }
 }

--- a/extensions-core/lookups-cached-single/pom.xml
+++ b/extensions-core/lookups-cached-single/pom.xml
@@ -96,12 +96,15 @@
       <artifactId>guava</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <!-- Included to improve the out-of-the-box experience for supported JDBC connectors -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${mysql.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <!-- Tests -->

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/jdbc/JdbcDataFetcherUrlCheckTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/jdbc/JdbcDataFetcherUrlCheckTest.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.lookup.jdbc;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+
+@RunWith(Enclosed.class)
+public class JdbcDataFetcherUrlCheckTest
+{
+  private static final String TABLE_NAME = "tableName";
+  private static final String KEY_COLUMN = "keyColumn";
+  private static final String VALUE_COLUMN = "valueColumn";
+
+  public static class MySqlTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testThrowWhenUrlHasDisallowedPropertiesWhenEnforcingAllowedProperties()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenUrlHasDisallowedPropertiesWhenNotEnforcingAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return false;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenInvalidUrlFormat()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Invalid URL format [jdbc:mysql:/invalid-url::3006]");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql:/invalid-url::3006";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+
+  public static class PostgreSqlTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testThrowWhenUrlHasDisallowedPropertiesWhenEnforcingAllowedProperties()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenUrlHasDisallowedPropertiesWhenNotEnforcingAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return false;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenInvalidUrlFormat()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Invalid URL format [jdbc:postgresql://invalid-url::3006]");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://invalid-url::3006";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+
+  public static class UnknownSchemeTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testThrowWhenUnknownFormatIsNotAllowed()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Unknown JDBC connection scheme: mydb");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isAllowUnknownJdbcUrlFormat()
+            {
+              return false;
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testSkipUrlParsingWhenUnknownFormatIsAllowed()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isAllowUnknownJdbcUrlFormat()
+            {
+              return true;
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+}

--- a/extensions-core/mysql-metadata-storage/pom.xml
+++ b/extensions-core/mysql-metadata-storage/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>commons-dbcp2</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/firehose/sql/MySQLFirehoseDatabaseConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/firehose/sql/MySQLFirehoseDatabaseConnectorTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.firehose.sql;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Set;
+
+public class MySQLFirehoseDatabaseConnectorTest
+{
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testSuccessWhenNoPropertyInUriAndNoAllowlist()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:mysql://localhost:3306/test";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of());
+
+    new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testSuccessWhenAllowlistAndNoProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:mysql://localhost:3306/test";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user"));
+
+    new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testFailWhenNoAllowlistAndHaveProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:mysql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
+
+    expectedException.expectMessage("The property [password] is not in the allowed list");
+    expectedException.expect(IllegalArgumentException.class);
+
+    new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testSuccessOnlyValidProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:mysql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(
+        ImmutableSet.of("user", "password", "keyonly", "etc")
+    );
+
+    new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testFailOnlyInvalidProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:mysql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
+
+    expectedException.expectMessage("The property [password] is not in the allowed list");
+    expectedException.expect(IllegalArgumentException.class);
+
+    new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testFailValidAndInvalidProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:mysql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
+
+    expectedException.expectMessage("The property [password] is not in the allowed list");
+    expectedException.expect(IllegalArgumentException.class);
+
+    new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testIgnoreInvalidPropertyWhenNotEnforcingAllowList()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:mysql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = new JdbcAccessSecurityConfig()
+    {
+      @Override
+      public Set<String> getAllowedProperties()
+      {
+        return ImmutableSet.of("user", "nonenone");
+      }
+    };
+
+    new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testFindPropertyKeysFromInvalidConnectUrl()
+  {
+    final String url = "jdbc:mysql:/invalid-url::3006";
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return url;
+      }
+    };
+
+    MySQLFirehoseDatabaseConnector connector = new MySQLFirehoseDatabaseConnector(
+        connectorConfig,
+        new JdbcAccessSecurityConfig()
+    );
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(StringUtils.format("Invalid URL format for MySQL: [%s]", url));
+    connector.findPropertyKeysFromConnectURL(url);
+  }
+
+  private static JdbcAccessSecurityConfig newSecurityConfigEnforcingAllowList(Set<String> allowedProperties)
+  {
+    return new JdbcAccessSecurityConfig()
+    {
+      @Override
+      public Set<String> getAllowedProperties()
+      {
+        return allowedProperties;
+      }
+
+      @Override
+      public boolean isEnforceAllowedProperties()
+      {
+        return true;
+      }
+    };
+  }
+}

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnector.java
@@ -19,12 +19,21 @@
 
 package org.apache.druid.firehose;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.Sets;
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.SQLFirehoseDatabaseConnector;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.postgresql.Driver;
 import org.skife.jdbi.v2.DBI;
+
+import java.util.Properties;
+import java.util.Set;
 
 
 @JsonTypeName("postgresql")
@@ -33,12 +42,14 @@ public class PostgresqlFirehoseDatabaseConnector extends SQLFirehoseDatabaseConn
   private final DBI dbi;
   private final MetadataStorageConnectorConfig connectorConfig;
 
+  @JsonCreator
   public PostgresqlFirehoseDatabaseConnector(
-      @JsonProperty("connectorConfig") MetadataStorageConnectorConfig connectorConfig
+      @JsonProperty("connectorConfig") MetadataStorageConnectorConfig connectorConfig,
+      @JacksonInject JdbcAccessSecurityConfig securityConfig
   )
   {
     this.connectorConfig = connectorConfig;
-    final BasicDataSource datasource = getDatasource(connectorConfig);
+    final BasicDataSource datasource = getDatasource(connectorConfig, securityConfig);
     datasource.setDriverClassLoader(getClass().getClassLoader());
     datasource.setDriverClassName("org.postgresql.Driver");
     this.dbi = new DBI(datasource);
@@ -54,5 +65,22 @@ public class PostgresqlFirehoseDatabaseConnector extends SQLFirehoseDatabaseConn
   public DBI getDBI()
   {
     return dbi;
+  }
+
+  @Override
+  public Set<String> findPropertyKeysFromConnectURL(String connectUri)
+  {
+    // This method should be in sync with
+    // - org.apache.druid.server.lookup.jdbc.JdbcDataFetcher.checkConnectionURL()
+    // - org.apache.druid.query.lookup.namespace.JdbcExtractionNamespace.checkConnectionURL()
+
+    // Postgresql JDBC driver is embedded and thus must be loaded.
+    Properties properties = Driver.parseURL(connectUri, null);
+    if (properties == null) {
+      throw new IAE("Invalid URL format for PostgreSQL: [%s]", connectUri);
+    }
+    Set<String> keys = Sets.newHashSetWithExpectedSize(properties.size());
+    properties.forEach((k, v) -> keys.add((String) k));
+    return keys;
   }
 }

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
@@ -57,7 +57,7 @@ public class PostgreSQLConnector extends SQLMetadataConnector
   private volatile Boolean canUpsert;
 
   private final String dbTableSchema;
-  
+
   @Inject
   public PostgreSQLConnector(
       Supplier<MetadataStorageConnectorConfig> config,

--- a/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnectorTest.java
@@ -87,7 +87,7 @@ public class PostgresqlFirehoseDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
 
-    expectedException.expectMessage("The property [keyonly] is not in the allowed list");
+    expectedException.expectMessage("is not in the allowed list");
     expectedException.expect(IllegalArgumentException.class);
 
     new PostgresqlFirehoseDatabaseConnector(
@@ -132,7 +132,7 @@ public class PostgresqlFirehoseDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
 
-    expectedException.expectMessage("The property [keyonly] is not in the allowed list");
+    expectedException.expectMessage("is not in the allowed list");
     expectedException.expect(IllegalArgumentException.class);
 
     new PostgresqlFirehoseDatabaseConnector(
@@ -155,7 +155,7 @@ public class PostgresqlFirehoseDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
 
-    expectedException.expectMessage("The property [keyonly] is not in the allowed list");
+    expectedException.expectMessage("is not in the allowed list");
     expectedException.expect(IllegalArgumentException.class);
 
     new PostgresqlFirehoseDatabaseConnector(

--- a/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnectorTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.firehose;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Set;
+
+public class PostgresqlFirehoseDatabaseConnectorTest
+{
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testSuccessWhenNoPropertyInUriAndNoAllowlist()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:postgresql://localhost:3306/test";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of());
+
+    new PostgresqlFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testSuccessWhenAllowlistAndNoProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:postgresql://localhost:3306/test";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user"));
+
+    new PostgresqlFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testFailWhenNoAllowlistAndHaveProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
+
+    expectedException.expectMessage("The property [keyonly] is not in the allowed list");
+    expectedException.expect(IllegalArgumentException.class);
+
+    new PostgresqlFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testSuccessOnlyValidProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(
+        ImmutableSet.of("user", "password", "keyonly", "etc")
+    );
+
+    new PostgresqlFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testFailOnlyInvalidProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
+
+    expectedException.expectMessage("The property [keyonly] is not in the allowed list");
+    expectedException.expect(IllegalArgumentException.class);
+
+    new PostgresqlFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testFailValidAndInvalidProperty()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
+
+    expectedException.expectMessage("The property [keyonly] is not in the allowed list");
+    expectedException.expect(IllegalArgumentException.class);
+
+    new PostgresqlFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  @Test
+  public void testIgnoreInvalidPropertyWhenNotEnforcingAllowList()
+  {
+    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
+    {
+      @Override
+      public String getConnectURI()
+      {
+        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+      }
+    };
+
+    JdbcAccessSecurityConfig securityConfig = new JdbcAccessSecurityConfig()
+    {
+      @Override
+      public Set<String> getAllowedProperties()
+      {
+        return ImmutableSet.of("user", "nonenone");
+      }
+    };
+
+    new PostgresqlFirehoseDatabaseConnector(
+        connectorConfig,
+        securityConfig
+    );
+  }
+
+  private static JdbcAccessSecurityConfig newSecurityConfigEnforcingAllowList(Set<String> allowedProperties)
+  {
+    return new JdbcAccessSecurityConfig()
+    {
+      @Override
+      public Set<String> getAllowedProperties()
+      {
+        return allowedProperties;
+      }
+
+      @Override
+      public boolean isEnforceAllowedProperties()
+      {
+        return true;
+      }
+    };
+  }
+}

--- a/server/src/main/java/org/apache/druid/initialization/Initialization.java
+++ b/server/src/main/java/org/apache/druid/initialization/Initialization.java
@@ -63,6 +63,7 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMediumModule;
 import org.apache.druid.server.emitter.EmitterModule;
 import org.apache.druid.server.initialization.AuthenticatorMapperModule;
 import org.apache.druid.server.initialization.AuthorizerMapperModule;
+import org.apache.druid.server.initialization.ExternalStorageAccessSecurityModule;
 import org.apache.druid.server.initialization.jetty.JettyServerModule;
 import org.apache.druid.server.metrics.MetricsModule;
 import org.apache.druid.server.security.TLSCertificateCheckerModule;
@@ -411,7 +412,8 @@ public class Initialization
         new EscalatorModule(),
         new AuthorizerModule(),
         new AuthorizerMapperModule(),
-        new StartupLoggingModule()
+        new StartupLoggingModule(),
+        new ExternalStorageAccessSecurityModule()
     );
 
     ModuleList actualModules = new ModuleList(baseInjector);

--- a/server/src/main/java/org/apache/druid/metadata/BasicDataSourceExt.java
+++ b/server/src/main/java/org/apache/druid/metadata/BasicDataSourceExt.java
@@ -42,8 +42,17 @@ public class BasicDataSourceExt extends BasicDataSource
 {
   private static final Logger LOGGER = new Logger(BasicDataSourceExt.class);
 
-  private Properties connectionProperties;
   private final MetadataStorageConnectorConfig connectorConfig;
+
+  /**
+   * The properties that will be used for the JDBC connection.
+   *
+   * Note that these properties are not currently checked against any security configuration such as
+   * an allow list for JDBC properties. Instead, they are supposed to be checked before adding to this class.
+   *
+   * @see SQLFirehoseDatabaseConnector#validateConfigs
+   */
+  private Properties connectionProperties;
 
   public BasicDataSourceExt(MetadataStorageConnectorConfig connectorConfig)
   {

--- a/server/src/main/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModule.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.initialization;
+
+import com.fasterxml.jackson.databind.Module;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import org.apache.druid.guice.JsonConfigProvider;
+import org.apache.druid.initialization.DruidModule;
+
+import java.util.List;
+
+public class ExternalStorageAccessSecurityModule implements DruidModule
+{
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    JsonConfigProvider.bind(binder, "druid.access.jdbc", JdbcAccessSecurityConfig.class);
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/initialization/JdbcAccessSecurityConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/JdbcAccessSecurityConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.initialization;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * A config class that applies to all JDBC connections to other databases.
+ *
+ * @see org.apache.druid.utils.ConnectionUriUtils
+ */
+public class JdbcAccessSecurityConfig
+{
+  static final Set<String> DEFAULT_ALLOWED_PROPERTIES = ImmutableSet.of(
+      // MySQL
+      "useSSL",
+      "requireSSL",
+
+      // PostgreSQL
+      "ssl",
+      "sslmode"
+  );
+
+  /**
+   * Prefixes of the properties that can be added automatically by {@link java.sql.Driver} during
+   * connection URL parsing. Any properties resulted by connection URL parsing are regarded as
+   * system properties if they start with the prefixes in this set.
+   * Only these non-system properties are checkaed against {@link #getAllowedProperties()}.
+   */
+  private static final Set<String> SYSTEM_PROPERTY_PREFIXES = ImmutableSet.of(
+      // MySQL
+      // There can be multiple host and port properties if multiple addresses are specified.
+      // The pattern of the property name is HOST.i and PORT.i where i is an integer.
+      "HOST",
+      "PORT",
+      "NUM_HOSTS",
+      "DBNAME",
+
+      // PostgreSQL
+      "PGHOST",
+      "PGPORT",
+      "PGDBNAME"
+  );
+
+  @JsonProperty
+  private Set<String> allowedProperties = DEFAULT_ALLOWED_PROPERTIES;
+
+  @JsonProperty
+  private boolean allowUnknownJdbcUrlFormat = true;
+
+  // Enforcing allow list check can break rolling upgrade. This is not good for patch releases
+  // and is why this config is added. However, from the security point of view, this config
+  // should be always enabled in production to secure your cluster. As a result, this config
+  // is deprecated and will be removed in the near future.
+  @Deprecated
+  @JsonProperty
+  private boolean enforceAllowedProperties = false;
+
+  @JsonIgnore
+  public Set<String> getSystemPropertyPrefixes()
+  {
+    return SYSTEM_PROPERTY_PREFIXES;
+  }
+
+  public Set<String> getAllowedProperties()
+  {
+    return allowedProperties;
+  }
+
+  public boolean isAllowUnknownJdbcUrlFormat()
+  {
+    return allowUnknownJdbcUrlFormat;
+  }
+
+  public boolean isEnforceAllowedProperties()
+  {
+    return enforceAllowedProperties;
+  }
+}

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseFactoryTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.segment.realtime.firehose;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.data.input.Firehose;
 import org.apache.druid.data.input.Row;
@@ -31,8 +30,6 @@ import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.TimeAndDimsParseSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.metadata.MetadataStorageConnectorConfig;
-import org.apache.druid.metadata.SQLFirehoseDatabaseConnector;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.metadata.input.SqlTestUtils;
 import org.apache.druid.segment.TestHelper;
@@ -42,7 +39,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.skife.jdbi.v2.DBI;
 
 import java.io.File;
 import java.io.IOException;
@@ -235,23 +231,5 @@ public class SqlFirehoseFactoryTest
     testUtils.dropTable(TABLE_NAME_1);
     testUtils.dropTable(TABLE_NAME_2);
 
-  }
-  private static class TestDerbyFirehoseConnector extends SQLFirehoseDatabaseConnector
-  {
-    private final DBI dbi;
-
-    private TestDerbyFirehoseConnector(MetadataStorageConnectorConfig metadataStorageConnectorConfig, DBI dbi)
-    {
-      final BasicDataSource datasource = getDatasource(metadataStorageConnectorConfig);
-      datasource.setDriverClassLoader(getClass().getClassLoader());
-      datasource.setDriverClassName("org.apache.derby.jdbc.ClientDriver");
-      this.dbi = dbi;
-    }
-
-    @Override
-    public DBI getDBI()
-    {
-      return dbi;
-    }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModuleTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.initialization;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.druid.guice.DruidGuiceExtensions;
+import org.apache.druid.guice.JsonConfigurator;
+import org.apache.druid.guice.LazySingleton;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Properties;
+
+public class ExternalStorageAccessSecurityModuleTest
+{
+  @Test
+  public void testSecurityConfigDefault()
+  {
+    JdbcAccessSecurityConfig securityConfig = makeInjectorWithProperties(new Properties()).getInstance(
+        JdbcAccessSecurityConfig.class
+    );
+    Assert.assertNotNull(securityConfig);
+    Assert.assertEquals(
+        JdbcAccessSecurityConfig.DEFAULT_ALLOWED_PROPERTIES,
+        securityConfig.getAllowedProperties()
+    );
+    Assert.assertTrue(securityConfig.isAllowUnknownJdbcUrlFormat());
+    Assert.assertFalse(securityConfig.isEnforceAllowedProperties());
+  }
+
+  @Test
+  public void testSecurityConfigOverride()
+  {
+    Properties properties = new Properties();
+    properties.setProperty("druid.access.jdbc.allowedProperties", "[\"valid1\", \"valid2\", \"valid3\"]");
+    properties.setProperty("druid.access.jdbc.allowUnknownJdbcUrlFormat", "false");
+    properties.setProperty("druid.access.jdbc.enforceAllowedProperties", "true");
+    JdbcAccessSecurityConfig securityConfig = makeInjectorWithProperties(properties).getInstance(
+        JdbcAccessSecurityConfig.class
+    );
+    Assert.assertNotNull(securityConfig);
+    Assert.assertEquals(
+        ImmutableSet.of(
+            "valid1",
+            "valid2",
+            "valid3"
+        ),
+        securityConfig.getAllowedProperties()
+    );
+    Assert.assertFalse(securityConfig.isAllowUnknownJdbcUrlFormat());
+    Assert.assertTrue(securityConfig.isEnforceAllowedProperties());
+  }
+
+  private static Injector makeInjectorWithProperties(final Properties props)
+  {
+    return Guice.createInjector(
+        ImmutableList.of(
+            new DruidGuiceExtensions(),
+            binder -> {
+              binder.bind(Validator.class).toInstance(Validation.buildDefaultValidatorFactory().getValidator());
+              binder.bind(JsonConfigurator.class).in(LazySingleton.class);
+              binder.bind(Properties.class).toInstance(props);
+            },
+            new ExternalStorageAccessSecurityModule()
+        )
+    );
+  }
+}

--- a/website/.spelling
+++ b/website/.spelling
@@ -370,6 +370,7 @@ reingest
 reingesting
 reingestion
 repo
+requireSSL
 rollup
 rollups
 rsync
@@ -385,6 +386,8 @@ sharding
 skipHeaderRows
 smooshed
 splittable
+ssl
+sslmode
 stdout
 storages
 stringified
@@ -420,6 +423,7 @@ unparsed
 unsetting
 untrusted
 useFilterCNF
+useSSL
 uptime
 uris
 urls


### PR DESCRIPTION
### Description

This is a backport PR of https://github.com/apache/druid/commit/48953e3508967f5156c69676432b5d4dd25ea678. [CVE-2021-26919](https://lists.apache.org/thread.html/rd87451fce34df54796e66321c40d743a68fb4553d72e7f6f0bc62ebd%40%3Cdev.druid.apache.org%3E) is filed for the security vulnerability of remote code execution using vulnerable MySQL JDBC properties. This PR adds an allow list for JDBC connection properties that is enforced against every JDBC connections for ingestion and lookups but not metadata stores. The allow list is enforced to connections to postgresql as well as mysql. This is because, even though the known security vulnerability can be exploitable with only MySQL, we want to be conservative and avoid the same issue even with PostgreSQL that can be potentially exploitable in the future. The JDBC connection will fail if it uses a property that is not in the allow list.

Implementation-wise, this PR uses vendor-specific libraries to parse JDBC connection URLs because the JDBC URL format is diverse across different vendors. This introduces new compatibility issues.

1) The JDBC driver version in the classpath at runtime should be compatible to the version that is used for URL parsing at compile time. 
2) Druid can enforce the allow list to only the JDBC connections that it knows how to parse. However, we should restrict allowed JDBC properties for other database systems to avoid similar issues that can be potentially found in the future.

As a result, URL parsing should be a short-term workaround to mitigate this vulnerability. Longer term, we should rather disallow arbitrary URLs in JDBC connections. Instead, we can only accept connection properties individually including host, port and user name.

<hr>

##### Key changed/added classes in this PR
 * `JdbcAccessSecurityConfig`
 * `JdbcExtractionNamespace`
 * `JdbcFetcher`
 * `MySQLFirehoseDatabaseConnector`
 * `PostgresqlFirehoseDatabaseConnector`

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.