### PR TITLE
fix lookup nullable

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
@@ -40,7 +40,7 @@ public class QueryLookupOperatorConversion implements SqlOperatorConversion
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("LOOKUP")
       .operandTypes(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)
-      .returnTypeNonNull(SqlTypeName.VARCHAR)
+      .returnTypeNullable(SqlTypeName.VARCHAR)
       .functionCategory(SqlFunctionCategory.STRING)
       .build();
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -17091,26 +17091,36 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Test
   public void testLookupWithNull() throws Exception
   {
+    List<Object[]> expected;
+    if (useDefault) {
+      expected = ImmutableList.<Object[]>builder().add(
+          new Object[]{NULL_STRING, NULL_STRING},
+          new Object[]{NULL_STRING, NULL_STRING},
+          new Object[]{NULL_STRING, NULL_STRING}
+      ).build();
+    } else {
+      expected = ImmutableList.<Object[]>builder().add(
+          new Object[]{NULL_STRING, NULL_STRING},
+          new Object[]{NULL_STRING, NULL_STRING}
+      ).build();
+    }
     testQuery(
-        "SELECT dim1 ,lookup(dim1,'lookyloo') from foo where dim1 = 'def'",
+        "SELECT dim2 ,lookup(dim2,'lookyloo') from foo where dim2 is null",
         ImmutableList.of(
             new Druids.ScanQueryBuilder()
-            .dataSource(CalciteTests.DATASOURCE1)
-            .intervals(querySegmentSpec(Filtration.eternity()))
-            .virtualColumns(
-                expressionVirtualColumn("v0", "'def'", ValueType.STRING),
-                expressionVirtualColumn("v1", "null", ValueType.STRING)
-            )
-            .columns("v0", "v1")
-            .legacy(false)
-            .filters(new SelectorDimFilter("dim1", "def", null))
-            .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-            .context(QUERY_CONTEXT_DEFAULT)
-            .build()
+                .dataSource(CalciteTests.DATASOURCE1)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .virtualColumns(
+                    expressionVirtualColumn("v0", "null", ValueType.STRING)
+                )
+                .columns("v0")
+                .legacy(false)
+                .filters(new SelectorDimFilter("dim2", NULL_STRING, null))
+                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
         ),
-        ImmutableList.<Object[]>builder().add(
-            new Object[]{"def", NULL_STRING}
-        ).build()
+        expected
     );
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -17092,25 +17092,24 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   public void testLookupWithNull() throws Exception
   {
     testQuery(
-        "SELECT dim2 ,lookup(dim2,'lookyloo') from foo where dim2 is null",
+        "SELECT dim1 ,lookup(dim1,'lookyloo') from foo where dim1 = 'def'",
         ImmutableList.of(
             new Druids.ScanQueryBuilder()
             .dataSource(CalciteTests.DATASOURCE1)
             .intervals(querySegmentSpec(Filtration.eternity()))
             .virtualColumns(
-                expressionVirtualColumn("v0", "null", ValueType.STRING)
+                expressionVirtualColumn("v0", "'def'", ValueType.STRING),
+                expressionVirtualColumn("v1", "null", ValueType.STRING)
             )
-            .columns("v0")
+            .columns("v0", "v1")
             .legacy(false)
-            .filters(new SelectorDimFilter("dim2", "", null))
+            .filters(new SelectorDimFilter("dim1", "def", null))
             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
             .context(QUERY_CONTEXT_DEFAULT)
             .build()
         ),
         ImmutableList.<Object[]>builder().add(
-            new Object[]{"", NULL_STRING},
-            new Object[]{"", NULL_STRING},
-            new Object[]{"", NULL_STRING}
+            new Object[]{"def", NULL_STRING}
         ).build()
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -17086,4 +17086,32 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ).build()
     );
   }
+
+
+  @Test
+  public void testLookupWithNull() throws Exception
+  {
+    testQuery(
+        "SELECT dim2 ,lookup(dim2,'lookyloo') from foo where dim2 is null",
+        ImmutableList.of(
+            new Druids.ScanQueryBuilder()
+            .dataSource(CalciteTests.DATASOURCE1)
+            .intervals(querySegmentSpec(Filtration.eternity()))
+            .virtualColumns(
+                expressionVirtualColumn("v0", "null", ValueType.STRING)
+            )
+            .columns("v0")
+            .legacy(false)
+            .filters(new SelectorDimFilter("dim2", "", null))
+            .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+            .context(QUERY_CONTEXT_DEFAULT)
+            .build()
+        ),
+        ImmutableList.<Object[]>builder().add(
+            new Object[]{"", NULL_STRING},
+            new Object[]{"", NULL_STRING},
+            new Object[]{"", NULL_STRING}
+        ).build()
+    );
+  }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #11038.



### Description
When we use `lookup` func in sql, we will  return null value if we don't found. However, in `org.apache.druid.sql.calcite.expression.builtin.QueryLookupOperatorConversion`, it's returnType was defined as `returnTypeNonNull`, which casue a validation error in calcites.


### Solution
Change lookup func's return as nullable with `returnTypeNonNull`.

##### Key changed/added classes in this PR
 * `org.apache.druid.sql.calcite.expression.builtin.QueryLookupOperatorConversion`
<hr>


This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage]
- [x] been tested in a test Druid cluster.
