### PR TITLE
Enforce allow list for JDBC properties by default

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -537,7 +537,7 @@ the [HTTP input source](../ingestion/native-batch.md#http-input-source) and the 
 |`druid.ingestion.http.allowedProtocols`|List of protocols|Allowed protocols for the HTTP input source and HTTP firehose.|["http", "https"]|
 
 
-### Ingestion Security Configuration
+### External Data Access Security Configuration
 
 #### JDBC Connections to External Databases
 
@@ -551,7 +551,7 @@ These properties do not apply to metadata storage connections.
 
 |Property|Possible Values|Description|Default|
 |--------|---------------|-----------|-------|
-|`druid.access.jdbc.enforceAllowedProperties`|Boolean|When true, Druid applies `druid.access.jdbc.allowedProperties` to JDBC connections starting with `jdbc:postgresql:` or `jdbc:mysql:`. When false, Druid allows any kind of JDBC connections without JDBC property validation. This config is deprecated and will be removed in a future release.|false|
+|`druid.access.jdbc.enforceAllowedProperties`|Boolean|When true, Druid applies `druid.access.jdbc.allowedProperties` to JDBC connections starting with `jdbc:postgresql:` or `jdbc:mysql:`. When false, Druid allows any kind of JDBC connections without JDBC property validation. This config is for backward compatibility especially during upgrades since enforcing allow list can break existing ingestion jobs or lookups based on JDBC. This config is deprecated and will be removed in a future release.|true|
 |`druid.access.jdbc.allowedProperties`|List of JDBC properties|Defines a list of allowed JDBC properties. Druid always enforces the list for all JDBC connections starting with `jdbc:postgresql:` or `jdbc:mysql:` if `druid.access.jdbc.enforceAllowedProperties` is set to true.<br/><br/>This option is tested against MySQL connector 5.1.48 and PostgreSQL connector 42.2.14. Other connector versions might not work.|["useSSL", "requireSSL", "ssl", "sslmode"]|
 |`druid.access.jdbc.allowUnknownJdbcUrlFormat`|Boolean|When false, Druid only accepts JDBC connections starting with `jdbc:postgresql:` or `jdbc:mysql:`. When true, Druid allows JDBC connections to any kind of database, but only enforces `druid.access.jdbc.allowedProperties` for PostgreSQL and MySQL.|true|
 

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/firehose/sql/MySQLFirehoseDatabaseConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/firehose/sql/MySQLFirehoseDatabaseConnectorTest.java
@@ -184,6 +184,12 @@ public class MySQLFirehoseDatabaseConnectorTest
       {
         return ImmutableSet.of("user", "nonenone");
       }
+
+      @Override
+      public boolean isEnforceAllowedProperties()
+      {
+        return false;
+      }
     };
 
     new MySQLFirehoseDatabaseConnector(
@@ -205,13 +211,12 @@ public class MySQLFirehoseDatabaseConnectorTest
       }
     };
 
-    MySQLFirehoseDatabaseConnector connector = new MySQLFirehoseDatabaseConnector(
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(StringUtils.format("Invalid URL format for MySQL: [%s]", url));
+    new MySQLFirehoseDatabaseConnector(
         connectorConfig,
         new JdbcAccessSecurityConfig()
     );
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(StringUtils.format("Invalid URL format for MySQL: [%s]", url));
-    connector.findPropertyKeysFromConnectURL(url);
   }
 
   private static JdbcAccessSecurityConfig newSecurityConfigEnforcingAllowList(Set<String> allowedProperties)

--- a/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/firehose/PostgresqlFirehoseDatabaseConnectorTest.java
@@ -183,6 +183,12 @@ public class PostgresqlFirehoseDatabaseConnectorTest
       {
         return ImmutableSet.of("user", "nonenone");
       }
+
+      @Override
+      public boolean isEnforceAllowedProperties()
+      {
+        return false;
+      }
     };
 
     new PostgresqlFirehoseDatabaseConnector(

--- a/server/src/main/java/org/apache/druid/server/initialization/JdbcAccessSecurityConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/JdbcAccessSecurityConfig.java
@@ -69,13 +69,12 @@ public class JdbcAccessSecurityConfig
   @JsonProperty
   private boolean allowUnknownJdbcUrlFormat = true;
 
-  // Enforcing allow list check can break rolling upgrade. This is not good for patch releases
-  // and is why this config is added. However, from the security point of view, this config
-  // should be always enabled in production to secure your cluster. As a result, this config
-  // is deprecated and will be removed in the near future.
+  // This config is for compatibility as enforcing allow list can break existing ingestion jobs or lookups.
+  // However, from the security point of view, this config should be always enabled in production to secure
+  // your cluster. As a result, this config is deprecated and will be removed in a future release.
   @Deprecated
   @JsonProperty
-  private boolean enforceAllowedProperties = false;
+  private boolean enforceAllowedProperties = true;
 
   @JsonIgnore
   public Set<String> getSystemPropertyPrefixes()

--- a/server/src/test/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModuleTest.java
@@ -47,7 +47,7 @@ public class ExternalStorageAccessSecurityModuleTest
         securityConfig.getAllowedProperties()
     );
     Assert.assertTrue(securityConfig.isAllowUnknownJdbcUrlFormat());
-    Assert.assertFalse(securityConfig.isEnforceAllowedProperties());
+    Assert.assertTrue(securityConfig.isEnforceAllowedProperties());
   }
 
   @Test


### PR DESCRIPTION
### Description

A follow-up to https://github.com/apache/druid/pull/11047. This PR changes the default to enforce the allow list for JDBC connection properties. `allowUnknownJdbcUrlFormat` still remains as true by default because, at least the known security vulnerability can be exploitable only with MySQL which Druid will always enforce the allow list once it's enabled regardless of `allowUnknownJdbcUrlFormat`.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.