### PR TITLE
Enable rewriting certain inner joins as filters.

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/IndexedTableJoinCursorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/IndexedTableJoinCursorBenchmark.java
@@ -186,6 +186,7 @@ public class IndexedTableJoinCursorBenchmark
                     enableFilterPushdown,
                     enableFilterRewrite,
                     enableFilterRewriteValueFilters,
+                    QueryContexts.DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER,
                     QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
                 ),
                 clauses,

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
@@ -150,6 +150,7 @@ public class JoinAndLookupBenchmark
                     false,
                     false,
                     false,
+                    false,
                     0
                 ),
                 joinableClausesLookupStringKey,
@@ -182,6 +183,7 @@ public class JoinAndLookupBenchmark
         JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
             new JoinFilterPreAnalysisKey(
                 new JoinFilterRewriteConfig(
+                    false,
                     false,
                     false,
                     false,
@@ -220,6 +222,7 @@ public class JoinAndLookupBenchmark
                     false,
                     false,
                     false,
+                    false,
                     0
                 ),
                 joinableClausesLookupLongKey,
@@ -252,6 +255,7 @@ public class JoinAndLookupBenchmark
         JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
             new JoinFilterPreAnalysisKey(
                 new JoinFilterRewriteConfig(
+                    false,
                     false,
                     false,
                     false,

--- a/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/LoadingLookup.java
+++ b/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/LoadingLookup.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -112,9 +113,21 @@ public class LoadingLookup extends LookupExtractor
   }
 
   @Override
+  public boolean canGetKeySet()
+  {
+    return false;
+  }
+
+  @Override
   public Iterable<Map.Entry<String, String>> iterable()
   {
     throw new UnsupportedOperationException("Cannot iterate");
+  }
+
+  @Override
+  public Set<String> keySet()
+  {
+    throw new UnsupportedOperationException("Cannot get key set");
   }
 
   @Override

--- a/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/PollingLookup.java
+++ b/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/PollingLookup.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -174,9 +175,21 @@ public class PollingLookup extends LookupExtractor
   }
 
   @Override
+  public boolean canGetKeySet()
+  {
+    return false;
+  }
+
+  @Override
   public Iterable<Map.Entry<String, String>> iterable()
   {
     throw new UnsupportedOperationException("Cannot iterate");
+  }
+
+  @Override
+  public Set<String> keySet()
+  {
+    throw new UnsupportedOperationException("Cannot get key set");
   }
 
   @Override

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
@@ -26,7 +26,9 @@ import org.apache.druid.server.lookup.cache.loading.LoadingCache;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,6 +41,9 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
   LoadingCache lookupCache = EasyMock.createStrictMock(LoadingCache.class);
   LoadingCache reverseLookupCache = EasyMock.createStrictMock(LoadingCache.class);
   LoadingLookup loadingLookup = new LoadingLookup(dataFetcher, lookupCache, reverseLookupCache);
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testApplyEmptyOrNull() throws ExecutionException
@@ -122,5 +127,18 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
   public void testGetCacheKey()
   {
     Assert.assertFalse(Arrays.equals(loadingLookup.getCacheKey(), loadingLookup.getCacheKey()));
+  }
+
+  @Test
+  public void testCanGetKeySet()
+  {
+    Assert.assertFalse(loadingLookup.canGetKeySet());
+  }
+
+  @Test
+  public void testKeySet()
+  {
+    expectedException.expect(UnsupportedOperationException.class);
+    loadingLookup.keySet();
   }
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupTest.java
@@ -34,7 +34,9 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -61,6 +63,9 @@ public class PollingLookupTest extends InitializedNullHandlingTest
   );
 
   private static final long POLL_PERIOD = 1000L;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @JsonTypeName("mock")
   private static class MockDataFetcher implements DataFetcher
@@ -202,6 +207,19 @@ public class PollingLookupTest extends InitializedNullHandlingTest
   {
     PollingLookup pollingLookup2 = new PollingLookup(1L, dataFetcher, pollingCacheFactory);
     Assert.assertFalse(Arrays.equals(pollingLookup2.getCacheKey(), pollingLookup.getCacheKey()));
+  }
+
+  @Test
+  public void testCanGetKeySet()
+  {
+    Assert.assertFalse(pollingLookup.canGetKeySet());
+  }
+
+  @Test
+  public void testKeySet()
+  {
+    expectedException.expect(UnsupportedOperationException.class);
+    pollingLookup.keySet();
   }
 
   private void assertMapLookup(Map<String, String> map, LookupExtractor lookup)

--- a/processing/src/main/java/org/apache/druid/query/Query.java
+++ b/processing/src/main/java/org/apache/druid/query/Query.java
@@ -46,6 +46,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
@@ -192,5 +193,21 @@ public interface Query<T>
   default VirtualColumns getVirtualColumns()
   {
     return VirtualColumns.EMPTY;
+  }
+
+  /**
+   * Returns the set of columns that this query will need to access out of its datasource.
+   *
+   * This method does not "look into" what the datasource itself is doing. For example, if a query is built on a
+   * {@link QueryDataSource}, this method will not return the columns used by that subquery. As another example, if a
+   * query is built on a {@link JoinDataSource}, this method will not return the columns from the underlying datasources
+   * that are used by the join condition, unless those columns are also used by this query in other ways.
+   *
+   * Returns null if the set of required columns cannot be known ahead of time.
+   */
+  @Nullable
+  default Set<String> getRequiredColumns()
+  {
+    return null;
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -54,6 +54,7 @@ public class QueryContexts
   public static final String JOIN_FILTER_PUSH_DOWN_KEY = "enableJoinFilterPushDown";
   public static final String JOIN_FILTER_REWRITE_ENABLE_KEY = "enableJoinFilterRewrite";
   public static final String JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY = "enableJoinFilterRewriteValueColumnFilters";
+  public static final String REWRITE_JOIN_TO_FILTER_ENABLE_KEY = "enableRewriteJoinToFilter";
   public static final String JOIN_FILTER_REWRITE_MAX_SIZE_KEY = "joinFilterRewriteMaxSize";
   // This flag control whether a sql join query with left scan should be attempted to be run as direct table access
   // instead of being wrapped inside a query. With direct table access enabled, druid can push down the join operation to
@@ -80,6 +81,7 @@ public class QueryContexts
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_REWRITE = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS = false;
+  public static final boolean DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER = false;
   public static final long DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE = 10000;
   public static final boolean DEFAULT_ENABLE_SQL_JOIN_LEFT_SCAN_DIRECT = false;
   public static final boolean DEFAULT_USE_FILTER_CNF = false;
@@ -274,11 +276,21 @@ public class QueryContexts
   {
     return parseInt(query, BROKER_PARALLELISM, defaultValue);
   }
+
   public static <T> boolean getEnableJoinFilterRewriteValueColumnFilters(Query<T> query)
   {
     return parseBoolean(
         query,
         JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY,
+        DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS
+    );
+  }
+
+  public static <T> boolean getEnableRewriteJoinToFilter(Query<T> query)
+  {
+    return parseBoolean(
+        query,
+        REWRITE_JOIN_TO_FILTER_ENABLE_KEY,
         DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS
     );
   }

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -291,7 +291,7 @@ public class QueryContexts
     return parseBoolean(
         query,
         REWRITE_JOIN_TO_FILTER_ENABLE_KEY,
-        DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS
+        DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @JsonTypeName("map")
@@ -129,9 +130,21 @@ public class MapLookupExtractor extends LookupExtractor
   }
 
   @Override
+  public boolean canGetKeySet()
+  {
+    return true;
+  }
+
+  @Override
   public Iterable<Map.Entry<String, String>> iterable()
   {
     return map.entrySet();
+  }
+
+  @Override
+  public Set<String> keySet()
+  {
+    return Collections.unmodifiableSet(map.keySet());
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -73,6 +73,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -776,6 +777,19 @@ public class GroupByQuery extends BaseQuery<ResultRow>
   public Sequence<ResultRow> postProcess(Sequence<ResultRow> results)
   {
     return postProcessingFn.apply(results);
+  }
+
+  @Nullable
+  @Override
+  public Set<String> getRequiredColumns()
+  {
+    return Queries.computeRequiredColumns(
+        virtualColumns,
+        dimFilter,
+        dimensions,
+        aggregatorSpecs,
+        Collections.emptyList()
+    );
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
@@ -121,7 +121,7 @@ public abstract class LookupExtractor
   /**
    * Returns a Set of all keys in this lookup extractor. The returned Set will not change.
    *
-   * @throws UnsupportedOperationException if {@link #canIterate()} returns false.
+   * @throws UnsupportedOperationException if {@link #canGetKeySet()} returns false.
    */
   public abstract Set<String> keySet();
 

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
@@ -106,11 +107,23 @@ public abstract class LookupExtractor
   public abstract boolean canIterate();
 
   /**
+   * Returns true if this lookup extractor's {@link #keySet()} method will return a valid set.
+   */
+  public abstract boolean canGetKeySet();
+
+  /**
    * Returns an Iterable that iterates over the keys and values in this lookup extractor.
    *
    * @throws UnsupportedOperationException if {@link #canIterate()} returns false.
    */
   public abstract Iterable<Map.Entry<String, String>> iterable();
+
+  /**
+   * Returns a Set of all keys in this lookup extractor. The returned Set will not change.
+   *
+   * @throws UnsupportedOperationException if {@link #canIterate()} returns false.
+   */
+  public abstract Set<String> keySet();
 
   /**
    * Create a cache key for use in results caching

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
@@ -31,6 +31,7 @@ import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.Druids;
+import org.apache.druid.query.Queries;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.spec.QuerySegmentSpec;
@@ -38,10 +39,12 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnHolder;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class ScanQuery extends BaseQuery<ScanResultValue>
 {
@@ -309,6 +312,24 @@ public class ScanQuery extends BaseQuery<ScanResultValue>
             : Comparator.<ScanResultValue>naturalOrder().reversed()
         )
     );
+  }
+
+  @Nullable
+  @Override
+  public Set<String> getRequiredColumns()
+  {
+    if (columns == null || columns.isEmpty()) {
+      // We don't know what columns we require. We'll find out when the segment shows up.
+      return null;
+    } else {
+      return Queries.computeRequiredColumns(
+          virtualColumns,
+          dimFilter,
+          Collections.emptyList(),
+          Collections.emptyList(),
+          columns
+      );
+    }
   }
 
   public ScanQuery withOffset(final long newOffset)

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQuery.java
@@ -38,10 +38,13 @@ import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.spec.QuerySegmentSpec;
 import org.apache.druid.segment.VirtualColumns;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  */
@@ -155,6 +158,19 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
   public boolean isSkipEmptyBuckets()
   {
     return getContextBoolean(SKIP_EMPTY_BUCKETS, false);
+  }
+
+  @Nullable
+  @Override
+  public Set<String> getRequiredColumns()
+  {
+    return Queries.computeRequiredColumns(
+        virtualColumns,
+        dimFilter,
+        Collections.emptyList(),
+        aggregatorSpecs,
+        Collections.emptyList()
+    );
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
@@ -37,10 +37,13 @@ import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.spec.QuerySegmentSpec;
 import org.apache.druid.segment.VirtualColumns;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  */
@@ -154,6 +157,19 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
   public List<PostAggregator> getPostAggregatorSpecs()
   {
     return postAggregatorSpecs;
+  }
+
+  @Nullable
+  @Override
+  public Set<String> getRequiredColumns()
+  {
+    return Queries.computeRequiredColumns(
+        virtualColumns,
+        dimFilter,
+        Collections.singletonList(dimensionSpec),
+        aggregatorSpecs,
+        Collections.emptyList()
+    );
   }
 
   public void initTopNAlgorithmSelector(TopNAlgorithmSelector selector)

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegment.java
@@ -66,9 +66,9 @@ public class HashJoinSegment implements SegmentReference
     this.clauses = clauses;
     this.joinFilterPreAnalysis = joinFilterPreAnalysis;
 
-    // Verify 'clauses' is nonempty (otherwise it's a waste to create this object, and the caller should know)
-    if (clauses.isEmpty()) {
-      throw new IAE("'clauses' is empty, no need to create HashJoinSegment");
+    // Verify this virtual segment is doing something useful (otherwise it's a waste to create this object)
+    if (clauses.isEmpty() && baseFilter == null) {
+      throw new IAE("'clauses' and 'baseFilter' are both empty, no need to create HashJoinSegment");
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -37,16 +37,19 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysisKey;
 import org.apache.druid.segment.join.filter.JoinFilterSplit;
+import org.apache.druid.segment.vector.VectorCursor;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -56,6 +59,8 @@ import java.util.Set;
 public class HashJoinSegmentStorageAdapter implements StorageAdapter
 {
   private final StorageAdapter baseAdapter;
+
+  @Nullable
   private final Filter baseFilter;
   private final List<JoinableClause> clauses;
   private final JoinFilterPreAnalysis joinFilterPreAnalysis;
@@ -84,7 +89,7 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
    */
   HashJoinSegmentStorageAdapter(
       final StorageAdapter baseAdapter,
-      final Filter baseFilter,
+      @Nullable final Filter baseFilter,
       final List<JoinableClause> clauses,
       final JoinFilterPreAnalysis joinFilterPreAnalysis
   )
@@ -222,6 +227,43 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public boolean canVectorize(@Nullable Filter filter, VirtualColumns virtualColumns, boolean descending)
+  {
+    // HashJoinEngine isn't vectorized yet.
+    // However, we can still vectorize if there are no clauses, since that means all we need to do is apply
+    // a base filter. That's easy enough!
+    return clauses.isEmpty() && baseAdapter.canVectorize(baseFilterAnd(filter), virtualColumns, descending);
+  }
+
+  @Nullable
+  @Override
+  public VectorCursor makeVectorCursor(
+      @Nullable Filter filter,
+      Interval interval,
+      VirtualColumns virtualColumns,
+      boolean descending,
+      int vectorSize,
+      @Nullable QueryMetrics<?> queryMetrics
+  )
+  {
+    if (!canVectorize(filter, virtualColumns, descending)) {
+      throw new ISE("Cannot vectorize. Check 'canVectorize' before calling 'makeVectorCursor'.");
+    }
+
+    // Should have been checked by canVectorize.
+    assert clauses.isEmpty();
+
+    return baseAdapter.makeVectorCursor(
+        baseFilterAnd(filter),
+        interval,
+        virtualColumns,
+        descending,
+        vectorSize,
+        queryMetrics
+    );
+  }
+
+  @Override
   public Sequence<Cursor> makeCursors(
       @Nullable final Filter filter,
       @Nonnull final Interval interval,
@@ -231,6 +273,19 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
       @Nullable final QueryMetrics<?> queryMetrics
   )
   {
+    final Filter combinedFilter = baseFilterAnd(filter);
+
+    if (clauses.isEmpty()) {
+      return baseAdapter.makeCursors(
+          combinedFilter,
+          interval,
+          virtualColumns,
+          gran,
+          descending,
+          queryMetrics
+      );
+    }
+
     // Filter pre-analysis key implied by the call to "makeCursors". We need to sanity-check that it matches
     // the actual pre-analysis that was done. Note: we can't infer a rewrite config from the "makeCursors" call (it
     // requires access to the query context) so we'll need to skip sanity-checking it, by re-using the one present
@@ -240,7 +295,7 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
             joinFilterPreAnalysis.getKey().getRewriteConfig(),
             clauses,
             virtualColumns,
-            filter
+            combinedFilter
         );
 
     final JoinFilterPreAnalysisKey keyCached = joinFilterPreAnalysis.getKey();
@@ -362,5 +417,11 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
                 .stream()
                 .filter(clause -> clause.includesColumn(column))
                 .findFirst();
+  }
+
+  @Nullable
+  private Filter baseFilterAnd(@Nullable final Filter other)
+  {
+    return Filters.maybeAnd(Arrays.asList(baseFilter, other)).orElse(null);
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinConditionAnalysis.java
@@ -29,6 +29,7 @@ import org.apache.druid.query.expression.ExprUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -58,6 +59,7 @@ public class JoinConditionAnalysis
   private final boolean isAlwaysTrue;
   private final boolean canHashJoin;
   private final Set<String> rightKeyColumns;
+  private final Set<String> requiredColumns;
 
   private JoinConditionAnalysis(
       final String originalExpression,
@@ -80,6 +82,7 @@ public class JoinConditionAnalysis
                                                                     ExprUtils.nilBindings()).asBoolean());
     canHashJoin = nonEquiConditions.stream().allMatch(Expr::isLiteral);
     rightKeyColumns = getEquiConditions().stream().map(Equality::getRightColumn).collect(Collectors.toSet());
+    requiredColumns = computeRequiredColumns(rightPrefix, equiConditions, nonEquiConditions);
   }
 
   /**
@@ -192,6 +195,15 @@ public class JoinConditionAnalysis
     return rightKeyColumns;
   }
 
+  /**
+   * Returns the set of column names required by this join condition. Columns from the right-hand side are returned
+   * with their prefixes included.
+   */
+  public Set<String> getRequiredColumns()
+  {
+    return requiredColumns;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -216,5 +228,25 @@ public class JoinConditionAnalysis
   public String toString()
   {
     return originalExpression;
+  }
+
+  private static Set<String> computeRequiredColumns(
+      final String rightPrefix,
+      final List<Equality> equiConditions,
+      final List<Expr> nonEquiConditions
+  )
+  {
+    final Set<String> requiredColumns = new HashSet<>();
+
+    for (Equality equality : equiConditions) {
+      requiredColumns.add(rightPrefix + equality.getRightColumn());
+      requiredColumns.addAll(equality.getLeftExpr().analyzeInputs().getRequiredBindings());
+    }
+
+    for (Expr expr : nonEquiConditions) {
+      requiredColumns.addAll(expr.analyzeInputs().getRequiredBindings());
+    }
+
+    return requiredColumns;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/join/Joinable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/Joinable.java
@@ -86,6 +86,15 @@ public interface Joinable extends ReferenceCountedObject
   );
 
   /**
+   * Returns all nonnull values from a particular column if they are all unique, if there are "maxNumValues" or fewer,
+   * and if the column exists and supports this operation. Otherwise, returns an empty Optional.
+   *
+   * @param columnName   name of the column
+   * @param maxNumValues maximum number of values to return
+   */
+  Optional<Set<String>> getNonNullColumnValuesIfAllUnique(String columnName, int maxNumValues);
+
+  /**
    * Searches a column from this Joinable for a particular value, finds rows that match,
    * and returns values of a second column for those rows.
    *
@@ -93,9 +102,9 @@ public interface Joinable extends ReferenceCountedObject
    * @param searchColumnValue Target value of the search column. This is the value that is being filtered on.
    * @param retrievalColumnName The column to retrieve values from. This is the column that is being joined against.
    * @param maxCorrelationSetSize Maximum number of values to retrieve. If we detect that more values would be
-   *                              returned than this limit, return an empty set.
+   *                              returned than this limit, return absent.
    * @param allowNonKeyColumnSearch If true, allow searchs on non-key columns. If this is false,
-   *                                a search on a non-key column should return an empty set.
+   *                                a search on a non-key column returns absent.
    * @return The set of correlated column values. If we cannot determine correlated values, return absent.
    *
    * In case either the search or retrieval column names are not found, this will return absent.

--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterRewriteConfig.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterRewriteConfig.java
@@ -48,6 +48,12 @@ public class JoinFilterRewriteConfig
   private final boolean enableRewriteValueColumnFilters;
 
   /**
+   * Whether to enable eliminating entire inner join clauses by rewriting them into filters on the base segment.
+   * In production this should generally be {@code QueryContexts.getEnableRewriteJoinToFilter(query)}.
+   */
+  private final boolean enableRewriteJoinToFilter;
+
+  /**
    * The max allowed size of correlated value sets for RHS rewrites. In production
    * This should generally be {@code QueryContexts.getJoinFilterRewriteMaxSize(query)}.
    */
@@ -57,12 +63,14 @@ public class JoinFilterRewriteConfig
       boolean enableFilterPushDown,
       boolean enableFilterRewrite,
       boolean enableRewriteValueColumnFilters,
+      boolean enableRewriteJoinToFilter,
       long filterRewriteMaxSize
   )
   {
     this.enableFilterPushDown = enableFilterPushDown;
     this.enableFilterRewrite = enableFilterRewrite;
     this.enableRewriteValueColumnFilters = enableRewriteValueColumnFilters;
+    this.enableRewriteJoinToFilter = enableRewriteJoinToFilter;
     this.filterRewriteMaxSize = filterRewriteMaxSize;
   }
 
@@ -72,6 +80,7 @@ public class JoinFilterRewriteConfig
         QueryContexts.getEnableJoinFilterPushDown(query),
         QueryContexts.getEnableJoinFilterRewrite(query),
         QueryContexts.getEnableJoinFilterRewriteValueColumnFilters(query),
+        QueryContexts.getEnableRewriteJoinToFilter(query),
         QueryContexts.getJoinFilterRewriteMaxSize(query)
     );
   }
@@ -91,6 +100,11 @@ public class JoinFilterRewriteConfig
     return enableRewriteValueColumnFilters;
   }
 
+  public boolean isEnableRewriteJoinToFilter()
+  {
+    return enableRewriteJoinToFilter;
+  }
+
   public long getFilterRewriteMaxSize()
   {
     return filterRewriteMaxSize;
@@ -106,10 +120,11 @@ public class JoinFilterRewriteConfig
       return false;
     }
     JoinFilterRewriteConfig that = (JoinFilterRewriteConfig) o;
-    return enableFilterPushDown == that.enableFilterPushDown &&
-           enableFilterRewrite == that.enableFilterRewrite &&
-           enableRewriteValueColumnFilters == that.enableRewriteValueColumnFilters &&
-           filterRewriteMaxSize == that.filterRewriteMaxSize;
+    return enableFilterPushDown == that.enableFilterPushDown
+           && enableFilterRewrite == that.enableFilterRewrite
+           && enableRewriteValueColumnFilters == that.enableRewriteValueColumnFilters
+           && enableRewriteJoinToFilter == that.enableRewriteJoinToFilter
+           && filterRewriteMaxSize == that.filterRewriteMaxSize;
   }
 
   @Override
@@ -119,7 +134,20 @@ public class JoinFilterRewriteConfig
         enableFilterPushDown,
         enableFilterRewrite,
         enableRewriteValueColumnFilters,
+        enableRewriteJoinToFilter,
         filterRewriteMaxSize
     );
+  }
+
+  @Override
+  public String toString()
+  {
+    return "JoinFilterRewriteConfig{" +
+           "enableFilterPushDown=" + enableFilterPushDown +
+           ", enableFilterRewrite=" + enableFilterRewrite +
+           ", enableRewriteValueColumnFilters=" + enableRewriteValueColumnFilters +
+           ", enableRewriteJoinToFilter=" + enableRewriteJoinToFilter +
+           ", filterRewriteMaxSize=" + filterRewriteMaxSize +
+           '}';
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/join/lookup/LookupJoinable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/lookup/LookupJoinable.java
@@ -112,7 +112,7 @@ public class LookupJoinable implements Joinable
 
       for (String value : nullEquivalentValues) {
         if (keys.contains(value)) {
-          nonNullKeys --;
+          nonNullKeys--;
         }
       }
 

--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
@@ -108,7 +108,7 @@ public class IndexedTableJoinable implements Joinable
       for (int i = 0; i < table.numRows(); i++) {
         final String s = DimensionHandlerUtils.convertObjectToString(reader.read(i));
 
-        if (NullHandling.isNullOrEquivalent(s)) {
+        if (!NullHandling.isNullOrEquivalent(s)) {
           if (!allValues.add(s)) {
             // Duplicate found. Since the values are not all unique, we must return an empty Optional.
             return Optional.empty();

--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.join.table;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.DimensionHandlerUtils;
@@ -107,7 +108,7 @@ public class IndexedTableJoinable implements Joinable
       for (int i = 0; i < table.numRows(); i++) {
         final String s = DimensionHandlerUtils.convertObjectToString(reader.read(i));
 
-        if (s != null) {
+        if (NullHandling.isNullOrEquivalent(s)) {
           if (!allValues.add(s)) {
             // Duplicate found. Since the values are not all unique, we must return an empty Optional.
             return Optional.empty();

--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.join.table;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.DimensionHandlerUtils;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.join.JoinConditionAnalysis;
 import org.apache.druid.segment.join.JoinMatcher;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 public class IndexedTableJoinable implements Joinable
 {
@@ -89,6 +91,42 @@ public class IndexedTableJoinable implements Joinable
   }
 
   @Override
+  public Optional<Set<String>> getNonNullColumnValuesIfAllUnique(final String columnName, final int maxNumValues)
+  {
+    final int columnPosition = table.rowSignature().indexOf(columnName);
+
+    if (columnPosition < 0) {
+      return Optional.empty();
+    }
+
+    try (final IndexedTable.Reader reader = table.columnReader(columnPosition)) {
+      // Sorted set to encourage "in" filters that result from this method to do dictionary lookups in order.
+      // The hopes are that this will improve locality and therefore improve performance.
+      final Set<String> allValues = new TreeSet<>();
+
+      for (int i = 0; i < table.numRows(); i++) {
+        final String s = DimensionHandlerUtils.convertObjectToString(reader.read(i));
+
+        if (s != null) {
+          if (!allValues.add(s)) {
+            // Duplicate found. Since the values are not all unique, we must return an empty Optional.
+            return Optional.empty();
+          }
+
+          if (allValues.size() > maxNumValues) {
+            return Optional.empty();
+          }
+        }
+      }
+
+      return Optional.of(allValues);
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
   public Optional<Set<String>> getCorrelatedColumnValues(
       String searchColumnName,
       String searchColumnValue,
@@ -112,7 +150,7 @@ public class IndexedTableJoinable implements Joinable
         IntList rowIndex = index.find(searchColumnValue);
         for (int i = 0; i < rowIndex.size(); i++) {
           int rowNum = rowIndex.getInt(i);
-          String correlatedDimVal = Objects.toString(reader.read(rowNum), null);
+          String correlatedDimVal = DimensionHandlerUtils.convertObjectToString(reader.read(rowNum));
           correlatedValues.add(correlatedDimVal);
 
           if (correlatedValues.size() > maxCorrelationSetSize) {
@@ -132,7 +170,7 @@ public class IndexedTableJoinable implements Joinable
         for (int i = 0; i < table.numRows(); i++) {
           String dimVal = Objects.toString(dimNameReader.read(i), null);
           if (searchColumnValue.equals(dimVal)) {
-            String correlatedDimVal = Objects.toString(correlatedColumnReader.read(i), null);
+            String correlatedDimVal = DimensionHandlerUtils.convertObjectToString(correlatedColumnReader.read(i));
             correlatedValues.add(correlatedDimVal);
             if (correlatedValues.size() > maxCorrelationSetSize) {
               return Optional.empty();

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryTest.java
@@ -21,11 +21,13 @@ package org.apache.druid.query.groupby;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunnerTestHelper;
@@ -40,6 +42,7 @@ import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.spec.QuerySegmentSpec;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -78,6 +81,33 @@ public class GroupByQueryTest
     Query serdeQuery = JSON_MAPPER.readValue(json, Query.class);
 
     Assert.assertEquals(query, serdeQuery);
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    final GroupByQuery query = GroupByQuery
+        .builder()
+        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setVirtualColumns(new ExpressionVirtualColumn("v", "\"other\"", ValueType.STRING, ExprMacroTable.nil()))
+        .setDimensions(new DefaultDimensionSpec("quality", "alias"), DefaultDimensionSpec.of("v"))
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, new LongSumAggregatorFactory("idx", "index"))
+        .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
+        .setPostAggregatorSpecs(ImmutableList.of(new FieldAccessPostAggregator("x", "idx")))
+        .setLimitSpec(
+            new DefaultLimitSpec(
+                ImmutableList.of(new OrderByColumnSpec(
+                    "alias",
+                    OrderByColumnSpec.Direction.ASCENDING,
+                    StringComparators.LEXICOGRAPHIC
+                )),
+                100
+            )
+        )
+        .build();
+
+    Assert.assertEquals(ImmutableSet.of("__time", "quality", "other", "index"), query.getRequiredColumns());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
@@ -269,4 +269,32 @@ public class ScanQueryTest
     // This should throw an ISE
     List<ScanResultValue> res = borkedSequence.toList();
   }
+
+  @Test
+  public void testGetRequiredColumnsWithNoColumns()
+  {
+    final ScanQuery query =
+        Druids.newScanQueryBuilder()
+              .order(ScanQuery.Order.DESCENDING)
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+              .dataSource("some src")
+              .intervals(intervalSpec)
+              .build();
+
+    Assert.assertNull(query.getRequiredColumns());
+  }
+
+  @Test
+  public void testGetRequiredColumnsWithColumns()
+  {
+    final ScanQuery query =
+        Druids.newScanQueryBuilder()
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+              .dataSource("some src")
+              .intervals(intervalSpec)
+              .columns("foo", "bar")
+              .build();
+
+    Assert.assertEquals(ImmutableSet.of("__time", "foo", "bar"), query.getRequiredColumns());
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
@@ -285,6 +285,21 @@ public class ScanQueryTest
   }
 
   @Test
+  public void testGetRequiredColumnsWithEmptyColumns()
+  {
+    final ScanQuery query =
+        Druids.newScanQueryBuilder()
+              .order(ScanQuery.Order.DESCENDING)
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+              .dataSource("some src")
+              .intervals(intervalSpec)
+              .columns(Collections.emptyList())
+              .build();
+
+    Assert.assertNull(query.getRequiredColumns());
+  }
+
+  @Test
   public void testGetRequiredColumnsWithColumns()
   {
     final ScanQuery query =

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryTest.java
@@ -20,10 +20,15 @@
 package org.apache.druid.query.timeseries;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunnerTestHelper;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,13 +59,13 @@ public class TimeseriesQueryTest
   public void testQuerySerialization() throws IOException
   {
     Query query = Druids.newTimeseriesQueryBuilder()
-        .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
-        .granularity(QueryRunnerTestHelper.DAY_GRAN)
-        .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
-        .aggregators(QueryRunnerTestHelper.ROWS_COUNT, QueryRunnerTestHelper.INDEX_DOUBLE_SUM)
-        .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
-        .descending(descending)
-        .build();
+                        .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+                        .granularity(QueryRunnerTestHelper.DAY_GRAN)
+                        .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+                        .aggregators(QueryRunnerTestHelper.ROWS_COUNT, QueryRunnerTestHelper.INDEX_DOUBLE_SUM)
+                        .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
+                        .descending(descending)
+                        .build();
 
     String json = JSON_MAPPER.writeValueAsString(query);
     Query serdeQuery = JSON_MAPPER.readValue(json, Query.class);
@@ -68,4 +73,32 @@ public class TimeseriesQueryTest
     Assert.assertEquals(query, serdeQuery);
   }
 
+  @Test
+  public void testGetRequiredColumns() throws IOException
+  {
+    final TimeseriesQuery query =
+        Druids.newTimeseriesQueryBuilder()
+              .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+              .granularity(QueryRunnerTestHelper.DAY_GRAN)
+              .virtualColumns(
+                  new ExpressionVirtualColumn(
+                      "index",
+                      "\"fieldFromVirtualColumn\"",
+                      ValueType.LONG,
+                      ExprMacroTable.nil()
+                  )
+              )
+              .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+              .aggregators(
+                  QueryRunnerTestHelper.ROWS_COUNT,
+                  QueryRunnerTestHelper.INDEX_DOUBLE_SUM,
+                  QueryRunnerTestHelper.INDEX_LONG_MAX,
+                  new LongSumAggregatorFactory("beep", "aField")
+              )
+              .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
+              .descending(descending)
+              .build();
+
+    Assert.assertEquals(ImmutableSet.of("__time", "fieldFromVirtualColumn", "aField"), query.getRequiredColumns());
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryTest.java
@@ -74,7 +74,7 @@ public class TimeseriesQueryTest
   }
 
   @Test
-  public void testGetRequiredColumns() throws IOException
+  public void testGetRequiredColumns()
   {
     final TimeseriesQuery query =
         Druids.newTimeseriesQueryBuilder()

--- a/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.filter.JoinFilterAnalyzer;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysisKey;
@@ -48,6 +49,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 public class BaseHashJoinSegmentStorageAdapterTest
@@ -236,12 +238,16 @@ public class BaseHashJoinSegmentStorageAdapterTest
       VirtualColumns virtualColumns
   )
   {
+    // Seemingly-useless "Filter.maybeAnd" is here to dedupe filters, flatten stacks, etc, in the same way that
+    // JoinableFactoryWrapper's segmentMapFn would do.
+    final Filter filterToUse = Filters.maybeAnd(Collections.singletonList(originalFilter)).orElse(null);
+
     return JoinFilterAnalyzer.computeJoinFilterPreAnalysis(
         new JoinFilterPreAnalysisKey(
             DEFAULT_JOIN_FILTER_REWRITE_CONFIG,
             joinableClauses,
             virtualColumns,
-            originalFilter
+            filterToUse
         )
     );
   }

--- a/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
@@ -56,6 +56,7 @@ public class BaseHashJoinSegmentStorageAdapterTest
       true,
       true,
       true,
+      QueryContexts.DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER,
       QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
   );
 

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -2024,20 +2024,22 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   @Test
   public void test_makeCursors_factToCountryLeftWithBaseFilter()
   {
+    final Filter baseFilter = Filters.or(Arrays.asList(
+        new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
+        new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
+    ));
+
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.LEFT));
 
     JoinFilterPreAnalysis joinFilterPreAnalysis = makeDefaultConfigPreAnalysis(
-        null,
+        baseFilter,
         joinableClauses,
         VirtualColumns.EMPTY
     );
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
-            Filters.or(Arrays.asList(
-                new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
-                new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
-            )),
+            baseFilter,
             joinableClauses,
             joinFilterPreAnalysis
         ).makeCursors(
@@ -2067,19 +2069,21 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   @Test
   public void test_makeCursors_factToCountryInnerWithBaseFilter()
   {
+    final Filter baseFilter = Filters.or(Arrays.asList(
+        new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
+        new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
+    ));
+
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.INNER));
     JoinFilterPreAnalysis joinFilterPreAnalysis = makeDefaultConfigPreAnalysis(
-        null,
+        baseFilter,
         joinableClauses,
         VirtualColumns.EMPTY
     );
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
-            Filters.or(Arrays.asList(
-                new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
-                new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
-            )),
+            baseFilter,
             joinableClauses,
             joinFilterPreAnalysis
         ).makeCursors(
@@ -2108,19 +2112,21 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   @Test
   public void test_makeCursors_factToCountryRightWithBaseFilter()
   {
+    final Filter baseFilter = Filters.or(Arrays.asList(
+        new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
+        new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
+    ));
+
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.RIGHT));
     JoinFilterPreAnalysis joinFilterPreAnalysis = makeDefaultConfigPreAnalysis(
-        null,
+        baseFilter,
         joinableClauses,
         VirtualColumns.EMPTY
     );
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
-            Filters.or(Arrays.asList(
-                new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
-                new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
-            )),
+            baseFilter,
             joinableClauses,
             joinFilterPreAnalysis
         ).makeCursors(
@@ -2166,19 +2172,21 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
   @Test
   public void test_makeCursors_factToCountryFullWithBaseFilter()
   {
+    final Filter baseFilter = Filters.or(Arrays.asList(
+        new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
+        new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
+    ));
+
     List<JoinableClause> joinableClauses = ImmutableList.of(factToCountryOnIsoCode(JoinType.FULL));
     JoinFilterPreAnalysis joinFilterPreAnalysis = makeDefaultConfigPreAnalysis(
-        null,
+        baseFilter,
         joinableClauses,
         VirtualColumns.EMPTY
     );
     JoinTestHelper.verifyCursors(
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
-            Filters.or(Arrays.asList(
-                new SelectorDimFilter("countryIsoCode", "CA", null).toFilter(),
-                new SelectorDimFilter("countryIsoCode", "MatchNothing", null).toFilter()
-            )),
+            baseFilter,
             joinableClauses,
             joinFilterPreAnalysis
         ).makeCursors(

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
@@ -22,13 +22,11 @@ package org.apache.druid.segment.join;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.math.expr.ExprMacroTable;
-import org.apache.druid.query.QueryContexts;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.SegmentReference;
 import org.apache.druid.segment.StorageAdapter;
-import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
@@ -49,14 +47,6 @@ import java.util.Optional;
 
 public class HashJoinSegmentTest extends InitializedNullHandlingTest
 {
-  private static final JoinFilterRewriteConfig DEFAULT_JOIN_FILTER_REWRITE_CONFIG =
-      new JoinFilterRewriteConfig(
-          true,
-          true,
-          true,
-          QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
-      );
-
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
@@ -195,7 +195,7 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
   public void test_constructor_noClauses()
   {
     expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("'clauses' is empty, no need to create HashJoinSegment");
+    expectedException.expectMessage("'clauses' and 'baseFilter' are both empty, no need to create HashJoinSegment");
 
     List<JoinableClause> joinableClauses = ImmutableList.of();
 

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
@@ -275,6 +275,15 @@ public class JoinConditionAnalysisTest
   }
 
   @Test
+  public void test_getRequiredColumns()
+  {
+    final String expression = "(x == \"j.y\") && ((x + y == \"j.z\") || (z == \"j.zz\"))";
+    final JoinConditionAnalysis analysis = analyze(expression);
+
+    Assert.assertEquals(ImmutableSet.of("x", "j.y", "y", "j.z", "z", "j.zz"), analysis.getRequiredColumns());
+  }
+
+  @Test
   public void test_equals()
   {
     EqualsVerifier.forClass(JoinConditionAnalysis.class)

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinConditionAnalysisTest.java
@@ -290,7 +290,7 @@ public class JoinConditionAnalysisTest
                   .usingGetClass()
                   .withIgnoredFields(
                           // These fields are tightly coupled with originalExpression
-                          "equiConditions", "nonEquiConditions",
+                          "equiConditions", "nonEquiConditions", "requiredColumns",
                           // These fields are calculated from other other fields in the class
                           "isAlwaysTrue", "isAlwaysFalse", "canHashJoin", "rightKeyColumns")
                   .verify();

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
@@ -2092,6 +2092,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
                 false,
                 true,
                 true,
+                QueryContexts.DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER,
                 QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
             ),
             joinableClauses.getJoinableClauses(),
@@ -2171,6 +2172,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
                 true,
                 false,
                 true,
+                QueryContexts.DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER,
                 QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
             ),
             joinableClauses.getJoinableClauses(),
@@ -2591,6 +2593,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentStorageAdapterTes
                 true,
                 true,
                 true,
+                QueryContexts.DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER,
                 QueryContexts.DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE
             ),
             joinableClauses,

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
@@ -534,33 +534,6 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
   }
 
   @Test
-  public void test_convertJoinsToFilters_dontConvertUnknownRequiredColumns()
-  {
-    final JoinableClause clause = new JoinableClause(
-        "j.",
-        LookupJoinable.wrap(new MapLookupExtractor(TEST_LOOKUP, false)),
-        JoinType.INNER,
-        JoinConditionAnalysis.forExpression("x == \"j.k\"", "j.", ExprMacroTable.nil())
-    );
-
-    final Pair<List<Filter>, List<JoinableClause>> conversion = JoinableFactoryWrapper.convertJoinsToFilters(
-        ImmutableList.of(
-            clause
-        ),
-        null,
-        Integer.MAX_VALUE
-    );
-
-    Assert.assertEquals(
-        Pair.of(
-            ImmutableList.of(),
-            ImmutableList.of(clause)
-        ),
-        conversion
-    );
-  }
-
-  @Test
   public void test_convertJoinsToFilters_dontConvertLeftJoin()
   {
     final JoinableClause clause = new JoinableClause(

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
@@ -534,6 +534,33 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
   }
 
   @Test
+  public void test_convertJoinsToFilters_dontConvertUnknownRequiredColumns()
+  {
+    final JoinableClause clause = new JoinableClause(
+        "j.",
+        LookupJoinable.wrap(new MapLookupExtractor(TEST_LOOKUP, false)),
+        JoinType.INNER,
+        JoinConditionAnalysis.forExpression("x == \"j.k\"", "j.", ExprMacroTable.nil())
+    );
+
+    final Pair<List<Filter>, List<JoinableClause>> conversion = JoinableFactoryWrapper.convertJoinsToFilters(
+        ImmutableList.of(
+            clause
+        ),
+        null,
+        Integer.MAX_VALUE
+    );
+
+    Assert.assertEquals(
+        Pair.of(
+            ImmutableList.of(),
+            ImmutableList.of(clause)
+        ),
+        conversion
+    );
+  }
+
+  @Test
   public void test_convertJoinsToFilters_dontConvertLeftJoin()
   {
     final JoinableClause clause = new JoinableClause(

--- a/processing/src/test/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterRewriteConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/filter/rewrite/JoinFilterRewriteConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.join.filter.rewrite;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class JoinFilterRewriteConfigTest
+{
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(JoinFilterRewriteConfig.class).usingGetClass().verify();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
@@ -352,6 +352,14 @@ public class IndexedTableJoinableTest
   }
 
   @Test
+  public void getNonNullColumnValuesIfAllUniqueForNonexistentColumnShouldReturnEmpty()
+  {
+    final Optional<Set<String>> values = target.getNonNullColumnValuesIfAllUnique("nonexistent", Integer.MAX_VALUE);
+
+    Assert.assertEquals(Optional.empty(), values);
+  }
+
+  @Test
   public void getNonNullColumnValuesIfAllUniqueForKeyColumnShouldReturnValues()
   {
     final Optional<Set<String>> values = target.getNonNullColumnValuesIfAllUnique(KEY_COLUMN, Integer.MAX_VALUE);

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
@@ -50,6 +50,7 @@ public class IndexedTableJoinableTest
   private static final String PREFIX = "j.";
   private static final String KEY_COLUMN = "str";
   private static final String VALUE_COLUMN = "long";
+  private static final String ALL_SAME_COLUMN = "allsame";
   private static final String UNKNOWN_COLUMN = "unknown";
   private static final String SEARCH_KEY_NULL_VALUE = "baz";
   private static final String SEARCH_KEY_VALUE = "foo";
@@ -84,13 +85,14 @@ public class IndexedTableJoinableTest
 
   private final InlineDataSource inlineDataSource = InlineDataSource.fromIterable(
       ImmutableList.of(
-          new Object[]{"foo", 1L},
-          new Object[]{"bar", 2L},
-          new Object[]{"baz", null}
+          new Object[]{"foo", 1L, 1L},
+          new Object[]{"bar", 2L, 1L},
+          new Object[]{"baz", null, 1L}
       ),
       RowSignature.builder()
-                  .add("str", ValueType.STRING)
-                  .add("long", ValueType.LONG)
+                  .add(KEY_COLUMN, ValueType.STRING)
+                  .add(VALUE_COLUMN, ValueType.LONG)
+                  .add(ALL_SAME_COLUMN, ValueType.LONG)
                   .build()
   );
 
@@ -113,7 +115,7 @@ public class IndexedTableJoinableTest
   @Test
   public void getAvailableColumns()
   {
-    Assert.assertEquals(ImmutableList.of("str", "long"), target.getAvailableColumns());
+    Assert.assertEquals(ImmutableList.of(KEY_COLUMN, VALUE_COLUMN, ALL_SAME_COLUMN), target.getAvailableColumns());
   }
 
   @Test
@@ -339,5 +341,43 @@ public class IndexedTableJoinableTest
         10,
         true);
     Assert.assertEquals(Optional.of(ImmutableSet.of()), correlatedValues);
+  }
+
+  @Test
+  public void getNonNullColumnValuesIfAllUniqueForValueColumnShouldReturnValues()
+  {
+    final Optional<Set<String>> values = target.getNonNullColumnValuesIfAllUnique(VALUE_COLUMN, Integer.MAX_VALUE);
+
+    Assert.assertEquals(Optional.of(ImmutableSet.of("1", "2")), values);
+  }
+
+  @Test
+  public void getNonNullColumnValuesIfAllUniqueForKeyColumnShouldReturnValues()
+  {
+    final Optional<Set<String>> values = target.getNonNullColumnValuesIfAllUnique(KEY_COLUMN, Integer.MAX_VALUE);
+
+    Assert.assertEquals(
+        Optional.of(ImmutableSet.of("foo", "bar", "baz")),
+        values
+    );
+  }
+
+  @Test
+  public void getNonNullColumnValuesIfAllUniqueForAllSameColumnShouldReturnEmpty()
+  {
+    final Optional<Set<String>> values = target.getNonNullColumnValuesIfAllUnique(ALL_SAME_COLUMN, Integer.MAX_VALUE);
+
+    Assert.assertEquals(
+        Optional.empty(),
+        values
+    );
+  }
+
+  @Test
+  public void getNonNullColumnValuesIfAllUniqueForKeyColumnWithLowMaxValuesShouldReturnEmpty()
+  {
+    final Optional<Set<String>> values = target.getNonNullColumnValuesIfAllUnique(KEY_COLUMN, 1);
+
+    Assert.assertEquals(Optional.empty(), values);
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -849,6 +849,14 @@ public class BaseCalciteQueryTest extends CalciteTestBase
     skipVectorize = true;
   }
 
+  protected static boolean isRewriteJoinToFilter(final Map<String, Object> queryContext)
+  {
+    return (boolean) queryContext.getOrDefault(
+        QueryContexts.REWRITE_JOIN_TO_FILTER_ENABLE_KEY,
+        QueryContexts.DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER
+    );
+  }
+
   /**
    * This is a provider of query contexts that should be used by join tests.
    * It tests various configs that can be passed to join queries. All the configs provided by this provider should
@@ -862,23 +870,48 @@ public class BaseCalciteQueryTest extends CalciteTestBase
       return new Object[]{
           // default behavior
           QUERY_CONTEXT_DEFAULT,
-          // filter value re-writes enabled
+          // all rewrites enabled
           new ImmutableMap.Builder<String, Object>()
               .putAll(QUERY_CONTEXT_DEFAULT)
               .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, true)
               .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, true)
+              .put(QueryContexts.REWRITE_JOIN_TO_FILTER_ENABLE_KEY, true)
               .build(),
-          // rewrite values enabled but filter re-writes disabled.
-          // This should be drive the same behavior as the previous config
+          // filter-on-value-column rewrites disabled, everything else enabled
+          new ImmutableMap.Builder<String, Object>()
+              .putAll(QUERY_CONTEXT_DEFAULT)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, false)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, true)
+              .put(QueryContexts.REWRITE_JOIN_TO_FILTER_ENABLE_KEY, true)
+              .build(),
+          // filter rewrites fully disabled, join-to-filter enabled
+          new ImmutableMap.Builder<String, Object>()
+              .putAll(QUERY_CONTEXT_DEFAULT)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, false)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, false)
+              .put(QueryContexts.REWRITE_JOIN_TO_FILTER_ENABLE_KEY, true)
+              .build(),
+          // filter rewrites disabled, but value column filters still set to true (it should be ignored and this should
+          // behave the same as the previous context)
           new ImmutableMap.Builder<String, Object>()
               .putAll(QUERY_CONTEXT_DEFAULT)
               .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, true)
               .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, false)
+              .put(QueryContexts.REWRITE_JOIN_TO_FILTER_ENABLE_KEY, true)
               .build(),
-          // filter re-writes disabled
+          // filter rewrites fully enabled, join-to-filter disabled
           new ImmutableMap.Builder<String, Object>()
               .putAll(QUERY_CONTEXT_DEFAULT)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, true)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, true)
+              .put(QueryContexts.REWRITE_JOIN_TO_FILTER_ENABLE_KEY, false)
+              .build(),
+          // all rewrites disabled
+          new ImmutableMap.Builder<String, Object>()
+              .putAll(QUERY_CONTEXT_DEFAULT)
+              .put(QueryContexts.JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS_ENABLE_KEY, false)
               .put(QueryContexts.JOIN_FILTER_REWRITE_ENABLE_KEY, false)
+              .put(QueryContexts.REWRITE_JOIN_TO_FILTER_ENABLE_KEY, false)
               .build(),
           };
     }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -13780,7 +13780,12 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                                     .setGranularity(Granularities.ALL)
                                                     .setAggregatorSpecs(
                                                         new CountAggregatorFactory("_a0"),
-                                                        new CountAggregatorFactory("_a1")
+                                                        NullHandling.sqlCompatible()
+                                                        ? new FilteredAggregatorFactory(
+                                                            new CountAggregatorFactory("_a1"),
+                                                            not(selector("a0", null, null))
+                                                        )
+                                                        : new CountAggregatorFactory("_a1")
                                                     )
                                                     .setContext(QUERY_CONTEXT_DEFAULT)
                                                     .build()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -342,13 +342,17 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testJoinOuterGroupByAndSubqueryNoLimit() throws Exception
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testJoinOuterGroupByAndSubqueryNoLimit(Map<String, Object> queryContext) throws Exception
   {
-    // Cannot vectorize JOIN operator.
-    cannotVectorize();
+    // Fully removing the join allows this query to vectorize.
+    if (!isRewriteJoinToFilter(queryContext)) {
+      cannotVectorize();
+    }
 
     testQuery(
         "SELECT dim2, AVG(m2) FROM (SELECT * FROM foo AS t1 INNER JOIN foo AS t2 ON t1.m1 = t2.m1) AS t3 GROUP BY dim2",
+        queryContext,
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(
@@ -362,6 +366,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                         .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                                         .context(QUERY_CONTEXT_DEFAULT)
                                         .build()
+                                        .withOverriddenContext(queryContext)
                                 ),
                                 "j0.",
                                 equalsCondition(
@@ -403,6 +408,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
+                        .withOverriddenContext(queryContext)
         ),
         NullHandling.sqlCompatible()
         ? ImmutableList.of(
@@ -4273,12 +4279,17 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testUnionAllTwoQueriesLeftQueryIsJoin() throws Exception
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testUnionAllTwoQueriesLeftQueryIsJoin(Map<String, Object> queryContext) throws Exception
   {
-    cannotVectorize();
+    // Fully removing the join allows this query to vectorize.
+    if (!isRewriteJoinToFilter(queryContext)) {
+      cannotVectorize();
+    }
 
     testQuery(
         "(SELECT COUNT(*) FROM foo INNER JOIN lookup.lookyloo ON foo.dim1 = lookyloo.k)  UNION ALL SELECT SUM(cnt) FROM foo",
+        queryContext,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(
@@ -4293,7 +4304,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .granularity(Granularities.ALL)
                   .aggregators(aggregators(new CountAggregatorFactory("a0")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
-                  .build(),
+                  .build()
+                  .withOverriddenContext(queryContext),
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
                   .intervals(querySegmentSpec(Filtration.eternity()))
@@ -4301,18 +4313,24 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .aggregators(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
                   .build()
+                  .withOverriddenContext(queryContext)
         ),
         ImmutableList.of(new Object[]{1L}, new Object[]{6L})
     );
   }
 
   @Test
-  public void testUnionAllTwoQueriesRightQueryIsJoin() throws Exception
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testUnionAllTwoQueriesRightQueryIsJoin(Map<String, Object> queryContext) throws Exception
   {
-    cannotVectorize();
+    // Fully removing the join allows this query to vectorize.
+    if (!isRewriteJoinToFilter(queryContext)) {
+      cannotVectorize();
+    }
 
     testQuery(
         "(SELECT SUM(cnt) FROM foo UNION ALL SELECT COUNT(*) FROM foo INNER JOIN lookup.lookyloo ON foo.dim1 = lookyloo.k) ",
+        queryContext,
         ImmutableList.of(
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(CalciteTests.DATASOURCE1)
@@ -4320,7 +4338,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .granularity(Granularities.ALL)
                   .aggregators(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
-                  .build(),
+                  .build()
+                  .withOverriddenContext(queryContext),
             Druids.newTimeseriesQueryBuilder()
                   .dataSource(
                       join(
@@ -4335,6 +4354,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .aggregators(aggregators(new CountAggregatorFactory("a0")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
                   .build()
+                  .withOverriddenContext(queryContext)
         ),
         ImmutableList.of(new Object[]{6L}, new Object[]{1L})
     );
@@ -8107,8 +8127,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Parameters(source = QueryContextForJoinProvider.class)
   public void testTopNFilterJoin(Map<String, Object> queryContext) throws Exception
   {
-    // Cannot vectorize JOIN operator.
-    cannotVectorize();
+    // Fully removing the join allows this query to vectorize.
+    if (!isRewriteJoinToFilter(queryContext)) {
+      cannotVectorize();
+    }
 
     // Filters on top N values of some dimension by using an inner join.
     testQuery(
@@ -13173,8 +13195,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Parameters(source = QueryContextForJoinProvider.class)
   public void testUsingSubqueryAsPartOfAndFilter(Map<String, Object> queryContext) throws Exception
   {
-    // Cannot vectorize JOIN operator.
-    cannotVectorize();
+    // Fully removing the join allows this query to vectorize.
+    if (!isRewriteJoinToFilter(queryContext)) {
+      cannotVectorize();
+    }
 
     testQuery(
         "SELECT dim1, dim2, COUNT(*) FROM druid.foo\n"
@@ -13642,6 +13666,229 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testTwoSemiJoinsSimultaneously(Map<String, Object> queryContext) throws Exception
+  {
+    // Fully removing the join allows this query to vectorize.
+    if (!isRewriteJoinToFilter(queryContext)) {
+      cannotVectorize();
+    }
+
+    testQuery(
+        "SELECT dim1, COUNT(*) FROM foo\n"
+        + "WHERE dim1 IN ('abc', 'def')"
+        + "AND __time IN (SELECT MAX(__time) FROM foo WHERE cnt = 1)\n"
+        + "AND __time IN (SELECT MAX(__time) FROM foo WHERE cnt <> 2)\n"
+        + "GROUP BY 1",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            join(
+                                join(
+                                    new TableDataSource(CalciteTests.DATASOURCE1),
+                                    new QueryDataSource(
+                                        Druids.newTimeseriesQueryBuilder()
+                                              .dataSource(CalciteTests.DATASOURCE1)
+                                              .intervals(querySegmentSpec(Filtration.eternity()))
+                                              .granularity(Granularities.ALL)
+                                              .filters(selector("cnt", "1", null))
+                                              .aggregators(new LongMaxAggregatorFactory("a0", "__time"))
+                                              .context(TIMESERIES_CONTEXT_DEFAULT)
+                                              .build()
+                                    ),
+                                    "j0.",
+                                    "(\"__time\" == \"j0.a0\")",
+                                    JoinType.INNER
+                                ),
+                                new QueryDataSource(
+                                    Druids.newTimeseriesQueryBuilder()
+                                          .dataSource(CalciteTests.DATASOURCE1)
+                                          .intervals(querySegmentSpec(Filtration.eternity()))
+                                          .granularity(Granularities.ALL)
+                                          .filters(not(selector("cnt", "2", null)))
+                                          .aggregators(new LongMaxAggregatorFactory("a0", "__time"))
+                                          .context(TIMESERIES_CONTEXT_DEFAULT)
+                                          .build()
+                                ),
+                                "_j0.",
+                                "(\"__time\" == \"_j0.a0\")",
+                                JoinType.INNER
+                            )
+                        )
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimFilter(in("dim1", ImmutableList.of("abc", "def"), null))
+                        .setDimensions(dimensions(new DefaultDimensionSpec("dim1", "d0", ValueType.STRING)))
+                        .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
+                        .setContext(queryContext)
+                        .build()
+        ),
+        ImmutableList.of(new Object[]{"abc", 1L})
+    );
+  }
+
+  @Test
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testSemiAndAntiJoinSimultaneouslyUsingWhereInSubquery(Map<String, Object> queryContext) throws Exception
+  {
+    cannotVectorize();
+
+    testQuery(
+        "SELECT dim1, COUNT(*) FROM foo\n"
+        + "WHERE dim1 IN ('abc', 'def')\n"
+        + "AND __time IN (SELECT MAX(__time) FROM foo)\n"
+        + "AND __time NOT IN (SELECT MIN(__time) FROM foo)\n"
+        + "GROUP BY 1",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            join(
+                                join(
+                                    join(
+                                        new TableDataSource(CalciteTests.DATASOURCE1),
+                                        new QueryDataSource(
+                                            Druids.newTimeseriesQueryBuilder()
+                                                  .dataSource(CalciteTests.DATASOURCE1)
+                                                  .intervals(querySegmentSpec(Filtration.eternity()))
+                                                  .granularity(Granularities.ALL)
+                                                  .aggregators(new LongMaxAggregatorFactory("a0", "__time"))
+                                                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                                                  .build()
+                                        ),
+                                        "j0.",
+                                        "(\"__time\" == \"j0.a0\")",
+                                        JoinType.INNER
+                                    ),
+                                    new QueryDataSource(
+                                        GroupByQuery.builder()
+                                                    .setDataSource(
+                                                        new QueryDataSource(
+                                                            Druids.newTimeseriesQueryBuilder()
+                                                                  .dataSource(CalciteTests.DATASOURCE1)
+                                                                  .intervals(querySegmentSpec(Filtration.eternity()))
+                                                                  .granularity(Granularities.ALL)
+                                                                  .aggregators(
+                                                                      new LongMinAggregatorFactory("a0", "__time")
+                                                                  )
+                                                                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                                                                  .build()
+                                                        )
+                                                    )
+                                                    .setInterval(querySegmentSpec(Filtration.eternity()))
+                                                    .setGranularity(Granularities.ALL)
+                                                    .setAggregatorSpecs(
+                                                        new CountAggregatorFactory("_a0"),
+                                                        new CountAggregatorFactory("_a1")
+                                                    )
+                                                    .setContext(QUERY_CONTEXT_DEFAULT)
+                                                    .build()
+                                    ),
+                                    "_j0.",
+                                    "1",
+                                    JoinType.INNER
+                                ),
+                                new QueryDataSource(
+                                    Druids.newTimeseriesQueryBuilder()
+                                          .dataSource(CalciteTests.DATASOURCE1)
+                                          .intervals(querySegmentSpec(Filtration.eternity()))
+                                          .granularity(Granularities.ALL)
+                                          .aggregators(new LongMinAggregatorFactory("a0", "__time"))
+                                          .postAggregators(expressionPostAgg("p0", "1"))
+                                          .context(TIMESERIES_CONTEXT_DEFAULT)
+                                          .build()
+                                ),
+                                "__j0.",
+                                "(\"__time\" == \"__j0.a0\")",
+                                JoinType.LEFT
+                            )
+                        )
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimFilter(
+                            and(
+                                in("dim1", ImmutableList.of("abc", "def"), null),
+                                or(
+                                    selector("_j0._a0", "0", null),
+                                    and(selector("__j0.p0", null, null), expressionFilter("(\"_j0._a1\" >= \"_j0._a0\")"))
+                                )
+                            )
+                        )
+                        .setDimensions(dimensions(new DefaultDimensionSpec("dim1", "d0", ValueType.STRING)))
+                        .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
+                        .setContext(queryContext)
+                        .build()
+        ),
+        ImmutableList.of(new Object[]{"abc", 1L})
+    );
+  }
+
+  @Test
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testSemiAndAntiJoinSimultaneouslyUsingExplicitJoins(Map<String, Object> queryContext) throws Exception
+  {
+    cannotVectorize();
+
+    testQuery(
+        "SELECT dim1, COUNT(*) FROM\n"
+        + "foo\n"
+        + "INNER JOIN (SELECT MAX(__time) t FROM foo) t0 on t0.t = foo.__time\n"
+        + "LEFT JOIN (SELECT MIN(__time) t FROM foo) t1 on t1.t = foo.__time\n"
+        + "WHERE dim1 IN ('abc', 'def') AND t1.t is null\n"
+        + "GROUP BY 1",
+        queryContext,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            join(
+                                join(
+                                    new TableDataSource(CalciteTests.DATASOURCE1),
+                                    new QueryDataSource(
+                                        Druids.newTimeseriesQueryBuilder()
+                                              .dataSource(CalciteTests.DATASOURCE1)
+                                              .intervals(querySegmentSpec(Filtration.eternity()))
+                                              .granularity(Granularities.ALL)
+                                              .aggregators(new LongMaxAggregatorFactory("a0", "__time"))
+                                              .context(TIMESERIES_CONTEXT_DEFAULT)
+                                              .build()
+                                    ),
+                                    "j0.",
+                                    "(\"__time\" == \"j0.a0\")",
+                                    JoinType.INNER
+                                ),
+                                new QueryDataSource(
+                                    Druids.newTimeseriesQueryBuilder()
+                                          .dataSource(CalciteTests.DATASOURCE1)
+                                          .intervals(querySegmentSpec(Filtration.eternity()))
+                                          .granularity(Granularities.ALL)
+                                          .aggregators(new LongMinAggregatorFactory("a0", "__time"))
+                                          .context(TIMESERIES_CONTEXT_DEFAULT)
+                                          .build()
+                                ),
+                                "_j0.",
+                                "(\"__time\" == \"_j0.a0\")",
+                                JoinType.LEFT
+                            )
+                        )
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimFilter(
+                            and(
+                                in("dim1", ImmutableList.of("abc", "def"), null),
+                                selector("_j0.a0", null, null)
+                            )
+                        )
+                        .setDimensions(dimensions(new DefaultDimensionSpec("dim1", "d0", ValueType.STRING)))
+                        .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
+                        .setContext(queryContext)
+                        .build()
+        ),
+        ImmutableList.of(new Object[]{"abc", 1L})
+    );
+  }
+
+  @Test
   public void testSemiJoinWithOuterTimeExtractAggregateWithOrderBy() throws Exception
   {
     // Cannot vectorize due to virtual columns.
@@ -13723,8 +13970,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Parameters(source = QueryContextForJoinProvider.class)
   public void testInAggregationSubquery(Map<String, Object> queryContext) throws Exception
   {
-    // Cannot vectorize JOIN operator.
-    cannotVectorize();
+    // Fully removing the join allows this query to vectorize.
+    if (!isRewriteJoinToFilter(queryContext)) {
+      cannotVectorize();
+    }
 
     testQuery(
         "SELECT DISTINCT __time FROM druid.foo WHERE __time IN (SELECT MAX(__time) FROM druid.foo)",
@@ -13742,6 +13991,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                           .aggregators(new LongMaxAggregatorFactory("a0", "__time"))
                                           .context(TIMESERIES_CONTEXT_DEFAULT)
                                           .build()
+                                          .withOverriddenContext(queryContext)
                                 ),
                                 "j0.",
                                 equalsCondition(
@@ -13754,8 +14004,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setInterval(querySegmentSpec(Filtration.eternity()))
                         .setGranularity(Granularities.ALL)
                         .setDimensions(dimensions(new DefaultDimensionSpec("__time", "d0", ValueType.LONG)))
-                        .setContext(queryContext)
+                        .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
+                        .withOverriddenContext(queryContext)
         ),
         ImmutableList.of(
             new Object[]{timestamp("2001-01-03")}


### PR DESCRIPTION
The main logic for doing the rewrite is in **JoinableFactoryWrapper**'s
segmentMapFn method. The requirements are:

- It must be an inner equi-join.
- The right-hand columns referenced by the condition must not contain any
  duplicate values. (If they did, the inner join would not be guaranteed
  to return at most one row for each left-hand-side row.)
- No columns from the right-hand side can be used by anything other than
  the join condition itself.

**HashJoinSegmentStorageAdapter** is also modified to pass through to
the base adapter (even allowing vectorization!) in the case where 100%
of join clauses could be rewritten as filters.

In support of this goal:

- Add **Query getRequiredColumns()** method to help us figure out whether
  the right-hand side of a join datasource is being used or not.
- Add **JoinConditionAnalysis getRequiredColumns()** method to help us
  figure out if the right-hand side of a join is being used by later
  join clauses acting on the same base.
- Add **Joinable getNonNullColumnValuesIfAllUnique** method to enable
  retrieving the set of values that will form the "in" filter.
- Add **LookupExtractor canGetKeySet()** and **keySet()** methods to support
  LookupJoinable in its efforts to implement the new Joinable method.
- Add **enableRewriteJoinToFilter** feature flag to
  JoinFilterRewriteConfig. The default is disabled.

Testing strategy:

- Add join-to-filter conversion tests to JoinableFactorWrapperTests.
- Add getRequiredColumns tests to individual query engines.
- Add getNonNullColumnValuesIfAllUnique tests to LookupJoinable and IndexedTableJoinable.
- Extend BaseCalciteQueryTest's QueryContextForJoinProvider to also
  provide query contexts that enable this rewrite.
- Add some new tests to CalciteQueryTest that are designed to exercise
  this rewrite. (And some existing tests did, too.)