### PR TITLE
Incorrect cache property names in sample doc

### DIFF
--- a/docs/querying/using-caching.md
+++ b/docs/querying/using-caching.md
@@ -38,8 +38,8 @@ To use caching, it must be enabled in the settings for the service to perform ca
 ## Enabling query caching on Historicals
 Historicals only support **segment-level** caching, which is enabled by default. To control caching on the Historical, set the `useCache` and `populateCache` runtime properties. For example, to set the Historical to both use and populate the segment cache for queries:
  ```
- druid.broker.cache.useCache=true
- druid.broker.cache.populateCache=true
+ druid.historical.cache.useCache=true
+ druid.historical.cache.populateCache=true
  ```
 See [Historical caching](../configuration/index.md#historical-caching) for a description of all available Historical cache configurations.
  


### PR DESCRIPTION
The section about enabling query caching on Historicals refers to `broker` properties rather than `historical`. That is: 

```
druid.broker.cache.useCache=true
druid.broker.cache.populateCache=true
```

should be: 
```
druid.historical.cache.useCache=true
druid.historical.cache.populateCache=true
```