### PR TITLE
enable dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "com.google.guava:guava"

--- a/pom.xml
+++ b/pom.xml
@@ -1968,6 +1968,7 @@
                                 <exclude>LABELS</exclude>
                                 <exclude>.github/ISSUE_TEMPLATE/*.md</exclude>
                                 <exclude>.github/pull_request_template.md</exclude>
+                                <exclude>.github/dependabot.yml</exclude>
                                 <exclude>git.version</exclude>
                                 <exclude>node_modules/**</exclude>
                                 <exclude>coordinator-console/**</exclude>


### PR DESCRIPTION
As discussed in the dev@ mailing list I am proposing we start using GitHub's dependabot to manage updates.
If we agree, then checking in this file should automatically enable dependabot for us.