### PR TITLE
add round test

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Function.java
@@ -1311,6 +1311,9 @@ public interface Function
     public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
     {
       ExprEval value1 = args.get(0).eval(bindings);
+      if (NullHandling.sqlCompatible() && value1.isNumericNull()) {
+        return ExprEval.of(null);
+      }
       if (value1.type() != ExprType.LONG && value1.type() != ExprType.DOUBLE) {
         throw new IAE(
             "The first argument to the function[%s] should be integer or double type but got the type: %s",

--- a/core/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Function.java
@@ -1311,7 +1311,7 @@ public interface Function
     public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
     {
       ExprEval value1 = args.get(0).eval(bindings);
-      if (NullHandling.sqlCompatible() && value1.isNumericNull()) {
+      if (value1.isNumericNull()) {
         return ExprEval.of(null);
       }
       if (value1.type() != ExprType.LONG && value1.type() != ExprType.DOUBLE) {

--- a/core/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Function.java
@@ -1311,7 +1311,7 @@ public interface Function
     public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
     {
       ExprEval value1 = args.get(0).eval(bindings);
-      if (value1.isNumericNull()) {
+      if (NullHandling.sqlCompatible() && value1.isNumericNull()) {
         return ExprEval.of(null);
       }
       if (value1.type() != ExprType.LONG && value1.type() != ExprType.DOUBLE) {

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.math.expr;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -416,10 +417,10 @@ public class FunctionTest extends InitializedNullHandlingTest
     );
     for (Pair<String, String> argAndType : invalidArguments) {
       if (NullHandling.sqlCompatible()) {
-        assertExpr(String.format(Locale.ENGLISH, "round(%s)", argAndType.lhs), null);
+        assertExpr(StringUtils.format("round(%s)", argAndType.lhs), null);
       } else {
         try {
-          assertExpr(String.format(Locale.ENGLISH, "round(%s)", argAndType.lhs), null);
+          assertExpr(StringUtils.format("round(%s)", argAndType.lhs), null);
           Assert.fail("Did not throw IllegalArgumentException");
         }
         catch (IllegalArgumentException e) {

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -408,11 +408,22 @@ public class FunctionTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testRoundWithNullValue()
+  {
+    Set<Pair<String, String>> invalidArguments = ImmutableSet.of(
+        Pair.of("null", "STRING"),
+        Pair.of("x", "STRING")
+    );
+    for (Pair<String, String> argAndType : invalidArguments) {
+      assertExpr(String.format(Locale.ENGLISH, "round(%s)", argAndType.lhs), null);
+    }
+  }
+
+  @Test
   public void testRoundWithInvalidFirstArgument()
   {
     Set<Pair<String, String>> invalidArguments = ImmutableSet.of(
         Pair.of("b", "LONG_ARRAY"),
-        Pair.of("x", "STRING"),
         Pair.of("c", "DOUBLE_ARRAY"),
         Pair.of("a", "STRING_ARRAY")
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -17566,7 +17566,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .virtualColumns(
                     expressionVirtualColumn("v0", "round(\"d1\")", ValueType.DOUBLE)
                 )
-                .columns("d1","v0")
+                .columns("d1", "v0")
                 .legacy(false)
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                 .context(QUERY_CONTEXT_DEFAULT)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -17552,4 +17552,34 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         )
     );
   }
+
+  @Test
+  public void testRoundFuc() throws Exception
+  {
+
+    testQuery(
+        "SELECT d1, round(d1) FROM druid.numfoo",
+        ImmutableList.of(
+            new Druids.ScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .virtualColumns(
+                    expressionVirtualColumn("v0", "round(\"d1\")", ValueType.DOUBLE)
+                )
+                .columns("d1","v0")
+                .legacy(false)
+                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{1.0, 1.0},
+            new Object[]{1.7, 2.0},
+            new Object[]{0.0, 0.0},
+            new Object[]{0.0, 0.0},
+            new Object[]{0.0, 0.0},
+            new Object[]{0.0, 0.0}
+        )
+    );
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -17558,27 +17558,36 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   {
 
     testQuery(
-        "SELECT d1, round(d1) FROM druid.numfoo",
+        "SELECT f1, round(f1) FROM druid.numfoo",
         ImmutableList.of(
             new Druids.ScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
                 .intervals(querySegmentSpec(Filtration.eternity()))
                 .virtualColumns(
-                    expressionVirtualColumn("v0", "round(\"d1\")", ValueType.DOUBLE)
+                    expressionVirtualColumn("v0", "round(\"f1\")", ValueType.FLOAT)
                 )
-                .columns("d1", "v0")
+                .columns("f1", "v0")
                 .legacy(false)
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                 .context(QUERY_CONTEXT_DEFAULT)
                 .build()
         ),
-        ImmutableList.of(
-            new Object[]{1.0, 1.0},
-            new Object[]{1.7, 2.0},
-            new Object[]{0.0, 0.0},
-            new Object[]{0.0, 0.0},
-            new Object[]{0.0, 0.0},
-            new Object[]{0.0, 0.0}
+        NullHandling.sqlCompatible()
+        ? ImmutableList.of(
+            new Object[]{1.0f, 1.0f},
+            new Object[]{0.1f, 0.0f},
+            new Object[]{0.0f, 0.0f},
+            new Object[]{null, null},
+            new Object[]{null, null},
+            new Object[]{null, null}
+        )
+        : ImmutableList.of(
+            new Object[]{1.0f, 1.0f},
+            new Object[]{0.1f, 0.0f},
+            new Object[]{0.0f, 0.0f},
+            new Object[]{0.0f, 0.0f},
+            new Object[]{0.0f, 0.0f},
+            new Object[]{0.0f, 0.0f}
         )
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -904,7 +904,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     final SqlFunction roundFunction = new RoundOperatorConversion().calciteOperator();
 
-    if(!NullHandling.sqlCompatible()) {
+    if (!NullHandling.sqlCompatible()) {
       expectException(
           IAE.class,
           "The first argument to the function[round] should be integer or double type but got the type: STRING"

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -904,15 +904,17 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     final SqlFunction roundFunction = new RoundOperatorConversion().calciteOperator();
 
-    expectException(
-        IAE.class,
-        "The first argument to the function[round] should be integer or double type but got the type: STRING"
-    );
+    if(!NullHandling.sqlCompatible()) {
+      expectException(
+          IAE.class,
+          "The first argument to the function[round] should be integer or double type but got the type: STRING"
+      );
+    }
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("s"),
         DruidExpression.fromExpression("round(\"s\")"),
-        "IAE Exception"
+        NullHandling.sqlCompatible() ? null : "IAE Exception"
     );
   }
 


### PR DESCRIPTION
### Description

- Add  unit  test for round function for sql.
- Support null value for round function.
##### Key changed/added classes in this PR
 * `org.apache.druid.sql.calcite.CalciteQueryTest`
 * `org.apache.druid.math.expr.Function`
 * `org.apache.druid.math.expr.FunctionTest`
<hr>



This PR has:
- [x] been self-reviewed.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
