### PR TITLE
Suppress CVE in libthrift

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -307,6 +307,13 @@
      ]]></notes>
     <cve>CVE-2017-15288</cve>
   </suppress>
+  <suppress until="2021-04-30">
+    <!-- Suppress this until https://github.com/apache/druid/issues/11028 is resolved. -->
+    <notes><![CDATA[
+     This vulnerability should be fixed soon and the suppression should be removed.
+     ]]></notes>
+    <cve>CVE-2020-13949</cve>
+  </suppress>
 
   <suppress>
     <!-- (avro, parquet, integration-tests) we don't allow velocity templates to be uploaded by untrusted users -->


### PR DESCRIPTION
#11028 talks about bumping the libthrift dependency. This patch simply suppresses the CVE so that the cron CI will show it as successful since there is already a tracking issue to fix this.

To ensure that we do not forget about fixing the issue, the suppression has an expiration date of the end of the month.

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested locally
