### PR TITLE
LongsLongEncodingReader: Implement "duplicate", fixing concurrency bug.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/CompressionFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressionFactory.java
@@ -287,6 +287,11 @@ public class CompressionFactory
 
     int read(long[] out, int outPosition, int[] indexes, int length, int indexOffset, int limit);
 
+    /**
+     * Duplicates this reader, creating a new reader that does not share any state. Important to achieve thread-safety,
+     * because a common pattern is to duplicate a reader multiple times and then call {@link #setBuffer} on the
+     * various duplicates.
+     */
     LongEncodingReader duplicate();
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/data/LongsLongEncodingReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/LongsLongEncodingReader.java
@@ -69,6 +69,6 @@ public class LongsLongEncodingReader implements CompressionFactory.LongEncodingR
   @Override
   public CompressionFactory.LongEncodingReader duplicate()
   {
-    return this;
+    return new LongsLongEncodingReader(buffer.getByteBuffer(), buffer.getTypeByteOrder());
   }
 }


### PR DESCRIPTION
Regression introduced in #11004 due to overzealous optimization. Even though
we replaced stateful usage of ByteBuffer with stateless usage of Memory, we
still need to create a new object on "duplicate" due to semantics of setBuffer.

This issue was causing LongFilteringTest.testMultithreaded to be flaky. I didn't
add new tests for this issue, because LongFilteringTest.testMultithreaded already
covers it — it's just that the flaky test retrier was too zealous in retrying. Maybe
we should tune it down a bit (perhaps create a list of known-flaky tests and
don't retry others?)

Credit to @clintropolis for noticing this.