### PR TITLE
Rename BitmapOperationTest base class to avoid flaky test.

### DIFF
--- a/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapOperationAgainstConsecutiveRunsTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapOperationAgainstConsecutiveRunsTest.java
@@ -26,7 +26,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 import java.util.BitSet;
 
-public class BitmapOperationAgainstConsecutiveRunsTest extends BitmapOperationTest
+public class BitmapOperationAgainstConsecutiveRunsTest extends BitmapOperationTestBase
 {
 
   public static final double DENSITY = 0.001;

--- a/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapOperationAgainstUniformDistributionTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapOperationAgainstUniformDistributionTest.java
@@ -26,7 +26,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 import java.util.BitSet;
 
-public class BitmapOperationAgainstUniformDistributionTest extends BitmapOperationTest
+public class BitmapOperationAgainstUniformDistributionTest extends BitmapOperationTestBase
 {
   public static final double DENSITY = 0.01;
   public static final int MIN_INTERSECT = 50;

--- a/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapOperationTestBase.java
+++ b/processing/src/test/java/org/apache/druid/collections/bitmap/BitmapOperationTestBase.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Random;
 
-public class BitmapOperationTest
+public abstract class BitmapOperationTestBase
 {
   public static final int BITMAP_LENGTH = 500_000;
   public static final int NUM_BITMAPS = 1000;


### PR DESCRIPTION
PR #10936 renamed BitmapBenchmark, the parent of a couple of bitmap tests, to
BitmapOperationTest. This patch renames it to BitmapOperationTestBase so JUnit
doesn't pick it up as a test case. When JUnit picks it up, it becomes a flaky
test, since its behavior and correctness depends on whether it runs before
or after its subclasses.