### PR TITLE
Backport security prs to 0.21.0

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>10.0.0</kubernetes.client.version>
+    <kubernetes.client.version>10.0.1</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -93,6 +93,12 @@
       <version>1.68</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-ext-jdk15on</artifactId>
+      <version>1.68</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- others -->
     <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -841,7 +841,7 @@ name: kubernetes official java client
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java
 
@@ -851,7 +851,7 @@ name: kubernetes official java client api
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java-api
 
@@ -861,7 +861,7 @@ name: kubernetes official java client extended
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java-extended
 
@@ -981,7 +981,7 @@ name: io.kubernetes client-java-proto
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.0
+version: 10.0.1
 libraries:
   - io.kubernetes: client-java-proto
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1041,7 +1041,7 @@ name: org.bouncycastle bcprov-ext-jdk15on
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: MIT License
-version: 1.66
+version: 1.68
 libraries:
   - org.bouncycastle: bcprov-ext-jdk15on
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1975,6 +1975,7 @@ libraries:
   - org.eclipse.jetty: jetty-servlet
   - org.eclipse.jetty: jetty-servlets
   - org.eclipse.jetty: jetty-util
+  - org.eclipse.jetty: jetty-util-ajax
 notice: |
   ==============================================================
    Jetty Web Container

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1962,7 +1962,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.34.v20201102
+version: 9.4.39.v20210325
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -300,4 +300,11 @@
      <cve>CVE-2018-11765</cve>
      <cve>CVE-2020-9492</cve>
   </suppress>
+  <suppress>
+    <!-- We don't use scala compilation daemon. -->
+    <notes><![CDATA[
+     file name: kafka-clients-2.7.0.jar
+     ]]></notes>
+    <cve>CVE-2017-15288</cve>
+  </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -307,4 +307,12 @@
      ]]></notes>
     <cve>CVE-2017-15288</cve>
   </suppress>
+
+  <suppress>
+    <!-- (avro, parquet, integration-tests) we don't allow velocity templates to be uploaded by untrusted users -->
+    <notes><![CDATA[
+     file name: velocity-engine-core-2.2.jar:
+     ]]></notes>
+    <cve>CVE-2020-13936</cve>
+  </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -307,6 +307,13 @@
      ]]></notes>
     <cve>CVE-2017-15288</cve>
   </suppress>
+  <suppress until="2021-04-30">
+    <!-- Suppress this until https://github.com/apache/druid/issues/11028 is resolved. -->
+    <notes><![CDATA[
+     This vulnerability should be fixed soon and the suppression should be removed.
+     ]]></notes>
+    <cve>CVE-2020-13949</cve>
+  </suppress>
 
   <suppress>
     <!-- (avro, parquet, integration-tests) we don't allow velocity templates to be uploaded by untrusted users -->

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -315,4 +315,25 @@
      ]]></notes>
     <cve>CVE-2020-13936</cve>
   </suppress>
+
+  <suppress>
+     <!-- (ranger, ambari, and aliyun-oss) these vulnerabilities are legit, but their latest releases still use the vulnerable jackson version -->
+     <notes><![CDATA[
+     file name: jackson-xc-1.9.x.jar or jackson-jaxrs-1.9.x.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson-(xc|jaxrs)@1.9.*$</packageUrl>
+     <cve>CVE-2018-14718</cve>
+     <cve>CVE-2018-7489</cve>
+  </suppress>
+
+  <suppress>
+     <notes><![CDATA[
+     file name: solr-solrj-7.7.1.jar
+     ]]></notes>
+     <packageUrl regex="true">^pkg:maven/org\.apache\.solr/solr-solrj@7.7.1$</packageUrl>
+     <cve>CVE-2020-13957</cve>
+     <cve>CVE-2019-17558</cve>
+     <cve>CVE-2019-0193</cve>
+     <cve>CVE-2020-13941</cve>
+  </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -58,6 +58,17 @@
     <cve>CVE-2020-12691</cve>
   </suppress>
 
+
+  <suppress>
+    <!-- Not much for us to do as a user of the client lib, and no patch is available,
+     see https://github.com/kubernetes/kubernetes/issues/97076 -->
+    <notes><![CDATA[
+   file name: client-java-10.0.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.kubernetes/client\-java.*@10.0.1$</packageUrl>
+    <cve>CVE-2020-8554</cve>
+  </suppress>
+
   <!-- FIXME: These are suppressed so that CI can enforce that no new vulnerable dependencies are added. -->
   <suppress>
     <!--

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -298,5 +298,6 @@
      ]]></notes>
      <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop/hadoop\-.*@.*$</packageUrl>
      <cve>CVE-2018-11765</cve>
+     <cve>CVE-2020-9492</cve>
   </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.39.v20210325</jetty.version>
         <jersey.version>1.19.3</jersey.version>
         <jackson.version>2.10.2</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>


### PR DESCRIPTION
Backport of #10826, #10847, #10933, #11002, #11030, #11076, and #11093 to 0.21.0. For #11093, I will call out that the thrift version we are using have a known security vulnerability in the release notes.