### PR TITLE
Make it possible to use a different S3 endpoint for ingestion

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input.s3;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import org.apache.commons.lang.StringUtils;
 import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputFileAttribute;
 import org.apache.druid.data.input.InputSplit;
@@ -63,7 +65,7 @@ public class S3InputSource extends CloudObjectInputSource
   /**
    * Constructor for S3InputSource
    * @param s3Client                The default ServerSideEncryptingAmazonS3 client built with all default configs
-   *                                from Guice. This injected singleton client is use when {@param s3InputSourceConfig}
+   *                                from Guice. This injected singleton client is used when {@param s3InputSourceConfig}
    *                                is not provided and hence, we can skip building a new client from
    *                                {@param s3ClientBuilder}
    * @param s3ClientBuilder         Use for building a new s3Client to use instead of the default injected
@@ -102,6 +104,10 @@ public class S3InputSource extends CloudObjectInputSource
                   )
               );
               s3ClientBuilder.getAmazonS3ClientBuilder().withCredentials(credentials);
+            }
+            if (StringUtils.isNotEmpty(s3InputSourceConfig.getEndpointUrl())) {
+              s3ClientBuilder.getAmazonS3ClientBuilder().setEndpointConfiguration(
+                new EndpointConfiguration(s3InputSourceConfig.getEndpointUrl(), s3ClientBuilder.getAmazonS3ClientBuilder().getEndpoint().getSigningRegion()));
             }
             return s3ClientBuilder.build();
           } else {

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
@@ -36,10 +36,13 @@ public class S3InputSourceConfig
 {
   @JsonCreator
   public S3InputSourceConfig(
+      // TODO: Maybe an AWSEndpointConfig
+      @JsonProperty("endpointUrl") @Nullable String endpointUrl,
       @JsonProperty("accessKeyId") @Nullable PasswordProvider accessKeyId,
       @JsonProperty("secretAccessKey") @Nullable PasswordProvider secretAccessKey
   )
   {
+    this.endpointUrl = endpointUrl;
     if (accessKeyId != null || secretAccessKey != null) {
       this.accessKeyId = Preconditions.checkNotNull(accessKeyId, "accessKeyId cannot be null if secretAccessKey is given");
       this.secretAccessKey = Preconditions.checkNotNull(secretAccessKey, "secretAccessKey cannot be null if accessKeyId is given");
@@ -47,11 +50,18 @@ public class S3InputSourceConfig
   }
 
   @JsonProperty
+  private final String endpointUrl;
+
+  @JsonProperty
   private PasswordProvider accessKeyId;
 
   @JsonProperty
   private PasswordProvider secretAccessKey;
 
+  public String getEndpointUrl()
+  {
+    return endpointUrl;
+  }
 
   public PasswordProvider getAccessKeyId()
   {
@@ -74,6 +84,7 @@ public class S3InputSourceConfig
   public String toString()
   {
     return "S3InputSourceConfig{" +
+            "endpointUrl=" + endpointUrl +
            "accessKeyId=" + accessKeyId +
            ", secretAccessKey=" + secretAccessKey +
            '}';
@@ -89,13 +100,15 @@ public class S3InputSourceConfig
       return false;
     }
     S3InputSourceConfig that = (S3InputSourceConfig) o;
-    return Objects.equals(accessKeyId, that.accessKeyId) &&
+    return this.endpointUrl.equals(that.endpointUrl) &&
+            Objects.equals(accessKeyId, that.accessKeyId) &&
            Objects.equals(secretAccessKey, that.secretAccessKey);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(accessKeyId, secretAccessKey);
+    // TODO: Revisit
+    return Objects.hash(accessKeyId, secretAccessKey) * endpointUrl.hashCode();
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -120,7 +120,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
   );
 
   private static final S3InputSourceConfig CLOUD_CONFIG_PROPERTIES = new S3InputSourceConfig(
-      new DefaultPasswordProvider("myKey"), new DefaultPasswordProvider("mySecret"));
+          null, new DefaultPasswordProvider("myKey"), new DefaultPasswordProvider("mySecret"));
 
   private static final List<CloudObjectLocation> EXPECTED_LOCATION =
       ImmutableList.of(new CloudObjectLocation("foo", "bar/file.csv"));


### PR DESCRIPTION
Hello,

### Description

This adresses #10893, I've started a PR to get your attention and to show you that adding the feature won't require a lot of changes.

Based on the work done in https://github.com/apache/druid/pull/9375 (I know thought that PasswordProvider has been deprecated)

Let me know what you think.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
