### PR TITLE
Set default value of ZK_VERSION in docker compose file

### DIFF
--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -54,7 +54,7 @@ services:
     env_file:
       - ./environment-configs/common
     environment:
-      - ZK_VERSION
+      - ZK_VERSION=${ZK_VERSION:-3.5}
 
   druid-metadata-storage:
     image: druid/cluster

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -435,7 +435,6 @@
                 <docker.build.skip>false</docker.build.skip>
                 <docker.build.hadoop>false</docker.build.hadoop>
                 <it.indexer>middleManager</it.indexer>
-                <zk.version>3.5</zk.version>
                 <override.config.path />
                 <resource.file.dir.path />
 
@@ -466,7 +465,6 @@
                                         <DRUID_INTEGRATION_TEST_SKIP_RUN_DOCKER>${docker.run.skip}</DRUID_INTEGRATION_TEST_SKIP_RUN_DOCKER>
                                         <DRUID_INTEGRATION_TEST_INDEXER>${it.indexer}</DRUID_INTEGRATION_TEST_INDEXER>
                                         <MYSQL_VERSION>${mysql.version}</MYSQL_VERSION>
-                                        <ZK_VERSION>${zk.version}</ZK_VERSION>
                                     </environmentVariables>
                                     <executable>${project.basedir}/build_run_cluster.sh</executable>
                                 </configuration>


### PR DESCRIPTION
### Description

 #10786 Introduced an environment variable `ZK_VERSION` in `docker-compose.base.yml` and this env variable is set to `3.5` in pom.xml of integration-test module and the travis file `.travis.yml` .

In the README of integration-test module, there's a section describing how to manually bring up Druid cluster by docker-compose. And because of lacking of description that `ZK_VERSION` must be set, following the steps in that section leads to failure of starting up `druid-zookeeper-kafka` service.

Of course one way to solve that problem is by updating the README to add a step to tell users to set ZK_VERSION before manually bringing up Druid cluster. But I think it's not friendly for users to do this because ZK_VERSION is an interval environment variable mainly for backward compatibility and not a variable exposed to users.

So, I make a slight change to the compose file to set the default value of ZK_VERSION to 3.5, so that users don't care about setting this value. 
- If ZK_VERSION is not set by shell environment variable, it will default to 3.5
- If ZK_VERSION is set by shell environment variable, it will use the value set by shell

Such behaviors are compatible with current ways.

Since the default value of ZK_VERSION is set in compose file, I also remove zk.version property from pom.xml in integration-test module to simply the management of default version.


This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
