### PR TITLE
Keep traitSet of logicalValues

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
@@ -76,7 +76,7 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
     return new DruidQueryRel(
         scanRel.getCluster(),
         scanRel.getCluster().traitSetOf(Convention.NONE),
-        table,
+        Preconditions.checkNotNull(table, "table"),
         druidTable,
         queryMaker,
         PartialDruidQuery.create(scanRel)
@@ -91,7 +91,7 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
   {
     return new DruidQueryRel(
         valuesRel.getCluster(),
-        valuesRel.getCluster().traitSetOf(Convention.NONE),
+        valuesRel.getTraitSet(), // the traitSet of valuesRel should be kept
         null,
         druidTable,
         queryMaker,


### PR DESCRIPTION
### Description

https://github.com/apache/druid/pull/11058 added a new rule to handle empty tables, but Druid still uses `BindableConvention` for certain queries that read empty tables. The queries used in unit tests that are changed in this PR are such queries. The bug is in the `traitSet` of `DruidQueryRel` being set to a single trait of `Convention.NONE` when a `DruidQueryRel` is created from a `LogicalValues`. However, `LogicalValues` sometimes have extra traits set such as `RelCollation`. This makes `VolcanoPlanner` think the `DruidQueryRel` is not related to the `LogicalValues` even though `DruidQueryRel` is created from it.

There is another method that changes `traitSet` when creating `DruidQueryRel` from `LogicalTableScan` which doesn't seem necessary as well. I will do some testing to make sure that it's not necessary and make another PR to fix it.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
