### PR TITLE
fix serde issues with time-min-max extension

### DIFF
--- a/extensions-contrib/time-min-max/pom.xml
+++ b/extensions-contrib/time-min-max/pom.xml
@@ -90,6 +90,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-core</artifactId>
       <version>${project.parent.version}</version>

--- a/extensions-contrib/time-min-max/pom.xml
+++ b/extensions-contrib/time-min-max/pom.xml
@@ -55,6 +55,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>provided</scope>
@@ -67,11 +77,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregator.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregator.java
@@ -38,7 +38,6 @@ public class TimestampAggregator implements Aggregator
   }
 
   private final BaseObjectColumnValueSelector selector;
-  private final String name;
   private final TimestampSpec timestampSpec;
   private final Comparator<Long> comparator;
   private final Long initValue;
@@ -46,14 +45,12 @@ public class TimestampAggregator implements Aggregator
   private long most;
 
   public TimestampAggregator(
-      String name,
       BaseObjectColumnValueSelector selector,
       TimestampSpec timestampSpec,
       Comparator<Long> comparator,
       Long initValue
   )
   {
-    this.name = name;
     this.selector = selector;
     this.timestampSpec = timestampSpec;
     this.comparator = comparator;

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMaxAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMaxAggregatorFactory.java
@@ -22,28 +22,46 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 public class TimestampMaxAggregatorFactory extends TimestampAggregatorFactory
 {
   @JsonCreator
   public TimestampMaxAggregatorFactory(
       @JsonProperty("name") String name,
-      @JsonProperty("fieldName") String fieldName,
-      @JsonProperty("timeFormat") String timeFormat
+      @JsonProperty("fieldName") @Nullable String fieldName,
+      @JsonProperty("timeFormat") @Nullable String timeFormat
   )
   {
     super(name, fieldName, timeFormat, Ordering.natural(), Long.MIN_VALUE);
     Preconditions.checkNotNull(name, "Must have a valid, non-null aggregator name");
-    Preconditions.checkNotNull(fieldName, "Must have a valid, non-null fieldName");
+  }
+
+  @Override
+  public AggregatorFactory getCombiningFactory()
+  {
+    return new TimestampMaxAggregatorFactory(name, name, timeFormat);
+  }
+
+  @Override
+  public List<AggregatorFactory> getRequiredColumns()
+  {
+    return ImmutableList.of(
+        new TimestampMaxAggregatorFactory(name, fieldName, timeFormat)
+    );
   }
 
   @Override
   public String toString()
   {
     return "TimestampMaxAggregatorFactory{" +
-        "fieldName='" + fieldName + '\'' +
-        ", name='" + name + '\'' +
-        '}';
+           "name='" + name + '\'' +
+           ", fieldName='" + fieldName + '\'' +
+           ", timeFormat='" + timeFormat + '\'' +
+           '}';
   }
 }

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMinAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMinAggregatorFactory.java
@@ -22,7 +22,10 @@ package org.apache.druid.query.aggregation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
+
+import java.util.List;
 
 public class TimestampMinAggregatorFactory extends TimestampAggregatorFactory
 {
@@ -35,15 +38,29 @@ public class TimestampMinAggregatorFactory extends TimestampAggregatorFactory
   {
     super(name, fieldName, timeFormat, Ordering.natural().reverse(), Long.MAX_VALUE);
     Preconditions.checkNotNull(name, "Must have a valid, non-null aggregator name");
-    Preconditions.checkNotNull(fieldName, "Must have a valid, non-null fieldName");
+  }
+
+  @Override
+  public AggregatorFactory getCombiningFactory()
+  {
+    return new TimestampMinAggregatorFactory(name, name, timeFormat);
+  }
+
+  @Override
+  public List<AggregatorFactory> getRequiredColumns()
+  {
+    return ImmutableList.of(
+        new TimestampMinAggregatorFactory(name, fieldName, timeFormat)
+    );
   }
 
   @Override
   public String toString()
   {
     return "TimestampMinAggregatorFactory{" +
-        "fieldName='" + fieldName + '\'' +
-        ", name='" + name + '\'' +
-        '}';
+           "name='" + name + '\'' +
+           ", fieldName='" + fieldName + '\'' +
+           ", timeFormat='" + timeFormat + '\'' +
+           '}';
   }
 }

--- a/extensions-contrib/time-min-max/src/test/java/org/apache/druid/query/aggregation/TimestampMinMaxAggregatorFactoryTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/org/apache/druid/query/aggregation/TimestampMinMaxAggregatorFactoryTest.java
@@ -19,12 +19,16 @@
 
 package org.apache.druid.query.aggregation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.apache.druid.query.aggregation.post.FinalizingFieldAccessPostAggregator;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
+import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.junit.Assert;
@@ -32,6 +36,54 @@ import org.junit.Test;
 
 public class TimestampMinMaxAggregatorFactoryTest
 {
+  private static final ObjectMapper JSON_MAPPER = TestHelper.makeJsonMapper();
+
+  @Test
+  public void testSerde() throws JsonProcessingException
+  {
+    TimestampMaxAggregatorFactory maxAgg = new TimestampMaxAggregatorFactory("timeMax", "__time", null);
+    TimestampMinAggregatorFactory minAgg = new TimestampMinAggregatorFactory("timeMin", "__time", null);
+
+    Assert.assertEquals(
+        maxAgg,
+        JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(maxAgg), TimestampMaxAggregatorFactory.class)
+    );
+    Assert.assertEquals(
+        maxAgg.getCombiningFactory(),
+        JSON_MAPPER.readValue(
+            JSON_MAPPER.writeValueAsString(maxAgg.getCombiningFactory()),
+            TimestampMaxAggregatorFactory.class
+        )
+    );
+
+    Assert.assertEquals(
+        minAgg,
+        JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(minAgg), TimestampMinAggregatorFactory.class)
+    );
+    Assert.assertEquals(
+        minAgg.getCombiningFactory(),
+        JSON_MAPPER.readValue(
+            JSON_MAPPER.writeValueAsString(minAgg.getCombiningFactory()),
+            TimestampMinAggregatorFactory.class
+        )
+    );
+  }
+
+  @Test
+  public void testEqualsAndHashcode()
+  {
+    EqualsVerifier.forClass(TimestampMinAggregatorFactory.class)
+                  .withNonnullFields("name", "comparator", "initValue")
+                  .withIgnoredFields("timestampSpec")
+                  .usingGetClass()
+                  .verify();
+    EqualsVerifier.forClass(TimestampMaxAggregatorFactory.class)
+                  .withNonnullFields("name", "comparator", "initValue")
+                  .withIgnoredFields("timestampSpec")
+                  .usingGetClass()
+                  .verify();
+  }
+
   @Test
   public void testResultArraySignature()
   {


### PR DESCRIPTION
Fixes #10207.

### Description

This extension was implementing `AggregatorFactory.getCombiningFactory` in the base class `TimestampAggregatorFactory` which would create a new `TimestampAggregatorFactory`, instead of a `TimestampMaxAggregatorFactory` or `TimestampMinAggregatorFactory`. This meant the combining factory would create a type that was no longer round trip serializable, causing the issue reported in #10207.

This PR fixes this by making `TimestampAggregatorFactory` abstract, and implementing this method directly in the min and max agg factories. I also cleaned up equals/hashcode which were missing the format arguments, added `@Nullable` annotations to things which looked like they could be null (I decided this includes `fieldName` since `timestampSpec` uses the default time column if it is null), switched to using `CacheKeyBuilder` (and added format since was missing from cache key).

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
