### PR TITLE
Web console: Misc QueryView UX improvements

### DIFF
--- a/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
+++ b/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sql view matches snapshot 1`] = `
+exports[`QueryView matches snapshot 1`] = `
 <div
   className="query-view app-view"
 >
@@ -63,6 +63,7 @@ exports[`sql view matches snapshot 1`] = `
           liveQueryMode="auto"
           onLiveQueryModeChange={[Function]}
         />
+        <Memo(QueryTimer) />
       </div>
     </div>
     <div
@@ -77,7 +78,7 @@ exports[`sql view matches snapshot 1`] = `
 </div>
 `;
 
-exports[`sql view matches snapshot with query 1`] = `
+exports[`QueryView matches snapshot with query 1`] = `
 <div
   className="query-view app-view"
 >
@@ -140,6 +141,7 @@ exports[`sql view matches snapshot with query 1`] = `
           liveQueryMode="auto"
           onLiveQueryModeChange={[Function]}
         />
+        <Memo(QueryTimer) />
       </div>
     </div>
     <div

--- a/web-console/src/views/query-view/query-extra-info/__snapshots__/query-extra-info.spec.tsx.snap
+++ b/web-console/src/views/query-view/query-extra-info/__snapshots__/query-extra-info.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`query extra info matches snapshot 1`] = `
+exports[`QueryExtraInfo matches snapshot 1`] = `
 <div
   class="query-extra-info"
 >

--- a/web-console/src/views/query-view/query-output/query-output.scss
+++ b/web-console/src/views/query-view/query-output/query-output.scss
@@ -20,6 +20,11 @@
 @import '../../../blueprint-overrides/common/colors';
 
 .query-output {
+  &.more-results .-totalPages {
+    // Hide the total page counter as it can be confusing due to the auto limit
+    display: none;
+  }
+
   .ReactTable {
     position: absolute;
     top: 0;

--- a/web-console/src/views/query-view/query-output/query-output.spec.tsx
+++ b/web-console/src/views/query-view/query-output/query-output.spec.tsx
@@ -48,7 +48,8 @@ ORDER BY "Count" DESC`);
           false,
           true,
         ).attachQuery({}, parsedQuery)}
-        onQueryChange={() => null}
+        onQueryChange={() => {}}
+        onLoadMore={() => {}}
       />
     );
 

--- a/web-console/src/views/query-view/query-timer/__snapshots__/query-timer.spec.tsx.snap
+++ b/web-console/src/views/query-view/query-timer/__snapshots__/query-timer.spec.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QueryTimer matches snapshot 1`] = `
+<div
+  class="query-timer"
+>
+  1.85s
+  <button
+    class="bp3-button bp3-minimal"
+    type="button"
+  >
+    <span
+      class="bp3-icon bp3-icon-stopwatch"
+      icon="stopwatch"
+    >
+      <svg
+        data-icon="stopwatch"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <desc>
+          stopwatch
+        </desc>
+        <path
+          d="M9 2v1.083A6.002 6.002 0 018 15 6 6 0 017 3.083V2H6a1 1 0 110-2h4a1 1 0 010 2H9zM8 5a4 4 0 104 4H8V5z"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </span>
+  </button>
+</div>
+`;

--- a/web-console/src/views/query-view/query-timer/query-timer.scss
+++ b/web-console/src/views/query-view/query-timer/query-timer.scss
@@ -16,25 +16,8 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
-import { QueryResult } from 'druid-query-toolkit';
-import React from 'react';
-
-import { QueryExtraInfo } from './query-extra-info';
-
-describe('QueryExtraInfo', () => {
-  it('matches snapshot', () => {
-    const queryExtraInfo = (
-      <QueryExtraInfo
-        queryResult={QueryResult.BLANK.attachQueryId(
-          'e3ee781b-c0b6-4385-9d99-a8a1994bebac',
-        ).changeQueryDuration(8000)}
-        onDownload={() => {}}
-        onLoadMore={() => {}}
-      />
-    );
-
-    const { container } = render(queryExtraInfo);
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
+.query-timer {
+  line-height: 30px;
+  white-space: nowrap;
+  pointer-events: none;
+}

--- a/web-console/src/views/query-view/query-timer/query-timer.spec.tsx
+++ b/web-console/src/views/query-view/query-timer/query-timer.spec.tsx
@@ -17,24 +17,26 @@
  */
 
 import { render } from '@testing-library/react';
-import { QueryResult } from 'druid-query-toolkit';
 import React from 'react';
 
-import { QueryExtraInfo } from './query-extra-info';
+import { QueryTimer } from './query-timer';
 
-describe('QueryExtraInfo', () => {
+describe('QueryTimer', () => {
+  beforeEach(() => {
+    let nowCalls = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      return 1619201218452 + 2000 * nowCalls++;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('matches snapshot', () => {
-    const queryExtraInfo = (
-      <QueryExtraInfo
-        queryResult={QueryResult.BLANK.attachQueryId(
-          'e3ee781b-c0b6-4385-9d99-a8a1994bebac',
-        ).changeQueryDuration(8000)}
-        onDownload={() => {}}
-        onLoadMore={() => {}}
-      />
-    );
+    const queryTimer = <QueryTimer />;
 
-    const { container } = render(queryExtraInfo);
+    const { container } = render(queryTimer);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/web-console/src/views/query-view/query-timer/query-timer.tsx
+++ b/web-console/src/views/query-view/query-timer/query-timer.tsx
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import React, { useState } from 'react';
+
+import { useInterval } from '../../../hooks';
+
+import './query-timer.scss';
+
+// This is roughly the time in ms that it takes the component to mount and unmount, without this the timer appears to over count a little bit
+const FUDGE_OFFSET = 150;
+
+export const QueryTimer = React.memo(function QueryTimer() {
+  const [startTime] = useState(Date.now() + FUDGE_OFFSET);
+  const [currentTime, setCurrentTime] = useState(Date.now());
+
+  useInterval(() => {
+    setCurrentTime(Date.now());
+  }, 25);
+
+  const elapsed = currentTime - startTime;
+  if (elapsed <= 0) return null;
+  return (
+    <div className="query-timer">
+      {`${(elapsed / 1000).toFixed(2)}s`}
+      <Button icon={IconNames.STOPWATCH} minimal />
+    </div>
+  );
+});

--- a/web-console/src/views/query-view/query-view.scss
+++ b/web-console/src/views/query-view/query-view.scss
@@ -77,7 +77,8 @@ $nav-width: 250px;
           }
         }
 
-        .query-extra-info {
+        .query-extra-info,
+        .query-timer {
           position: absolute;
           right: 0;
           top: 0;

--- a/web-console/src/views/query-view/query-view.spec.tsx
+++ b/web-console/src/views/query-view/query-view.spec.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 import { QueryView } from './query-view';
 
-describe('sql view', () => {
+describe('QueryView', () => {
   it('matches snapshot', () => {
     const sqlView = shallow(<QueryView initQuery="test" />);
     expect(sqlView).toMatchSnapshot();


### PR DESCRIPTION
Just a number of UX improvements to the query view ✨ based on feedback from users.

Firstly there is a cute little stopwatch ⏱️ to keep you company while the query runs:

![image](https://user-images.githubusercontent.com/177816/115913282-41d2a080-a425-11eb-8fd2-65b643d1089c.png)

Also added:
- Improved page indication in the results table when the total number of results is not known due to auto limit
- Automatically increase the auto limit by 10x every time you reach the last loaded page
- Don't auto run the query when fresh opening the query view (prevents you from running a stale query)
- Page in the query output get reset to 0 if number of query result changes (vs leaving you in an empty page)

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
