### PR TITLE
Add feature to automatically remove rules based on retention period

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -750,6 +750,9 @@ These Coordinator static configurations can be defined in the `coordinator/runti
 |`druid.coordinator.kill.audit.on`| Boolean value for whether to enable automatic deletion of audit logs. If set to true, Coordinator will periodically remove audit logs from the audit table entries in metadata storage.| No | False| 
 |`druid.coordinator.kill.audit.period`| How often to do automatic deletion of audit logs in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) duration format. Value must be greater than `druid.coordinator.period.metadataStoreManagementPeriod`. Only applies if `druid.coordinator.kill.audit.on` is set to True.| No| `P1D`|
 |`druid.coordinator.kill.audit.durationToRetain`| Duration of audit logs to be retained from created time in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) duration format. Only applies if `druid.coordinator.kill.audit.on` is set to True.| Yes if `druid.coordinator.kill.audit.on` is set to True| None|
+|`druid.coordinator.kill.rule.on`| Boolean value for whether to enable automatic deletion of rules. If set to true, Coordinator will periodically remove rules of inactive datasource (datasource with no used and unused segments) from the rule table in metadata storage.| No | False| 
+|`druid.coordinator.kill.rule.period`| How often to do automatic deletion of rules in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) duration format. Value must be greater than `druid.coordinator.period.metadataStoreManagementPeriod`. Only applies if `druid.coordinator.kill.rule.on` is set to True.| No| `P1D`|
+|`druid.coordinator.kill.rule.durationToRetain`| Duration of rules to be retained from created time in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) duration format. Only applies if `druid.coordinator.kill.rule.on` is set to True.| Yes if `druid.coordinator.kill.rule.on` is set to True| None|
 
 ##### Segment Management
 |Property|Possible Values|Description|Default|

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -257,6 +257,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`coordinator/time`|Approximate Coordinator duty runtime in milliseconds. The duty dimension is the string alias of the Duty that is being run.|duty.|Varies.|
 |`coordinator/global/time`|Approximate runtime of a full coordination cycle in milliseconds. The `dutyGroup` dimension indicates what type of coordination this run was. i.e. Historical Management vs Indexing|`dutyGroup`|Varies.|
 |`metadata/kill/audit/count`|Total number of audit logs automatically deleted from metadata store audit table per each Coordinator kill audit duty run. This metric can help adjust `druid.coordinator.kill.audit.durationToRetain` configuration based on if more or less audit logs need to be deleted per cycle. Note that this metric is only emitted when `druid.coordinator.kill.audit.on` is set to true.| |Varies.|
+|`metadata/kill/rule/count`|Total number of rules automatically deleted from metadata store rule table per each Coordinator kill rule duty run. This metric can help adjust `druid.coordinator.kill.rule.durationToRetain` configuration based on if more or less rules need to be deleted per cycle. Note that this metric is only emitted when `druid.coordinator.kill.rule.on` is set to true.| |Varies.|
 
 
 If `emitBalancingStats` is set to `true` in the Coordinator [dynamic configuration](../configuration/index.md#dynamic-configuration), then [log entries](../configuration/logging.md) for class

--- a/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
@@ -42,4 +42,12 @@ public interface MetadataRuleManager
   List<Rule> getRulesWithDefault(String dataSource);
 
   boolean overrideRule(String dataSource, List<Rule> rulesConfig, AuditInfo auditInfo);
+
+  /**
+   * Remove rules for non-existence datasource (datasource with no segment) created older than the given timestamp.
+   *
+   * @param timestamp timestamp in milliseconds
+   * @return number of rules removed
+   */
+  int removeRulesOlderThan(long timestamp);
 }

--- a/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/MetadataRuleManager.java
@@ -49,5 +49,5 @@ public interface MetadataRuleManager
    * @param timestamp timestamp in milliseconds
    * @return number of rules removed
    */
-  int removeRulesOlderThan(long timestamp);
+  int removeRulesForEmptyDatasourcesOlderThan(long timestamp);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -63,6 +63,14 @@ public abstract class DruidCoordinatorConfig
   @Default("PT-1s")
   public abstract Duration getCoordinatorAuditKillDurationToRetain();
 
+  @Config("druid.coordinator.kill.rule.period")
+  @Default("P1D")
+  public abstract Duration getCoordinatorRuleKillPeriod();
+
+  @Config("druid.coordinator.kill.rule.durationToRetain")
+  @Default("PT-1s")
+  public abstract Duration getCoordinatorRuleKillDurationToRetain();
+
   @Config("druid.coordinator.load.timeout")
   public Duration getLoadTimeoutDelay()
   {

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillRules.java
@@ -61,7 +61,7 @@ public class KillRules implements CoordinatorDuty
       lastKillTime = System.currentTimeMillis();
 
       long timestamp = System.currentTimeMillis() - retainDuration;
-      int ruleRemoved = params.getDatabaseRuleManager().removeRulesOlderThan(timestamp);
+      int ruleRemoved = params.getDatabaseRuleManager().removeRulesForEmptyDatasourcesOlderThan(timestamp);
       ServiceEmitter emitter = params.getEmitter();
       emitter.emit(
           new ServiceMetricEvent.Builder().build(

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillRules.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.server.coordinator.DruidCoordinatorConfig;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+
+public class KillRules implements CoordinatorDuty
+{
+  private static final Logger log = new Logger(KillRules.class);
+
+  private final long period;
+  private final long retainDuration;
+  private long lastKillTime = 0;
+
+  @Inject
+  public KillRules(
+      DruidCoordinatorConfig config
+  )
+  {
+    this.period = config.getCoordinatorRuleKillPeriod().getMillis();
+    Preconditions.checkArgument(
+        this.period >= config.getCoordinatorMetadataStoreManagementPeriod().getMillis(),
+        "coordinator rule kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod"
+    );
+    this.retainDuration = config.getCoordinatorRuleKillDurationToRetain().getMillis();
+    Preconditions.checkArgument(this.retainDuration >= 0, "coordinator rule kill retainDuration must be >= 0");
+    log.debug(
+        "Rule Kill Task scheduling enabled with period [%s], retainDuration [%s]",
+        this.period,
+        this.retainDuration
+    );
+  }
+
+  @Override
+  public DruidCoordinatorRuntimeParams run(DruidCoordinatorRuntimeParams params)
+  {
+    if ((lastKillTime + period) < System.currentTimeMillis()) {
+      lastKillTime = System.currentTimeMillis();
+
+      long timestamp = System.currentTimeMillis() - retainDuration;
+      int ruleRemoved = params.getDatabaseRuleManager().removeRulesOlderThan(timestamp);
+      ServiceEmitter emitter = params.getEmitter();
+      emitter.emit(
+          new ServiceMetricEvent.Builder().build(
+              "metadata/kill/rule/count",
+              ruleRemoved
+          )
+      );
+      log.info("Finished running KillRules duty. Removed %,d rule", ruleRemoved);
+    }
+    return params;
+  }
+}

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -23,19 +23,25 @@ package org.apache.druid.metadata;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.audit.AuditEntry;
 import org.apache.druid.audit.AuditInfo;
 import org.apache.druid.audit.AuditManager;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.audit.SQLAuditManager;
 import org.apache.druid.server.audit.SQLAuditManagerConfig;
 import org.apache.druid.server.coordinator.rules.IntervalLoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -55,8 +61,9 @@ public class SQLMetadataRuleManagerTest
   private MetadataStorageTablesConfig tablesConfig;
   private SQLMetadataRuleManager ruleManager;
   private AuditManager auditManager;
+  private SQLMetadataSegmentPublisher publisher;
   private final ObjectMapper mapper = new DefaultObjectMapper();
-
+  private final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
 
   @Before
   public void setUp()
@@ -79,6 +86,12 @@ public class SQLMetadataRuleManagerTest
         tablesConfig,
         connector,
         auditManager
+    );
+    connector.createSegmentTable();
+    publisher = new SQLMetadataSegmentPublisher(
+        jsonMapper,
+        derbyConnectorRule.metadataTablesConfigSupplier().get(),
+        connector
     );
   }
 
@@ -199,6 +212,143 @@ public class SQLMetadataRuleManagerTest
       );
       Assert.assertEquals(auditInfo, entry.getAuditInfo());
     }
+  }
+
+  @Test
+  public void testRemoveRulesOlderThanWithNonExistenceDatasourceAndOlderThanTimestampShouldDelete()
+  {
+    List<Rule> rules = ImmutableList.of(
+        new IntervalLoadRule(
+            Intervals.of("2015-01-01/2015-02-01"), ImmutableMap.of(
+            DruidServer.DEFAULT_TIER,
+            DruidServer.DEFAULT_NUM_REPLICANTS
+        )
+        )
+    );
+    AuditInfo auditInfo = new AuditInfo("test_author", "test_comment", "127.0.0.1");
+    ruleManager.overrideRule(
+        "test_dataSource",
+        rules,
+        auditInfo
+    );
+    // Verify that rule was added
+    ruleManager.poll();
+    Map<String, List<Rule>> allRules = ruleManager.getAllRules();
+    Assert.assertEquals(1, allRules.size());
+    Assert.assertEquals(1, allRules.get("test_dataSource").size());
+
+    // Now delete rules
+    ruleManager.removeRulesOlderThan(System.currentTimeMillis());
+
+    // Verify that rule was deleted
+    ruleManager.poll();
+    allRules = ruleManager.getAllRules();
+    Assert.assertEquals(0, allRules.size());
+  }
+
+  @Test
+  public void testRemoveRulesOlderThanWithNonExistenceDatasourceAndNewerThanTimestampShouldNotDelete()
+  {
+    List<Rule> rules = ImmutableList.of(
+        new IntervalLoadRule(
+            Intervals.of("2015-01-01/2015-02-01"), ImmutableMap.of(
+            DruidServer.DEFAULT_TIER,
+            DruidServer.DEFAULT_NUM_REPLICANTS
+        )
+        )
+    );
+    AuditInfo auditInfo = new AuditInfo("test_author", "test_comment", "127.0.0.1");
+    ruleManager.overrideRule(
+        "test_dataSource",
+        rules,
+        auditInfo
+    );
+    // Verify that rule was added
+    ruleManager.poll();
+    Map<String, List<Rule>> allRules = ruleManager.getAllRules();
+    Assert.assertEquals(1, allRules.size());
+    Assert.assertEquals(1, allRules.get("test_dataSource").size());
+
+    // This will not delete the rule as the rule was created just now so it will have the created timestamp later than
+    // the timestamp 2012-01-01T00:00:00Z
+    ruleManager.removeRulesOlderThan(DateTimes.of("2012-01-01T00:00:00Z").getMillis());
+
+    // Verify that rule was not deleted
+    ruleManager.poll();
+    allRules = ruleManager.getAllRules();
+    Assert.assertEquals(1, allRules.size());
+    Assert.assertEquals(1, allRules.get("test_dataSource").size());
+  }
+
+  @Test
+  public void testRemoveRulesOlderThanWithActiveDatasourceShouldNotDelete() throws Exception
+  {
+    List<Rule> rules = ImmutableList.of(
+        new IntervalLoadRule(
+            Intervals.of("2015-01-01/2015-02-01"), ImmutableMap.of(
+            DruidServer.DEFAULT_TIER,
+            DruidServer.DEFAULT_NUM_REPLICANTS
+        )
+        )
+    );
+    AuditInfo auditInfo = new AuditInfo("test_author", "test_comment", "127.0.0.1");
+    ruleManager.overrideRule(
+        "test_dataSource",
+        rules,
+        auditInfo
+    );
+
+    // Verify that rule was added
+    ruleManager.poll();
+    Map<String, List<Rule>> allRules = ruleManager.getAllRules();
+    Assert.assertEquals(1, allRules.size());
+    Assert.assertEquals(1, allRules.get("test_dataSource").size());
+
+    // Add segment metadata to segment table so that the datasource is considered active
+    DataSegment dataSegment = new DataSegment(
+        "test_dataSource",
+        Intervals.of("2015-01-01/2015-02-01"),
+        "1",
+        ImmutableMap.of(
+            "type", "s3_zip",
+            "bucket", "test",
+            "key", "test_dataSource/xxx"
+        ),
+        ImmutableList.of("dim1", "dim2", "dim3"),
+        ImmutableList.of("count", "value"),
+        NoneShardSpec.instance(),
+        1,
+        1234L
+    );
+    publisher.publishSegment(dataSegment);
+
+    // This will not delete the rule as the datasource has segment in the segment metadata table
+    ruleManager.removeRulesOlderThan(System.currentTimeMillis());
+
+    // Verify that rule was not deleted
+    ruleManager.poll();
+    allRules = ruleManager.getAllRules();
+    Assert.assertEquals(1, allRules.size());
+    Assert.assertEquals(1, allRules.get("test_dataSource").size());
+  }
+
+  @Test
+  public void testRemoveRulesOlderThanShouldNotDeleteDefault()
+  {
+    // Create the default rule
+    ruleManager.start();
+    // Verify the default rule
+    ruleManager.poll();
+    Map<String, List<Rule>> allRules = ruleManager.getAllRules();
+    Assert.assertEquals(1, allRules.size());
+    Assert.assertEquals(1, allRules.get("_default").size());
+    // Delete everything
+    ruleManager.removeRulesOlderThan(System.currentTimeMillis());
+    // Verify the default rule was not deleted
+    ruleManager.poll();
+    allRules = ruleManager.getAllRules();
+    Assert.assertEquals(1, allRules.size());
+    Assert.assertEquals(1, allRules.get("_default").size());
   }
 
   @After

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -34,7 +34,6 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
-import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.audit.SQLAuditManager;
 import org.apache.druid.server.audit.SQLAuditManagerConfig;
 import org.apache.druid.server.coordinator.rules.IntervalLoadRule;

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -237,7 +237,7 @@ public class SQLMetadataRuleManagerTest
     Assert.assertEquals(1, allRules.get("test_dataSource").size());
 
     // Now delete rules
-    ruleManager.removeRulesOlderThan(System.currentTimeMillis());
+    ruleManager.removeRulesForEmptyDatasourcesOlderThan(System.currentTimeMillis());
 
     // Verify that rule was deleted
     ruleManager.poll();
@@ -270,7 +270,7 @@ public class SQLMetadataRuleManagerTest
 
     // This will not delete the rule as the rule was created just now so it will have the created timestamp later than
     // the timestamp 2012-01-01T00:00:00Z
-    ruleManager.removeRulesOlderThan(DateTimes.of("2012-01-01T00:00:00Z").getMillis());
+    ruleManager.removeRulesForEmptyDatasourcesOlderThan(DateTimes.of("2012-01-01T00:00:00Z").getMillis());
 
     // Verify that rule was not deleted
     ruleManager.poll();
@@ -322,7 +322,7 @@ public class SQLMetadataRuleManagerTest
     publisher.publishSegment(dataSegment);
 
     // This will not delete the rule as the datasource has segment in the segment metadata table
-    ruleManager.removeRulesOlderThan(System.currentTimeMillis());
+    ruleManager.removeRulesForEmptyDatasourcesOlderThan(System.currentTimeMillis());
 
     // Verify that rule was not deleted
     ruleManager.poll();
@@ -342,7 +342,7 @@ public class SQLMetadataRuleManagerTest
     Assert.assertEquals(1, allRules.size());
     Assert.assertEquals(1, allRules.get("_default").size());
     // Delete everything
-    ruleManager.removeRulesOlderThan(System.currentTimeMillis());
+    ruleManager.removeRulesForEmptyDatasourcesOlderThan(System.currentTimeMillis());
     // Verify the default rule was not deleted
     ruleManager.poll();
     allRules = ruleManager.getAllRules();

--- a/server/src/test/java/org/apache/druid/server/coordinator/CuratorDruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CuratorDruidCoordinatorTest.java
@@ -174,6 +174,8 @@ public class CuratorDruidCoordinatorTest extends CuratorTestBase
         null,
         null,
         null,
+        null,
+        null,
         10,
         new Duration("PT0s")
     );

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -146,6 +146,8 @@ public class DruidCoordinatorTest extends CuratorTestBase
         null,
         null,
         null,
+        null,
+        null,
         10,
         new Duration("PT0s")
     );

--- a/server/src/test/java/org/apache/druid/server/coordinator/HttpLoadQueuePeonTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/HttpLoadQueuePeonTest.java
@@ -83,6 +83,8 @@ public class HttpLoadQueuePeonTest
       null,
       null,
       null,
+      null,
+      null,
       10,
       Duration.ZERO
   )

--- a/server/src/test/java/org/apache/druid/server/coordinator/LoadQueuePeonTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/LoadQueuePeonTest.java
@@ -98,6 +98,8 @@ public class LoadQueuePeonTest extends CuratorTestBase
             null,
             null,
             null,
+            null,
+            null,
             10,
             Duration.millis(0)
         )
@@ -296,6 +298,8 @@ public class LoadQueuePeonTest extends CuratorTestBase
             null,
             null,
             null,
+            null,
+            null,
             10,
             new Duration("PT1s")
         )
@@ -347,6 +351,8 @@ public class LoadQueuePeonTest extends CuratorTestBase
             null,
             null,
             new Duration(1),
+            null,
+            null,
             null,
             null,
             null,

--- a/server/src/test/java/org/apache/druid/server/coordinator/LoadQueuePeonTester.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/LoadQueuePeonTester.java
@@ -47,6 +47,8 @@ public class LoadQueuePeonTester extends CuratorLoadQueuePeon
             null,
             null,
             null,
+            null,
+            null,
             10,
             new Duration("PT1s")
         )

--- a/server/src/test/java/org/apache/druid/server/coordinator/TestDruidCoordinatorConfig.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/TestDruidCoordinatorConfig.java
@@ -33,6 +33,8 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   private final Duration coordinatorKillDurationToRetain;
   private final Duration coordinatorAuditKillPeriod;
   private final Duration coordinatorAuditKillDurationToRetain;
+  private final Duration coordinatorRuleKillPeriod;
+  private final Duration coordinatorRuleKillDurationToRetain;
   private final Duration getLoadQueuePeonRepeatDelay;
   private final int coordinatorKillMaxSegments;
 
@@ -46,6 +48,8 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
       Duration coordinatorKillDurationToRetain,
       Duration coordinatorAuditKillPeriod,
       Duration coordinatorAuditKillDurationToRetain,
+      Duration coordinatorRuleKillPeriod,
+      Duration coordinatorRuleKillDurationToRetain,
       int coordinatorKillMaxSegments,
       Duration getLoadQueuePeonRepeatDelay
   )
@@ -59,6 +63,8 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
     this.coordinatorKillDurationToRetain = coordinatorKillDurationToRetain;
     this.coordinatorAuditKillPeriod = coordinatorAuditKillPeriod;
     this.coordinatorAuditKillDurationToRetain = coordinatorAuditKillDurationToRetain;
+    this.coordinatorRuleKillPeriod = coordinatorRuleKillPeriod;
+    this.coordinatorRuleKillDurationToRetain = coordinatorRuleKillDurationToRetain;
     this.coordinatorKillMaxSegments = coordinatorKillMaxSegments;
     this.getLoadQueuePeonRepeatDelay = getLoadQueuePeonRepeatDelay;
   }
@@ -109,6 +115,18 @@ public class TestDruidCoordinatorConfig extends DruidCoordinatorConfig
   public Duration getCoordinatorAuditKillDurationToRetain()
   {
     return coordinatorAuditKillDurationToRetain;
+  }
+
+  @Override
+  public Duration getCoordinatorRuleKillPeriod()
+  {
+    return coordinatorRuleKillPeriod;
+  }
+
+  @Override
+  public Duration getCoordinatorRuleKillDurationToRetain()
+  {
+    return coordinatorRuleKillDurationToRetain;
   }
 
   @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillRulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillRulesTest.java
@@ -102,7 +102,7 @@ public class KillRulesTest
     );
     killRules = new KillRules(druidCoordinatorConfig);
     killRules.run(mockDruidCoordinatorRuntimeParams);
-    Mockito.verify(mockRuleManager).removeRulesOlderThan(ArgumentMatchers.anyLong());
+    Mockito.verify(mockRuleManager).removeRulesForEmptyDatasourcesOlderThan(ArgumentMatchers.anyLong());
     Mockito.verify(mockServiceEmitter).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillRulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillRulesTest.java
@@ -19,12 +19,13 @@
 
 package org.apache.druid.server.coordinator.duty;
 
-import org.apache.druid.audit.AuditManager;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
+import org.apache.druid.metadata.MetadataRuleManager;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.TestDruidCoordinatorConfig;
 import org.joda.time.Duration;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -35,10 +36,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class KillAuditLogTest
+public class KillRulesTest
 {
   @Mock
-  private AuditManager mockAuditManager;
+  private MetadataRuleManager mockRuleManager;
 
   @Mock
   private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
@@ -49,7 +50,13 @@ public class KillAuditLogTest
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
-  private KillAuditLog killAuditLog;
+  private KillRules killRules;
+
+  @Before
+  public void setup()
+  {
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getDatabaseRuleManager()).thenReturn(mockRuleManager);
+  }
 
   @Test
   public void testRunSkipIfLastRunLessThanPeriod()
@@ -62,16 +69,16 @@ public class KillAuditLogTest
         null,
         null,
         null,
+        null,
+        null,
         new Duration(Long.MAX_VALUE),
         new Duration("PT1S"),
-        null,
-        null,
         10,
         null
     );
-    killAuditLog = new KillAuditLog(mockAuditManager, druidCoordinatorConfig);
-    killAuditLog.run(mockDruidCoordinatorRuntimeParams);
-    Mockito.verifyZeroInteractions(mockAuditManager);
+    killRules = new KillRules(druidCoordinatorConfig);
+    killRules.run(mockDruidCoordinatorRuntimeParams);
+    Mockito.verifyZeroInteractions(mockRuleManager);
   }
 
   @Test
@@ -86,16 +93,16 @@ public class KillAuditLogTest
         null,
         null,
         null,
+        null,
+        null,
         new Duration("PT6S"),
         new Duration("PT1S"),
-        null,
-        null,
         10,
         null
     );
-    killAuditLog = new KillAuditLog(mockAuditManager, druidCoordinatorConfig);
-    killAuditLog.run(mockDruidCoordinatorRuntimeParams);
-    Mockito.verify(mockAuditManager).removeAuditLogsOlderThan(ArgumentMatchers.anyLong());
+    killRules = new KillRules(druidCoordinatorConfig);
+    killRules.run(mockDruidCoordinatorRuntimeParams);
+    Mockito.verify(mockRuleManager).removeRulesOlderThan(ArgumentMatchers.anyLong());
     Mockito.verify(mockServiceEmitter).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
 
@@ -110,16 +117,16 @@ public class KillAuditLogTest
         null,
         null,
         null,
+        null,
+        null,
         new Duration("PT3S"),
         new Duration("PT1S"),
-        null,
-        null,
         10,
         null
     );
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("coordinator audit kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod");
-    killAuditLog = new KillAuditLog(mockAuditManager, druidCoordinatorConfig);
+    exception.expectMessage("coordinator rule kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod");
+    killRules = new KillRules(druidCoordinatorConfig);
   }
 
   @Test
@@ -133,15 +140,15 @@ public class KillAuditLogTest
         null,
         null,
         null,
+        null,
+        null,
         new Duration("PT6S"),
         new Duration("PT-1S"),
-        null,
-        null,
         10,
         null
     );
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("coordinator audit kill retainDuration must be >= 0");
-    killAuditLog = new KillAuditLog(mockAuditManager, druidCoordinatorConfig);
+    exception.expectMessage("coordinator rule kill retainDuration must be >= 0");
+    killRules = new KillRules(druidCoordinatorConfig);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -111,6 +111,8 @@ public class KillUnusedSegmentsTest
             Duration.parse("PT86400S"),
             null,
             null,
+            null,
+            null,
             1000,
             Duration.ZERO
         )

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -73,6 +73,7 @@ import org.apache.druid.server.coordinator.KillStalePendingSegments;
 import org.apache.druid.server.coordinator.LoadQueueTaskMaster;
 import org.apache.druid.server.coordinator.duty.CoordinatorDuty;
 import org.apache.druid.server.coordinator.duty.KillAuditLog;
+import org.apache.druid.server.coordinator.duty.KillRules;
 import org.apache.druid.server.coordinator.duty.KillUnusedSegments;
 import org.apache.druid.server.http.ClusterResource;
 import org.apache.druid.server.http.CompactionResource;
@@ -255,6 +256,11 @@ public class CliCoordinator extends ServerRunnable
                 "druid.coordinator.kill.audit.on",
                 Predicates.equalTo("true"),
                 KillAuditLog.class
+            );
+            conditionalMetadataStoreManagementDutyMultibind.addConditionBinding(
+                "druid.coordinator.kill.rule.on",
+                Predicates.equalTo("true"),
+                KillRules.class
             );
 
             bindNodeRoleAndAnnouncer(


### PR DESCRIPTION
Add feature to automatically remove rules based on retention period

### Description

We currently already have tasklog auto cleanup (https://github.com/apache/druid/pull/3677) and audit logs auto cleanup (https://github.com/apache/druid/pull/11084). This PR adds a similar auto cleanup based on duration (time to retained) but for the rules table to auto clean up rules of inactive datasource (datasource with no used and unused segments)

This is useful when Druid user has a high churn of task / datasource in a short amount of time causing the metadata store size to grow uncontrollably. 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
