### PR TITLE
InDimFilter: Fix NPE involving certain Set types.

### DIFF
--- a/core/src/main/java/org/apache/druid/common/config/NullHandling.java
+++ b/core/src/main/java/org/apache/druid/common/config/NullHandling.java
@@ -94,11 +94,6 @@ public class NullHandling
     //CHECKSTYLE.ON: Regexp
   }
 
-  public static boolean needsEmptyToNull(@Nullable String value)
-  {
-    return replaceWithDefault() && Strings.isNullOrEmpty(value);
-  }
-
   @Nullable
   public static String defaultStringValue()
   {

--- a/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
@@ -31,7 +31,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
@@ -48,6 +47,7 @@ import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.BitmapResultFactory;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
 
 public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
 {
@@ -91,6 +92,16 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
   @JsonIgnore
   private final Supplier<byte[]> cacheKeySupplier;
 
+  /**
+   * Creates a new filter.
+   *
+   * @param dimension    column to search
+   * @param values       set of values to match. This collection may be reused to avoid copying a big collection.
+   *                     Therefore, callers should <b>not</b> modify the collection after it is passed to this
+   *                     constructor.
+   * @param extractionFn extraction function to apply to the column before checking against "values"
+   * @param filterTuning optional tuning
+   */
   @JsonCreator
   public InDimFilter(
       @JsonProperty("dimension") String dimension,
@@ -111,10 +122,12 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
   }
 
   /**
+   * Creates a new filter without an extraction function or any special filter tuning.
    *
-   * @param dimension
-   * @param values This collection instance can be reused if possible to avoid copying a big collection.
-   *               Callers should <b>not</b> modify the collection after it is passed to this constructor.
+   * @param dimension column to search
+   * @param values    set of values to match. This collection may be reused to avoid copying a big collection.
+   *                  Therefore, callers should <b>not</b> modify the collection after it is passed to this
+   *                  constructor.
    */
   public InDimFilter(
       String dimension,
@@ -408,8 +421,17 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
 
   private byte[] computeCacheKey()
   {
-    final List<String> sortedValues = new ArrayList<>(values);
-    sortedValues.sort(Comparator.nullsFirst(Ordering.natural()));
+    final Collection<String> sortedValues;
+
+    if (values instanceof SortedSet && isNaturalOrder(((SortedSet<String>) values).comparator())) {
+      // Avoid copying "values" when it is already in the order we need for cache key computation.
+      sortedValues = values;
+    } else {
+      final List<String> sortedValuesList = new ArrayList<>(values);
+      sortedValuesList.sort(Comparators.naturalNullsFirst());
+      sortedValues = sortedValuesList;
+    }
+
     final Hasher hasher = Hashing.sha256().newHasher();
     for (String v : sortedValues) {
       if (v == null) {
@@ -464,6 +486,17 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     return this;
   }
 
+  /**
+   * Returns true if the comparator is null or the singleton {@link Comparators#naturalNullsFirst()}. Useful for
+   * detecting if a sorted set is in natural order or not.
+   *
+   * May return false negatives (i.e. there are naturally-ordered comparators that will return false here).
+   */
+  private static <T> boolean isNaturalOrder(@Nullable final Comparator<T> comparator)
+  {
+    return comparator == null || Comparators.naturalNullsFirst().equals(comparator);
+  }
+
   private static Iterable<ImmutableBitmap> getBitmapIterable(final Set<String> values, final BitmapIndex bitmapIndex)
   {
     return Filters.bitmapsFromIndexes(getBitmapIndexIterable(values, bitmapIndex), bitmapIndex);
@@ -489,6 +522,32 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     };
   }
 
+  private static Predicate<String> createStringPredicate(final Set<String> values)
+  {
+    Preconditions.checkNotNull(values, "values");
+
+    try {
+      // Check to see if values.contains(null) will throw a NullPointerException. Jackson JSON deserialization won't
+      // lead to this (it will create a HashSet, which can accept nulls). But when InDimFilters are created
+      // programmatically as a result of optimizations like rewriting inner joins as filters, the passed-in Set may
+      // not be able to accept nulls. We don't want to copy the Sets (since they may be large) so instead we'll wrap
+      // it in a null-checking lambda if needed.
+
+      //noinspection ResultOfMethodCallIgnored
+      values.contains(null);
+
+      // Safe to do values.contains(null).
+      return values::contains;
+    }
+    catch (NullPointerException ignored) {
+      // Fall through
+    }
+
+    // Not safe to do values.contains(null); must return a wrapper.
+    // Return false for null, since an exception means the set cannot accept null (and therefore does not include it).
+    return value -> value != null && values.contains(value);
+  }
+
   private static DruidLongPredicate createLongPredicate(final Set<String> values)
   {
     LongArrayList longs = new LongArrayList(values.size());
@@ -498,7 +557,6 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
         longs.add((long) longValue);
       }
     }
-
 
     final LongOpenHashSet longHashSet = new LongOpenHashSet(longs);
     return longHashSet::contains;
@@ -537,6 +595,7 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
   {
     private final ExtractionFn extractionFn;
     private final Set<String> values;
+    private final Supplier<Predicate<String>> stringPredicateSupplier;
     private final Supplier<DruidLongPredicate> longPredicateSupplier;
     private final Supplier<DruidFloatPredicate> floatPredicateSupplier;
     private final Supplier<DruidDoublePredicate> doublePredicateSupplier;
@@ -553,6 +612,7 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
       // only once. Pass in a common long predicate supplier to all filters created by .toFilter(), so that we only
       // compute the long hashset/array once per query. This supplier must be thread-safe, since this DimFilter will be
       // accessed in the query runners.
+      this.stringPredicateSupplier = Suppliers.memoize(() -> createStringPredicate(values));
       this.longPredicateSupplier = Suppliers.memoize(() -> createLongPredicate(values));
       this.floatPredicateSupplier = Suppliers.memoize(() -> createFloatPredicate(values));
       this.doublePredicateSupplier = Suppliers.memoize(() -> createDoublePredicate(values));
@@ -562,9 +622,10 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     public Predicate<String> makeStringPredicate()
     {
       if (extractionFn != null) {
-        return input -> values.contains(extractionFn.apply(input));
+        final Predicate<String> stringPredicate = stringPredicateSupplier.get();
+        return input -> stringPredicate.apply(extractionFn.apply(input));
       } else {
-        return values::contains;
+        return stringPredicateSupplier.get();
       }
     }
 
@@ -572,7 +633,8 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     public DruidLongPredicate makeLongPredicate()
     {
       if (extractionFn != null) {
-        return input -> values.contains(extractionFn.apply(input));
+        final Predicate<String> stringPredicate = stringPredicateSupplier.get();
+        return input -> stringPredicate.apply(extractionFn.apply(input));
       } else {
         return longPredicateSupplier.get();
       }
@@ -582,7 +644,8 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     public DruidFloatPredicate makeFloatPredicate()
     {
       if (extractionFn != null) {
-        return input -> values.contains(extractionFn.apply(input));
+        final Predicate<String> stringPredicate = stringPredicateSupplier.get();
+        return input -> stringPredicate.apply(extractionFn.apply(input));
       } else {
         return floatPredicateSupplier.get();
       }
@@ -592,9 +655,11 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     public DruidDoublePredicate makeDoublePredicate()
     {
       if (extractionFn != null) {
-        return input -> values.contains(extractionFn.apply(input));
+        final Predicate<String> stringPredicate = stringPredicateSupplier.get();
+        return input -> stringPredicate.apply(extractionFn.apply(input));
+      } else {
+        return doublePredicateSupplier.get();
       }
-      return input -> doublePredicateSupplier.get().applyDouble(input);
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/IndexedTableJoinable.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.join.table;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.DimensionHandlerUtils;
@@ -103,7 +104,10 @@ public class IndexedTableJoinable implements Joinable
     try (final IndexedTable.Reader reader = table.columnReader(columnPosition)) {
       // Sorted set to encourage "in" filters that result from this method to do dictionary lookups in order.
       // The hopes are that this will improve locality and therefore improve performance.
-      final Set<String> allValues = new TreeSet<>();
+      //
+      // Note: we are using Comparators.naturalNullsFirst() because it prevents the need for lambda-wrapping in
+      // InDimFilter's "createStringPredicate" method.
+      final Set<String> allValues = new TreeSet<>(Comparators.naturalNullsFirst());
 
       for (int i = 0; i < table.numRows(); i++) {
         final String s = DimensionHandlerUtils.convertObjectToString(reader.read(i));

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -180,5 +180,13 @@ public class InDimFilterTest extends InitializedNullHandlingTest
 
     // This would throw an exception without InDimFilter's null-checking lambda wrapping.
     Assert.assertFalse(matcher.matches());
+
+    row.put("dim", "foo");
+    // Now it should match.
+    Assert.assertTrue(matcher.matches());
+
+    row.put("dim", "fox");
+    // Now it *shouldn't* match.
+    Assert.assertFalse(matcher.matches());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -22,6 +22,8 @@ package org.apache.druid.query.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.MapBasedRow;
@@ -93,6 +95,20 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final InDimFilter dimFilter1 = new InDimFilter("dim", ImmutableList.of("v1", "v2"), null);
     final InDimFilter dimFilter2 = new InDimFilter("dim", ImmutableList.of("v2", "v1"), null);
     Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter2.getCacheKey());
+  }
+
+  @Test
+  public void testGetCacheKeyReturningSameKeyForSetsOfDifferentTypesAndComparators()
+  {
+    final Set<String> reverseOrderSet = new TreeSet<>(Ordering.natural().reversed());
+    final InDimFilter dimFilter1 = new InDimFilter("dim", Sets.newTreeSet(Arrays.asList("v1", "v2")));
+    final InDimFilter dimFilter2 = new InDimFilter("dim", Sets.newHashSet("v2", "v1"));
+    final InDimFilter dimFilter3 = new InDimFilter("dim", ImmutableSortedSet.copyOf(Arrays.asList("v2", "v1")));
+    reverseOrderSet.addAll(Arrays.asList("v1", "v2"));
+    final InDimFilter dimFilter4 = new InDimFilter("dim", reverseOrderSet);
+    Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter2.getCacheKey());
+    Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter3.getCacheKey());
+    Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter4.getCacheKey());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
@@ -396,7 +396,12 @@ public class InFilterTest extends BaseFilterTest
     EqualsVerifier.forClass(InDimFilter.InFilterDruidPredicateFactory.class)
                   .usingGetClass()
                   .withNonnullFields("values")
-                  .withIgnoredFields("longPredicateSupplier", "floatPredicateSupplier", "doublePredicateSupplier")
+                  .withIgnoredFields(
+                      "longPredicateSupplier",
+                      "floatPredicateSupplier",
+                      "doublePredicateSupplier",
+                      "stringPredicateSupplier"
+                  )
                   .verify();
   }
 


### PR DESCRIPTION
Normally, InDimFilters that come from JSON have HashSets for "values".
However, programmatically-generated filters (like the ones from #11068)
may use other set types. Some set types, like TreeSets with natural
ordering, will throw NPE on "contains(null)", which causes the
InDimFilter's ValueMatcher to throw NPE if it encounters a null value.

This patch adds code to detect if the values set can support
contains(null), and if not, wrap that in a null-checking lambda.

Also included:

- Remove unneeded NullHandling.needsEmptyToNull method.
- Update IndexedTableJoinable to generate a TreeSet that does not
  require lambda-wrapping. (This particular TreeSet is how I noticed
  the bug in the first place.)