### PR TITLE
Fix is null selector returning incorrect value for Long data type

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -47,8 +47,10 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
   private final LruEvalCache lruEvalCache;
 
   // Last read input value.
-  @Nullable
-  private Long lastInput;
+  private long lastInput;
+
+  // Last read input value is null.
+  private boolean lastInputIsNull;
 
   // Last computed output value, or null if there is none.
   @Nullable
@@ -100,7 +102,7 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
   public ExprEval getObject()
   {
     final Long input = selector.isNull() ? null : selector.getLong();
-    final boolean cached = Objects.equals(input, lastInput) && lastOutput != null;
+    final boolean cached = (Objects.equals(input, lastInput) && lastOutput != null) || (input == null && lastInputIsNull);
 
     if (!cached) {
       if (lruEvalCache == null || input == null) {
@@ -110,7 +112,10 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
         lastOutput = lruEvalCache.compute(input);
       }
 
-      lastInput = input;
+      lastInputIsNull = input == null ? true : false;
+      if (!lastInputIsNull) {
+        lastInput = input;
+      }
     }
 
     return lastOutput;

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -47,6 +47,7 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
   private final LruEvalCache lruEvalCache;
 
   // Last read input value.
+  @Nullable
   private Long lastInput;
 
   // Last computed output value, or null if there is none.

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -99,7 +99,8 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
   {
     // things can still call this even when underlying selector is null (e.g. ExpressionColumnValueSelector#isNull)
     if (selector.isNull()) {
-      return ExprEval.ofLong(null);
+      bindings.set(null);
+      return expression.eval(bindings);
     }
     // No assert for null handling, as the delegate selector already has it.
     final long input = selector.getLong();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -4926,53 +4926,53 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Test
   public void testLongPredicateIsNull() throws Exception
   {
-      if (NullHandling.replaceWithDefault()) {
-          testQuery(
-                  "SELECT l1 is null FROM druid.numfoo",
-                  ImmutableList.of(
-                          newScanQueryBuilder()
-                                  .dataSource(CalciteTests.DATASOURCE3)
-                                  .intervals(querySegmentSpec(Filtration.eternity()))
-                                  .columns("v0")
-                                  .virtualColumns(
-                                          expressionVirtualColumn("v0", "0", ValueType.LONG)
-                                  )
-                                  .context(QUERY_CONTEXT_DEFAULT)
-                                  .build()
-                  ),
-                  ImmutableList.of(
-                          new Object[]{false},
-                          new Object[]{false},
-                          new Object[]{false},
-                          new Object[]{false},
-                          new Object[]{false},
-                          new Object[]{false}
-                  )
-          );
-      } else {
-          testQuery(
-                  "SELECT l1 is null FROM druid.numfoo",
-                  ImmutableList.of(
-                          newScanQueryBuilder()
-                                  .dataSource(CalciteTests.DATASOURCE3)
-                                  .intervals(querySegmentSpec(Filtration.eternity()))
-                                  .columns("v0")
-                                  .virtualColumns(
-                                          expressionVirtualColumn("v0", "isnull(\"l1\")", ValueType.LONG)
-                                  )
-                                  .context(QUERY_CONTEXT_DEFAULT)
-                                  .build()
-                  ),
-                  ImmutableList.of(
-                          new Object[]{false},
-                          new Object[]{false},
-                          new Object[]{false},
-                          new Object[]{true},
-                          new Object[]{true},
-                          new Object[]{true}
-                  )
-          );
-      }
+    if (NullHandling.replaceWithDefault()) {
+      testQuery(
+          "SELECT l1 is null FROM druid.numfoo",
+          ImmutableList.of(
+            newScanQueryBuilder()
+            .dataSource(CalciteTests.DATASOURCE3)
+            .intervals(querySegmentSpec(Filtration.eternity()))
+            .columns("v0")
+            .virtualColumns(
+            expressionVirtualColumn("v0", "0", ValueType.LONG)
+        )
+          .context(QUERY_CONTEXT_DEFAULT)
+          .build()
+        ),
+          ImmutableList.of(
+            new Object[]{false},
+            new Object[]{false},
+            new Object[]{false},
+            new Object[]{false},
+            new Object[]{false},
+            new Object[]{false}
+          )
+      );
+    } else {
+      testQuery(
+          "SELECT l1 is null FROM druid.numfoo",
+          ImmutableList.of(
+             newScanQueryBuilder()
+             .dataSource(CalciteTests.DATASOURCE3)
+             .intervals(querySegmentSpec(Filtration.eternity()))
+             .columns("v0")
+             .virtualColumns(
+               expressionVirtualColumn("v0", "isnull(\"l1\")", ValueType.LONG)
+             )
+             .context(QUERY_CONTEXT_DEFAULT)
+             .build()
+           ),
+           ImmutableList.of(
+             new Object[]{false},
+             new Object[]{false},
+             new Object[]{false},
+             new Object[]{true},
+             new Object[]{true},
+             new Object[]{true}
+           )
+      );
+    }
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -4926,8 +4926,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Test
   public void testLongPredicateIsNull() throws Exception
   {
-    if (NullHandling.replaceWithDefault()) {
-      testQuery(
+    testQuery(
           "SELECT l1 is null FROM druid.numfoo",
           ImmutableList.of(
             newScanQueryBuilder()
@@ -4935,44 +4934,29 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             .intervals(querySegmentSpec(Filtration.eternity()))
             .columns("v0")
             .virtualColumns(
-            expressionVirtualColumn("v0", "0", ValueType.LONG)
+            expressionVirtualColumn("v0", NullHandling.replaceWithDefault() ? "0" : "isnull(\"l1\")", ValueType.LONG)
         )
           .context(QUERY_CONTEXT_DEFAULT)
           .build()
         ),
-          ImmutableList.of(
-            new Object[]{false},
-            new Object[]{false},
-            new Object[]{false},
-            new Object[]{false},
-            new Object[]{false},
-            new Object[]{false}
-          )
-      );
-    } else {
-      testQuery(
-          "SELECT l1 is null FROM druid.numfoo",
-          ImmutableList.of(
-             newScanQueryBuilder()
-             .dataSource(CalciteTests.DATASOURCE3)
-             .intervals(querySegmentSpec(Filtration.eternity()))
-             .columns("v0")
-             .virtualColumns(
-               expressionVirtualColumn("v0", "isnull(\"l1\")", ValueType.LONG)
-             )
-             .context(QUERY_CONTEXT_DEFAULT)
-             .build()
-           ),
-           ImmutableList.of(
-             new Object[]{false},
-             new Object[]{false},
-             new Object[]{false},
-             new Object[]{true},
-             new Object[]{true},
-             new Object[]{true}
-           )
-      );
-    }
+              NullHandling.replaceWithDefault() ?
+                      ImmutableList.of(
+                              new Object[]{false},
+                              new Object[]{false},
+                              new Object[]{false},
+                              new Object[]{false},
+                              new Object[]{false},
+                              new Object[]{false}
+                      ) :
+                      ImmutableList.of(
+                              new Object[]{false},
+                              new Object[]{false},
+                              new Object[]{false},
+                              new Object[]{true},
+                              new Object[]{true},
+                              new Object[]{true}
+                      )
+    );
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -4924,6 +4924,58 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testLongPredicateIsNull() throws Exception
+  {
+      if (NullHandling.replaceWithDefault()) {
+          testQuery(
+                  "SELECT l1 is null FROM druid.numfoo",
+                  ImmutableList.of(
+                          newScanQueryBuilder()
+                                  .dataSource(CalciteTests.DATASOURCE3)
+                                  .intervals(querySegmentSpec(Filtration.eternity()))
+                                  .columns("v0")
+                                  .virtualColumns(
+                                          expressionVirtualColumn("v0", "0", ValueType.LONG)
+                                  )
+                                  .context(QUERY_CONTEXT_DEFAULT)
+                                  .build()
+                  ),
+                  ImmutableList.of(
+                          new Object[]{false},
+                          new Object[]{false},
+                          new Object[]{false},
+                          new Object[]{false},
+                          new Object[]{false},
+                          new Object[]{false}
+                  )
+          );
+      } else {
+          testQuery(
+                  "SELECT l1 is null FROM druid.numfoo",
+                  ImmutableList.of(
+                          newScanQueryBuilder()
+                                  .dataSource(CalciteTests.DATASOURCE3)
+                                  .intervals(querySegmentSpec(Filtration.eternity()))
+                                  .columns("v0")
+                                  .virtualColumns(
+                                          expressionVirtualColumn("v0", "isnull(\"l1\")", ValueType.LONG)
+                                  )
+                                  .context(QUERY_CONTEXT_DEFAULT)
+                                  .build()
+                  ),
+                  ImmutableList.of(
+                          new Object[]{false},
+                          new Object[]{false},
+                          new Object[]{false},
+                          new Object[]{true},
+                          new Object[]{true},
+                          new Object[]{true}
+                  )
+          );
+      }
+  }
+
+  @Test
   public void testLongPredicateFilterNulls() throws Exception
   {
     testQuery(


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #10073.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug:
After setting `druid.generic.useDefaultValueForNull=false`, it was discovered that for columns of type `Long` the sql `is null` selector returns `null` if the input is `null` but that behavior is incorrect for the `is null` function.

To fix the issue I have set the `bindings` variable to `null` so that if the selector is `is null`and the value is `null` then it will be evaluated to `true` as expected from this selector. This solution lets the expression handle the behavior for `null` by sending the value of `bindings` to be evaluated in the `eval` function. 

If the previous input value was also `null` then the computation will be skipped and the cached value for `lastOutput` will be returned to improve performance.

I have also added a test to the `CalciteQuery` suite to ensure that this case is handled correctly.

#### Other options considered:
We can hardcode this special case into `SingleLongInputCachingExpressionColumnValueSelector.java` by checking if the expression `is null` and then returning `true` within that function. This is not the best solution and changing the logic within this function might affect other areas of the code that we don’t know about.
We could use a different selector for `is null` expressions but this seemed more complicated to implement and is not done for any of the other data types.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * New unit test `testLongPredicateIsNull`
 * Extra logic for returning `true` instead of `null` in `SingleLongInputCachingExpressionColumnValueSelector.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
