### PR TITLE
[Backport] Change the `id` for `kubernetes` doc link to work

### DIFF
--- a/docs/development/extensions-core/kubernetes.md
+++ b/docs/development/extensions-core/kubernetes.md
@@ -1,5 +1,5 @@
 ---
-id: druid-kubernetes
+id: kubernetes
 title: "Kubernetes"
 ---
 

--- a/docs/development/extensions.md
+++ b/docs/development/extensions.md
@@ -62,6 +62,7 @@ Core extensions are maintained by Druid committers.
 |postgresql-metadata-storage|PostgreSQL metadata store.|[link](../development/extensions-core/postgresql.md)|
 |simple-client-sslcontext|Simple SSLContext provider module to be used by Druid's internal HttpClient when talking to other Druid processes over HTTPS.|[link](../development/extensions-core/simple-client-sslcontext.md)|
 |druid-pac4j|OpenID Connect authentication for druid processes.|[link](../development/extensions-core/druid-pac4j.md)|
+|druid-kubernetes-extensions|Druid cluster deployment on Kubernetes without Zookeeper.|[link](../development/extensions-core/kubernetes.md)|
 
 ## Community extensions
 


### PR DESCRIPTION
Backport of #11176 to 0.21.0.