### PR TITLE
Vectorize the DataSketches quantiles aggregator.

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildBufferAggregatorHelper.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildBufferAggregatorHelper.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.apache.datasketches.memory.WritableMemory;
+import org.apache.datasketches.quantiles.CompactDoublesSketch;
+import org.apache.datasketches.quantiles.DoublesSketch;
+import org.apache.datasketches.quantiles.UpdateDoublesSketch;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.IdentityHashMap;
+
+public class DoublesSketchBuildBufferAggregatorHelper
+{
+  private final int size;
+  private final int maxIntermediateSize;
+  private final IdentityHashMap<ByteBuffer, WritableMemory> memCache = new IdentityHashMap<>();
+  private final IdentityHashMap<ByteBuffer, Int2ObjectMap<UpdateDoublesSketch>> sketches = new IdentityHashMap<>();
+
+  public DoublesSketchBuildBufferAggregatorHelper(final int size, final int maxIntermediateSize)
+  {
+    this.size = size;
+    this.maxIntermediateSize = maxIntermediateSize;
+  }
+
+  public void init(final ByteBuffer buffer, final int position)
+  {
+    final WritableMemory mem = getMemory(buffer);
+    final WritableMemory region = mem.writableRegion(position, maxIntermediateSize);
+    final UpdateDoublesSketch sketch = DoublesSketch.builder().setK(size).build(region);
+    putSketch(buffer, position, sketch);
+  }
+
+  public CompactDoublesSketch get(final ByteBuffer buffer, final int position)
+  {
+    return sketches.get(buffer).get(position).compact();
+  }
+
+  // A small number of sketches may run out of the given memory, request more memory on heap and move there.
+  // In that case we need to reuse the object from the cache as opposed to wrapping the new buffer.
+  public void relocate(int oldPosition, int newPosition, ByteBuffer oldBuffer, ByteBuffer newBuffer)
+  {
+    UpdateDoublesSketch sketch = sketches.get(oldBuffer).get(oldPosition);
+    final WritableMemory oldRegion = getMemory(oldBuffer).writableRegion(oldPosition, maxIntermediateSize);
+    if (sketch.isSameResource(oldRegion)) { // sketch was not relocated on heap
+      final WritableMemory newRegion = getMemory(newBuffer).writableRegion(newPosition, maxIntermediateSize);
+      sketch = UpdateDoublesSketch.wrap(newRegion);
+    }
+    putSketch(newBuffer, newPosition, sketch);
+
+    final Int2ObjectMap<UpdateDoublesSketch> map = sketches.get(oldBuffer);
+    map.remove(oldPosition);
+    if (map.isEmpty()) {
+      sketches.remove(oldBuffer);
+      memCache.remove(oldBuffer);
+    }
+  }
+
+  public void clear()
+  {
+    sketches.clear();
+    memCache.clear();
+  }
+
+  /**
+   * Retrieves the sketch at a particular position.
+   */
+  public UpdateDoublesSketch getSketchAtPosition(final ByteBuffer buf, final int position)
+  {
+    return sketches.get(buf).get(position);
+  }
+
+  private WritableMemory getMemory(final ByteBuffer buffer)
+  {
+    return memCache.computeIfAbsent(buffer, buf -> WritableMemory.wrap(buf, ByteOrder.LITTLE_ENDIAN));
+  }
+
+  private void putSketch(final ByteBuffer buffer, final int position, final UpdateDoublesSketch sketch)
+  {
+    Int2ObjectMap<UpdateDoublesSketch> map = sketches.computeIfAbsent(buffer, buf -> new Int2ObjectOpenHashMap<>());
+    map.put(position, sketch);
+  }
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildVectorAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildVectorAggregator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles;
+
+import org.apache.datasketches.quantiles.UpdateDoublesSketch;
+import org.apache.druid.query.aggregation.VectorAggregator;
+import org.apache.druid.segment.vector.VectorValueSelector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+public class DoublesSketchBuildVectorAggregator implements VectorAggregator
+{
+  private final VectorValueSelector selector;
+  private final DoublesSketchBuildBufferAggregatorHelper helper;
+
+  DoublesSketchBuildVectorAggregator(
+      final VectorValueSelector selector,
+      final int size,
+      final int maxIntermediateSize
+  )
+  {
+    this.selector = selector;
+    this.helper = new DoublesSketchBuildBufferAggregatorHelper(size, maxIntermediateSize);
+  }
+
+  @Override
+  public void init(final ByteBuffer buf, final int position)
+  {
+    helper.init(buf, position);
+  }
+
+  @Override
+  public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
+  {
+    final double[] doubles = selector.getDoubleVector();
+    final boolean[] nulls = selector.getNullVector();
+
+    final UpdateDoublesSketch sketch = helper.getSketchAtPosition(buf, position);
+
+    for (int i = startRow; i < endRow; i++) {
+      if (nulls == null || !nulls[i]) {
+        sketch.update(doubles[i]);
+      }
+    }
+  }
+
+  @Override
+  public void aggregate(
+      final ByteBuffer buf,
+      final int numRows,
+      final int[] positions,
+      @Nullable final int[] rows,
+      final int positionOffset
+  )
+  {
+    final double[] doubles = selector.getDoubleVector();
+    final boolean[] nulls = selector.getNullVector();
+
+    for (int i = 0; i < numRows; i++) {
+      final int idx = rows != null ? rows[i] : i;
+
+      if (nulls == null || !nulls[idx]) {
+        final int position = positions[i] + positionOffset;
+        helper.getSketchAtPosition(buf, position).update(doubles[idx]);
+      }
+    }
+  }
+
+  @Override
+  public Object get(final ByteBuffer buf, final int position)
+  {
+    return helper.get(buf, position);
+  }
+
+  @Override
+  public void relocate(final int oldPosition, final int newPosition, final ByteBuffer oldBuf, final ByteBuffer newBuf)
+  {
+    helper.relocate(oldPosition, newPosition, oldBuf, newBuf);
+  }
+
+  @Override
+  public void close()
+  {
+    helper.clear();
+  }
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeBufferAggregatorHelper.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeBufferAggregatorHelper.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.apache.datasketches.memory.WritableMemory;
+import org.apache.datasketches.quantiles.DoublesUnion;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.IdentityHashMap;
+
+public class DoublesSketchMergeBufferAggregatorHelper
+{
+  private final int k;
+  private final int maxIntermediateSize;
+  private final IdentityHashMap<ByteBuffer, WritableMemory> memCache = new IdentityHashMap<>();
+  private final IdentityHashMap<ByteBuffer, Int2ObjectMap<DoublesUnion>> unions = new IdentityHashMap<>();
+
+  public DoublesSketchMergeBufferAggregatorHelper(
+      final int k,
+      final int maxIntermediateSize
+  )
+  {
+    this.k = k;
+    this.maxIntermediateSize = maxIntermediateSize;
+  }
+
+  public void init(final ByteBuffer buffer, final int position)
+  {
+    final WritableMemory mem = getMemory(buffer);
+    final WritableMemory region = mem.writableRegion(position, maxIntermediateSize);
+    final DoublesUnion union = DoublesUnion.builder().setMaxK(k).build(region);
+    putUnion(buffer, position, union);
+  }
+
+  public Object get(final ByteBuffer buffer, final int position)
+  {
+    return unions.get(buffer).get(position).getResult();
+  }
+
+  public void clear()
+  {
+    unions.clear();
+    memCache.clear();
+  }
+
+  // A small number of sketches may run out of the given memory, request more memory on heap and move there.
+  // In that case we need to reuse the object from the cache as opposed to wrapping the new buffer.
+  public void relocate(int oldPosition, int newPosition, ByteBuffer oldBuffer, ByteBuffer newBuffer)
+  {
+    DoublesUnion union = unions.get(oldBuffer).get(oldPosition);
+    final WritableMemory oldMem = getMemory(oldBuffer).writableRegion(oldPosition, maxIntermediateSize);
+    if (union.isSameResource(oldMem)) { // union was not relocated on heap
+      final WritableMemory newMem = getMemory(newBuffer).writableRegion(newPosition, maxIntermediateSize);
+      union = DoublesUnion.wrap(newMem);
+    }
+    putUnion(newBuffer, newPosition, union);
+
+    Int2ObjectMap<DoublesUnion> map = unions.get(oldBuffer);
+    map.remove(oldPosition);
+    if (map.isEmpty()) {
+      unions.remove(oldBuffer);
+      memCache.remove(oldBuffer);
+    }
+  }
+
+  /**
+   * Retrieves the sketch at a particular position.
+   */
+  public DoublesUnion getSketchAtPosition(final ByteBuffer buf, final int position)
+  {
+    return unions.get(buf).get(position);
+  }
+
+  private WritableMemory getMemory(final ByteBuffer buffer)
+  {
+    return memCache.computeIfAbsent(buffer, buf -> WritableMemory.wrap(buf, ByteOrder.LITTLE_ENDIAN));
+  }
+
+  private void putUnion(final ByteBuffer buffer, final int position, final DoublesUnion union)
+  {
+    Int2ObjectMap<DoublesUnion> map = unions.computeIfAbsent(buffer, buf -> new Int2ObjectOpenHashMap<>());
+    map.put(position, union);
+  }
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeVectorAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeVectorAggregator.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles;
+
+import org.apache.datasketches.quantiles.DoublesSketch;
+import org.apache.datasketches.quantiles.DoublesUnion;
+import org.apache.druid.query.aggregation.VectorAggregator;
+import org.apache.druid.segment.vector.VectorObjectSelector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+public class DoublesSketchMergeVectorAggregator implements VectorAggregator
+{
+  private final VectorObjectSelector selector;
+  private final DoublesSketchMergeBufferAggregatorHelper helper;
+
+  public DoublesSketchMergeVectorAggregator(
+      final VectorObjectSelector selector,
+      final int k,
+      final int maxIntermediateSize
+  )
+  {
+    this.selector = selector;
+    this.helper = new DoublesSketchMergeBufferAggregatorHelper(k, maxIntermediateSize);
+  }
+
+  @Override
+  public void init(ByteBuffer buf, int position)
+  {
+    helper.init(buf, position);
+  }
+
+  @Override
+  public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
+  {
+    final Object[] vector = selector.getObjectVector();
+
+    final DoublesUnion union = helper.getSketchAtPosition(buf, position);
+
+    for (int i = startRow; i < endRow; i++) {
+      final DoublesSketch sketch = (DoublesSketch) vector[i];
+      if (sketch != null) {
+        union.update(sketch);
+      }
+    }
+  }
+
+  @Override
+  public void aggregate(
+      final ByteBuffer buf,
+      final int numRows,
+      final int[] positions,
+      @Nullable final int[] rows,
+      final int positionOffset
+  )
+  {
+    final Object[] vector = selector.getObjectVector();
+
+    for (int i = 0; i < numRows; i++) {
+      final DoublesSketch sketch = (DoublesSketch) vector[rows != null ? rows[i] : i];
+
+      if (sketch != null) {
+        final int position = positions[i] + positionOffset;
+        final DoublesUnion union = helper.getSketchAtPosition(buf, position);
+        union.update(sketch);
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object get(ByteBuffer buf, int position)
+  {
+    return helper.get(buf, position);
+  }
+
+  @Override
+  public void close()
+  {
+    helper.clear();
+  }
+
+  @Override
+  public void relocate(int oldPosition, int newPosition, ByteBuffer oldBuffer, ByteBuffer newBuffer)
+  {
+    helper.relocate(oldPosition, newPosition, oldBuffer, newBuffer);
+  }
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchOperations.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchOperations.java
@@ -41,8 +41,9 @@ public class DoublesSketchOperations
       return (DoublesSketch) serializedSketch;
     }
     throw new ISE(
-        "Object is not of a type that can be deserialized to a quantiles DoublsSketch: "
-            + serializedSketch.getClass());
+        "Object is not of a type that can be deserialized to a quantiles DoublesSketch: %s",
+        serializedSketch == null ? "null" : serializedSketch.getClass()
+    );
   }
 
   public static DoublesSketch deserializeFromBase64EncodedString(final String str)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/NoopDoublesSketchBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/NoopDoublesSketchBufferAggregator.java
@@ -20,20 +20,42 @@
 package org.apache.druid.query.aggregation.datasketches.quantiles;
 
 import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.VectorAggregator;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
-public class NoopDoublesSketchBufferAggregator implements BufferAggregator
+public class NoopDoublesSketchBufferAggregator implements BufferAggregator, VectorAggregator
 {
   @Override
   public void init(final ByteBuffer buf, final int position)
   {
+    // Nothing to do.
   }
 
   @Override
   public void aggregate(final ByteBuffer buf, final int position)
   {
+    // Nothing to do.
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int position, int startRow, int endRow)
+  {
+    // Nothing to do.
+  }
+
+  @Override
+  public void aggregate(
+      ByteBuffer buf,
+      int numRows,
+      int[] positions,
+      @Nullable int[] rows,
+      int positionOffset
+  )
+  {
+    // Nothing to do.
   }
 
   @Override
@@ -55,12 +77,20 @@ public class NoopDoublesSketchBufferAggregator implements BufferAggregator
   }
 
   @Override
+  public void relocate(int oldPosition, int newPosition, ByteBuffer oldBuffer, ByteBuffer newBuffer)
+  {
+    // Nothing to do.
+  }
+
+  @Override
   public void close()
   {
+    // Nothing to do.
   }
 
   @Override
   public void inspectRuntimeShape(final RuntimeShapeInspector inspector)
   {
+    // Nothing to do.
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
@@ -77,7 +77,6 @@ import java.util.Map;
 
 public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
 {
-  private static final AuthenticationResult AUTH_RESULT = CalciteTests.REGULAR_USER_AUTH_RESULT;
   private static final DruidOperatorTable OPERATOR_TABLE = new DruidOperatorTable(
       ImmutableSet.of(
           new DoublesSketchApproxQuantileSqlAggregator(),
@@ -683,24 +682,24 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
                 1.0d,
                 "[0.0,0.0,1.0]",
                 "\n"
-                + "### Quantiles HeapUpdateDoublesSketch SUMMARY: \n"
-                + "   Empty                        : false\n"
-                + "   Direct, Capacity bytes       : false, \n"
-                + "   Estimation Mode              : false\n"
-                + "   K                            : 128\n"
-                + "   N                            : 6\n"
-                + "   Levels (Needed, Total, Valid): 0, 0, 0\n"
-                + "   Level Bit Pattern            : 0\n"
-                + "   BaseBufferCount              : 6\n"
-                + "   Combined Buffer Capacity     : 8\n"
-                + "   Retained Items               : 6\n"
-                + "   Compact Storage Bytes        : 80\n"
-                + "   Updatable Storage Bytes      : 96\n"
-                + "   Normalized Rank Error        : 1.406%\n"
-                + "   Normalized Rank Error (PMF)  : 1.711%\n"
-                + "   Min Value                    : 1.000000e+00\n"
-                + "   Max Value                    : 1.000000e+00\n"
-                + "### END SKETCH SUMMARY\n"
+                  + "### Quantiles HeapUpdateDoublesSketch SUMMARY: \n"
+                  + "   Empty                        : false\n"
+                  + "   Direct, Capacity bytes       : false, \n"
+                  + "   Estimation Mode              : false\n"
+                  + "   K                            : 128\n"
+                  + "   N                            : 6\n"
+                  + "   Levels (Needed, Total, Valid): 0, 0, 0\n"
+                  + "   Level Bit Pattern            : 0\n"
+                  + "   BaseBufferCount              : 6\n"
+                  + "   Combined Buffer Capacity     : 8\n"
+                  + "   Retained Items               : 6\n"
+                  + "   Compact Storage Bytes        : 80\n"
+                  + "   Updatable Storage Bytes      : 96\n"
+                  + "   Normalized Rank Error        : 1.406%\n"
+                  + "   Normalized Rank Error (PMF)  : 1.711%\n"
+                  + "   Min Value                    : 1.000000e+00\n"
+                  + "   Max Value                    : 1.000000e+00\n"
+                  + "### END SKETCH SUMMARY\n"
             }
         )
     );
@@ -731,7 +730,11 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
                               new FieldAccessPostAggregator("p1", "a0:agg"),
                               0.5
                           ),
-                          new DoublesSketchToQuantilePostAggregator("s1", new FieldAccessPostAggregator("s0", "p0"), 0.5),
+                          new DoublesSketchToQuantilePostAggregator(
+                              "s1",
+                              new FieldAccessPostAggregator("s0", "p0"),
+                              0.5
+                          ),
                           new DoublesSketchToQuantilePostAggregator(
                               "s3",
                               new FieldAccessPostAggregator("s2", "p0"),

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
@@ -23,12 +23,10 @@ import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.Druids;
-import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryDataSource;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -70,10 +68,10 @@ import org.apache.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
 import org.apache.druid.sql.http.SqlParameter;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -172,166 +170,136 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testQuantileOnFloatAndLongs() throws Exception
   {
-    SqlLifecycle sqlLifecycle = getSqlLifecycle();
-    final String sql = "SELECT\n"
-                       + "APPROX_QUANTILE_DS(m1, 0.01),\n"
-                       + "APPROX_QUANTILE_DS(m1, 0.5, 64),\n"
-                       + "APPROX_QUANTILE_DS(m1, 0.98, 256),\n"
-                       + "APPROX_QUANTILE_DS(m1, 0.99),\n"
-                       + "APPROX_QUANTILE_DS(m1 * 2, 0.97),\n"
-                       + "APPROX_QUANTILE_DS(m1, 0.99) FILTER(WHERE dim1 = 'abc'),\n"
-                       + "APPROX_QUANTILE_DS(m1, 0.999) FILTER(WHERE dim1 <> 'abc'),\n"
-                       + "APPROX_QUANTILE_DS(m1, 0.999) FILTER(WHERE dim1 = 'abc'),\n"
-                       + "APPROX_QUANTILE_DS(cnt, 0.5)\n"
-                       + "FROM foo";
-
-    // Verify results
-    final List<Object[]> results = sqlLifecycle.runSimple(
-        sql,
-        TIMESERIES_CONTEXT_DEFAULT,
-        DEFAULT_PARAMETERS,
-        AUTH_RESULT
-    ).toList();
-    final List<Object[]> expectedResults = ImmutableList.of(
-        new Object[]{
-            1.0,
-            4.0,
-            6.0,
-            6.0,
-            12.0,
-            6.0,
-            5.0,
-            6.0,
-            1.0
-        }
-    );
-    Assert.assertEquals(expectedResults.size(), results.size());
-    for (int i = 0; i < expectedResults.size(); i++) {
-      Assert.assertArrayEquals(expectedResults.get(i), results.get(i));
-    }
-
-    // Verify query
-    Assert.assertEquals(
-        Druids.newTimeseriesQueryBuilder()
-              .dataSource(CalciteTests.DATASOURCE1)
-              .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-              .granularity(Granularities.ALL)
-              .virtualColumns(
-                  new ExpressionVirtualColumn(
-                      "v0",
-                      "(\"m1\" * 2)",
-                      ValueType.FLOAT,
-                      TestExprMacroTable.INSTANCE
+    testQuery(
+        "SELECT\n"
+        + "APPROX_QUANTILE_DS(m1, 0.01),\n"
+        + "APPROX_QUANTILE_DS(m1, 0.5, 64),\n"
+        + "APPROX_QUANTILE_DS(m1, 0.98, 256),\n"
+        + "APPROX_QUANTILE_DS(m1, 0.99),\n"
+        + "APPROX_QUANTILE_DS(m1 * 2, 0.97),\n"
+        + "APPROX_QUANTILE_DS(m1, 0.99) FILTER(WHERE dim1 = 'abc'),\n"
+        + "APPROX_QUANTILE_DS(m1, 0.999) FILTER(WHERE dim1 <> 'abc'),\n"
+        + "APPROX_QUANTILE_DS(m1, 0.999) FILTER(WHERE dim1 = 'abc'),\n"
+        + "APPROX_QUANTILE_DS(cnt, 0.5)\n"
+        + "FROM foo",
+        Collections.singletonList(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                  .granularity(Granularities.ALL)
+                  .virtualColumns(
+                      new ExpressionVirtualColumn(
+                          "v0",
+                          "(\"m1\" * 2)",
+                          ValueType.FLOAT,
+                          TestExprMacroTable.INSTANCE
+                      )
                   )
-              )
-              .aggregators(ImmutableList.of(
-                  new DoublesSketchAggregatorFactory("a0:agg", "m1", null),
-                  new DoublesSketchAggregatorFactory("a1:agg", "m1", 64),
-                  new DoublesSketchAggregatorFactory("a2:agg", "m1", 256),
-                  new DoublesSketchAggregatorFactory("a4:agg", "v0", null),
-                  new FilteredAggregatorFactory(
-                      new DoublesSketchAggregatorFactory("a5:agg", "m1", null),
-                      new SelectorDimFilter("dim1", "abc", null)
-                  ),
-                  new FilteredAggregatorFactory(
-                      new DoublesSketchAggregatorFactory("a6:agg", "m1", null),
-                      new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
-                  ),
-                  new DoublesSketchAggregatorFactory("a8:agg", "cnt", null)
-              ))
-              .postAggregators(
-                  new DoublesSketchToQuantilePostAggregator("a0", makeFieldAccessPostAgg("a0:agg"), 0.01f),
-                  new DoublesSketchToQuantilePostAggregator("a1", makeFieldAccessPostAgg("a1:agg"), 0.50f),
-                  new DoublesSketchToQuantilePostAggregator("a2", makeFieldAccessPostAgg("a2:agg"), 0.98f),
-                  new DoublesSketchToQuantilePostAggregator("a3", makeFieldAccessPostAgg("a0:agg"), 0.99f),
-                  new DoublesSketchToQuantilePostAggregator("a4", makeFieldAccessPostAgg("a4:agg"), 0.97f),
-                  new DoublesSketchToQuantilePostAggregator("a5", makeFieldAccessPostAgg("a5:agg"), 0.99f),
-                  new DoublesSketchToQuantilePostAggregator("a6", makeFieldAccessPostAgg("a6:agg"), 0.999f),
-                  new DoublesSketchToQuantilePostAggregator("a7", makeFieldAccessPostAgg("a5:agg"), 0.999f),
-                  new DoublesSketchToQuantilePostAggregator("a8", makeFieldAccessPostAgg("a8:agg"), 0.50f)
-              )
-              .context(TIMESERIES_CONTEXT_DEFAULT)
-              .build(),
-        Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
+                  .aggregators(ImmutableList.of(
+                      new DoublesSketchAggregatorFactory("a0:agg", "m1", null),
+                      new DoublesSketchAggregatorFactory("a1:agg", "m1", 64),
+                      new DoublesSketchAggregatorFactory("a2:agg", "m1", 256),
+                      new DoublesSketchAggregatorFactory("a4:agg", "v0", null),
+                      new FilteredAggregatorFactory(
+                          new DoublesSketchAggregatorFactory("a5:agg", "m1", null),
+                          new SelectorDimFilter("dim1", "abc", null)
+                      ),
+                      new FilteredAggregatorFactory(
+                          new DoublesSketchAggregatorFactory("a6:agg", "m1", null),
+                          new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
+                      ),
+                      new DoublesSketchAggregatorFactory("a8:agg", "cnt", null)
+                  ))
+                  .postAggregators(
+                      new DoublesSketchToQuantilePostAggregator("a0", makeFieldAccessPostAgg("a0:agg"), 0.01f),
+                      new DoublesSketchToQuantilePostAggregator("a1", makeFieldAccessPostAgg("a1:agg"), 0.50f),
+                      new DoublesSketchToQuantilePostAggregator("a2", makeFieldAccessPostAgg("a2:agg"), 0.98f),
+                      new DoublesSketchToQuantilePostAggregator("a3", makeFieldAccessPostAgg("a0:agg"), 0.99f),
+                      new DoublesSketchToQuantilePostAggregator("a4", makeFieldAccessPostAgg("a4:agg"), 0.97f),
+                      new DoublesSketchToQuantilePostAggregator("a5", makeFieldAccessPostAgg("a5:agg"), 0.99f),
+                      new DoublesSketchToQuantilePostAggregator("a6", makeFieldAccessPostAgg("a6:agg"), 0.999f),
+                      new DoublesSketchToQuantilePostAggregator("a7", makeFieldAccessPostAgg("a5:agg"), 0.999f),
+                      new DoublesSketchToQuantilePostAggregator("a8", makeFieldAccessPostAgg("a8:agg"), 0.50f)
+                  )
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{
+                1.0,
+                4.0,
+                6.0,
+                6.0,
+                12.0,
+                6.0,
+                5.0,
+                6.0,
+                1.0
+            }
+        )
     );
   }
 
   @Test
   public void testQuantileOnComplexColumn() throws Exception
   {
-    SqlLifecycle lifecycle = getSqlLifecycle();
-    final String sql = "SELECT\n"
-                       + "APPROX_QUANTILE_DS(qsketch_m1, 0.01),\n"
-                       + "APPROX_QUANTILE_DS(qsketch_m1, 0.5, 64),\n"
-                       + "APPROX_QUANTILE_DS(qsketch_m1, 0.98, 256),\n"
-                       + "APPROX_QUANTILE_DS(qsketch_m1, 0.99),\n"
-                       + "APPROX_QUANTILE_DS(qsketch_m1, 0.99) FILTER(WHERE dim1 = 'abc'),\n"
-                       + "APPROX_QUANTILE_DS(qsketch_m1, 0.999) FILTER(WHERE dim1 <> 'abc'),\n"
-                       + "APPROX_QUANTILE_DS(qsketch_m1, 0.999) FILTER(WHERE dim1 = 'abc')\n"
-                       + "FROM foo";
-
-    // Verify results
-    final List<Object[]> results = lifecycle.runSimple(
-        sql,
-        TIMESERIES_CONTEXT_DEFAULT,
-        DEFAULT_PARAMETERS,
-        AUTH_RESULT
-    ).toList();
-    final List<Object[]> expectedResults = ImmutableList.of(
-        new Object[]{
-            1.0,
-            4.0,
-            6.0,
-            6.0,
-            6.0,
-            5.0,
-            6.0
-        }
-    );
-    Assert.assertEquals(expectedResults.size(), results.size());
-    for (int i = 0; i < expectedResults.size(); i++) {
-      Assert.assertArrayEquals(expectedResults.get(i), results.get(i));
-    }
-
-    // Verify query
-    Assert.assertEquals(
-        Druids.newTimeseriesQueryBuilder()
-              .dataSource(CalciteTests.DATASOURCE1)
-              .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-              .granularity(Granularities.ALL)
-              .aggregators(ImmutableList.of(
-                  new DoublesSketchAggregatorFactory("a0:agg", "qsketch_m1", null),
-                  new DoublesSketchAggregatorFactory("a1:agg", "qsketch_m1", 64),
-                  new DoublesSketchAggregatorFactory("a2:agg", "qsketch_m1", 256),
-                  new FilteredAggregatorFactory(
-                      new DoublesSketchAggregatorFactory("a4:agg", "qsketch_m1", null),
-                      new SelectorDimFilter("dim1", "abc", null)
-                  ),
-                  new FilteredAggregatorFactory(
-                      new DoublesSketchAggregatorFactory("a5:agg", "qsketch_m1", null),
-                      new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
+    testQuery(
+        "SELECT\n"
+        + "APPROX_QUANTILE_DS(qsketch_m1, 0.01),\n"
+        + "APPROX_QUANTILE_DS(qsketch_m1, 0.5, 64),\n"
+        + "APPROX_QUANTILE_DS(qsketch_m1, 0.98, 256),\n"
+        + "APPROX_QUANTILE_DS(qsketch_m1, 0.99),\n"
+        + "APPROX_QUANTILE_DS(qsketch_m1, 0.99) FILTER(WHERE dim1 = 'abc'),\n"
+        + "APPROX_QUANTILE_DS(qsketch_m1, 0.999) FILTER(WHERE dim1 <> 'abc'),\n"
+        + "APPROX_QUANTILE_DS(qsketch_m1, 0.999) FILTER(WHERE dim1 = 'abc')\n"
+        + "FROM foo",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                  .granularity(Granularities.ALL)
+                  .aggregators(ImmutableList.of(
+                      new DoublesSketchAggregatorFactory("a0:agg", "qsketch_m1", null),
+                      new DoublesSketchAggregatorFactory("a1:agg", "qsketch_m1", 64),
+                      new DoublesSketchAggregatorFactory("a2:agg", "qsketch_m1", 256),
+                      new FilteredAggregatorFactory(
+                          new DoublesSketchAggregatorFactory("a4:agg", "qsketch_m1", null),
+                          new SelectorDimFilter("dim1", "abc", null)
+                      ),
+                      new FilteredAggregatorFactory(
+                          new DoublesSketchAggregatorFactory("a5:agg", "qsketch_m1", null),
+                          new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
+                      )
+                  ))
+                  .postAggregators(
+                      new DoublesSketchToQuantilePostAggregator("a0", makeFieldAccessPostAgg("a0:agg"), 0.01f),
+                      new DoublesSketchToQuantilePostAggregator("a1", makeFieldAccessPostAgg("a1:agg"), 0.50f),
+                      new DoublesSketchToQuantilePostAggregator("a2", makeFieldAccessPostAgg("a2:agg"), 0.98f),
+                      new DoublesSketchToQuantilePostAggregator("a3", makeFieldAccessPostAgg("a0:agg"), 0.99f),
+                      new DoublesSketchToQuantilePostAggregator("a4", makeFieldAccessPostAgg("a4:agg"), 0.99f),
+                      new DoublesSketchToQuantilePostAggregator("a5", makeFieldAccessPostAgg("a5:agg"), 0.999f),
+                      new DoublesSketchToQuantilePostAggregator("a6", makeFieldAccessPostAgg("a4:agg"), 0.999f)
                   )
-              ))
-              .postAggregators(
-                  new DoublesSketchToQuantilePostAggregator("a0", makeFieldAccessPostAgg("a0:agg"), 0.01f),
-                  new DoublesSketchToQuantilePostAggregator("a1", makeFieldAccessPostAgg("a1:agg"), 0.50f),
-                  new DoublesSketchToQuantilePostAggregator("a2", makeFieldAccessPostAgg("a2:agg"), 0.98f),
-                  new DoublesSketchToQuantilePostAggregator("a3", makeFieldAccessPostAgg("a0:agg"), 0.99f),
-                  new DoublesSketchToQuantilePostAggregator("a4", makeFieldAccessPostAgg("a4:agg"), 0.99f),
-                  new DoublesSketchToQuantilePostAggregator("a5", makeFieldAccessPostAgg("a5:agg"), 0.999f),
-                  new DoublesSketchToQuantilePostAggregator("a6", makeFieldAccessPostAgg("a4:agg"), 0.999f)
-              )
-              .context(TIMESERIES_CONTEXT_DEFAULT)
-              .build(),
-        Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{
+                1.0,
+                4.0,
+                6.0,
+                6.0,
+                6.0,
+                5.0,
+                6.0
+            }
+        )
     );
   }
 
   @Test
   public void testQuantileOnCastedString() throws Exception
   {
-    cannotVectorize();
-
     final List<Object[]> expectedResults;
     if (NullHandling.replaceWithDefault()) {
       expectedResults = ImmutableList.of(
@@ -425,92 +393,72 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testQuantileOnInnerQuery() throws Exception
   {
-    SqlLifecycle sqlLifecycle = getSqlLifecycle();
-    final String sql = "SELECT AVG(x), APPROX_QUANTILE_DS(x, 0.98)\n"
-                       + "FROM (SELECT dim2, SUM(m1) AS x FROM foo GROUP BY dim2)";
-
-    // Verify results
-    final List<Object[]> results = sqlLifecycle.runSimple(
-        sql,
-        QUERY_CONTEXT_DEFAULT,
-        DEFAULT_PARAMETERS,
-        AUTH_RESULT
-    ).toList();
     final List<Object[]> expectedResults;
     if (NullHandling.replaceWithDefault()) {
       expectedResults = ImmutableList.of(new Object[]{7.0, 11.0});
     } else {
       expectedResults = ImmutableList.of(new Object[]{5.25, 8.0});
     }
-    Assert.assertEquals(expectedResults.size(), results.size());
-    for (int i = 0; i < expectedResults.size(); i++) {
-      Assert.assertArrayEquals(expectedResults.get(i), results.get(i));
-    }
 
-    // Verify query
-    Assert.assertEquals(
-        GroupByQuery.builder()
-                    .setDataSource(
-                        new QueryDataSource(
-                            GroupByQuery.builder()
-                                        .setDataSource(CalciteTests.DATASOURCE1)
-                                        .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-                                        .setGranularity(Granularities.ALL)
-                                        .setDimensions(new DefaultDimensionSpec("dim2", "d0"))
-                                        .setAggregatorSpecs(
-                                            ImmutableList.of(
-                                                new DoubleSumAggregatorFactory("a0", "m1")
+    testQuery(
+        "SELECT AVG(x), APPROX_QUANTILE_DS(x, 0.98)\n"
+        + "FROM (SELECT dim2, SUM(m1) AS x FROM foo GROUP BY dim2)",
+        Collections.singletonList(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            new QueryDataSource(
+                                GroupByQuery.builder()
+                                            .setDataSource(CalciteTests.DATASOURCE1)
+                                            .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                                            .setGranularity(Granularities.ALL)
+                                            .setDimensions(new DefaultDimensionSpec("dim2", "d0"))
+                                            .setAggregatorSpecs(
+                                                ImmutableList.of(
+                                                    new DoubleSumAggregatorFactory("a0", "m1")
+                                                )
                                             )
-                                        )
-                                        .setContext(QUERY_CONTEXT_DEFAULT)
-                                        .build()
+                                            .setContext(QUERY_CONTEXT_DEFAULT)
+                                            .build()
+                            )
                         )
-                    )
-                    .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-                    .setGranularity(Granularities.ALL)
-                    .setAggregatorSpecs(
-                        new DoubleSumAggregatorFactory("_a0:sum", "a0"),
-                        new CountAggregatorFactory("_a0:count"),
-                        new DoublesSketchAggregatorFactory(
-                            "_a1:agg",
-                            "a0",
-                            null
+                        .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                        .setGranularity(Granularities.ALL)
+                        .setAggregatorSpecs(
+                            new DoubleSumAggregatorFactory("_a0:sum", "a0"),
+                            new CountAggregatorFactory("_a0:count"),
+                            new DoublesSketchAggregatorFactory(
+                                "_a1:agg",
+                                "a0",
+                                null
+                            )
                         )
-                    )
-                    .setPostAggregatorSpecs(
-                        ImmutableList.of(
-                            new ArithmeticPostAggregator(
-                                "_a0",
-                                "quotient",
-                                ImmutableList.of(
-                                    new FieldAccessPostAggregator(null, "_a0:sum"),
-                                    new FieldAccessPostAggregator(null, "_a0:count")
+                        .setPostAggregatorSpecs(
+                            ImmutableList.of(
+                                new ArithmeticPostAggregator(
+                                    "_a0",
+                                    "quotient",
+                                    ImmutableList.of(
+                                        new FieldAccessPostAggregator(null, "_a0:sum"),
+                                        new FieldAccessPostAggregator(null, "_a0:count")
+                                    )
+                                ),
+                                new DoublesSketchToQuantilePostAggregator(
+                                    "_a1",
+                                    makeFieldAccessPostAgg("_a1:agg"),
+                                    0.98f
                                 )
-                            ),
-                            new DoublesSketchToQuantilePostAggregator("_a1", makeFieldAccessPostAgg("_a1:agg"), 0.98f)
+                            )
                         )
-                    )
-                    .setContext(QUERY_CONTEXT_DEFAULT)
-                    .build(),
-        Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        expectedResults
     );
   }
 
   @Test
   public void testQuantileOnInnerQuantileQuery() throws Exception
   {
-    SqlLifecycle sqlLifecycle = getSqlLifecycle();
-    final String sql = "SELECT dim1, APPROX_QUANTILE_DS(x, 0.5)\n"
-                       + "FROM (SELECT dim1, dim2, APPROX_QUANTILE_DS(m1, 0.5) AS x FROM foo GROUP BY dim1, dim2) GROUP BY dim1";
-
-
-    final List<Object[]> results = sqlLifecycle.runSimple(
-        sql,
-        QUERY_CONTEXT_DEFAULT,
-        DEFAULT_PARAMETERS,
-        AUTH_RESULT
-    ).toList();
-
     ImmutableList.Builder<Object[]> builder = ImmutableList.builder();
     builder.add(new Object[]{"", 1.0});
     builder.add(new Object[]{"1", 4.0});
@@ -519,296 +467,288 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
     builder.add(new Object[]{"abc", 6.0});
     builder.add(new Object[]{"def", 5.0});
     final List<Object[]> expectedResults = builder.build();
-    Assert.assertEquals(expectedResults.size(), results.size());
-    for (int i = 0; i < expectedResults.size(); i++) {
-      Assert.assertArrayEquals(expectedResults.get(i), results.get(i));
-    }
 
-    // Verify query
-    Assert.assertEquals(
-        GroupByQuery.builder()
-                    .setDataSource(
-                        new QueryDataSource(
-                            GroupByQuery.builder()
-                                        .setDataSource(CalciteTests.DATASOURCE1)
-                                        .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-                                        .setGranularity(Granularities.ALL)
-                                        .setDimensions(
-                                            new DefaultDimensionSpec("dim1", "d0"),
-                                            new DefaultDimensionSpec("dim2", "d1")
-                                        )
-                                        .setAggregatorSpecs(
-                                            ImmutableList.of(
-                                                new DoublesSketchAggregatorFactory("a0:agg", "m1", 128)
+    testQuery(
+        "SELECT dim1, APPROX_QUANTILE_DS(x, 0.5)\n"
+        + "FROM (SELECT dim1, dim2, APPROX_QUANTILE_DS(m1, 0.5) AS x FROM foo GROUP BY dim1, dim2) GROUP BY dim1",
+        Collections.singletonList(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            new QueryDataSource(
+                                GroupByQuery.builder()
+                                            .setDataSource(CalciteTests.DATASOURCE1)
+                                            .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                                            .setGranularity(Granularities.ALL)
+                                            .setDimensions(
+                                                new DefaultDimensionSpec("dim1", "d0"),
+                                                new DefaultDimensionSpec("dim2", "d1")
                                             )
-                                        )
-                                        .setPostAggregatorSpecs(
-                                            ImmutableList.of(
-                                                new DoublesSketchToQuantilePostAggregator(
-                                                    "a0",
-                                                    makeFieldAccessPostAgg("a0:agg"),
-                                                    0.5f
+                                            .setAggregatorSpecs(
+                                                ImmutableList.of(
+                                                    new DoublesSketchAggregatorFactory("a0:agg", "m1", 128)
                                                 )
                                             )
-                                        )
-                                        .setContext(QUERY_CONTEXT_DEFAULT)
-                                        .build()
+                                            .setPostAggregatorSpecs(
+                                                ImmutableList.of(
+                                                    new DoublesSketchToQuantilePostAggregator(
+                                                        "a0",
+                                                        makeFieldAccessPostAgg("a0:agg"),
+                                                        0.5f
+                                                    )
+                                                )
+                                            )
+                                            .setContext(QUERY_CONTEXT_DEFAULT)
+                                            .build()
+                            )
                         )
-                    )
-                    .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-                    .setGranularity(Granularities.ALL)
-                    .setDimensions(new DefaultDimensionSpec("d0", "_d0", ValueType.STRING))
-                    .setAggregatorSpecs(
-                        new DoublesSketchAggregatorFactory("_a0:agg", "a0", 128)
-                    )
-                    .setPostAggregatorSpecs(
-                        ImmutableList.of(
-                            new DoublesSketchToQuantilePostAggregator("_a0", makeFieldAccessPostAgg("_a0:agg"), 0.5f)
+                        .setInterval(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(new DefaultDimensionSpec("d0", "_d0", ValueType.STRING))
+                        .setAggregatorSpecs(
+                            new DoublesSketchAggregatorFactory("_a0:agg", "a0", 128)
                         )
-                    )
-                    .setContext(QUERY_CONTEXT_DEFAULT)
-                    .build(),
-        Iterables.getOnlyElement(queryLogHook.getRecordedQueries())
+                        .setPostAggregatorSpecs(
+                            ImmutableList.of(
+                                new DoublesSketchToQuantilePostAggregator(
+                                    "_a0",
+                                    makeFieldAccessPostAgg("_a0:agg"),
+                                    0.5f
+                                )
+                            )
+                        )
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        expectedResults
     );
   }
 
   @Test
   public void testDoublesSketchPostAggs() throws Exception
   {
-    SqlLifecycle sqlLifecycle = getSqlLifecycle();
-    final String sql = "SELECT\n"
-                       + "  SUM(cnt),\n"
-                       + "  APPROX_QUANTILE_DS(cnt, 0.5) + 1,\n"
-                       + "  DS_GET_QUANTILE(DS_QUANTILES_SKETCH(cnt), 0.5) + 1000,\n"
-                       + "  DS_GET_QUANTILE(DS_QUANTILES_SKETCH(cnt + 123), 0.5) + 1000,\n"
-                       + "  ABS(DS_GET_QUANTILE(DS_QUANTILES_SKETCH(cnt), 0.5)),\n"
-                       + "  DS_GET_QUANTILES(DS_QUANTILES_SKETCH(cnt), 0.5, 0.8),\n"
-                       + "  DS_HISTOGRAM(DS_QUANTILES_SKETCH(cnt), 0.2, 0.6),\n"
-                       + "  DS_RANK(DS_QUANTILES_SKETCH(cnt), 3),\n"
-                       + "  DS_CDF(DS_QUANTILES_SKETCH(cnt), 0.2, 0.6),\n"
-                       + "  DS_QUANTILE_SUMMARY(DS_QUANTILES_SKETCH(cnt))\n"
-                       + "FROM foo";
-
-    // Verify results
-    final List<Object[]> results = sqlLifecycle.runSimple(
-        sql,
-        TIMESERIES_CONTEXT_DEFAULT,
-        DEFAULT_PARAMETERS,
-        AUTH_RESULT
-    ).toList();
-    final List<Object[]> expectedResults = ImmutableList.of(
-        new Object[]{
-            6L,
-            2.0d,
-            1001.0d,
-            1124.0d,
-            1.0d,
-            "[1.0,1.0]",
-            "[0.0,0.0,6.0]",
-            1.0d,
-            "[0.0,0.0,1.0]",
-            "\n"
-              + "### Quantiles HeapUpdateDoublesSketch SUMMARY: \n"
-              + "   Empty                        : false\n"
-              + "   Direct, Capacity bytes       : false, \n"
-              + "   Estimation Mode              : false\n"
-              + "   K                            : 128\n"
-              + "   N                            : 6\n"
-              + "   Levels (Needed, Total, Valid): 0, 0, 0\n"
-              + "   Level Bit Pattern            : 0\n"
-              + "   BaseBufferCount              : 6\n"
-              + "   Combined Buffer Capacity     : 8\n"
-              + "   Retained Items               : 6\n"
-              + "   Compact Storage Bytes        : 80\n"
-              + "   Updatable Storage Bytes      : 96\n"
-              + "   Normalized Rank Error        : 1.406%\n"
-              + "   Normalized Rank Error (PMF)  : 1.711%\n"
-              + "   Min Value                    : 1.000000e+00\n"
-              + "   Max Value                    : 1.000000e+00\n"
-              + "### END SKETCH SUMMARY\n"
-        }
+    testQuery(
+        "SELECT\n"
+        + "  SUM(cnt),\n"
+        + "  APPROX_QUANTILE_DS(cnt, 0.5) + 1,\n"
+        + "  DS_GET_QUANTILE(DS_QUANTILES_SKETCH(cnt), 0.5) + 1000,\n"
+        + "  DS_GET_QUANTILE(DS_QUANTILES_SKETCH(cnt + 123), 0.5) + 1000,\n"
+        + "  ABS(DS_GET_QUANTILE(DS_QUANTILES_SKETCH(cnt), 0.5)),\n"
+        + "  DS_GET_QUANTILES(DS_QUANTILES_SKETCH(cnt), 0.5, 0.8),\n"
+        + "  DS_HISTOGRAM(DS_QUANTILES_SKETCH(cnt), 0.2, 0.6),\n"
+        + "  DS_RANK(DS_QUANTILES_SKETCH(cnt), 3),\n"
+        + "  DS_CDF(DS_QUANTILES_SKETCH(cnt), 0.2, 0.6),\n"
+        + "  -- The nonvectorized query uses a regular Aggregator, and the vectorized query uses a buffer-based\n"
+        + "  -- VectorAggregator. The buffer-based aggregators return HeapCompactDoublesSketch instead of\n"
+        + "  -- HeapUpdateDoublesSketch since they must make a copy out of the buffer before returning something.\n"
+        + "  -- Use REPLACE to normalize summaries.\n"
+        + "  REPLACE("
+        + "    REPLACE("
+        + "      DS_QUANTILE_SUMMARY(DS_QUANTILES_SKETCH(cnt)),"
+        + "      'HeapCompactDoublesSketch',"
+        + "      'HeapUpdateDoublesSketch'"
+        + "    ),"
+        + "    'Combined Buffer Capacity     : 6',"
+        + "    'Combined Buffer Capacity     : 8'"
+        + "  )\n"
+        + "FROM foo",
+        Collections.singletonList(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                  .granularity(Granularities.ALL)
+                  .virtualColumns(
+                      new ExpressionVirtualColumn(
+                          "v0",
+                          "(\"cnt\" + 123)",
+                          ValueType.FLOAT,
+                          TestExprMacroTable.INSTANCE
+                      )
+                  )
+                  .aggregators(ImmutableList.of(
+                      new LongSumAggregatorFactory("a0", "cnt"),
+                      new DoublesSketchAggregatorFactory("a1:agg", "cnt", 128),
+                      new DoublesSketchAggregatorFactory("a2:agg", "cnt", 128),
+                      new DoublesSketchAggregatorFactory("a3:agg", "v0", 128)
+                  ))
+                  .postAggregators(
+                      new DoublesSketchToQuantilePostAggregator(
+                          "a1",
+                          makeFieldAccessPostAgg("a1:agg"),
+                          0.5f
+                      ),
+                      new ExpressionPostAggregator(
+                          "p0",
+                          "(\"a1\" + 1)",
+                          null,
+                          TestExprMacroTable.INSTANCE
+                      ),
+                      new DoublesSketchToQuantilePostAggregator(
+                          "p2",
+                          new FieldAccessPostAggregator(
+                              "p1",
+                              "a2:agg"
+                          ),
+                          0.5f
+                      ),
+                      new ExpressionPostAggregator(
+                          "p3",
+                          "(p2 + 1000)",
+                          null,
+                          TestExprMacroTable.INSTANCE
+                      ),
+                      new DoublesSketchToQuantilePostAggregator(
+                          "p5",
+                          new FieldAccessPostAggregator(
+                              "p4",
+                              "a3:agg"
+                          ),
+                          0.5f
+                      ),
+                      new ExpressionPostAggregator(
+                          "p6",
+                          "(p5 + 1000)",
+                          null,
+                          TestExprMacroTable.INSTANCE
+                      ),
+                      new DoublesSketchToQuantilePostAggregator(
+                          "p8",
+                          new FieldAccessPostAggregator(
+                              "p7",
+                              "a2:agg"
+                          ),
+                          0.5f
+                      ),
+                      new ExpressionPostAggregator("p9", "abs(p8)", null, TestExprMacroTable.INSTANCE),
+                      new DoublesSketchToQuantilesPostAggregator(
+                          "p11",
+                          new FieldAccessPostAggregator(
+                              "p10",
+                              "a2:agg"
+                          ),
+                          new double[]{0.5d, 0.8d}
+                      ),
+                      new DoublesSketchToHistogramPostAggregator(
+                          "p13",
+                          new FieldAccessPostAggregator(
+                              "p12",
+                              "a2:agg"
+                          ),
+                          new double[]{0.2d, 0.6d},
+                          null
+                      ),
+                      new DoublesSketchToRankPostAggregator(
+                          "p15",
+                          new FieldAccessPostAggregator(
+                              "p14",
+                              "a2:agg"
+                          ),
+                          3.0d
+                      ),
+                      new DoublesSketchToCDFPostAggregator(
+                          "p17",
+                          new FieldAccessPostAggregator(
+                              "p16",
+                              "a2:agg"
+                          ),
+                          new double[]{0.2d, 0.6d}
+                      ),
+                      new DoublesSketchToStringPostAggregator(
+                          "p19",
+                          new FieldAccessPostAggregator(
+                              "p18",
+                              "a2:agg"
+                          )
+                      ),
+                      new ExpressionPostAggregator(
+                          "p20",
+                          "replace(replace(p19,'HeapCompactDoublesSketch','HeapUpdateDoublesSketch'),"
+                          + "'Combined Buffer Capacity     : 6',"
+                          + "'Combined Buffer Capacity     : 8')",
+                          null,
+                          ExprMacroTable.nil()
+                      )
+                  )
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{
+                6L,
+                2.0d,
+                1001.0d,
+                1124.0d,
+                1.0d,
+                "[1.0,1.0]",
+                "[0.0,0.0,6.0]",
+                1.0d,
+                "[0.0,0.0,1.0]",
+                "\n"
+                + "### Quantiles HeapUpdateDoublesSketch SUMMARY: \n"
+                + "   Empty                        : false\n"
+                + "   Direct, Capacity bytes       : false, \n"
+                + "   Estimation Mode              : false\n"
+                + "   K                            : 128\n"
+                + "   N                            : 6\n"
+                + "   Levels (Needed, Total, Valid): 0, 0, 0\n"
+                + "   Level Bit Pattern            : 0\n"
+                + "   BaseBufferCount              : 6\n"
+                + "   Combined Buffer Capacity     : 8\n"
+                + "   Retained Items               : 6\n"
+                + "   Compact Storage Bytes        : 80\n"
+                + "   Updatable Storage Bytes      : 96\n"
+                + "   Normalized Rank Error        : 1.406%\n"
+                + "   Normalized Rank Error (PMF)  : 1.711%\n"
+                + "   Min Value                    : 1.000000e+00\n"
+                + "   Max Value                    : 1.000000e+00\n"
+                + "### END SKETCH SUMMARY\n"
+            }
+        )
     );
-    Assert.assertEquals(expectedResults.size(), results.size());
-    for (int i = 0; i < expectedResults.size(); i++) {
-      Assert.assertArrayEquals(expectedResults.get(i), results.get(i));
-    }
-
-    Query actualQuery = Iterables.getOnlyElement(queryLogHook.getRecordedQueries());
-    Query expectedQuery = Druids.newTimeseriesQueryBuilder()
-                                .dataSource(CalciteTests.DATASOURCE1)
-                                .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-                                .granularity(Granularities.ALL)
-                                .virtualColumns(
-                                    new ExpressionVirtualColumn(
-                                        "v0",
-                                        "(\"cnt\" + 123)",
-                                        ValueType.FLOAT,
-                                        TestExprMacroTable.INSTANCE
-                                    )
-                                )
-                                .aggregators(ImmutableList.of(
-                                    new LongSumAggregatorFactory("a0", "cnt"),
-                                    new DoublesSketchAggregatorFactory("a1:agg", "cnt", 128),
-                                    new DoublesSketchAggregatorFactory("a2:agg", "cnt", 128),
-                                    new DoublesSketchAggregatorFactory("a3:agg", "v0", 128)
-                                ))
-                                .postAggregators(
-                                    new DoublesSketchToQuantilePostAggregator(
-                                        "a1",
-                                        makeFieldAccessPostAgg("a1:agg"),
-                                        0.5f
-                                    ),
-                                    new ExpressionPostAggregator(
-                                        "p0",
-                                        "(\"a1\" + 1)",
-                                        null,
-                                        TestExprMacroTable.INSTANCE
-                                    ),
-                                    new DoublesSketchToQuantilePostAggregator(
-                                        "p2",
-                                        new FieldAccessPostAggregator(
-                                            "p1",
-                                            "a2:agg"
-                                        ),
-                                        0.5f
-                                    ),
-                                    new ExpressionPostAggregator(
-                                        "p3",
-                                        "(p2 + 1000)",
-                                        null,
-                                        TestExprMacroTable.INSTANCE
-                                    ),
-                                    new DoublesSketchToQuantilePostAggregator(
-                                        "p5",
-                                        new FieldAccessPostAggregator(
-                                            "p4",
-                                            "a3:agg"
-                                        ),
-                                        0.5f
-                                    ),
-                                    new ExpressionPostAggregator(
-                                        "p6",
-                                        "(p5 + 1000)",
-                                        null,
-                                        TestExprMacroTable.INSTANCE
-                                    ),
-                                    new DoublesSketchToQuantilePostAggregator(
-                                        "p8",
-                                        new FieldAccessPostAggregator(
-                                            "p7",
-                                            "a2:agg"
-                                        ),
-                                        0.5f
-                                    ),
-                                    new ExpressionPostAggregator("p9", "abs(p8)", null, TestExprMacroTable.INSTANCE),
-                                    new DoublesSketchToQuantilesPostAggregator(
-                                        "p11",
-                                        new FieldAccessPostAggregator(
-                                            "p10",
-                                            "a2:agg"
-                                        ),
-                                        new double[]{0.5d, 0.8d}
-                                    ),
-                                    new DoublesSketchToHistogramPostAggregator(
-                                        "p13",
-                                        new FieldAccessPostAggregator(
-                                            "p12",
-                                            "a2:agg"
-                                        ),
-                                        new double[]{0.2d, 0.6d},
-                                        null
-                                    ),
-                                    new DoublesSketchToRankPostAggregator(
-                                        "p15",
-                                        new FieldAccessPostAggregator(
-                                            "p14",
-                                            "a2:agg"
-                                        ),
-                                        3.0d
-                                    ),
-                                    new DoublesSketchToCDFPostAggregator(
-                                        "p17",
-                                        new FieldAccessPostAggregator(
-                                            "p16",
-                                            "a2:agg"
-                                        ),
-                                        new double[]{0.2d, 0.6d}
-                                    ),
-                                    new DoublesSketchToStringPostAggregator(
-                                        "p19",
-                                        new FieldAccessPostAggregator(
-                                            "p18",
-                                            "a2:agg"
-                                        )
-                                    )
-                                )
-                                .context(TIMESERIES_CONTEXT_DEFAULT)
-                                .build();
-
-    // Verify query
-    Assert.assertEquals(expectedQuery, actualQuery);
   }
 
   @Test
   public void testDoublesSketchPostAggsPostSort() throws Exception
   {
-    SqlLifecycle sqlLifecycle = getSqlLifecycle();
-
-    final String sql = "SELECT DS_QUANTILES_SKETCH(m1) as y FROM druid.foo ORDER BY  DS_GET_QUANTILE(DS_QUANTILES_SKETCH(m1), 0.5) DESC LIMIT 10";
-    final String sql2 = StringUtils.format("SELECT DS_GET_QUANTILE(y, 0.5), DS_GET_QUANTILE(y, 0.98) from (%s)", sql);
-
-    // Verify results
-    final List<Object[]> results = sqlLifecycle.runSimple(
-        sql2,
-        TIMESERIES_CONTEXT_DEFAULT,
-        DEFAULT_PARAMETERS,
-        AUTH_RESULT
-    ).toList();
-    final List<Object[]> expectedResults = ImmutableList.of(
-        new Object[]{
-            4.0d,
-            6.0d
-        }
-    );
-
-    Assert.assertEquals(expectedResults.size(), results.size());
-    for (int i = 0; i < expectedResults.size(); i++) {
-      Assert.assertArrayEquals(expectedResults.get(i), results.get(i));
-    }
-
-    Query actualQuery = Iterables.getOnlyElement(queryLogHook.getRecordedQueries());
-
-    Query expectedQuery =
-        Druids.newTimeseriesQueryBuilder()
-              .dataSource(CalciteTests.DATASOURCE1)
-              .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
-              .granularity(Granularities.ALL)
-              .aggregators(
-                  ImmutableList.of(
-                      new DoublesSketchAggregatorFactory("a0:agg", "m1", 128)
-                  )
-              )
-              .postAggregators(
-                  ImmutableList.of(
-                      new FieldAccessPostAggregator("p0", "a0:agg"),
-                      new DoublesSketchToQuantilePostAggregator(
-                          "p2",
-                          new FieldAccessPostAggregator("p1", "a0:agg"),
-                          0.5
-                      ),
-                      new DoublesSketchToQuantilePostAggregator("s1", new FieldAccessPostAggregator("s0", "p0"), 0.5),
-                      new DoublesSketchToQuantilePostAggregator(
-                          "s3",
-                          new FieldAccessPostAggregator("s2", "p0"),
-                          0.9800000190734863
+    testQuery(
+        "SELECT DS_GET_QUANTILE(y, 0.5), DS_GET_QUANTILE(y, 0.98) from ("
+        + "SELECT DS_QUANTILES_SKETCH(m1) as y FROM druid.foo ORDER BY  DS_GET_QUANTILE(DS_QUANTILES_SKETCH(m1), 0.5) DESC LIMIT 10"
+        + ")",
+        Collections.singletonList(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                  .granularity(Granularities.ALL)
+                  .aggregators(
+                      ImmutableList.of(
+                          new DoublesSketchAggregatorFactory("a0:agg", "m1", 128)
                       )
                   )
-              )
-              .context(TIMESERIES_CONTEXT_DEFAULT)
-              .build();
-
-    // Verify query
-    Assert.assertEquals(expectedQuery, actualQuery);
+                  .postAggregators(
+                      ImmutableList.of(
+                          new FieldAccessPostAggregator("p0", "a0:agg"),
+                          new DoublesSketchToQuantilePostAggregator(
+                              "p2",
+                              new FieldAccessPostAggregator("p1", "a0:agg"),
+                              0.5
+                          ),
+                          new DoublesSketchToQuantilePostAggregator("s1", new FieldAccessPostAggregator("s0", "p0"), 0.5),
+                          new DoublesSketchToQuantilePostAggregator(
+                              "s3",
+                              new FieldAccessPostAggregator("s2", "p0"),
+                              0.9800000190734863
+                          )
+                      )
+                  )
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{
+                4.0d,
+                6.0d
+            }
+        )
+    );
   }
 
   private static PostAggregator makeFieldAccessPostAgg(String name)


### PR DESCRIPTION
Also removes synchronization for the BufferAggregator and VectorAggregator
implementations, since it is not necessary (similar to #11115).

Extends DoublesSketchAggregatorTest and DoublesSketchSqlAggregatorTest
to run all test cases in vectorized mode.

Benchmarks from a group by query:

```
Benchmark              (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt   Score   Error  Units
SqlBenchmark.querySql        1            500000        false  avgt   15  41.275 ± 2.392  ms/op
SqlBenchmark.querySql        1            500000        force  avgt   15  31.584 ± 1.052  ms/op
```