### PR TITLE
fix bug with aggregator expressions on realtime index with string columns always producing 0 values

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
@@ -543,7 +543,18 @@ public abstract class ExprEval<T>
   }
 
   /**
-   * returns true if numeric primitive value for this ExprEval is null, otherwise false.
+   * The method returns true if numeric primitive value for this {@link ExprEval} is null, otherwise false.
+   *
+   * If this method returns false, then the values returned by {@link #asLong()}, {@link #asDouble()},
+   * and {@link #asInt()} are "valid", since this method is primarily used during {@link Expr} evaluation to decide
+   * if primitive numbers can be fetched to use.
+   *
+   * If a type cannot sanely convert into a primitive numeric value, then this method should always return true so that
+   * these primitive numeric getters are not called, since returning false is assumed to mean these values are valid.
+   *
+   * Note that all types must still return values for {@link #asInt()}, {@link #asLong()}}, and {@link #asDouble()},
+   * since this can still happen if {@link NullHandling#sqlCompatible()} is false, but it should be assumed that this
+   * can only happen in that mode and 0s are typical and expected for values that would otherwise be null.
    */
   public abstract boolean isNumericNull();
 
@@ -552,10 +563,25 @@ public abstract class ExprEval<T>
     return false;
   }
 
+  /**
+   * Get the primtive integer value. Callers should check {@link #isNumericNull()} prior to calling this method,
+   * otherwise it may improperly return placeholder a value (typically zero, which is expected if
+   * {@link NullHandling#sqlCompatible()} is false)
+   */
   public abstract int asInt();
 
+  /**
+   * Get the primtive long value. Callers should check {@link #isNumericNull()} prior to calling this method,
+   * otherwise it may improperly return a placeholder value (typically zero, which is expected if
+   * {@link NullHandling#sqlCompatible()} is false)
+   */
   public abstract long asLong();
 
+  /**
+   * Get the primtive double value. Callers should check {@link #isNumericNull()} prior to calling this method,
+   * otherwise it may improperly return a placeholder value (typically zero, which is expected if
+   * {@link NullHandling#sqlCompatible()} is false)
+   */
   public abstract double asDouble();
 
   public abstract boolean asBoolean();

--- a/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
@@ -954,6 +954,12 @@ public abstract class ExprEval<T>
       if (!isStringValueCached()) {
         if (value == null) {
           cacheStringValue(null);
+        } else if (value.length == 1) {
+          if (value[0] == null) {
+            cacheStringValue(null);
+          } else {
+            cacheStringValue(String.valueOf(value[0]));
+          }
         } else {
           cacheStringValue(Arrays.toString(value));
         }
@@ -965,6 +971,9 @@ public abstract class ExprEval<T>
     @Override
     public boolean isNumericNull()
     {
+      if (value != null && value.length == 1) {
+        return value[0] == null;
+      }
       return false;
     }
 
@@ -1025,6 +1034,54 @@ public abstract class ExprEval<T>
       return ExprType.LONG_ARRAY;
     }
 
+    @Override
+    public int asInt()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return 0;
+        }
+        return value[0].intValue();
+      }
+      return super.asInt();
+    }
+
+    @Override
+    public long asLong()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return 0L;
+        }
+        return value[0];
+      }
+      return super.asLong();
+    }
+
+    @Override
+    public double asDouble()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return 0.0;
+        }
+        return value[0].doubleValue();
+      }
+      return super.asDouble();
+    }
+
+    @Override
+    public boolean asBoolean()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return false;
+        }
+        return Evals.asBoolean(value[0]);
+      }
+      return super.asBoolean();
+    }
+
     @Nullable
     @Override
     public String[] asStringArray()
@@ -1053,6 +1110,21 @@ public abstract class ExprEval<T>
         return StringExprEval.OF_NULL;
       }
       switch (castTo) {
+        case STRING:
+          if (value.length == 1) {
+            return ExprEval.of(asString());
+          }
+          break;
+        case LONG:
+          if (value.length == 1) {
+            return isNumericNull() ? ExprEval.ofLong(null) : ExprEval.ofLong(asLong());
+          }
+          break;
+        case DOUBLE:
+          if (value.length == 1) {
+            return isNumericNull() ? ExprEval.ofDouble(null) : ExprEval.ofDouble(asDouble());
+          }
+          break;
         case LONG_ARRAY:
           return this;
         case DOUBLE_ARRAY:
@@ -1084,6 +1156,54 @@ public abstract class ExprEval<T>
       return ExprType.DOUBLE_ARRAY;
     }
 
+    @Override
+    public int asInt()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return 0;
+        }
+        return value[0].intValue();
+      }
+      return super.asInt();
+    }
+
+    @Override
+    public long asLong()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return 0L;
+        }
+        return value[0].longValue();
+      }
+      return super.asLong();
+    }
+
+    @Override
+    public double asDouble()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return 0.0;
+        }
+        return value[0];
+      }
+      return super.asDouble();
+    }
+
+    @Override
+    public boolean asBoolean()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return false;
+        }
+        return Evals.asBoolean(value[0]);
+      }
+      return super.asBoolean();
+    }
+
     @Nullable
     @Override
     public String[] asStringArray()
@@ -1112,6 +1232,21 @@ public abstract class ExprEval<T>
         return StringExprEval.OF_NULL;
       }
       switch (castTo) {
+        case STRING:
+          if (value.length == 1) {
+            return ExprEval.of(asString());
+          }
+          break;
+        case LONG:
+          if (value.length == 1) {
+            return isNumericNull() ? ExprEval.ofLong(null) : ExprEval.ofLong(asLong());
+          }
+          break;
+        case DOUBLE:
+          if (value.length == 1) {
+            return isNumericNull() ? ExprEval.ofDouble(null) : ExprEval.ofDouble(asDouble());
+          }
+          break;
         case LONG_ARRAY:
           return ExprEval.ofLongArray(asLongArray());
         case DOUBLE_ARRAY:
@@ -1146,6 +1281,66 @@ public abstract class ExprEval<T>
     public ExprType type()
     {
       return ExprType.STRING_ARRAY;
+    }
+
+    @Override
+    public boolean isNumericNull()
+    {
+      if (value != null && value.length == 1) {
+        return computeNumber(value[0]) == null;
+      }
+      return false;
+    }
+
+    @Override
+    public int asInt()
+    {
+      if (value != null && value.length == 1) {
+        Number number = computeNumber(value[0]);
+        if (number == null) {
+          return 0;
+        }
+        return number.intValue();
+      }
+      return super.asInt();
+    }
+
+    @Override
+    public long asLong()
+    {
+      if (value != null && value.length == 1) {
+        Number number = computeNumber(value[0]);
+        if (number == null) {
+          return 0L;
+        }
+        return number.longValue();
+      }
+      return super.asLong();
+    }
+
+    @Override
+    public double asDouble()
+    {
+      if (value != null && value.length == 1) {
+        Number number = computeNumber(value[0]);
+        if (number == null) {
+          return 0.0;
+        }
+        return number.doubleValue();
+      }
+      return super.asDouble();
+    }
+
+    @Override
+    public boolean asBoolean()
+    {
+      if (value != null && value.length == 1) {
+        if (value[0] == null) {
+          return false;
+        }
+        return Evals.asBoolean(value[0]);
+      }
+      return super.asBoolean();
     }
 
     @Nullable
@@ -1184,6 +1379,21 @@ public abstract class ExprEval<T>
         return StringExprEval.OF_NULL;
       }
       switch (castTo) {
+        case STRING:
+          if (value.length == 1) {
+            return ExprEval.of(asString());
+          }
+          break;
+        case LONG:
+          if (value.length == 1) {
+            return isNumericNull() ? ExprEval.ofLong(null) : ExprEval.ofLong(asLong());
+          }
+          break;
+        case DOUBLE:
+          if (value.length == 1) {
+            return isNumericNull() ? ExprEval.ofDouble(null) : ExprEval.ofDouble(asDouble());
+          }
+          break;
         case STRING_ARRAY:
           return this;
         case LONG_ARRAY:

--- a/core/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Function.java
@@ -1437,9 +1437,11 @@ public interface Function
     public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
     {
       ExprEval value1 = args.get(0).eval(bindings);
+
       if (NullHandling.sqlCompatible() && value1.isNumericNull()) {
         return ExprEval.of(null);
       }
+
       if (value1.type() != ExprType.LONG && value1.type() != ExprType.DOUBLE) {
         throw new IAE(
             "The first argument to the function[%s] should be integer or double type but got the type: %s",

--- a/core/src/test/java/org/apache/druid/math/expr/EvalTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/EvalTest.java
@@ -159,11 +159,8 @@ public class EvalTest extends InitializedNullHandlingTest
     Assert.assertEquals(true, ExprEval.ofLongArray(new Long[]{1L}).asBoolean());
     Assert.assertEquals("1", ExprEval.ofLongArray(new Long[]{1L}).asString());
 
-    Assert.assertEquals(0L, ExprEval.ofLongArray(new Long[]{null}).asLong());
-    Assert.assertEquals(0.0, ExprEval.ofLongArray(new Long[]{null}).asDouble(), 0.0);
+
     Assert.assertEquals(null, ExprEval.ofLongArray(new Long[]{null}).asString());
-    Assert.assertEquals(0, ExprEval.ofLongArray(new Long[]{null}).asInt());
-    Assert.assertEquals(false, ExprEval.ofLongArray(new Long[]{null}).asBoolean());
 
     Assert.assertEquals(0L, ExprEval.ofLongArray(new Long[]{1L, 2L}).asLong());
     Assert.assertEquals(0.0, ExprEval.ofLongArray(new Long[]{1L, 2L}).asDouble(), 0.0);
@@ -177,11 +174,7 @@ public class EvalTest extends InitializedNullHandlingTest
     Assert.assertEquals(1, ExprEval.ofDoubleArray(new Double[]{1.1}).asInt());
     Assert.assertEquals(true, ExprEval.ofDoubleArray(new Double[]{1.1}).asBoolean());
 
-    Assert.assertEquals(0.0, ExprEval.ofDoubleArray(new Double[]{null}).asDouble(), 0.0);
-    Assert.assertEquals(0L, ExprEval.ofDoubleArray(new Double[]{null}).asLong());
     Assert.assertEquals(null, ExprEval.ofDoubleArray(new Double[]{null}).asString());
-    Assert.assertEquals(0, ExprEval.ofDoubleArray(new Double[]{null}).asInt());
-    Assert.assertEquals(false, ExprEval.ofDoubleArray(new Double[]{null}).asBoolean());
 
     Assert.assertEquals(0.0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asDouble(), 0.0);
     Assert.assertEquals(0L, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asLong());
@@ -190,10 +183,6 @@ public class EvalTest extends InitializedNullHandlingTest
     Assert.assertEquals(false, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asBoolean());
 
     Assert.assertEquals("foo", ExprEval.ofStringArray(new String[]{"foo"}).asString());
-    Assert.assertEquals(0L, ExprEval.ofStringArray(new String[]{"foo"}).asLong());
-    Assert.assertEquals(0.0, ExprEval.ofStringArray(new String[]{"foo"}).asDouble(), 0.0);
-    Assert.assertEquals(0, ExprEval.ofStringArray(new String[]{"foo"}).asInt());
-    Assert.assertEquals(false, ExprEval.ofStringArray(new String[]{"foo"}).asBoolean());
 
     Assert.assertEquals("1", ExprEval.ofStringArray(new String[]{"1"}).asString());
     Assert.assertEquals(1L, ExprEval.ofStringArray(new String[]{"1"}).asLong());
@@ -314,15 +303,15 @@ public class EvalTest extends InitializedNullHandlingTest
       Assert.assertFalse(ExprEval.of("1").isNumericNull());
 
       Assert.assertFalse(ExprEval.ofLongArray(new Long[]{1L}).isNumericNull());
-      Assert.assertFalse(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
       Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null}).isNumericNull());
 
       Assert.assertFalse(ExprEval.ofDoubleArray(new Double[]{1.1}).isNumericNull());
-      Assert.assertFalse(ExprEval.ofDoubleArray(new Double[]{null, 1.1, 2.2}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofDoubleArray(new Double[]{null, 1.1, 2.2}).isNumericNull());
       Assert.assertTrue(ExprEval.ofDoubleArray(new Double[]{null}).isNumericNull());
 
       Assert.assertFalse(ExprEval.ofStringArray(new String[]{"1"}).isNumericNull());
-      Assert.assertFalse(ExprEval.ofStringArray(new String[]{null, "1", "2"}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofStringArray(new String[]{null, "1", "2"}).isNumericNull());
       Assert.assertTrue(ExprEval.ofStringArray(new String[]{"one"}).isNumericNull());
       Assert.assertTrue(ExprEval.ofStringArray(new String[]{null}).isNumericNull());
     } else {
@@ -339,15 +328,15 @@ public class EvalTest extends InitializedNullHandlingTest
 
       // arrays can still have nulls
       Assert.assertFalse(ExprEval.ofLongArray(new Long[]{1L}).isNumericNull());
-      Assert.assertFalse(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
       Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null}).isNumericNull());
 
       Assert.assertFalse(ExprEval.ofDoubleArray(new Double[]{1.1}).isNumericNull());
-      Assert.assertFalse(ExprEval.ofDoubleArray(new Double[]{null, 1.1, 2.2}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofDoubleArray(new Double[]{null, 1.1, 2.2}).isNumericNull());
       Assert.assertTrue(ExprEval.ofDoubleArray(new Double[]{null}).isNumericNull());
 
       Assert.assertFalse(ExprEval.ofStringArray(new String[]{"1"}).isNumericNull());
-      Assert.assertFalse(ExprEval.ofStringArray(new String[]{null, "1", "2"}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofStringArray(new String[]{null, "1", "2"}).isNumericNull());
       Assert.assertTrue(ExprEval.ofStringArray(new String[]{"one"}).isNumericNull());
       Assert.assertTrue(ExprEval.ofStringArray(new String[]{null}).isNumericNull());
     }

--- a/core/src/test/java/org/apache/druid/math/expr/EvalTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/EvalTest.java
@@ -154,49 +154,77 @@ public class EvalTest extends InitializedNullHandlingTest
   public void testArrayToScalar()
   {
     Assert.assertEquals(1L, ExprEval.ofLongArray(new Long[]{1L}).asLong());
-    Assert.assertEquals(0L, ExprEval.ofLongArray(new Long[]{null}).asLong());
     Assert.assertEquals(1.0, ExprEval.ofLongArray(new Long[]{1L}).asDouble(), 0.0);
+    Assert.assertEquals(1, ExprEval.ofLongArray(new Long[]{1L}).asInt());
+    Assert.assertEquals(true, ExprEval.ofLongArray(new Long[]{1L}).asBoolean());
     Assert.assertEquals("1", ExprEval.ofLongArray(new Long[]{1L}).asString());
+
+    Assert.assertEquals(0L, ExprEval.ofLongArray(new Long[]{null}).asLong());
+    Assert.assertEquals(0.0, ExprEval.ofLongArray(new Long[]{null}).asDouble(), 0.0);
+    Assert.assertEquals(null, ExprEval.ofLongArray(new Long[]{null}).asString());
+    Assert.assertEquals(0, ExprEval.ofLongArray(new Long[]{null}).asInt());
+    Assert.assertEquals(false, ExprEval.ofLongArray(new Long[]{null}).asBoolean());
+
     Assert.assertEquals(0L, ExprEval.ofLongArray(new Long[]{1L, 2L}).asLong());
     Assert.assertEquals(0.0, ExprEval.ofLongArray(new Long[]{1L, 2L}).asDouble(), 0.0);
     Assert.assertEquals("[1, 2]", ExprEval.ofLongArray(new Long[]{1L, 2L}).asString());
+    Assert.assertEquals(0, ExprEval.ofLongArray(new Long[]{1L, 2L}).asInt());
+    Assert.assertEquals(false, ExprEval.ofLongArray(new Long[]{1L, 2L}).asBoolean());
 
     Assert.assertEquals(1.1, ExprEval.ofDoubleArray(new Double[]{1.1}).asDouble(), 0.0);
-    Assert.assertEquals(0.0, ExprEval.ofDoubleArray(new Double[]{null}).asDouble(), 0.0);
     Assert.assertEquals(1L, ExprEval.ofDoubleArray(new Double[]{1.1}).asLong());
     Assert.assertEquals("1.1", ExprEval.ofDoubleArray(new Double[]{1.1}).asString());
+    Assert.assertEquals(1, ExprEval.ofDoubleArray(new Double[]{1.1}).asInt());
+    Assert.assertEquals(true, ExprEval.ofDoubleArray(new Double[]{1.1}).asBoolean());
+
+    Assert.assertEquals(0.0, ExprEval.ofDoubleArray(new Double[]{null}).asDouble(), 0.0);
+    Assert.assertEquals(0L, ExprEval.ofDoubleArray(new Double[]{null}).asLong());
+    Assert.assertEquals(null, ExprEval.ofDoubleArray(new Double[]{null}).asString());
+    Assert.assertEquals(0, ExprEval.ofDoubleArray(new Double[]{null}).asInt());
+    Assert.assertEquals(false, ExprEval.ofDoubleArray(new Double[]{null}).asBoolean());
+
     Assert.assertEquals(0.0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asDouble(), 0.0);
     Assert.assertEquals(0L, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asLong());
     Assert.assertEquals("[1.1, 2.2]", ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asString());
-
+    Assert.assertEquals(0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asInt());
+    Assert.assertEquals(false, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).asBoolean());
 
     Assert.assertEquals("foo", ExprEval.ofStringArray(new String[]{"foo"}).asString());
     Assert.assertEquals(0L, ExprEval.ofStringArray(new String[]{"foo"}).asLong());
     Assert.assertEquals(0.0, ExprEval.ofStringArray(new String[]{"foo"}).asDouble(), 0.0);
+    Assert.assertEquals(0, ExprEval.ofStringArray(new String[]{"foo"}).asInt());
+    Assert.assertEquals(false, ExprEval.ofStringArray(new String[]{"foo"}).asBoolean());
+
     Assert.assertEquals("1", ExprEval.ofStringArray(new String[]{"1"}).asString());
     Assert.assertEquals(1L, ExprEval.ofStringArray(new String[]{"1"}).asLong());
     Assert.assertEquals(1.0, ExprEval.ofStringArray(new String[]{"1"}).asDouble(), 0.0);
+    Assert.assertEquals(1, ExprEval.ofStringArray(new String[]{"1"}).asInt());
+    Assert.assertEquals(false, ExprEval.ofStringArray(new String[]{"1"}).asBoolean());
+    Assert.assertEquals(true, ExprEval.ofStringArray(new String[]{"true"}).asBoolean());
+
     Assert.assertEquals("[1, 2.2]", ExprEval.ofStringArray(new String[]{"1", "2.2"}).asString());
     Assert.assertEquals(0L, ExprEval.ofStringArray(new String[]{"1", "2.2"}).asLong());
     Assert.assertEquals(0.0, ExprEval.ofStringArray(new String[]{"1", "2.2"}).asDouble(), 0.0);
+    Assert.assertEquals(0, ExprEval.ofStringArray(new String[]{"1", "2.2"}).asInt());
+    Assert.assertEquals(false, ExprEval.ofStringArray(new String[]{"1", "2.2"}).asBoolean());
 
-
+    // test casting arrays to scalars
     Assert.assertEquals(1L, ExprEval.ofLongArray(new Long[]{1L}).castTo(ExprType.LONG).value());
-    Assert.assertEquals(0L, ExprEval.ofLongArray(new Long[]{null}).castTo(ExprType.LONG).value());
+    Assert.assertEquals(NullHandling.defaultLongValue(), ExprEval.ofLongArray(new Long[]{null}).castTo(ExprType.LONG).value());
     Assert.assertEquals(1.0, ExprEval.ofLongArray(new Long[]{1L}).castTo(ExprType.DOUBLE).asDouble(), 0.0);
     Assert.assertEquals("1", ExprEval.ofLongArray(new Long[]{1L}).castTo(ExprType.STRING).value());
 
     Assert.assertEquals(1.1, ExprEval.ofDoubleArray(new Double[]{1.1}).castTo(ExprType.DOUBLE).asDouble(), 0.0);
-    Assert.assertEquals(0.0, ExprEval.ofDoubleArray(new Double[]{null}).castTo(ExprType.DOUBLE).asDouble(), 0.0);
+    Assert.assertEquals(NullHandling.defaultDoubleValue(), ExprEval.ofDoubleArray(new Double[]{null}).castTo(ExprType.DOUBLE).value());
     Assert.assertEquals(1L, ExprEval.ofDoubleArray(new Double[]{1.1}).castTo(ExprType.LONG).value());
     Assert.assertEquals("1.1", ExprEval.ofDoubleArray(new Double[]{1.1}).castTo(ExprType.STRING).value());
 
     Assert.assertEquals("foo", ExprEval.ofStringArray(new String[]{"foo"}).castTo(ExprType.STRING).value());
-    Assert.assertEquals(0L, ExprEval.ofStringArray(new String[]{"foo"}).castTo(ExprType.LONG).value());
-    Assert.assertEquals(0.0, ExprEval.ofStringArray(new String[]{"foo"}).castTo(ExprType.DOUBLE).asDouble(), 0.0);
+    Assert.assertEquals(NullHandling.defaultLongValue(), ExprEval.ofStringArray(new String[]{"foo"}).castTo(ExprType.LONG).value());
+    Assert.assertEquals(NullHandling.defaultDoubleValue(), ExprEval.ofStringArray(new String[]{"foo"}).castTo(ExprType.DOUBLE).value());
     Assert.assertEquals("1", ExprEval.ofStringArray(new String[]{"1"}).castTo(ExprType.STRING).value());
     Assert.assertEquals(1L, ExprEval.ofStringArray(new String[]{"1"}).castTo(ExprType.LONG).value());
-    Assert.assertEquals(1.0, ExprEval.ofStringArray(new String[]{"1"}).castTo(ExprType.DOUBLE).asDouble(), 0.0);
+    Assert.assertEquals(1.0, ExprEval.ofStringArray(new String[]{"1"}).castTo(ExprType.DOUBLE).value());
   }
 
   @Test
@@ -285,6 +313,31 @@ public class EvalTest extends InitializedNullHandlingTest
       Assert.assertTrue(ExprEval.of("one").isNumericNull());
       Assert.assertFalse(ExprEval.of("1").isNumericNull());
 
+      Assert.assertFalse(ExprEval.ofLongArray(new Long[]{1L}).isNumericNull());
+      Assert.assertFalse(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null}).isNumericNull());
+
+      Assert.assertFalse(ExprEval.ofDoubleArray(new Double[]{1.1}).isNumericNull());
+      Assert.assertFalse(ExprEval.ofDoubleArray(new Double[]{null, 1.1, 2.2}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofDoubleArray(new Double[]{null}).isNumericNull());
+
+      Assert.assertFalse(ExprEval.ofStringArray(new String[]{"1"}).isNumericNull());
+      Assert.assertFalse(ExprEval.ofStringArray(new String[]{null, "1", "2"}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofStringArray(new String[]{"one"}).isNumericNull());
+      Assert.assertTrue(ExprEval.ofStringArray(new String[]{null}).isNumericNull());
+    } else {
+      Assert.assertFalse(ExprEval.ofLong(1L).isNumericNull());
+      Assert.assertFalse(ExprEval.ofLong(null).isNumericNull());
+
+      Assert.assertFalse(ExprEval.ofDouble(1.0).isNumericNull());
+      Assert.assertFalse(ExprEval.ofDouble(null).isNumericNull());
+
+      // strings are still null
+      Assert.assertTrue(ExprEval.of(null).isNumericNull());
+      Assert.assertTrue(ExprEval.of("one").isNumericNull());
+      Assert.assertFalse(ExprEval.of("1").isNumericNull());
+
+      // arrays can still have nulls
       Assert.assertFalse(ExprEval.ofLongArray(new Long[]{1L}).isNumericNull());
       Assert.assertFalse(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
       Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null}).isNumericNull());

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -430,11 +430,14 @@ public class FunctionTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testRoundWithNullValue()
+  public void testRoundWithNullValueOrInvalid()
   {
     Set<Pair<String, String>> invalidArguments = ImmutableSet.of(
         Pair.of("null", "STRING"),
-        Pair.of("x", "STRING")
+        Pair.of("x", "STRING"),
+        Pair.of("b", "LONG_ARRAY"),
+        Pair.of("c", "DOUBLE_ARRAY"),
+        Pair.of("a", "STRING_ARRAY")
     );
     for (Pair<String, String> argAndType : invalidArguments) {
       if (NullHandling.sqlCompatible()) {
@@ -446,41 +449,13 @@ public class FunctionTest extends InitializedNullHandlingTest
         }
         catch (IllegalArgumentException e) {
           Assert.assertEquals(
-              String.format(
-                  Locale.ENGLISH,
+              StringUtils.format(
                   "The first argument to the function[round] should be integer or double type but got the type: %s",
                   argAndType.rhs
               ),
               e.getMessage()
           );
         }
-      }
-    }
-  }
-
-  @Test
-  public void testRoundWithInvalidFirstArgument()
-  {
-    Set<Pair<String, String>> invalidArguments = ImmutableSet.of(
-        Pair.of("b", "LONG_ARRAY"),
-        Pair.of("c", "DOUBLE_ARRAY"),
-        Pair.of("a", "STRING_ARRAY")
-
-    );
-    for (Pair<String, String> argAndType : invalidArguments) {
-      try {
-        assertExpr(String.format(Locale.ENGLISH, "round(%s)", argAndType.lhs), null);
-        Assert.fail("Did not throw IllegalArgumentException");
-      }
-      catch (IllegalArgumentException e) {
-        Assert.assertEquals(
-            String.format(
-                Locale.ENGLISH,
-                "The first argument to the function[round] should be integer or double type but got the type: %s",
-                argAndType.rhs
-            ),
-            e.getMessage()
-        );
       }
     }
   }
@@ -502,8 +477,7 @@ public class FunctionTest extends InitializedNullHandlingTest
       }
       catch (IllegalArgumentException e) {
         Assert.assertEquals(
-            String.format(
-                Locale.ENGLISH,
+            StringUtils.format(
                 "The second argument to the function[round] should be integer type but got the type: %s",
                 argAndType.rhs
             ),

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -49,7 +49,6 @@ import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.js.JavaScriptConfig;
-import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.BySegmentResultValue;
 import org.apache.druid.query.BySegmentResultValueClass;
 import org.apache.druid.query.ChainedExecutionQueryRunner;
@@ -11117,28 +11116,35 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
                 "v",
                 "qualityDouble * qualityLong",
                 ValueType.LONG,
-                ExprMacroTable.nil()
+                TestExprMacroTable.INSTANCE
+            ),
+            new ExpressionVirtualColumn(
+                "two",
+                "2",
+                null,
+                TestExprMacroTable.INSTANCE
             )
         )
         .setDimensions(
             new DefaultDimensionSpec("v", "v", ValueType.LONG)
         )
-        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, new LongSumAggregatorFactory("twosum", null, "1 + two", TestExprMacroTable.INSTANCE))
         .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
         .setLimit(5)
         .build();
 
     List<ResultRow> expectedResults = Arrays.asList(
-        makeRow(query, "2011-04-01", "v", 10000000L, "rows", 2L),
-        makeRow(query, "2011-04-01", "v", 12100000L, "rows", 2L),
-        makeRow(query, "2011-04-01", "v", 14400000L, "rows", 2L),
-        makeRow(query, "2011-04-01", "v", 16900000L, "rows", 2L),
-        makeRow(query, "2011-04-01", "v", 19600000L, "rows", 6L)
+        makeRow(query, "2011-04-01", "v", 10000000L, "rows", 2L, "twosum", 6L),
+        makeRow(query, "2011-04-01", "v", 12100000L, "rows", 2L, "twosum", 6L),
+        makeRow(query, "2011-04-01", "v", 14400000L, "rows", 2L, "twosum", 6L),
+        makeRow(query, "2011-04-01", "v", 16900000L, "rows", 2L, "twosum", 6L),
+        makeRow(query, "2011-04-01", "v", 19600000L, "rows", 6L, "twosum", 18L)
     );
 
     Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy");
   }
+
 
   @Test
   public void testGroupByWithExpressionAggregator()

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -45,8 +45,10 @@ import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleMaxAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleMinAggregatorFactory;
+import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.ExpressionLambdaAggregatorFactory;
 import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
+import org.apache.druid.query.aggregation.FloatSumAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.first.DoubleFirstAggregatorFactory;
 import org.apache.druid.query.aggregation.last.DoubleLastAggregatorFactory;
@@ -2201,10 +2203,12 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
             Lists.newArrayList(
                 Iterables.concat(
                     aggregatorFactoryList,
-                    Collections.singletonList(new FilteredAggregatorFactory(
-                        new CountAggregatorFactory("filteredAgg"),
-                        new SelectorDimFilter(QueryRunnerTestHelper.MARKET_DIMENSION, "spot", null)
-                    ))
+                    ImmutableList.of(
+                        new FilteredAggregatorFactory(
+                            new CountAggregatorFactory("filteredAgg"),
+                            new SelectorDimFilter(QueryRunnerTestHelper.MARKET_DIMENSION, "spot", null)
+                        )
+                    )
                 )
             )
         )
@@ -2218,13 +2222,81 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
         new Result<>(
             DateTimes.of("2011-04-01"),
             new TimeseriesResultValue(
-                ImmutableMap.of(
-                    "filteredAgg", 18L,
-                    "addRowsIndexConstant", 12486.361190795898d,
-                    "index", 12459.361190795898d,
-                    "uniques", 9.019833517963864d,
-                    "rows", 26L
+                ImmutableMap.<String, Object>builder()
+                            .put("filteredAgg", 18L)
+                            .put("addRowsIndexConstant", 12486.361190795898d)
+                            .put("index", 12459.361190795898d)
+                            .put("uniques", 9.019833517963864d)
+                            .put("rows", 26L)
+                            .build()
+            )
+        )
+    );
+
+    assertExpectedResults(expectedResults, actualResults);
+  }
+
+  @Test
+  public void testTimeSeriesWithFilteredAggAndExpressionFilteredAgg()
+  {
+    // can't vectorize if expression
+    cannotVectorize();
+    TimeseriesQuery query = Druids
+        .newTimeseriesQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .granularity(QueryRunnerTestHelper.ALL_GRAN)
+        .intervals(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .aggregators(
+            Lists.newArrayList(
+                Iterables.concat(
+                    aggregatorFactoryList,
+                    ImmutableList.of(
+                        new FilteredAggregatorFactory(
+                            new CountAggregatorFactory("filteredAgg"),
+                            new SelectorDimFilter(QueryRunnerTestHelper.MARKET_DIMENSION, "spot", null)
+                        ),
+                        new LongSumAggregatorFactory(
+                            "altLongCount",
+                            null,
+                            "if (market == 'spot', 1, 0)",
+                            TestExprMacroTable.INSTANCE
+                        ),
+                        new DoubleSumAggregatorFactory(
+                            "altDoubleCount",
+                            null,
+                            "if (market == 'spot', 1, 0)",
+                            TestExprMacroTable.INSTANCE
+                        ),
+                        new FloatSumAggregatorFactory(
+                            "altFloatCount",
+                            null,
+                            "if (market == 'spot', 1, 0)",
+                            TestExprMacroTable.INSTANCE
+                        )
+                    )
                 )
+            )
+        )
+        .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
+        .descending(descending)
+        .context(makeContext())
+        .build();
+
+    Iterable<Result<TimeseriesResultValue>> actualResults = runner.run(QueryPlus.wrap(query)).toList();
+    List<Result<TimeseriesResultValue>> expectedResults = Collections.singletonList(
+        new Result<>(
+            DateTimes.of("2011-04-01"),
+            new TimeseriesResultValue(
+                ImmutableMap.<String, Object>builder()
+                            .put("filteredAgg", 18L)
+                            .put("addRowsIndexConstant", 12486.361190795898d)
+                            .put("index", 12459.361190795898d)
+                            .put("uniques", 9.019833517963864d)
+                            .put("rows", 26L)
+                            .put("altLongCount", 18L)
+                            .put("altDoubleCount", 18.0)
+                            .put("altFloatCount", 18.0f)
+                            .build()
             )
         )
     );


### PR DESCRIPTION
Fixes #8970 (well it was already fixed somewhere along the way, but fixes another issue discovered in the comments)

### Description
This PR fixes an issue when using expression virtual columns that reference string values on realtime query segments, where an automatic transform to handle possible multi-valued string inputs forces array output from the selector, which the aggregators are not prepared to handle. See https://github.com/apache/druid/issues/8970#issuecomment-829762963 for details.

This PR adds a modification that fixes the side-effect of these transformations, to allow array typed `ExprEval` to provide scalar values if and only if the array has a single element. Otherwise it will retain its current behavior where methods like `getLong` and `getDouble` return default zero values. This changes makes array expression results mirror the the behavior of scalar expression results, where scalar expressions are currently allowed to present themselves as single element arrays (which exists to handle cases where array functions are used and the input value is a string column is multi-valued in one segment, but single valued in another).

This PR does not address an issue that could occur if legitimate multi-valued rows are processed that are not manipulated with explicit array functions and so are implicitly transformed. Since arrays larger than 1 will still return `0` for primitive value getters, expressions against these values should explicitly decide how to handle actual array inputs and combine them back into a scalar value that the primitive numeric aggregators can understand. Making this a failure condition seemed a bit drastic, but it might be worth considering.


This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
