### PR TITLE
adjust topn heap algorithm to only use known cardinality path when dictionary is unique

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/topn/HeapBasedTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/HeapBasedTopNAlgorithm.java
@@ -42,7 +42,6 @@ public class HeapBasedTopNAlgorithm
   )
   {
     super(storageAdapter);
-
     this.query = query;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/TimeExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TimeExtractionTopNAlgorithm.java
@@ -87,10 +87,6 @@ public class TimeExtractionTopNAlgorithm extends BaseTopNAlgorithm<int[], Map<Co
       Map<Comparable<?>, Aggregator[]> aggregatesStore
   )
   {
-    if (params.getCardinality() < 0) {
-      throw new UnsupportedOperationException("Cannot operate on a dimension with unknown cardinality");
-    }
-
     final Cursor cursor = params.getCursor();
     final DimensionSelector dimSelector = params.getDimSelector();
 

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -202,7 +202,7 @@ public class TopNQueryEngine
   }
 
   /**
-   * {@link ExtractionFn} which are one to one may have their execution deferred until as late as possible, since the
+   * {@link ExtractionFn} which are one to one may have their execution deferred until as late as possible, since
    * which value is used as the grouping key itself doesn't particularly matter. For top-n, this method allows the
    * query to be transformed in {@link TopNQueryQueryToolChest#preMergeQueryDecoration} to strip off the
    * {@link ExtractionFn} on the broker, so that a more optimized algorithm (e.g. {@link PooledTopNAlgorithm}) can be

--- a/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
@@ -121,11 +121,12 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
     // we must know cardinality to use array based aggregation
     // we check for uniquely dictionary encoded values because non-unique (meaning dictionary ids do not have a 1:1
     // relation with values) negates many of the benefits of array aggregation:
-    // - if different dictionary ids map to the same value but dictionary ids are unique to that value, then array
-    //   aggregation will be correct but will still have to potentially perform many map lookups and lose the
+    // - if different dictionary ids map to the same value but dictionary ids are unique to that value (*:1), then
+    //   array aggregation will be correct but will still have to potentially perform many map lookups and lose the
     //   performance benefit array aggregation is trying to provide
-    // - in cases where the same dictionary ids map to different values, results can be entirely incorrect since an
-    //   aggregator for a different value might be chosen from the array based on the re-used dictionary id
+    // - in cases where the same dictionary ids map to different values (1:* or *:*), results can be entirely
+    //   incorrect since an aggregator for a different value might be chosen from the array based on the re-used
+    //   dictionary id
     if (notUnknown && unique) {
       return scanAndAggregateWithCardinalityKnown(query, cursor, selector, rowSelector);
     } else {

--- a/processing/src/main/java/org/apache/druid/query/topn/types/TopNColumnAggregatesProcessorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/TopNColumnAggregatesProcessorFactory.java
@@ -48,7 +48,7 @@ public class TopNColumnAggregatesProcessorFactory
     final ValueType selectorType = capabilities.getType();
 
     if (selectorType.equals(ValueType.STRING)) {
-      return new StringTopNColumnAggregatesProcessor(dimensionType);
+      return new StringTopNColumnAggregatesProcessor(capabilities, dimensionType);
     } else if (selectorType.isNumeric()) {
       final Function<Object, Comparable<?>> converter;
       final ValueType strategyType;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -17474,6 +17474,45 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testTopNOnStringWithNonSortedOrUniqueDictionaryOrderByDim(Map<String, Object> queryContext) throws Exception
+  {
+    testQuery(
+        "SELECT druid.broadcast.dim4, COUNT(*)\n"
+        + "FROM druid.numfoo\n"
+        + "INNER JOIN druid.broadcast ON numfoo.dim4 = broadcast.dim4\n"
+        + "GROUP BY 1 ORDER BY 1 DESC LIMIT 4",
+        queryContext,
+        ImmutableList.of(
+            new TopNQueryBuilder()
+                .dataSource(
+                    join(
+                        new TableDataSource(CalciteTests.DATASOURCE3),
+                        new GlobalTableDataSource(CalciteTests.BROADCAST_DATASOURCE),
+                        "j0.",
+                        equalsCondition(
+                            DruidExpression.fromColumn("dim4"),
+                            DruidExpression.fromColumn("j0.dim4")
+                        ),
+                        JoinType.INNER
+                    )
+                )
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .dimension(new DefaultDimensionSpec("j0.dim4", "_d0", ValueType.STRING))
+                .threshold(4)
+                .aggregators(aggregators(new CountAggregatorFactory("a0")))
+                .context(queryContext)
+                .metric(new InvertedTopNMetricSpec(new DimensionTopNMetricSpec(null, StringComparators.LEXICOGRAPHIC)))
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"b", 9L},
+            new Object[]{"a", 9L}
+        )
+    );
+  }
+
+  @Test
   public void testTimeStampAddZeroDayPeriod() throws Exception
   {
     testQuery(


### PR DESCRIPTION
### Description
This PR adjusts the heap based topN algorithm to only use known the "known" cardinality path only when the dictionary contains unique values. The known cardinality path to aggregate values uses an array based approach, where an array of aggregator arrays the size of the value cardinality is created, and the dictionaryId is expected to index to an array position with the aggregators for that value, as an optimization to avoid a map lookup. 

However, when a selector is aggregated which does not have unique dictionaryIds, but does know its cardinality, such as a selector from an `IndexedTable` from a join result which uses the row number as the dictionaryId instead, it means that each dictionaryId will be 'new', and thus have a null array entry and still incur the map interaction this path is trying to avoid.

Instead, these selectors will now just use the map directly by using the cardinality "unknown" path instead.


This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
