### PR TITLE
fixed array syntax

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -595,7 +595,7 @@ All 'array' references in the multi-value string function documentation can refe
 
 |Function|Notes|
 |--------|-----|
-| `ARRAY(expr1,expr ...)` | constructs a SQL ARRAY literal from the expression arguments, using the type of the first argument as the output array type |
+| `ARRAY[expr1,expr ...]` | constructs a SQL ARRAY literal from the expression arguments, using the type of the first argument as the output array type |
 | `MV_LENGTH(arr)` | returns length of array expression |
 | `MV_OFFSET(arr,long)` | returns the array element at the 0 based index supplied, or null for an out of range index|
 | `MV_ORDINAL(arr,long)` | returns the array element at the 1 based index supplied, or null for an out of range index |


### PR DESCRIPTION
Fixes an issue with syntax for multi-value string functions.

This PR has:
- [X ] been self-reviewed.
@techdocsmith @sthetland @weishiuntsai
