### PR TITLE
Fix example of prefixes for Cloud Input Sources(eg. S3)

### DIFF
--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -864,7 +864,7 @@ Sample specs:
       "type": "index_parallel",
       "inputSource": {
         "type": "s3",
-        "prefixes": ["s3://foo/bar", "s3://bar/foo"]
+        "prefixes": ["s3://foo/bar/", "s3://bar/foo/"]
       },
       "inputFormat": {
         "type": "json"
@@ -954,7 +954,7 @@ Sample specs:
       "type": "index_parallel",
       "inputSource": {
         "type": "google",
-        "prefixes": ["gs://foo/bar", "gs://bar/foo"]
+        "prefixes": ["gs://foo/bar/", "gs://bar/foo/"]
       },
       "inputFormat": {
         "type": "json"
@@ -1033,7 +1033,7 @@ Sample specs:
       "type": "index_parallel",
       "inputSource": {
         "type": "azure",
-        "prefixes": ["azure://container/prefix1", "azure://container/prefix2"]
+        "prefixes": ["azure://container/prefix1/", "azure://container/prefix2/"]
       },
       "inputFormat": {
         "type": "json"


### PR DESCRIPTION
Fixed a syntax error in "prefix" lines in docs/ingestion/native-batch.md

S3 requires a trailing slash for directory like structures, so this updates the examples to include the trailing slashes.

This PR has:
- [X] been self-reviewed.
 @techdocsmith @sthetland 