### PR TITLE
Web Console: allow pollPeriod to be defined in JDBC lookup config

### DIFF
--- a/web-console/src/druid-models/lookup-spec.spec.ts
+++ b/web-console/src/druid-models/lookup-spec.spec.ts
@@ -416,6 +416,7 @@ describe('lookup-spec', () => {
               table: 'some_lookup_table',
               keyColumn: 'the_old_dim_value',
               valueColumn: 'the_new_dim_value',
+              pollPeriod: 600000,
             },
           }),
         ).toBe(false);

--- a/web-console/src/druid-models/lookup-spec.tsx
+++ b/web-console/src/druid-models/lookup-spec.tsx
@@ -264,8 +264,7 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
     type: 'string',
     defaultValue: '0',
     defined: (model: LookupSpec) =>
-      deepGet(model, 'extractionNamespace.type') === 'uri' ||
-      deepGet(model, 'extractionNamespace.type') === 'jdbc',
+      oneOf(deepGet(model, 'extractionNamespace.type'), 'uri', 'jdbc'),
     info: `Period between polling for updates`,
   },
 

--- a/web-console/src/druid-models/lookup-spec.tsx
+++ b/web-console/src/druid-models/lookup-spec.tsx
@@ -263,7 +263,9 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
     name: 'extractionNamespace.pollPeriod',
     type: 'string',
     defaultValue: '0',
-    defined: (model: LookupSpec) => deepGet(model, 'extractionNamespace.type') === 'uri',
+    defined: (model: LookupSpec) =>
+      deepGet(model, 'extractionNamespace.type') === 'uri' ||
+      deepGet(model, 'extractionNamespace.type') === 'jdbc',
     info: `Period between polling for updates`,
   },
 


### PR DESCRIPTION
[JDBC lookups can have a pollPeriod](https://github.com/apache/druid/blob/master/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java#L75), but the web console was configured to only validate them as part of uri lookups. This PR fixes it to do the thing.