### PR TITLE
clarify that appenderator persist byte sizes are estimations

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -323,7 +323,7 @@ public class AppenderatorImpl implements Appenderator
     if (bytesCurrentlyInMemory.get() >= maxBytesTuningConfig) {
       persist = true;
       persistReasons.add(StringUtils.format(
-          "bytesCurrentlyInMemory[%d] is greater than maxBytesInMemory[%d]",
+          "(estimated) bytesCurrentlyInMemory[%d] is greater than maxBytesInMemory[%d]",
           bytesCurrentlyInMemory.get(),
           maxBytesTuningConfig
       ));
@@ -669,7 +669,7 @@ public class AppenderatorImpl implements Appenderator
     rowsCurrentlyInMemory.addAndGet(-numPersistedRows);
     bytesCurrentlyInMemory.addAndGet(-bytesPersisted);
 
-    log.info("Persisted rows[%,d] and bytes[%,d]", numPersistedRows, bytesPersisted);
+    log.info("Persisted rows[%,d] and (estimated) bytes[%,d]", numPersistedRows, bytesPersisted);
 
     return future;
   }


### PR DESCRIPTION
These log messages that appear whenever an indexing task persists segments:
```
2021-05-04T03:03:50,004 INFO [task-runner-0-priority-0] org.apache.druid.segment.realtime.appenderator.AppenderatorImpl - Persisted rows[3,519] and bytes[477,231,910]
```
are printing the estimated bytes in memory, but it isn't clear that this is an estimated value, not the actual number of bytes written, which is confusing. This PR adjusts the logging to clarify that these values are not actual byte sizes (which might be nice to have available so we can compare how far our estimates are off from reality, but I'll save for another day).