### PR TITLE
Web console: fix SegmentTimeline query

### DIFF
--- a/web-console/src/components/segment-timeline/segment-timeline.spec.tsx
+++ b/web-console/src/components/segment-timeline/segment-timeline.spec.tsx
@@ -17,6 +17,7 @@
  */
 
 import { render } from '@testing-library/react';
+import { sane } from 'druid-query-toolkit/build/test-utils';
 import { mount } from 'enzyme';
 import React from 'react';
 
@@ -25,6 +26,22 @@ import { Capabilities, QueryManager } from '../../utils';
 import { SegmentTimeline } from './segment-timeline';
 
 describe('Segment Timeline', () => {
+  it('.getSqlQuery', () => {
+    expect(SegmentTimeline.getSqlQuery(3)).toEqual(sane`
+      SELECT
+        "start", "end", "datasource",
+        COUNT(*) AS "count",
+        SUM("size") AS "size"
+      FROM sys.segments
+      WHERE
+        "start" > TIME_FORMAT(TIMESTAMPADD(MONTH, -3, CURRENT_TIMESTAMP), 'yyyy-MM-dd''T''hh:mm:ss.SSS') AND
+        is_published = 1 AND
+        is_overshadowed = 0
+      GROUP BY 1, 2, 3
+      ORDER BY "start" DESC
+    `);
+  });
+
   it('matches snapshot', () => {
     const segmentTimeline = (
       <SegmentTimeline capabilities={Capabilities.FULL} chartHeight={100} chartWidth={100} />

--- a/web-console/src/components/segment-timeline/segment-timeline.tsx
+++ b/web-console/src/components/segment-timeline/segment-timeline.tsx
@@ -256,9 +256,13 @@ export class SegmentTimeline extends React.PureComponent<
             const query = `
 SELECT
   "start", "end", "datasource",
-  COUNT(*) AS "count", SUM("size") as "size"
+  COUNT(*) AS "count",
+  SUM("size") AS "size"
 FROM sys.segments
-WHERE "start" > TIME_FORMAT(TIMESTAMPADD(MONTH, -${timeSpan}, CURRENT_TIMESTAMP), 'yyyy-MM-dd''T''hh:mm:ss.SSS')
+WHERE
+  "start" > TIME_FORMAT(TIMESTAMPADD(MONTH, -${timeSpan}, CURRENT_TIMESTAMP), 'yyyy-MM-dd''T''hh:mm:ss.SSS') AND
+  is_published = 1 AND
+  is_overshadowed = 0
 GROUP BY 1, 2, 3
 ORDER BY "start" DESC`;
 

--- a/web-console/src/components/segment-timeline/segment-timeline.tsx
+++ b/web-console/src/components/segment-timeline/segment-timeline.tsx
@@ -114,6 +114,20 @@ export class SegmentTimeline extends React.PureComponent<
     return SegmentTimeline.COLORS[index % SegmentTimeline.COLORS.length];
   }
 
+  static getSqlQuery(timeSpan: number): string {
+    return `SELECT
+  "start", "end", "datasource",
+  COUNT(*) AS "count",
+  SUM("size") AS "size"
+FROM sys.segments
+WHERE
+  "start" > TIME_FORMAT(TIMESTAMPADD(MONTH, -${timeSpan}, CURRENT_TIMESTAMP), 'yyyy-MM-dd''T''hh:mm:ss.SSS') AND
+  is_published = 1 AND
+  is_overshadowed = 0
+GROUP BY 1, 2, 3
+ORDER BY "start" DESC`;
+  }
+
   static processRawData(data: IntervalRow[]) {
     if (data === null) return [];
 
@@ -253,20 +267,7 @@ export class SegmentTimeline extends React.PureComponent<
           let intervals: IntervalRow[];
           let datasources: string[];
           if (capabilities.hasSql()) {
-            const query = `
-SELECT
-  "start", "end", "datasource",
-  COUNT(*) AS "count",
-  SUM("size") AS "size"
-FROM sys.segments
-WHERE
-  "start" > TIME_FORMAT(TIMESTAMPADD(MONTH, -${timeSpan}, CURRENT_TIMESTAMP), 'yyyy-MM-dd''T''hh:mm:ss.SSS') AND
-  is_published = 1 AND
-  is_overshadowed = 0
-GROUP BY 1, 2, 3
-ORDER BY "start" DESC`;
-
-            intervals = await queryDruidSql({ query });
+            intervals = await queryDruidSql({ query: SegmentTimeline.getSqlQuery(timeSpan) });
             datasources = uniq(intervals.map(r => r.datasource));
           } else if (capabilities.hasCoordinatorAccess()) {
             const before = new Date();


### PR DESCRIPTION
Fix the issue that the segment timeline was showing unpublished and overshadowed segments.
Adds a filter of `is_published = 1 AND is_overshadowed = 0` to the SQL query.

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
