### PR TITLE
fix count and average SQL aggregators on constant virtual columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.query.PerSegmentQueryOptimizationContext;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.Filter;
@@ -166,7 +168,10 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   @Override
   public List<String> requiredFields()
   {
-    return delegate.requiredFields();
+    return ImmutableList.copyOf(
+        // use a set to get rid of dupes
+        ImmutableSet.<String>builder().addAll(delegate.requiredFields()).addAll(filter.getRequiredColumns()).build()
+    );
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/aggregation/FilteredAggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/FilteredAggregatorFactoryTest.java
@@ -19,11 +19,14 @@
 
 package org.apache.druid.query.aggregation;
 
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.filter.TrueDimFilter;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class FilteredAggregatorFactoryTest
+public class FilteredAggregatorFactoryTest extends InitializedNullHandlingTest
 {
   @Test
   public void testSimpleNaming()
@@ -43,5 +46,17 @@ public class FilteredAggregatorFactoryTest
         TrueDimFilter.instance(),
         null
     ).getName());
+  }
+
+  @Test
+  public void testRequiredFields()
+  {
+    Assert.assertEquals(
+        ImmutableList.of("x", "y"),
+        new FilteredAggregatorFactory(
+            new LongSumAggregatorFactory("x", "x"),
+            new SelectorDimFilter("y", "wat", null )
+        ).requiredFields()
+    );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
@@ -31,6 +31,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
+import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -78,37 +79,7 @@ public class AvgSqlAggregator implements SqlAggregator
       return null;
     }
 
-    final String fieldName;
-    final String expression;
-    final DruidExpression arg = Iterables.getOnlyElement(arguments);
-
-    if (arg.isDirectColumnAccess()) {
-      fieldName = arg.getDirectColumn();
-      expression = null;
-    } else {
-      fieldName = null;
-      expression = arg.getExpression();
-    }
-
-    final ExprMacroTable macroTable = plannerContext.getExprMacroTable();
-
-    final ValueType sumType;
-    // Use 64-bit sum regardless of the type of the AVG aggregator.
-    if (SqlTypeName.INT_TYPES.contains(aggregateCall.getType().getSqlTypeName())) {
-      sumType = ValueType.LONG;
-    } else {
-      sumType = ValueType.DOUBLE;
-    }
-
-    final String sumName = Calcites.makePrefixedName(name, "sum");
     final String countName = Calcites.makePrefixedName(name, "count");
-    final AggregatorFactory sum = SumSqlAggregator.createSumAggregatorFactory(
-        sumType,
-        sumName,
-        fieldName,
-        expression,
-        macroTable
-    );
     final AggregatorFactory count = CountSqlAggregator.createCountAggregatorFactory(
         countName,
         plannerContext,
@@ -119,7 +90,40 @@ public class AvgSqlAggregator implements SqlAggregator
         project
     );
 
+    final String fieldName;
+    final String expression;
+    final DruidExpression arg = Iterables.getOnlyElement(arguments);
+
+
+    final ExprMacroTable macroTable = plannerContext.getExprMacroTable();
+    final ValueType sumType;
+    // Use 64-bit sum regardless of the type of the AVG aggregator.
+    if (SqlTypeName.INT_TYPES.contains(aggregateCall.getType().getSqlTypeName())) {
+      sumType = ValueType.LONG;
+    } else {
+      sumType = ValueType.DOUBLE;
+    }
+
+    if (arg.isDirectColumnAccess()) {
+      fieldName = arg.getDirectColumn();
+      expression = null;
+    } else {
+      // if the filter or anywhere else defined a virtual column for us, re-use it
+      VirtualColumn vc = virtualColumnRegistry.getVirtualColumnByExpression(arg.getExpression());
+      fieldName = vc != null ? vc.getOutputName() : null;
+      expression = vc != null ? null : arg.getExpression();
+    }
+    final String sumName = Calcites.makePrefixedName(name, "sum");
+    final AggregatorFactory sum = SumSqlAggregator.createSumAggregatorFactory(
+        sumType,
+        sumName,
+        fieldName,
+        expression,
+        macroTable
+    );
+
     return Aggregation.create(
+        virtualColumnRegistry.findVirtualColumns(count.requiredFields()),
         ImmutableList.of(sum, count),
         new ArithmeticPostAggregator(
             name,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
@@ -134,7 +134,7 @@ public class CountSqlAggregator implements SqlAggregator
     } else {
       // Not COUNT(*), not distinct
       // COUNT(x) should count all non-null values of x.
-      return Aggregation.create(createCountAggregatorFactory(
+      AggregatorFactory theCount = createCountAggregatorFactory(
             name,
             plannerContext,
             rowSignature,
@@ -142,7 +142,9 @@ public class CountSqlAggregator implements SqlAggregator
             rexBuilder,
             aggregateCall,
             project
-      ));
+      );
+
+      return Aggregation.create(virtualColumnRegistry.findVirtualColumns(theCount.requiredFields()), theCount);
     }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
@@ -29,7 +29,9 @@ import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Provides facilities to create and re-use {@link VirtualColumn} definitions for dimensions, filters, and filtered
@@ -128,6 +130,12 @@ public class VirtualColumnRegistry
     return virtualColumnsByName.get(virtualColumnName);
   }
 
+  @Nullable
+  public VirtualColumn getVirtualColumnByExpression(String expression)
+  {
+    return virtualColumnsByExpression.get(expression);
+  }
+
   /**
    * Get a signature representing the base signature plus all registered virtual columns.
    */
@@ -144,5 +152,16 @@ public class VirtualColumnRegistry
     }
 
     return builder.build();
+  }
+
+  /**
+   * Given a list of column names, find any corresponding {@link VirtualColumn} with the same name
+   */
+  public List<VirtualColumn> findVirtualColumns(List<String> allColumns)
+  {
+    return allColumns.stream()
+                     .filter(this::isVirtualColumnDefined)
+                     .map(this::getVirtualColumn)
+                     .collect(Collectors.toList());
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -50,6 +50,7 @@ import org.apache.druid.query.QueryException;
 import org.apache.druid.query.ResourceLimitExceededException;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.UnionDataSource;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleMaxAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleMinAggregatorFactory;
@@ -112,6 +113,8 @@ import org.apache.druid.query.topn.DimensionTopNMetricSpec;
 import org.apache.druid.query.topn.InvertedTopNMetricSpec;
 import org.apache.druid.query.topn.NumericTopNMetricSpec;
 import org.apache.druid.query.topn.TopNQueryBuilder;
+import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.join.JoinType;
@@ -18510,6 +18513,78 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
 
         ),
         expectedResults
+    );
+  }
+
+  @Test
+  public void testCountAndAverageByConstantVirtualColumn() throws Exception
+  {
+    List<VirtualColumn> virtualColumns;
+    List<AggregatorFactory> aggs;
+    if (useDefault) {
+      aggs = ImmutableList.of(
+          new FilteredAggregatorFactory(
+              new CountAggregatorFactory("a0"),
+              not(selector("v0", null, null))
+          ),
+          new LongSumAggregatorFactory("a1:sum", null, "325323", TestExprMacroTable.INSTANCE),
+          new CountAggregatorFactory("a1:count")
+      );
+      virtualColumns = ImmutableList.of(
+          expressionVirtualColumn("v0", "'10.1'", ValueType.STRING)
+      );
+    } else {
+      aggs = ImmutableList.of(
+          new FilteredAggregatorFactory(
+              new CountAggregatorFactory("a0"),
+              not(selector("v0", null, null))
+          ),
+          new LongSumAggregatorFactory("a1:sum", "v1"),
+          new FilteredAggregatorFactory(
+              new CountAggregatorFactory("a1:count"),
+              not(selector("v1", null, null))
+          )
+      );
+      virtualColumns = ImmutableList.of(
+          expressionVirtualColumn("v0", "'10.1'", ValueType.STRING),
+          expressionVirtualColumn("v1", "325323", ValueType.LONG)
+      );
+
+    }
+    testQuery(
+        "SELECT dim5, COUNT(dim1), AVG(l1) FROM druid.numfoo WHERE dim1 = '10.1' AND l1 = 325323 GROUP BY dim5",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE3)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setDimFilter(
+                            and(
+                                selector("dim1", "10.1", null),
+                                selector("l1", "325323", null)
+                            )
+                        )
+                        .setGranularity(Granularities.ALL)
+                        .setVirtualColumns(VirtualColumns.create(virtualColumns))
+                        .setDimensions(new DefaultDimensionSpec("dim5", "_d0", ValueType.STRING))
+                        .setAggregatorSpecs(aggs)
+                        .setPostAggregatorSpecs(
+                            ImmutableList.of(
+                                new ArithmeticPostAggregator(
+                                    "a1",
+                                    "quotient",
+                                    ImmutableList.of(
+                                        new FieldAccessPostAggregator(null, "a1:sum"),
+                                        new FieldAccessPostAggregator(null, "a1:count")
+                                    )
+                                )
+                            )
+                        )
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"ab", 1L, 325323L}
+        )
     );
   }
 }


### PR DESCRIPTION
### Description
This PR fixes a regression I believed was caused by #10135, which refactored the `AVG` and `COUNT` `SqlAggregator` implementations to directly construct the `FilteredAggregatorFactory` instead of [using `Aggregation.create(...).filter(...)`](https://github.com/apache/druid/pull/10135/files#diff-8816fcddac6763b07323c31d729ba5c3991c1fb902b74999b3f3385e407431a5L120), which caused any virtual columns which were created by the filter to no longer be associated with the `Aggregation` and so [not retained when the final query was constructed](https://github.com/apache/druid/blob/master/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java#L639), effectively making these aggregators process nil inputs instead of the correct values.

While looking into this issue, I noticed that `FilteredAggregatorFactory.requiredFields` did not include the required columns of the `DimFilter`, but only of the delegate `AggregatorFactory`. This seemed a mistake to me so I have adjusted this so that it will now return the correct set of columns, and am using this, along with a new method on `VirtualColumnRegistry` which can filter a list of columns to only include columns which are virtual so that we can continue to populate the `Aggregation` virtual columns list.

I think we can rework `Aggregation` to not require having this list of `VirtualColumn` at all and instead just check the registry against `requiredFields` when constructing the query, but it was a more disruptive change than I wanted to tie up in this fix, so I will save it for a follow-up.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
