### PR TITLE
Suppressing false positive CVE-2020-7791

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -158,10 +158,11 @@
     <cve>CVE-2019-17195</cve>
   </suppress>
   <suppress>
+    <!-- This CVE is a false positive. The CVE is not for apacheds-i18n -->
     <notes><![CDATA[
    file name: apacheds-i18n-2.0.0-M15.jar
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/apacheds\-i18n@2.0.0\-M15$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/apacheds\-i18n@.*$</packageUrl>
     <cve>CVE-2020-7791</cve>
   </suppress>
   <suppress>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -158,6 +158,13 @@
     <cve>CVE-2019-17195</cve>
   </suppress>
   <suppress>
+    <notes><![CDATA[
+   file name: apacheds-i18n-2.0.0-M15.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/apacheds\-i18n@2.0.0\-M15$</packageUrl>
+    <cve>CVE-2020-7791</cve>
+  </suppress>
+  <suppress>
       <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
       <notes><![CDATA[
    file name: libthrift-0.6.1.jar


### PR DESCRIPTION
Suppressing false positive CVE-2020-7791

### Description
CVE-2020-7791 (https://snyk.io/vuln/SNYK-DOTNET-I18N-1050179) refers to https://github.com/turquoiseowl/i18n where the issue is indicated to be in some .cs file (which is C#). Apache Druid which has a dependency on hadoop-auth, where hadoop-auth has a dependency on apacheds-kerberos-codec which in turn has a dependency on apacheds-i18n. The apacheds-i18n that is used here  is https://github.com/apache/directory-server/tree/master/i18n (Java) and is different from the one in the CVE-2020-7791

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
