### PR TITLE
[Backport] Suppressing false positive CVE-2020-7791

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -158,6 +158,14 @@
     <cve>CVE-2019-17195</cve>
   </suppress>
   <suppress>
+    <!-- This CVE is a false positive. The CVE is not for apacheds-i18n -->
+    <notes><![CDATA[
+   file name: apacheds-i18n-2.0.0-M15.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/apacheds\-i18n@.*$</packageUrl>
+    <cve>CVE-2020-7791</cve>
+  </suppress>
+  <suppress>
       <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
       <notes><![CDATA[
    file name: libthrift-0.6.1.jar


### PR DESCRIPTION
Backport of #11215 to 0.21.1.