### PR TITLE
Bump and centralise Confluent platform version

### DIFF
--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -35,7 +35,6 @@
 
   <properties>
     <schemarepo.version>0.1.3</schemarepo.version>
-    <confluent.version>5.5.1</confluent.version>
   </properties>
 
   <repositories>

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -34,7 +34,6 @@
   </parent>
 
   <properties>
-    <confluent.version>6.0.1</confluent.version>
     <commons-io.version>2.6</commons-io.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <avatica.version>1.17.0</avatica.version>
         <avro.version>1.9.2</avro.version>
         <calcite.version>1.21.0</calcite.version>
+        <confluent.version>6.1.1</confluent.version>
         <datasketches.version>2.0.0</datasketches.version>
         <datasketches.memory.version>1.3.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>


### PR DESCRIPTION
Both avro-extensions and protobuf-extensions use the Confluent schema
registry client.

Move the version property to the parent POM and bump to latest.
