### PR TITLE
Web console: Fix required field treatment

### DIFF
--- a/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
+++ b/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
@@ -5,8 +5,8 @@ exports[`AutoForm matches snapshot 1`] = `
   className="auto-form"
 >
   <Memo(FormGroupWithInfo)
-    key="testOne"
-    label="Test one"
+    key="testNumber"
+    label="Test number"
   >
     <Memo(NumericInputWithDefault)
       disabled={false}
@@ -18,8 +18,8 @@ exports[`AutoForm matches snapshot 1`] = `
     />
   </Memo(FormGroupWithInfo)>
   <Memo(FormGroupWithInfo)
-    key="testTwo"
-    label="Test two"
+    key="testSizeBytes"
+    label="Test size bytes"
   >
     <Blueprint3.NumericInput
       allowNumericCharactersOnly={true}
@@ -40,8 +40,8 @@ exports[`AutoForm matches snapshot 1`] = `
     />
   </Memo(FormGroupWithInfo)>
   <Memo(FormGroupWithInfo)
-    key="testThree"
-    label="Test three"
+    key="testString"
+    label="Test string"
   >
     <Memo(SuggestibleInput)
       disabled={false}
@@ -52,8 +52,20 @@ exports[`AutoForm matches snapshot 1`] = `
     />
   </Memo(FormGroupWithInfo)>
   <Memo(FormGroupWithInfo)
-    key="testFour"
-    label="Test four"
+    key="testStringWithDefault"
+    label="Test string with default"
+  >
+    <Memo(SuggestibleInput)
+      disabled={false}
+      onBlur={[Function]}
+      onValueChange={[Function]}
+      placeholder=""
+      value="Hello World"
+    />
+  </Memo(FormGroupWithInfo)>
+  <Memo(FormGroupWithInfo)
+    key="testBoolean"
+    label="Test boolean"
   >
     <Blueprint3.ButtonGroup>
       <Blueprint3.Button
@@ -73,8 +85,8 @@ exports[`AutoForm matches snapshot 1`] = `
     </Blueprint3.ButtonGroup>
   </Memo(FormGroupWithInfo)>
   <Memo(FormGroupWithInfo)
-    key="testFourWithDefault"
-    label="Test four with default"
+    key="testBooleanWithDefault"
+    label="Test boolean with default"
   >
     <Blueprint3.ButtonGroup>
       <Blueprint3.Button
@@ -94,8 +106,8 @@ exports[`AutoForm matches snapshot 1`] = `
     </Blueprint3.ButtonGroup>
   </Memo(FormGroupWithInfo)>
   <Memo(FormGroupWithInfo)
-    key="testFive"
-    label="Test five"
+    key="testStringArray"
+    label="Test string array"
   >
     <Memo(ArrayInput)
       disabled={false}
@@ -105,8 +117,24 @@ exports[`AutoForm matches snapshot 1`] = `
     />
   </Memo(FormGroupWithInfo)>
   <Memo(FormGroupWithInfo)
-    key="testSix"
-    label="Test six"
+    key="testStringArrayWithDefault"
+    label="Test string array with default"
+  >
+    <Memo(ArrayInput)
+      disabled={false}
+      onChange={[Function]}
+      placeholder=""
+      values={
+        Array [
+          "Hello",
+          "World",
+        ]
+      }
+    />
+  </Memo(FormGroupWithInfo)>
+  <Memo(FormGroupWithInfo)
+    key="testJson"
+    label="Test json"
   >
     <Memo(JsonInput)
       onChange={[Function]}
@@ -114,12 +142,16 @@ exports[`AutoForm matches snapshot 1`] = `
     />
   </Memo(FormGroupWithInfo)>
   <Memo(FormGroupWithInfo)
-    key="testSeven"
-    label="Test seven"
+    key="testStringRequiredAndDefaultValue"
+    label="Test string required and default value"
   >
-    <Memo(JsonInput)
-      onChange={[Function]}
+    <Memo(SuggestibleInput)
+      disabled={false}
+      intent="primary"
+      onBlur={[Function]}
+      onValueChange={[Function]}
       placeholder=""
+      value=""
     />
   </Memo(FormGroupWithInfo)>
   <Blueprint3.FormGroup

--- a/web-console/src/components/auto-form/auto-form.spec.tsx
+++ b/web-console/src/components/auto-form/auto-form.spec.tsx
@@ -28,14 +28,26 @@ describe('AutoForm', () => {
     const autoForm = shallow(
       <AutoForm
         fields={[
-          { name: 'testOne', type: 'number' },
-          { name: 'testTwo', type: 'size-bytes' },
-          { name: 'testThree', type: 'string' },
-          { name: 'testFour', type: 'boolean' },
-          { name: 'testFourWithDefault', type: 'boolean', defaultValue: false },
-          { name: 'testFive', type: 'string-array' },
-          { name: 'testSix', type: 'json' },
-          { name: 'testSeven', type: 'json' },
+          { name: 'testNumber', type: 'number' },
+          { name: 'testSizeBytes', type: 'size-bytes' },
+          { name: 'testString', type: 'string' },
+          { name: 'testStringWithDefault', type: 'string', defaultValue: 'Hello World' },
+          { name: 'testBoolean', type: 'boolean' },
+          { name: 'testBooleanWithDefault', type: 'boolean', defaultValue: false },
+          { name: 'testStringArray', type: 'string-array' },
+          {
+            name: 'testStringArrayWithDefault',
+            type: 'string-array',
+            defaultValue: ['Hello', 'World'],
+          },
+          { name: 'testJson', type: 'json' },
+
+          {
+            name: 'testStringRequiredAndDefaultValue',
+            type: 'string',
+            defaultValue: 'hello',
+            required: () => true,
+          },
 
           { name: 'testNotDefined', type: 'string', defined: false },
           { name: 'testAdvanced', type: 'string', hideInMore: true },

--- a/web-console/src/druid-models/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec.tsx
@@ -883,7 +883,6 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
             'kinesis.us-gov-east-1.amazonaws.com',
             'kinesis.us-gov-west-1.amazonaws.com',
           ],
-          required: true,
           info: (
             <>
               The Amazon Kinesis stream endpoint for a region. You can find a list of endpoints{' '}

--- a/web-console/src/druid-models/timestamp-spec.tsx
+++ b/web-console/src/druid-models/timestamp-spec.tsx
@@ -107,7 +107,6 @@ export const TIMESTAMP_SPEC_FIELDS: Field<TimestampSpec>[] = [
     name: 'column',
     type: 'string',
     defaultValue: 'timestamp',
-    required: true,
   },
   {
     name: 'format',

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -712,7 +712,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     comboType: IngestionComboTypeWithExtra,
     disabled?: boolean,
   ): JSX.Element | undefined {
-    const { overlordModules, selectedComboType } = this.state;
+    const { overlordModules, selectedComboType, spec } = this.state;
     if (!overlordModules) return;
     const requiredModule = getRequiredModule(comboType);
     const goodToGo = !disabled && (!requiredModule || overlordModules.includes(requiredModule));
@@ -722,10 +722,15 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         className={classNames({ disabled: !goodToGo, active: selectedComboType === comboType })}
         interactive
         elevation={1}
-        onClick={() => {
-          this.setState({
-            selectedComboType: selectedComboType !== comboType ? comboType : undefined,
-          });
+        onClick={e => {
+          if (e.altKey && e.shiftKey) {
+            this.updateSpec(updateIngestionType(spec, comboType as any));
+            this.updateStep('connect');
+          } else {
+            this.setState({
+              selectedComboType: selectedComboType !== comboType ? comboType : undefined,
+            });
+          }
         }}
       >
         <img


### PR DESCRIPTION
This PR fixes a bug in the data loader flow when connecting Kinesis.

The issue is that the `Endpoint` field looks like it is filled in with the default value but it also is `required` so it requires input.
The issue is fixed as a one line change in `ingestion-spec.tsx` per the docs the `endpoint` field is not required.

In addition to fixing this issue:

- AutoForm has been upgraded so that `defaultValue` is ignored when `required` is evaluated to true
- Tests have been greatly expanded
- I scanned the code for more instances of this issue and found one in the `TIMESTAMP_SPEC_FIELDS`
- Added the ability to Alt+Shift+Click a tile in the ingestion screen to go to its connection step even if the extension is not loaded.

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
