### PR TITLE
Allow configuration of AvroBytesDecoder when using web console to load data

### DIFF
--- a/web-console/src/druid-models/input-format.tsx
+++ b/web-console/src/druid-models/input-format.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 import { AutoForm, ExternalLink, Field } from '../components';
 import { getLink } from '../links';
-import { oneOf } from '../utils';
+import { deepGet, oneOf } from '../utils';
 
 import { FlattenSpec } from './flatten-spec';
 
@@ -35,6 +35,8 @@ export interface InputFormat {
   function?: string;
   flattenSpec?: FlattenSpec;
   keepNullColumns?: boolean;
+  binaryAsString?: boolean;
+  avroBytesDecoder?: any;
 }
 
 export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
@@ -132,6 +134,80 @@ export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
       <>
         Specifies if the binary column which is not logically marked as a string should be treated
         as a UTF-8 encoded string.
+      </>
+    ),
+  },
+  {
+    name: 'avroBytesDecoder.{type}',
+    label: 'Avro Decoder',
+    type: 'string',
+    required: true,
+    suggestions: ['schema_inline', 'multiple_schemas_inline', 'schema_repo', 'schema_registry'],
+    defined: (p: InputFormat) => oneOf(p.type, 'avro_stream'),
+    info: (
+      <>
+        <ExternalLink href={`${getLink('DOCS')}/ingestion/data-formats#avro-bytes-decoder`}>
+          avroBytesDecoder
+        </ExternalLink>
+        <p>Avro decoder to use to parse each record</p>
+      </>
+    ),
+  },
+  {
+    name: 'avroBytesDecoder.{schema}',
+    label: 'Schema',
+    type: 'json',
+    required: true,
+    defined: (p: InputFormat) => deepGet(p, 'avroBytesDecoder.type') === 'schema_inline',
+    info: <>Avro schema in JSON format</>,
+  },
+  {
+    name: 'avroBytesDecoder.{schemas}',
+    label: 'Schemas',
+    type: 'json',
+    required: true,
+    defined: (p: InputFormat) => deepGet(p, 'avroBytesDecoder.type') === 'multiple_schemas_inline',
+    info: <>JSON object mapping schema IDs to Avro schemas in JSON format</>,
+  },
+  {
+    name: 'avroBytesDecoder.schemaRepository.{url}',
+    label: 'Schema Repository URL',
+    type: 'string',
+    required: true,
+    defined: (p: InputFormat) => deepGet(p, 'avroBytesDecoder.type') === 'schema_repo',
+    placeholder: 'http(s)://hostname:port',
+    info: <>Endpoint url of your Avro-1124 schema repository</>,
+  },
+  {
+    name: 'avroBytesDecoder.subjectAndIdConverter.{topic}',
+    label: 'Topic',
+    type: 'string',
+    required: true,
+    defined: (p: InputFormat) => deepGet(p, 'avroBytesDecoder.type') === 'schema_repo',
+    placeholder: 'topic',
+    info: <>Specifies the topic of your Kafka stream</>,
+  },
+  {
+    name: 'avroBytesDecoder.{url}',
+    label: 'Schema Registry URL',
+    type: 'string',
+    required: true,
+    defined: (p: InputFormat) => deepGet(p, 'avroBytesDecoder.type') === 'schema_registry',
+    placeholder: 'http(s)://hostname:port',
+    info: <>Schema Registry URL</>,
+  },
+  {
+    name: 'avroBytesDecoder',
+    label: 'Avro Decoder Configuration',
+    type: 'json',
+    defined: (p: InputFormat) => oneOf(p.type, 'avro_stream'),
+    required: true,
+    info: (
+      <>
+        <ExternalLink href={`${getLink('DOCS')}/ingestion/data-formats#avro-bytes-decoder`}>
+          avroBytesDecoder
+        </ExternalLink>
+        <p>JSON object containing avroBytesDecoder configuration</p>
       </>
     ),
   },


### PR DESCRIPTION
Unlike `avro_ocf` which doesn't require any configuration the
`avro_stream` input format requires the user to either provide schema(s)
or a mechanism to resolve the schema for a message.

This changes adds configuration options to the input format phase to
allow specifying these options in a structured way and allow override
similar to how Kafka `consumerProperties` is handled.