### PR TITLE
add estimated byte size limit enforcement for heap based expression agg

### DIFF
--- a/core/src/test/java/org/apache/druid/math/expr/ExprEvalTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ExprEvalTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.math.expr;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -53,7 +54,12 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   public void testStringSerdeTooBig()
   {
     expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format("Unable to serialize [%s], size [%s] is larger than max [%s]", ExprType.STRING, 16, 10));
+    expectedException.expectMessage(StringUtils.format(
+        "Unable to serialize [%s], size [%s] is larger than max [%s]",
+        ExprType.STRING,
+        16,
+        10
+    ));
     assertExpr(0, ExprEval.of("hello world"), 10);
   }
 
@@ -77,49 +83,104 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   @Test
   public void testStringArraySerde()
   {
-    assertExpr(0, new String[] {"hello", "hi", "hey"});
-    assertExpr(1024, new String[] {"hello", null, "hi", "hey"});
-    assertExpr(2048, new String[] {});
+    assertExpr(0, new String[]{"hello", "hi", "hey"});
+    assertExpr(1024, new String[]{"hello", null, "hi", "hey"});
+    assertExpr(2048, new String[]{});
   }
 
   @Test
   public void testStringArraySerdeToBig()
   {
     expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format("Unable to serialize [%s], size [%s] is larger than max [%s]", ExprType.STRING_ARRAY, 14, 10));
-    assertExpr(0, ExprEval.ofStringArray(new String[] {"hello", "hi", "hey"}), 10);
+    expectedException.expectMessage(StringUtils.format(
+        "Unable to serialize [%s], size [%s] is larger than max [%s]",
+        ExprType.STRING_ARRAY,
+        14,
+        10
+    ));
+    assertExpr(0, ExprEval.ofStringArray(new String[]{"hello", "hi", "hey"}), 10);
+  }
+
+  @Test
+  public void testStringArrayEvalToBig()
+  {
+    expectedException.expect(ISE.class);
+    // this has a different failure size than string serde because it doesn't check incrementally
+    expectedException.expectMessage(StringUtils.format(
+        "Unable to serialize [%s], size [%s] is larger than max [%s]",
+        ExprType.STRING_ARRAY,
+        27,
+        10
+    ));
+    assertEstimatedBytes(ExprEval.ofStringArray(new String[]{"hello", "hi", "hey"}), 10);
   }
 
   @Test
   public void testLongArraySerde()
   {
-    assertExpr(0, new Long[] {1L, 2L, 3L});
-    assertExpr(1234, new Long[] {1L, 2L, null, 3L});
-    assertExpr(1234, new Long[] {});
+    assertExpr(0, new Long[]{1L, 2L, 3L});
+    assertExpr(1234, new Long[]{1L, 2L, null, 3L});
+    assertExpr(1234, new Long[]{});
   }
 
   @Test
   public void testLongArraySerdeTooBig()
   {
     expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format("Unable to serialize [%s], size [%s] is larger than max [%s]", ExprType.LONG_ARRAY, 29, 10));
-    assertExpr(0, ExprEval.ofLongArray(new Long[] {1L, 2L, 3L}), 10);
+    expectedException.expectMessage(StringUtils.format(
+        "Unable to serialize [%s], size [%s] is larger than max [%s]",
+        ExprType.LONG_ARRAY,
+        29,
+        10
+    ));
+    assertExpr(0, ExprEval.ofLongArray(new Long[]{1L, 2L, 3L}), 10);
+  }
+
+  @Test
+  public void testLongArrayEvalTooBig()
+  {
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage(StringUtils.format(
+        "Unable to serialize [%s], size [%s] is larger than max [%s]",
+        ExprType.LONG_ARRAY,
+        NullHandling.sqlCompatible() ? 32 : 29,
+        10
+    ));
+    assertEstimatedBytes(ExprEval.ofLongArray(new Long[]{1L, 2L, 3L}), 10);
   }
 
   @Test
   public void testDoubleArraySerde()
   {
-    assertExpr(0, new Double[] {1.1, 2.2, 3.3});
-    assertExpr(1234, new Double[] {1.1, 2.2, null, 3.3});
-    assertExpr(1234, new Double[] {});
+    assertExpr(0, new Double[]{1.1, 2.2, 3.3});
+    assertExpr(1234, new Double[]{1.1, 2.2, null, 3.3});
+    assertExpr(1234, new Double[]{});
   }
 
   @Test
   public void testDoubleArraySerdeTooBig()
   {
     expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format("Unable to serialize [%s], size [%s] is larger than max [%s]", ExprType.DOUBLE_ARRAY, 29, 10));
-    assertExpr(0, ExprEval.ofDoubleArray(new Double[] {1.1, 2.2, 3.3}), 10);
+    expectedException.expectMessage(StringUtils.format(
+        "Unable to serialize [%s], size [%s] is larger than max [%s]",
+        ExprType.DOUBLE_ARRAY,
+        29,
+        10
+    ));
+    assertExpr(0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2, 3.3}), 10);
+  }
+
+  @Test
+  public void testDoubleArrayEvalTooBig()
+  {
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage(StringUtils.format(
+        "Unable to serialize [%s], size [%s] is larger than max [%s]",
+        ExprType.DOUBLE_ARRAY,
+        NullHandling.sqlCompatible() ? 32 : 29,
+        10
+    ));
+    assertEstimatedBytes(ExprEval.ofDoubleArray(new Double[]{1.1, 2.2, 3.3}), 10);
   }
 
   @Test
@@ -216,5 +277,11 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     } else {
       Assert.assertEquals(expected.value(), ExprEval.deserialize(buffer, position).value());
     }
+    assertEstimatedBytes(expected, maxSizeBytes);
+  }
+
+  private void assertEstimatedBytes(ExprEval eval, int maxSizeBytes)
+  {
+    ExprEval.estimateAndCheckMaxBytes(eval, maxSizeBytes);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregator.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.aggregation;
 
 import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
 
 import javax.annotation.Nullable;
 
@@ -27,17 +28,21 @@ public class ExpressionLambdaAggregator implements Aggregator
 {
   private final Expr lambda;
   private final ExpressionLambdaAggregatorInputBindings bindings;
+  private final int maxSizeBytes;
 
-  public ExpressionLambdaAggregator(Expr lambda, ExpressionLambdaAggregatorInputBindings bindings)
+  public ExpressionLambdaAggregator(Expr lambda, ExpressionLambdaAggregatorInputBindings bindings, int maxSizeBytes)
   {
     this.lambda = lambda;
     this.bindings = bindings;
+    this.maxSizeBytes = maxSizeBytes;
   }
 
   @Override
   public void aggregate()
   {
-    bindings.accumulate(lambda.eval(bindings));
+    final ExprEval<?> eval = lambda.eval(bindings);
+    ExprEval.estimateAndCheckMaxBytes(eval, maxSizeBytes);
+    bindings.accumulate(eval);
   }
 
   @Nullable

--- a/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
@@ -248,7 +248,8 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
     FactorizePlan thePlan = new FactorizePlan(metricFactory);
     return new ExpressionLambdaAggregator(
         thePlan.getExpression(),
-        thePlan.getBindings()
+        thePlan.getBindings(),
+        maxSizeBytes.getBytesInInt()
     );
   }
 


### PR DESCRIPTION
### Description
Does what the title says, and adds max bytes limit enforcement to the heap based `ExpressionLambdaAggregator` to bring its behavior inline with `ExpressionLambdaBufferAggregator` and `ExpressionLambdaVectorAggregator`.

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
