### PR TITLE
chill, travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
       install: skip
       before_script: &setup_generate_license
         - sudo apt-get update && sudo apt-get install python3 python3-pip python3-setuptools -y
-        - ./check-test-suite.py && travis_terminate 0
+        - ./check-test-suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml
       script:
@@ -106,7 +106,7 @@ jobs:
       install: skip
       # Strict compilation requires more than 2 GB
       script: >
-        ./check-test-suite.py && travis_terminate 0  || MAVEN_OPTS='-Xmx3000m' ${MVN} clean -Pstrict compile test-compile --fail-at-end
+        ./check-test-suite.py && travis_terminate 0 || MAVEN_OPTS='-Xmx3000m' ${MVN} clean -Pstrict compile test-compile --fail-at-end
         -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
     - name: "analyze dependencies"
@@ -133,7 +133,7 @@ jobs:
 
     - name: "intellij inspections"
       script: >
-        ./check-test-suite.py && travis_terminate 0  || docker run --rm
+        ./check-test-suite.py && travis_terminate 0 || docker run --rm
         -v $(pwd):/project
         -v ~/.m2:/home/inspect/.m2
         ccaominh/intellij-inspect:1.0.0
@@ -309,14 +309,14 @@ jobs:
       before_install: *setup_generate_license
       install: web-console/script/druid build
       before_script:
-        - ./check-test-suite.py && travis_terminate 0
+        - ./check-test-suite.py && travis_terminate 0 || echo 'Starting nvm install...'
         - nvm install 10.24.0
         - web-console/script/druid start
       script: (cd web-console && npm run test-e2e)
       after_script: web-console/script/druid stop
 
     - name: "docs"
-      install: ./check-test-suite.py && travis_terminate 0  || (cd website && npm install)
+      install: ./check-test-suite.py && travis_terminate 0 || (cd website && npm install)
       script: |-
         (cd website && npm run lint && npm run spellcheck) || { echo "
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,10 @@ addons:
       - maven
       - python3
 
-before_script: ./check-test-suite.py && travis_terminate 0
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
-install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+install: ./check-test-suite.py && travis_terminate 0  || echo 'Running maven install...' && MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
 # There are 3 stages of tests
 # 1. Tests - phase 1
@@ -134,7 +133,7 @@ jobs:
 
     - name: "intellij inspections"
       script: >
-        docker run --rm
+        ./check-test-suite.py && travis_terminate 0  || docker run --rm
         -v $(pwd):/project
         -v ~/.m2:/home/inspect/.m2
         ccaominh/intellij-inspect:1.0.0
@@ -162,7 +161,6 @@ jobs:
       env:
       - MAVEN_PROJECTS='processing'
       before_script:
-        - ./check-test-suite.py && travis_terminate 0
         - export DRUID_USE_DEFAULT_VALUE_FOR_NULL=true
       script:
         - unset _JAVA_OPTIONS
@@ -229,7 +227,6 @@ jobs:
       stage: Tests - phase 1
       before_script: &setup_sqlcompat
         - export DRUID_USE_DEFAULT_VALUE_FOR_NULL=false
-        - ./check-test-suite.py && travis_terminate 0
 
     - <<: *test_processing_module_sqlcompat
       name: "(openjdk11) processing module test (SQL Compatibility)"
@@ -240,7 +237,7 @@ jobs:
       <<: *test_processing_module
       name: "(openjdk8) indexing modules test"
       env:
-      - MAVEN_PROJECTS='indexing-hadoop,indexing-service,extensions-core/kafka-indexing-service,extensions-core/kinesis-indexing-service'
+        - MAVEN_PROJECTS='indexing-hadoop,indexing-service,extensions-core/kafka-indexing-service,extensions-core/kinesis-indexing-service'
 
     - <<: *test_indexing_module
       name: "(openjdk11) indexing modules test"
@@ -304,7 +301,7 @@ jobs:
       install: skip
       stage: Tests - phase 1
       script:
-        - ./check-test-suite.py && travis_terminate 0  || ${MVN} test -pl 'web-console'
+        - ${MVN} test -pl 'web-console'
       after_success:
         - (cd web-console && travis_retry npm run codecov)  # retry in case of network error
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,12 @@ addons:
     packages:
       - maven
       - python3
-    
+
+before_script: ./check-test-suite.py && travis_terminate 0
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
-install: ./check-test-suite.py && travis_terminate 0  || echo 'Running maven install...' && MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
 # There are 3 stages of tests
 # 1. Tests - phase 1
@@ -88,6 +89,7 @@ jobs:
       install: skip
       before_script: &setup_generate_license
         - sudo apt-get update && sudo apt-get install python3 python3-pip python3-setuptools -y
+        - ./check-test-suite.py && travis_terminate 0
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml
       script:
@@ -105,7 +107,7 @@ jobs:
       install: skip
       # Strict compilation requires more than 2 GB
       script: >
-        MAVEN_OPTS='-Xmx3000m' ${MVN} clean -Pstrict compile test-compile --fail-at-end
+        ./check-test-suite.py && travis_terminate 0  || MAVEN_OPTS='-Xmx3000m' ${MVN} clean -Pstrict compile test-compile --fail-at-end
         -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
     - name: "analyze dependencies"
@@ -132,7 +134,7 @@ jobs:
 
     - name: "intellij inspections"
       script: >
-        ./check-test-suite.py && travis_terminate 0  || docker run --rm
+        docker run --rm
         -v $(pwd):/project
         -v ~/.m2:/home/inspect/.m2
         ccaominh/intellij-inspect:1.0.0
@@ -160,6 +162,7 @@ jobs:
       env:
       - MAVEN_PROJECTS='processing'
       before_script:
+        - ./check-test-suite.py && travis_terminate 0
         - export DRUID_USE_DEFAULT_VALUE_FOR_NULL=true
       script:
         - unset _JAVA_OPTIONS
@@ -225,7 +228,8 @@ jobs:
       name: "(openjdk8) processing module test (SQL Compatibility)"
       stage: Tests - phase 1
       before_script: &setup_sqlcompat
-      - export DRUID_USE_DEFAULT_VALUE_FOR_NULL=false
+        - export DRUID_USE_DEFAULT_VALUE_FOR_NULL=false
+        - ./check-test-suite.py && travis_terminate 0
 
     - <<: *test_processing_module_sqlcompat
       name: "(openjdk11) processing module test (SQL Compatibility)"
@@ -300,7 +304,7 @@ jobs:
       install: skip
       stage: Tests - phase 1
       script:
-        - ${MVN} test -pl 'web-console'
+        - ./check-test-suite.py && travis_terminate 0  || ${MVN} test -pl 'web-console'
       after_success:
         - (cd web-console && travis_retry npm run codecov)  # retry in case of network error
 
@@ -308,15 +312,16 @@ jobs:
       before_install: *setup_generate_license
       install: web-console/script/druid build
       before_script:
+        - ./check-test-suite.py && travis_terminate 0
         - nvm install 10.24.0
         - web-console/script/druid start
-      script: ./check-test-suite.py && travis_terminate 0  || (cd web-console && npm run test-e2e)
+      script: (cd web-console && npm run test-e2e)
       after_script: web-console/script/druid stop
 
     - name: "docs"
-      install: (cd website && npm install)
+      install: ./check-test-suite.py && travis_terminate 0  || (cd website && npm install)
       script: |-
-        ./check-test-suite.py && travis_terminate 0  || (cd website && npm run lint && npm run spellcheck) || { echo "
+        (cd website && npm run lint && npm run spellcheck) || { echo "
 
         If there are spell check errors:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -301,7 +301,7 @@ jobs:
       install: skip
       stage: Tests - phase 1
       script:
-        - ${MVN} test -pl 'web-console'
+        - ./check-test-suite.py && travis_terminate 0 || ${MVN} test -pl 'web-console'
       after_success:
         - (cd web-console && travis_retry npm run codecov)  # retry in case of network error
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,12 @@ addons:
   apt:
     packages:
       - maven
+      - python3
     
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
-install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+install: ./check-test-suite.py || MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
 # There are 3 stages of tests
 # 1. Tests - phase 1
@@ -66,10 +67,10 @@ jobs:
   include:
     - name: "animal sniffer checks"
       stage: Tests - phase 1
-      script: ${MVN} animal-sniffer:check --fail-at-end
+      script: ./check-test-suite.py || ${MVN} animal-sniffer:check --fail-at-end
 
     - name: "checkstyle"
-      script: ${MVN} checkstyle:checkstyle --fail-at-end
+      script: ./check-test-suite.py || ${MVN} checkstyle:checkstyle --fail-at-end
 
     - name: "enforcer checks"
       script: ${MVN} enforcer:enforce --fail-at-end
@@ -131,7 +132,7 @@ jobs:
 
     - name: "intellij inspections"
       script: >
-        docker run --rm
+        ./check-test-suite.py || docker run --rm
         -v $(pwd):/project
         -v ~/.m2:/home/inspect/.m2
         ccaominh/intellij-inspect:1.0.0
@@ -309,13 +310,13 @@ jobs:
       before_script:
         - nvm install 10.24.0
         - web-console/script/druid start
-      script: (cd web-console && npm run test-e2e)
+      script: ./check-test-suite.py || (cd web-console && npm run test-e2e)
       after_script: web-console/script/druid stop
 
     - name: "docs"
       install: (cd website && npm install)
       script: |-
-        (cd website && npm run lint && npm run spellcheck) || { echo "
+        ./check-test-suite.py || (cd website && npm run lint && npm run spellcheck) || { echo "
 
         If there are spell check errors:
 
@@ -342,7 +343,7 @@ jobs:
         - docker
       env: TESTNG_GROUPS='-Dgroups=batch-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
       script: &run_integration_test
-        - ${MVN} verify -pl integration-tests -P integration-tests ${TESTNG_GROUPS} ${JVM_RUNTIME} -Dit.indexer=${USE_INDEXER} -Dzk.version=${ZK_VERSION} ${MAVEN_SKIP}
+        - ./check-test-suite.py || ${MVN} verify -pl integration-tests -P integration-tests ${TESTNG_GROUPS} ${JVM_RUNTIME} -Dit.indexer=${USE_INDEXER} -Dzk.version=${ZK_VERSION} ${MAVEN_SKIP}
       after_failure: &integration_test_diags
         - for v in ~/shared/logs/*.log ; do
           echo $v logtail ======================== ; tail -100 $v ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ addons:
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
-install: ./check-test-suite.py || MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+install: ./check-test-suite.py && travis_terminate 0  || echo 'Running maven install...' && MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
 # There are 3 stages of tests
 # 1. Tests - phase 1
@@ -67,10 +67,10 @@ jobs:
   include:
     - name: "animal sniffer checks"
       stage: Tests - phase 1
-      script: ./check-test-suite.py || ${MVN} animal-sniffer:check --fail-at-end
+      script: ${MVN} animal-sniffer:check --fail-at-end
 
     - name: "checkstyle"
-      script: ./check-test-suite.py || ${MVN} checkstyle:checkstyle --fail-at-end
+      script: ${MVN} checkstyle:checkstyle --fail-at-end
 
     - name: "enforcer checks"
       script: ${MVN} enforcer:enforce --fail-at-end
@@ -132,7 +132,7 @@ jobs:
 
     - name: "intellij inspections"
       script: >
-        ./check-test-suite.py || docker run --rm
+        ./check-test-suite.py && travis_terminate 0  || docker run --rm
         -v $(pwd):/project
         -v ~/.m2:/home/inspect/.m2
         ccaominh/intellij-inspect:1.0.0
@@ -310,13 +310,13 @@ jobs:
       before_script:
         - nvm install 10.24.0
         - web-console/script/druid start
-      script: ./check-test-suite.py || (cd web-console && npm run test-e2e)
+      script: ./check-test-suite.py && travis_terminate 0  || (cd web-console && npm run test-e2e)
       after_script: web-console/script/druid stop
 
     - name: "docs"
       install: (cd website && npm install)
       script: |-
-        ./check-test-suite.py || (cd website && npm run lint && npm run spellcheck) || { echo "
+        ./check-test-suite.py && travis_terminate 0  || (cd website && npm run lint && npm run spellcheck) || { echo "
 
         If there are spell check errors:
 
@@ -343,7 +343,7 @@ jobs:
         - docker
       env: TESTNG_GROUPS='-Dgroups=batch-index' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
       script: &run_integration_test
-        - ./check-test-suite.py || ${MVN} verify -pl integration-tests -P integration-tests ${TESTNG_GROUPS} ${JVM_RUNTIME} -Dit.indexer=${USE_INDEXER} -Dzk.version=${ZK_VERSION} ${MAVEN_SKIP}
+        - ${MVN} verify -pl integration-tests -P integration-tests ${TESTNG_GROUPS} ${JVM_RUNTIME} -Dit.indexer=${USE_INDEXER} -Dzk.version=${ZK_VERSION} ${MAVEN_SKIP}
       after_failure: &integration_test_diags
         - for v in ~/shared/logs/*.log ; do
           echo $v logtail ======================== ; tail -100 $v ;

--- a/check-test-suite.py
+++ b/check-test-suite.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+
+# ignore completely - .idea, anything in distribution except pom,
+# java - ignore docs, website, web-console only changes, otherwise run
+# docs - diff in docs/ or website/
+# web-console - diff in web-console/
+
+ignore_prefixes = ['.idea', 'distribution/bin', 'distribution/docker', 'distribution/asf-release-process-guide.md']
+docs_prefixes = ['docs/', 'website/']
+web_console_prefixes = ['web-console/']
+docs_jobs = ['docs']
+web_console_jobs = ['web console', 'web console end-to-end test']
+
+
+def check_ignore(file):
+    is_always_ignore = True in (file.startswith(prefix) for prefix in ignore_prefixes)
+    if is_always_ignore:
+        print("found ignorable file change: {}".format(file))
+    return is_always_ignore
+
+def check_docs(file):
+    is_docs = True in (file.startswith(prefix) for prefix in docs_prefixes)
+    if is_docs:
+        print("found docs file change: {}".format(file))
+    return is_docs
+
+def check_console(file):
+    is_console = True in (file.startswith(prefix) for prefix in web_console_prefixes)
+    if is_console:
+        print("found web-console file change: {}".format(file))
+    return is_console
+
+def check_should_run_suite(suite, diff_files):
+    all_ignore = True
+    any_docs = False
+    all_docs = True
+    any_console = False
+    all_console = True
+
+    for f in diff_files:
+        all_ignore = all_ignore and check_ignore(f)
+        is_docs = check_docs(f)
+        any_docs = any_docs or is_docs
+        all_docs = all_docs and is_docs
+        is_console = check_console(f)
+        any_console = any_console or is_console
+        all_console = any_console and is_console
+
+    if all_ignore:
+        return False
+    if suite in docs_jobs:
+        return any_docs
+    if all_docs:
+        return False
+    if suite in web_console_jobs:
+        return any_console
+    if all_console:
+        return False
+
+    return True
+
+suite_name = ""
+
+if len(sys.argv) != 2:
+    if 'TRAVIS_JOB_NAME' in os.environ:
+        suite_name = os.environ['TRAVIS_JOB_NAME']
+    else:
+        sys.stderr.write("usage: check-test-suite.py <test-suite-name>\n")
+        sys.stderr.write("  e.g., check-test-suite.py docs")
+        sys.exit(1)
+else:
+    suite_name = sys.argv[1]
+
+
+all_changed_files_string = subprocess.check_output("git diff --name-only HEAD~1", shell=True).decode('UTF-8')
+all_changed_files = all_changed_files_string.splitlines()
+
+print("Checking if suite '{}' needs to run test on diff:\n{}".format(suite_name, all_changed_files_string))
+
+needs_run = check_should_run_suite(suite_name, all_changed_files)
+if needs_run:
+    print("Changes detected, need to run test suite '{}'".format(suite_name))
+    sys.exit(1)
+
+print("No applicable changes detected, can skip test suite '{}'".format(suite_name))
+sys.exit(0)
+

--- a/check-test-suite.py
+++ b/check-test-suite.py
@@ -27,7 +27,7 @@ always_run_jobs = ['license check']
 # of CI can be skipped
 ignore_prefixes = ['.github', '.idea', '.asf.yaml', '.backportrc.json', '.codecov.yml', '.dockerignore', '.gitignore',
                    '.lgtm.yml', 'CONTRIBUTING.md', 'setup-hooks.sh', 'upload.sh', 'dev', 'distribution/docker',
-                   'distribution/asf-release-process-guide.md']
+                   'distribution/asf-release-process-guide.md', '.travis.yml', 'check-test-suite.py']
 # these files are docs changes
 # if changes are limited to this set then we can skip web-console and java
 # if no changes in this set we can skip docs
@@ -111,12 +111,10 @@ else:
     failWithUsage()
 
 
-needs_run = True
-if 'TRAVIS_BRANCH' not in os.environ or os.environ['TRAVIS_BRANCH'] != 'false':
-    all_changed_files_string = subprocess.check_output("git diff --name-only HEAD~1", shell=True).decode('UTF-8')
-    all_changed_files = all_changed_files_string.splitlines()
-    print("Checking if suite '{}' needs to run test on diff:\n{}".format(suite_name, all_changed_files_string))
-    needs_run = check_should_run_suite(suite_name, all_changed_files)
+all_changed_files_string = subprocess.check_output("git diff --name-only HEAD~1", shell=True).decode('UTF-8')
+all_changed_files = all_changed_files_string.splitlines()
+print("Checking if suite '{}' needs to run test on diff:\n{}".format(suite_name, all_changed_files_string))
+needs_run = check_should_run_suite(suite_name, all_changed_files)
 
 if needs_run:
     print("Changes detected, need to run test suite '{}'".format(suite_name))

--- a/check-test-suite.py
+++ b/check-test-suite.py
@@ -21,7 +21,7 @@ import sys
 
 # do some primitive examination of git diff to determine if a test suite needs to be run or not
 
-always_run_jobs = ['license check']
+always_run_jobs = ['license check', '(openjdk8) packaging check', '(openjdk11) packaging check']
 
 # ignore changes to these files completely since they don't impact CI, if the changes are only to these files then all
 # of CI can be skipped

--- a/check-test-suite.py
+++ b/check-test-suite.py
@@ -21,7 +21,7 @@ import sys
 
 # do some primitive examination of git diff to determine if a test suite needs to be run or not
 
-always_run_jobs = ['license check', '(openjdk8) packaging check', '(openjdk11) packaging check']
+always_run_jobs = ['license checks', '(openjdk8) packaging check', '(openjdk11) packaging check']
 
 # ignore changes to these files completely since they don't impact CI, if the changes are only to these files then all
 # of CI can be skipped


### PR DESCRIPTION
Initial attempt at making travis be a bit more selective about what it runs, since every change takes like.. over a day of compute time. 

This PR adds a new script, `check-test-suite.py`, which is used in `.travis.yml` jobs to check whether or not a given job should run. It does this based on an admittedly primitive git diff file path prefix matching against stuff hard coded into the script, initially dividing into 3 categories: 'docs', 'web-console' and like, everything else. We do some similar stuff for code coverage diff checking enforcement for java projects, so a follow-up improvement could provide finer granularity for the 'everything else' bucket.

I'm sure there is a better way to configure this than hard coding stuff into the script as well, but, its a start and should let us at least cut down a tiny amount of the global warming we are surely causing with all of this CI.

I think the only thing that is questionable is considering changes to `.travis.yml` skippable, which will result in newly added configurations of existing tests not getting triggered I think, but maybe that isn't a common situation? Also, I have the license checks and packaging checks running always, because they seem like useful sanity checks to make sure all license stuff is cool and that a distribution can be built from source.