### PR TITLE
fix sql planner bug with inner offset causing loop

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -803,11 +803,6 @@ public class DruidQuery
           Iterables.getOnlyElement(grouping.getDimensions()).toDimensionSpec().getOutputName()
       );
       if (sorting != null) {
-        if (sorting.getOffsetLimit().hasOffset()) {
-          // Timeseries cannot handle offsets.
-          return null;
-        }
-
         if (sorting.getOffsetLimit().hasLimit()) {
           final long limit = sorting.getOffsetLimit().getLimit();
 
@@ -837,6 +832,11 @@ public class DruidQuery
       }
     } else {
       // More than one dimension, timeseries cannot handle.
+      return null;
+    }
+
+    if (sorting != null && sorting.getOffsetLimit().hasOffset()) {
+      // Timeseries cannot handle offsets.
       return null;
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -780,6 +780,11 @@ public class DruidQuery
       return null;
     }
 
+    if (sorting != null && sorting.getOffsetLimit().hasOffset()) {
+      // Timeseries cannot handle offsets.
+      return null;
+    }
+
     final Granularity queryGranularity;
     final boolean descending;
     int timeseriesLimit = 0;
@@ -832,11 +837,6 @@ public class DruidQuery
       }
     } else {
       // More than one dimension, timeseries cannot handle.
-      return null;
-    }
-
-    if (sorting != null && sorting.getOffsetLimit().hasOffset()) {
-      // Timeseries cannot handle offsets.
       return null;
     }
 


### PR DESCRIPTION
### Description
This PR fixes a bug in the Druid SQL planner where a query with an offset would incorrectly try to plan to a timeseries query, (which does not support offset), effectively ignoring it which could lead to an infinite loop in the planner rewriting the Sort of a query such as this example, which has been added to the tests:

```sql
SELECT r0.c, r1.c
FROM (
  SELECT COUNT(*) AS c
  FROM "foo"
  GROUP BY ()
  OFFSET 1
) AS r0
LEFT JOIN (
  SELECT COUNT(*) AS c
  FROM "foo"
  GROUP BY ()
) AS r1 ON TRUE
LIMIT 10
```

This is because the timeseries query construction during planning was only checking that offset was not present if there was at least one grouping dimension (when it should've always been checking this), so simply moving this check outside of an 'if' statement resolves the issue.

Credit to @vogievetsky for finding this :+1:

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

