### PR TITLE
Improve doc of movingAverage

### DIFF
--- a/docs/development/extensions-contrib/moving-average-query.md
+++ b/docs/development/extensions-contrib/moving-average-query.md
@@ -71,6 +71,7 @@ druid.extensions.loadList=["druid-moving-average-query"]
 There are currently no configuration properties specific to Moving Average.
 
 ## Limitations
+* movingAverage is not supported by Druid router(including the Web Console), all queries should be sent to broker nodes directly.
 * movingAverage is missing support for the following groupBy properties: `subtotalsSpec`, `virtualColumns`.
 * movingAverage is missing support for the following timeseries properties: `descending`.
 * movingAverage is missing support for [SQL-compatible null handling](https://github.com/apache/druid/issues/4349) (So setting druid.generic.useDefaultValueForNull in configuration will give an error).

--- a/docs/development/extensions-contrib/moving-average-query.md
+++ b/docs/development/extensions-contrib/moving-average-query.md
@@ -50,7 +50,22 @@ It runs the query in two main phases:
 
 
 ## Operations
-To use this extension, make sure to [load](../../development/extensions.md#loading-extensions) `druid-moving-average-query` only to the Broker.
+
+### Installation
+Use [pull-deps](../../operations/pull-deps.md) tool shipped with Druid to install this [extension](../../development/extensions.md#community-extensions) on all Druid broker nodes.
+
+```bash
+java -classpath "<your_druid_dir>/lib/*" org.apache.druid.cli.Main tools pull-deps -c org.apache.druid.extensions.contrib:druid-moving-average-query:{VERSION}
+```
+
+### Enabling
+After installation, to enable this extension, just add `druid-moving-average-query` to `druid.extensions.loadList` in brokers' `runtime.properties` file and then restart broker nodes.
+
+For example:
+
+```bash
+druid.extensions.loadList=["druid-moving-average-query"]
+```
 
 ## Configuration
 There are currently no configuration properties specific to Moving Average.

--- a/website/.spelling
+++ b/website/.spelling
@@ -582,6 +582,7 @@ longSum
 movingAverage
 postAggregations
 postAveragers
+pull-deps
  - ../docs/development/extensions-contrib/opentsdb-emitter.md
 defaultMetrics.json
 namespacePrefix


### PR DESCRIPTION

### Description

There're some questions about how to enable movingAverage on brokers(eg #11086), this PR improves the doc to make operational steps more directive and also adds a limitation that movingAverage is not supported  by druid router.


This PR has:
- [X] been self-reviewed.

