### PR TITLE
Catch exception inside ITRetryUtil to fix one of the causes for flaky integration tests

### DIFF
--- a/integration-tests/docker/docker-compose.base.yml
+++ b/integration-tests/docker/docker-compose.base.yml
@@ -398,4 +398,4 @@ services:
       SCHEMA_REGISTRY_AUTHENTICATION_METHOD: BASIC
       SCHEMA_REGISTRY_AUTHENTICATION_REALM: druid
       SCHEMA_REGISTRY_AUTHENTICATION_ROLES: users
-      SCHEMA_REGISTRY_OPTS: -Djava.security.auth.login.config=/usr/lib/druid/conf/jaas_config.file
+      SCHEMA_REGISTRY_OPTS: -Djava.security.auth.login.config=/usr/lib/druid/conf/jaas_config.file -Xmx32m

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
@@ -57,11 +57,12 @@ public class ITRetryUtil
 
     while (true) {
       try {
+        LOG.info("Trying attempt[%d/%d]...", currentTry, retryCount);
         if (currentTry > retryCount || callable.call() == expectedValue) {
           break;
         }
         LOG.info(
-            "Attempt[%d/%d]: Task %s still not complete. Next retry in %d ms",
+            "Attempt[%d/%d] did not pass: Task %s still not complete. Next retry in %d ms",
             currentTry, retryCount, taskMessage, delayInMillis
         );
         Thread.sleep(delayInMillis);

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
@@ -52,23 +52,42 @@ public class ITRetryUtil
       String taskMessage
   )
   {
-    try {
-      int currentTry = 0;
-      while (callable.call() != expectedValue) {
-        if (currentTry > retryCount) {
-          throw new ISE("Max number of retries[%d] exceeded for Task[%s]. Failing.", retryCount, taskMessage);
+    int currentTry = 0;
+    Exception lastException = null;
+
+    while (true) {
+      try {
+        if (currentTry > retryCount || callable.call() == expectedValue) {
+          break;
         }
         LOG.info(
-            "Attempt[%d]: Task %s still not complete. Next retry in %d ms",
-            currentTry, taskMessage, delayInMillis
+            "Attempt[%d/%d]: Task %s still not complete. Next retry in %d ms",
+            currentTry, retryCount, taskMessage, delayInMillis
         );
         Thread.sleep(delayInMillis);
-
         currentTry++;
       }
+      catch (Exception e) {
+        // just continue retrying if there is an exception (it may be transient!) but save the last:
+        lastException = e;
+      }
     }
-    catch (Exception e) {
-      throw new RuntimeException(e);
+
+    if (currentTry > retryCount) {
+      if (lastException != null) {
+        throw new ISE(
+            "Max number of retries[%d] exceeded for Task[%s]. Failing.",
+            retryCount,
+            taskMessage,
+            lastException
+        );
+      } else {
+        throw new ISE(
+            "Max number of retries[%d] exceeded for Task[%s]. Failing.",
+            retryCount,
+            taskMessage
+        );
+      }
     }
   }
 


### PR DESCRIPTION
The  current `ITRetryUtil` class stops retrying if the provided lambda encounters an exception. This behavior causes false positives in some tests (such as `it-kafka-data-format`). After this PR it will continue retrying until the retry count is hit. In this case, it remembers and propagates the last exception. So if an exception is due to transient conditions then it may succeed and no false positive failure will be reported.
