### PR TITLE
Fix ClassCastException in movingAverage

### DIFF
--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryRunner.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryRunner.java
@@ -55,7 +55,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 /**
@@ -123,11 +122,11 @@ public class MovingAverageQueryRunner implements QueryRunner<Row>
       GroupByQuery gbq = builder.build();
 
       ResponseContext gbqResponseContext = ResponseContext.createEmpty();
+      gbqResponseContext.merge(responseContext);
       gbqResponseContext.put(
           ResponseContext.Key.QUERY_FAIL_DEADLINE_MILLIS,
           System.currentTimeMillis() + QueryContexts.getTimeout(gbq)
       );
-      gbqResponseContext.put(ResponseContext.Key.QUERY_TOTAL_BYTES_GATHERED, new AtomicLong());
 
       Sequence<ResultRow> results = gbq.getRunner(walker).run(QueryPlus.wrap(gbq), gbqResponseContext);
       try {
@@ -164,11 +163,11 @@ public class MovingAverageQueryRunner implements QueryRunner<Row>
           maq.getContext()
       );
       ResponseContext tsqResponseContext = ResponseContext.createEmpty();
+      tsqResponseContext.merge(responseContext);
       tsqResponseContext.put(
           ResponseContext.Key.QUERY_FAIL_DEADLINE_MILLIS,
           System.currentTimeMillis() + QueryContexts.getTimeout(tsq)
       );
-      tsqResponseContext.put(ResponseContext.Key.QUERY_TOTAL_BYTES_GATHERED, new AtomicLong());
 
       Sequence<Result<TimeseriesResultValue>> results = tsq.getRunner(walker).run(QueryPlus.wrap(tsq), tsqResponseContext);
       try {


### PR DESCRIPTION
Fixes #10799 

### Description

This PR fixes a ClassCastException in broker when issuing a moving average query. This exception appears after changes made in #10082  since 0.19.

In 10082, `REMAINING_RESPONSES_FROM_QUERY_SERVERS` is added to `ResponseContext` as a hash map

https://github.com/apache/druid/blob/3be8e29269f0865798840312a8475f9c2db7d0a7/server/src/main/java/org/apache/druid/client/DirectDruidClient.java#L121

And when a query is executed, the right server num is added to this hash map.

https://github.com/apache/druid/blob/3be8e29269f0865798840312a8475f9c2db7d0a7/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java#L217-L220

While for moving average query, it constructs a new ResponseContext object by itself and of course does not initialize such hash map object, when executing the code above, it triggers the exception.

This PR fixes the code in moving average by copying all objects in response context from caller to the response object it creates so that all initialization for response context won't be missed for such query.

For testing, it's better to add an integration test for this bug. Currently there's no IT integrated for community contributed extensions, I don't add the test but test this change on my computer.

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
