### PR TITLE
Improve IT job 79 ITNestedQueryPushDownTest integration test

### DIFF
--- a/integration-tests/k8s/tiny-cluster.yaml
+++ b/integration-tests/k8s/tiny-cluster.yaml
@@ -323,12 +323,12 @@ spec:
       replicas: 1
       runtime.properties: |
         druid.service=druid/middleManager
-        druid.worker.capacity=10
-        druid.indexer.runner.javaOpts=-server -XX:MaxDirectMemorySize=10240g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/druid/data/tmp -Dlog4j.debug -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=50 -XX:GCLogFileSize=10m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Xloggc:/druid/data/logs/peon.gc.%t.%p.log -XX:HeapDumpPath=/druid/data/logs/peon.%t.%p.hprof -Xms256m -Xmx256m
+        druid.worker.capacity=2
+        druid.indexer.runner.javaOpts=-server -Xms128m -Xmx128m -XX:MaxDirectMemorySize=256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/druid/data/tmp -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
         druid.indexer.task.baseTaskDir=/druid/data/baseTaskDir
         druid.server.http.numThreads=10
-        druid.indexer.fork.property.druid.processing.buffer.sizeBytes=268435456
-        druid.indexer.fork.property.druid.processing.numMergeBuffers=1
+        druid.indexer.fork.property.druid.processing.buffer.sizeBytes=25000000
+        druid.indexer.fork.property.druid.processing.numMergeBuffers=2
         druid.indexer.fork.property.druid.processing.numThreads=1
       extra.jvm.options: |-
         -Xmx64m

--- a/integration-tests/k8s/tiny-cluster.yaml
+++ b/integration-tests/k8s/tiny-cluster.yaml
@@ -331,8 +331,8 @@ spec:
         druid.indexer.fork.property.druid.processing.numMergeBuffers=1
         druid.indexer.fork.property.druid.processing.numThreads=1
       extra.jvm.options: |-
-        -Xmx256m
-        -Xms256m
+        -Xmx64m
+        -Xms64m
       volumeMounts:
         - mountPath: /druid/data
           name: data-volume
@@ -342,6 +342,6 @@ spec:
             path: REPLACE_VOLUMES/tmp
       resources:
         requests:
-          memory: "3G"
+          memory: "1G"
         limits:
-          memory: "3G"
+          memory: "1G"

--- a/integration-tests/script/setup_druid_on_k8s.sh
+++ b/integration-tests/script/setup_druid_on_k8s.sh
@@ -44,7 +44,7 @@ sed -i "s|REPLACE_VOLUMES|`pwd`|g" integration-tests/k8s/tiny-cluster.yaml
 $KUBECTL apply -f integration-tests/k8s/tiny-cluster.yaml
 
 # Wait a bit
-sleep 60
+sleep 180
 
 ## Debug And FastFail
 


### PR DESCRIPTION
### Description
Integrate Test Job 79 sometimes fails for the following reasons：
1. Many services are started through pods and take up many resources.
2. Service pods can't start up in 60s and test using this unhealthy cluster will be failed.

This PR change the memory request of MiddleManger from 3G to 1G
Also change sleep time from 60s to 120s

##### Key changed/added classes in this PR
 * `integration-tests/k8s/tiny-cluster.yaml`
 * `integration-tests/script/setup_druid_on_k8s.sh`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.