### PR TITLE
fix issue with empty array converting to string expression instead of string array

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
@@ -378,7 +378,7 @@ public abstract class ExprEval<T>
       return new String[]{null};
     } else {
       if (val != null) {
-        return val.toArray();
+        return new String[0];
       }
       return null;
     }

--- a/core/src/test/java/org/apache/druid/math/expr/ExprEvalTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ExprEvalTest.java
@@ -273,6 +273,16 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     );
   }
 
+  @Test
+  public void testEmptyArrayFromList()
+  {
+    // empty arrays will materialize from JSON into an empty list, which coerce list to array will make into Object[]
+    // make sure we can handle it
+    ExprEval someEmptyArray = ExprEval.bestEffortOf(new ArrayList<>());
+    Assert.assertTrue(someEmptyArray.isArray());
+    Assert.assertEquals(0, someEmptyArray.asArray().length);
+  }
+
   private void assertExpr(int position, Object expected)
   {
     assertExpr(position, ExprEval.bestEffortOf(expected));


### PR DESCRIPTION
### Description
This PR fixes an issue with expression evaluation for array value bindings when input is provided by JSON deserialized values (rather than parsing a constant or provided by a column for example), such as when results are being merged on a broker.

The main issue is that an empty array result from a historical is later deserialized from JSON into an empty ArrayList, which `ExprEval.coerceListToArray` converts into `Object[0]`, but `ExprEval.bestEffortOf` is unable to handle this. This PR fixes the issue by treating this empty list as an empty string array (since string array is the default in the other cases of this method, as strings are traditionally the more flexible type in druid)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
