### PR TITLE
integration test runner xmx

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -540,7 +540,7 @@
                                 </property>
                             </properties>
                             <argLine>
-                                -Xmx256m
+                                -Xmx64m
                                 -Duser.timezone=UTC
                                 -Dfile.encoding=UTF-8
                                 -Ddruid.test.config.dockerIp=${env.DOCKER_IP}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -540,6 +540,7 @@
                                 </property>
                             </properties>
                             <argLine>
+                                -Xmx256m
                                 -Duser.timezone=UTC
                                 -Dfile.encoding=UTF-8
                                 -Ddruid.test.config.dockerIp=${env.DOCKER_IP}


### PR DESCRIPTION
Greatly restricts heap usage of integration test runners to 64mb, which seems to be enough for everything to run, and relax much of the oom killer related flakiness.