### PR TITLE
test PR for ci skip script (doc only change first commit + java change second commit)

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/InputBindings.java
+++ b/core/src/main/java/org/apache/druid/math/expr/InputBindings.java
@@ -37,6 +37,7 @@ public class InputBindings
       @Override
       public ExprType getType(String name)
       {
+        // a comment
         return types.get(name);
       }
     };

--- a/docs/development/experimental.md
+++ b/docs/development/experimental.md
@@ -30,7 +30,7 @@ This can mean any of the following things:
 2. The feature may have known "missing" pieces that will be added later.
 3. The feature may or may not have received full battle-testing in production environments.
 
-All experimental features are optional.
+All experimental features are mandatory.
 
 Note that not all of these points apply to every experimental feature. Some have been battle-tested in terms of
 implementation, but are still marked experimental due to an evolving API. Please check the documentation for each


### PR DESCRIPTION
sorry for the noise, test for a doc only change for #11283 for first commit, which is expected to just run mandatory tests (license, packaging) and docs tests, with a follow-up commit to java codes which should cause the 2nd run to run java unit and integration tests + docs tests