### PR TITLE
Add metrics for thread, pool, and realtime process.

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -62,6 +62,9 @@ Available Metrics
 |`query/segments/count`|This metric is not enabled by default. See the `QueryMetrics` Interface for reference regarding enabling this metric. Number of segments that will be touched by the query. In the broker, it makes a plan to distribute the query to realtime tasks and historicals based on a snapshot of segment distribution state. If there are some segments moved after this snapshot is created, certain historicals and realtime tasks can report those segments as missing to the broker. The broker will re-send the query to the new servers that serve those segments after move. In this case, those segments can be counted more than once in this metric.|Varies.|
 |`sqlQuery/time`|Milliseconds taken to complete a SQL query.|id, nativeQueryIds, dataSource, remoteAddress, success.|< 1s|
 |`sqlQuery/bytes`|number of bytes returned in SQL query response.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
+|`query/mergeBufferMaxNum`|Maximum number of merge buffers. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. |configuration value of `druid.processing.numMergeBuffers`|
+|`query/mergeBufferAvailNum`|Number of available merge buffers. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. |<= `query/mergeBufferMaxNum`|
+|`query/intermResultBufferAvailNum`|Number of available buffers used by intermediate query result. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. ||
 
 ### Historical
 
@@ -78,6 +81,12 @@ Available Metrics
 |`query/failed/count`|number of failed queries|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/mergeBufferMaxNum`|Maximum number of merge buffers. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. |configuration value of `druid.processing.numMergeBuffers`|
+|`query/mergeBufferAvailNum`|Number of available merge buffers. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. |<= `query/mergeBufferMaxNum`|
+|`query/intermResultBufferAvailNum`|Number of available buffers used by intermediate query result. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. ||
+|`thread/maxCount`|Number of Druid threads.| |configuration value of `druid.processing.numThreads`|
+|`thread/active`|Number of active Druid threads. | |< `thread/maxCount` |
+|`thread/task/pending`|Number of pending tasks in thread pool. | ||
 
 ### Real-time
 
@@ -88,9 +97,15 @@ Available Metrics
 |`segment/scan/pending`|Number of segments in queue waiting to be scanned.||Close to 0|
 |`query/count`|number of total queries|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/success/count`|number of queries successfully processed|This metric is only available if the QueryCountStatsMonitor module is included.||
-|`query/failed/count`|number of failed queries|This metric is only available if the QueryCountStatsMonitor module is included.||
-|`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
-|`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/failed/count`|number of failed queries|This metric is only available if `QueryCountStatsMonitor` module is included.||
+|`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if `QueryCountStatsMonitor` module is included.||
+|`query/timeout/count`|number of timed out queries.|This metric is only available if `QueryCountStatsMonitor` module is included.||
+|`query/mergeBufferMaxNum`|Maximum number of merge buffers. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. |configuration value of `druid.processing.numMergeBuffers`|
+|`query/mergeBufferAvailNum`|Number of available merge buffers. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. |<= `query/mergeBufferMaxNum`|
+|`query/intermResultBufferAvailNum`|Number of available buffers used by intermediate query result. |This metric is only available if `QueryBufferPoolStatsMonitor` module is included. ||
+|`thread/maxCount`|Number of Druid threads.| |configuration value of `druid.processing.numThreads`|
+|`thread/active`|Number of active Druid threads. | |< `thread/maxCount` |
+|`thread/task/pending`|Number of pending tasks in thread pool. | ||
 
 ### Jetty
 
@@ -178,6 +193,10 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/events/duplicate`|Number of events rejected because the events are duplicated.|dataSource, taskId, taskType.|0|
 |`ingest/events/processed`|Number of events successfully processed per emission period.|dataSource, taskId, taskType.|Equal to your # of events per emission period.|
 |`ingest/rows/output`|Number of Druid rows persisted.|dataSource, taskId, taskType.|Your # of events with rollup.|
+|`ingest/rows/inMemory`|Number of Druid rows currently in memory.|dataSource.|Your # of events with rollup that are currently in memory.|
+|`ingest/rows/MaxInMemory`|Max number of Druid rows configured to be in memory before triggering persistence.|dataSource.|maxRowsInMemory in tuningConfig.|
+|`ingest/bytes/inMemory`|Number of bytes of Druid rows currently in memory.|dataSource.|Bytes of your events with rollup that are currently in memory.|
+|`ingest/bytes/maxInMemory`|Max number of bytes of Druid rows configured to be in memory before triggering persistence.|dataSource.|maxBytesInMemory in tuningConfig.|
 |`ingest/persists/count`|Number of times persist occurred.|dataSource, taskId, taskType.|Depends on configuration.|
 |`ingest/persists/time`|Milliseconds spent doing intermediate persist.|dataSource, taskId, taskType.|Depends on configuration. Generally a few minutes at most.|
 |`ingest/persists/cpu`|Cpu time in Nanoseconds spent on doing intermediate persist.|dataSource, taskId, taskType.|Depends on configuration. Generally a few minutes at most.|

--- a/extensions-contrib/ambari-metrics-emitter/src/main/resources/defaultWhiteListMap.json
+++ b/extensions-contrib/ambari-metrics-emitter/src/main/resources/defaultWhiteListMap.json
@@ -11,6 +11,18 @@
   "ingest/rows/output": [
     "dataSource"
   ],
+  "ingest/rows/inMemory": [
+    "dataSource"
+  ],
+  "ingest/rows/maxInMemory": [
+    "dataSource"
+  ],
+  "ingest/bytes/inMemory": [
+    "dataSource"
+  ],
+  "ingest/bytes/maxInMemory": [
+    "dataSource"
+  ],
   "ingest/merge": [
     "dataSource"
   ],

--- a/extensions-contrib/graphite-emitter/src/main/resources/defaultWhiteListMap.json
+++ b/extensions-contrib/graphite-emitter/src/main/resources/defaultWhiteListMap.json
@@ -3,6 +3,10 @@
   "ingest/handoff/failed": [],
   "ingest/persists": [],
   "ingest/rows/output": [],
+  "ingest/rows/inMemory": [],
+  "ingest/rows/maxInMemory": [],
+  "ingest/bytes/inMemory": [],
+  "ingest/bytes/maxInMemory": [],
   "jvm/gc": [],
   "jvm/mem": [],
   "query/cpu/time": [

--- a/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
@@ -53,6 +53,9 @@
   "query/cache/total/averageBytes": [],
   "query/cache/total/timeouts": [],
   "query/cache/total/errors": [],
+  "query/mergeBufferMaxNum": [],
+  "query/mergeBufferAvailNum": [],
+  "query/intermResultBufferAvailNum": [],
   "ingest/events/thrownAway": [
     "dataSource"
   ],
@@ -66,6 +69,18 @@
     "dataSource"
   ],
   "ingest/rows/output": [
+    "dataSource"
+  ],
+  "ingest/rows/inMemory": [
+    "dataSource"
+  ],
+  "ingest/rows/maxInMemory": [
+    "dataSource"
+  ],
+  "ingest/bytes/inMemory": [
+    "dataSource"
+  ],
+  "ingest/bytes/maxInMemory": [
     "dataSource"
   ],
   "ingest/persists/count": [
@@ -179,6 +194,9 @@
     "dataSource"
   ],
   "segment/pendingDelete": [],
+  "thread/active": [],
+  "thread/task/pending": [],
+  "thread/maxCount" : [],
   "jvm/pool/committed": [],
   "jvm/pool/init": [],
   "jvm/pool/max": [],

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -38,12 +38,20 @@
   "query/cache/total/timeouts" : { "dimensions" : [], "type" : "gauge" },
   "query/cache/total/errors" : { "dimensions" : [], "type" : "gauge" },
 
+  "query/mergeBufferMaxNum" : { "dimensions" : [], "type" : "gauge"},
+  "query/mergeBufferAvailNum" : { "dimensions" : [], "type" : "gauge"},
+  "query/intermResultBufferAvailNum" : { "dimensions" : [], "type" : "gauge"},
+
   "ingest/events/thrownAway" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/events/unparseable" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/events/duplicate" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/events/processed" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/events/messageGap" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "ingest/rows/output" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "ingest/rows/inMemory" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "ingest/rows/maxInMemory" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "ingest/bytes/inMemory" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "ingest/bytes/maxInMemory" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "ingest/persists/count" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/persists/time" : { "dimensions" : ["dataSource"], "type" : "timer" },
   "ingest/persists/cpu" : { "dimensions" : ["dataSource"], "type" : "timer" },
@@ -95,6 +103,10 @@
   "segment/used" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" },
   "segment/usedPercent" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge", "convertRange" : true },
   "segment/pendingDelete" : { "dimensions" : [], "type" : "gauge"},
+
+  "thread/active" : { "dimensions" : [], "type" : "gauge"},
+  "thread/task/pending" : { "dimensions" : [], "type" : "gauge"},
+  "thread/maxCount" : { "dimensions" : [], "type" : "gauge"},
 
   "jvm/pool/committed" : { "dimensions" : ["poolKind", "poolName"], "type" : "gauge" },
   "jvm/pool/init" : { "dimensions" : ["poolKind", "poolName"], "type" : "gauge" },

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/stats/TaskRealtimeMetricsMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/stats/TaskRealtimeMetricsMonitor.java
@@ -104,6 +104,10 @@ public class TaskRealtimeMetricsMonitor extends AbstractMonitor
     emitter.emit(builder.build("ingest/events/duplicate", dedup));
 
     emitter.emit(builder.build("ingest/rows/output", metrics.rowOutput() - previousFireDepartmentMetrics.rowOutput()));
+    emitter.emit(builder.build("ingest/rows/inMemory", metrics.rowsInMemory()));
+    emitter.emit(builder.build("ingest/rows/maxInMemory", metrics.maxRowsInMemory()));
+    emitter.emit(builder.build("ingest/bytes/inMemory", metrics.bytesInMemory()));
+    emitter.emit(builder.build("ingest/bytes/maxInMemory", metrics.maxBytesInMemory()));
     emitter.emit(builder.build("ingest/persists/count", metrics.numPersists() - previousFireDepartmentMetrics.numPersists()));
     emitter.emit(builder.build("ingest/persists/time", metrics.persistTimeMillis() - previousFireDepartmentMetrics.persistTimeMillis()));
     emitter.emit(builder.build("ingest/persists/cpu", metrics.persistCpuTime() - previousFireDepartmentMetrics.persistCpuTime()));

--- a/processing/src/main/java/org/apache/druid/query/MetricsEmittingQueryProcessingPool.java
+++ b/processing/src/main/java/org/apache/druid/query/MetricsEmittingQueryProcessingPool.java
@@ -41,6 +41,9 @@ public class MetricsEmittingQueryProcessingPool extends ForwardingQueryProcessin
   {
     if (delegate() instanceof PrioritizedExecutorService) {
       emitter.emit(metricBuilder.build("segment/scan/pending", ((PrioritizedExecutorService) delegate()).getQueueSize()));
+      emitter.emit(metricBuilder.build("thread/active", ((PrioritizedExecutorService) delegate()).getActiveThreadCount()));
+      emitter.emit(metricBuilder.build("thread/task/pending", ((PrioritizedExecutorService) delegate()).getPendingTaskCount()));
+      emitter.emit(metricBuilder.build("thread/maxCount", ((PrioritizedExecutorService) delegate()).getMaxThreadCount()));
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/PrioritizedExecutorService.java
+++ b/processing/src/main/java/org/apache/druid/query/PrioritizedExecutorService.java
@@ -203,6 +203,21 @@ public class PrioritizedExecutorService extends AbstractExecutorService implemen
   {
     return delegateQueue.size();
   }
+
+  public int getMaxThreadCount()
+  {
+    return threadPoolExecutor.getMaximumPoolSize();
+  }
+
+  public int getActiveThreadCount()
+  {
+    return threadPoolExecutor.getActiveCount();
+  }
+
+  public long getPendingTaskCount()
+  {
+    return threadPoolExecutor.getTaskCount() - threadPoolExecutor.getCompletedTaskCount();
+  }
 }
 
 class PrioritizedListenableFutureTask<V> implements RunnableFuture<V>,

--- a/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
@@ -48,6 +48,10 @@ public class FireDepartmentMetrics
   private final AtomicLong messageMaxTimestamp = new AtomicLong(0);
   private final AtomicLong messageGap = new AtomicLong(0);
   private final AtomicLong messageProcessingCompletionTime = new AtomicLong(DEFAULT_PROCESSING_COMPLETION_TIME);
+  private final AtomicLong rowsInMemory = new AtomicLong(0);
+  private final AtomicLong bytesInMemory = new AtomicLong(0);
+  private final AtomicLong maxRowsInMemory = new AtomicLong(0);
+  private final AtomicLong maxBytesInMemory = new AtomicLong(0);
 
   public void incrementProcessed()
   {
@@ -151,6 +155,26 @@ public class FireDepartmentMetrics
     return messageProcessingCompletionTime.get();
   }
 
+  public void setRowsInMemory(long rowsInMemory)
+  {
+    this.rowsInMemory.set(rowsInMemory);
+  }
+
+  public void setBytesInMemory(long bytesInMemory)
+  {
+    this.bytesInMemory.set(bytesInMemory);
+  }
+
+  public void setMaxBytesInMemory(long maxBytesInMemory)
+  {
+    this.maxBytesInMemory.set(maxBytesInMemory);
+  }
+
+  public void setMaxRowsInMemory(long maxRowsInMemory)
+  {
+    this.maxRowsInMemory.set(maxRowsInMemory);
+  }
+
   public long processed()
   {
     return processedCount.get();
@@ -231,6 +255,26 @@ public class FireDepartmentMetrics
     return sinkCount.get();
   }
 
+  public long rowsInMemory()
+  {
+    return rowsInMemory.get();
+  }
+
+  public long bytesInMemory()
+  {
+    return bytesInMemory.get();
+  }
+
+  public long maxRowsInMemory()
+  {
+    return maxRowsInMemory.get();
+  }
+
+  public long maxBytesInMemory()
+  {
+    return maxBytesInMemory.get();
+  }
+
   public long messageMaxTimestamp()
   {
     return messageMaxTimestamp.get();
@@ -264,6 +308,10 @@ public class FireDepartmentMetrics
     retVal.messageProcessingCompletionTime.set(messageProcessingCompletionTime.get());
     retVal.messageProcessingCompletionTime.compareAndSet(DEFAULT_PROCESSING_COMPLETION_TIME, System.currentTimeMillis());
     retVal.messageGap.set(retVal.messageProcessingCompletionTime.get() - messageMaxTimestamp.get());
+    retVal.rowsInMemory.set(rowsInMemory.get());
+    retVal.bytesInMemory.set(bytesInMemory.get());
+    retVal.maxRowsInMemory.set(maxRowsInMemory.get());
+    retVal.maxBytesInMemory.set(maxBytesInMemory.get());
     return retVal;
   }
 }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -238,12 +238,14 @@ public class AppenderatorImpl implements Appenderator
     maxBytesTuningConfig = tuningConfig.getMaxBytesInMemoryOrDefault();
     skipBytesInMemoryOverheadCheck = tuningConfig.isSkipBytesInMemoryOverheadCheck();
 
+    this.metrics.setMaxBytesInMemory(maxBytesTuningConfig);
+    this.metrics.setMaxRowsInMemory(tuningConfig.getMaxRowsInMemory());
+
     if (isOpenSegments) {
       log.info("Running open segments appenderator");
     } else {
       log.info("Running closed segments appenderator");
     }
-
   }
 
   @Override
@@ -325,8 +327,8 @@ public class AppenderatorImpl implements Appenderator
     }
 
     final int numAddedRows = sinkRowsInMemoryAfterAdd - sinkRowsInMemoryBeforeAdd;
-    rowsCurrentlyInMemory.addAndGet(numAddedRows);
-    bytesCurrentlyInMemory.addAndGet(bytesInMemoryAfterAdd - bytesInMemoryBeforeAdd);
+    metrics.setRowsInMemory(rowsCurrentlyInMemory.addAndGet(numAddedRows));
+    metrics.setBytesInMemory(bytesCurrentlyInMemory.addAndGet(bytesInMemoryAfterAdd - bytesInMemoryBeforeAdd));
     totalRows.addAndGet(numAddedRows);
 
     boolean isPersistRequired = false;

--- a/server/src/main/java/org/apache/druid/server/metrics/QueryBufferPoolStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/QueryBufferPoolStatsMonitor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import com.google.inject.Inject;
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.collections.DefaultBlockingPool;
+import org.apache.druid.collections.NonBlockingPool;
+import org.apache.druid.collections.StupidPool;
+import org.apache.druid.guice.annotations.Global;
+import org.apache.druid.guice.annotations.Merging;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.metrics.AbstractMonitor;
+
+import java.nio.ByteBuffer;
+
+public class QueryBufferPoolStatsMonitor extends AbstractMonitor
+{
+  private final BlockingPool<ByteBuffer> mergeBufferPool;
+  private final StupidPool<ByteBuffer> intermediateResultPool;
+
+  @Inject
+  public QueryBufferPoolStatsMonitor(
+      @Merging BlockingPool<ByteBuffer> mergeBufferPool,
+      @Global NonBlockingPool<ByteBuffer> intermediateResultPool
+  )
+  {
+    this.mergeBufferPool = mergeBufferPool;
+    this.intermediateResultPool = (StupidPool<ByteBuffer>) intermediateResultPool;
+  }
+
+  @Override
+  public boolean doMonitor(ServiceEmitter emitter)
+  {
+    int mergeBufferMaxNum = mergeBufferPool.maxSize();
+    emitter.emit(new ServiceMetricEvent.Builder().build("query/mergeBufferMaxNum", mergeBufferMaxNum));
+
+    int mergeBufferAvailNum = ((DefaultBlockingPool<ByteBuffer>) mergeBufferPool).getPoolSize();
+    emitter.emit(new ServiceMetricEvent.Builder().build("query/mergeBufferAvailNum", mergeBufferAvailNum));
+
+    long intermediateResultPoolSize = intermediateResultPool.poolSize();
+    emitter.emit(new ServiceMetricEvent.Builder().build("query/intermResultBufferAvailNum",
+                                                        intermediateResultPoolSize));
+
+    return true;
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/metrics/QueryBufferPoolStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/QueryBufferPoolStatsMonitorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import com.google.common.base.Supplier;
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.collections.DefaultBlockingPool;
+import org.apache.druid.collections.NonBlockingPool;
+import org.apache.druid.collections.StupidPool;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.apache.druid.offheap.OffheapBufferGenerator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QueryBufferPoolStatsMonitorTest
+{
+  private BlockingPool<ByteBuffer> mergeBufferPool;
+  private NonBlockingPool<ByteBuffer> intermediateResultPool;
+
+  @Before
+  public void setUp()
+  {
+    Supplier<ByteBuffer> generator = new OffheapBufferGenerator("test", 100);
+
+    mergeBufferPool = new DefaultBlockingPool<>(generator, 10);
+    mergeBufferPool.takeBatch(3);
+
+    intermediateResultPool = new StupidPool<>("intermediatePool", generator, 5, 6);
+    intermediateResultPool.take();
+  }
+
+  @Test
+  public void testMonitor()
+  {
+    final QueryBufferPoolStatsMonitor monitor = new QueryBufferPoolStatsMonitor(mergeBufferPool,
+                                                                                intermediateResultPool);
+    final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
+    monitor.doMonitor(emitter);
+    Map<String, Object> resultMap = emitter.getEvents()
+                                           .stream()
+                                           .collect(Collectors.toMap(
+                                               event -> (String) event.toMap().get("metric"),
+                                               event -> (Object) event.toMap().get("value")
+                                           ));
+    Assert.assertEquals(3, resultMap.size());
+    Assert.assertEquals(10, (int) resultMap.get("query/mergeBufferMaxNum"));
+    Assert.assertEquals(7, (int) resultMap.get("query/mergeBufferAvailNum"));
+    Assert.assertEquals(4L, (long) resultMap.get("query/intermResultBufferAvailNum"));
+  }
+}


### PR DESCRIPTION
### Description
Add metrics for druid thread usage, buffer pool usage, and realtime ingestion in-memory data status.

##### Key changed/added classes in this PR
 * `TaskRealtimeMetricsMonitor`
 * `MetricsEmittingExecutorService`
 *  `PrioritizedExecutorService`
 *  `FireDepartmentMetrics`
 *  `AppenderatorImpl`
 * `QueryBufferPoolStatsMonitor`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
