### PR TITLE
fix future control bug for taskClient.pause

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClient.java
@@ -39,12 +39,17 @@ import org.joda.time.Duration;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class SeekableStreamIndexTaskClient<PartitionIdType, SequenceOffsetType> extends IndexTaskClient
 {
   private static final EmittingLogger log = new EmittingLogger(SeekableStreamIndexTaskClient.class);
+
+  private Map<ListenableFuture<Map<PartitionIdType, SequenceOffsetType>>, PauseCallable> pauseFutureMap = new ConcurrentHashMap<>();
 
   public SeekableStreamIndexTaskClient(
       HttpClient httpClient,
@@ -97,70 +102,6 @@ public abstract class SeekableStreamIndexTaskClient<PartitionIdType, SequenceOff
     catch (NoTaskLocationException | IOException e) {
       log.warn(e, "Exception while stopping task [%s]", id);
       return false;
-    }
-  }
-
-  public Map<PartitionIdType, SequenceOffsetType> pause(final String id)
-  {
-    log.debug("Pause task[%s]", id);
-
-    try {
-      final StringFullResponseHolder response = submitRequestWithEmptyContent(
-          id,
-          HttpMethod.POST,
-          "pause",
-          null,
-          true
-      );
-
-      final HttpResponseStatus responseStatus = response.getStatus();
-      final String responseContent = response.getContent();
-
-      if (responseStatus.equals(HttpResponseStatus.OK)) {
-        log.info("Task [%s] paused successfully", id);
-        return deserializeMap(responseContent, Map.class, getPartitionType(), getSequenceType());
-      } else if (responseStatus.equals(HttpResponseStatus.ACCEPTED)) {
-        // The task received the pause request, but its status hasn't been changed yet.
-        while (true) {
-          final SeekableStreamIndexTaskRunner.Status status = getStatus(id);
-          if (status == SeekableStreamIndexTaskRunner.Status.PAUSED) {
-            return getCurrentOffsets(id, true);
-          }
-
-          final Duration delay = newRetryPolicy().getAndIncrementRetryDelay();
-          if (delay == null) {
-            throw new ISE(
-                "Task [%s] failed to change its status from [%s] to [%s], aborting",
-                id,
-                status,
-                SeekableStreamIndexTaskRunner.Status.PAUSED
-            );
-          } else {
-            final long sleepTime = delay.getMillis();
-            log.info(
-                "Still waiting for task [%s] to change its status to [%s]; will try again in [%s]",
-                id,
-                SeekableStreamIndexTaskRunner.Status.PAUSED,
-                new Duration(sleepTime).toString()
-            );
-            Thread.sleep(sleepTime);
-          }
-        }
-      } else {
-        throw new ISE(
-            "Pause request for task [%s] failed with response [%s] : [%s]",
-            id,
-            responseStatus,
-            responseContent
-        );
-      }
-    }
-    catch (NoTaskLocationException e) {
-      log.error("Exception [%s] while pausing Task [%s]", e.getMessage(), id);
-      return ImmutableMap.of();
-    }
-    catch (IOException | InterruptedException e) {
-      throw new RE(e, "Exception [%s] while pausing Task [%s]", e.getMessage(), id);
     }
   }
 
@@ -321,29 +262,71 @@ public abstract class SeekableStreamIndexTaskClient<PartitionIdType, SequenceOff
     return doAsync(() -> stop(id, publish));
   }
 
-
   public ListenableFuture<Boolean> resumeAsync(final String id)
   {
     return doAsync(() -> resume(id));
   }
-
 
   public ListenableFuture<DateTime> getStartTimeAsync(final String id)
   {
     return doAsync(() -> getStartTime(id));
   }
 
+  /**
+   * Not used. Only to compatible with test code
+   *
+   * @param id
+   * @return
+   */
+  public Map<PartitionIdType, SequenceOffsetType> pause(final String id)
+  {
+    PauseCallable pauseCallable = new PauseCallable(id);
+    return pauseCallable.call();
+  }
 
   public ListenableFuture<Map<PartitionIdType, SequenceOffsetType>> pauseAsync(final String id)
   {
-    return doAsync(() -> pause(id));
+    PauseCallable pauseCallable = new PauseCallable(id);
+    ListenableFuture<Map<PartitionIdType, SequenceOffsetType>> future = doAsync(pauseCallable);
+    pauseFutureMap.put(future, pauseCallable);
+    return future;
+  }
+
+  public void stopUnfinishedPauseTasks()
+  {
+    Iterator<Map.Entry<ListenableFuture<Map<PartitionIdType, SequenceOffsetType>>, PauseCallable>> iterator = pauseFutureMap.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Map.Entry<ListenableFuture<Map<PartitionIdType, SequenceOffsetType>>, PauseCallable> entry = iterator.next();
+      ListenableFuture<Map<PartitionIdType, SequenceOffsetType>> future = entry.getKey();
+      PauseCallable pauseCallable = entry.getValue();
+
+      if (!future.isDone()) {
+        this.stopTask(future, pauseCallable);
+        log.info("Stop unfinished pause task [%s]", pauseCallable.getTaskId());
+      } else {
+        log.info("Finished pause task [%s]", pauseCallable.getTaskId());
+      }
+
+      iterator.remove();
+    }
+  }
+
+  private void stopTask(ListenableFuture<Map<PartitionIdType, SequenceOffsetType>> future, PauseCallable pauseCallable)
+  {
+    pauseCallable.stop();
+
+    try {
+      future.get();
+    }
+    catch (Exception e) {
+      log.warn(e, "Future get() exception, taskId = %s", pauseCallable.getTaskId());
+    }
   }
 
   public ListenableFuture<Boolean> setEndOffsetsAsync(
       final String id,
       final Map<PartitionIdType, SequenceOffsetType> endOffsets,
-      final boolean finalize
-  )
+      final boolean finalize)
   {
     return doAsync(() -> setEndOffsets(id, endOffsets, finalize));
   }
@@ -376,6 +359,101 @@ public abstract class SeekableStreamIndexTaskClient<PartitionIdType, SequenceOff
   protected abstract Class<PartitionIdType> getPartitionType();
 
   protected abstract Class<SequenceOffsetType> getSequenceType();
+
+  private class PauseCallable implements Callable<Map<PartitionIdType, SequenceOffsetType>>
+  {
+    private String taskId;
+
+    private volatile boolean running = true;
+
+    public PauseCallable(String taskId)
+    {
+      this.taskId = taskId;
+    }
+
+    public String getTaskId()
+    {
+      return this.taskId;
+    }
+
+    public Map<PartitionIdType, SequenceOffsetType> pause()
+    {
+      log.info("Pause task[%s]", taskId);
+
+      try {
+        final StringFullResponseHolder response = submitRequestWithEmptyContent(
+                taskId,
+                HttpMethod.POST,
+                "pause",
+                null,
+                true
+        );
+
+        final HttpResponseStatus responseStatus = response.getStatus();
+        final String responseContent = response.getContent();
+
+        if (responseStatus.equals(HttpResponseStatus.OK)) {
+          log.info("Task [%s] paused successfully", taskId);
+          return deserializeMap(responseContent, Map.class, getPartitionType(), getSequenceType());
+        } else if (responseStatus.equals(HttpResponseStatus.ACCEPTED)) {
+          // The task received the pause request, but its status hasn't been changed yet.
+          while (this.running) {
+            final SeekableStreamIndexTaskRunner.Status status = getStatus(taskId);
+            if (status == SeekableStreamIndexTaskRunner.Status.PAUSED) {
+              return getCurrentOffsets(taskId, true);
+            }
+
+            final Duration delay = newRetryPolicy().getAndIncrementRetryDelay();
+            if (delay == null) {
+              throw new ISE(
+                      "Task [%s] failed to change its status from [%s] to [%s], aborting",
+                      taskId,
+                      status,
+                      SeekableStreamIndexTaskRunner.Status.PAUSED
+              );
+            } else {
+              final long sleepTime = delay.getMillis();
+              log.info(
+                      "Still waiting for task [%s] to change its status to [%s]; will try again in [%s]",
+                      taskId,
+                      SeekableStreamIndexTaskRunner.Status.PAUSED,
+                      new Duration(sleepTime).toString()
+              );
+              Thread.sleep(sleepTime);
+            }
+          }
+
+          log.info("Task [%s] pause timeout, force to be finished", taskId);
+          return ImmutableMap.of();
+        } else {
+          throw new ISE(
+                  "Pause request for task [%s] failed with response [%s] : [%s]",
+                  taskId,
+                  responseStatus,
+                  responseContent
+          );
+        }
+      }
+      catch (NoTaskLocationException e) {
+        log.error("Exception [%s] while pausing Task [%s]", e.getMessage(), taskId);
+        return ImmutableMap.of();
+      }
+      catch (IOException | InterruptedException e) {
+        throw new RE(e, "Exception [%s] while pausing Task [%s]", e.getMessage(), taskId);
+      }
+    }
+
+    public void stop()
+    {
+      this.running = false;
+    }
+
+    @Override
+    public Map<PartitionIdType, SequenceOffsetType> call()
+    {
+      return pause();
+    }
+  }
 }
 
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2527,7 +2527,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
   }
 
-  private void checkTaskDuration() throws ExecutionException, InterruptedException, TimeoutException
+  private void checkTaskDuration()
   {
     final List<ListenableFuture<Map<PartitionIdType, SequenceOffsetType>>> futures = new ArrayList<>();
     final List<Integer> futureGroupIds = new ArrayList<>();
@@ -2544,7 +2544,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         }
       }
 
-
       boolean stopTasksEarly = false;
       if (earlyStopTime != null && (earlyStopTime.isBeforeNow() || earlyStopTime.isEqualNow())) {
         log.info("Early stop requested - signalling tasks to complete");
@@ -2552,7 +2551,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         earlyStopTime = null;
         stopTasksEarly = true;
       }
-
 
       // if this task has run longer than the configured duration, signal all tasks in the group to persist
       if (earliestTaskStart.plus(ioConfig.getTaskDuration()).isBeforeNow() || stopTasksEarly) {
@@ -2562,60 +2560,84 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       }
     }
 
-    List<Map<PartitionIdType, SequenceOffsetType>> results = Futures.successfulAsList(futures)
-                                                                    .get(futureTimeoutInSeconds, TimeUnit.SECONDS);
-    for (int j = 0; j < results.size(); j++) {
-      Integer groupId = futureGroupIds.get(j);
-      TaskGroup group = activelyReadingTaskGroups.get(groupId);
-      Map<PartitionIdType, SequenceOffsetType> endOffsets = results.get(j);
+    try {
+      Futures.successfulAsList(futures).get(futureTimeoutInSeconds, TimeUnit.SECONDS);
+    }
+    catch (Exception e) {
+      log.warn(e, "Pause exception, GroupIds [%s]", Joiner.on(",").join(futureGroupIds));
+    }
+    finally {
+      for (int i = 0; i < futureGroupIds.size(); ++i) {
+        Integer groupId = futureGroupIds.get(i);
+        ListenableFuture<Map<PartitionIdType, SequenceOffsetType>> future = futures.get(i);
 
-      if (endOffsets != null) {
-        // set a timeout and put this group in pendingCompletionTaskGroups so that it can be monitored for completion
-        group.completionTimeout = DateTimes.nowUtc().plus(ioConfig.getCompletionTimeout());
-        pendingCompletionTaskGroups.computeIfAbsent(groupId, k -> new CopyOnWriteArrayList<>()).add(group);
+        if (future.isDone()) {
+          log.info("GroupId [%d] checking task finished", groupId);
 
-
-        boolean endOffsetsAreInvalid = false;
-        for (Entry<PartitionIdType, SequenceOffsetType> entry : endOffsets.entrySet()) {
-          if (entry.getValue().equals(getEndOfPartitionMarker())) {
-            log.info(
-                "Got end of partition marker for partition [%s] in checkTaskDuration, not updating partition offset.",
-                entry.getKey()
-            );
-            endOffsetsAreInvalid = true;
+          try {
+            this.moveGroupFromReadingToPending(groupId, future.get());
           }
-        }
-
-        // set endOffsets as the next startOffsets
-        // If we received invalid endOffset values, we clear the known offset to refetch the last committed offset
-        // from metadata. If any endOffset values are invalid, we treat the entire set as invalid as a safety measure.
-        if (!endOffsetsAreInvalid) {
-          for (Entry<PartitionIdType, SequenceOffsetType> entry : endOffsets.entrySet()) {
-            partitionOffsets.put(entry.getKey(), entry.getValue());
+          catch (Exception e1) {
+            log.warn(e1, "Get future result failed for groupId[%d]", groupId);
           }
         } else {
-          for (Entry<PartitionIdType, SequenceOffsetType> entry : endOffsets.entrySet()) {
-            partitionOffsets.put(entry.getKey(), getNotSetMarker());
-          }
-        }
-      } else {
-        for (String id : group.taskIds()) {
-          killTask(
-              id,
-              "All tasks in group [%s] failed to transition to publishing state",
-              groupId
-          );
-        }
-        // clear partitionGroups, so that latest sequences from db is used as start sequences not the stale ones
-        // if tasks did some successful incremental handoffs
-        for (PartitionIdType partitionId : group.startingSequences.keySet()) {
-          partitionOffsets.put(partitionId, getNotSetMarker());
+          log.warn("GroupId [%d] checking task not finished", groupId);
         }
       }
 
-      // remove this task group from the list of current task groups now that it has been handled
-      activelyReadingTaskGroups.remove(groupId);
+      taskClient.stopUnfinishedPauseTasks();
     }
+  }
+
+  private void moveGroupFromReadingToPending(Integer groupId, Map<PartitionIdType, SequenceOffsetType> endOffsets)
+  {
+    TaskGroup group = activelyReadingTaskGroups.get(groupId);
+
+    if (endOffsets != null) {
+      // set a timeout and put this group in pendingCompletionTaskGroups so that it can be monitored for completion
+      group.completionTimeout = DateTimes.nowUtc().plus(ioConfig.getCompletionTimeout());
+      pendingCompletionTaskGroups.computeIfAbsent(groupId, k -> new CopyOnWriteArrayList<>()).add(group);
+
+      boolean endOffsetsAreInvalid = false;
+      for (Entry<PartitionIdType, SequenceOffsetType> entry : endOffsets.entrySet()) {
+        if (entry.getValue().equals(getEndOfPartitionMarker())) {
+          log.info(
+              "Got end of partition marker for partition [%s] in checkTaskDuration, not updating partition offset.",
+              entry.getKey()
+          );
+          endOffsetsAreInvalid = true;
+        }
+      }
+
+      // set endOffsets as the next startOffsets
+      // If we received invalid endOffset values, we clear the known offset to refetch the last committed offset
+      // from metadata. If any endOffset values are invalid, we treat the entire set as invalid as a safety measure.
+      if (!endOffsetsAreInvalid) {
+        for (Entry<PartitionIdType, SequenceOffsetType> entry : endOffsets.entrySet()) {
+          partitionOffsets.put(entry.getKey(), entry.getValue());
+        }
+      } else {
+        for (Entry<PartitionIdType, SequenceOffsetType> entry : endOffsets.entrySet()) {
+          partitionOffsets.put(entry.getKey(), getNotSetMarker());
+        }
+      }
+    } else {
+      for (String id : group.taskIds()) {
+        killTask(
+            id,
+            "All tasks in group [%s] failed to transition to publishing state",
+            groupId
+        );
+      }
+      // clear partitionGroups, so that latest sequences from db is used as start sequences not the stale ones
+      // if tasks did some successful incremental handoffs
+      for (PartitionIdType partitionId : group.startingSequences.keySet()) {
+        partitionOffsets.put(partitionId, getNotSetMarker());
+      }
+    }
+
+    // remove this task group from the list of current task groups now that it has been handled
+    activelyReadingTaskGroups.remove(groupId);
   }
 
   private ListenableFuture<Map<PartitionIdType, SequenceOffsetType>> checkpointTaskGroup(


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
1. In our production system, a case like this:
For `org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor#checkTaskDuration()`, if the following code timeout happens, then pausing tasks in taskClient were still running. 
`List<Map<PartitionIdType, SequenceOffsetType>> results = Futures.successfulAsList(futures).get(futureTimeoutInSeconds, TimeUnit.SECONDS);`

But finally the pausing task finished normally, the groupId will not be moved from `activelyReadingTaskGroups` to `pendingCompletionTaskGroups`, because the code block after above code will not be executed.

Then next round `checkTaskDuration()` executed when the task has been PUBLISHING, "Can't pause exception" thrown.

2. Furthermore, if the wild pausing task executed in thread pool for long time, the bad result is unknown. So if `checkTaskDuraion()` reaches to end whether normally or abnormally, all pausing tasks should be finished.

3. Solution
1) In `SeekableStreamIndexTaskClient`, add some code to manage the pausing tasks, can submit and stop task.
2) In `SeekableStreamSupervisor`, If `checkTaskDuraion()` reaches to end, `taskClient` can ensure that all the pausing tasks are finished.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
1. SeeableStreamIndexTaskClient
[Class organization and design]
1) Add a class `PauseCallable`, implements from Callable,  to wrap the pausing task feature and provide `stop()` to trigger the pausing task can be finished.
2) Move `pause()` from `class SeeableStreamIndexTaskClient` to `class PauseCallable`

2. SeeableStreamIndexSupervisor
[Method organization and design]
1) Add a single method `moveGroupFromReadingToPending()` for each finished pausing task.
2) Add finally block in `checkTaskDuration()`, that ensures taskClient can control all the running tasks.

#### Renamed the class ...
[No]

#### Added a forbidden-apis entry ...
[No]

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor` (changed)
 * `org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskClient` (changed)


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ x] been self-reviewed.
   - [x ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
