### PR TITLE
Fix permission problems in docker

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -56,12 +56,13 @@ RUN addgroup -S -g 1000 druid \
 
 COPY --chown=druid:druid --from=builder /opt /opt
 COPY distribution/docker/druid.sh /druid.sh
-RUN mkdir /opt/druid/var \
- && chown druid:druid /opt/druid/var \
- && chmod 775 /opt/druid/var \
- && mkdir /opt/data \
- && chown druid:druid /opt/data \
- && chmod 775 /opt/data
+
+# create necessary directories which could be mounted as volume
+#   /opt/druid/var is used to keep individual files(e.g. log) of each Druid service
+#   /opt/shared is used to keep segments and task logs shared among Druid services
+RUN mkdir /opt/druid/var /opt/shared \
+ && chown druid:druid /opt/druid/var /opt/shared \
+ && chmod 775 /opt/druid/var /opt/shared
 
 USER druid
 VOLUME /opt/druid/var

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluat
       -Dexpression=project.version -DforceStdout=true \
     ) \
  && tar -zxf ./distribution/target/apache-druid-${VERSION}-bin.tar.gz -C /opt \
- && ln -s /opt/apache-druid-${VERSION} /opt/druid
+ && mv /opt/apache-druid-${VERSION} /opt/druid
 
 FROM amd64/busybox:1.30.0-glibc as busybox
 

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -58,7 +58,10 @@ COPY --chown=druid:druid --from=builder /opt /opt
 COPY distribution/docker/druid.sh /druid.sh
 RUN mkdir /opt/druid/var \
  && chown druid:druid /opt/druid/var \
- && chmod 775 /opt/druid/var
+ && chmod 775 /opt/druid/var \
+ && mkdir /opt/data \
+ && chown druid:druid /opt/data \
+ && chmod 775 /opt/data
 
 USER druid
 VOLUME /opt/druid/var

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -25,7 +25,7 @@ volumes:
   broker_var: {}
   coordinator_var: {}
   router_var: {}
-  druid_data: {}
+  druid_shared: {}
 
 
 services:
@@ -52,7 +52,7 @@ services:
     image: apache/druid:0.22.0
     container_name: coordinator
     volumes:
-      - druid_data:/opt/data
+      - druid_shared:/opt/shared
       - coordinator_var:/opt/druid/var
     depends_on: 
       - zookeeper
@@ -84,7 +84,7 @@ services:
     image: apache/druid:0.22.0
     container_name: historical
     volumes:
-      - druid_data:/opt/data
+      - druid_shared:/opt/shared
       - historical_var:/opt/druid/var
     depends_on: 
       - zookeeper
@@ -101,7 +101,7 @@ services:
     image: apache/druid:0.22.0
     container_name: middlemanager
     volumes:
-      - druid_data:/opt/data
+      - druid_shared:/opt/shared
       - middle_var:/opt/druid/var
     depends_on: 
       - zookeeper

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -25,6 +25,7 @@ volumes:
   broker_var: {}
   coordinator_var: {}
   router_var: {}
+  druid_data: {}
 
 
 services:
@@ -51,7 +52,7 @@ services:
     image: apache/druid:0.22.0
     container_name: coordinator
     volumes:
-      - ./storage:/opt/data
+      - druid_data:/opt/data
       - coordinator_var:/opt/druid/var
     depends_on: 
       - zookeeper
@@ -83,7 +84,7 @@ services:
     image: apache/druid:0.22.0
     container_name: historical
     volumes:
-      - ./storage:/opt/data
+      - druid_data:/opt/data
       - historical_var:/opt/druid/var
     depends_on: 
       - zookeeper
@@ -100,7 +101,7 @@ services:
     image: apache/druid:0.22.0
     container_name: middlemanager
     volumes:
-      - ./storage:/opt/data
+      - druid_data:/opt/data
       - middle_var:/opt/druid/var
     depends_on: 
       - zookeeper

--- a/distribution/docker/environment
+++ b/distribution/docker/environment
@@ -39,12 +39,12 @@ druid_metadata_storage_connector_password=FoolishPassword
 druid_coordinator_balancer_strategy=cachingCost
 
 druid_indexer_runner_javaOptsArray=["-server", "-Xmx1g", "-Xms1g", "-XX:MaxDirectMemorySize=3g", "-Duser.timezone=UTC", "-Dfile.encoding=UTF-8", "-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid_indexer_fork_property_druid_processing_buffer_sizeBytes=268435456
+druid_indexer_fork_property_druid_processing_buffer_sizeBytes=256MiB
 
 druid_storage_type=local
-druid_storage_storageDirectory=/opt/data/segments
+druid_storage_storageDirectory=/opt/shared/segments
 druid_indexer_logs_type=file
-druid_indexer_logs_directory=/opt/data/indexing-logs
+druid_indexer_logs_directory=/opt/shared/indexing-logs
 
 druid_processing_numThreads=2
 druid_processing_numMergeBuffers=2

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -36,9 +36,9 @@ The Druid source code contains [an example `docker-compose.yml`](https://github.
 
 ### Compose file
 
-The example `docker-compose.yml` will create a container for each Druid service, as well as Zookeeper and a PostgreSQL container as the metadata store. 
+The example `docker-compose.yml` will create a container for each Druid service, as well as ZooKeeper and a PostgreSQL container as the metadata store. 
 
-It will also create a named volumes `druid-data`, which is mounted as `opt/data` in container, as deep storage to keep and share segments and task logs among Druid services.
+It will also create a named volumes `druid_shared`, which is mounted as `opt/shared` in container, as deep storage to keep and share segments and task logs among Druid services.
 
 The Druid containers are configured via an [environment file](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/environment).
 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -89,14 +89,21 @@ From here you can follow along with the [Quickstart](./index.md#step-4-load-data
 > sudo docker exec --user root middlemanager chown druid:druid /opt/data
 > ```
 >
-> or use a named volume in docker-compose.yml by replacing all lines
+> or use a named volume in the docker-compose.yml by replacing all lines
 > ```
 > ./storage:/opt/data
 > ```
-> in the example docker-compose.yml to
+> to
 > ```
 > druid_data_storage:/opt/data
 > ```
+> and declare the named volume under the 'volumes' property as
+> ```
+> volumes:
+>   ...
+>   druid_data_storage: {}
+> ```
+> 
 
 ## Docker Memory Requirements
 If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6 GB may be a good place to start. 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -83,6 +83,5 @@ It takes a few seconds for all the Druid processes to fully start up. If you ope
 
 From here you can follow along with the [Quickstart](./index.md#step-4-load-data), or elaborate on your `docker-compose.yml` to add any additional external service dependencies as necessary.
 
-
 ## Docker Memory Requirements
-If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6 GB may be a good place to start.
+If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6 GB may be a good place to start. 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -79,5 +79,24 @@ It takes a few seconds for all the Druid processes to fully start up. If you ope
 
 From here you can follow along with the [Quickstart](./index.md#step-4-load-data), or elaborate on your `docker-compose.yml` to add any additional external service dependencies as necessary.
 
+> Note: The example docker-compose.yml mounts a local directory `distribution/docker/storage` for docker processes to keep Druid task logs and segments.
+>
+> On some Linux platforms, ingestion tasks won't success due to a permission problem of this directory.
+>
+> You could execute following command to set up permission correctly after launching the cluster
+>
+> ```
+> sudo docker exec --user root middlemanager chown druid:druid /opt/data
+> ```
+>
+> or use a named volume in docker-compose.yml by replacing all lines
+> ```
+> ./storage:/opt/data
+> ```
+> in the example docker-compose.yml to
+> ```
+> druid_data_storage:/opt/data
+> ```
+
 ## Docker Memory Requirements
 If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6 GB may be a good place to start. 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -36,7 +36,11 @@ The Druid source code contains [an example `docker-compose.yml`](https://github.
 
 ### Compose file
 
-The example `docker-compose.yml` will create a container for each Druid service, as well as Zookeeper and a PostgreSQL container as the metadata store. Deep storage will be a local directory, by default configured as `./storage` relative to your `docker-compose.yml` file, and will be mounted as `/opt/data` and shared between Druid containers which require access to deep storage. The Druid containers are configured via an [environment file](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/environment).
+The example `docker-compose.yml` will create a container for each Druid service, as well as Zookeeper and a PostgreSQL container as the metadata store. 
+
+It will also create a named volumes `druid-data`, which is mounted as `opt/data` in container, as deep storage to keep and share segments and task logs among Druid services.
+
+The Druid containers are configured via an [environment file](https://github.com/apache/druid/blob/{{DRUIDVERSION}}/distribution/docker/environment).
 
 ### Configuration
 
@@ -79,31 +83,6 @@ It takes a few seconds for all the Druid processes to fully start up. If you ope
 
 From here you can follow along with the [Quickstart](./index.md#step-4-load-data), or elaborate on your `docker-compose.yml` to add any additional external service dependencies as necessary.
 
-> Note: The example docker-compose.yml mounts a local directory `distribution/docker/storage` for docker processes to keep Druid task logs and segments.
->
-> On some Linux platforms, ingestion tasks won't success due to a permission problem of this directory.
->
-> You could execute following command to set up permission correctly after launching the cluster
->
-> ```
-> sudo docker exec --user root middlemanager chown druid:druid /opt/data
-> ```
->
-> or use a named volume in the docker-compose.yml by replacing all lines
-> ```
-> ./storage:/opt/data
-> ```
-> to
-> ```
-> druid_data_storage:/opt/data
-> ```
-> and declare the named volume under the 'volumes' property as
-> ```
-> volumes:
->   ...
->   druid_data_storage: {}
-> ```
-> 
 
 ## Docker Memory Requirements
-If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6 GB may be a good place to start. 
+If you experience any processes crashing with a 137 error code you likely don't have enough memory allocated to Docker. 6 GB may be a good place to start.


### PR DESCRIPTION
Fixes #11278 , #11298 

### Description

To fix 11278, `mv` instruction is used to replace original `ln` instruction to eliminate symlink so that the docker image works with AWS Fargate. This change has been verified with the help of @mattmassicotte , reporter of that issue.

To fix 11298, `/opt/shared` is created in the Dockerfile so that a named volume could be used in the docker-compose. And a named volume `druid_shared` is used to share segments and task log files among Druid services

Because the problems we have encountered are platform independent, I test these changes on 3 different platform following the steps below

### Test Steps
1. Execute command `docker volume prune` to clean up previous volumes 
2. Launch the example docker-compose
3. Start an ingestion task | Task Successes
4. Task successes

### Test Result
| Host OS | Host OS Version | Docker Versoin | Test Result |
|---|---|---|---|
| CentOS | 7.2.1511 | 20.10.6 | OK |
| Ubuntu | 20.04.2 | 20.10.2 | OK |
| macOS | 11.3 | 3.3.1 | OK |



This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
