### PR TITLE
Add integer parsing in HiLoQueryLaningStrategy

### DIFF
--- a/server/src/main/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategy.java
@@ -67,8 +67,12 @@ public class HiLoQueryLaningStrategy implements QueryLaningStrategy
   public <T> Optional<String> computeLane(QueryPlus<T> query, Set<SegmentServerSelector> segments)
   {
     final Query<T> theQuery = query.getQuery();
-    // QueryContexts.getPriority gives a default, since we are setting priority
-    final Integer priority = theQuery.getContextValue(QueryContexts.PRIORITY_KEY);
+    // QueryContexts.getPriority gives a default, but it can parse the value to integer. Before calling QueryContexts.getPriority
+    // we make sure that priority has been set.
+    Integer priority = null;
+    if (null != theQuery.getContextValue(QueryContexts.PRIORITY_KEY)) {
+      priority = QueryContexts.getPriority(theQuery);
+    }
     final String lane = theQuery.getContextValue(QueryContexts.LANE_KEY);
     if (lane == null && priority != null && priority < 0) {
       return Optional.of(LOW);

--- a/server/src/test/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategyTest.java
@@ -156,9 +156,27 @@ public class HiLoQueryLaningStrategyTest
   }
 
   @Test
+  public void testLaningInteractivePriority_String()
+  {
+    TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, "100")).build();
+    Assert.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+  }
+
+  @Test
   public void testLaningLowPriority()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, -1)).build();
+    Assert.assertTrue(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assert.assertEquals(
+        HiLoQueryLaningStrategy.LOW,
+        strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
+    );
+  }
+
+  @Test
+  public void testLaningLowPriority_String()
+  {
+    TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, "-1")).build();
     Assert.assertTrue(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
     Assert.assertEquals(
         HiLoQueryLaningStrategy.LOW,


### PR DESCRIPTION
We can get a classCastException in `org.apache.druid.server.scheduling.HiLoQueryLaningStrategy#computeLane` if the priority is set as string in query context

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
