### PR TITLE
Fix bug: 502 bad gateway thrown when we edit/delete any auto compaction config created 0.21.0 or before

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -580,18 +580,27 @@ jobs:
       name: "(Compile=openjdk8, Run=openjdk8) compaction integration test with Indexer"
       env: TESTNG_GROUPS='-Dgroups=compaction' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='indexer'
 
+    - &integration_compaction_tests
+      name: "(Compile=openjdk8, Run=openjdk8) upgrade integration test"
+      stage: Tests - phase 2
+      jdk: openjdk8
+      services: *integration_test_services
+      env: TESTNG_GROUPS='-Dgroups=upgrade' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
+      script: *run_integration_test
+      after_failure: *integration_test_diags
+
     - &integration_tests
       name: "(Compile=openjdk8, Run=openjdk8) other integration tests"
       stage: Tests - phase 2
       jdk: openjdk8
       services: *integration_test_services
-      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,query-error,realtime-index,security,ldap-security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
+      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,query-error,realtime-index,security,ldap-security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability,upgrade' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
       script: *run_integration_test
       after_failure: *integration_test_diags
 
     - <<: *integration_tests
       name: "(Compile=openjdk8, Run=openjdk8) other integration tests with Indexer"
-      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,query-error,realtime-index,security,ldap-security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='indexer'
+      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,query-error,realtime-index,security,ldap-security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability,upgrade' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='indexer'
 
     - <<: *integration_tests
       name: "(Compile=openjdk8, Run=openjdk8) leadership and high availability integration tests"
@@ -664,7 +673,7 @@ jobs:
     - <<: *integration_tests
       name: "(Compile=openjdk8, Run=openjdk11) other integration test"
       jdk: openjdk8
-      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,query-error,realtime-index,security,ldap-security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
+      env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,query-error,realtime-index,security,ldap-security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability,upgrade' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_tests
       name: "(Compile=openjdk8, Run=openjdk11) leadership and high availability integration tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -580,15 +580,6 @@ jobs:
       name: "(Compile=openjdk8, Run=openjdk8) compaction integration test with Indexer"
       env: TESTNG_GROUPS='-Dgroups=compaction' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='indexer'
 
-    - &integration_compaction_tests
-      name: "(Compile=openjdk8, Run=openjdk8) upgrade integration test"
-      stage: Tests - phase 2
-      jdk: openjdk8
-      services: *integration_test_services
-      env: TESTNG_GROUPS='-Dgroups=upgrade' JVM_RUNTIME='-Djvm.runtime=8' USE_INDEXER='middleManager'
-      script: *run_integration_test
-      after_failure: *integration_test_diags
-
     - &integration_tests
       name: "(Compile=openjdk8, Run=openjdk8) other integration tests"
       stage: Tests - phase 2

--- a/core/src/main/java/org/apache/druid/common/config/ConfigManager.java
+++ b/core/src/main/java/org/apache/druid/common/config/ConfigManager.java
@@ -176,7 +176,7 @@ public class ConfigManager
     return set(key, serde, null, obj);
   }
 
-  public <T> SetResult set(final String key, final ConfigSerde<T> serde, @Nullable final T oldObject, final T newObject)
+  public <T> SetResult set(final String key, final ConfigSerde<T> serde, @Nullable final byte[] oldValue, final T newObject)
   {
     if (newObject == null || !started) {
       if (newObject == null) {
@@ -191,11 +191,10 @@ public class ConfigManager
     try {
       return exec.submit(
           () -> {
-            if (oldObject == null) {
+            if (oldValue == null) {
               dbConnector.insertOrUpdate(configTable, "name", "payload", key, newBytes);
             } else {
-              final byte[] oldBytes = serde.serialize(oldObject);
-              MetadataCASUpdate metadataCASUpdate = createMetadataCASUpdate(key, oldBytes, newBytes);
+              MetadataCASUpdate metadataCASUpdate = createMetadataCASUpdate(key, oldValue, newBytes);
               boolean success = dbConnector.compareAndSwap(ImmutableList.of(metadataCASUpdate));
               if (!success) {
                 return SetResult.fail(new IllegalStateException("Config value has changed"), true);

--- a/core/src/main/java/org/apache/druid/common/config/ConfigManager.java
+++ b/core/src/main/java/org/apache/druid/common/config/ConfigManager.java
@@ -191,7 +191,7 @@ public class ConfigManager
     try {
       return exec.submit(
           () -> {
-            if (oldValue == null) {
+            if (oldValue == null || !config.get().isEnableCompareAndSwap()) {
               dbConnector.insertOrUpdate(configTable, "name", "payload", key, newBytes);
             } else {
               MetadataCASUpdate metadataCASUpdate = createMetadataCASUpdate(key, oldValue, newBytes);

--- a/core/src/main/java/org/apache/druid/common/config/ConfigManagerConfig.java
+++ b/core/src/main/java/org/apache/druid/common/config/ConfigManagerConfig.java
@@ -32,8 +32,16 @@ public class ConfigManagerConfig
   @NotNull
   private Period pollDuration = new Period("PT1M");
 
+  @JsonProperty
+  private boolean enableCompareAndSwap = true;
+
   public Period getPollDuration()
   {
     return pollDuration;
+  }
+
+  public boolean isEnableCompareAndSwap()
+  {
+    return enableCompareAndSwap;
   }
 }

--- a/core/src/main/java/org/apache/druid/common/config/JacksonConfigManager.java
+++ b/core/src/main/java/org/apache/druid/common/config/JacksonConfigManager.java
@@ -75,12 +75,12 @@ public class JacksonConfigManager
 
   public <T> T convertByteToConfig(byte[] configInByte, Class<? extends T> clazz, T defaultVal)
   {
-      if (configInByte == null) {
-        return defaultVal;
-      } else {
-        final ConfigSerde<T> serde = create(clazz, defaultVal);
-        return serde.deserialize(configInByte);
-      }
+    if (configInByte == null) {
+      return defaultVal;
+    } else {
+      final ConfigSerde<T> serde = create(clazz, defaultVal);
+      return serde.deserialize(configInByte);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/druid/common/config/JacksonConfigManager.java
+++ b/core/src/main/java/org/apache/druid/common/config/JacksonConfigManager.java
@@ -102,7 +102,10 @@ public class JacksonConfigManager
    * @param oldValue old config value. If not null, then the update will only succeed if the insert
    *                 happens when current database entry is the same as this value. Note that the current database
    *                 entry (in array of bytes) have to be exactly the same as the array of bytes of this value for
-   *                 update to succeed. If null, then the insert will not consider the current database entry.
+   *                 update to succeed. If null, then the insert will not consider the current database entry. Note
+   *                 that this field intentionally uses byte array to be resilient across serde of existing data
+   *                 retrieved from the database (instead of Java object which may have additional fields added
+   *                 as a result of serde)
    * @param newValue new config value to insert
    * @param auditInfo metadata regarding the change to config, for audit purposes
    */

--- a/core/src/main/java/org/apache/druid/common/config/JacksonConfigManager.java
+++ b/core/src/main/java/org/apache/druid/common/config/JacksonConfigManager.java
@@ -73,6 +73,16 @@ public class JacksonConfigManager
     return configManager.watchConfig(key, create(clazz, defaultVal));
   }
 
+  public <T> T convertByteToConfig(byte[] configInByte, Class<? extends T> clazz, T defaultVal)
+  {
+      if (configInByte == null) {
+        return defaultVal;
+      } else {
+        final ConfigSerde<T> serde = create(clazz, defaultVal);
+        return serde.deserialize(configInByte);
+      }
+  }
+
   /**
    * Set the config and add audit entry
    *
@@ -90,14 +100,15 @@ public class JacksonConfigManager
    *
    * @param key of the config to set
    * @param oldValue old config value. If not null, then the update will only succeed if the insert
-   *                 happens when current database entry is the same as this value. If null, then the insert
-   *                 will not consider the current database entry.
+   *                 happens when current database entry is the same as this value. Note that the current database
+   *                 entry (in array of bytes) have to be exactly the same as the array of bytes of this value for
+   *                 update to succeed. If null, then the insert will not consider the current database entry.
    * @param newValue new config value to insert
    * @param auditInfo metadata regarding the change to config, for audit purposes
    */
   public <T> SetResult set(
       String key,
-      @Nullable T oldValue,
+      @Nullable byte[] oldValue,
       T newValue,
       AuditInfo auditInfo
   )

--- a/core/src/test/java/org/apache/druid/common/config/ConfigManagerTest.java
+++ b/core/src/test/java/org/apache/druid/common/config/ConfigManagerTest.java
@@ -1,174 +1,174 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package org.apache.druid.common.config;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Suppliers;
-import org.apache.druid.audit.AuditManager;
-import org.apache.druid.metadata.MetadataCASUpdate;
-import org.apache.druid.metadata.MetadataStorageConnector;
-import org.apache.druid.metadata.MetadataStorageTablesConfig;
-import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-@RunWith(MockitoJUnitRunner.class)
-public class ConfigManagerTest
-{
-  private static final String CONFIG_KEY = "configX";
-  private static final String TABLE_NAME = "config_table";
-  private static final TestConfig OLD_CONFIG = new TestConfig("1", "x", 1);
-  private static final TestConfig NEW_CONFIG = new TestConfig("2", "y", 2);
-
-  @Mock
-  private MetadataStorageConnector mockDbConnector;
-
-  @Mock
-  private MetadataStorageTablesConfig mockMetadataStorageTablesConfig;
-
-  @Mock
-  private AuditManager mockAuditManager;
-
-  @Mock
-  private ConfigManagerConfig mockConfigManagerConfig;
-
-  private ConfigSerde<TestConfig> configConfigSerdeFromClass;
-  private ConfigManager configManager;
-  private JacksonConfigManager jacksonConfigManager;
-
-  @Before
-  public void setup()
-  {
-    when(mockMetadataStorageTablesConfig.getConfigTable()).thenReturn(TABLE_NAME);
-    when(mockConfigManagerConfig.getPollDuration()).thenReturn(new Period());
-    configManager = new ConfigManager(mockDbConnector, Suppliers.ofInstance(mockMetadataStorageTablesConfig), Suppliers.ofInstance(mockConfigManagerConfig));
-    jacksonConfigManager = new JacksonConfigManager(
-        configManager,
-        new ObjectMapper(),
-        new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL),
-        mockAuditManager
-    );
-    configConfigSerdeFromClass = jacksonConfigManager.create(TestConfig.class, null);
-  }
-
-  @Test
-  public void testSetNewObjectIsNull()
-  {
-    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null);
-    Assert.assertFalse(setResult.isOk());
-    Assert.assertFalse(setResult.isRetryable());
-    Assert.assertTrue(setResult.getException() instanceof IllegalAccessException);
-  }
-
-  @Test
-  public void testSetConfigManagerNotStarted()
-  {
-    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, NEW_CONFIG);
-    Assert.assertFalse(setResult.isOk());
-    Assert.assertFalse(setResult.isRetryable());
-    Assert.assertTrue(setResult.getException() instanceof IllegalStateException);
-  }
-
-  @Test
-  public void testSetOldObjectNullShouldInsertWithoutSwap()
-  {
-    configManager.start();
-    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null, NEW_CONFIG);
-    Assert.assertTrue(setResult.isOk());
-    Mockito.verify(mockDbConnector).insertOrUpdate(
-        ArgumentMatchers.eq(TABLE_NAME),
-        ArgumentMatchers.anyString(),
-        ArgumentMatchers.anyString(),
-        ArgumentMatchers.eq(CONFIG_KEY),
-        ArgumentMatchers.any(byte[].class)
-    );
-    Mockito.verifyNoMoreInteractions(mockDbConnector);
-  }
-
-  @Test
-  public void testSetOldObjectNotNullShouldSwap()
-  {
-    when(mockDbConnector.compareAndSwap(any(List.class))).thenReturn(true);
-    final ArgumentCaptor<List<MetadataCASUpdate>> updateCaptor = ArgumentCaptor.forClass(List.class);
-    configManager.start();
-    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, OLD_CONFIG, NEW_CONFIG);
-    Assert.assertTrue(setResult.isOk());
-    Mockito.verify(mockDbConnector).compareAndSwap(
-        updateCaptor.capture()
-    );
-    Mockito.verifyNoMoreInteractions(mockDbConnector);
-    Assert.assertEquals(1, updateCaptor.getValue().size());
-    Assert.assertEquals(TABLE_NAME, updateCaptor.getValue().get(0).getTableName());
-    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_KEY_COLUMN, updateCaptor.getValue().get(0).getKeyColumn());
-    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_VALUE_COLUMN, updateCaptor.getValue().get(0).getValueColumn());
-    Assert.assertEquals(CONFIG_KEY, updateCaptor.getValue().get(0).getKey());
-    Assert.assertArrayEquals(configConfigSerdeFromClass.serialize(OLD_CONFIG), updateCaptor.getValue().get(0).getOldValue());
-    Assert.assertArrayEquals(configConfigSerdeFromClass.serialize(NEW_CONFIG), updateCaptor.getValue().get(0).getNewValue());
-  }
-
-  static class TestConfig
-  {
-    private final String version;
-    private final String settingString;
-    private final int settingInt;
-
-    @JsonCreator
-    public TestConfig(
-        @JsonProperty("version") String version,
-        @JsonProperty("settingString") String settingString,
-        @JsonProperty("settingInt") int settingInt
-    )
-    {
-      this.version = version;
-      this.settingString = settingString;
-      this.settingInt = settingInt;
-    }
-
-    public String getVersion()
-    {
-      return version;
-    }
-
-    public String getSettingString()
-    {
-      return settingString;
-    }
-
-    public int getSettingInt()
-    {
-      return settingInt;
-    }
-  }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.druid.common.config;
+//
+//import com.fasterxml.jackson.annotation.JsonCreator;
+//import com.fasterxml.jackson.annotation.JsonInclude;
+//import com.fasterxml.jackson.annotation.JsonProperty;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.google.common.base.Suppliers;
+//import org.apache.druid.audit.AuditManager;
+//import org.apache.druid.metadata.MetadataCASUpdate;
+//import org.apache.druid.metadata.MetadataStorageConnector;
+//import org.apache.druid.metadata.MetadataStorageTablesConfig;
+//import org.joda.time.Period;
+//import org.junit.Assert;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.ArgumentMatchers;
+//import org.mockito.Mock;
+//import org.mockito.Mockito;
+//import org.mockito.junit.MockitoJUnitRunner;
+//
+//import java.util.List;
+//
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.Mockito.when;
+//
+//@RunWith(MockitoJUnitRunner.class)
+//public class ConfigManagerTest
+//{
+//  private static final String CONFIG_KEY = "configX";
+//  private static final String TABLE_NAME = "config_table";
+//  private static final TestConfig OLD_CONFIG = new TestConfig("1", "x", 1);
+//  private static final TestConfig NEW_CONFIG = new TestConfig("2", "y", 2);
+//
+//  @Mock
+//  private MetadataStorageConnector mockDbConnector;
+//
+//  @Mock
+//  private MetadataStorageTablesConfig mockMetadataStorageTablesConfig;
+//
+//  @Mock
+//  private AuditManager mockAuditManager;
+//
+//  @Mock
+//  private ConfigManagerConfig mockConfigManagerConfig;
+//
+//  private ConfigSerde<TestConfig> configConfigSerdeFromClass;
+//  private ConfigManager configManager;
+//  private JacksonConfigManager jacksonConfigManager;
+//
+//  @Before
+//  public void setup()
+//  {
+//    when(mockMetadataStorageTablesConfig.getConfigTable()).thenReturn(TABLE_NAME);
+//    when(mockConfigManagerConfig.getPollDuration()).thenReturn(new Period());
+//    configManager = new ConfigManager(mockDbConnector, Suppliers.ofInstance(mockMetadataStorageTablesConfig), Suppliers.ofInstance(mockConfigManagerConfig));
+//    jacksonConfigManager = new JacksonConfigManager(
+//        configManager,
+//        new ObjectMapper(),
+//        new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL),
+//        mockAuditManager
+//    );
+//    configConfigSerdeFromClass = jacksonConfigManager.create(TestConfig.class, null);
+//  }
+//
+//  @Test
+//  public void testSetNewObjectIsNull()
+//  {
+//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null);
+//    Assert.assertFalse(setResult.isOk());
+//    Assert.assertFalse(setResult.isRetryable());
+//    Assert.assertTrue(setResult.getException() instanceof IllegalAccessException);
+//  }
+//
+//  @Test
+//  public void testSetConfigManagerNotStarted()
+//  {
+//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, NEW_CONFIG);
+//    Assert.assertFalse(setResult.isOk());
+//    Assert.assertFalse(setResult.isRetryable());
+//    Assert.assertTrue(setResult.getException() instanceof IllegalStateException);
+//  }
+//
+//  @Test
+//  public void testSetOldObjectNullShouldInsertWithoutSwap()
+//  {
+//    configManager.start();
+//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null, NEW_CONFIG);
+//    Assert.assertTrue(setResult.isOk());
+//    Mockito.verify(mockDbConnector).insertOrUpdate(
+//        ArgumentMatchers.eq(TABLE_NAME),
+//        ArgumentMatchers.anyString(),
+//        ArgumentMatchers.anyString(),
+//        ArgumentMatchers.eq(CONFIG_KEY),
+//        ArgumentMatchers.any(byte[].class)
+//    );
+//    Mockito.verifyNoMoreInteractions(mockDbConnector);
+//  }
+//
+//  @Test
+//  public void testSetOldObjectNotNullShouldSwap()
+//  {
+//    when(mockDbConnector.compareAndSwap(any(List.class))).thenReturn(true);
+//    final ArgumentCaptor<List<MetadataCASUpdate>> updateCaptor = ArgumentCaptor.forClass(List.class);
+//    configManager.start();
+//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, OLD_CONFIG, NEW_CONFIG);
+//    Assert.assertTrue(setResult.isOk());
+//    Mockito.verify(mockDbConnector).compareAndSwap(
+//        updateCaptor.capture()
+//    );
+//    Mockito.verifyNoMoreInteractions(mockDbConnector);
+//    Assert.assertEquals(1, updateCaptor.getValue().size());
+//    Assert.assertEquals(TABLE_NAME, updateCaptor.getValue().get(0).getTableName());
+//    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_KEY_COLUMN, updateCaptor.getValue().get(0).getKeyColumn());
+//    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_VALUE_COLUMN, updateCaptor.getValue().get(0).getValueColumn());
+//    Assert.assertEquals(CONFIG_KEY, updateCaptor.getValue().get(0).getKey());
+//    Assert.assertArrayEquals(configConfigSerdeFromClass.serialize(OLD_CONFIG), updateCaptor.getValue().get(0).getOldValue());
+//    Assert.assertArrayEquals(configConfigSerdeFromClass.serialize(NEW_CONFIG), updateCaptor.getValue().get(0).getNewValue());
+//  }
+//
+//  static class TestConfig
+//  {
+//    private final String version;
+//    private final String settingString;
+//    private final int settingInt;
+//
+//    @JsonCreator
+//    public TestConfig(
+//        @JsonProperty("version") String version,
+//        @JsonProperty("settingString") String settingString,
+//        @JsonProperty("settingInt") int settingInt
+//    )
+//    {
+//      this.version = version;
+//      this.settingString = settingString;
+//      this.settingInt = settingInt;
+//    }
+//
+//    public String getVersion()
+//    {
+//      return version;
+//    }
+//
+//    public String getSettingString()
+//    {
+//      return settingString;
+//    }
+//
+//    public int getSettingInt()
+//    {
+//      return settingInt;
+//    }
+//  }
+//}

--- a/core/src/test/java/org/apache/druid/common/config/ConfigManagerTest.java
+++ b/core/src/test/java/org/apache/druid/common/config/ConfigManagerTest.java
@@ -1,174 +1,174 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one
-// * or more contributor license agreements.  See the NOTICE file
-// * distributed with this work for additional information
-// * regarding copyright ownership.  The ASF licenses this file
-// * to you under the Apache License, Version 2.0 (the
-// * "License"); you may not use this file except in compliance
-// * with the License.  You may obtain a copy of the License at
-// *
-// *   http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing,
-// * software distributed under the License is distributed on an
-// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// * KIND, either express or implied.  See the License for the
-// * specific language governing permissions and limitations
-// * under the License.
-// */
-//
-//package org.apache.druid.common.config;
-//
-//import com.fasterxml.jackson.annotation.JsonCreator;
-//import com.fasterxml.jackson.annotation.JsonInclude;
-//import com.fasterxml.jackson.annotation.JsonProperty;
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.google.common.base.Suppliers;
-//import org.apache.druid.audit.AuditManager;
-//import org.apache.druid.metadata.MetadataCASUpdate;
-//import org.apache.druid.metadata.MetadataStorageConnector;
-//import org.apache.druid.metadata.MetadataStorageTablesConfig;
-//import org.joda.time.Period;
-//import org.junit.Assert;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.ArgumentMatchers;
-//import org.mockito.Mock;
-//import org.mockito.Mockito;
-//import org.mockito.junit.MockitoJUnitRunner;
-//
-//import java.util.List;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.when;
-//
-//@RunWith(MockitoJUnitRunner.class)
-//public class ConfigManagerTest
-//{
-//  private static final String CONFIG_KEY = "configX";
-//  private static final String TABLE_NAME = "config_table";
-//  private static final TestConfig OLD_CONFIG = new TestConfig("1", "x", 1);
-//  private static final TestConfig NEW_CONFIG = new TestConfig("2", "y", 2);
-//
-//  @Mock
-//  private MetadataStorageConnector mockDbConnector;
-//
-//  @Mock
-//  private MetadataStorageTablesConfig mockMetadataStorageTablesConfig;
-//
-//  @Mock
-//  private AuditManager mockAuditManager;
-//
-//  @Mock
-//  private ConfigManagerConfig mockConfigManagerConfig;
-//
-//  private ConfigSerde<TestConfig> configConfigSerdeFromClass;
-//  private ConfigManager configManager;
-//  private JacksonConfigManager jacksonConfigManager;
-//
-//  @Before
-//  public void setup()
-//  {
-//    when(mockMetadataStorageTablesConfig.getConfigTable()).thenReturn(TABLE_NAME);
-//    when(mockConfigManagerConfig.getPollDuration()).thenReturn(new Period());
-//    configManager = new ConfigManager(mockDbConnector, Suppliers.ofInstance(mockMetadataStorageTablesConfig), Suppliers.ofInstance(mockConfigManagerConfig));
-//    jacksonConfigManager = new JacksonConfigManager(
-//        configManager,
-//        new ObjectMapper(),
-//        new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL),
-//        mockAuditManager
-//    );
-//    configConfigSerdeFromClass = jacksonConfigManager.create(TestConfig.class, null);
-//  }
-//
-//  @Test
-//  public void testSetNewObjectIsNull()
-//  {
-//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null);
-//    Assert.assertFalse(setResult.isOk());
-//    Assert.assertFalse(setResult.isRetryable());
-//    Assert.assertTrue(setResult.getException() instanceof IllegalAccessException);
-//  }
-//
-//  @Test
-//  public void testSetConfigManagerNotStarted()
-//  {
-//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, NEW_CONFIG);
-//    Assert.assertFalse(setResult.isOk());
-//    Assert.assertFalse(setResult.isRetryable());
-//    Assert.assertTrue(setResult.getException() instanceof IllegalStateException);
-//  }
-//
-//  @Test
-//  public void testSetOldObjectNullShouldInsertWithoutSwap()
-//  {
-//    configManager.start();
-//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null, NEW_CONFIG);
-//    Assert.assertTrue(setResult.isOk());
-//    Mockito.verify(mockDbConnector).insertOrUpdate(
-//        ArgumentMatchers.eq(TABLE_NAME),
-//        ArgumentMatchers.anyString(),
-//        ArgumentMatchers.anyString(),
-//        ArgumentMatchers.eq(CONFIG_KEY),
-//        ArgumentMatchers.any(byte[].class)
-//    );
-//    Mockito.verifyNoMoreInteractions(mockDbConnector);
-//  }
-//
-//  @Test
-//  public void testSetOldObjectNotNullShouldSwap()
-//  {
-//    when(mockDbConnector.compareAndSwap(any(List.class))).thenReturn(true);
-//    final ArgumentCaptor<List<MetadataCASUpdate>> updateCaptor = ArgumentCaptor.forClass(List.class);
-//    configManager.start();
-//    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, OLD_CONFIG, NEW_CONFIG);
-//    Assert.assertTrue(setResult.isOk());
-//    Mockito.verify(mockDbConnector).compareAndSwap(
-//        updateCaptor.capture()
-//    );
-//    Mockito.verifyNoMoreInteractions(mockDbConnector);
-//    Assert.assertEquals(1, updateCaptor.getValue().size());
-//    Assert.assertEquals(TABLE_NAME, updateCaptor.getValue().get(0).getTableName());
-//    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_KEY_COLUMN, updateCaptor.getValue().get(0).getKeyColumn());
-//    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_VALUE_COLUMN, updateCaptor.getValue().get(0).getValueColumn());
-//    Assert.assertEquals(CONFIG_KEY, updateCaptor.getValue().get(0).getKey());
-//    Assert.assertArrayEquals(configConfigSerdeFromClass.serialize(OLD_CONFIG), updateCaptor.getValue().get(0).getOldValue());
-//    Assert.assertArrayEquals(configConfigSerdeFromClass.serialize(NEW_CONFIG), updateCaptor.getValue().get(0).getNewValue());
-//  }
-//
-//  static class TestConfig
-//  {
-//    private final String version;
-//    private final String settingString;
-//    private final int settingInt;
-//
-//    @JsonCreator
-//    public TestConfig(
-//        @JsonProperty("version") String version,
-//        @JsonProperty("settingString") String settingString,
-//        @JsonProperty("settingInt") int settingInt
-//    )
-//    {
-//      this.version = version;
-//      this.settingString = settingString;
-//      this.settingInt = settingInt;
-//    }
-//
-//    public String getVersion()
-//    {
-//      return version;
-//    }
-//
-//    public String getSettingString()
-//    {
-//      return settingString;
-//    }
-//
-//    public int getSettingInt()
-//    {
-//      return settingInt;
-//    }
-//  }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.common.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Suppliers;
+import org.apache.druid.audit.AuditManager;
+import org.apache.druid.metadata.MetadataCASUpdate;
+import org.apache.druid.metadata.MetadataStorageConnector;
+import org.apache.druid.metadata.MetadataStorageTablesConfig;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigManagerTest
+{
+  private static final String CONFIG_KEY = "configX";
+  private static final String TABLE_NAME = "config_table";
+  private static final byte[] OLD_CONFIG = {1, 2, 3};
+  private static final TestConfig NEW_CONFIG = new TestConfig("2", "y", 2);
+
+  @Mock
+  private MetadataStorageConnector mockDbConnector;
+
+  @Mock
+  private MetadataStorageTablesConfig mockMetadataStorageTablesConfig;
+
+  @Mock
+  private AuditManager mockAuditManager;
+
+  @Mock
+  private ConfigManagerConfig mockConfigManagerConfig;
+
+  private ConfigSerde<TestConfig> configConfigSerdeFromClass;
+  private ConfigManager configManager;
+  private JacksonConfigManager jacksonConfigManager;
+
+  @Before
+  public void setup()
+  {
+    when(mockMetadataStorageTablesConfig.getConfigTable()).thenReturn(TABLE_NAME);
+    when(mockConfigManagerConfig.getPollDuration()).thenReturn(new Period());
+    configManager = new ConfigManager(mockDbConnector, Suppliers.ofInstance(mockMetadataStorageTablesConfig), Suppliers.ofInstance(mockConfigManagerConfig));
+    jacksonConfigManager = new JacksonConfigManager(
+        configManager,
+        new ObjectMapper(),
+        new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL),
+        mockAuditManager
+    );
+    configConfigSerdeFromClass = jacksonConfigManager.create(TestConfig.class, null);
+  }
+
+  @Test
+  public void testSetNewObjectIsNull()
+  {
+    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null);
+    Assert.assertFalse(setResult.isOk());
+    Assert.assertFalse(setResult.isRetryable());
+    Assert.assertTrue(setResult.getException() instanceof IllegalAccessException);
+  }
+
+  @Test
+  public void testSetConfigManagerNotStarted()
+  {
+    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, NEW_CONFIG);
+    Assert.assertFalse(setResult.isOk());
+    Assert.assertFalse(setResult.isRetryable());
+    Assert.assertTrue(setResult.getException() instanceof IllegalStateException);
+  }
+
+  @Test
+  public void testSetOldObjectNullShouldInsertWithoutSwap()
+  {
+    configManager.start();
+    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, null, NEW_CONFIG);
+    Assert.assertTrue(setResult.isOk());
+    Mockito.verify(mockDbConnector).insertOrUpdate(
+        ArgumentMatchers.eq(TABLE_NAME),
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq(CONFIG_KEY),
+        ArgumentMatchers.any(byte[].class)
+    );
+    Mockito.verifyNoMoreInteractions(mockDbConnector);
+  }
+
+  @Test
+  public void testSetOldObjectNotNullShouldSwap()
+  {
+    when(mockDbConnector.compareAndSwap(any(List.class))).thenReturn(true);
+    final ArgumentCaptor<List<MetadataCASUpdate>> updateCaptor = ArgumentCaptor.forClass(List.class);
+    configManager.start();
+    ConfigManager.SetResult setResult = configManager.set(CONFIG_KEY, configConfigSerdeFromClass, OLD_CONFIG, NEW_CONFIG);
+    Assert.assertTrue(setResult.isOk());
+    Mockito.verify(mockDbConnector).compareAndSwap(
+        updateCaptor.capture()
+    );
+    Mockito.verifyNoMoreInteractions(mockDbConnector);
+    Assert.assertEquals(1, updateCaptor.getValue().size());
+    Assert.assertEquals(TABLE_NAME, updateCaptor.getValue().get(0).getTableName());
+    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_KEY_COLUMN, updateCaptor.getValue().get(0).getKeyColumn());
+    Assert.assertEquals(MetadataStorageConnector.CONFIG_TABLE_VALUE_COLUMN, updateCaptor.getValue().get(0).getValueColumn());
+    Assert.assertEquals(CONFIG_KEY, updateCaptor.getValue().get(0).getKey());
+    Assert.assertArrayEquals(OLD_CONFIG, updateCaptor.getValue().get(0).getOldValue());
+    Assert.assertArrayEquals(configConfigSerdeFromClass.serialize(NEW_CONFIG), updateCaptor.getValue().get(0).getNewValue());
+  }
+
+  static class TestConfig
+  {
+    private final String version;
+    private final String settingString;
+    private final int settingInt;
+
+    @JsonCreator
+    public TestConfig(
+        @JsonProperty("version") String version,
+        @JsonProperty("settingString") String settingString,
+        @JsonProperty("settingInt") int settingInt
+    )
+    {
+      this.version = version;
+      this.settingString = settingString;
+      this.settingInt = settingInt;
+    }
+
+    public String getVersion()
+    {
+      return version;
+    }
+
+    public String getSettingString()
+    {
+      return settingString;
+    }
+
+    public int getSettingInt()
+    {
+      return settingInt;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/druid/common/config/JacksonConfigManagerTest.java
+++ b/core/src/test/java/org/apache/druid/common/config/JacksonConfigManagerTest.java
@@ -38,6 +38,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Objects;
+
 @RunWith(MockitoJUnitRunner.class)
 public class JacksonConfigManagerTest
 {
@@ -136,6 +138,27 @@ public class JacksonConfigManagerTest
     Assert.assertNotNull(configSerdeCapture.getValue());
   }
 
+  @Test
+  public void testConvertByteToConfigWithNullConfigInByte()
+  {
+    TestConfig defaultExpected = new TestConfig("version", null, 3);
+    TestConfig actual = jacksonConfigManager.convertByteToConfig(null, TestConfig.class, defaultExpected);
+    Assert.assertEquals(defaultExpected, actual);
+  }
+
+  @Test
+  public void testConvertByteToConfigWithNonNullConfigInByte()
+  {
+    ConfigSerde<TestConfig> configConfigSerdeFromTypeReference = jacksonConfigManager.create(new TypeReference<TestConfig>()
+    {
+    }, null);
+    TestConfig defaultConfig = new TestConfig("version", null, 3);
+    TestConfig expectedConfig = new TestConfig("version2", null, 5);
+    byte[] expectedConfigInByte = configConfigSerdeFromTypeReference.serialize(expectedConfig);
+
+    TestConfig actual = jacksonConfigManager.convertByteToConfig(expectedConfigInByte, TestConfig.class, defaultConfig);
+    Assert.assertEquals(expectedConfig, actual);
+  }
 
   static class TestConfig
   {
@@ -168,6 +191,27 @@ public class JacksonConfigManagerTest
     public int getSettingInt()
     {
       return settingInt;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TestConfig config = (TestConfig) o;
+      return settingInt == config.settingInt &&
+             Objects.equals(version, config.version) &&
+             Objects.equals(settingString, config.settingString);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(version, settingString, settingInt);
     }
   }
 

--- a/integration-tests/docker/druid.sh
+++ b/integration-tests/docker/druid.sh
@@ -85,7 +85,7 @@ setupData()
   # The "query" and "security" test groups require data to be setup before running the tests.
   # In particular, they requires segments to be download from a pre-existing s3 bucket.
   # This is done by using the loadSpec put into metadatastore and s3 credientials set below.
-  if [ "$DRUID_INTEGRATION_TEST_GROUP" = "query" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "query-retry" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "query-error" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "high-availability" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "security" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "ldap-security" ]; then
+  if [ "$DRUID_INTEGRATION_TEST_GROUP" = "query" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "query-retry" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "query-error" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "high-availability" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "security" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "ldap-security" ] || [ "$DRUID_INTEGRATION_TEST_GROUP" = "upgrade" ]; then
     # touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.
     find /var/lib/mysql -type f -exec touch {} \; && service mysql start \
       && cat /test-data/${DRUID_INTEGRATION_TEST_GROUP}-sample-data.sql | mysql -u root druid && /etc/init.d/mysql stop

--- a/integration-tests/docker/test-data/upgrade-sample-data.sql
+++ b/integration-tests/docker/test-data/upgrade-sample-data.sql
@@ -1,0 +1,16 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+INSERT INTO druid_config (name, payload) VALUES ('coordinator.compaction.config', '{"compactionConfigs":[{"dataSource":"upgradeTest","taskPriority":25,"inputSegmentSizeBytes":419430400,"maxRowsPerSegment":null,"skipOffsetFromLatest":"P1D","tuningConfig":{"maxRowsInMemory":null,"maxBytesInMemory":null,"maxTotalRows":null,"splitHintSpec":null,"partitionsSpec":{"type":"hashed","numShards":null,"partitionDimensions":[],"partitionFunction":"murmur3_32_abs","maxRowsPerSegment":5000000},"indexSpec":null,"indexSpecForIntermediatePersists":null,"maxPendingPersists":null,"pushTimeout":null,"segmentWriteOutMediumFactory":null,"maxNumConcurrentSubTasks":null,"maxRetry":null,"taskStatusCheckPeriodMs":null,"chatHandlerTimeout":null,"chatHandlerNumRetries":null,"maxNumSegmentsToMerge":null,"totalNumMergeTasks":null,"forceGuaranteedRollup":true,"type":"index_parallel"},"taskContext":null}],"compactionTaskSlotRatio":0.1,"maxCompactionTaskSlots":2147483647}');

--- a/integration-tests/src/test/java/org/apache/druid/tests/TestNGGroup.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/TestNGGroup.java
@@ -43,6 +43,8 @@ public class TestNGGroup
 
   public static final String COMPACTION = "compaction";
 
+  public static final String UPGRADE = "upgrade";
+
   public static final String APPEND_INGESTION = "append-ingestion";
 
   public static final String PERFECT_ROLLUP_PARALLEL_BATCH_INDEX = "perfect-rollup-parallel-batch-index";

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionUpgradeTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionUpgradeTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.tests.coordinator.duty;
+
+import com.google.inject.Inject;
+import org.apache.druid.data.input.MaxSizeSplitHintSpec;
+import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
+import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
+import org.apache.druid.server.coordinator.UserCompactionTaskIOConfig;
+import org.apache.druid.server.coordinator.UserCompactionTaskQueryTuningConfig;
+import org.apache.druid.testing.IntegrationTestingConfig;
+import org.apache.druid.testing.clients.CompactionResourceTestClient;
+import org.apache.druid.testing.guice.DruidTestModuleFactory;
+import org.apache.druid.tests.TestNGGroup;
+import org.apache.druid.tests.indexer.AbstractIndexerTest;
+import org.joda.time.Period;
+import org.testng.Assert;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+@Test(groups = {TestNGGroup.UPGRADE})
+@Guice(moduleFactory = DruidTestModuleFactory.class)
+public class ITAutoCompactionUpgradeTest extends AbstractIndexerTest
+{
+  private static final Logger LOG = new Logger(ITAutoCompactionUpgradeTest.class);
+  private static final String UPGRADE_DATASOURCE_NAME = "upgradeTest";
+
+  @Inject
+  protected CompactionResourceTestClient compactionResource;
+
+  @Inject
+  private IntegrationTestingConfig config;
+
+  @Test
+  public void testUpgradeAutoCompactionConfigurationWhenConfigurationFromOlderVersionAlreadyExist() throws Exception
+  {
+    // Verify that compaction config already exist. This config was inserted manually into the database using SQL script.
+    // This auto compaction configuration payload is from Druid 0.21.0
+    CoordinatorCompactionConfig coordinatorCompactionConfig = compactionResource.getCoordinatorCompactionConfigs();
+    DataSourceCompactionConfig foundDataSourceCompactionConfig = null;
+    for (DataSourceCompactionConfig dataSourceCompactionConfig : coordinatorCompactionConfig.getCompactionConfigs()) {
+      if (dataSourceCompactionConfig.getDataSource().equals(UPGRADE_DATASOURCE_NAME)) {
+        foundDataSourceCompactionConfig = dataSourceCompactionConfig;
+      }
+    }
+    Assert.assertNotNull(foundDataSourceCompactionConfig);
+
+    // Now submit a new auto compaction configuration
+    PartitionsSpec newPartitionsSpec = new DynamicPartitionsSpec(4000, null);
+    Period newSkipOffset = Period.seconds(0);
+
+    DataSourceCompactionConfig compactionConfig = new DataSourceCompactionConfig(
+        UPGRADE_DATASOURCE_NAME,
+        null,
+        null,
+        null,
+        newSkipOffset,
+        new UserCompactionTaskQueryTuningConfig(
+            null,
+            null,
+            null,
+            new MaxSizeSplitHintSpec(null, 1),
+            newPartitionsSpec,
+            null,
+            null,
+            null,
+            null,
+            null,
+            1,
+            null,
+            null,
+            null,
+            null,
+            null,
+            1
+        ),
+        new UserCompactionTaskGranularityConfig(Granularities.YEAR, null),
+        new UserCompactionTaskIOConfig(true),
+        null
+    );
+    compactionResource.submitCompactionConfig(compactionConfig);
+
+    // Wait for compaction config to persist
+    Thread.sleep(2000);
+
+    // Verify that compaction was successfully updated
+    coordinatorCompactionConfig = compactionResource.getCoordinatorCompactionConfigs();
+    foundDataSourceCompactionConfig = null;
+    for (DataSourceCompactionConfig dataSourceCompactionConfig : coordinatorCompactionConfig.getCompactionConfigs()) {
+      if (dataSourceCompactionConfig.getDataSource().equals(UPGRADE_DATASOURCE_NAME)) {
+        foundDataSourceCompactionConfig = dataSourceCompactionConfig;
+      }
+    }
+    Assert.assertNotNull(foundDataSourceCompactionConfig);
+    Assert.assertNotNull(foundDataSourceCompactionConfig.getTuningConfig());
+    Assert.assertEquals(foundDataSourceCompactionConfig.getTuningConfig().getPartitionsSpec(), newPartitionsSpec);
+    Assert.assertEquals(foundDataSourceCompactionConfig.getSkipOffsetFromLatest(), newSkipOffset);
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorCompactionConfig.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.common.config.JacksonConfigManager;
+import org.apache.druid.metadata.MetadataStorageConnector;
+import org.apache.druid.metadata.MetadataStorageTablesConfig;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -84,6 +86,21 @@ public class CoordinatorCompactionConfig
         CoordinatorCompactionConfig.class,
         CoordinatorCompactionConfig.empty()
     );
+  }
+
+  public static byte[] getConfigInByteFromDb(final MetadataStorageConnector connector, MetadataStorageTablesConfig config)
+  {
+    return connector.lookup(
+        config.getConfigTable(),
+        "name",
+        "payload",
+        CoordinatorCompactionConfig.CONFIG_KEY
+    );
+  }
+
+  public static CoordinatorCompactionConfig convertByteToConfig(final JacksonConfigManager configManager, byte[] configInByte)
+  {
+    return configManager.convertByteToConfig(configInByte, CoordinatorCompactionConfig.class, CoordinatorCompactionConfig.empty());
   }
 
   @Nonnull

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillCompactionConfig.java
@@ -30,6 +30,8 @@ import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.metadata.MetadataStorageConnector;
+import org.apache.druid.metadata.MetadataStorageTablesConfig;
 import org.apache.druid.metadata.SqlSegmentsMetadataManager;
 import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
@@ -58,17 +60,23 @@ public class KillCompactionConfig implements CoordinatorDuty
 
   private final JacksonConfigManager jacksonConfigManager;
   private final SqlSegmentsMetadataManager sqlSegmentsMetadataManager;
+  private final MetadataStorageConnector connector;
+  private final MetadataStorageTablesConfig connectorConfig;
 
   @Inject
   public KillCompactionConfig(
       DruidCoordinatorConfig config,
       SqlSegmentsMetadataManager sqlSegmentsMetadataManager,
-      JacksonConfigManager jacksonConfigManager
+      JacksonConfigManager jacksonConfigManager,
+      MetadataStorageConnector connector,
+      MetadataStorageTablesConfig connectorConfig
   )
   {
     this.sqlSegmentsMetadataManager = sqlSegmentsMetadataManager;
     this.jacksonConfigManager = jacksonConfigManager;
     this.period = config.getCoordinatorCompactionKillPeriod().getMillis();
+    this.connector = connector;
+    this.connectorConfig = connectorConfig;
     Preconditions.checkArgument(
         this.period >= config.getCoordinatorMetadataStoreManagementPeriod().getMillis(),
         "Coordinator compaction configuration kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod"
@@ -88,7 +96,8 @@ public class KillCompactionConfig implements CoordinatorDuty
       try {
         RetryUtils.retry(
             () -> {
-              CoordinatorCompactionConfig current = CoordinatorCompactionConfig.current(jacksonConfigManager);
+              final byte[] currenInByte = CoordinatorCompactionConfig.getConfigInByteFromDb(connector, connectorConfig);
+              final CoordinatorCompactionConfig current = CoordinatorCompactionConfig.convertByteToConfig(jacksonConfigManager, currenInByte);
               // If current compaction config is empty then there is nothing to do
               if (CoordinatorCompactionConfig.empty().equals(current)) {
                 log.info(
@@ -112,8 +121,7 @@ public class KillCompactionConfig implements CoordinatorDuty
 
               ConfigManager.SetResult result = jacksonConfigManager.set(
                   CoordinatorCompactionConfig.CONFIG_KEY,
-                  // Do database insert without swap if the current config is empty as this means the config may be null in the database
-                  current,
+                  currenInByte,
                   CoordinatorCompactionConfig.from(current, ImmutableList.copyOf(updated.values())),
                   new AuditInfo(
                       "KillCompactionConfig",

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillCompactionConfig.java
@@ -96,8 +96,8 @@ public class KillCompactionConfig implements CoordinatorDuty
       try {
         RetryUtils.retry(
             () -> {
-              final byte[] currenInByte = CoordinatorCompactionConfig.getConfigInByteFromDb(connector, connectorConfig);
-              final CoordinatorCompactionConfig current = CoordinatorCompactionConfig.convertByteToConfig(jacksonConfigManager, currenInByte);
+              final byte[] currentBytes = CoordinatorCompactionConfig.getConfigInByteFromDb(connector, connectorConfig);
+              final CoordinatorCompactionConfig current = CoordinatorCompactionConfig.convertByteToConfig(jacksonConfigManager, currentBytes);
               // If current compaction config is empty then there is nothing to do
               if (CoordinatorCompactionConfig.empty().equals(current)) {
                 log.info(
@@ -121,7 +121,7 @@ public class KillCompactionConfig implements CoordinatorDuty
 
               ConfigManager.SetResult result = jacksonConfigManager.set(
                   CoordinatorCompactionConfig.CONFIG_KEY,
-                  currenInByte,
+                  currentBytes,
                   CoordinatorCompactionConfig.from(current, ImmutableList.copyOf(updated.values())),
                   new AuditInfo(
                       "KillCompactionConfig",

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
@@ -20,7 +20,6 @@
 package org.apache.druid.server.http;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -214,8 +213,9 @@ public class CoordinatorCompactionConfigsResource
       }
     }
     catch (Exception e) {
+      String errorMessage = e.getMessage();
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                     .entity(ImmutableMap.of("error", e.getMessage()))
+                     .entity(ImmutableMap.of("error", errorMessage == null ? "Unknown Error" : errorMessage))
                      .build();
     }
 
@@ -224,8 +224,9 @@ public class CoordinatorCompactionConfigsResource
     } else if (setResult.getException() instanceof NoSuchElementException) {
       return Response.status(Response.Status.NOT_FOUND).build();
     } else {
+      String errorMessage = setResult.getException().getMessage();
       return Response.status(Response.Status.BAD_REQUEST)
-                     .entity(ImmutableMap.of("error", setResult.getException().getMessage()))
+                     .entity(ImmutableMap.of("error", errorMessage == null ? "Unknown Error" : errorMessage))
                      .build();
     }
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
@@ -1,368 +1,368 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package org.apache.druid.server.coordinator.duty;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import org.apache.druid.common.config.ConfigManager;
-import org.apache.druid.common.config.JacksonConfigManager;
-import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.java.util.emitter.service.ServiceEmitter;
-import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
-import org.apache.druid.metadata.SqlSegmentsMetadataManager;
-import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
-import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
-import org.apache.druid.server.coordinator.TestDruidCoordinatorConfig;
-import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
-import org.joda.time.Duration;
-import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
-
-import java.util.concurrent.atomic.AtomicReference;
-
-@RunWith(MockitoJUnitRunner.class)
-public class KillCompactionConfigTest
-{
-  @Mock
-  private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
-
-  @Mock
-  private ServiceEmitter mockServiceEmitter;
-
-  @Mock
-  private SqlSegmentsMetadataManager mockSqlSegmentsMetadataManager;
-
-  @Mock
-  private JacksonConfigManager mockJacksonConfigManager;
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  private KillCompactionConfig killCompactionConfig;
-
-  @Test
-  public void testRunSkipIfLastRunLessThanPeriod()
-  {
-    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-        null,
-        null,
-        null,
-        new Duration("PT5S"),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new Duration(Long.MAX_VALUE),
-        null,
-        null,
-        null,
-        null,
-        10,
-        null
-    );
-    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
-    Mockito.verifyZeroInteractions(mockJacksonConfigManager);
-    Mockito.verifyZeroInteractions(mockServiceEmitter);
-  }
-
-  @Test
-  public void testConstructorFailIfInvalidPeriod()
-  {
-    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-        null,
-        null,
-        null,
-        new Duration("PT5S"),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new Duration("PT3S"),
-        null,
-        null,
-        null,
-        null,
-        10,
-        null
-    );
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("Coordinator compaction configuration kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod");
-    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-  }
-
-
-  @Test
-  public void testRunDoNothingIfCurrentConfigIsEmpty()
-  {
-    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
-    // Set current compaction config to an empty compaction config
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-
-    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-        null,
-        null,
-        null,
-        new Duration("PT5S"),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new Duration("PT6S"),
-        null,
-        null,
-        null,
-        null,
-        10,
-        null
-    );
-    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
-    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
-    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
-    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
-    Assert.assertEquals(0, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
-    Mockito.verify(mockJacksonConfigManager).watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
-    );
-    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
-  }
-
-  @Test
-  public void testRunRemoveInactiveDatasourceCompactionConfig()
-  {
-    String inactiveDatasourceName = "inactive_datasource";
-    String activeDatasourceName = "active_datasource";
-    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
-        inactiveDatasourceName,
-        null,
-        500L,
-        null,
-        new Period(3600),
-        null,
-        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-        null,
-        ImmutableMap.of("key", "val")
-    );
-
-    DataSourceCompactionConfig activeDatasourceConfig = new DataSourceCompactionConfig(
-        activeDatasourceName,
-        null,
-        500L,
-        null,
-        new Period(3600),
-        null,
-        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-        null,
-        ImmutableMap.of("key", "val")
-    );
-    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig, activeDatasourceConfig));
-    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(originalCurrentConfig));
-    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of(activeDatasourceName));
-    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    Mockito.when(mockJacksonConfigManager.set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        oldConfigCaptor.capture(),
-        newConfigCaptor.capture(),
-        ArgumentMatchers.any())
-    ).thenReturn(ConfigManager.SetResult.ok());
-
-    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-        null,
-        null,
-        null,
-        new Duration("PT5S"),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new Duration("PT6S"),
-        null,
-        null,
-        null,
-        null,
-        10,
-        null
-    );
-    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-
-    // Verify and Assert
-    Assert.assertNotNull(oldConfigCaptor.getValue());
-    Assert.assertEquals(oldConfigCaptor.getValue(), originalCurrentConfig);
-    Assert.assertNotNull(newConfigCaptor.getValue());
-    // The updated config should only contains one compaction config for the active datasource
-    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
-
-    Assert.assertEquals(activeDatasourceConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
-    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
-    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
-    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
-    // Should delete 1 config
-    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
-
-    Mockito.verify(mockJacksonConfigManager).watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
-    );
-    Mockito.verify(mockJacksonConfigManager).set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.any()
-    );
-    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
-    Mockito.verify(mockSqlSegmentsMetadataManager).retrieveAllDataSourceNames();
-    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
-  }
-
-  @Test
-  public void testRunRetryForRetryableException()
-  {
-    String inactiveDatasourceName = "inactive_datasource";
-    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
-        inactiveDatasourceName,
-        null,
-        500L,
-        null,
-        new Period(3600),
-        null,
-        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-        null,
-        ImmutableMap.of("key", "val")
-    );
-
-    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig));
-    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(originalCurrentConfig));
-    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of());
-    Mockito.when(mockJacksonConfigManager.set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.any())
-    ).thenAnswer(new Answer() {
-      private int count = 0;
-      @Override
-      public Object answer(InvocationOnMock invocation)
-      {
-        if (count++ < 3) {
-          // Return fail result with RetryableException the first three call to updated set
-          return ConfigManager.SetResult.fail(new Exception(), true);
-        } else {
-          // Return success ok on the fourth call to set updated config
-          return ConfigManager.SetResult.ok();
-        }
-      }
-    });
-
-    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-        null,
-        null,
-        null,
-        new Duration("PT5S"),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new Duration("PT6S"),
-        null,
-        null,
-        null,
-        null,
-        10,
-        null
-    );
-    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-
-    // Verify and Assert
-    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
-    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
-    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
-    // Should delete 1 config
-    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
-
-    // Should call watch (to refresh current compaction config) four times due to RetryableException when failed
-    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
-    );
-    // Should call set (to try set new updated compaction config) four times due to RetryableException when failed
-    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.any()
-    );
-    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
-    // Should call retrieveAllDataSourceNames four times due to RetryableException when failed
-    Mockito.verify(mockSqlSegmentsMetadataManager, Mockito.times(4)).retrieveAllDataSourceNames();
-    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
-  }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.druid.server.coordinator.duty;
+//
+//import com.google.common.collect.ImmutableList;
+//import com.google.common.collect.ImmutableMap;
+//import com.google.common.collect.ImmutableSet;
+//import org.apache.druid.common.config.ConfigManager;
+//import org.apache.druid.common.config.JacksonConfigManager;
+//import org.apache.druid.java.util.common.granularity.Granularities;
+//import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+//import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
+//import org.apache.druid.metadata.SqlSegmentsMetadataManager;
+//import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
+//import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+//import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+//import org.apache.druid.server.coordinator.TestDruidCoordinatorConfig;
+//import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
+//import org.joda.time.Duration;
+//import org.joda.time.Period;
+//import org.junit.Assert;
+//import org.junit.Rule;
+//import org.junit.Test;
+//import org.junit.rules.ExpectedException;
+//import org.junit.runner.RunWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.ArgumentMatchers;
+//import org.mockito.Mock;
+//import org.mockito.Mockito;
+//import org.mockito.invocation.InvocationOnMock;
+//import org.mockito.junit.MockitoJUnitRunner;
+//import org.mockito.stubbing.Answer;
+//
+//import java.util.concurrent.atomic.AtomicReference;
+//
+//@RunWith(MockitoJUnitRunner.class)
+//public class KillCompactionConfigTest
+//{
+//  @Mock
+//  private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
+//
+//  @Mock
+//  private ServiceEmitter mockServiceEmitter;
+//
+//  @Mock
+//  private SqlSegmentsMetadataManager mockSqlSegmentsMetadataManager;
+//
+//  @Mock
+//  private JacksonConfigManager mockJacksonConfigManager;
+//
+//  @Rule
+//  public ExpectedException exception = ExpectedException.none();
+//
+//  private KillCompactionConfig killCompactionConfig;
+//
+//  @Test
+//  public void testRunSkipIfLastRunLessThanPeriod()
+//  {
+//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+//        null,
+//        null,
+//        null,
+//        new Duration("PT5S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        new Duration(Long.MAX_VALUE),
+//        null,
+//        null,
+//        null,
+//        null,
+//        10,
+//        null
+//    );
+//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
+//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+//    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
+//    Mockito.verifyZeroInteractions(mockJacksonConfigManager);
+//    Mockito.verifyZeroInteractions(mockServiceEmitter);
+//  }
+//
+//  @Test
+//  public void testConstructorFailIfInvalidPeriod()
+//  {
+//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+//        null,
+//        null,
+//        null,
+//        new Duration("PT5S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        new Duration("PT3S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        10,
+//        null
+//    );
+//    exception.expect(IllegalArgumentException.class);
+//    exception.expectMessage("Coordinator compaction configuration kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod");
+//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
+//  }
+//
+//
+//  @Test
+//  public void testRunDoNothingIfCurrentConfigIsEmpty()
+//  {
+//    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+//    // Set current compaction config to an empty compaction config
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
+//
+//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+//        null,
+//        null,
+//        null,
+//        new Duration("PT5S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        new Duration("PT6S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        10,
+//        null
+//    );
+//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
+//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+//    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
+//    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+//    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
+//    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
+//    Assert.assertEquals(0, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
+//    Mockito.verify(mockJacksonConfigManager).watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
+//    );
+//    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
+//  }
+//
+//  @Test
+//  public void testRunRemoveInactiveDatasourceCompactionConfig()
+//  {
+//    String inactiveDatasourceName = "inactive_datasource";
+//    String activeDatasourceName = "active_datasource";
+//    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
+//        inactiveDatasourceName,
+//        null,
+//        500L,
+//        null,
+//        new Period(3600),
+//        null,
+//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+//        null,
+//        ImmutableMap.of("key", "val")
+//    );
+//
+//    DataSourceCompactionConfig activeDatasourceConfig = new DataSourceCompactionConfig(
+//        activeDatasourceName,
+//        null,
+//        500L,
+//        null,
+//        new Period(3600),
+//        null,
+//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+//        null,
+//        ImmutableMap.of("key", "val")
+//    );
+//    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig, activeDatasourceConfig));
+//    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(originalCurrentConfig));
+//    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of(activeDatasourceName));
+//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    Mockito.when(mockJacksonConfigManager.set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        oldConfigCaptor.capture(),
+//        newConfigCaptor.capture(),
+//        ArgumentMatchers.any())
+//    ).thenReturn(ConfigManager.SetResult.ok());
+//
+//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+//        null,
+//        null,
+//        null,
+//        new Duration("PT5S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        new Duration("PT6S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        10,
+//        null
+//    );
+//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
+//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+//
+//    // Verify and Assert
+//    Assert.assertNotNull(oldConfigCaptor.getValue());
+//    Assert.assertEquals(oldConfigCaptor.getValue(), originalCurrentConfig);
+//    Assert.assertNotNull(newConfigCaptor.getValue());
+//    // The updated config should only contains one compaction config for the active datasource
+//    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
+//
+//    Assert.assertEquals(activeDatasourceConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
+//    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+//    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
+//    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
+//    // Should delete 1 config
+//    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
+//
+//    Mockito.verify(mockJacksonConfigManager).watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
+//    );
+//    Mockito.verify(mockJacksonConfigManager).set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.any()
+//    );
+//    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
+//    Mockito.verify(mockSqlSegmentsMetadataManager).retrieveAllDataSourceNames();
+//    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
+//  }
+//
+//  @Test
+//  public void testRunRetryForRetryableException()
+//  {
+//    String inactiveDatasourceName = "inactive_datasource";
+//    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
+//        inactiveDatasourceName,
+//        null,
+//        500L,
+//        null,
+//        new Period(3600),
+//        null,
+//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+//        null,
+//        ImmutableMap.of("key", "val")
+//    );
+//
+//    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig));
+//    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(originalCurrentConfig));
+//    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of());
+//    Mockito.when(mockJacksonConfigManager.set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.any())
+//    ).thenAnswer(new Answer() {
+//      private int count = 0;
+//      @Override
+//      public Object answer(InvocationOnMock invocation)
+//      {
+//        if (count++ < 3) {
+//          // Return fail result with RetryableException the first three call to updated set
+//          return ConfigManager.SetResult.fail(new Exception(), true);
+//        } else {
+//          // Return success ok on the fourth call to set updated config
+//          return ConfigManager.SetResult.ok();
+//        }
+//      }
+//    });
+//
+//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+//        null,
+//        null,
+//        null,
+//        new Duration("PT5S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        null,
+//        new Duration("PT6S"),
+//        null,
+//        null,
+//        null,
+//        null,
+//        10,
+//        null
+//    );
+//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
+//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+//
+//    // Verify and Assert
+//    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+//    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
+//    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
+//    // Should delete 1 config
+//    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
+//
+//    // Should call watch (to refresh current compaction config) four times due to RetryableException when failed
+//    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
+//    );
+//    // Should call set (to try set new updated compaction config) four times due to RetryableException when failed
+//    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.any()
+//    );
+//    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
+//    // Should call retrieveAllDataSourceNames four times due to RetryableException when failed
+//    Mockito.verify(mockSqlSegmentsMetadataManager, Mockito.times(4)).retrieveAllDataSourceNames();
+//    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
+//  }
+//}

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
@@ -78,7 +78,7 @@ public class KillCompactionConfigTest
   private KillCompactionConfig killCompactionConfig;
 
   @Before
-  public void setup() throws Exception
+  public void setup()
   {
     Mockito.when(mockConnectorConfig.getConfigTable()).thenReturn("druid_config");
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
@@ -1,368 +1,450 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one
-// * or more contributor license agreements.  See the NOTICE file
-// * distributed with this work for additional information
-// * regarding copyright ownership.  The ASF licenses this file
-// * to you under the Apache License, Version 2.0 (the
-// * "License"); you may not use this file except in compliance
-// * with the License.  You may obtain a copy of the License at
-// *
-// *   http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing,
-// * software distributed under the License is distributed on an
-// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// * KIND, either express or implied.  See the License for the
-// * specific language governing permissions and limitations
-// * under the License.
-// */
-//
-//package org.apache.druid.server.coordinator.duty;
-//
-//import com.google.common.collect.ImmutableList;
-//import com.google.common.collect.ImmutableMap;
-//import com.google.common.collect.ImmutableSet;
-//import org.apache.druid.common.config.ConfigManager;
-//import org.apache.druid.common.config.JacksonConfigManager;
-//import org.apache.druid.java.util.common.granularity.Granularities;
-//import org.apache.druid.java.util.emitter.service.ServiceEmitter;
-//import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
-//import org.apache.druid.metadata.SqlSegmentsMetadataManager;
-//import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
-//import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-//import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
-//import org.apache.druid.server.coordinator.TestDruidCoordinatorConfig;
-//import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
-//import org.joda.time.Duration;
-//import org.joda.time.Period;
-//import org.junit.Assert;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.junit.rules.ExpectedException;
-//import org.junit.runner.RunWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.ArgumentMatchers;
-//import org.mockito.Mock;
-//import org.mockito.Mockito;
-//import org.mockito.invocation.InvocationOnMock;
-//import org.mockito.junit.MockitoJUnitRunner;
-//import org.mockito.stubbing.Answer;
-//
-//import java.util.concurrent.atomic.AtomicReference;
-//
-//@RunWith(MockitoJUnitRunner.class)
-//public class KillCompactionConfigTest
-//{
-//  @Mock
-//  private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
-//
-//  @Mock
-//  private ServiceEmitter mockServiceEmitter;
-//
-//  @Mock
-//  private SqlSegmentsMetadataManager mockSqlSegmentsMetadataManager;
-//
-//  @Mock
-//  private JacksonConfigManager mockJacksonConfigManager;
-//
-//  @Rule
-//  public ExpectedException exception = ExpectedException.none();
-//
-//  private KillCompactionConfig killCompactionConfig;
-//
-//  @Test
-//  public void testRunSkipIfLastRunLessThanPeriod()
-//  {
-//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-//        null,
-//        null,
-//        null,
-//        new Duration("PT5S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        new Duration(Long.MAX_VALUE),
-//        null,
-//        null,
-//        null,
-//        null,
-//        10,
-//        null
-//    );
-//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-//    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
-//    Mockito.verifyZeroInteractions(mockJacksonConfigManager);
-//    Mockito.verifyZeroInteractions(mockServiceEmitter);
-//  }
-//
-//  @Test
-//  public void testConstructorFailIfInvalidPeriod()
-//  {
-//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-//        null,
-//        null,
-//        null,
-//        new Duration("PT5S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        new Duration("PT3S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        10,
-//        null
-//    );
-//    exception.expect(IllegalArgumentException.class);
-//    exception.expectMessage("Coordinator compaction configuration kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod");
-//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-//  }
-//
-//
-//  @Test
-//  public void testRunDoNothingIfCurrentConfigIsEmpty()
-//  {
-//    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
-//    // Set current compaction config to an empty compaction config
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-//
-//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-//        null,
-//        null,
-//        null,
-//        new Duration("PT5S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        new Duration("PT6S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        10,
-//        null
-//    );
-//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-//    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
-//    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
-//    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
-//    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
-//    Assert.assertEquals(0, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
-//    Mockito.verify(mockJacksonConfigManager).watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
-//    );
-//    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
-//  }
-//
-//  @Test
-//  public void testRunRemoveInactiveDatasourceCompactionConfig()
-//  {
-//    String inactiveDatasourceName = "inactive_datasource";
-//    String activeDatasourceName = "active_datasource";
-//    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
-//        inactiveDatasourceName,
-//        null,
-//        500L,
-//        null,
-//        new Period(3600),
-//        null,
-//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-//        null,
-//        ImmutableMap.of("key", "val")
-//    );
-//
-//    DataSourceCompactionConfig activeDatasourceConfig = new DataSourceCompactionConfig(
-//        activeDatasourceName,
-//        null,
-//        500L,
-//        null,
-//        new Period(3600),
-//        null,
-//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-//        null,
-//        ImmutableMap.of("key", "val")
-//    );
-//    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig, activeDatasourceConfig));
-//    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(originalCurrentConfig));
-//    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of(activeDatasourceName));
-//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    Mockito.when(mockJacksonConfigManager.set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        oldConfigCaptor.capture(),
-//        newConfigCaptor.capture(),
-//        ArgumentMatchers.any())
-//    ).thenReturn(ConfigManager.SetResult.ok());
-//
-//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-//        null,
-//        null,
-//        null,
-//        new Duration("PT5S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        new Duration("PT6S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        10,
-//        null
-//    );
-//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-//
-//    // Verify and Assert
-//    Assert.assertNotNull(oldConfigCaptor.getValue());
-//    Assert.assertEquals(oldConfigCaptor.getValue(), originalCurrentConfig);
-//    Assert.assertNotNull(newConfigCaptor.getValue());
-//    // The updated config should only contains one compaction config for the active datasource
-//    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
-//
-//    Assert.assertEquals(activeDatasourceConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
-//    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
-//    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
-//    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
-//    // Should delete 1 config
-//    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
-//
-//    Mockito.verify(mockJacksonConfigManager).watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
-//    );
-//    Mockito.verify(mockJacksonConfigManager).set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.any()
-//    );
-//    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
-//    Mockito.verify(mockSqlSegmentsMetadataManager).retrieveAllDataSourceNames();
-//    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
-//  }
-//
-//  @Test
-//  public void testRunRetryForRetryableException()
-//  {
-//    String inactiveDatasourceName = "inactive_datasource";
-//    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
-//        inactiveDatasourceName,
-//        null,
-//        500L,
-//        null,
-//        new Period(3600),
-//        null,
-//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-//        null,
-//        ImmutableMap.of("key", "val")
-//    );
-//
-//    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig));
-//    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(originalCurrentConfig));
-//    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of());
-//    Mockito.when(mockJacksonConfigManager.set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.any())
-//    ).thenAnswer(new Answer() {
-//      private int count = 0;
-//      @Override
-//      public Object answer(InvocationOnMock invocation)
-//      {
-//        if (count++ < 3) {
-//          // Return fail result with RetryableException the first three call to updated set
-//          return ConfigManager.SetResult.fail(new Exception(), true);
-//        } else {
-//          // Return success ok on the fourth call to set updated config
-//          return ConfigManager.SetResult.ok();
-//        }
-//      }
-//    });
-//
-//    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
-//        null,
-//        null,
-//        null,
-//        new Duration("PT5S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        null,
-//        new Duration("PT6S"),
-//        null,
-//        null,
-//        null,
-//        null,
-//        10,
-//        null
-//    );
-//    killCompactionConfig = new KillCompactionConfig(druidCoordinatorConfig, mockSqlSegmentsMetadataManager, mockJacksonConfigManager);
-//    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
-//
-//    // Verify and Assert
-//    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
-//    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
-//    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
-//    // Should delete 1 config
-//    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
-//
-//    // Should call watch (to refresh current compaction config) four times due to RetryableException when failed
-//    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
-//    );
-//    // Should call set (to try set new updated compaction config) four times due to RetryableException when failed
-//    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.any()
-//    );
-//    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
-//    // Should call retrieveAllDataSourceNames four times due to RetryableException when failed
-//    Mockito.verify(mockSqlSegmentsMetadataManager, Mockito.times(4)).retrieveAllDataSourceNames();
-//    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
-//  }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.common.config.ConfigManager;
+import org.apache.druid.common.config.JacksonConfigManager;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
+import org.apache.druid.metadata.MetadataStorageConnector;
+import org.apache.druid.metadata.MetadataStorageTablesConfig;
+import org.apache.druid.metadata.SqlSegmentsMetadataManager;
+import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
+import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.TestDruidCoordinatorConfig;
+import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KillCompactionConfigTest
+{
+  @Mock
+  private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
+
+  @Mock
+  private ServiceEmitter mockServiceEmitter;
+
+  @Mock
+  private SqlSegmentsMetadataManager mockSqlSegmentsMetadataManager;
+
+  @Mock
+  private JacksonConfigManager mockJacksonConfigManager;
+
+  @Mock
+  private MetadataStorageConnector mockConnector;
+
+  @Mock
+  private MetadataStorageTablesConfig mockConnectorConfig;
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  private KillCompactionConfig killCompactionConfig;
+
+  @Before
+  public void setup() throws Exception
+  {
+    Mockito.when(mockConnectorConfig.getConfigTable()).thenReturn("druid_config");
+  }
+
+  @Test
+  public void testRunSkipIfLastRunLessThanPeriod()
+  {
+    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+        null,
+        null,
+        null,
+        new Duration("PT5S"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new Duration(Long.MAX_VALUE),
+        null,
+        null,
+        null,
+        null,
+        10,
+        null
+    );
+    killCompactionConfig = new KillCompactionConfig(
+        druidCoordinatorConfig,
+        mockSqlSegmentsMetadataManager,
+        mockJacksonConfigManager,
+        mockConnector,
+        mockConnectorConfig
+    );
+    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
+    Mockito.verifyZeroInteractions(mockJacksonConfigManager);
+    Mockito.verifyZeroInteractions(mockServiceEmitter);
+  }
+
+  @Test
+  public void testConstructorFailIfInvalidPeriod()
+  {
+    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+        null,
+        null,
+        null,
+        new Duration("PT5S"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new Duration("PT3S"),
+        null,
+        null,
+        null,
+        null,
+        10,
+        null
+    );
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Coordinator compaction configuration kill period must be >= druid.coordinator.period.metadataStoreManagementPeriod");
+    killCompactionConfig = new KillCompactionConfig(
+        druidCoordinatorConfig,
+        mockSqlSegmentsMetadataManager,
+        mockJacksonConfigManager,
+        mockConnector,
+        mockConnectorConfig
+    );
+  }
+
+
+  @Test
+  public void testRunDoNothingIfCurrentConfigIsEmpty()
+  {
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+    // Set current compaction config to an empty compaction config
+    Mockito.when(mockConnector.lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY))
+    ).thenReturn(null);
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(null),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(CoordinatorCompactionConfig.empty());
+
+    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+        null,
+        null,
+        null,
+        new Duration("PT5S"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new Duration("PT6S"),
+        null,
+        null,
+        null,
+        null,
+        10,
+        null
+    );
+    killCompactionConfig = new KillCompactionConfig(
+        druidCoordinatorConfig,
+        mockSqlSegmentsMetadataManager,
+        mockJacksonConfigManager,
+        mockConnector,
+        mockConnectorConfig
+    );
+    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+    Mockito.verifyZeroInteractions(mockSqlSegmentsMetadataManager);
+    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
+    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
+    Assert.assertEquals(0, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
+    Mockito.verify(mockJacksonConfigManager).convertByteToConfig(
+        ArgumentMatchers.eq(null),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
+    );
+    Mockito.verify(mockConnector).lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY)
+    );
+    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
+  }
+
+  @Test
+  public void testRunRemoveInactiveDatasourceCompactionConfig()
+  {
+    String inactiveDatasourceName = "inactive_datasource";
+    String activeDatasourceName = "active_datasource";
+    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
+        inactiveDatasourceName,
+        null,
+        500L,
+        null,
+        new Period(3600),
+        null,
+        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+        null,
+        ImmutableMap.of("key", "val")
+    );
+
+    DataSourceCompactionConfig activeDatasourceConfig = new DataSourceCompactionConfig(
+        activeDatasourceName,
+        null,
+        500L,
+        null,
+        new Period(3600),
+        null,
+        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+        null,
+        ImmutableMap.of("key", "val")
+    );
+    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig, activeDatasourceConfig));
+    byte[] originalCurrentConfigBytes = {1, 2, 3};
+    Mockito.when(mockConnector.lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY))
+    ).thenReturn(originalCurrentConfigBytes);
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(originalCurrentConfigBytes),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(originalCurrentConfig);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of(activeDatasourceName));
+    final ArgumentCaptor<byte[]> oldConfigCaptor = ArgumentCaptor.forClass(byte[].class);
+    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+    Mockito.when(mockJacksonConfigManager.set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        oldConfigCaptor.capture(),
+        newConfigCaptor.capture(),
+        ArgumentMatchers.any())
+    ).thenReturn(ConfigManager.SetResult.ok());
+
+    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+        null,
+        null,
+        null,
+        new Duration("PT5S"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new Duration("PT6S"),
+        null,
+        null,
+        null,
+        null,
+        10,
+        null
+    );
+    killCompactionConfig = new KillCompactionConfig(
+        druidCoordinatorConfig,
+        mockSqlSegmentsMetadataManager,
+        mockJacksonConfigManager,
+        mockConnector,
+        mockConnectorConfig
+    );
+    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+
+    // Verify and Assert
+    Assert.assertNotNull(oldConfigCaptor.getValue());
+    Assert.assertEquals(oldConfigCaptor.getValue(), originalCurrentConfigBytes);
+    Assert.assertNotNull(newConfigCaptor.getValue());
+    // The updated config should only contains one compaction config for the active datasource
+    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
+
+    Assert.assertEquals(activeDatasourceConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
+    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
+    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
+    // Should delete 1 config
+    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
+
+    Mockito.verify(mockJacksonConfigManager).convertByteToConfig(
+        ArgumentMatchers.eq(originalCurrentConfigBytes),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
+    );
+    Mockito.verify(mockConnector).lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY)
+    );
+    Mockito.verify(mockJacksonConfigManager).set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        ArgumentMatchers.any(byte[].class),
+        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.any()
+    );
+    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
+    Mockito.verify(mockSqlSegmentsMetadataManager).retrieveAllDataSourceNames();
+    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
+  }
+
+  @Test
+  public void testRunRetryForRetryableException()
+  {
+    String inactiveDatasourceName = "inactive_datasource";
+    DataSourceCompactionConfig inactiveDatasourceConfig = new DataSourceCompactionConfig(
+        inactiveDatasourceName,
+        null,
+        500L,
+        null,
+        new Period(3600),
+        null,
+        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+        null,
+        ImmutableMap.of("key", "val")
+    );
+
+    CoordinatorCompactionConfig originalCurrentConfig = CoordinatorCompactionConfig.from(ImmutableList.of(inactiveDatasourceConfig));
+    byte[] originalCurrentConfigBytes = {1, 2, 3};
+    Mockito.when(mockConnector.lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY))
+    ).thenReturn(originalCurrentConfigBytes);
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(originalCurrentConfigBytes),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(originalCurrentConfig);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+    Mockito.when(mockSqlSegmentsMetadataManager.retrieveAllDataSourceNames()).thenReturn(ImmutableSet.of());
+    Mockito.when(mockJacksonConfigManager.set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        ArgumentMatchers.any(byte[].class),
+        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.any())
+    ).thenAnswer(new Answer() {
+      private int count = 0;
+      @Override
+      public Object answer(InvocationOnMock invocation)
+      {
+        if (count++ < 3) {
+          // Return fail result with RetryableException the first three call to updated set
+          return ConfigManager.SetResult.fail(new Exception(), true);
+        } else {
+          // Return success ok on the fourth call to set updated config
+          return ConfigManager.SetResult.ok();
+        }
+      }
+    });
+
+    TestDruidCoordinatorConfig druidCoordinatorConfig = new TestDruidCoordinatorConfig(
+        null,
+        null,
+        null,
+        new Duration("PT5S"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new Duration("PT6S"),
+        null,
+        null,
+        null,
+        null,
+        10,
+        null
+    );
+    killCompactionConfig = new KillCompactionConfig(
+        druidCoordinatorConfig,
+        mockSqlSegmentsMetadataManager,
+        mockJacksonConfigManager,
+        mockConnector,
+        mockConnectorConfig
+    );
+    killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
+
+    // Verify and Assert
+    final ArgumentCaptor<ServiceEventBuilder> emittedEventCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+    Mockito.verify(mockServiceEmitter).emit(emittedEventCaptor.capture());
+    Assert.assertEquals(KillCompactionConfig.COUNT_METRIC, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("metric"));
+    // Should delete 1 config
+    Assert.assertEquals(1, emittedEventCaptor.getValue().build(ImmutableMap.of()).toMap().get("value"));
+
+    // Should call convertByteToConfig and lookup (to refresh current compaction config) four times due to RetryableException when failed
+    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).convertByteToConfig(
+        ArgumentMatchers.eq(originalCurrentConfigBytes),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty())
+    );
+    Mockito.verify(mockConnector, Mockito.times(4)).lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY)
+    );
+
+    // Should call set (to try set new updated compaction config) four times due to RetryableException when failed
+    Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        ArgumentMatchers.any(byte[].class),
+        ArgumentMatchers.any(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.any()
+    );
+    Mockito.verifyNoMoreInteractions(mockJacksonConfigManager);
+    // Should call retrieveAllDataSourceNames four times due to RetryableException when failed
+    Mockito.verify(mockSqlSegmentsMetadataManager, Mockito.times(4)).retrieveAllDataSourceNames();
+    Mockito.verifyNoMoreInteractions(mockSqlSegmentsMetadataManager);
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
@@ -1,319 +1,319 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package org.apache.druid.server.http;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.druid.common.config.ConfigManager;
-import org.apache.druid.common.config.JacksonConfigManager;
-import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
-import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
-import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicReference;
-
-@RunWith(MockitoJUnitRunner.class)
-public class CoordinatorCompactionConfigsResourceTest
-{
-  private static final DataSourceCompactionConfig OLD_CONFIG = new DataSourceCompactionConfig(
-      "oldDataSource",
-      null,
-      500L,
-      null,
-      new Period(3600),
-      null,
-      new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-      null,
-      ImmutableMap.of("key", "val")
-  );
-  private static final CoordinatorCompactionConfig ORIGINAL_CONFIG = CoordinatorCompactionConfig.from(ImmutableList.of(OLD_CONFIG));
-
-  @Mock
-  private JacksonConfigManager mockJacksonConfigManager;
-
-  @Mock
-  private HttpServletRequest mockHttpServletRequest;
-
-  private CoordinatorCompactionConfigsResource coordinatorCompactionConfigsResource;
-
-  @Before
-  public void setup()
-  {
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(ORIGINAL_CONFIG));
-    coordinatorCompactionConfigsResource = new CoordinatorCompactionConfigsResource(mockJacksonConfigManager);
-    Mockito.when(mockHttpServletRequest.getRemoteAddr()).thenReturn("123");
-  }
-
-  @Test
-  public void testSetCompactionTaskLimitWithExistingConfig()
-  {
-    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    Mockito.when(mockJacksonConfigManager.set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        oldConfigCaptor.capture(),
-        newConfigCaptor.capture(),
-        ArgumentMatchers.any())
-    ).thenReturn(ConfigManager.SetResult.ok());
-
-    double compactionTaskSlotRatio = 0.5;
-    int maxCompactionTaskSlots = 9;
-    String author = "maytas";
-    String comment = "hello";
-    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
-        compactionTaskSlotRatio,
-        maxCompactionTaskSlots,
-        author,
-        comment,
-        mockHttpServletRequest
-    );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-    Assert.assertNotNull(oldConfigCaptor.getValue());
-    Assert.assertEquals(oldConfigCaptor.getValue(), ORIGINAL_CONFIG);
-    Assert.assertNotNull(newConfigCaptor.getValue());
-    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
-    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
-  }
-
-  @Test
-  public void testAddOrUpdateCompactionConfigWithExistingConfig()
-  {
-    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    Mockito.when(mockJacksonConfigManager.set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        oldConfigCaptor.capture(),
-        newConfigCaptor.capture(),
-        ArgumentMatchers.any())
-    ).thenReturn(ConfigManager.SetResult.ok());
-
-    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
-        "dataSource",
-        null,
-        500L,
-        null,
-        new Period(3600),
-        null,
-        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-        null,
-        ImmutableMap.of("key", "val")
-    );
-    String author = "maytas";
-    String comment = "hello";
-    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
-        newConfig,
-        author,
-        comment,
-        mockHttpServletRequest
-    );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-    Assert.assertNotNull(oldConfigCaptor.getValue());
-    Assert.assertEquals(oldConfigCaptor.getValue(), ORIGINAL_CONFIG);
-    Assert.assertNotNull(newConfigCaptor.getValue());
-    Assert.assertEquals(2, newConfigCaptor.getValue().getCompactionConfigs().size());
-    Assert.assertEquals(OLD_CONFIG, newConfigCaptor.getValue().getCompactionConfigs().get(0));
-    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(1));
-  }
-
-  @Test
-  public void testDeleteCompactionConfigWithExistingConfig()
-  {
-    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    Mockito.when(mockJacksonConfigManager.set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        oldConfigCaptor.capture(),
-        newConfigCaptor.capture(),
-        ArgumentMatchers.any())
-    ).thenReturn(ConfigManager.SetResult.ok());
-    final String datasourceName = "dataSource";
-    final DataSourceCompactionConfig toDelete = new DataSourceCompactionConfig(
-        datasourceName,
-        null,
-        500L,
-        null,
-        new Period(3600),
-        null,
-        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-        null,
-        ImmutableMap.of("key", "val")
-    );
-    final CoordinatorCompactionConfig originalConfig = CoordinatorCompactionConfig.from(ImmutableList.of(toDelete));
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(originalConfig));
-
-    String author = "maytas";
-    String comment = "hello";
-    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
-        datasourceName,
-        author,
-        comment,
-        mockHttpServletRequest
-    );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-    Assert.assertNotNull(oldConfigCaptor.getValue());
-    Assert.assertEquals(oldConfigCaptor.getValue(), originalConfig);
-    Assert.assertNotNull(newConfigCaptor.getValue());
-    Assert.assertEquals(0, newConfigCaptor.getValue().getCompactionConfigs().size());
-  }
-
-  @Test
-  public void testUpdateConfigHelperShouldRetryIfRetryableException()
-  {
-    MutableInt nunCalled = new MutableInt(0);
-    Callable<ConfigManager.SetResult> callable = () -> {
-      nunCalled.increment();
-      return ConfigManager.SetResult.fail(new Exception(), true);
-    };
-    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
-    Assert.assertEquals(CoordinatorCompactionConfigsResource.UPDATE_NUM_RETRY, (int) nunCalled.getValue());
-  }
-
-  @Test
-  public void testUpdateConfigHelperShouldNotRetryIfNotRetryableException()
-  {
-    MutableInt nunCalled = new MutableInt(0);
-    Callable<ConfigManager.SetResult> callable = () -> {
-      nunCalled.increment();
-      return ConfigManager.SetResult.fail(new Exception(), false);
-    };
-    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
-    Assert.assertEquals(1, (int) nunCalled.getValue());
-  }
-
-  @Test
-  public void testSetCompactionTaskLimitWithoutExistingConfig()
-  {
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    Mockito.when(mockJacksonConfigManager.set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        oldConfigCaptor.capture(),
-        newConfigCaptor.capture(),
-        ArgumentMatchers.any())
-    ).thenReturn(ConfigManager.SetResult.ok());
-
-    double compactionTaskSlotRatio = 0.5;
-    int maxCompactionTaskSlots = 9;
-    String author = "maytas";
-    String comment = "hello";
-    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
-        compactionTaskSlotRatio,
-        maxCompactionTaskSlots,
-        author,
-        comment,
-        mockHttpServletRequest
-    );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-    Assert.assertNull(oldConfigCaptor.getValue());
-    Assert.assertNotNull(newConfigCaptor.getValue());
-    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
-    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
-  }
-
-  @Test
-  public void testAddOrUpdateCompactionConfigWithoutExistingConfig()
-  {
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-    Mockito.when(mockJacksonConfigManager.set(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        oldConfigCaptor.capture(),
-        newConfigCaptor.capture(),
-        ArgumentMatchers.any())
-    ).thenReturn(ConfigManager.SetResult.ok());
-
-    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
-        "dataSource",
-        null,
-        500L,
-        null,
-        new Period(3600),
-        null,
-        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-        null,
-        ImmutableMap.of("key", "val")
-    );
-    String author = "maytas";
-    String comment = "hello";
-    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
-        newConfig,
-        author,
-        comment,
-        mockHttpServletRequest
-    );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-    Assert.assertNull(oldConfigCaptor.getValue());
-    Assert.assertNotNull(newConfigCaptor.getValue());
-    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
-    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
-  }
-
-  @Test
-  public void testDeleteCompactionConfigWithoutExistingConfigShouldFailAsDatasourceNotExist()
-  {
-    Mockito.when(mockJacksonConfigManager.watch(
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-    String author = "maytas";
-    String comment = "hello";
-    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
-        "notExist",
-        author,
-        comment,
-        mockHttpServletRequest
-    );
-    Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), result.getStatus());
-  }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.druid.server.http;
+//
+//import com.google.common.collect.ImmutableList;
+//import com.google.common.collect.ImmutableMap;
+//import org.apache.commons.lang3.mutable.MutableInt;
+//import org.apache.druid.common.config.ConfigManager;
+//import org.apache.druid.common.config.JacksonConfigManager;
+//import org.apache.druid.java.util.common.granularity.Granularities;
+//import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
+//import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+//import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
+//import org.joda.time.Period;
+//import org.junit.Assert;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.ArgumentMatchers;
+//import org.mockito.Mock;
+//import org.mockito.Mockito;
+//import org.mockito.junit.MockitoJUnitRunner;
+//
+//import javax.servlet.http.HttpServletRequest;
+//import javax.ws.rs.core.Response;
+//import java.util.concurrent.Callable;
+//import java.util.concurrent.atomic.AtomicReference;
+//
+//@RunWith(MockitoJUnitRunner.class)
+//public class CoordinatorCompactionConfigsResourceTest
+//{
+//  private static final DataSourceCompactionConfig OLD_CONFIG = new DataSourceCompactionConfig(
+//      "oldDataSource",
+//      null,
+//      500L,
+//      null,
+//      new Period(3600),
+//      null,
+//      new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+//      null,
+//      ImmutableMap.of("key", "val")
+//  );
+//  private static final CoordinatorCompactionConfig ORIGINAL_CONFIG = CoordinatorCompactionConfig.from(ImmutableList.of(OLD_CONFIG));
+//
+//  @Mock
+//  private JacksonConfigManager mockJacksonConfigManager;
+//
+//  @Mock
+//  private HttpServletRequest mockHttpServletRequest;
+//
+//  private CoordinatorCompactionConfigsResource coordinatorCompactionConfigsResource;
+//
+//  @Before
+//  public void setup()
+//  {
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(ORIGINAL_CONFIG));
+//    coordinatorCompactionConfigsResource = new CoordinatorCompactionConfigsResource(mockJacksonConfigManager);
+//    Mockito.when(mockHttpServletRequest.getRemoteAddr()).thenReturn("123");
+//  }
+//
+//  @Test
+//  public void testSetCompactionTaskLimitWithExistingConfig()
+//  {
+//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    Mockito.when(mockJacksonConfigManager.set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        oldConfigCaptor.capture(),
+//        newConfigCaptor.capture(),
+//        ArgumentMatchers.any())
+//    ).thenReturn(ConfigManager.SetResult.ok());
+//
+//    double compactionTaskSlotRatio = 0.5;
+//    int maxCompactionTaskSlots = 9;
+//    String author = "maytas";
+//    String comment = "hello";
+//    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
+//        compactionTaskSlotRatio,
+//        maxCompactionTaskSlots,
+//        author,
+//        comment,
+//        mockHttpServletRequest
+//    );
+//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+//    Assert.assertNotNull(oldConfigCaptor.getValue());
+//    Assert.assertEquals(oldConfigCaptor.getValue(), ORIGINAL_CONFIG);
+//    Assert.assertNotNull(newConfigCaptor.getValue());
+//    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
+//    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
+//  }
+//
+//  @Test
+//  public void testAddOrUpdateCompactionConfigWithExistingConfig()
+//  {
+//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    Mockito.when(mockJacksonConfigManager.set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        oldConfigCaptor.capture(),
+//        newConfigCaptor.capture(),
+//        ArgumentMatchers.any())
+//    ).thenReturn(ConfigManager.SetResult.ok());
+//
+//    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
+//        "dataSource",
+//        null,
+//        500L,
+//        null,
+//        new Period(3600),
+//        null,
+//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+//        null,
+//        ImmutableMap.of("key", "val")
+//    );
+//    String author = "maytas";
+//    String comment = "hello";
+//    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
+//        newConfig,
+//        author,
+//        comment,
+//        mockHttpServletRequest
+//    );
+//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+//    Assert.assertNotNull(oldConfigCaptor.getValue());
+//    Assert.assertEquals(oldConfigCaptor.getValue(), ORIGINAL_CONFIG);
+//    Assert.assertNotNull(newConfigCaptor.getValue());
+//    Assert.assertEquals(2, newConfigCaptor.getValue().getCompactionConfigs().size());
+//    Assert.assertEquals(OLD_CONFIG, newConfigCaptor.getValue().getCompactionConfigs().get(0));
+//    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(1));
+//  }
+//
+//  @Test
+//  public void testDeleteCompactionConfigWithExistingConfig()
+//  {
+//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    Mockito.when(mockJacksonConfigManager.set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        oldConfigCaptor.capture(),
+//        newConfigCaptor.capture(),
+//        ArgumentMatchers.any())
+//    ).thenReturn(ConfigManager.SetResult.ok());
+//    final String datasourceName = "dataSource";
+//    final DataSourceCompactionConfig toDelete = new DataSourceCompactionConfig(
+//        datasourceName,
+//        null,
+//        500L,
+//        null,
+//        new Period(3600),
+//        null,
+//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+//        null,
+//        ImmutableMap.of("key", "val")
+//    );
+//    final CoordinatorCompactionConfig originalConfig = CoordinatorCompactionConfig.from(ImmutableList.of(toDelete));
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(originalConfig));
+//
+//    String author = "maytas";
+//    String comment = "hello";
+//    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
+//        datasourceName,
+//        author,
+//        comment,
+//        mockHttpServletRequest
+//    );
+//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+//    Assert.assertNotNull(oldConfigCaptor.getValue());
+//    Assert.assertEquals(oldConfigCaptor.getValue(), originalConfig);
+//    Assert.assertNotNull(newConfigCaptor.getValue());
+//    Assert.assertEquals(0, newConfigCaptor.getValue().getCompactionConfigs().size());
+//  }
+//
+//  @Test
+//  public void testUpdateConfigHelperShouldRetryIfRetryableException()
+//  {
+//    MutableInt nunCalled = new MutableInt(0);
+//    Callable<ConfigManager.SetResult> callable = () -> {
+//      nunCalled.increment();
+//      return ConfigManager.SetResult.fail(new Exception(), true);
+//    };
+//    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
+//    Assert.assertEquals(CoordinatorCompactionConfigsResource.UPDATE_NUM_RETRY, (int) nunCalled.getValue());
+//  }
+//
+//  @Test
+//  public void testUpdateConfigHelperShouldNotRetryIfNotRetryableException()
+//  {
+//    MutableInt nunCalled = new MutableInt(0);
+//    Callable<ConfigManager.SetResult> callable = () -> {
+//      nunCalled.increment();
+//      return ConfigManager.SetResult.fail(new Exception(), false);
+//    };
+//    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
+//    Assert.assertEquals(1, (int) nunCalled.getValue());
+//  }
+//
+//  @Test
+//  public void testSetCompactionTaskLimitWithoutExistingConfig()
+//  {
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
+//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    Mockito.when(mockJacksonConfigManager.set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        oldConfigCaptor.capture(),
+//        newConfigCaptor.capture(),
+//        ArgumentMatchers.any())
+//    ).thenReturn(ConfigManager.SetResult.ok());
+//
+//    double compactionTaskSlotRatio = 0.5;
+//    int maxCompactionTaskSlots = 9;
+//    String author = "maytas";
+//    String comment = "hello";
+//    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
+//        compactionTaskSlotRatio,
+//        maxCompactionTaskSlots,
+//        author,
+//        comment,
+//        mockHttpServletRequest
+//    );
+//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+//    Assert.assertNull(oldConfigCaptor.getValue());
+//    Assert.assertNotNull(newConfigCaptor.getValue());
+//    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
+//    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
+//  }
+//
+//  @Test
+//  public void testAddOrUpdateCompactionConfigWithoutExistingConfig()
+//  {
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
+//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+//    Mockito.when(mockJacksonConfigManager.set(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        oldConfigCaptor.capture(),
+//        newConfigCaptor.capture(),
+//        ArgumentMatchers.any())
+//    ).thenReturn(ConfigManager.SetResult.ok());
+//
+//    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
+//        "dataSource",
+//        null,
+//        500L,
+//        null,
+//        new Period(3600),
+//        null,
+//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+//        null,
+//        ImmutableMap.of("key", "val")
+//    );
+//    String author = "maytas";
+//    String comment = "hello";
+//    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
+//        newConfig,
+//        author,
+//        comment,
+//        mockHttpServletRequest
+//    );
+//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+//    Assert.assertNull(oldConfigCaptor.getValue());
+//    Assert.assertNotNull(newConfigCaptor.getValue());
+//    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
+//    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
+//  }
+//
+//  @Test
+//  public void testDeleteCompactionConfigWithoutExistingConfigShouldFailAsDatasourceNotExist()
+//  {
+//    Mockito.when(mockJacksonConfigManager.watch(
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
+//    String author = "maytas";
+//    String comment = "hello";
+//    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
+//        "notExist",
+//        author,
+//        comment,
+//        mockHttpServletRequest
+//    );
+//    Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), result.getStatus());
+//  }
+//}

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
@@ -1,319 +1,357 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one
-// * or more contributor license agreements.  See the NOTICE file
-// * distributed with this work for additional information
-// * regarding copyright ownership.  The ASF licenses this file
-// * to you under the Apache License, Version 2.0 (the
-// * "License"); you may not use this file except in compliance
-// * with the License.  You may obtain a copy of the License at
-// *
-// *   http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing,
-// * software distributed under the License is distributed on an
-// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// * KIND, either express or implied.  See the License for the
-// * specific language governing permissions and limitations
-// * under the License.
-// */
-//
-//package org.apache.druid.server.http;
-//
-//import com.google.common.collect.ImmutableList;
-//import com.google.common.collect.ImmutableMap;
-//import org.apache.commons.lang3.mutable.MutableInt;
-//import org.apache.druid.common.config.ConfigManager;
-//import org.apache.druid.common.config.JacksonConfigManager;
-//import org.apache.druid.java.util.common.granularity.Granularities;
-//import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
-//import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-//import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
-//import org.joda.time.Period;
-//import org.junit.Assert;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.ArgumentMatchers;
-//import org.mockito.Mock;
-//import org.mockito.Mockito;
-//import org.mockito.junit.MockitoJUnitRunner;
-//
-//import javax.servlet.http.HttpServletRequest;
-//import javax.ws.rs.core.Response;
-//import java.util.concurrent.Callable;
-//import java.util.concurrent.atomic.AtomicReference;
-//
-//@RunWith(MockitoJUnitRunner.class)
-//public class CoordinatorCompactionConfigsResourceTest
-//{
-//  private static final DataSourceCompactionConfig OLD_CONFIG = new DataSourceCompactionConfig(
-//      "oldDataSource",
-//      null,
-//      500L,
-//      null,
-//      new Period(3600),
-//      null,
-//      new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-//      null,
-//      ImmutableMap.of("key", "val")
-//  );
-//  private static final CoordinatorCompactionConfig ORIGINAL_CONFIG = CoordinatorCompactionConfig.from(ImmutableList.of(OLD_CONFIG));
-//
-//  @Mock
-//  private JacksonConfigManager mockJacksonConfigManager;
-//
-//  @Mock
-//  private HttpServletRequest mockHttpServletRequest;
-//
-//  private CoordinatorCompactionConfigsResource coordinatorCompactionConfigsResource;
-//
-//  @Before
-//  public void setup()
-//  {
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(ORIGINAL_CONFIG));
-//    coordinatorCompactionConfigsResource = new CoordinatorCompactionConfigsResource(mockJacksonConfigManager);
-//    Mockito.when(mockHttpServletRequest.getRemoteAddr()).thenReturn("123");
-//  }
-//
-//  @Test
-//  public void testSetCompactionTaskLimitWithExistingConfig()
-//  {
-//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    Mockito.when(mockJacksonConfigManager.set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        oldConfigCaptor.capture(),
-//        newConfigCaptor.capture(),
-//        ArgumentMatchers.any())
-//    ).thenReturn(ConfigManager.SetResult.ok());
-//
-//    double compactionTaskSlotRatio = 0.5;
-//    int maxCompactionTaskSlots = 9;
-//    String author = "maytas";
-//    String comment = "hello";
-//    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
-//        compactionTaskSlotRatio,
-//        maxCompactionTaskSlots,
-//        author,
-//        comment,
-//        mockHttpServletRequest
-//    );
-//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-//    Assert.assertNotNull(oldConfigCaptor.getValue());
-//    Assert.assertEquals(oldConfigCaptor.getValue(), ORIGINAL_CONFIG);
-//    Assert.assertNotNull(newConfigCaptor.getValue());
-//    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
-//    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
-//  }
-//
-//  @Test
-//  public void testAddOrUpdateCompactionConfigWithExistingConfig()
-//  {
-//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    Mockito.when(mockJacksonConfigManager.set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        oldConfigCaptor.capture(),
-//        newConfigCaptor.capture(),
-//        ArgumentMatchers.any())
-//    ).thenReturn(ConfigManager.SetResult.ok());
-//
-//    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
-//        "dataSource",
-//        null,
-//        500L,
-//        null,
-//        new Period(3600),
-//        null,
-//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-//        null,
-//        ImmutableMap.of("key", "val")
-//    );
-//    String author = "maytas";
-//    String comment = "hello";
-//    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
-//        newConfig,
-//        author,
-//        comment,
-//        mockHttpServletRequest
-//    );
-//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-//    Assert.assertNotNull(oldConfigCaptor.getValue());
-//    Assert.assertEquals(oldConfigCaptor.getValue(), ORIGINAL_CONFIG);
-//    Assert.assertNotNull(newConfigCaptor.getValue());
-//    Assert.assertEquals(2, newConfigCaptor.getValue().getCompactionConfigs().size());
-//    Assert.assertEquals(OLD_CONFIG, newConfigCaptor.getValue().getCompactionConfigs().get(0));
-//    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(1));
-//  }
-//
-//  @Test
-//  public void testDeleteCompactionConfigWithExistingConfig()
-//  {
-//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    Mockito.when(mockJacksonConfigManager.set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        oldConfigCaptor.capture(),
-//        newConfigCaptor.capture(),
-//        ArgumentMatchers.any())
-//    ).thenReturn(ConfigManager.SetResult.ok());
-//    final String datasourceName = "dataSource";
-//    final DataSourceCompactionConfig toDelete = new DataSourceCompactionConfig(
-//        datasourceName,
-//        null,
-//        500L,
-//        null,
-//        new Period(3600),
-//        null,
-//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-//        null,
-//        ImmutableMap.of("key", "val")
-//    );
-//    final CoordinatorCompactionConfig originalConfig = CoordinatorCompactionConfig.from(ImmutableList.of(toDelete));
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(originalConfig));
-//
-//    String author = "maytas";
-//    String comment = "hello";
-//    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
-//        datasourceName,
-//        author,
-//        comment,
-//        mockHttpServletRequest
-//    );
-//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-//    Assert.assertNotNull(oldConfigCaptor.getValue());
-//    Assert.assertEquals(oldConfigCaptor.getValue(), originalConfig);
-//    Assert.assertNotNull(newConfigCaptor.getValue());
-//    Assert.assertEquals(0, newConfigCaptor.getValue().getCompactionConfigs().size());
-//  }
-//
-//  @Test
-//  public void testUpdateConfigHelperShouldRetryIfRetryableException()
-//  {
-//    MutableInt nunCalled = new MutableInt(0);
-//    Callable<ConfigManager.SetResult> callable = () -> {
-//      nunCalled.increment();
-//      return ConfigManager.SetResult.fail(new Exception(), true);
-//    };
-//    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
-//    Assert.assertEquals(CoordinatorCompactionConfigsResource.UPDATE_NUM_RETRY, (int) nunCalled.getValue());
-//  }
-//
-//  @Test
-//  public void testUpdateConfigHelperShouldNotRetryIfNotRetryableException()
-//  {
-//    MutableInt nunCalled = new MutableInt(0);
-//    Callable<ConfigManager.SetResult> callable = () -> {
-//      nunCalled.increment();
-//      return ConfigManager.SetResult.fail(new Exception(), false);
-//    };
-//    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
-//    Assert.assertEquals(1, (int) nunCalled.getValue());
-//  }
-//
-//  @Test
-//  public void testSetCompactionTaskLimitWithoutExistingConfig()
-//  {
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    Mockito.when(mockJacksonConfigManager.set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        oldConfigCaptor.capture(),
-//        newConfigCaptor.capture(),
-//        ArgumentMatchers.any())
-//    ).thenReturn(ConfigManager.SetResult.ok());
-//
-//    double compactionTaskSlotRatio = 0.5;
-//    int maxCompactionTaskSlots = 9;
-//    String author = "maytas";
-//    String comment = "hello";
-//    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
-//        compactionTaskSlotRatio,
-//        maxCompactionTaskSlots,
-//        author,
-//        comment,
-//        mockHttpServletRequest
-//    );
-//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-//    Assert.assertNull(oldConfigCaptor.getValue());
-//    Assert.assertNotNull(newConfigCaptor.getValue());
-//    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
-//    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
-//  }
-//
-//  @Test
-//  public void testAddOrUpdateCompactionConfigWithoutExistingConfig()
-//  {
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-//    final ArgumentCaptor<CoordinatorCompactionConfig> oldConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
-//    Mockito.when(mockJacksonConfigManager.set(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        oldConfigCaptor.capture(),
-//        newConfigCaptor.capture(),
-//        ArgumentMatchers.any())
-//    ).thenReturn(ConfigManager.SetResult.ok());
-//
-//    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
-//        "dataSource",
-//        null,
-//        500L,
-//        null,
-//        new Period(3600),
-//        null,
-//        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
-//        null,
-//        ImmutableMap.of("key", "val")
-//    );
-//    String author = "maytas";
-//    String comment = "hello";
-//    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
-//        newConfig,
-//        author,
-//        comment,
-//        mockHttpServletRequest
-//    );
-//    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
-//    Assert.assertNull(oldConfigCaptor.getValue());
-//    Assert.assertNotNull(newConfigCaptor.getValue());
-//    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
-//    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
-//  }
-//
-//  @Test
-//  public void testDeleteCompactionConfigWithoutExistingConfigShouldFailAsDatasourceNotExist()
-//  {
-//    Mockito.when(mockJacksonConfigManager.watch(
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
-//        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
-//    ).thenReturn(new AtomicReference<>(CoordinatorCompactionConfig.empty()));
-//    String author = "maytas";
-//    String comment = "hello";
-//    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
-//        "notExist",
-//        author,
-//        comment,
-//        mockHttpServletRequest
-//    );
-//    Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), result.getStatus());
-//  }
-//}
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.http;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.druid.common.config.ConfigManager;
+import org.apache.druid.common.config.JacksonConfigManager;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.metadata.MetadataStorageConnector;
+import org.apache.druid.metadata.MetadataStorageTablesConfig;
+import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
+import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import java.util.concurrent.Callable;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CoordinatorCompactionConfigsResourceTest
+{
+  private static final DataSourceCompactionConfig OLD_CONFIG = new DataSourceCompactionConfig(
+      "oldDataSource",
+      null,
+      500L,
+      null,
+      new Period(3600),
+      null,
+      new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+      null,
+      ImmutableMap.of("key", "val")
+  );
+  private static final byte[] OLD_CONFIG_IN_BYTES = {1, 2, 3};
+
+  private static final CoordinatorCompactionConfig ORIGINAL_CONFIG = CoordinatorCompactionConfig.from(ImmutableList.of(OLD_CONFIG));
+
+  @Mock
+  private JacksonConfigManager mockJacksonConfigManager;
+
+  @Mock
+  private HttpServletRequest mockHttpServletRequest;
+
+  @Mock
+  private MetadataStorageConnector mockConnector;
+
+  @Mock
+  private MetadataStorageTablesConfig mockConnectorConfig;
+
+  private CoordinatorCompactionConfigsResource coordinatorCompactionConfigsResource;
+
+  @Before
+  public void setup()
+  {
+    Mockito.when(mockConnector.lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY))
+    ).thenReturn(OLD_CONFIG_IN_BYTES);
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(OLD_CONFIG_IN_BYTES),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(ORIGINAL_CONFIG);
+    Mockito.when(mockConnectorConfig.getConfigTable()).thenReturn("druid_config");
+    coordinatorCompactionConfigsResource = new CoordinatorCompactionConfigsResource(
+        mockJacksonConfigManager,
+        mockConnector,
+        mockConnectorConfig
+    );
+    Mockito.when(mockHttpServletRequest.getRemoteAddr()).thenReturn("123");
+  }
+
+  @Test
+  public void testSetCompactionTaskLimitWithExistingConfig()
+  {
+    final ArgumentCaptor<byte[]> oldConfigCaptor = ArgumentCaptor.forClass(byte[].class);
+    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+    Mockito.when(mockJacksonConfigManager.set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        oldConfigCaptor.capture(),
+        newConfigCaptor.capture(),
+        ArgumentMatchers.any())
+    ).thenReturn(ConfigManager.SetResult.ok());
+
+    double compactionTaskSlotRatio = 0.5;
+    int maxCompactionTaskSlots = 9;
+    String author = "maytas";
+    String comment = "hello";
+    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
+        compactionTaskSlotRatio,
+        maxCompactionTaskSlots,
+        author,
+        comment,
+        mockHttpServletRequest
+    );
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+    Assert.assertNotNull(oldConfigCaptor.getValue());
+    Assert.assertEquals(oldConfigCaptor.getValue(), OLD_CONFIG_IN_BYTES);
+    Assert.assertNotNull(newConfigCaptor.getValue());
+    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
+    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
+  }
+
+  @Test
+  public void testAddOrUpdateCompactionConfigWithExistingConfig()
+  {
+    final ArgumentCaptor<byte[]> oldConfigCaptor = ArgumentCaptor.forClass(byte[].class);
+    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+    Mockito.when(mockJacksonConfigManager.set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        oldConfigCaptor.capture(),
+        newConfigCaptor.capture(),
+        ArgumentMatchers.any())
+    ).thenReturn(ConfigManager.SetResult.ok());
+
+    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
+        "dataSource",
+        null,
+        500L,
+        null,
+        new Period(3600),
+        null,
+        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+        null,
+        ImmutableMap.of("key", "val")
+    );
+    String author = "maytas";
+    String comment = "hello";
+    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
+        newConfig,
+        author,
+        comment,
+        mockHttpServletRequest
+    );
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+    Assert.assertNotNull(oldConfigCaptor.getValue());
+    Assert.assertEquals(oldConfigCaptor.getValue(), OLD_CONFIG_IN_BYTES);
+    Assert.assertNotNull(newConfigCaptor.getValue());
+    Assert.assertEquals(2, newConfigCaptor.getValue().getCompactionConfigs().size());
+    Assert.assertEquals(OLD_CONFIG, newConfigCaptor.getValue().getCompactionConfigs().get(0));
+    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(1));
+  }
+
+  @Test
+  public void testDeleteCompactionConfigWithExistingConfig()
+  {
+    final ArgumentCaptor<byte[]> oldConfigCaptor = ArgumentCaptor.forClass(byte[].class);
+    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+    Mockito.when(mockJacksonConfigManager.set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        oldConfigCaptor.capture(),
+        newConfigCaptor.capture(),
+        ArgumentMatchers.any())
+    ).thenReturn(ConfigManager.SetResult.ok());
+    final String datasourceName = "dataSource";
+    final DataSourceCompactionConfig toDelete = new DataSourceCompactionConfig(
+        datasourceName,
+        null,
+        500L,
+        null,
+        new Period(3600),
+        null,
+        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+        null,
+        ImmutableMap.of("key", "val")
+    );
+    final CoordinatorCompactionConfig originalConfig = CoordinatorCompactionConfig.from(ImmutableList.of(toDelete));
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(OLD_CONFIG_IN_BYTES),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(originalConfig);
+
+    String author = "maytas";
+    String comment = "hello";
+    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
+        datasourceName,
+        author,
+        comment,
+        mockHttpServletRequest
+    );
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+    Assert.assertNotNull(oldConfigCaptor.getValue());
+    Assert.assertEquals(oldConfigCaptor.getValue(), OLD_CONFIG_IN_BYTES);
+    Assert.assertNotNull(newConfigCaptor.getValue());
+    Assert.assertEquals(0, newConfigCaptor.getValue().getCompactionConfigs().size());
+  }
+
+  @Test
+  public void testUpdateConfigHelperShouldRetryIfRetryableException()
+  {
+    MutableInt nunCalled = new MutableInt(0);
+    Callable<ConfigManager.SetResult> callable = () -> {
+      nunCalled.increment();
+      return ConfigManager.SetResult.fail(new Exception(), true);
+    };
+    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
+    Assert.assertEquals(CoordinatorCompactionConfigsResource.UPDATE_NUM_RETRY, (int) nunCalled.getValue());
+  }
+
+  @Test
+  public void testUpdateConfigHelperShouldNotRetryIfNotRetryableException()
+  {
+    MutableInt nunCalled = new MutableInt(0);
+    Callable<ConfigManager.SetResult> callable = () -> {
+      nunCalled.increment();
+      return ConfigManager.SetResult.fail(new Exception(), false);
+    };
+    coordinatorCompactionConfigsResource.updateConfigHelper(callable);
+    Assert.assertEquals(1, (int) nunCalled.getValue());
+  }
+
+  @Test
+  public void testSetCompactionTaskLimitWithoutExistingConfig()
+  {
+    Mockito.when(mockConnector.lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY))
+    ).thenReturn(null);
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(null),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(CoordinatorCompactionConfig.empty());
+    final ArgumentCaptor<byte[]> oldConfigCaptor = ArgumentCaptor.forClass(byte[].class);
+    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+    Mockito.when(mockJacksonConfigManager.set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        oldConfigCaptor.capture(),
+        newConfigCaptor.capture(),
+        ArgumentMatchers.any())
+    ).thenReturn(ConfigManager.SetResult.ok());
+
+    double compactionTaskSlotRatio = 0.5;
+    int maxCompactionTaskSlots = 9;
+    String author = "maytas";
+    String comment = "hello";
+    Response result = coordinatorCompactionConfigsResource.setCompactionTaskLimit(
+        compactionTaskSlotRatio,
+        maxCompactionTaskSlots,
+        author,
+        comment,
+        mockHttpServletRequest
+    );
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+    Assert.assertNull(oldConfigCaptor.getValue());
+    Assert.assertNotNull(newConfigCaptor.getValue());
+    Assert.assertEquals(newConfigCaptor.getValue().getMaxCompactionTaskSlots(), maxCompactionTaskSlots);
+    Assert.assertEquals(compactionTaskSlotRatio, newConfigCaptor.getValue().getCompactionTaskSlotRatio(), 0);
+  }
+
+  @Test
+  public void testAddOrUpdateCompactionConfigWithoutExistingConfig()
+  {
+    Mockito.when(mockConnector.lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY))
+    ).thenReturn(null);
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(null),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(CoordinatorCompactionConfig.empty());
+    final ArgumentCaptor<byte[]> oldConfigCaptor = ArgumentCaptor.forClass(byte[].class);
+    final ArgumentCaptor<CoordinatorCompactionConfig> newConfigCaptor = ArgumentCaptor.forClass(CoordinatorCompactionConfig.class);
+    Mockito.when(mockJacksonConfigManager.set(
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY),
+        oldConfigCaptor.capture(),
+        newConfigCaptor.capture(),
+        ArgumentMatchers.any())
+    ).thenReturn(ConfigManager.SetResult.ok());
+
+    final DataSourceCompactionConfig newConfig = new DataSourceCompactionConfig(
+        "dataSource",
+        null,
+        500L,
+        null,
+        new Period(3600),
+        null,
+        new UserCompactionTaskGranularityConfig(Granularities.HOUR, null),
+        null,
+        ImmutableMap.of("key", "val")
+    );
+    String author = "maytas";
+    String comment = "hello";
+    Response result = coordinatorCompactionConfigsResource.addOrUpdateCompactionConfig(
+        newConfig,
+        author,
+        comment,
+        mockHttpServletRequest
+    );
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
+    Assert.assertNull(oldConfigCaptor.getValue());
+    Assert.assertNotNull(newConfigCaptor.getValue());
+    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
+    Assert.assertEquals(newConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
+  }
+
+  @Test
+  public void testDeleteCompactionConfigWithoutExistingConfigShouldFailAsDatasourceNotExist()
+  {
+    Mockito.when(mockConnector.lookup(
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq("name"),
+        ArgumentMatchers.eq("payload"),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.CONFIG_KEY))
+    ).thenReturn(null);
+    Mockito.when(mockJacksonConfigManager.convertByteToConfig(
+        ArgumentMatchers.eq(null),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.class),
+        ArgumentMatchers.eq(CoordinatorCompactionConfig.empty()))
+    ).thenReturn(CoordinatorCompactionConfig.empty());
+    String author = "maytas";
+    String comment = "hello";
+    Response result = coordinatorCompactionConfigsResource.deleteCompactionConfig(
+        "notExist",
+        author,
+        comment,
+        mockHttpServletRequest
+    );
+    Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), result.getStatus());
+  }
+}


### PR DESCRIPTION
Fix bug 502 bad gateway thrown when we edit/delete any auto compaction config created 0.21.0 or before

### Description

This is a bug introduced by https://github.com/apache/druid/pull/11144

This issue will only happen if user has one or more auto compaction configuration created in a version before latest (0.21.0 or earlier) then upgrade to latest (0.22.0 or later). If this was the case, once user upgraded to 0.22.0 or later,
- The user will not be able to add, edited or deleted any auto-compaction configuration (for both old datasource created prior to upgrade and new datasources created after the upgrade). 
- The user will also not be able to change auto compaction task ratio and max task slot.
- Existing auto compactions created prior to the upgrade will still run and create compaction tasks as expected 

This happen because when you have a auto compaction created in 0.21.0 or earlier,
the spec stored in db will be something like
`{"compactionConfigs":[{"dataSource":"wikipedia","taskPriority":25,"inputSegmentSizeBytes":419430400,"maxRowsPerSegment":null,"skipOffsetFromLatest":"P1D","tuningConfig":{"maxRowsInMemory":null,"maxBytesInMemory":null,"maxTotalRows":null,"splitHintSpec":null,"partitionsSpec":{"type":"hashed","numShards":null,"partitionDimensions":[],"partitionFunction":"murmur3_32_abs","maxRowsPerSegment":5000000},"indexSpec":null,"indexSpecForIntermediatePersists":null,"maxPendingPersists":null,"pushTimeout":null,"segmentWriteOutMediumFactory":null,"maxNumConcurrentSubTasks":null,"maxRetry":null,"taskStatusCheckPeriodMs":null,"chatHandlerTimeout":null,"chatHandlerNumRetries":null,"maxNumSegmentsToMerge":null,"totalNumMergeTasks":null,"forceGuaranteedRollup":true,"type":"index_parallel"},"taskContext":null}],"compactionTaskSlotRatio":0.1,"maxCompactionTaskSlots":2147483647}`.
Notice that this compaction config does not have some of the newer fields like granularitySpec and ioConfig that was added in 0.22.0. In latest (0.22.0). When we update the auto compaction config, we read the current config from the database and deserialize it into Java object (CoordinatorCompactionConfig).When we try to write the update to the db, we do a compareAndSwap (added in https://github.com/apache/druid/pull/11144) which make sure that `current` config we read earlier from the db and deserialize in Java Object converted to byte is still the same as what is in the db. 
However, the current config have the new fields (added when it was deserialize to Java CoordinatorCompactionConfig class (although those new fields are set to null) and hence it doesn’t match what is in the db anymore. This causes any update to auto compaction config to consistently fail. 

This PR modify CoordinatorCompactionConfigsResource and KillCompactionConfig (which use compareAndSwap to update the Compaction config) to read the raw bytes payload directly from the db (instead of using the ConfigHolder in ConfigManager). We would then store the raw bytes of the config in a local variable before deserialize into CoordinatorCompactionConfig. Finally, when we call compareAndSwap to update the compaction config, we would use the stored raw bytes as the old value for the purpose of comparing with db current value.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
