### PR TITLE
Fix Index hadoop failing with index.zip is not a valid DFS filename

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
@@ -476,8 +476,8 @@ public class JobHelper
 
     return new DataSegmentAndIndexZipFilePath(
         finalSegment,
-        tmpPath.toUri().getPath(),
-        finalIndexZipFilePath.toUri().getPath()
+        tmpPath.toUri().toString(),
+        finalIndexZipFilePath.toUri().toString()
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -540,6 +540,9 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
     }
   }
 
+  /**
+   * Must be called only when the hadoopy classloader is the current classloader
+   */
   private void renameSegmentIndexFilesJob(
       String hadoopIngestionSpecStr,
       String dataSegmentAndIndexZipFilePathListStr
@@ -547,10 +550,10 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
   {
     final ClassLoader loader = Thread.currentThread().getContextClassLoader();
     try {
-      Object renameSegmentIndexFilesRunner = getForeignClassloaderObject(
-          "org.apache.druid.indexing.common.task.HadoopIndexTask$HadoopRenameSegmentIndexFilesRunner",
-          loader
+      final Class<?> clazz = loader.loadClass(
+          "org.apache.druid.indexing.common.task.HadoopIndexTask$HadoopRenameSegmentIndexFilesRunner"
       );
+      Object renameSegmentIndexFilesRunner = clazz.newInstance();
 
       String[] renameSegmentIndexFilesJobInput = new String[]{
           hadoopIngestionSpecStr,

--- a/integration-tests/docker/environment-configs/override-examples/hadoop/s3_to_hdfs
+++ b/integration-tests/docker/environment-configs/override-examples/hadoop/s3_to_hdfs
@@ -31,4 +31,4 @@ AWS_REGION=<OVERRIDE_THIS>
 
 druid_extensions_loadList=["druid-s3-extensions","druid-hdfs-storage"]
 
-druid.indexer.task.defaultHadoopCoordinates=["org.apache.hadoop:hadoop-client:2.8.5", "org.apache.hadoop:hadoop-aws:2.8.5"]
+druid_indexer_task_defaultHadoopCoordinates=["org.apache.hadoop:hadoop-client:2.8.5", "org.apache.hadoop:hadoop-aws:2.8.5"]

--- a/integration-tests/docker/environment-configs/override-examples/hadoop/s3_to_s3
+++ b/integration-tests/docker/environment-configs/override-examples/hadoop/s3_to_s3
@@ -32,4 +32,4 @@ AWS_REGION=<OVERRIDE_THIS>
 
 druid_extensions_loadList=["druid-s3-extensions","druid-hdfs-storage"]
 
-druid.indexer.task.defaultHadoopCoordinates=["org.apache.hadoop:hadoop-client:2.8.5", "org.apache.hadoop:hadoop-aws:2.8.5"]
+druid_indexer_task_defaultHadoopCoordinates=["org.apache.hadoop:hadoop-client:2.8.5", "org.apache.hadoop:hadoop-aws:2.8.5"]


### PR DESCRIPTION
This fixes a bug which caused hadoop based ingestion tasks to fail whenever the deep storage directory has a character that is not permitted in hdfs. This caused by the deep storage segment file path being returned without the scheme (s3, gcs, etc). Hadoop client uses the scheme to determine the FileSystem class implementation to use when performing file operations. If no scheme is set, it default to hdfs file. Fixed the issue by returning the full uri of the segment file, which includes the scheme.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
