### PR TITLE
mapping exception stacktrace logging

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
@@ -37,6 +37,7 @@ import org.apache.druid.indexing.input.InputRowSchemas;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.aggregation.Aggregator;
@@ -60,6 +61,7 @@ import java.util.stream.Collectors;
 
 public class InputSourceSampler
 {
+  private static final Logger log = new Logger(InputSourceSampler.class);
   private static final String SAMPLER_DATA_SOURCE = "sampler";
 
   private static final DataSchema DEFAULT_DATA_SCHEMA = new DataSchema(
@@ -203,6 +205,7 @@ public class InputSourceSampler
       }
     }
     catch (Exception e) {
+      log.error(e, "Cannot sample");
       throw new SamplerException(e, "Failed to sample data: %s", e.getMessage());
     }
   }

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapper.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapper.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.initialization.jetty;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.logger.Logger;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -30,9 +31,11 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class CustomExceptionMapper implements ExceptionMapper<JsonMappingException>
 {
+  private static final Logger log = new Logger(CustomExceptionMapper.class);
   @Override
   public Response toResponse(JsonMappingException exception)
   {
+    log.debug(exception, "Mapping failure");
     return Response.status(Response.Status.BAD_REQUEST)
                    .entity(ImmutableMap.of(
                        "error",

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapper.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapper.java
@@ -32,6 +32,7 @@ import javax.ws.rs.ext.Provider;
 public class CustomExceptionMapper implements ExceptionMapper<JsonMappingException>
 {
   private static final Logger log = new Logger(CustomExceptionMapper.class);
+
   @Override
   public Response toResponse(JsonMappingException exception)
   {


### PR DESCRIPTION

### Description

When you try a new Druid API or new parameters, the error message can lack details and one has to start a debugging session to find a line that produces an exception. For example, this message doesn't say what parameter produced NullPointerException (line 15 here doesn't say where the error happened in source code):
```
{"error":"Cannot construct instance of `org.apache.druid.indexing.input.GeneratorInputSource`, problem: `java.lang.NullPointerException`\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 15, column: 9] (through reference chain: org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask[\"spec\"]->org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexIngestionSpec[\"ioConfig\"]->org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexIOConfig[\"inputSource\"])"}
```

This logging writes a stacktrace to the logfile, it can be conveniently set up in configuration to log in production or not, besides the logging can be dynamically altered using JMX console too.

I've also added error logging to InputSourceSampler.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
