### PR TITLE
restrict travis builds to main and release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+branches:
+  only:
+  - master
+  - /^\d+\.\d+\.\d+(-\S*)?$/ # release branches
+
 language: java
 
 dist: xenial


### PR DESCRIPTION
dependabot (enabled in #11079) creates PR branches in the main repository, which triggers travis builds for each of those branches in addition to the PR build. We should restrict the branch builds only to trunk and release branches to avoid unnecessary CI resource usage.