### PR TITLE
Add thrift input format

### DIFF
--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -270,6 +270,39 @@ The `inputFormat` to load data of Avro format in stream ingestion. An example is
 |`avroBytesDecoder`| JSON Object |Specifies how to decode bytes to Avro record. | yes |
 | binaryAsString | Boolean | Specifies if the bytes Avro column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
 
+### Thrift Stream
+
+> You need to include the [`druid-thrift-extensions`](../development/extensions-contrib/thrift.md) as an extension to use the Thrift Stream input format.
+
+The `inputFormat` to load data of Thrift format in stream ingestion. An example is:
+```json
+"ioConfig": {
+  "inputFormat": {
+    "type": "thrift",
+    "flattenSpec": {
+      "useFieldDiscovery": true,
+      "fields": [
+        {
+          "type": "path",
+          "name": "someRecord_subInt",
+          "expr": "$.someRecord.subInt"
+        }
+      ]
+    },
+    "binaryAsString": false
+  },
+  ...
+}
+```
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+|type| String| This should be set to `thrift` to read Thrift serialized data| yes |
+|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Thrift record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
+| binaryAsString | Boolean | Specifies if the bytes Thrift column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
+| thriftJar   | String      | path of thrift jar, if not provided, it will try to find the thrift class in classpath. Thrift jar in batch ingestion should be uploaded to HDFS first and configure `jobProperties` with `"tmpjars":"/path/to/your/thrift.jar"` | no       |
+| thriftClass | String      | classname of thrift                      | yes      |
+
 ##### Avro Bytes Decoder
 
 If `type` is not included, the avroBytesDecoder defaults to `schema_repo`.

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -223,6 +223,41 @@ The Parquet `inputFormat` has the following components:
 |flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Parquet file. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
 | binaryAsString | Boolean | Specifies if the bytes parquet column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
 
+### Thrift Stream
+
+> You need to include the [`druid-thrift-extensions`](../development/extensions-contrib/thrift.md) as an extension to use the Thrift Stream input format.
+
+The `inputFormat` to load data of Thrift format in stream ingestion. An example is:
+```json
+"ioConfig": {
+  "inputFormat": {
+    "type": "thrift",
+    "flattenSpec": {
+      "useFieldDiscovery": true,
+      "jarPath": "book.jar",
+      "thriftClass": "org.apache.druid.data.input.thrift.Book",
+      "fields": [
+        {
+          "type": "path",
+          "name": "someRecord_subInt",
+          "expr": "$.someRecord.subInt"
+        }
+      ]
+    },
+    "binaryAsString": false
+  },
+  ...
+}
+```
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+|type| String| This should be set to `thrift` to read Thrift serialized data| yes |
+|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Thrift record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
+| binaryAsString | Boolean | Specifies if the bytes Thrift column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
+| thriftJar   | String      | path of Thrift jar, if not provided, it will try to find the Thrift class in classpath.| no       |
+| thriftClass | String      | classname of Thrift                      | yes      |
+
 ### Avro Stream
 
 > You need to include the [`druid-avro-extensions`](../development/extensions-core/avro.md) as an extension to use the Avro Stream input format.
@@ -269,41 +304,6 @@ The `inputFormat` to load data of Avro format in stream ingestion. An example is
 |flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Avro record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
 |`avroBytesDecoder`| JSON Object |Specifies how to decode bytes to Avro record. | yes |
 | binaryAsString | Boolean | Specifies if the bytes Avro column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
-
-### Thrift Stream
-
-> You need to include the [`druid-thrift-extensions`](../development/extensions-contrib/thrift.md) as an extension to use the Thrift Stream input format.
-
-The `inputFormat` to load data of Thrift format in stream ingestion. An example is:
-```json
-"ioConfig": {
-  "inputFormat": {
-    "type": "thrift",
-    "flattenSpec": {
-      "useFieldDiscovery": true,
-      "jarPath": "book.jar",
-      "thriftClass": "org.apache.druid.data.input.thrift.Book",
-      "fields": [
-        {
-          "type": "path",
-          "name": "someRecord_subInt",
-          "expr": "$.someRecord.subInt"
-        }
-      ]
-    },
-    "binaryAsString": false
-  },
-  ...
-}
-```
-
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-|type| String| This should be set to `thrift` to read Thrift serialized data| yes |
-|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Thrift record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
-| binaryAsString | Boolean | Specifies if the bytes Thrift column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
-| thriftJar   | String      | path of Thrift jar, if not provided, it will try to find the Thrift class in classpath.| no       |
-| thriftClass | String      | classname of Thrift                      | yes      |
 
 ##### Avro Bytes Decoder
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -281,6 +281,8 @@ The `inputFormat` to load data of Thrift format in stream ingestion. An example 
     "type": "thrift",
     "flattenSpec": {
       "useFieldDiscovery": true,
+      "jarPath": "book.jar",
+      "thriftClass": "org.apache.druid.data.input.thrift.Book",
       "fields": [
         {
           "type": "path",
@@ -300,8 +302,8 @@ The `inputFormat` to load data of Thrift format in stream ingestion. An example 
 |type| String| This should be set to `thrift` to read Thrift serialized data| yes |
 |flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Thrift record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
 | binaryAsString | Boolean | Specifies if the bytes Thrift column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
-| thriftJar   | String      | path of thrift jar, if not provided, it will try to find the thrift class in classpath. Thrift jar in batch ingestion should be uploaded to HDFS first and configure `jobProperties` with `"tmpjars":"/path/to/your/thrift.jar"` | no       |
-| thriftClass | String      | classname of thrift                      | yes      |
+| thriftJar   | String      | path of Thrift jar, if not provided, it will try to find the Thrift class in classpath.| no       |
+| thriftClass | String      | classname of Thrift                      | yes      |
 
 ##### Avro Bytes Decoder
 

--- a/extensions-contrib/thrift-extensions/pom.xml
+++ b/extensions-contrib/thrift-extensions/pom.xml
@@ -141,6 +141,36 @@
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>2.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.9.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.10.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>0.22.0-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftExtensionsModule.java
+++ b/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftExtensionsModule.java
@@ -37,7 +37,8 @@ public class ThriftExtensionsModule implements DruidModule
     return Collections.singletonList(
         new SimpleModule("ThriftInputRowParserModule")
             .registerSubtypes(
-                new NamedType(ThriftInputRowParser.class, "thrift")
+                new NamedType(ThriftInputRowParser.class, "thrift"),
+                new NamedType(ThriftInputFormat.class, "thrift")
             )
     );
   }

--- a/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftInputFormat.java
+++ b/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftInputFormat.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.thrift;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import org.apache.druid.data.input.InputEntity;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.NestedInputFormat;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.util.Objects;
+
+public class ThriftInputFormat extends NestedInputFormat
+{
+  private final String jarPath;
+  private final String thriftClassName;
+
+  @JsonCreator
+  public ThriftInputFormat(
+      @JsonProperty("flattenSpec") @Nullable JSONPathSpec flattenSpec,
+      @JsonProperty("thriftJar") String jarPath,
+      @JsonProperty("thriftClass") String thriftClassName
+  )
+  {
+    super(flattenSpec);
+    this.jarPath = jarPath;
+    this.thriftClassName = thriftClassName;
+    Preconditions.checkNotNull(thriftClassName, "thrift class name");
+  }
+
+  @Override
+  public boolean isSplittable()
+  {
+    return false;
+  }
+
+  @Override
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  {
+    return new ThriftReader(
+        inputRowSchema,
+        source,
+        jarPath,
+        thriftClassName,
+        getFlattenSpec()
+    );
+  }
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ThriftInputFormat that = (ThriftInputFormat) o;
+    return Objects.equals(getFlattenSpec(), that.getFlattenSpec()) &&
+        Objects.equals(jarPath, that.jarPath) &&
+        Objects.equals(thriftClassName, that.thriftClassName);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(jarPath, thriftClassName, getFlattenSpec());
+  }
+
+}

--- a/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftInputFormat.java
+++ b/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftInputFormat.java
@@ -57,6 +57,18 @@ public class ThriftInputFormat extends NestedInputFormat
     return false;
   }
 
+  @JsonProperty
+  public String getThriftJar()
+  {
+    return jarPath;
+  }
+
+  @JsonProperty
+  public String getThriftClass()
+  {
+    return thriftClassName;
+  }
+
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {

--- a/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftReader.java
+++ b/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftReader.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.thrift;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterators;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.commons.io.IOUtils;
+import org.apache.druid.data.input.InputEntity;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.IntermediateRowParsingReader;
+import org.apache.druid.data.input.impl.MapInputRowParser;
+import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.JSONFlattenerMaker;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.common.parsers.ObjectFlattener;
+import org.apache.druid.java.util.common.parsers.ObjectFlatteners;
+import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.java.util.common.parsers.Parser;
+import org.apache.druid.utils.CollectionUtils;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ThriftReader extends IntermediateRowParsingReader<DynamicMessage>
+{
+  private final InputRowSchema inputRowSchema;
+  private final InputEntity source;
+  private final JSONPathSpec flattenSpec;
+  private final ObjectFlattener<JsonNode> recordFlattener;
+  private final String jarPath;
+  private final String thriftClassName;
+  private Parser<String, Object> parser;
+  private volatile Class<TBase> thriftClass = null;
+
+  ThriftReader(
+      InputRowSchema inputRowSchema,
+      InputEntity source,
+      String jarPath,
+      String thriftClassName,
+      JSONPathSpec flattenSpec
+  )
+  {
+    if (flattenSpec == null) {
+      this.inputRowSchema = new ProtobufInputRowSchema(inputRowSchema);
+      this.recordFlattener = null;
+    } else {
+      this.inputRowSchema = inputRowSchema;
+      this.recordFlattener = ObjectFlatteners.create(flattenSpec, new JSONFlattenerMaker(true));
+    }
+
+    this.source = source;
+    this.jarPath = jarPath;
+    this.thriftClassName = thriftClassName;
+    this.flattenSpec = flattenSpec;
+    if (thriftClass == null) {
+      try {
+        thriftClass = getThriftClass();
+      }
+      catch (IOException e) {
+        e.printStackTrace();
+      }
+      catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      }
+      catch (IllegalAccessException e) {
+        e.printStackTrace();
+      }
+      catch (InstantiationException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public Class<TBase> getThriftClass()
+      throws IOException, ClassNotFoundException, IllegalAccessException, InstantiationException
+  {
+    final Class<TBase> thrift;
+    if (jarPath != null) {
+      File jar = new File(jarPath);
+      URLClassLoader child = new URLClassLoader(
+          new URL[] {jar.toURI().toURL()},
+          this.getClass().getClassLoader()
+      );
+      thrift = (Class<TBase>) Class.forName(thriftClassName, true, child);
+    } else {
+      thrift = (Class<TBase>) Class.forName(thriftClassName);
+    }
+    thrift.newInstance();
+    return thrift;
+  }
+
+  @Override
+  protected CloseableIterator<DynamicMessage> intermediateRowIterator() throws IOException
+  {
+    final String json;
+    try {
+      final byte[] bytes = IOUtils.toByteArray(source.open());
+      TBase o = thriftClass.newInstance();
+      ThriftDeserialization.detectAndDeserialize(bytes, o);
+      json = ThriftDeserialization.SERIALIZER_SIMPLE_JSON.get().toString(o);
+    }
+    catch (IllegalAccessException | InstantiationException | TException e) {
+      throw new IAE("some thing wrong with your thrift?");
+    }
+
+    Map<String, Object> record = parser.parseToMap(json);
+    ThriftDeserialization.detectAndDeserialize(bytes, o);
+    return CloseableIterators.withEmptyBaggage(
+        Iterators.singletonIterator(protobufBytesDecoder.parse(ByteBuffer.wrap(IOUtils.toByteArray(source.open()))))
+    );
+  }
+
+  @Override
+  protected List<InputRow> parseInputRows(DynamicMessage intermediateRow) throws ParseException, JsonProcessingException
+  {
+    Map<String, Object> record;
+
+    if (flattenSpec == null) {
+      try {
+        record = CollectionUtils.mapKeys(intermediateRow.getAllFields(), k -> k.getJsonName());
+      } catch (Exception ex) {
+        throw new ParseException(ex, "Protobuf message could not be parsed");
+      }
+    } else {
+      try {
+        String json = JsonFormat.printer().print(intermediateRow);
+        JsonNode document = new ObjectMapper().readValue(json, JsonNode.class);
+        record = recordFlattener.flatten(document);
+      } catch (InvalidProtocolBufferException e) {
+        throw new ParseException(e, "Protobuf message could not be parsed");
+      }
+    }
+
+    return Collections.singletonList(MapInputRowParser.parse(inputRowSchema, record));
+  }
+
+  @Override
+  protected List<Map<String, Object>> toMap(DynamicMessage intermediateRow) throws JsonProcessingException, InvalidProtocolBufferException
+  {
+    return Collections.singletonList(new ObjectMapper().readValue(JsonFormat.printer().print(intermediateRow), Map.class));
+  }
+}

--- a/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftReader.java
+++ b/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftReader.java
@@ -82,16 +82,13 @@ public class ThriftReader extends IntermediateRowParsingReader<String>
         thriftClass = getThriftClass();
       }
       catch (IOException e) {
-        e.printStackTrace();
+        throw new IAE(e, "failed to load jar [%s]", jarPath);
       }
       catch (ClassNotFoundException e) {
-        e.printStackTrace();
+        throw new IAE(e, "class [%s] not found in jar", thriftClassName);
       }
-      catch (IllegalAccessException e) {
-        e.printStackTrace();
-      }
-      catch (InstantiationException e) {
-        e.printStackTrace();
+      catch (InstantiationException | IllegalAccessException e) {
+        throw new IAE(e, "instantiation thrift instance failed");
       }
     }
   }

--- a/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftInputFormatTest.java
+++ b/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftInputFormatTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.thrift;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.NestedInputFormat;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TJSONProtocol;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.apache.druid.data.input.thrift.ThriftReaderTest.verifyFlattenData;
+import static org.apache.druid.data.input.thrift.ThriftReaderTest.verifyNestedData;
+
+public class ThriftInputFormatTest
+{
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private InputRowSchema inputRowSchema;
+  private InputRowSchema flattenInputRowSchema;
+  private JSONPathSpec flattenSpec;
+  private DateTime dateTime;
+  private String date;
+
+  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
+
+  @Before
+  public void setUp()
+  {
+    TimestampSpec timestampSpec = new TimestampSpec("date", "auto", null);
+    DimensionsSpec dimensionsSpec = new DimensionsSpec(Lists.newArrayList(
+        new StringDimensionSchema("title"),
+        new StringDimensionSchema("lastName")
+    ), null, null);
+    DimensionsSpec flattenDimensionsSpec = new DimensionsSpec(Collections.singletonList(
+        new StringDimensionSchema("title")
+    ), null, null);
+    flattenSpec = new JSONPathSpec(
+        true,
+        Lists.newArrayList(
+            new JSONPathFieldSpec(JSONPathFieldType.ROOT, "title", "title"),
+            new JSONPathFieldSpec(JSONPathFieldType.PATH, "lastName", "$.author.lastName")
+        )
+    );
+
+    inputRowSchema = new InputRowSchema(timestampSpec, dimensionsSpec, null);
+    flattenInputRowSchema = new InputRowSchema(timestampSpec, flattenDimensionsSpec, null);
+    dateTime = new DateTime(2016, 8, 29, 0, 0, ISOChronology.getInstanceUTC());
+    date = "2016-08-29";
+
+    for (Module jacksonModule : new ThriftExtensionsModule().getJacksonModules()) {
+      jsonMapper.registerModule(jacksonModule);
+    }
+  }
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    ThriftInputFormat thriftInputFormat = new ThriftInputFormat(flattenSpec, "example/book.jar", "org.apache.druid.data.input.thrift.Book");
+
+    NestedInputFormat thriftInputFormat2 = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(thriftInputFormat),
+        NestedInputFormat.class
+    );
+
+    Assert.assertEquals(thriftInputFormat, thriftInputFormat2);
+  }
+
+
+  @Test
+  public void testParseNestedData() throws Exception
+  {
+    Book book = new Book().setDate(date).setPrice(19.9).setTitle("title")
+        .setAuthor(new Author().setFirstName("first").setLastName("last"));
+    TSerializer serializer;
+    byte[] bytes;
+    serializer = new TSerializer(new TJSONProtocol.Factory());
+    bytes = serializer.serialize(book);
+    final ByteEntity entity = new ByteEntity(bytes);
+
+    ThriftInputFormat thriftInputFormat = new ThriftInputFormat(flattenSpec, "example/book.jar", "org.apache.druid.data.input.thrift.Book");
+    InputRow row = thriftInputFormat.createReader(inputRowSchema, entity, null).read().next();
+
+    verifyNestedData(row, this.dateTime);
+  }
+
+  @Test
+  public void testParseFlatData() throws Exception
+  {
+    Book book = new Book().setDate(date).setPrice(19.9).setTitle("title");
+    TSerializer serializer;
+    byte[] bytes;
+    serializer = new TSerializer(new TJSONProtocol.Factory());
+    bytes = serializer.serialize(book);
+    final ByteEntity entity = new ByteEntity(bytes);
+
+    ThriftInputFormat thriftInputFormat = new ThriftInputFormat(null, "example/book.jar", "org.apache.druid.data.input.thrift.Book");
+    InputRow row = thriftInputFormat.createReader(flattenInputRowSchema, entity, null).read().next();
+
+    verifyFlattenData(row, this.dateTime);
+  }
+}

--- a/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftReaderTest.java
+++ b/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftReaderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.thrift;
+
+import com.google.common.collect.Lists;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TJSONProtocol;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ThriftReaderTest
+{
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private InputRowSchema inputRowSchema;
+  private InputRowSchema flattenInputRowSchema;
+  private JSONPathSpec flattenSpec;
+  private DateTime dateTime;
+  private String date;
+
+  @Before
+  public void setUp()
+  {
+    TimestampSpec timestampSpec = new TimestampSpec("date", "auto", null);
+    DimensionsSpec dimensionsSpec = new DimensionsSpec(Lists.newArrayList(
+        new StringDimensionSchema("title"),
+        new StringDimensionSchema("lastName")
+    ), null, null);
+    DimensionsSpec flattenDimensionsSpec = new DimensionsSpec(Collections.singletonList(
+        new StringDimensionSchema("title")
+    ), null, null);
+    flattenSpec = new JSONPathSpec(
+        true,
+        Lists.newArrayList(
+            new JSONPathFieldSpec(JSONPathFieldType.ROOT, "title", "title"),
+            new JSONPathFieldSpec(JSONPathFieldType.PATH, "lastName", "$.author.lastName")
+        )
+    );
+
+    inputRowSchema = new InputRowSchema(timestampSpec, dimensionsSpec, null);
+    flattenInputRowSchema = new InputRowSchema(timestampSpec, flattenDimensionsSpec, null);
+    dateTime = new DateTime(2016, 8, 29, 0, 0, ISOChronology.getInstanceUTC());
+    date = "2016-08-29";
+  }
+
+  @Test
+  public void testParseNestedData() throws Exception
+  {
+    Book book = new Book().setDate(date).setPrice(19.9).setTitle("title")
+        .setAuthor(new Author().setFirstName("first").setLastName("last"));
+    TSerializer serializer;
+    byte[] bytes;
+    serializer = new TSerializer(new TJSONProtocol.Factory());
+    bytes = serializer.serialize(book);
+    final ByteEntity entity = new ByteEntity(bytes);
+
+    ThriftReader reader = new ThriftReader(inputRowSchema, entity, "example/book.jar", "org.apache.druid.data.input.thrift.Book", flattenSpec);
+    InputRow row = reader.read().next();
+
+    verifyNestedData(row, this.dateTime);
+  }
+
+  @Test
+  public void testParseFlatData() throws Exception
+  {
+    Book book = new Book().setDate(date).setPrice(19.9).setTitle("title");
+    TSerializer serializer;
+    byte[] bytes;
+    serializer = new TSerializer(new TJSONProtocol.Factory());
+    bytes = serializer.serialize(book);
+    final ByteEntity entity = new ByteEntity(bytes);
+
+    ThriftReader reader = new ThriftReader(flattenInputRowSchema, entity, "example/book.jar", "org.apache.druid.data.input.thrift.Book", JSONPathSpec.DEFAULT);
+    InputRow row = reader.read().next();
+
+    verifyFlattenData(row, this.dateTime);
+  }
+
+
+  static void verifyNestedData(InputRow row, DateTime dateTime)
+  {
+    Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+
+    assertDimensionEquals(row, "title", "title");
+    assertDimensionEquals(row, "lastName", "last");
+
+    Assert.assertEquals(19.9F, row.getMetric("price").floatValue(), 0.0);
+  }
+
+  static void verifyFlattenData(InputRow row, DateTime dateTime)
+  {
+    Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+
+    assertDimensionEquals(row, "title", "title");
+
+    Assert.assertEquals(19.9F, row.getMetric("price").floatValue(), 0.0);
+  }
+
+  private static void assertDimensionEquals(InputRow row, String dimension, Object expected)
+  {
+    List<String> values = row.getDimension(dimension);
+    Assert.assertEquals(1, values.size());
+    Assert.assertEquals(expected, values.get(0));
+  }
+
+}


### PR DESCRIPTION
Because of deprecated of parseSpec, I develop ThriftInputFormat for new interface, which supports stream ingestion for data encoded by Thrift.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
