### PR TITLE
Add DynamicConfigProvider for Schema Registry

### DIFF
--- a/core/src/main/java/org/apache/druid/utils/DynamicConfigProviderUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/DynamicConfigProviderUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.metadata.DynamicConfigProvider;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DynamicConfigProviderUtils
+{
+  public static Map<String, String> extraConfigAndSetStringMap(Map<String, Object> config, String dynamicConfigProviderKey, ObjectMapper mapper)
+  {
+    HashMap<String, String> newConfig = new HashMap<>();
+    if (config != null) {
+      for (Map.Entry<String, Object> entry : config.entrySet()) {
+        if (!dynamicConfigProviderKey.equals(entry.getKey())) {
+          newConfig.put(entry.getKey(), entry.getValue().toString());
+        }
+      }
+      Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(dynamicConfigProviderKey), mapper);
+      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+        newConfig.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return newConfig;
+  }
+
+  public static Map<String, Object> extraConfigAndSetObjectMap(Map<String, Object> config, String dynamicConfigProviderKey, ObjectMapper mapper)
+  {
+    HashMap<String, Object> newConfig = new HashMap<>();
+    if (config != null) {
+      for (Map.Entry<String, Object> entry : config.entrySet()) {
+        if (!dynamicConfigProviderKey.equals(entry.getKey())) {
+          newConfig.put(entry.getKey(), entry.getValue());
+        }
+      }
+      Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(dynamicConfigProviderKey), mapper);
+      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+        newConfig.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return newConfig;
+  }
+
+  private static Map<String, String> extraConfigFromProvider(Object dynamicConfigProviderJson, ObjectMapper mapper)
+  {
+    if (dynamicConfigProviderJson != null) {
+      DynamicConfigProvider dynamicConfigProvider = mapper.convertValue(dynamicConfigProviderJson, DynamicConfigProvider.class);
+      return dynamicConfigProvider.getConfig();
+    }
+    return Collections.emptyMap();
+  }
+}

--- a/core/src/test/java/org/apache/druid/utils/DynamicConfigProviderUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/utils/DynamicConfigProviderUtilsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.metadata.DynamicConfigProvider;
+import org.apache.druid.metadata.MapStringDynamicConfigProvider;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+@RunWith(Enclosed.class)
+public class DynamicConfigProviderUtilsTest
+{
+  public static class ThrowIfURLHasNotAllowedPropertiesTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final String DYNAMIC_CONFIG_PROVIDER = "druid.dynamic.config.provider";
+
+    @Test
+    public void testExtraConfigAndSetStringMap()
+    {
+      DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+          ImmutableMap.of("prop2", "value2")
+      );
+
+      Map<String, Object> properties = ImmutableMap.of(
+          "prop1", "value1",
+          "prop2", "value3",
+          DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER.convertValue(dynamicConfigProvider, Map.class)
+      );
+      Map<String, String> res = DynamicConfigProviderUtils.extraConfigAndSetStringMap(properties, DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER);
+
+      Assert.assertEquals(2, res.size());
+      Assert.assertEquals("value1", res.get("prop1"));
+      Assert.assertEquals("value2", res.get("prop2"));
+    }
+
+    @Test
+    public void testExtraConfigAndSetObjectMap()
+    {
+      DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+          ImmutableMap.of("prop2", "value2")
+      );
+
+      Map<String, Object> properties = ImmutableMap.of(
+          "prop1", "value1",
+          "prop2", "value3",
+          DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER.convertValue(dynamicConfigProvider, Map.class)
+      );
+      Map<String, Object> res = DynamicConfigProviderUtils.extraConfigAndSetObjectMap(properties, DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER);
+
+      Assert.assertEquals(2, res.size());
+      Assert.assertEquals("value1", res.get("prop1").toString());
+      Assert.assertEquals("value2", res.get("prop2").toString());
+    }
+  }
+}

--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -26,7 +26,7 @@ title: "Apache Avro"
 
 This Apache Druid extension enables Druid to ingest and understand the Apache Avro data format. This extension provides 
 two Avro Parsers for stream ingestion and Hadoop batch ingestion. 
-See [Avro Hadoop Parser](../../ingestion/data-formats.md#avro-hadoop-parser) and [Avro Stream Parser](../../ingestion/c.md#avro-stream-parser)
+See [Avro Hadoop Parser](../../ingestion/data-formats.md#avro-hadoop-parser) and [Avro Stream Parser](../../ingestion/data-formats.md#avro-stream-parser)
 for more details about how to use these in an ingestion spec.
 
 Additionally, it provides an InputFormat for reading Avro OCF files when using

--- a/docs/development/extensions-core/avro.md
+++ b/docs/development/extensions-core/avro.md
@@ -26,7 +26,7 @@ title: "Apache Avro"
 
 This Apache Druid extension enables Druid to ingest and understand the Apache Avro data format. This extension provides 
 two Avro Parsers for stream ingestion and Hadoop batch ingestion. 
-See [Avro Hadoop Parser](../../ingestion/data-formats.md#avro-hadoop-parser) and [Avro Stream Parser](../../ingestion/data-formats.md#avro-stream-parser)
+See [Avro Hadoop Parser](../../ingestion/data-formats.md#avro-hadoop-parser) and [Avro Stream Parser](../../ingestion/c.md#avro-stream-parser)
 for more details about how to use these in an ingestion spec.
 
 Additionally, it provides an InputFormat for reading Avro OCF files when using

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -380,8 +380,8 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | url | String | Specifies the url endpoint of the Schema Registry. | yes |
 | capacity | Integer | Specifies the max size of the cache (default = Integer.MAX_VALUE). | no |
 | urls | Array<String> | Specifies the url endpoints of the multiple Schema Registry instances. | yes(if `url` is not provided) |
-| config | Json | To send additional configurations, configured for Schema Registry | no |
-| headers | Json | To send headers to the Schema Registry | no |
+| config | Json | To send additional configurations, configured for Schema Registry.  User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json. | no |
+| headers | Json | To send headers to the Schema Registry.  User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json. | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 
@@ -1223,8 +1223,8 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | url | String | Specifies the url endpoint of the Schema Registry. | yes |
 | capacity | Integer | Specifies the max size of the cache (default = Integer.MAX_VALUE). | no |
 | urls | Array<String> | Specifies the url endpoints of the multiple Schema Registry instances. | yes(if `url` is not provided) |
-| config | Json | To send additional configurations, configured for Schema Registry | no |
-| headers | Json | To send headers to the Schema Registry | no |
+| config | Json | To send additional configurations, configured for Schema Registry. User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json.  | no |
+| headers | Json | To send headers to the Schema Registry.  User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json. | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -380,8 +380,8 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | url | String | Specifies the url endpoint of the Schema Registry. | yes |
 | capacity | Integer | Specifies the max size of the cache (default = Integer.MAX_VALUE). | no |
 | urls | Array<String> | Specifies the url endpoints of the multiple Schema Registry instances. | yes(if `url` is not provided) |
-| config | Json | To send additional configurations, configured for Schema Registry.  This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md) | no |
-| headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md) | no |
+| config | Json | To send additional configurations, configured for Schema Registry.  This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md) | no |
+| headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md) | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 
@@ -1231,8 +1231,8 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | url | String | Specifies the url endpoint of the Schema Registry. | yes |
 | capacity | Integer | Specifies the max size of the cache (default = Integer.MAX_VALUE). | no |
 | urls | Array<String> | Specifies the url endpoints of the multiple Schema Registry instances. | yes(if `url` is not provided) |
-| config | Json | To send additional configurations, configured for Schema Registry. This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md).  | no |
-| headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md) | no |
+| config | Json | To send additional configurations, configured for Schema Registry. This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md).  | no |
+| headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md) | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -380,8 +380,8 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | url | String | Specifies the url endpoint of the Schema Registry. | yes |
 | capacity | Integer | Specifies the max size of the cache (default = Integer.MAX_VALUE). | no |
 | urls | Array<String> | Specifies the url endpoints of the multiple Schema Registry instances. | yes(if `url` is not provided) |
-| config | Json | To send additional configurations, configured for Schema Registry.  User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json. | no |
-| headers | Json | To send headers to the Schema Registry.  User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json. | no |
+| config | Json | To send additional configurations, configured for Schema Registry.  This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md) | no |
+| headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md) | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 
@@ -408,12 +408,20 @@ Multiple Instances:
         "schema.registry.ssl.truststore.password": "<password>",
         "schema.registry.ssl.keystore.location": "/some/secrets/kafka.client.keystore.jks",
         "schema.registry.ssl.keystore.password": "<password>",
-        "schema.registry.ssl.key.password": "<password>"
+        "schema.registry.ssl.key.password": "<password>",
+        "schema.registry.ssl.key.password",
        ... 
    },
    "headers": {
        "traceID" : "b29c5de2-0db4-490b-b421",
        "timeStamp" : "1577191871865",
+       "druid.dynamic.config.provider":{
+            "type":"mapString", 
+            "config":{
+                 "registry.header.prop.1":"value.1", 
+                 "registry.header.prop.2":"value.2"
+                 }
+            }
        ...
     }
 }
@@ -1223,8 +1231,8 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | url | String | Specifies the url endpoint of the Schema Registry. | yes |
 | capacity | Integer | Specifies the max size of the cache (default = Integer.MAX_VALUE). | no |
 | urls | Array<String> | Specifies the url endpoints of the multiple Schema Registry instances. | yes(if `url` is not provided) |
-| config | Json | To send additional configurations, configured for Schema Registry. User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json.  | no |
-| headers | Json | To send headers to the Schema Registry.  User can implement a `DynamicConfigProvider` to supply some properties at runtime, by adding `"druid.dynamic.config.provider"`:`{"type": "<registered_dynamic_config_provider_name>", ...}` in json. | no |
+| config | Json | To send additional configurations, configured for Schema Registry. This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md).  | no |
+| headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../../operations/dynamic-config-provider.md) | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 
@@ -1259,6 +1267,13 @@ Multiple Instances:
   "headers": {
       "traceID" : "b29c5de2-0db4-490b-b421",
       "timeStamp" : "1577191871865",
+      "druid.dynamic.config.provider":{
+           "type":"mapString", 
+           "config":{
+                "registry.header.prop.1":"value.1", 
+                "registry.header.prop.2":"value.2"
+                }
+           }
       ...
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -38,6 +38,7 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.metadata.DynamicConfigProvider;
+import org.apache.druid.utils.DynamicConfigProviderUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -76,9 +77,9 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
     this.headers = headers;
     this.jsonMapper = jsonMapper;
     if (url != null && !url.isEmpty()) {
-      this.registry = new CachedSchemaRegistryClient(this.url, this.capacity, createRegistryConfig(), createRegistryHeader());
+      this.registry = new CachedSchemaRegistryClient(this.url, this.capacity, DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
     } else {
-      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, createRegistryConfig(), createRegistryHeader());
+      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
     }
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -130,15 +130,15 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
   {
     HashMap<String, Object> registryConfig = new HashMap<>();
     if (config != null) {
-      for (String key : config.keySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(key)) {
-          registryConfig.put(key, config.get(key));
+      for (Map.Entry<String, Object> entry : config.entrySet()) {
+        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
+          registryConfig.put(entry.getKey(), entry.getValue());
         }
       }
       if (config.containsKey(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY)) {
         Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-        for (String key : dynamicConfig.keySet()) {
-          registryConfig.put(key, dynamicConfig.get(key));
+        for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+          registryConfig.put(entry.getKey(), entry.getValue());
         }
       }
     }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -37,14 +37,11 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -111,51 +108,6 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
   public Map<String, Object> getHeaders()
   {
     return headers;
-  }
-
-  protected Map<String, String> createRegistryHeader()
-  {
-    HashMap<String, String> registryHeader = new HashMap<>();
-    if (headers != null) {
-      for (Map.Entry<String, Object> entry : headers.entrySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
-          registryHeader.put(entry.getKey(), entry.getValue().toString());
-        }
-      }
-      Map<String, String> dynamicConfig = extraConfigFromProvider(headers.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
-        registryHeader.put(entry.getKey(), entry.getValue());
-      }
-    }
-    return registryHeader;
-  }
-
-  protected Map<String, Object> createRegistryConfig()
-  {
-    HashMap<String, Object> registryConfig = new HashMap<>();
-    if (config != null) {
-      for (Map.Entry<String, Object> entry : config.entrySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
-          registryConfig.put(entry.getKey(), entry.getValue());
-        }
-      }
-      if (config.containsKey(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY)) {
-        Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-        for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
-          registryConfig.put(entry.getKey(), entry.getValue());
-        }
-      }
-    }
-    return registryConfig;
-  }
-
-  private Map<String, String> extraConfigFromProvider(Object dynamicConfigProviderJson)
-  {
-    if (dynamicConfigProviderJson != null) {
-      DynamicConfigProvider dynamicConfigProvider = jsonMapper.convertValue(dynamicConfigProviderJson, DynamicConfigProvider.class);
-      return dynamicConfigProvider.getConfig();
-    }
-    return Collections.emptyMap();
   }
 
   //For UT only

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -74,9 +74,9 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
     this.headers = headers;
     this.jsonMapper = jsonMapper;
     if (url != null && !url.isEmpty()) {
-      this.registry = new CachedSchemaRegistryClient(this.url, this.capacity, DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
+      this.registry = new CachedSchemaRegistryClient(this.url, this.capacity, DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper));
     } else {
-      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
+      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper));
     }
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.avro;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +34,7 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.metadata.DynamicConfigProvider;
@@ -54,7 +56,7 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
   private final List<String> urls;
   private final Map<String, Object> config;
   private final Map<String, Object> headers;
-  private final ObjectMapper mapper;
+  private final ObjectMapper jsonMapper;
   public static final String DRUID_DYNAMIC_CONFIG_PROVIDER_KEY = "druid.dynamic.config.provider";
 
   @JsonCreator
@@ -63,7 +65,8 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
       @JsonProperty("capacity") Integer capacity,
       @JsonProperty("urls") @Nullable List<String> urls,
       @JsonProperty("config") @Nullable Map<String, Object> config,
-      @JsonProperty("headers") @Nullable Map<String, Object> headers
+      @JsonProperty("headers") @Nullable Map<String, Object> headers,
+      @JacksonInject @Json ObjectMapper jsonMapper
   )
   {
     this.url = url;
@@ -71,7 +74,7 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
     this.urls = urls;
     this.config = config;
     this.headers = headers;
-    this.mapper = new ObjectMapper();
+    this.jsonMapper = jsonMapper;
     if (url != null && !url.isEmpty()) {
       this.registry = new CachedSchemaRegistryClient(this.url, this.capacity, createRegistryConfig(), createRegistryHeader());
     } else {
@@ -148,7 +151,7 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
   private Map<String, String> extraConfigFromProvider(Object dynamicConfigProviderJson)
   {
     if (dynamicConfigProviderJson != null) {
-      DynamicConfigProvider dynamicConfigProvider = mapper.convertValue(dynamicConfigProviderJson, DynamicConfigProvider.class);
+      DynamicConfigProvider dynamicConfigProvider = jsonMapper.convertValue(dynamicConfigProviderJson, DynamicConfigProvider.class);
       return dynamicConfigProvider.getConfig();
     }
     return Collections.emptyMap();
@@ -164,7 +167,7 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
     this.config = null;
     this.headers = null;
     this.registry = registry;
-    this.mapper = new ObjectMapper();
+    this.jsonMapper = new ObjectMapper();
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -113,14 +113,14 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
   {
     HashMap<String, String> registryHeader = new HashMap<>();
     if (headers != null) {
-      for (String key : headers.keySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(key)) {
-          registryHeader.put(key, headers.get(key).toString());
+      for (Map.Entry<String, Object> entry : headers.entrySet()) {
+        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
+          registryHeader.put(entry.getKey(), entry.getValue().toString());
         }
       }
       Map<String, String> dynamicConfig = extraConfigFromProvider(headers.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-      for (String key : dynamicConfig.keySet()) {
-        registryHeader.put(key, dynamicConfig.get(key));
+      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+        registryHeader.put(entry.getKey(), entry.getValue());
       }
     }
     return registryHeader;

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -109,6 +110,9 @@ public class AvroStreamInputFormatTest
     for (Module jacksonModule : new AvroExtensionsModule().getJacksonModules()) {
       jsonMapper.registerModule(jacksonModule);
     }
+    jsonMapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
   }
 
   @Test
@@ -134,7 +138,7 @@ public class AvroStreamInputFormatTest
   {
     AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
         flattenSpec,
-        new SchemaRegistryBasedAvroBytesDecoder("http://test:8081", 100, null, null, null),
+        new SchemaRegistryBasedAvroBytesDecoder("http://test:8081", 100, null, null, null, null),
         false,
         false
     );

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.data.input.avro;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
@@ -31,6 +32,7 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.druid.data.input.AvroStreamInputRowParserTest;
 import org.apache.druid.data.input.SomeAvroDatum;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.Assert;
@@ -58,7 +60,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testMultipleUrls() throws Exception
   {
     String json = "{\"urls\":[\"http://localhost\"],\"type\": \"schema_registry\"}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedAvroBytesDecoder decoder;
     decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
         .readerFor(AvroBytesDecoder.class)
@@ -72,7 +77,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testUrl() throws Exception
   {
     String json = "{\"url\":\"http://localhost\",\"type\": \"schema_registry\"}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedAvroBytesDecoder decoder;
     decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
         .readerFor(AvroBytesDecoder.class)
@@ -86,7 +94,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testConfig() throws Exception
   {
     String json = "{\"url\":\"http://localhost\",\"type\": \"schema_registry\", \"config\":{}}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedAvroBytesDecoder decoder;
     decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
         .readerFor(AvroBytesDecoder.class)
@@ -170,7 +181,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testParseHeader() throws JsonProcessingException
   {
     String json = "{\"url\":\"http://localhost\",\"type\":\"schema_registry\",\"config\":{},\"headers\":{\"druid.dynamic.config.provider\":{\"type\":\"mapString\", \"config\":{\"registry.header.prop.2\":\"value.2\", \"registry.header.prop.3\":\"value.3\"}},\"registry.header.prop.1\":\"value.1\",\"registry.header.prop.2\":\"value.4\"}}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedAvroBytesDecoder decoder;
     decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
         .readerFor(AvroBytesDecoder.class)
@@ -189,7 +203,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   public void testParseConfig() throws JsonProcessingException
   {
     String json = "{\"url\":\"http://localhost\",\"type\":\"schema_registry\",\"config\":{\"druid.dynamic.config.provider\":{\"type\":\"mapString\", \"config\":{\"registry.config.prop.2\":\"value.2\", \"registry.config.prop.3\":\"value.3\"}},\"registry.config.prop.1\":\"value.1\",\"registry.config.prop.2\":\"value.4\"},\"headers\":{}}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedAvroBytesDecoder decoder;
     decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
         .readerFor(AvroBytesDecoder.class)

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.data.input.SomeAvroDatum;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -190,7 +191,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
         .readerFor(AvroBytesDecoder.class)
         .readValue(json);
 
-    Map<String, String> heaeder = decoder.createRegistryHeader();
+    Map<String, String> heaeder = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
     Assert.assertEquals(3, heaeder.size());
@@ -212,12 +213,12 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
         .readerFor(AvroBytesDecoder.class)
         .readValue(json);
 
-    Map<String, ?> heaeder = decoder.createRegistryConfig();
+    Map<String, ?> config = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getConfig(), SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
-    Assert.assertEquals(3, heaeder.size());
-    Assert.assertEquals("value.1", heaeder.get("registry.config.prop.1"));
-    Assert.assertEquals("value.2", heaeder.get("registry.config.prop.2"));
-    Assert.assertEquals("value.3", heaeder.get("registry.config.prop.3"));
+    Assert.assertEquals(3, config.size());
+    Assert.assertEquals("value.1", config.get("registry.config.prop.1"));
+    Assert.assertEquals("value.2", config.get("registry.config.prop.2"));
+    Assert.assertEquals("value.3", config.get("registry.config.prop.3"));
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -191,13 +191,13 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
         .readerFor(AvroBytesDecoder.class)
         .readValue(json);
 
-    Map<String, String> heaeder = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
+    Map<String, String> header = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
-    Assert.assertEquals(3, heaeder.size());
-    Assert.assertEquals("value.1", heaeder.get("registry.header.prop.1"));
-    Assert.assertEquals("value.2", heaeder.get("registry.header.prop.2"));
-    Assert.assertEquals("value.3", heaeder.get("registry.header.prop.3"));
+    Assert.assertEquals(3, header.size());
+    Assert.assertEquals("value.1", header.get("registry.header.prop.1"));
+    Assert.assertEquals("value.2", header.get("registry.header.prop.2"));
+    Assert.assertEquals("value.3", header.get("registry.header.prop.3"));
   }
 
   @Test

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
@@ -132,14 +132,14 @@ public class SchemaRegistryBasedProtobufBytesDecoder implements ProtobufBytesDec
   {
     HashMap<String, String> registryHeader = new HashMap<>();
     if (headers != null) {
-      for (String key : headers.keySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(key)) {
-          registryHeader.put(key, headers.get(key).toString());
+      for (Map.Entry<String, Object> entry : headers.entrySet()) {
+        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
+          registryHeader.put(entry.getKey(), entry.getValue().toString());
         }
       }
       Map<String, String> dynamicConfig = extraConfigFromProvider(headers.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-      for (String key : dynamicConfig.keySet()) {
-        registryHeader.put(key, dynamicConfig.get(key));
+      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+        registryHeader.put(entry.getKey(), entry.getValue());
       }
     }
     return registryHeader;

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
@@ -149,15 +149,15 @@ public class SchemaRegistryBasedProtobufBytesDecoder implements ProtobufBytesDec
   {
     HashMap<String, Object> registryConfig = new HashMap<>();
     if (config != null) {
-      for (String key : config.keySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(key)) {
-          registryConfig.put(key, config.get(key));
+      for (Map.Entry<String, Object> entry : config.entrySet()) {
+        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
+          registryConfig.put(entry.getKey(), entry.getValue());
         }
       }
       if (config.containsKey(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY)) {
         Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-        for (String key : dynamicConfig.keySet()) {
-          registryConfig.put(key, dynamicConfig.get(key));
+        for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+          registryConfig.put(entry.getKey(), entry.getValue());
         }
       }
     }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
@@ -76,9 +76,9 @@ public class SchemaRegistryBasedProtobufBytesDecoder implements ProtobufBytesDec
     this.headers = headers;
     this.jsonMapper = jsonMapper;
     if (url != null && !url.isEmpty()) {
-      this.registry = new CachedSchemaRegistryClient(Collections.singletonList(this.url), this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
+      this.registry = new CachedSchemaRegistryClient(Collections.singletonList(this.url), this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper));
     } else {
-      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
+      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, this.jsonMapper));
     }
   }
 

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoder.java
@@ -34,14 +34,13 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.metadata.DynamicConfigProvider;
+import org.apache.druid.utils.DynamicConfigProviderUtils;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -77,9 +76,9 @@ public class SchemaRegistryBasedProtobufBytesDecoder implements ProtobufBytesDec
     this.headers = headers;
     this.jsonMapper = jsonMapper;
     if (url != null && !url.isEmpty()) {
-      this.registry = new CachedSchemaRegistryClient(Collections.singletonList(this.url), this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), createRegistryConfig(), createRegistryHeader());
+      this.registry = new CachedSchemaRegistryClient(Collections.singletonList(this.url), this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
     } else {
-      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), createRegistryConfig(), createRegistryHeader());
+      this.registry = new CachedSchemaRegistryClient(this.urls, this.capacity, Collections.singletonList(new ProtobufSchemaProvider()), DynamicConfigProviderUtils.extraConfigAndSetObjectMap(config, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper), DynamicConfigProviderUtils.extraConfigAndSetStringMap(headers, DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, jsonMapper));
     }
   }
 
@@ -129,51 +128,6 @@ public class SchemaRegistryBasedProtobufBytesDecoder implements ProtobufBytesDec
     this.headers = null;
     this.registry = registry;
     this.jsonMapper = new ObjectMapper();
-  }
-
-  protected Map<String, String> createRegistryHeader()
-  {
-    HashMap<String, String> registryHeader = new HashMap<>();
-    if (headers != null) {
-      for (Map.Entry<String, Object> entry : headers.entrySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
-          registryHeader.put(entry.getKey(), entry.getValue().toString());
-        }
-      }
-      Map<String, String> dynamicConfig = extraConfigFromProvider(headers.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
-        registryHeader.put(entry.getKey(), entry.getValue());
-      }
-    }
-    return registryHeader;
-  }
-
-  protected Map<String, Object> createRegistryConfig()
-  {
-    HashMap<String, Object> registryConfig = new HashMap<>();
-    if (config != null) {
-      for (Map.Entry<String, Object> entry : config.entrySet()) {
-        if (!DRUID_DYNAMIC_CONFIG_PROVIDER_KEY.equals(entry.getKey())) {
-          registryConfig.put(entry.getKey(), entry.getValue());
-        }
-      }
-      if (config.containsKey(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY)) {
-        Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(DRUID_DYNAMIC_CONFIG_PROVIDER_KEY));
-        for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
-          registryConfig.put(entry.getKey(), entry.getValue());
-        }
-      }
-    }
-    return registryConfig;
-  }
-
-  private Map<String, String> extraConfigFromProvider(Object dynamicConfigProviderJson)
-  {
-    if (dynamicConfigProviderJson != null) {
-      DynamicConfigProvider dynamicConfigProvider = jsonMapper.convertValue(dynamicConfigProviderJson, DynamicConfigProvider.class);
-      return dynamicConfigProvider.getConfig();
-    }
-    return Collections.emptyMap();
   }
 
   @Override

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.protobuf;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -77,6 +78,9 @@ public class ProtobufInputFormatTest
     for (Module jacksonModule : new ProtobufExtensionsModule().getJacksonModules()) {
       jsonMapper.registerModule(jacksonModule);
     }
+    jsonMapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
   }
 
   @Test
@@ -99,7 +103,7 @@ public class ProtobufInputFormatTest
   {
     ProtobufInputFormat inputFormat = new ProtobufInputFormat(
         flattenSpec,
-        new SchemaRegistryBasedProtobufBytesDecoder("http://test:8081", 100, null, null, null)
+        new SchemaRegistryBasedProtobufBytesDecoder("http://test:8081", 100, null, null, null, null)
     );
     NestedInputFormat inputFormat2 = jsonMapper.readValue(
         jsonMapper.writeValueAsString(inputFormat),

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
@@ -30,6 +30,7 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
 import org.junit.Assert;
@@ -184,7 +185,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
-    Map<String, String> heaeder = decoder.createRegistryHeader();
+    Map<String, String> heaeder = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
     Assert.assertEquals(3, heaeder.size());
@@ -206,7 +207,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
-    Map<String, ?> heaeder = decoder.createRegistryConfig();
+    Map<String, ?> heaeder = DynamicConfigProviderUtils.extraConfigAndSetObjectMap(decoder.getConfig(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
     Assert.assertEquals(3, heaeder.size());

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
@@ -185,13 +185,13 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
-    Map<String, String> heaeder = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
+    Map<String, String> header = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
-    Assert.assertEquals(3, heaeder.size());
-    Assert.assertEquals("value.1", heaeder.get("registry.header.prop.1"));
-    Assert.assertEquals("value.2", heaeder.get("registry.header.prop.2"));
-    Assert.assertEquals("value.3", heaeder.get("registry.header.prop.3"));
+    Assert.assertEquals(3, header.size());
+    Assert.assertEquals("value.1", header.get("registry.header.prop.1"));
+    Assert.assertEquals("value.2", header.get("registry.header.prop.2"));
+    Assert.assertEquals("value.3", header.get("registry.header.prop.3"));
   }
 
   @Test

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.data.input.protobuf;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.DynamicMessage;
@@ -27,6 +28,7 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.commons.io.IOUtils;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
@@ -95,7 +97,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   public void testDefaultCapacity()
   {
     // Given
-    SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", null, null, null, null);
+    SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", null, null, null, null, null);
     // When
     Assert.assertEquals(schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity(), Integer.MAX_VALUE);
   }
@@ -105,7 +107,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   {
     int capacity = 100;
     // Given
-    SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", capacity, null, null, null);
+    SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", capacity, null, null, null, null);
     // When
     Assert.assertEquals(schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity(), capacity);
   }
@@ -122,7 +124,10 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   public void testMultipleUrls() throws Exception
   {
     String json = "{\"urls\":[\"http://localhost\"],\"type\": \"schema_registry\"}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
     decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
         .readerFor(ProtobufBytesDecoder.class)
@@ -136,7 +141,10 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   public void testUrl() throws Exception
   {
     String json = "{\"url\":\"http://localhost\",\"type\": \"schema_registry\"}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
     decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
         .readerFor(ProtobufBytesDecoder.class)
@@ -150,7 +158,10 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   public void testConfig() throws Exception
   {
     String json = "{\"url\":\"http://localhost\",\"type\": \"schema_registry\", \"config\":{}}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
     decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
         .readerFor(ProtobufBytesDecoder.class)
@@ -164,7 +175,10 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   public void testParseHeader() throws JsonProcessingException
   {
     String json = "{\"url\":\"http://localhost\",\"type\":\"schema_registry\",\"config\":{},\"headers\":{\"druid.dynamic.config.provider\":{\"type\":\"mapString\", \"config\":{\"registry.header.prop.2\":\"value.2\", \"registry.header.prop.3\":\"value.3\"}},\"registry.header.prop.1\":\"value.1\",\"registry.header.prop.2\":\"value.4\"}}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
     decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
         .readerFor(ProtobufBytesDecoder.class)
@@ -183,7 +197,10 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   public void testParseConfig() throws JsonProcessingException
   {
     String json = "{\"url\":\"http://localhost\",\"type\":\"schema_registry\",\"config\":{\"druid.dynamic.config.provider\":{\"type\":\"mapString\", \"config\":{\"registry.config.prop.2\":\"value.2\", \"registry.config.prop.3\":\"value.3\"}},\"registry.config.prop.1\":\"value.1\",\"registry.config.prop.2\":\"value.4\"},\"headers\":{}}";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.setInjectableValues(
+        new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
     decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
         .readerFor(ProtobufBytesDecoder.class)


### PR DESCRIPTION
DynamicConfigProvider is an interface for users to to get secure configuration in various places in an extensible way. This feature allow users who use Confluent schema registry can pass config and headers with this interface.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
