### PR TITLE
Docker copy before env and respect JAVA_OPTS

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -89,6 +89,21 @@ setJavaKey() {
     echo $value >> $file
 }
 
+# This is to allow configuration via a Kubernetes configMap without
+# e.g. using subPath (you can also mount the configMap on /tmp/conf/druid)
+if [ -n "$DRUID_CONFIG_COMMON" ]
+then
+    cp -f "$DRUID_CONFIG_COMMON" $COMMON_CONF_DIR/common.runtime.properties
+fi
+
+SCONFIG=$(printf "%s_%s" DRUID_CONFIG ${SERVICE})
+SCONFIG=$(eval echo \$$(echo $SCONFIG))
+
+if [ -n "${SCONFIG}" ]
+then
+    cp -f "${SCONFIG}" $SERVICE_CONF_DIR/runtime.properties
+fi
+
 ## Setup host names
 if [ -n "${ZOOKEEPER}" ];
 then
@@ -115,21 +130,6 @@ do
     var=$(echo "$evar" | sed -e 's?^\([^=]*\)=.*?\1?g' -e 's?_?.?' -e 's?_?-?g')
     echo "$var=$val" >>$COMMON_CONF_DIR/jets3t.properties
 done
-
-# This is to allow configuration via a Kubernetes configMap without
-# e.g. using subPath (you can also mount the configMap on /tmp/conf/druid)
-if [ -n "$DRUID_CONFIG_COMMON" ]
-then
-    cp -f "$DRUID_CONFIG_COMMON" $COMMON_CONF_DIR/common.runtime.properties
-fi
-
-SCONFIG=$(printf "%s_%s" DRUID_CONFIG ${SERVICE})
-SCONFIG=$(eval echo \$$(echo $SCONFIG))
-
-if [ -n "${SCONFIG}" ]
-then
-    cp -f "${SCONFIG}" $SERVICE_CONF_DIR/runtime.properties
-fi
 
 # Now do the java options
 

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -139,7 +139,7 @@ if [ -n "$DRUID_MAXNEWSIZE" ]; then setJavaKey ${SERVICE} -XX:MaxNewSize -XX:Max
 if [ -n "$DRUID_NEWSIZE" ]; then setJavaKey ${SERVICE} -XX:NewSize -XX:NewSize=${DRUID_NEWSIZE}; fi
 if [ -n "$DRUID_MAXDIRECTMEMORYSIZE" ]; then setJavaKey ${SERVICE} -XX:MaxDirectMemorySize -XX:MaxDirectMemorySize=${DRUID_MAXDIRECTMEMORYSIZE}; fi
 
-JAVA_OPTS="$JAVA_OPTS $(cat $SERVICE_CONF_DIR/jvm.config | xargs)"
+JAVA_OPTS="$(cat $SERVICE_CONF_DIR/jvm.config | xargs) $JAVA_OPTS"
 
 if [ -n "$DRUID_LOG_LEVEL" ]
 then


### PR DESCRIPTION
Increase the user-friendliness of the Docker image by allowing environment variables to override configuration file values.
Additionally specify user provided JAVA_OPTS after those from `jvm.config` so they take precedence, mostly useful for overriding things like `-Djava.io.tmpdir`.