### PR TITLE
Fix an exception when using redis cluster as cache

### DIFF
--- a/extensions-contrib/redis-cache/pom.xml
+++ b/extensions-contrib/redis-cache/pom.xml
@@ -122,6 +122,11 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/extensions-contrib/redis-cache/pom.xml
+++ b/extensions-contrib/redis-cache/pom.xml
@@ -122,11 +122,6 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>
 

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/AbstractRedisCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/AbstractRedisCache.java
@@ -26,6 +26,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import redis.clients.jedis.exceptions.JedisException;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -105,7 +106,7 @@ public abstract class AbstractRedisCache implements Cache
         errorCount.incrementAndGet();
       }
       log.warn(e, "Exception pulling items from cache");
-      return null;
+      return Collections.emptyMap();
     }
   }
 

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/AbstractRedisCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/AbstractRedisCache.java
@@ -161,7 +161,7 @@ public abstract class AbstractRedisCache implements Cache
   protected abstract void putToRedis(byte[] key, byte[] value, RedisCacheConfig.DurationConfig expiration);
 
   /**
-   * The lhs of the returned pair the count of input keys
+   * The lhs of the returned pair is the count of input keys
    * The rhs of the returned pair is a map holding the values of their corresponding keys
    */
   protected abstract Pair<Integer, Map<NamedKey, byte[]>> mgetFromRedis(Iterable<NamedKey> keys);

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisClusterCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisClusterCache.java
@@ -80,7 +80,7 @@ public class RedisClusterCache extends AbstractRedisCache
       slot2Keys.computeIfAbsent(keySlot, val -> new ArrayList<>()).add(cachableKey);
     }
 
-    Map<NamedKey, byte[]> results = new ConcurrentHashMap<>();
+    ConcurrentHashMap<NamedKey, byte[]> results = new ConcurrentHashMap<>();
     slot2Keys.keySet()
              .parallelStream()
              .forEach(slot -> {

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisClusterCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisClusterCache.java
@@ -75,7 +75,7 @@ public class RedisClusterCache extends AbstractRedisCache
   {
     int inputKeyCount = 0;
 
-    // group keys based on their slot
+    // group keys based on their slots
     Map<Integer, List<CachableKey>> slot2Keys = new HashMap<>();
     for (NamedKey key : keys) {
       inputKeyCount++;

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisStandaloneCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisStandaloneCache.java
@@ -20,6 +20,7 @@
 package org.apache.druid.client.cache;
 
 import com.google.common.collect.Lists;
+import org.apache.druid.java.util.common.Pair;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
@@ -55,7 +56,7 @@ public class RedisStandaloneCache extends AbstractRedisCache
   }
 
   @Override
-  protected Map<NamedKey, byte[]> mgetFromRedis(Iterable<NamedKey> keys)
+  protected Pair<Integer, Map<NamedKey, byte[]>> mgetFromRedis(Iterable<NamedKey> keys)
   {
     List<NamedKey> namedKeys = Lists.newArrayList(keys);
     List<byte[]> byteKeys = Lists.transform(namedKeys, NamedKey::toByteArray);
@@ -70,7 +71,8 @@ public class RedisStandaloneCache extends AbstractRedisCache
           results.put(namedKeys.get(i), byteValues.get(i));
         }
       }
-      return results;
+
+      return new Pair<>(namedKeys.size(), results);
     }
   }
 

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisStandaloneCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisStandaloneCache.java
@@ -19,14 +19,17 @@
 
 package org.apache.druid.client.cache;
 
+import com.google.common.collect.Lists;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class RedisStandaloneCache extends AbstractRedisCache
 {
-  private JedisPool pool;
+  private final JedisPool pool;
 
   RedisStandaloneCache(JedisPool pool, RedisCacheConfig config)
   {
@@ -52,10 +55,22 @@ public class RedisStandaloneCache extends AbstractRedisCache
   }
 
   @Override
-  protected List<byte[]> mgetFromRedis(byte[]... keys)
+  protected Map<NamedKey, byte[]> mgetFromRedis(Iterable<NamedKey> keys)
   {
+    List<NamedKey> namedKeys = Lists.newArrayList(keys);
+    List<byte[]> byteKeys = Lists.transform(namedKeys, NamedKey::toByteArray);
+
     try (Jedis jedis = pool.getResource()) {
-      return jedis.mget(keys);
+
+      List<byte[]> byteValues = jedis.mget(byteKeys.toArray(new byte[0][]));
+
+      Map<NamedKey, byte[]> results = new HashMap<>();
+      for (int i = 0; i < byteValues.size(); ++i) {
+        if (byteValues.get(i) != null) {
+          results.put(namedKeys.get(i), byteValues.get(i));
+        }
+      }
+      return results;
     }
   }
 

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
@@ -133,7 +133,7 @@ public class RedisClusterCacheTest
     Assert.assertEquals(0x02030405, Ints.fromByteArray(cache.get(key2)));
     Assert.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
     Assert.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
-    Assert.assertEquals(null, cache.get(notExist));
+    Assert.assertNull(cache.get(notExist));
 
     this.mgetCount.set(0);
 

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
@@ -73,7 +73,7 @@ public class RedisClusterCacheTest
     // some methods must be overriden for test cases
     cache = new RedisClusterCache(new MockJedisCluster(Collections.singleton(new HostAndPort("localhost", 6379)))
     {
-      final Map<String, byte[]> cacheStorage = new ConcurrentHashMap<>();
+      final ConcurrentHashMap<String, byte[]> cacheStorage = new ConcurrentHashMap<>();
 
       @Override
       public String setex(final byte[] key, final int seconds, final byte[] value)

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
@@ -33,9 +33,10 @@ import redis.clients.jedis.JedisPoolConfig;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class RedisClusterCacheTest
 {
@@ -58,6 +59,7 @@ public class RedisClusterCacheTest
   };
 
   private RedisClusterCache cache;
+  private AtomicLong mgetCount = new AtomicLong();
 
   @Before
   public void setUp()
@@ -71,7 +73,7 @@ public class RedisClusterCacheTest
     // some methods must be overriden for test cases
     cache = new RedisClusterCache(new MockJedisCluster(Collections.singleton(new HostAndPort("localhost", 6379)))
     {
-      Map<String, byte[]> cacheStorage = new HashMap<>();
+      final Map<String, byte[]> cacheStorage = new ConcurrentHashMap<>();
 
       @Override
       public String setex(final byte[] key, final int seconds, final byte[] value)
@@ -89,13 +91,12 @@ public class RedisClusterCacheTest
       @Override
       public List<byte[]> mget(final byte[]... keys)
       {
+        mgetCount.incrementAndGet();
         List<byte[]> ret = new ArrayList<>();
         for (byte[] key : keys) {
           String k = StringUtils.encodeBase64String(key);
           byte[] value = cacheStorage.get(k);
-          if (value != null) {
-            ret.add(value);
-          }
+          ret.add(value);
         }
         return ret;
       }
@@ -122,6 +123,7 @@ public class RedisClusterCacheTest
     Cache.NamedKey key1 = new Cache.NamedKey("the", HI);
     Cache.NamedKey key2 = new Cache.NamedKey("the", HO);
     Cache.NamedKey key3 = new Cache.NamedKey("a", HI);
+    Cache.NamedKey notExist = new Cache.NamedKey("notExist", HI);
 
     //test put and get
     cache.put(key1, new byte[]{1, 2, 3, 4});
@@ -130,15 +132,24 @@ public class RedisClusterCacheTest
     Assert.assertEquals(0x01020304, Ints.fromByteArray(cache.get(key1)));
     Assert.assertEquals(0x02030405, Ints.fromByteArray(cache.get(key2)));
     Assert.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
+    Assert.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
+    Assert.assertEquals(null, cache.get(notExist));
+
+    this.mgetCount.set(0);
 
     //test multi get
     Map<Cache.NamedKey, byte[]> result = cache.getBulk(
         Lists.newArrayList(
             key1,
             key2,
-            key3
+            key3,
+            notExist
         )
     );
+
+    // these 4 keys are distributed among different nodes, so there should be 4 times call of MGET
+    Assert.assertEquals(mgetCount.get(), 4);
+    Assert.assertEquals(result.size(), 3);
     Assert.assertEquals(0x01020304, Ints.fromByteArray(result.get(key1)));
     Assert.assertEquals(0x02030405, Ints.fromByteArray(result.get(key2)));
     Assert.assertEquals(0x03040506, Ints.fromByteArray(result.get(key3)));


### PR DESCRIPTION

Fixes #10753

### Description

When using redis cluster as cache, there will be warning logs which print exception stack as below

```
2021-01-15T22:06:13,611 WARN [DruidSchema-Cache-0] org.apache.druid.client.cache.AbstractRedisCache - Exception pulling items from cache
redis.clients.jedis.exceptions.JedisClusterException: No way to dispatch this command to Redis Cluster because keys have different slots.
	at redis.clients.jedis.JedisClusterCommand.runBinary(JedisClusterCommand.java:75) ~[?:?]
	at redis.clients.jedis.BinaryJedisCluster.mget(BinaryJedisCluster.java:1362) ~[?:?]
	at org.apache.druid.client.cache.RedisClusterCache.mgetFromRedis(RedisClusterCache.java:52) ~[?:?]
	at org.apache.druid.client.cache.AbstractRedisCache.getBulk(AbstractRedisCache.java:102) ~[?:?]
	at org.apache.druid.client.CachingClusteredClient$SpecificQueryRunnable.computeCachedValues(CachingClusteredClient.java:586) ~[druid-server-0.20.0.jar:0.20.0]
	at org.apache.druid.client.CachingClusteredClient$SpecificQueryRunnable.pruneSegmentsWithCachedResults(CachingClusteredClient.java:546) ~[druid-server-0.20.0.jar:0.20.0]
	at org.apache.druid.client.CachingClusteredClient$SpecificQueryRunnable.run(CachingClusteredClient.java:359) ~[druid-server-0.20.0.jar:0.20.0]
	at org.apache.druid.client.CachingClusteredClient.run(CachingClusteredClient.java:196) ~[druid-server-0.20.0.jar:0.20.0]
	at org.apache.druid.client.CachingClusteredClient.access$100(CachingClusteredClient.java:111) ~[druid-server-0.20.0.jar:0.20.0]
```

This exception occurs when querying a data source containing multiple segments. The exception comes out because Jedis, current redis driver used by `redis-cache` extension, DOES NOT support MGET operation among different redis nodes. This is NOT a constraint of redis cluster, but an implementation limit imposed by Jedis.

This PR simply implements a widely used workaround: grouping keys by pre-calculated redis slot to ensure keys in one group maps to a same redis node , and then MGET keys one group by group. 

A better way is to use Lettuce driver to replace Jedis, MGET on redis cluster is supported natively by Lettuce. But since this is a community extension, I don't think it's worthy of refactoring this extension from its core right now.

### Key changed/added classes in this PR
- Implementation of `AbstractRedisCache#getBulk` is pushed down to `RedisClusterCache#mgetFromRedis` and `RedisStandaloneCache#mgetFromRedis`.

- In `RedisClusterCache#mgetFromRedis`, it first groups keys by their slots and then executes MGET command one group by group.

<hr>

This PR has:
- [X] been self-reviewed.
   - [X] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
