### PR TITLE
Clarify that Broker caching for groupBy v2 queries does not work

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1773,6 +1773,9 @@ You can optionally only configure caching to be enabled on the Broker by setting
 
 See [cache configuration](#cache-configuration) for how to configure cache settings.
 
+> Note: Even if cache is enabled, Brokers never cache group-by queries when [groupBy v2 strategy](../querying/groupbyquery.md#strategies), which is the default, is configured.
+> See [Differences between v1 and v2](../querying/groupbyquery.md#differences-between-v1-and-v2) query strategies for more information.
+
 #### Segment Discovery
 |Property|Possible Values|Description|Default|
 |--------|---------------|-----------|-------|

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1773,7 +1773,7 @@ You can optionally only configure caching to be enabled on the Broker by setting
 
 See [cache configuration](#cache-configuration) for how to configure cache settings.
 
-> Note: Even if cache is enabled, Brokers never cache group-by queries when [groupBy v2 strategy](../querying/groupbyquery.md#strategies), which is the default, is configured.
+> Note: Even if cache is enabled, Brokers never cache groupBy queries when [groupBy v2 strategy](../querying/groupbyquery.md#strategies), which is the default, is configured.
 > See [Differences between v1 and v2](../querying/groupbyquery.md#differences-between-v1-and-v2) query strategies for more information.
 
 #### Segment Discovery

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1773,8 +1773,8 @@ You can optionally only configure caching to be enabled on the Broker by setting
 
 See [cache configuration](#cache-configuration) for how to configure cache settings.
 
-> Note: Even if cache is enabled, Brokers never cache groupBy queries when [groupBy v2 strategy](../querying/groupbyquery.md#strategies), which is the default, is configured.
-> See [Differences between v1 and v2](../querying/groupbyquery.md#differences-between-v1-and-v2) query strategies for more information.
+> Note: Even if cache is enabled, for [groupBy v2](../querying/groupbyquery.md#strategies) queries, both of non-result level cache and result level cache do not work on Brokers.
+> See [Differences between v1 and v2](../querying/groupbyquery.md#differences-between-v1-and-v2) and [Query caching](../querying/caching.md) for more information.
 
 #### Segment Discovery
 |Property|Possible Values|Description|Default|


### PR DESCRIPTION

### Description

Broker caching has been disabled for groupBy v2 queries since #3950, and this limitation is stated  under the section [Differences between v1 and v2](https://druid.apache.org/docs/latest/querying/groupbyquery.html#differences-between-v1-and-v2) of groupBy query doc. But since that's a large block of text, it's not intuitive for users to notice this constraint.

This PR adds a note under the section `Broker Caching` of the configuration doc to give users a more clear hint when they follow that doc to enable broker caching.


This PR has:
- [X] been self-reviewed.
