### PR TITLE
Add DynamicConfigProvider for Kafka Emitter

### DIFF
--- a/core/src/main/java/org/apache/druid/utils/DynamicConfigProviderUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/DynamicConfigProviderUtils.java
@@ -25,6 +25,7 @@ import org.apache.druid.metadata.DynamicConfigProvider;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 public class DynamicConfigProviderUtils
 {
@@ -62,7 +63,29 @@ public class DynamicConfigProviderUtils
     return newConfig;
   }
 
-  private static Map<String, String> extraConfigFromProvider(Object dynamicConfigProviderJson, ObjectMapper mapper)
+  public static void extraConfigAndSetProperty(Map<String, Object> config, String dynamicConfigProviderKey, ObjectMapper mapper, Properties properties)
+  {
+    if (config != null) {
+      for (Map.Entry<String, Object> entry : config.entrySet()) {
+        if (!dynamicConfigProviderKey.equals(entry.getKey())) {
+          properties.setProperty(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+      }
+      extraDynamicConfigAndSetProperty(config, dynamicConfigProviderKey, mapper, properties);
+    }
+  }
+
+  public static void extraDynamicConfigAndSetProperty(Map<String, Object> config, String dynamicConfigProviderKey, ObjectMapper mapper, Properties properties)
+  {
+    if (config != null) {
+      Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(dynamicConfigProviderKey), mapper);
+      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
+        properties.setProperty(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  public static Map<String, String> extraConfigFromProvider(Object dynamicConfigProviderJson, ObjectMapper mapper)
   {
     if (dynamicConfigProviderJson != null) {
       DynamicConfigProvider dynamicConfigProvider = mapper.convertValue(dynamicConfigProviderJson, DynamicConfigProvider.class);

--- a/core/src/test/java/org/apache/druid/utils/DynamicConfigProviderUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/utils/DynamicConfigProviderUtilsTest.java
@@ -31,6 +31,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.util.Map;
+import java.util.Properties;
 
 @RunWith(Enclosed.class)
 public class DynamicConfigProviderUtilsTest
@@ -79,6 +80,43 @@ public class DynamicConfigProviderUtilsTest
       Assert.assertEquals(2, res.size());
       Assert.assertEquals("value1", res.get("prop1").toString());
       Assert.assertEquals("value2", res.get("prop2").toString());
+    }
+
+    @Test
+    public void testExtraConfigAndSetProperty()
+    {
+      Properties props = new Properties();
+      DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+          ImmutableMap.of("prop2", "value2")
+      );
+
+      Map<String, Object> properties = ImmutableMap.of(
+          "prop1", "value1",
+          "prop2", "value3",
+          DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER.convertValue(dynamicConfigProvider, Map.class)
+      );
+      DynamicConfigProviderUtils.extraConfigAndSetProperty(properties, DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER, props);
+
+      Assert.assertEquals(2, props.size());
+      Assert.assertEquals("value1", props.get("prop1").toString());
+      Assert.assertEquals("value2", props.get("prop2").toString());
+    }
+
+    @Test
+    public void testExtraDynamicConfigAndSetProperty()
+    {
+      Properties props = new Properties();
+      DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+          ImmutableMap.of("prop1", "value1")
+      );
+
+      Map<String, Object> properties = ImmutableMap.of(
+          DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER.convertValue(dynamicConfigProvider, Map.class)
+      );
+      DynamicConfigProviderUtils.extraDynamicConfigAndSetProperty(properties, DYNAMIC_CONFIG_PROVIDER, OBJECT_MAPPER, props);
+
+      Assert.assertEquals(1, props.size());
+      Assert.assertEquals("value1", props.get("prop1").toString());
     }
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -105,8 +105,14 @@ public class KafkaEmitter implements Emitter
       props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
       props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
       props.putAll(config.getKafkaProducerConfig());
+      if (config.getKafkaProducerConfigProvider() != null) {
+        Map<String, String> dynamicConfig = config.getKafkaProducerConfigProvider().getConfig();
+        for (Map.Entry<String, String> e : dynamicConfig.entrySet()) {
+          props.setProperty(e.getKey(), e.getValue());
+        }
+      }
 
-      return new KafkaProducer<>(props);
+      return new KafkaProducer<>(props).;
     }
     finally {
       Thread.currentThread().setContextClassLoader(currCtxCl);

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -112,7 +112,7 @@ public class KafkaEmitter implements Emitter
         }
       }
 
-      return new KafkaProducer<>(props).;
+      return new KafkaProducer<>(props);
     }
     finally {
       Thread.currentThread().setContextClassLoader(currCtxCl);

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import javax.annotation.Nullable;
@@ -43,6 +44,8 @@ public class KafkaEmitterConfig
   private final String clusterName;
   @JsonProperty("producer.config")
   private Map<String, String> kafkaProducerConfig;
+  @JsonProperty("producer.dynamic.config")
+  private DynamicConfigProvider kafkaProducerConfigProvider;
 
   @JsonCreator
   public KafkaEmitterConfig(
@@ -51,7 +54,8 @@ public class KafkaEmitterConfig
       @JsonProperty("alert.topic") String alertTopic,
       @Nullable @JsonProperty("request.topic") String requestTopic,
       @JsonProperty("clusterName") String clusterName,
-      @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig
+      @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig,
+      @JsonProperty("producer.dynamic.config") @Nullable DynamicConfigProvider kafkaProducerConfigProvider
   )
   {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
@@ -60,6 +64,7 @@ public class KafkaEmitterConfig
     this.requestTopic = requestTopic;
     this.clusterName = clusterName;
     this.kafkaProducerConfig = kafkaProducerConfig == null ? ImmutableMap.of() : kafkaProducerConfig;
+    this.kafkaProducerConfigProvider = kafkaProducerConfigProvider;
   }
 
   @JsonProperty
@@ -98,6 +103,12 @@ public class KafkaEmitterConfig
     return kafkaProducerConfig;
   }
 
+  @JsonProperty
+  public DynamicConfigProvider getKafkaProducerConfigProvider()
+  {
+    return kafkaProducerConfigProvider;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -127,6 +138,10 @@ public class KafkaEmitterConfig
     if (getClusterName() != null ? !getClusterName().equals(that.getClusterName()) : that.getClusterName() != null) {
       return false;
     }
+
+    if (getKafkaProducerConfigProvider() != null ? !getKafkaProducerConfigProvider().getConfig().equals(that.getKafkaProducerConfigProvider().getConfig()) : that.getKafkaProducerConfigProvider() != null) {
+      return false;
+    }
     return getKafkaProducerConfig().equals(that.getKafkaProducerConfig());
   }
 
@@ -139,6 +154,7 @@ public class KafkaEmitterConfig
     result = 31 * result + (getRequestTopic() != null ? getRequestTopic().hashCode() : 0);
     result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
     result = 31 * result + getKafkaProducerConfig().hashCode();
+    result = 31 * result + getKafkaProducerConfigProvider().hashCode();
     return result;
   }
 

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -23,29 +23,28 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import javax.annotation.Nullable;
+
 import java.util.Map;
 
 public class KafkaEmitterConfig
 {
-
+  public static final String DRUID_DYNAMIC_CONFIG_PROVIDER_KEY = "druid.dynamic.config.provider";
   @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
   private final String bootstrapServers;
   @JsonProperty("metric.topic")
   private final String metricTopic;
   @JsonProperty("alert.topic")
   private final String alertTopic;
-  @Nullable @JsonProperty("request.topic")
+  @Nullable
+  @JsonProperty("request.topic")
   private final String requestTopic;
   @JsonProperty
   private final String clusterName;
   @JsonProperty("producer.config")
-  private Map<String, String> kafkaProducerConfig;
-  @JsonProperty("producer.dynamic.config")
-  private DynamicConfigProvider kafkaProducerConfigProvider;
+  private Map<String, Object> kafkaProducerConfig;
 
   @JsonCreator
   public KafkaEmitterConfig(
@@ -54,8 +53,7 @@ public class KafkaEmitterConfig
       @JsonProperty("alert.topic") String alertTopic,
       @Nullable @JsonProperty("request.topic") String requestTopic,
       @JsonProperty("clusterName") String clusterName,
-      @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig,
-      @JsonProperty("producer.dynamic.config") @Nullable DynamicConfigProvider kafkaProducerConfigProvider
+      @JsonProperty("producer.config") @Nullable Map<String, Object> kafkaProducerConfig
   )
   {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
@@ -64,7 +62,6 @@ public class KafkaEmitterConfig
     this.requestTopic = requestTopic;
     this.clusterName = clusterName;
     this.kafkaProducerConfig = kafkaProducerConfig == null ? ImmutableMap.of() : kafkaProducerConfig;
-    this.kafkaProducerConfigProvider = kafkaProducerConfigProvider;
   }
 
   @JsonProperty
@@ -98,15 +95,9 @@ public class KafkaEmitterConfig
   }
 
   @JsonProperty
-  public Map<String, String> getKafkaProducerConfig()
+  public Map<String, Object> getKafkaProducerConfig()
   {
     return kafkaProducerConfig;
-  }
-
-  @JsonProperty
-  public DynamicConfigProvider getKafkaProducerConfigProvider()
-  {
-    return kafkaProducerConfigProvider;
   }
 
   @Override
@@ -139,9 +130,6 @@ public class KafkaEmitterConfig
       return false;
     }
 
-    if (getKafkaProducerConfigProvider() != null ? !getKafkaProducerConfigProvider().getConfig().equals(that.getKafkaProducerConfigProvider().getConfig()) : that.getKafkaProducerConfigProvider() != null) {
-      return false;
-    }
     return getKafkaProducerConfig().equals(that.getKafkaProducerConfig());
   }
 
@@ -154,7 +142,6 @@ public class KafkaEmitterConfig
     result = 31 * result + (getRequestTopic() != null ? getRequestTopic().hashCode() : 0);
     result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
     result = 31 * result + getKafkaProducerConfig().hashCode();
-    result = 31 * result + getKafkaProducerConfigProvider().hashCode();
     return result;
   }
 
@@ -162,12 +149,12 @@ public class KafkaEmitterConfig
   public String toString()
   {
     return "KafkaEmitterConfig{" +
-           "bootstrap.servers='" + bootstrapServers + '\'' +
-           ", metric.topic='" + metricTopic + '\'' +
-           ", alert.topic='" + alertTopic + '\'' +
-           ", request.topic='" + requestTopic + '\'' +
-           ", clusterName='" + clusterName + '\'' +
-           ", Producer.config=" + kafkaProducerConfig +
-           '}';
+        "bootstrap.servers='" + bootstrapServers + '\'' +
+        ", metric.topic='" + metricTopic + '\'' +
+        ", alert.topic='" + alertTopic + '\'' +
+        ", request.topic='" + requestTopic + '\'' +
+        ", clusterName='" + clusterName + '\'' +
+        ", Producer.config=" + kafkaProducerConfig +
+        '}';
   }
 }

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -23,12 +23,14 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.metadata.MapStringDynamicConfigProvider;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class KafkaEmitterConfigTest
 {
@@ -43,12 +45,14 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeserKafkaEmitterConfig() throws IOException
   {
+    DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+        ImmutableMap.of("testKey2", "testValue2")
+    );
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
         "alertTest", "requestTest",
-        "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build(), new MapStringDynamicConfigProvider(
-        ImmutableMap.of("testKey2", "testValue2")
-    )
+        "clusterNameTest", ImmutableMap.<String, Object>builder()
+        .put("testKey", "testValue").put("druid.dynamic.config.provider", mapper.convertValue(dynamicConfigProvider, Map.class)
+        ).build()
     );
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
@@ -61,9 +65,8 @@ public class KafkaEmitterConfigTest
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
         "alertTest", "requestTest",
-        "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build(), null
-    );
+        "clusterNameTest", ImmutableMap.<String, Object>builder()
+        .put("testKey", "testValue").build());
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
         .readValue(kafkaEmitterConfigString);
@@ -73,12 +76,14 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeserKafkaEmitterConfigNullRequestTopic() throws IOException
   {
+    DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+        ImmutableMap.of("testKey2", "testValue2")
+    );
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
         "alertTest", null,
-        "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build(), new MapStringDynamicConfigProvider(
-        ImmutableMap.of("testKey2", "testValue2"))
-    );
+        "clusterNameTest", ImmutableMap.<String, Object>builder()
+        .put("testKey", "testValue").put("druid.dynamic.config.provider", mapper.convertValue(dynamicConfigProvider, Map.class)
+        ).build());
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
         .readValue(kafkaEmitterConfigString);
@@ -90,9 +95,7 @@ public class KafkaEmitterConfigTest
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", "metricTest",
         "alertTest", null,
-        "clusterNameTest", null, new MapStringDynamicConfigProvider(
-        ImmutableMap.of("testKey2", "testValue2"))
-    );
+        "clusterNameTest", null);
     try {
       @SuppressWarnings("unused")
       KafkaEmitter emitter = new KafkaEmitter(kafkaEmitterConfig, mapper);

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -57,6 +57,20 @@ public class KafkaEmitterConfigTest
   }
 
   @Test
+  public void testSerDeserKafkaEmitterConfigNullDynamicConfigProvider() throws IOException
+  {
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
+        "alertTest", "requestTest",
+        "clusterNameTest", ImmutableMap.<String, String>builder()
+        .put("testKey", "testValue").build(), null
+    );
+    String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
+    KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
+        .readValue(kafkaEmitterConfigString);
+    Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
+  }
+
+  @Test
   public void testSerDeserKafkaEmitterConfigNullRequestTopic() throws IOException
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
@@ -76,7 +90,8 @@ public class KafkaEmitterConfigTest
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", "metricTest",
         "alertTest", null,
-        "clusterNameTest", null, null
+        "clusterNameTest", null, new MapStringDynamicConfigProvider(
+        ImmutableMap.of("testKey2", "testValue2"))
     );
     try {
       @SuppressWarnings("unused")

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.metadata.MapStringDynamicConfigProvider;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +46,9 @@ public class KafkaEmitterConfigTest
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
         "alertTest", "requestTest",
         "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build()
+        .put("testKey", "testValue").build(), new MapStringDynamicConfigProvider(
+        ImmutableMap.of("testKey2", "testValue2")
+    )
     );
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
@@ -59,7 +62,8 @@ public class KafkaEmitterConfigTest
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
         "alertTest", null,
         "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build()
+        .put("testKey", "testValue").build(), new MapStringDynamicConfigProvider(
+        ImmutableMap.of("testKey2", "testValue2"))
     );
     String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
@@ -72,7 +76,7 @@ public class KafkaEmitterConfigTest
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", "metricTest",
         "alertTest", null,
-        "clusterNameTest", null
+        "clusterNameTest", null, null
     );
     try {
       @SuppressWarnings("unused")

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -82,7 +82,7 @@ public class KafkaEmitterTest
         requestTopic == null ? totalEventsExcludingRequestLogEvents : totalEvents);
     final KafkaProducer<String, String> producer = EasyMock.createStrictMock(KafkaProducer.class);
     final KafkaEmitter kafkaEmitter = new KafkaEmitter(
-        new KafkaEmitterConfig("", "metrics", "alerts", requestTopic, "test-cluster", null),
+        new KafkaEmitterConfig("", "metrics", "alerts", requestTopic, "test-cluster", null, null),
         new ObjectMapper()
     )
     {

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -82,7 +82,7 @@ public class KafkaEmitterTest
         requestTopic == null ? totalEventsExcludingRequestLogEvents : totalEvents);
     final KafkaProducer<String, String> producer = EasyMock.createStrictMock(KafkaProducer.class);
     final KafkaEmitter kafkaEmitter = new KafkaEmitter(
-        new KafkaEmitterConfig("", "metrics", "alerts", requestTopic, "test-cluster", null, null),
+        new KafkaEmitterConfig("", "metrics", "alerts", requestTopic, "test-cluster", null),
         new ObjectMapper()
     )
     {

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -31,8 +31,8 @@ import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.metadata.PasswordProvider;
+import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
@@ -214,15 +214,8 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long, KafkaR
     }
 
     // Additional DynamicConfigProvider based extensible support for all consumer properties
-    Object dynamicConfigProviderJson = consumerProperties.get(KafkaSupervisorIOConfig.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY);
-    if (dynamicConfigProviderJson != null) {
-      DynamicConfigProvider dynamicConfigProvider = configMapper.convertValue(dynamicConfigProviderJson, DynamicConfigProvider.class);
-      Map<String, String> dynamicConfig = dynamicConfigProvider.getConfig();
+    DynamicConfigProviderUtils.extraDynamicConfigAndSetProperty(consumerProperties, KafkaSupervisorIOConfig.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, configMapper, properties);
 
-      for (Map.Entry<String, String> e : dynamicConfig.entrySet()) {
-        properties.setProperty(e.getKey(), e.getValue());
-      }
-    }
   }
 
   private static Deserializer getKafkaDeserializer(Properties properties, String kafkaConfigKey)


### PR DESCRIPTION
[ #10309](https://github.com/apache/druid/pull/10309) introduced a DynamicConfigProvider for setting Kafka properties. KafkaEmitter also needs Kafka properties. This PR use DynamicConfigProvider help to set properties in KafkaEmitter.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
