### PR TITLE
Update kafka-ingestion.md to update PasswordProvider support limitation

### DIFF
--- a/docs/development/extensions-core/kafka-ingestion.md
+++ b/docs/development/extensions-core/kafka-ingestion.md
@@ -268,7 +268,7 @@ For such consumer properties, user can implement a [DynamicConfigProvider](../..
 `druid.dynamic.config.provider`=`{"type": "<registered_dynamic_config_provider_name>", ...}`
 in consumerProperties map.
 
-Note: In 0.20.0 or older Druid versions, for SSL connections, the `keystore`, `truststore` and `key` passwords can also be provided as a [Password Provider](../../operations/password-provider.md). This is deprecated.
+Note: SSL connections may also be supplied using the deprecated [Password Provider](../../operations/password-provider.md) interface to define the `keystore`, `truststore`, and `key`. This functionality might be removed in a future release.
 
 #### Specifying data format
 


### PR DESCRIPTION
`kafka-ingestion.md` depicts that `PasswordProvider` is deprecated but is supported until the version of `0.20.0`. However, according to the code below, `PasswordProvider` still works. I updated the Druid version in the note to help readers understand clearly.

https://github.com/apache/druid/blob/ef006fd2571228984b04b95f3a3e2b03d930dce3/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java#L203-L207

This PR has:
- [x] been self-reviewed.
