### PR TITLE
avoid logging pause message multiple times

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1279,8 +1279,8 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
         status = Status.PAUSED;
         hasPaused.signalAll();
 
+        log.debug("Received pause command, pausing ingestion until resumed.");
         while (pauseRequested) {
-          log.debug("Received pause command, pausing ingestion until resumed.");
           shouldResume.await();
         }
 


### PR DESCRIPTION
In some instances the ingestion thread could be woken up spuriously,
resulting in the "Received pause command..." log message getting
logged multiple times. This change ensures we only log it once the first
time the pause is requested.
