### PR TITLE
Add Environment Variable DynamicConfigProvider

### DIFF
--- a/core/src/main/java/org/apache/druid/metadata/DynamicConfigProvider.java
+++ b/core/src/main/java/org/apache/druid/metadata/DynamicConfigProvider.java
@@ -32,6 +32,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = MapStringDynamicConfigProvider.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "mapString", value = MapStringDynamicConfigProvider.class),
+    @JsonSubTypes.Type(name = "environment", value = EnvironmentVariableDynamicConfigProvider.class)
 })
 public interface DynamicConfigProvider<T>
 {

--- a/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
+++ b/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.java.util.common.logger.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,9 +30,6 @@ import java.util.Objects;
 
 public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigProvider<String>
 {
-
-  private static final Logger log = new Logger(EnvironmentVariableDynamicConfigProvider.class);
-
   private final ImmutableMap<String, String> variables;
 
   @JsonCreator

--- a/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
+++ b/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
@@ -21,6 +21,7 @@ package org.apache.druid.metadata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.logger.Logger;
 
@@ -33,20 +34,14 @@ public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigPr
 
   private static final Logger log = new Logger(EnvironmentVariableDynamicConfigProvider.class);
 
-  private ImmutableMap<String, String> variables;
+  private final ImmutableMap<String, String> variables;
 
   @JsonCreator
   public EnvironmentVariableDynamicConfigProvider(
       @JsonProperty("variables") Map<String, String> config
   )
   {
-    try {
-      this.variables = ImmutableMap.copyOf(config);
-    }
-    catch (NullPointerException e) {
-      log.error(e, "Can not parse config by EnvironmentVariableDynamicConfigProvider! Please check your config file.");
-      throw e;
-    }
+    this.variables = ImmutableMap.copyOf(Preconditions.checkNotNull(config, "config"));
   }
 
   @JsonProperty("variables")

--- a/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
+++ b/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.metadata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigProvider
+{
+  private final ImmutableMap<String, String> variables;
+
+  @JsonCreator
+  public EnvironmentVariableDynamicConfigProvider(
+      @JsonProperty("variables") Map<String, String> config
+  )
+  {
+    this.variables = ImmutableMap.copyOf(config);
+  }
+
+  @JsonProperty("variables")
+  public Map<String, String> getVariables()
+  {
+    return variables;
+  }
+
+  @Override
+  public Map getConfig()
+  {
+    HashMap<String, String> map = new HashMap<>();
+    for (Map.Entry<String, String> entry : variables.entrySet()) {
+      map.put(entry.getKey(), System.getenv(entry.getValue()));
+    }
+    return map;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "EnvironmentVariablePasswordProvider{" +
+        "variable='" + variables + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    EnvironmentVariableDynamicConfigProvider that = (EnvironmentVariableDynamicConfigProvider) o;
+
+    return Objects.equals(variables, that.variables);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return variables != null ? variables.hashCode() : 0;
+  }
+
+
+}

--- a/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
+++ b/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
@@ -22,21 +22,31 @@ package org.apache.druid.metadata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.logger.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigProvider
+public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigProvider<String>
 {
-  private final ImmutableMap<String, String> variables;
+
+  private static final Logger log = new Logger(EnvironmentVariableDynamicConfigProvider.class);
+
+  private ImmutableMap<String, String> variables;
 
   @JsonCreator
   public EnvironmentVariableDynamicConfigProvider(
       @JsonProperty("variables") Map<String, String> config
   )
   {
-    this.variables = ImmutableMap.copyOf(config);
+    try {
+      this.variables = ImmutableMap.copyOf(config);
+    }
+    catch (NullPointerException e) {
+      log.error(e, "Can not parse config by EnvironmentVariableDynamicConfigProvider! Please check your config file.");
+      throw e;
+    }
   }
 
   @JsonProperty("variables")
@@ -46,7 +56,7 @@ public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigPr
   }
 
   @Override
-  public Map getConfig()
+  public Map<String, String> getConfig()
   {
     HashMap<String, String> map = new HashMap<>();
     for (Map.Entry<String, String> entry : variables.entrySet()) {
@@ -82,8 +92,7 @@ public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigPr
   @Override
   public int hashCode()
   {
-    return variables != null ? variables.hashCode() : 0;
+    return variables.hashCode();
   }
-
 
 }

--- a/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
+++ b/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
@@ -73,7 +73,8 @@ public class EnvironmentVariableDynamicConfigProviderTest
       theCaseInsensitiveEnvironmentField.setAccessible(true);
       Map<String, String> cienv = (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
       cienv.putAll(newenv);
-    } catch (NoSuchFieldException e) {
+    }
+    catch (NoSuchFieldException e) {
       Class[] classes = Collections.class.getDeclaredClasses();
       Map<String, String> env = System.getenv();
       for (Class cl : classes) {

--- a/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
+++ b/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
@@ -20,14 +20,25 @@
 package org.apache.druid.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
 
 public class EnvironmentVariableDynamicConfigProviderTest
 {
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+  @Before
+  public void setupTest() throws Exception
+  {
+    setEnv(ImmutableMap.of("DRUID_USER", "druid", "DRUID_PASSWORD", "123"));
+  }
 
   @Test
   public void testSerde() throws IOException
@@ -38,5 +49,43 @@ public class EnvironmentVariableDynamicConfigProviderTest
     Assert.assertEquals("testValue", ((EnvironmentVariableDynamicConfigProvider) provider).getVariables().get("testKey"));
     DynamicConfigProvider serde = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(provider), DynamicConfigProvider.class);
     Assert.assertEquals(provider, serde);
+  }
+
+  @Test
+  public void testGetConfig() throws Exception
+  {
+    String providerString = "{\"type\": \"environment\", \"variables\" : {\"user\":\"DRUID_USER\",\"password\":\"DRUID_PASSWORD\"}}";
+    DynamicConfigProvider provider = JSON_MAPPER.readValue(providerString, DynamicConfigProvider.class);
+    Assert.assertTrue(provider instanceof EnvironmentVariableDynamicConfigProvider);
+    Assert.assertEquals("druid", ((EnvironmentVariableDynamicConfigProvider) provider).getConfig().get("user"));
+    Assert.assertEquals("123", ((EnvironmentVariableDynamicConfigProvider) provider).getConfig().get("password"));
+  }
+
+  protected static void setEnv(Map<String, String> newenv) throws Exception
+  {
+    try {
+      Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
+      Field theEnvironmentField = processEnvironmentClass.getDeclaredField("theEnvironment");
+      theEnvironmentField.setAccessible(true);
+      Map<String, String> env = (Map<String, String>) theEnvironmentField.get(null);
+      env.putAll(newenv);
+      Field theCaseInsensitiveEnvironmentField = processEnvironmentClass.getDeclaredField("theCaseInsensitiveEnvironment");
+      theCaseInsensitiveEnvironmentField.setAccessible(true);
+      Map<String, String> cienv = (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
+      cienv.putAll(newenv);
+    } catch (NoSuchFieldException e) {
+      Class[] classes = Collections.class.getDeclaredClasses();
+      Map<String, String> env = System.getenv();
+      for (Class cl : classes) {
+        if ("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
+          Field field = cl.getDeclaredField("m");
+          field.setAccessible(true);
+          Object obj = field.get(env);
+          Map<String, String> map = (Map<String, String>) obj;
+          map.clear();
+          map.putAll(newenv);
+        }
+      }
+    }
   }
 }

--- a/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
+++ b/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.metadata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class EnvironmentVariableDynamicConfigProviderTest
+{
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    String providerString = "{\"type\": \"environment\", \"variables\" : {\"testKey\":\"testValue\"}}";
+    DynamicConfigProvider provider = JSON_MAPPER.readValue(providerString, DynamicConfigProvider.class);
+    Assert.assertTrue(provider instanceof EnvironmentVariableDynamicConfigProvider);
+    Assert.assertEquals("testValue", ((EnvironmentVariableDynamicConfigProvider) provider).getVariables().get("testKey"));
+    DynamicConfigProvider serde = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(provider), DynamicConfigProvider.class);
+    Assert.assertEquals(provider, serde);
+  }
+}

--- a/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
+++ b/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
@@ -83,10 +83,10 @@ public class EnvironmentVariableDynamicConfigProviderTest
   }
 
   /**
-   * This method use reflection to get system evniorment variables map in runtime JVM
+   * This method use reflection to get system environment variables map in runtime JVM
    * which can be changed.
    *
-   * @return system evniorment variables map.
+   * @return system environment variables map.
    */
   private static Map<String, String> getENVMap() throws Exception
   {

--- a/docs/operations/dynamic-config-provider.md
+++ b/docs/operations/dynamic-config-provider.md
@@ -33,7 +33,7 @@ For more information, see [Adding a new DynamicConfigProvider implementation](..
 
 ## Environment variable dynamic config provider
 
-`EnvironmentVariableDynamicConfigProvider` can be used to avoid exposing credentials or other secret information in the configuration files using environment variables. An example to use this configProvider is:
+`EnvironmentVariableDynamicConfigProvider` can be used to avoid exposing credentials or other secret information in the configuration files using environment variables. An example to use this `configProvider` is:
 ```json
 druid.some.config.dynamicConfigProvider={"type": "environment","variables":{"secret1": "SECRET1_VAR","secret2": "SECRET2_VAR"}}
 ```

--- a/docs/operations/dynamic-config-provider.md
+++ b/docs/operations/dynamic-config-provider.md
@@ -33,9 +33,9 @@ For more information, see [Adding a new DynamicConfigProvider implementation](..
 
 ## Environment variable dynamic config provider
 
-`EnvironmentVariableDynamicConfigProvider` can be used to replace `EnvironmentVariablePasswordProvider`. This class allow users to avoid exposing passwords or other secret information in the runtime.properties file. You can set environment variables in the following example:
+`EnvironmentVariableDynamicConfigProvider` can be used to avoid exposing credentials or other secret information in the configuration files using environment variables. An example to use this configProvider is:
 ```json
-druid.metadata.storage.connector.dynamicConfigProvider={"type": "environment","variables":{"user": "MY_USER_NAME_VAR","password": "MY_PASSWORD_VAR"}}
+druid.some.config.dynamicConfigProvider={"type": "environment","variables":{"secret1": "SECRET1_VAR","secret2": "SECRET2_VAR"}}
 ```
 The values are described below.
 

--- a/docs/operations/dynamic-config-provider.md
+++ b/docs/operations/dynamic-config-provider.md
@@ -31,7 +31,7 @@ Users can create custom extension of the `DynamicConfigProvider` interface that 
 
 For more information, see [Adding a new DynamicConfigProvider implementation](../development/modules.md#adding-a-new-dynamicconfigprovider-implementation).
 
-## EnvironmentVariableDynamicConfigProvider
+## Environment variable dynamic config provider
 
 `EnvironmentVariableDynamicConfigProvider` can be used to replace `EnvironmentVariablePasswordProvider`. This class allow users to avoid exposing passwords or other secret information in the runtime.properties file. You can set environment variables in the following example:
 ```json

--- a/docs/operations/dynamic-config-provider.md
+++ b/docs/operations/dynamic-config-provider.md
@@ -31,3 +31,16 @@ Users can create custom extension of the `DynamicConfigProvider` interface that 
 
 For more information, see [Adding a new DynamicConfigProvider implementation](../development/modules.md#adding-a-new-dynamicconfigprovider-implementation).
 
+## EnvironmentVariableDynamicConfigProvider
+
+`EnvironmentVariableDynamicConfigProvider` can be used to replace `EnvironmentVariablePasswordProvider`. This class allow users to avoid exposing passwords or other secret information in the runtime.properties file. You can set environment variables in the following example:
+```json
+druid.metadata.storage.connector.dynamicConfigProvider={"type": "environment","variables":{"user": "MY_USER_NAME_VAR","password": "MY_PASSWORD_VAR"}
+```
+The values are described below.
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|`type`|String|dynamic config provider type|Yes: `environment`|
+|`variables`|Map|environment variables to get information from|Yes|
+

--- a/docs/operations/dynamic-config-provider.md
+++ b/docs/operations/dynamic-config-provider.md
@@ -35,7 +35,7 @@ For more information, see [Adding a new DynamicConfigProvider implementation](..
 
 `EnvironmentVariableDynamicConfigProvider` can be used to replace `EnvironmentVariablePasswordProvider`. This class allow users to avoid exposing passwords or other secret information in the runtime.properties file. You can set environment variables in the following example:
 ```json
-druid.metadata.storage.connector.dynamicConfigProvider={"type": "environment","variables":{"user": "MY_USER_NAME_VAR","password": "MY_PASSWORD_VAR"}
+druid.metadata.storage.connector.dynamicConfigProvider={"type": "environment","variables":{"user": "MY_USER_NAME_VAR","password": "MY_PASSWORD_VAR"}}
 ```
 The values are described below.
 


### PR DESCRIPTION
As [#9351](https://github.com/apache/druid/issues/9351) described, DynamicConfigProvider should replace PasswordProvider. PasswordProvider has an implementation named EnvironmentVariablePasswordProvider, which allow users to read config from environment variable. This PR provides a same implementation for DynamicConfigProvider. There is an example for its usage:
```
"DynamicConfigProvider": {
  "type": "environment",
  "variables":
         {
            "userNameVariable": "MY_USER_NAME_VAR",
            "passwordVariable": "MY_PASSWORD_VAR"
         }
}
```

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
