### PR TITLE
fix time_floor expression performance issue when origin is null

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
@@ -93,6 +93,11 @@ public class DruidExpression
     return "null";
   }
 
+  public static String emptyLiteral()
+  {
+    return "''";
+  }
+
   public static String functionCall(final String functionName, final List<DruidExpression> args)
   {
     Preconditions.checkNotNull(functionName, "functionName");

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
@@ -155,7 +155,7 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
                 return Expressions.toDruidExpression(plannerContext, rowSignature, operand);
               }
             },
-            DruidExpression.fromExpression(DruidExpression.nullLiteral())
+            DruidExpression.fromExpression(DruidExpression.emptyLiteral())
         )
     );
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
@@ -83,7 +83,7 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                                                 .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
                                                                 .setVirtualColumns(new ExpressionVirtualColumn(
                                                                     "v0",
-                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    "timestamp_floor(\"__time\",'P1D','','UTC')",
                                                                     ValueType.LONG,
                                                                     TestExprMacroTable.INSTANCE
                                                                 ))
@@ -190,7 +190,7 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                                                 .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
                                                                 .setVirtualColumns(new ExpressionVirtualColumn(
                                                                     "v0",
-                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    "timestamp_floor(\"__time\",'P1D','','UTC')",
                                                                     ValueType.LONG,
                                                                     TestExprMacroTable.INSTANCE
                                                                 ))
@@ -277,7 +277,7 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                                                 .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
                                                                 .setVirtualColumns(new ExpressionVirtualColumn(
                                                                     "v0",
-                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    "timestamp_floor(\"__time\",'P1D','','UTC')",
                                                                     ValueType.LONG,
                                                                     TestExprMacroTable.INSTANCE
                                                                 ))
@@ -358,7 +358,7 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                                                 .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
                                                                 .setVirtualColumns(new ExpressionVirtualColumn(
                                                                     "v0",
-                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    "timestamp_floor(\"__time\",'P1D','','UTC')",
                                                                     ValueType.LONG,
                                                                     TestExprMacroTable.INSTANCE
                                                                 ))
@@ -445,7 +445,7 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                                                 .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
                                                                 .setVirtualColumns(new ExpressionVirtualColumn(
                                                                     "v0",
-                                                                    "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                                    "timestamp_floor(\"__time\",'P1D','','UTC')",
                                                                     ValueType.LONG,
                                                                     TestExprMacroTable.INSTANCE
                                                                 ))

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -615,7 +615,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                           .context(getTimeseriesContextWithFloorTime(TIMESERIES_CONTEXT_BY_GRAN, "d0"))
                                           .build()),
                                 "j0.",
-                                "((timestamp_floor(\"__time\",'PT1H',null,'UTC') == \"j0.d0\") && (\"m1\" == \"j0.a0\"))",
+                                "((timestamp_floor(\"__time\",'PT1H','','UTC') == \"j0.d0\") && (\"m1\" == \"j0.a0\"))",
                                 JoinType.INNER
                             )
                         )
@@ -664,7 +664,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                                 .setVirtualColumns(
                                                     expressionVirtualColumn(
                                                         "v0",
-                                                        "(timestamp_floor(\"__time\",'PT1H',null,'UTC') + 0)",
+                                                        "(timestamp_floor(\"__time\",'PT1H','','UTC') + 0)",
                                                         ValueType.LONG
                                                     )
                                                 )
@@ -677,7 +677,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                                 .setContext(QUERY_CONTEXT_DEFAULT)
                                                 .build()),
                                 "j0.",
-                                "((timestamp_floor(\"__time\",'PT1H',null,'UTC') == \"j0.d0\") && (\"m1\" == \"j0.a0\"))",
+                                "((timestamp_floor(\"__time\",'PT1H','','UTC') == \"j0.d0\") && (\"m1\" == \"j0.a0\"))",
                                 JoinType.INNER
                             )
                         )
@@ -7417,7 +7417,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .setInterval(querySegmentSpec(Filtration.eternity()))
                 .setGranularity(Granularities.ALL)
                 .setVirtualColumns(
-                    expressionVirtualColumn("v0", "timestamp_floor(\"cnt\",'P1Y',null,'UTC')", ValueType.LONG)
+                    expressionVirtualColumn("v0", "timestamp_floor(\"cnt\",'P1Y','','UTC')", ValueType.LONG)
                 )
                 .setDimFilter(
                     bound(
@@ -7946,7 +7946,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                             .setGranularity(Granularities.ALL)
                                             .setVirtualColumns(expressionVirtualColumn(
                                                 "v0",
-                                                "timestamp_floor(\"__time\",'P1D',null,'UTC')",
+                                                "timestamp_floor(\"__time\",'P1D','','UTC')",
                                                 ValueType.LONG
                                             ))
                                             .setDimensions(dimensions(
@@ -8146,7 +8146,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_floor(\"a0\",'PT1H',null,'UTC')",
+                                "timestamp_floor(\"a0\",'PT1H','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -10038,7 +10038,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_floor(\"__time\",'P1Y',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1Y','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -12234,7 +12234,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_floor(timestamp_shift(\"__time\",'P1D',-1,'UTC'),'P1M',null,'UTC')",
+                                "timestamp_floor(timestamp_shift(\"__time\",'P1D',-1,'UTC'),'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -12282,7 +12282,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_floor((\"__time\" + -86400000),'P1M',null,'UTC')",
+                                "timestamp_floor((\"__time\" + -86400000),'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13010,7 +13010,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_extract(timestamp_floor(\"__time\",'P1Y',null,'UTC'),'YEAR','UTC')",
+                                "timestamp_extract(timestamp_floor(\"__time\",'P1Y','','UTC'),'YEAR','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13048,7 +13048,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_extract(timestamp_floor(\"__time\",'P1Y',null,'America/Los_Angeles'),'YEAR','America/Los_Angeles')",
+                                "timestamp_extract(timestamp_floor(\"__time\",'P1Y','','America/Los_Angeles'),'YEAR','America/Los_Angeles')",
                                 ValueType.LONG
                             )
                         )
@@ -13143,7 +13143,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13203,7 +13203,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13272,7 +13272,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13338,7 +13338,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13490,7 +13490,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13544,7 +13544,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             ),
                             expressionVirtualColumn(
@@ -13606,7 +13606,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13667,7 +13667,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v2",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13729,7 +13729,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13785,7 +13785,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13858,7 +13858,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -13927,7 +13927,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -17126,7 +17126,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )
@@ -17193,7 +17193,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             ),
                             expressionVirtualColumn(
                                 "v1",
-                                "timestamp_floor(\"__time\",'P1M',null,'UTC')",
+                                "timestamp_floor(\"__time\",'P1M','','UTC')",
                                 ValueType.LONG
                             )
                         )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1312,7 +1312,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z")),
             testHelper.makeLiteral("PT1H")
         ),
-        DruidExpression.fromExpression("timestamp_floor(949550706000,'PT1H',null,'UTC')"),
+        DruidExpression.fromExpression("timestamp_floor(949550706000,'PT1H','','UTC')"),
         DateTimes.of("2000-02-03T04:00:00").getMillis()
     );
 
@@ -1324,7 +1324,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.TIMESTAMP),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D',null,'America/Los_Angeles')"),
+        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D','','America/Los_Angeles')"),
         DateTimes.of("2000-02-02T08:00:00").getMillis()
     );
   }
@@ -1340,7 +1340,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("t"),
             testHelper.makeFlag(TimeUnitRange.YEAR)
         ),
-        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1Y',null,'UTC')"),
+        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1Y','','UTC')"),
         DateTimes.of("2000").getMillis()
     );
   }
@@ -1354,7 +1354,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z")),
             testHelper.makeLiteral("PT1H")
         ),
-        DruidExpression.fromExpression("timestamp_ceil(949550706000,'PT1H',null,'UTC')"),
+        DruidExpression.fromExpression("timestamp_ceil(949550706000,'PT1H','','UTC')"),
         DateTimes.of("2000-02-03T05:00:00").getMillis()
     );
 
@@ -1366,7 +1366,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.TIMESTAMP),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_ceil(\"t\",'P1D',null,'America/Los_Angeles')"),
+        DruidExpression.fromExpression("timestamp_ceil(\"t\",'P1D','','America/Los_Angeles')"),
         DateTimes.of("2000-02-03T08:00:00").getMillis()
     );
   }
@@ -1382,7 +1382,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("t"),
             testHelper.makeFlag(TimeUnitRange.YEAR)
         ),
-        DruidExpression.fromExpression("timestamp_ceil(\"t\",'P1Y',null,'UTC')"),
+        DruidExpression.fromExpression("timestamp_ceil(\"t\",'P1Y','','UTC')"),
         DateTimes.of("2001").getMillis()
     );
   }


### PR DESCRIPTION
### Description

I noticed that `timestamp_floor("__time",'P1D',null,'Asia/Shanghai')` is extremely  slower(_**more than 3x in my case**_) than `timestamp_floor("__time",'P1D','','Asia/Shanghai')` when I test this sql

```sql
select
 sum("count") as c,
 Floor(__time to DAY) as __time
from
 "sms_normal"
where
 __time >= TIMESTAMP '2021-05-19 00:00:00'
 and __time < TIMESTAMP '2021-05-20 23:59:59'
group by
 Floor(__time to DAY)
having
 c>0
```

This is due to 
```java
    if (args.stream().skip(1).allMatch(Expr::isLiteral)) {
      return new TimestampFloorExpr(args);
    } else {
      return new TimestampFloorDynamicExpr(args);
    }
```
in `TimestampFloorExprMacro.java`

The "null" expr doesn't match `Expr::isLiteral()`, then TimestampFloorDynamicExpr is used, and `TimestampFloorDynamicExpr.eval()` create PeriodGranularity every time not like that only one time in `TimestampFloorExpr`'s constructor.
```java
    public ExprEval eval(final ObjectBinding bindings)
    {
      final PeriodGranularity granularity = computeGranularity(args, bindings);
      return ExprEval.of(granularity.bucketStart(args.get(0).eval(bindings).asLong()));
    }
```

This patch modifies the translation to `timestamp_floor("__time",'P1D','','Asia/Shanghai')` rather than `timestamp_floor("__time",'P1D',null,'Asia/Shanghai')`

<hr>

##### Key changed/added classes in this PR
 * `TimeFloorOperatorConversion`
 * `DruidExpression`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
