### PR TITLE
 Delete getPathForHadoop in DataSegmentPusher

### DIFF
--- a/core/src/main/java/org/apache/druid/segment/loading/DataSegmentPusher.java
+++ b/core/src/main/java/org/apache/druid/segment/loading/DataSegmentPusher.java
@@ -39,9 +39,6 @@ public interface DataSegmentPusher
 {
   Joiner JOINER = Joiner.on("/").skipNulls();
 
-  @Deprecated
-  String getPathForHadoop(String dataSource);
-
   String getPathForHadoop();
 
   /**
@@ -70,16 +67,6 @@ public interface DataSegmentPusher
 
   //use map instead of LoadSpec class to avoid dependency pollution.
   Map<String, Object> makeLoadSpec(URI finalIndexZipFilePath);
-
-  /**
-   * @deprecated backward-compatibiliy shim that should be removed on next major release;
-   * use {@link #getStorageDir(DataSegment, boolean)} instead.
-   */
-  @Deprecated
-  default String getStorageDir(DataSegment dataSegment)
-  {
-    return getStorageDir(dataSegment, false);
-  }
 
   default String getStorageDir(DataSegment dataSegment, boolean useUniquePath)
   {

--- a/core/src/main/java/org/apache/druid/segment/loading/NoopDataSegmentPusher.java
+++ b/core/src/main/java/org/apache/druid/segment/loading/NoopDataSegmentPusher.java
@@ -37,13 +37,6 @@ public class NoopDataSegmentPusher implements DataSegmentPusher
     return "noop";
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public DataSegment push(File file, DataSegment segment, boolean replaceExisting)
   {

--- a/extensions-contrib/aliyun-oss-extensions/src/main/java/org/apache/druid/storage/aliyun/OssDataSegmentPusher.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/main/java/org/apache/druid/storage/aliyun/OssDataSegmentPusher.java
@@ -60,13 +60,6 @@ public class OssDataSegmentPusher implements DataSegmentPusher
     return StringUtils.format("%s/%s", config.getBucket(), config.getPrefix());
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public List<String> getAllowedPropertyPrefixesForHadoop()
   {

--- a/extensions-contrib/cassandra-storage/src/main/java/org/apache/druid/storage/cassandra/CassandraDataSegmentPusher.java
+++ b/extensions-contrib/cassandra-storage/src/main/java/org/apache/druid/storage/cassandra/CassandraDataSegmentPusher.java
@@ -66,13 +66,6 @@ public class CassandraDataSegmentPusher extends CassandraStorage implements Data
     throw new UnsupportedOperationException("Cassandra storage does not support indexing via Hadoop");
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public DataSegment push(final File indexFilesDir, DataSegment segment, final boolean useUniquePath) throws IOException
   {

--- a/extensions-contrib/cloudfiles-extensions/src/main/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPusher.java
+++ b/extensions-contrib/cloudfiles-extensions/src/main/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPusher.java
@@ -61,13 +61,6 @@ public class CloudFilesDataSegmentPusher implements DataSegmentPusher
     return null;
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(final String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public DataSegment push(final File indexFilesDir, final DataSegment inSegment, final boolean useUniquePath)
   {

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPusher.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPusher.java
@@ -62,13 +62,6 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
     this.segmentConfig = segmentConfig;
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public String getPathForHadoop()
   {

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentPusherTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentPusherTest.java
@@ -322,7 +322,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   public void test_getPathForHadoop_noArgsWithoutPrefix_succeeds()
   {
     AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithoutPrefix);
-    String hadoopPath = pusher.getPathForHadoop("");
+    String hadoopPath = pusher.getPathForHadoop();
     Assert.assertEquals("wasbs://container@account.blob.core.windows.net/", hadoopPath);
   }
 
@@ -330,7 +330,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   public void test_getPathForHadoop_noArgsWithPrefix_succeeds()
   {
     AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix);
-    String hadoopPath = pusher.getPathForHadoop("");
+    String hadoopPath = pusher.getPathForHadoop();
     Assert.assertEquals("wasbs://container@account.blob.core.windows.net/prefix/", hadoopPath);
   }
 

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPusher.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPusher.java
@@ -57,13 +57,6 @@ public class GoogleDataSegmentPusher implements DataSegmentPusher
     this.config = config;
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public String getPathForHadoop()
   {

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -85,13 +85,6 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
     );
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public String getPathForHadoop()
   {

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusher.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusher.java
@@ -62,13 +62,6 @@ public class S3DataSegmentPusher implements DataSegmentPusher
     return StringUtils.format("s3n://%s/%s", config.getBucket(), config.getBaseKey());
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public List<String> getAllowedPropertyPrefixesForHadoop()
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusher.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusher.java
@@ -50,12 +50,6 @@ public class ShuffleDataSegmentPusher implements DataSegmentPusher
   }
 
   @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public String getPathForHadoop()
   {
     throw new UnsupportedOperationException();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/appenderator/BatchAppenderatorTester.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/appenderator/BatchAppenderatorTester.java
@@ -191,13 +191,6 @@ public class BatchAppenderatorTester implements AutoCloseable
     {
       private boolean mustFail = true;
 
-      @Deprecated
-      @Override
-      public String getPathForHadoop(String dataSource)
-      {
-        return getPathForHadoop();
-      }
-
       @Override
       public String getPathForHadoop()
       {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -528,13 +528,6 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
         throw new UnsupportedOperationException();
       }
 
-      @Deprecated
-      @Override
-      public String getPathForHadoop(String dataSource)
-      {
-        return getPathForHadoop();
-      }
-
       @Override
       public DataSegment push(File file, DataSegment segment, boolean useUniquePath)
       {
@@ -1181,13 +1174,6 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
   {
     dataSegmentPusher = new DataSegmentPusher()
     {
-      @Deprecated
-      @Override
-      public String getPathForHadoop(String s)
-      {
-        return getPathForHadoop();
-      }
-
       @Override
       public String getPathForHadoop()
       {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestDataSegmentPusher.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestDataSegmentPusher.java
@@ -28,12 +28,6 @@ import java.util.Map;
 
 public class TestDataSegmentPusher implements DataSegmentPusher
 {
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
 
   @Override
   public String getPathForHadoop()

--- a/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusher.java
@@ -54,13 +54,6 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
     return config.getStorageDirectory().getAbsoluteFile().toURI().toString();
   }
 
-  @Deprecated
-  @Override
-  public String getPathForHadoop(String dataSource)
-  {
-    return getPathForHadoop();
-  }
-
   @Override
   public DataSegment push(final File dataSegmentFile, final DataSegment segment, final boolean useUniquePath)
       throws IOException

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -223,13 +223,6 @@ public class AppenderatorTester implements AutoCloseable
     {
       private boolean mustFail = true;
 
-      @Deprecated
-      @Override
-      public String getPathForHadoop(String dataSource)
-      {
-        return getPathForHadoop();
-      }
-
       @Override
       public String getPathForHadoop()
       {


### PR DESCRIPTION
getPathForHadoop() is marked as deprecated in DataSegmentPusher and not used anywhere. So delete it is safe.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
