### PR TITLE
Adapt DynamicConfigProvider to Metadata

### DIFF
--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageConnectorConfig.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageConnectorConfig.java
@@ -49,7 +49,9 @@ public class MetadataStorageConnectorConfig
   @JsonProperty("dbcp")
   private Properties dbcpProperties;
 
-  @JsonProperty
+  @JsonProperty("dynamicConfigProvider")
+  private DynamicConfigProvider dynamicConfigProvider;
+
   public boolean isCreateTables()
   {
     return createTables;
@@ -79,13 +81,17 @@ public class MetadataStorageConnectorConfig
   @JsonProperty
   public String getUser()
   {
-    return user;
+    return (dynamicConfigProvider != null && dynamicConfigProvider.getConfig().get("user") != null) ? dynamicConfigProvider.getConfig().get("user").toString() : user;
   }
 
   @JsonProperty
   public String getPassword()
   {
-    return passwordProvider == null ? null : passwordProvider.getPassword();
+    if (dynamicConfigProvider != null && dynamicConfigProvider.getConfig().get("passward") != null) {
+      return dynamicConfigProvider.getConfig().get("passward").toString();
+    } else {
+      return passwordProvider == null ? null : passwordProvider.getPassword();
+    }
   }
 
   @JsonProperty("dbcp")
@@ -100,7 +106,7 @@ public class MetadataStorageConnectorConfig
     return "DbConnectorConfig{" +
            "createTables=" + createTables +
            ", connectURI='" + getConnectURI() + '\'' +
-           ", user='" + user + '\'' +
+           ", user='" + getUser() + '\'' +
            ", passwordProvider=" + passwordProvider +
            ", dbcpProperties=" + dbcpProperties +
            '}';
@@ -153,6 +159,7 @@ public class MetadataStorageConnectorConfig
     result = 31 * result + (getUser() != null ? getUser().hashCode() : 0);
     result = 31 * result + (passwordProvider != null ? passwordProvider.hashCode() : 0);
     result = 31 * result + (dbcpProperties != null ? dbcpProperties.hashCode() : 0);
+    result = 31 * result + (dynamicConfigProvider != null ? dynamicConfigProvider.hashCode() : 0);
     return result;
   }
 }

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorSslConfig.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorSslConfig.java
@@ -20,6 +20,7 @@
 package org.apache.druid.metadata.storage.mysql;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.metadata.PasswordProvider;
 
 import java.util.List;
@@ -56,6 +57,9 @@ public class MySQLConnectorSslConfig
   @JsonProperty
   private boolean verifyServerCertificate = false;
 
+  @JsonProperty("dynamicConfigProvider")
+  private DynamicConfigProvider dynamicConfigProvider;
+
   public boolean isUseSSL()
   {
     return useSSL;
@@ -73,7 +77,11 @@ public class MySQLConnectorSslConfig
 
   public String getTrustCertificateKeyStorePassword()
   {
-    return trustCertificateKeyStorePasswordProvider == null ? null : trustCertificateKeyStorePasswordProvider.getPassword();
+    if (dynamicConfigProvider != null && dynamicConfigProvider.getConfig().get("trustCertificateKeyStorePassword") != null) {
+      return dynamicConfigProvider.getConfig().get("trustCertificateKeyStorePassword").toString();
+    } else {
+      return trustCertificateKeyStorePasswordProvider == null ? null : trustCertificateKeyStorePasswordProvider.getPassword();
+    }
   }
 
   public String getClientCertificateKeyStoreUrl()
@@ -88,7 +96,11 @@ public class MySQLConnectorSslConfig
 
   public String getClientCertificateKeyStorePassword()
   {
-    return clientCertificateKeyStorePasswordProvider == null ? null : clientCertificateKeyStorePasswordProvider.getPassword();
+    if (dynamicConfigProvider != null && dynamicConfigProvider.getConfig().get("clientCertificateKeyStorePassword") != null) {
+      return dynamicConfigProvider.getConfig().get("clientCertificateKeyStorePassword").toString();
+    } else {
+      return clientCertificateKeyStorePasswordProvider == null ? null : clientCertificateKeyStorePasswordProvider.getPassword();
+    }
   }
 
   public List<String> getEnabledSSLCipherSuites()

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLMetadataStorageModuleTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLMetadataStorageModuleTest.java
@@ -76,6 +76,39 @@ public class MySQLMetadataStorageModuleTest
   }
 
   @Test
+  public void testSslConfigWithDynamicConfigProvider()
+  {
+    final Injector injector = createInjector();
+    final String propertyPrefix = "druid.metadata.mysql.ssl";
+    final JsonConfigProvider<MySQLConnectorSslConfig> provider = JsonConfigProvider.of(
+        propertyPrefix,
+        MySQLConnectorSslConfig.class
+    );
+    final Properties properties = new Properties();
+    properties.setProperty(propertyPrefix + ".useSSL", "true");
+    properties.setProperty(propertyPrefix + ".trustCertificateKeyStoreUrl", "url");
+    properties.setProperty(propertyPrefix + ".trustCertificateKeyStoreType", "type");
+    properties.setProperty(propertyPrefix + ".clientCertificateKeyStoreUrl", "url");
+    properties.setProperty(propertyPrefix + ".clientCertificateKeyStoreType", "type");
+    properties.setProperty(propertyPrefix + ".dynamicConfigProvider", "{\"type\":\"mapString\",\"config\":{\"trustCertificateKeyStorePassword\":\"secret\",\"clientCertificateKeyStorePassword\":\"secret\"}}");
+    properties.setProperty(propertyPrefix + ".enabledSSLCipherSuites", "[\"some\", \"ciphers\"]");
+    properties.setProperty(propertyPrefix + ".enabledTLSProtocols", "[\"some\", \"protocols\"]");
+    properties.setProperty(propertyPrefix + ".verifyServerCertificate", "true");
+    provider.inject(properties, injector.getInstance(JsonConfigurator.class));
+    final MySQLConnectorSslConfig config = provider.get().get();
+    Assert.assertTrue(config.isUseSSL());
+    Assert.assertEquals("url", config.getTrustCertificateKeyStoreUrl());
+    Assert.assertEquals("type", config.getTrustCertificateKeyStoreType());
+    Assert.assertEquals("secret", config.getTrustCertificateKeyStorePassword());
+    Assert.assertEquals("url", config.getClientCertificateKeyStoreUrl());
+    Assert.assertEquals("type", config.getClientCertificateKeyStoreType());
+    Assert.assertEquals("secret", config.getClientCertificateKeyStorePassword());
+    Assert.assertEquals(ImmutableList.of("some", "ciphers"), config.getEnabledSSLCipherSuites());
+    Assert.assertEquals(ImmutableList.of("some", "protocols"), config.getEnabledTLSProtocols());
+    Assert.assertTrue(config.isVerifyServerCertificate());
+  }
+
+  @Test
   public void testDriverConfigDefault()
   {
     final Injector injector = createInjector();

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexer.updater;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Supplier;
+import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
 import org.apache.druid.metadata.PasswordProvider;
@@ -57,6 +58,9 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
     return type;
   }
 
+  @JsonProperty("dynamicConfigProvider")
+  private DynamicConfigProvider dynamicConfigProvider;
+
   @Override
   public MetadataStorageConnectorConfig get()
   {
@@ -71,13 +75,17 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
       @Override
       public String getUser()
       {
-        return user;
+        return (dynamicConfigProvider != null && dynamicConfigProvider.getConfig().get("user") != null) ? dynamicConfigProvider.getConfig().get("user").toString() : user;
       }
 
       @Override
       public String getPassword()
       {
-        return passwordProvider == null ? null : passwordProvider.getPassword();
+        if (dynamicConfigProvider != null && dynamicConfigProvider.getConfig().get("passward") != null) {
+          return dynamicConfigProvider.getConfig().get("passward").toString();
+        } else {
+          return passwordProvider == null ? null : passwordProvider.getPassword();
+        }
       }
     };
   }


### PR DESCRIPTION
To Deprecate PasswordProvider which described in [#9351](https://github.com/apache/druid/issues/9351) DynamicConfigProvider must adapted to metadata. This is a PR to make this change.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
