### PR TITLE
revert commons-io to 2.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       # pin ZooKeeper dependencies to 3.5.x
       - dependency-name: "org.apache.zookeeper"
         versions: "[3.6,)"
+      # Keep commons-io at 2.6 until https://issues.apache.org/jira/browse/IO-741 is resolved
+      - dependency-name: "commons-io:commons-io"

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <confluent.version>6.0.1</confluent.version>
-    <commons-io.version>2.9.0</commons-io.version>
+    <commons-io.version>2.6</commons-io.version>
   </properties>
 
   <repositories>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -545,13 +545,13 @@ name: Apache Commons IO
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.9.0
+version: 2.6
 libraries:
   - commons-io: commons-io
 notices:
   - commons-io: |
       Apache Commons IO
-      Copyright 2002-2021 The Apache Software Foundation
+      Copyright 2002-2017 The Apache Software Foundation
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.9.0</version>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>

--- a/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
@@ -153,7 +153,7 @@ public class LocalDataSegmentPusherTest
   public void testPushCannotCreateDirectory() throws IOException
   {
     exception.expect(IOException.class);
-    exception.expectMessage("Cannot create directory");
+    exception.expectMessage("Unable to create directory");
     config.storageDirectory = new File(config.storageDirectory, "xxx");
     Assert.assertTrue(config.storageDirectory.mkdir());
     config.storageDirectory.setWritable(false);


### PR DESCRIPTION
Revert commons-io dependency from 2.9.0 to 2.6. This was package was upgraded to 2.9 by dependabot, and caused issues with loading extensions. In particular, when using version 2.9, if an extension's directory is a symlink, then none of the jars contained within the directory are found, which results in failure when loading the extension. Filed a bug with the commons-io project, https://issues.apache.org/jira/browse/IO-741. We can upgrade this dependency when this issue is resolved.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
