### PR TITLE
Fix expiration logic for ldap internal credential cache

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.security.basic.authentication;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.security.basic.BasicAuthUtils;
@@ -50,7 +51,8 @@ public class LdapUserPrincipal implements Principal
     this(name, credentials, searchResult, Instant.now());
   }
 
-  private LdapUserPrincipal(
+  @VisibleForTesting
+  public LdapUserPrincipal(
       String name,
       BasicAuthenticatorCredentials credentials,
       SearchResult searchResult,
@@ -106,16 +108,21 @@ public class LdapUserPrincipal implements Principal
     }
   }
 
-  public boolean isExpired(int duration, int maxDuration)
+  public boolean isExpired(int durationSeconds, int maxDurationSeconds)
   {
-    long now = System.currentTimeMillis();
-    long maxCutoff = now - (maxDuration * 1000L);
-    if (this.createdAt.toEpochMilli() < maxCutoff) {
+    return isExpired(durationSeconds, maxDurationSeconds, System.currentTimeMillis());
+  }
+
+  @VisibleForTesting
+  public boolean isExpired(int durationSeconds, int maxDurationSeconds, long nowMillis)
+  {
+    long maxCutoffMillis = nowMillis - (maxDurationSeconds * 1000L);
+    if (this.createdAt.toEpochMilli() < maxCutoffMillis) {
       // max cutoff is up...so expired
       return true;
     } else {
-      long cutoff = now - (duration * 1000L);
-      if (this.lastVerified.get().toEpochMilli() < cutoff) {
+      long cutoffMillis = nowMillis - (durationSeconds * 1000L);
+      if (this.lastVerified.get().toEpochMilli() < cutoffMillis) {
         // max cutoff not reached yet but cutoff since verified is up, so expired
         return true;
       }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
@@ -109,18 +109,18 @@ public class LdapUserPrincipal implements Principal
   public boolean isExpired(int duration, int maxDuration)
   {
     long now = System.currentTimeMillis();
-
     long maxCutoff = now - (maxDuration * 1000L);
     if (this.createdAt.toEpochMilli() < maxCutoff) {
+      // max cutoff is up...so expired
+      return true;
+    } else {
       long cutoff = now - (duration * 1000L);
       if (this.lastVerified.get().toEpochMilli() < cutoff) {
+        // max cutoff not reached yet but cutoff since verified is up, so expired
         return true;
-      } else {
-        return false;
       }
-    } else {
-      return false;
     }
+    return false;
   }
 
   @Override

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
@@ -114,7 +114,7 @@ public class LdapUserPrincipal implements Principal
   }
 
   @VisibleForTesting
-  public boolean isExpired(int durationSeconds, int maxDurationSeconds, long nowMillis)
+  boolean isExpired(int durationSeconds, int maxDurationSeconds, long nowMillis)
   {
     long maxCutoffMillis = nowMillis - (maxDurationSeconds * 1000L);
     if (this.createdAt.toEpochMilli() < maxCutoffMillis) {

--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/LdapUserPrincipalTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/LdapUserPrincipalTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.basic.authentication;
+
+import junit.framework.TestCase;
+import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorCredentialUpdate;
+import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorCredentials;
+import org.junit.Assert;
+
+import javax.naming.directory.SearchResult;
+
+public class LdapUserPrincipalTest extends TestCase
+{
+
+  private static final BasicAuthenticatorCredentials USER_CREDENTIALS = new BasicAuthenticatorCredentials(
+      new BasicAuthenticatorCredentialUpdate("helloworld", 20)
+  );
+
+  // this will create a cache with createdAt now():
+  private static final LdapUserPrincipal principal = new LdapUserPrincipal(
+      "foo",
+      USER_CREDENTIALS,
+      new SearchResult("foo", null, null)
+  );
+
+  public void testIsNotExpired()
+  {
+    Assert.assertFalse(principal.isExpired(1000, 1000));
+  }
+
+  public void testIsExpiredWhenMaxDurationIsSmall() throws InterruptedException
+  {
+    Thread.sleep(1000);
+    Assert.assertTrue(principal.isExpired(10, 1));
+  }
+
+  public void testIsExpiredWhenDurationIsSmall() throws InterruptedException
+  {
+    Thread.sleep(2000);
+    Assert.assertTrue(principal.isExpired(1, 10));
+  }
+
+  public void testIsExpiredWhenDurationsAreSmall() throws InterruptedException
+  {
+    Thread.sleep(1000);
+    Assert.assertTrue(principal.isExpired(1, 1));
+  }
+}

--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/LdapUserPrincipalTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/LdapUserPrincipalTest.java
@@ -55,17 +55,17 @@ public class LdapUserPrincipalTest extends TestCase
     Assert.assertTrue(PRINCIPAL.isExpired(100, 1000));
   }
 
-  public void testIsExpiredWhenMaxDurationIsSmall() throws InterruptedException
+  public void testIsExpiredWhenMaxDurationIsSmall()
   {
     Assert.assertTrue(PRINCIPAL.isExpired(10, 1, CREATED_MILLIS + 1001));
   }
 
-  public void testIsExpiredWhenDurationIsSmall() throws InterruptedException
+  public void testIsExpiredWhenDurationIsSmall()
   {
     Assert.assertTrue(PRINCIPAL.isExpired(1, 10, CREATED_MILLIS + 1001));
   }
 
-  public void testIsExpiredWhenDurationsAreSmall() throws InterruptedException
+  public void testIsExpiredWhenDurationsAreSmall() 
   {
     Assert.assertTrue(PRINCIPAL.isExpired(1, 1, CREATED_MILLIS + 1001));
   }


### PR DESCRIPTION
Fixes a bug with the expiration logic for `LdapUserPrincipal`. The entry should unconditionally expire when `maxDuration` is up among other conditions. It was not expiring in that case.

This PR has:
- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
