### PR TITLE
Update examples/bin/verify-java to allow spaces in java home

### DIFF
--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -59,7 +59,7 @@ if ($java_bin_dir eq "") {
   fail_check()
 }
 my $java_exec = "${java_bin_dir}/java";
-my $java_version = qx[$java_exec -version 2>&1];
+my $java_version = qx["$java_exec" -version 2>&1];
 if ($?) {
   fail_check();
 }


### PR DESCRIPTION
### Description

Quote the `$java_exec` var in `examples/bin/verify-java` to support spaces in `DRUID_JAVA_HOME`/`JAVA_HOME`. At present, the steps before and after the version check properly quote the path, but the version check spuriously fails when pointing to a Java 8 install that has a space in its path.

I manually verified that the quoted version correctly starts Druid using `bin/supervise -c conf/supervise/single-server/micro-quickstart.conf`.

<hr>

This PR has:
- [x] been self-reviewed.
