### PR TITLE
Web console: Data loading walkthrough fixes

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5164,7 +5164,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Imply Data
-version: 0.11.6
+version: 0.11.9
 
 ---
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5164,7 +5164,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Imply Data
-version: 0.11.9
+version: 0.11.10
 
 ---
 

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -7868,9 +7868,9 @@
       }
     },
     "druid-query-toolkit": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.11.9.tgz",
-      "integrity": "sha512-pfMcyXSw2n6bNIjueLCbKCz+ElkBAz8o7atQaXUxSDKCvj1Nz1cKcmWSCtU7w2IT3u3mFbgE8ErqRdL3ugcowA==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.11.10.tgz",
+      "integrity": "sha512-jKqec2YMxCVvow8e9lmmrRKXxq/ugyeyKTVPaAUPbjoP4VHxk55BS2gXJ/S2ysCeVgvyJbjGbg2ZIkUzg4Whuw==",
       "requires": {
         "tslib": "^2.2.0"
       }

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -7868,9 +7868,9 @@
       }
     },
     "druid-query-toolkit": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.11.6.tgz",
-      "integrity": "sha512-ThOhXW0CCEf08be+qpc4GwbSIewXZPoJViEAr0qx4s9B57vTIlz8VTdfrC0ei/r2PjfGNg+lx1RZAmvsbfo2tA==",
+      "version": "0.11.9",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.11.9.tgz",
+      "integrity": "sha512-pfMcyXSw2n6bNIjueLCbKCz+ElkBAz8o7atQaXUxSDKCvj1Nz1cKcmWSCtU7w2IT3u3mFbgE8ErqRdL3ugcowA==",
       "requires": {
         "tslib": "^2.2.0"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -79,7 +79,7 @@
     "d3-axis": "^1.0.12",
     "d3-scale": "^3.2.0",
     "d3-selection": "^1.4.0",
-    "druid-query-toolkit": "^0.11.6",
+    "druid-query-toolkit": "^0.11.9",
     "file-saver": "^2.0.2",
     "fontsource-open-sans": "^3.0.9",
     "has-own-prop": "^2.0.0",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -79,7 +79,7 @@
     "d3-axis": "^1.0.12",
     "d3-scale": "^3.2.0",
     "d3-selection": "^1.4.0",
-    "druid-query-toolkit": "^0.11.9",
+    "druid-query-toolkit": "^0.11.10",
     "file-saver": "^2.0.2",
     "fontsource-open-sans": "^3.0.9",
     "has-own-prop": "^2.0.0",

--- a/web-console/script/create-sql-docs.js
+++ b/web-console/script/create-sql-docs.js
@@ -23,8 +23,8 @@ const fs = require('fs-extra');
 const readfile = '../docs/querying/sql.md';
 const writefile = 'lib/sql-docs.js';
 
-const EXPECTED_NUMBER_OF_FUNCTIONS = 134;
-const EXPECTED_NUMBER_OF_DATA_TYPES = 14;
+const MINIMUM_EXPECTED_NUMBER_OF_FUNCTIONS = 134;
+const MINIMUM_EXPECTED_NUMBER_OF_DATA_TYPES = 14;
 
 function unwrapMarkdownLinks(str) {
   return str.replace(/\[([^\]]+)\]\([^)]+\)/g, (_, s) => s);
@@ -58,16 +58,16 @@ const readDoc = async () => {
   }
 
   // Make sure there are enough functions found
-  if (functionDocs.length < EXPECTED_NUMBER_OF_FUNCTIONS) {
+  if (functionDocs.length < MINIMUM_EXPECTED_NUMBER_OF_FUNCTIONS) {
     throw new Error(
-      `Did not find enough function entries did the structure of '${readfile}' change? (found ${functionDocs.length} but expected ${EXPECTED_NUMBER_OF_FUNCTIONS})`,
+      `Did not find enough function entries did the structure of '${readfile}' change? (found ${functionDocs.length} but expected at least ${MINIMUM_EXPECTED_NUMBER_OF_FUNCTIONS})`,
     );
   }
 
   // Make sure there are at least 10 data types for sanity
-  if (dataTypeDocs.length < EXPECTED_NUMBER_OF_DATA_TYPES) {
+  if (dataTypeDocs.length < MINIMUM_EXPECTED_NUMBER_OF_DATA_TYPES) {
     throw new Error(
-      `Did not find enough data type entries did the structure of '${readfile}' change? (found ${dataTypeDocs.length} but expected ${EXPECTED_NUMBER_OF_DATA_TYPES})`,
+      `Did not find enough data type entries did the structure of '${readfile}' change? (found ${dataTypeDocs.length} but expected at least ${MINIMUM_EXPECTED_NUMBER_OF_DATA_TYPES})`,
     );
   }
 

--- a/web-console/script/create-sql-docs.js
+++ b/web-console/script/create-sql-docs.js
@@ -23,6 +23,9 @@ const fs = require('fs-extra');
 const readfile = '../docs/querying/sql.md';
 const writefile = 'lib/sql-docs.js';
 
+const EXPECTED_NUMBER_OF_FUNCTIONS = 134;
+const EXPECTED_NUMBER_OF_DATA_TYPES = 14;
+
 function unwrapMarkdownLinks(str) {
   return str.replace(/\[([^\]]+)\]\([^)]+\)/g, (_, s) => s);
 }
@@ -34,16 +37,17 @@ const readDoc = async () => {
   const functionDocs = [];
   const dataTypeDocs = [];
   for (let line of lines) {
-    const functionMatch = line.match(/^\|`(\w+)\((.*)\)`\|(.+)\|$/);
+    const functionMatch = line.match(/^\|`(\w+)\(([^|]*)\)`\|([^|]+)\|(?:([^|]+)\|)?$/);
     if (functionMatch) {
       functionDocs.push([
         functionMatch[1],
         functionMatch[2],
         unwrapMarkdownLinks(functionMatch[3]),
+        // functionMatch[4] would be the default column but we ignore it for now
       ]);
     }
 
-    const dataTypeMatch = line.match(/^\|([A-Z]+)\|([A-Z]+)\|(.*)\|(.*)\|$/);
+    const dataTypeMatch = line.match(/^\|([A-Z]+)\|([A-Z]+)\|([^|]*)\|([^|]*)\|$/);
     if (dataTypeMatch) {
       dataTypeDocs.push([
         dataTypeMatch[1],
@@ -53,17 +57,17 @@ const readDoc = async () => {
     }
   }
 
-  // Make sure there are at least 10 functions for sanity
-  if (functionDocs.length < 10) {
+  // Make sure there are enough functions found
+  if (functionDocs.length < EXPECTED_NUMBER_OF_FUNCTIONS) {
     throw new Error(
-      `Did not find enough function entries did the structure of '${readfile}' change? (found ${functionDocs.length})`,
+      `Did not find enough function entries did the structure of '${readfile}' change? (found ${functionDocs.length} but expected ${EXPECTED_NUMBER_OF_FUNCTIONS})`,
     );
   }
 
   // Make sure there are at least 10 data types for sanity
-  if (dataTypeDocs.length < 10) {
+  if (dataTypeDocs.length < EXPECTED_NUMBER_OF_DATA_TYPES) {
     throw new Error(
-      `Did not find enough data type entries did the structure of '${readfile}' change? (found ${dataTypeDocs.length})`,
+      `Did not find enough data type entries did the structure of '${readfile}' change? (found ${dataTypeDocs.length} but expected ${EXPECTED_NUMBER_OF_DATA_TYPES})`,
     );
   }
 
@@ -94,6 +98,7 @@ exports.SQL_DATA_TYPES = ${JSON.stringify(dataTypeDocs, null, 2)};
 exports.SQL_FUNCTIONS = ${JSON.stringify(functionDocs, null, 2)};
 `;
 
+  console.log(`Found ${dataTypeDocs.length} data types and ${functionDocs.length} functions`);
   await fs.writeFile(writefile, content, 'utf-8');
 };
 

--- a/web-console/src/bootstrap/json-parser.tsx
+++ b/web-console/src/bootstrap/json-parser.tsx
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryResult } from 'druid-query-toolkit';
+import * as JSONBig from 'json-bigint-native';
+
+export function bootstrapJsonParse() {
+  QueryResult.jsonParse = JSONBig.parse;
+}

--- a/web-console/src/components/array-input/array-input.tsx
+++ b/web-console/src/components/array-input/array-input.tsx
@@ -32,30 +32,30 @@ export interface ArrayInputProps {
 }
 
 export const ArrayInput = React.memo(function ArrayInput(props: ArrayInputProps) {
-  const { className, placeholder, large, disabled, intent } = props;
-  const [stringValue, setStringValue] = useState<string>();
+  const { className, placeholder, large, disabled, intent, onChange } = props;
+  const [intermediateValue, setIntermediateValue] = useState<string | undefined>();
 
   const handleChange = (e: any) => {
-    const { onChange } = props;
     const stringValue = e.target.value;
-    const newValues: string[] = stringValue.split(/[,\s]+/).map((v: string) => v.trim());
-    const newValuesFiltered = compact(newValues);
-    if (stringValue === '') {
-      onChange(undefined);
-      setStringValue(undefined);
-    } else if (newValues.length === newValuesFiltered.length) {
-      onChange(newValuesFiltered);
-      setStringValue(undefined);
-    } else {
-      setStringValue(stringValue);
-    }
+    setIntermediateValue(stringValue);
+
+    onChange(
+      stringValue === ''
+        ? undefined
+        : compact(stringValue.split(/[,\s]+/).map((v: string) => v.trim())),
+    );
   };
 
   return (
     <TextArea
       className={className}
-      value={stringValue ?? props.values?.join(', ') ?? ''}
+      value={
+        typeof intermediateValue !== 'undefined'
+          ? intermediateValue
+          : props.values?.join(', ') || ''
+      }
       onChange={handleChange}
+      onBlur={() => setIntermediateValue(undefined)}
       placeholder={placeholder}
       large={large}
       disabled={disabled}

--- a/web-console/src/entry.ts
+++ b/web-console/src/entry.ts
@@ -23,6 +23,7 @@ import './bootstrap/ace';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { bootstrapJsonParse } from './bootstrap/json-parser';
 import { bootstrapReactTable } from './bootstrap/react-table-defaults';
 import { ConsoleApplication } from './console-application';
 import { Links, setLinkOverrides } from './links';
@@ -31,6 +32,7 @@ import { Api, UrlBaser } from './singletons';
 import './entry.scss';
 
 bootstrapReactTable();
+bootstrapJsonParse();
 
 const container = document.getElementsByClassName('app-container')[0];
 if (!container) throw new Error('container not found');

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -17,7 +17,7 @@
  */
 
 import {
-  alphanumericCompare,
+  arrangeWithPrefixSuffix,
   formatBytes,
   formatBytesCompact,
   formatInteger,
@@ -25,33 +25,30 @@ import {
   formatMillions,
   formatPercent,
   moveElement,
-  sortWithPrefixSuffix,
   sqlQueryCustomTableFilter,
   swapElements,
 } from './general';
 
 describe('general', () => {
-  describe('sortWithPrefixSuffix', () => {
+  describe('arrangeWithPrefixSuffix', () => {
     it('works in simple case', () => {
       expect(
-        sortWithPrefixSuffix(
+        arrangeWithPrefixSuffix(
           'abcdefgh'.split('').reverse(),
           'gef'.split(''),
           'ba'.split(''),
-          alphanumericCompare,
         ).join(''),
-      ).toEqual('gefcdhba');
+      ).toEqual('gefhdcba');
     });
 
     it('dedupes', () => {
       expect(
-        sortWithPrefixSuffix(
+        arrangeWithPrefixSuffix(
           'abcdefgh'.split('').reverse(),
           'gefgef'.split(''),
           'baba'.split(''),
-          alphanumericCompare,
         ).join(''),
-      ).toEqual('gefcdhba');
+      ).toEqual('gefhdcba');
     });
   });
 

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -72,10 +72,10 @@ describe('general', () => {
         String(
           sqlQueryCustomTableFilter({
             id: 'datasource',
-            value: `"hello"`,
+            value: `"Hello"`,
           }),
         ),
-      ).toEqual(`"datasource" = 'hello'`);
+      ).toEqual(`"datasource" = 'Hello'`);
     });
   });
 

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -100,28 +100,29 @@ interface NeedleAndMode {
 }
 
 export function getNeedleAndMode(filter: Filter): NeedleAndMode {
-  const input = filter.value.toLowerCase();
+  const input = filter.value;
   if (input.startsWith(`"`) && input.endsWith(`"`)) {
     return {
       needle: input.slice(1, -1),
       mode: 'exact',
     };
+  } else {
+    return {
+      needle: input.replace(/^"/, '').toLowerCase(),
+      mode: 'includes',
+    };
   }
-  return {
-    needle: input.startsWith(`"`) ? input.substring(1) : input,
-    mode: 'includes',
-  };
 }
 
 export function booleanCustomTableFilter(filter: Filter, value: any): boolean {
   if (value == null) return false;
-  const haystack = String(value).toLowerCase();
   const needleAndMode: NeedleAndMode = getNeedleAndMode(filter);
   const needle = needleAndMode.needle;
   if (needleAndMode.mode === 'exact') {
-    return needle === haystack;
+    return needle === String(value);
+  } else {
+    return String(value).toLowerCase().includes(needle);
   }
-  return haystack.includes(needle);
 }
 
 export function sqlQueryCustomTableFilter(filter: Filter): SqlExpression {

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -301,6 +301,10 @@ export function assemble<T>(...xs: (T | undefined | false | null | '')[]): T[] {
   return xs.filter(Boolean) as T[];
 }
 
+export function alphanumericCompare(a: string, b: string): number {
+  return String(a).localeCompare(b, undefined, { numeric: true });
+}
+
 export function arrangeWithPrefixSuffix(
   things: readonly string[],
   prefix: readonly string[],

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -301,20 +301,15 @@ export function assemble<T>(...xs: (T | undefined | false | null | '')[]): T[] {
   return xs.filter(Boolean) as T[];
 }
 
-export function alphanumericCompare(a: string, b: string): number {
-  return String(a).localeCompare(b, undefined, { numeric: true });
-}
-
-export function sortWithPrefixSuffix(
+export function arrangeWithPrefixSuffix(
   things: readonly string[],
   prefix: readonly string[],
   suffix: readonly string[],
-  cmp?: (a: string, b: string) => number,
 ): string[] {
   const pre = uniq(prefix.filter(x => things.includes(x)));
   const mid = things.filter(x => !prefix.includes(x) && !suffix.includes(x));
   const post = uniq(suffix.filter(x => things.includes(x)));
-  return pre.concat(cmp ? mid.sort(cmp) : mid, post);
+  return pre.concat(mid, post);
 }
 
 // ----------------------------

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -40,13 +40,7 @@ import {
 import { Api } from '../singletons';
 
 import { getDruidErrorMessage, queryDruidRune } from './druid-query';
-import {
-  alphanumericCompare,
-  EMPTY_ARRAY,
-  filterMap,
-  oneOf,
-  sortWithPrefixSuffix,
-} from './general';
+import { arrangeWithPrefixSuffix, EMPTY_ARRAY, filterMap, oneOf } from './general';
 import { deepGet, deepSet } from './object-change';
 
 const SAMPLER_URL = `/druid/indexer/v1/sampler`;
@@ -153,11 +147,10 @@ export interface HeaderFromSampleResponseOptions {
 export function headerFromSampleResponse(options: HeaderFromSampleResponseOptions): string[] {
   const { sampleResponse, ignoreTimeColumn, columnOrder, suffixColumnOrder } = options;
 
-  let columns = sortWithPrefixSuffix(
-    dedupe(sampleResponse.data.flatMap(s => (s.parsed ? Object.keys(s.parsed) : []))).sort(),
+  let columns = arrangeWithPrefixSuffix(
+    dedupe(sampleResponse.data.flatMap(s => (s.parsed ? Object.keys(s.parsed) : []))),
     columnOrder || [TIME_COLUMN],
     suffixColumnOrder || [],
-    alphanumericCompare,
   );
 
   if (ignoreTimeColumn) {
@@ -436,7 +429,6 @@ export async function sampleForTransform(
   cacheRows: CacheRows,
 ): Promise<SampleResponse> {
   const samplerType = getSpecType(spec);
-  const inputFormatColumns: string[] = deepGet(spec, 'spec.ioConfig.inputFormat.columns') || [];
   const timestampSpec: TimestampSpec = deepGet(spec, 'spec.dataSchema.timestampSpec');
   const transforms: Transform[] = deepGet(spec, 'spec.dataSchema.transformSpec.transforms') || [];
 
@@ -465,7 +457,6 @@ export async function sampleForTransform(
       headerFromSampleResponse({
         sampleResponse: sampleResponseHack,
         ignoreTimeColumn: true,
-        columnOrder: [TIME_COLUMN].concat(inputFormatColumns),
       }).concat(getDimensionNamesFromTransforms(transforms)),
     );
   }
@@ -494,7 +485,6 @@ export async function sampleForFilter(
   cacheRows: CacheRows,
 ): Promise<SampleResponse> {
   const samplerType = getSpecType(spec);
-  const inputFormatColumns: string[] = deepGet(spec, 'spec.ioConfig.inputFormat.columns') || [];
   const timestampSpec: TimestampSpec = deepGet(spec, 'spec.dataSchema.timestampSpec');
   const transforms: Transform[] = deepGet(spec, 'spec.dataSchema.transformSpec.transforms') || [];
   const filter: any = deepGet(spec, 'spec.dataSchema.transformSpec.filter');
@@ -524,7 +514,6 @@ export async function sampleForFilter(
       headerFromSampleResponse({
         sampleResponse: sampleResponseHack,
         ignoreTimeColumn: true,
-        columnOrder: [TIME_COLUMN].concat(inputFormatColumns),
       }).concat(getDimensionNamesFromTransforms(transforms)),
     );
   }

--- a/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
+++ b/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
@@ -422,6 +422,7 @@ exports[`tasks view matches snapshot 1`] = `
             },
             Object {
               "Aggregated": [Function],
+              "Cell": [Function],
               "Header": "Group ID",
               "accessor": "group_id",
               "show": true,

--- a/web-console/src/views/ingestion-view/ingestion-view.tsx
+++ b/web-console/src/views/ingestion-view/ingestion-view.tsx
@@ -749,6 +749,18 @@ ORDER BY "rank" DESC, "created_time" DESC`;
               accessor: 'group_id',
               width: 300,
               Aggregated: () => '',
+              Cell: row => {
+                const value = row.value;
+                return (
+                  <a
+                    onClick={() => {
+                      this.setState({ taskFilter: addFilter(taskFilter, 'group_id', value) });
+                    }}
+                  >
+                    {value}
+                  </a>
+                );
+              },
               show: hiddenTaskColumns.exists('Group ID'),
             },
             {

--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -171,6 +171,11 @@ export const PartitionMessage = React.memo(function PartitionMessage() {
     <FormGroup>
       <Callout>
         <p>Configure how Druid will partition data.</p>
+        <p>
+          Druid datasources are always partitioned by time into time chunks (
+          <Code>Primary partitioning</Code>), and each time chunk contains one or more segments (
+          <Code>Secondary partitioning</Code>).
+        </p>
         <LearnMore href={`${getLink('DOCS')}/ingestion/index.html#partitioning`} />
       </Callout>
     </FormGroup>

--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -46,7 +46,7 @@ export const ConnectMessage = React.memo(function ConnectMessage(props: ConnectM
         {inlineMode ? (
           <>
             <p>To get started, please paste some data in the box to the left.</p>
-            <p>Click &quot;Apply&quot to verify your data with Druid.</p>
+            <p>Click &quot;Apply&quot; to verify your data with Druid.</p>
           </>
         ) : (
           <p>To get started, please specify what data you want to ingest.</p>

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2121,7 +2121,25 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           )}
           {this.renderColumnFilterControls()}
         </div>
-        {this.renderNextBar({})}
+        {this.renderNextBar({
+          onNextStep: () => {
+            if (!filterQueryState.data) return false;
+
+            let newSpec = spec;
+            if (!deepGet(newSpec, 'spec.dataSchema.dimensionsSpec')) {
+              const currentRollup = deepGet(newSpec, 'spec.dataSchema.granularitySpec.rollup');
+              newSpec = updateSchemaWithSample(
+                newSpec,
+                filterQueryState.data,
+                'specific',
+                typeof currentRollup === 'boolean' ? currentRollup : DEFAULT_ROLLUP_SETTING,
+              );
+            }
+
+            this.updateSpec(newSpec);
+            return true;
+          },
+        })}
       </>
     );
   }

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -1308,8 +1308,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
   async queryForParser(initRun = false) {
     const { spec, sampleStrategy } = this.state;
     const ioConfig: IoConfig = deepGet(spec, 'spec.ioConfig') || EMPTY_OBJECT;
-    const inputFormatColumns: string[] =
-      deepGet(spec, 'spec.ioConfig.inputFormat.columns') || EMPTY_ARRAY;
 
     let issue: string | undefined;
     if (issueWithIoConfig(ioConfig)) {
@@ -1345,7 +1343,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         data: headerAndRowsFromSampleResponse({
           sampleResponse,
           ignoreTimeColumn: true,
-          columnOrder: inputFormatColumns,
         }),
         lastData: parserQueryState.getSomeData(),
       }),
@@ -1578,8 +1575,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
   async queryForTimestamp(initRun = false) {
     const { spec, cacheRows } = this.state;
-    const inputFormatColumns: string[] =
-      deepGet(spec, 'spec.ioConfig.inputFormat.columns') || EMPTY_ARRAY;
 
     if (!cacheRows) {
       this.setState(({ timestampQueryState }) => ({
@@ -1618,7 +1613,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         data: {
           headerAndRows: headerAndRowsFromSampleResponse({
             sampleResponse,
-            columnOrder: [TIME_COLUMN].concat(inputFormatColumns),
           }),
           spec,
         },
@@ -1773,8 +1767,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
   async queryForTransform(initRun = false) {
     const { spec, cacheRows } = this.state;
-    const inputFormatColumns: string[] =
-      deepGet(spec, 'spec.ioConfig.inputFormat.columns') || EMPTY_ARRAY;
 
     if (!cacheRows) {
       this.setState(({ transformQueryState }) => ({
@@ -1812,7 +1804,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       transformQueryState: new QueryState({
         data: headerAndRowsFromSampleResponse({
           sampleResponse,
-          columnOrder: [TIME_COLUMN].concat(inputFormatColumns),
         }),
         lastData: transformQueryState.getSomeData(),
       }),
@@ -1996,8 +1987,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
   async queryForFilter(initRun = false) {
     const { spec, cacheRows } = this.state;
-    const inputFormatColumns: string[] =
-      deepGet(spec, 'spec.ioConfig.inputFormat.columns') || EMPTY_ARRAY;
 
     if (!cacheRows) {
       this.setState(({ filterQueryState }) => ({
@@ -2030,7 +2019,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         filterQueryState: new QueryState({
           data: headerAndRowsFromSampleResponse({
             sampleResponse,
-            columnOrder: [TIME_COLUMN].concat(inputFormatColumns),
             parsedOnly: true,
           }),
           lastData: filterQueryState.getSomeData(),
@@ -2053,7 +2041,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
     const headerAndRowsNoFilter = headerAndRowsFromSampleResponse({
       sampleResponse: sampleResponseNoFilter,
-      columnOrder: [TIME_COLUMN].concat(inputFormatColumns),
       parsedOnly: true,
     });
 


### PR DESCRIPTION
Did a comprehensive review of the data loading flow in the web console and in the process found some small issues that are fixed here, 1 commit = 1 issue fixed.

The issues are:

- Quotes typo in description text
- The SQL doc structure changed (there was a column added) and the doc parsing was too lose - tightened up
- Make array input (used for column input in CSV parser) not lose your curser while typing 
- Make it possible to click-to-filter the group_id column in the tasks table
- Exact table search in the Segments table was unnecessarily lowercasing the search string
- Don't resort the columns alphabetically, trust the JSON instead - maintain column order (especially helpful for formats like CSV and TSV)
- Allow bypassing the transform step, if you go to filter directly and then click `Next` it should populate the schema at that point if it has not already been done.

