### PR TITLE
compaction/status API retains status for datasources that no longer existed causing in-memory used to grow unbounded

### DIFF
--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -468,7 +468,7 @@ This is only valid for dataSource which has compaction enabled.
 
 * `/druid/coordinator/v1/compaction/status`
 
-Returns the status and statistics from the latest auto compaction run of all dataSources which have/had auto compaction enabled.
+Returns the status and statistics from the auto compaction run of all dataSources which have auto compaction enabled in the latest run.
 The response payload includes a list of `latestStatus` objects. Each `latestStatus` represents the status for a dataSource (which has/had auto compaction enabled). 
 The `latestStatus` object has the following keys:
 * `dataSource`: name of the datasource for this status information

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/CompactionResourceTestClient.java
@@ -183,7 +183,9 @@ public class CompactionResourceTestClient
     StatusResponseHolder response = httpClient.go(
         new Request(HttpMethod.GET, new URL(url)), responseHandler
     ).get();
-    if (!response.getStatus().equals(HttpResponseStatus.OK)) {
+    if (response.getStatus().equals(HttpResponseStatus.NOT_FOUND)) {
+      return null;
+    } else if (!response.getStatus().equals(HttpResponseStatus.OK)) {
       throw new ISE(
           "Error while getting compaction status status[%s] content[%s]",
           response.getStatus(),

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -235,18 +235,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(0, null);
       checkCompactionIntervals(intervalsBeforeCompaction);
-      getAndAssertCompactionStatus(
-          fullDatasourceName,
-          AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0);
+      Assert.assertNull(compactionResource.getCompactionStatus(fullDatasourceName));
       // Update compaction slots to be 1
       updateCompactionTaskSlot(1, 1);
       // One day compacted (1 new segment) and one day remains uncompacted. (3 total)

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -210,7 +210,8 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       forceTriggerAutoCompaction(4);
       verifyQuery(INDEX_QUERIES_RESOURCE);
       verifySegmentsCompacted(0, null);
-
+      // Auto compaction stats should be deleted as compacation config was deleted
+      Assert.assertNull(compactionResource.getCompactionStatus(fullDatasourceName));
       checkCompactionIntervals(intervalsBeforeCompaction);
     }
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.coordinator.duty;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.apache.druid.client.indexing.ClientCompactionTaskGranularitySpec;
 import org.apache.druid.client.indexing.ClientCompactionTaskQuery;

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -213,11 +213,11 @@ public class CompactSegments implements CoordinatorDuty
         }
       } else {
         LOG.info("compactionConfig is empty. Skip.");
-        updateAutoCompactionSnapshotWhenNoCompactTaskScheduled(currentRunAutoCompactionSnapshotBuilders);
+        autoCompactionSnapshotPerDataSource.set(new HashMap<>());
       }
     } else {
       LOG.info("maxCompactionTaskSlots was set to 0. Skip compaction");
-      updateAutoCompactionSnapshotWhenNoCompactTaskScheduled(currentRunAutoCompactionSnapshotBuilders);
+      autoCompactionSnapshotPerDataSource.set(new HashMap<>());
     }
 
     return params.buildFromExisting()
@@ -312,16 +312,6 @@ public class CompactSegments implements CoordinatorDuty
     Set<String> enabledDatasources = compactionConfigList.stream()
                                                          .map(dataSourceCompactionConfig -> dataSourceCompactionConfig.getDataSource())
                                                          .collect(Collectors.toSet());
-    // Update AutoCompactionScheduleStatus for dataSource that now has auto compaction disabled
-    for (Map.Entry<String, AutoCompactionSnapshot> snapshot : autoCompactionSnapshotPerDataSource.get().entrySet()) {
-      if (!enabledDatasources.contains(snapshot.getKey())) {
-        currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
-            snapshot.getKey(),
-            k -> new AutoCompactionSnapshot.Builder(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.NOT_ENABLED)
-        );
-      }
-    }
-
     // Create and Update snapshot for dataSource that has auto compaction enabled
     for (String compactionConfigDataSource : enabledDatasources) {
       currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
@@ -418,42 +408,6 @@ public class CompactSegments implements CoordinatorDuty
                                            : new HashMap<>(configuredContext);
     newContext.put(STORE_COMPACTION_STATE_KEY, true);
     return newContext;
-  }
-
-  /**
-   * This method can be use to atomically update the snapshots in {@code autoCompactionSnapshotPerDataSource} when
-   * no compaction task is schedule in this run. Currently, this method does not update compaction statistics
-   * (bytes, interval count, segment count, etc) since we skip iterating through the segments and cannot get an update
-   * on those statistics. Thus, this method only updates the schedule status and task list (compaction statistics
-   * remains the same as the previous snapshot).
-   */
-  private void updateAutoCompactionSnapshotWhenNoCompactTaskScheduled(
-      Map<String, AutoCompactionSnapshot.Builder> currentRunAutoCompactionSnapshotBuilders
-  )
-  {
-    Map<String, AutoCompactionSnapshot> previousSnapshots = autoCompactionSnapshotPerDataSource.get();
-    for (Map.Entry<String, AutoCompactionSnapshot.Builder> autoCompactionSnapshotBuilderEntry : currentRunAutoCompactionSnapshotBuilders.entrySet()) {
-      final String dataSource = autoCompactionSnapshotBuilderEntry.getKey();
-      AutoCompactionSnapshot previousSnapshot = previousSnapshots.get(dataSource);
-      if (previousSnapshot != null) {
-        autoCompactionSnapshotBuilderEntry.getValue().incrementBytesAwaitingCompaction(previousSnapshot.getBytesAwaitingCompaction());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementBytesCompacted(previousSnapshot.getBytesCompacted());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementBytesSkipped(previousSnapshot.getBytesSkipped());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementSegmentCountAwaitingCompaction(previousSnapshot.getSegmentCountAwaitingCompaction());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementSegmentCountCompacted(previousSnapshot.getSegmentCountCompacted());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementSegmentCountSkipped(previousSnapshot.getSegmentCountSkipped());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementIntervalCountAwaitingCompaction(previousSnapshot.getIntervalCountAwaitingCompaction());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementIntervalCountCompacted(previousSnapshot.getIntervalCountCompacted());
-        autoCompactionSnapshotBuilderEntry.getValue().incrementIntervalCountSkipped(previousSnapshot.getIntervalCountSkipped());
-      }
-    }
-
-    Map<String, AutoCompactionSnapshot> currentAutoCompactionSnapshotPerDataSource = Maps.transformValues(
-        currentRunAutoCompactionSnapshotBuilders,
-        AutoCompactionSnapshot.Builder::build
-    );
-    // Atomic update of autoCompactionSnapshotPerDataSource with the latest from this coordinator run
-    autoCompactionSnapshotPerDataSource.set(currentAutoCompactionSnapshotPerDataSource);
   }
 
   private CoordinatorStats makeStats(

--- a/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CompactionResource.java
@@ -74,7 +74,7 @@ public class CompactionResource
   {
     final Long notCompactedSegmentSizeBytes = coordinator.getTotalSizeOfSegmentsAwaitingCompaction(dataSource);
     if (notCompactedSegmentSizeBytes == null) {
-      return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", "unknown dataSource")).build();
+      return Response.status(Response.Status.NOT_FOUND).entity(ImmutableMap.of("error", "unknown dataSource")).build();
     } else {
       return Response.ok(ImmutableMap.of("remainingSegmentSize", notCompactedSegmentSizeBytes)).build();
     }
@@ -94,7 +94,7 @@ public class CompactionResource
     } else {
       AutoCompactionSnapshot autoCompactionSnapshot = coordinator.getAutoCompactionSnapshotForDataSource(dataSource);
       if (autoCompactionSnapshot == null) {
-        return Response.status(Response.Status.BAD_REQUEST).entity(ImmutableMap.of("error", "unknown dataSource")).build();
+        return Response.status(Response.Status.NOT_FOUND).entity(ImmutableMap.of("error", "unknown dataSource")).build();
       }
       snapshots = ImmutableList.of(autoCompactionSnapshot);
     }

--- a/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CompactionResourceTest.java
@@ -117,6 +117,6 @@ public class CompactionResourceTest
     EasyMock.replay(mock);
 
     final Response response = new CompactionResource(mock).getCompactionSnapshotForDataSource(dataSourceName);
-    Assert.assertEquals(400, response.getStatus());
+    Assert.assertEquals(404, response.getStatus());
   }
 }


### PR DESCRIPTION
compaction/status API retains status for datasources that no longer existed causing in-memory used to grow unbounded

### Description
The compaction/status API retains stats of datasources that were previously compacted in memory. The purpose of this is to be able to maintain and report compaction status of datasource (how much of it was compacted, how much left to compacted, etc.) even after compaction was disabled (compaction config was deleted). The bug here is that the compaction/status API retains stats of datasources that was deleted too. This can causes the in-bound memory used to grow unbound. 

This change removes any datasource that does not have an enabled auto compaction config from the compaction/status API. This means that the compaction/status API will now only return datasource that has auto compaction config enabled in the latest auto compaction run only. The reason for removing stats for datasource that is active but has auto compaction disabled is that the latest stats will no longer be accurate and instead can be misleading as that datasource's shape changes (more data ingested, new intervals, etc.)

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
