### PR TITLE
ITRetryUtils - Fix retry sleep when callable throws exception

### DIFF
--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/ITRetryUtil.java
@@ -61,17 +61,23 @@ public class ITRetryUtil
         if (currentTry > retryCount || callable.call() == expectedValue) {
           break;
         }
-        LOG.info(
-            "Attempt[%d/%d] did not pass: Task %s still not complete. Next retry in %d ms",
-            currentTry, retryCount, taskMessage, delayInMillis
-        );
-        Thread.sleep(delayInMillis);
-        currentTry++;
       }
       catch (Exception e) {
         // just continue retrying if there is an exception (it may be transient!) but save the last:
         lastException = e;
       }
+
+      LOG.info(
+          "Attempt[%d/%d] did not pass: Task %s still not complete. Next retry in %d ms",
+          currentTry, retryCount, taskMessage, delayInMillis
+      );
+      try {
+        Thread.sleep(delayInMillis);
+      }
+      catch (InterruptedException e) {
+        // Ignore
+      }
+      currentTry++;
     }
 
     if (currentTry > retryCount) {


### PR DESCRIPTION
If the callable throws an exception, we neither increase the retry count nor sleep the thread.