### PR TITLE
Fix left join SQL queries with IS NOT NULL filter

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerConfig.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerConfig.java
@@ -32,6 +32,7 @@ public class PlannerConfig
   public static final String CTX_KEY_USE_APPROXIMATE_COUNT_DISTINCT = "useApproximateCountDistinct";
   public static final String CTX_KEY_USE_GROUPING_SET_FOR_EXACT_DISTINCT = "useGroupingSetForExactDistinct";
   public static final String CTX_KEY_USE_APPROXIMATE_TOPN = "useApproximateTopN";
+  public static final String CTX_COMPUTE_INNER_JOIN_COST_AS_FILTER = "computeInnerJoinCostAsFilter";
 
   @JsonProperty
   private Period metadataRefreshPeriod = new Period("PT1M");
@@ -62,6 +63,9 @@ public class PlannerConfig
 
   @JsonProperty
   private boolean useGroupingSetForExactDistinct = false;
+
+  @JsonProperty
+  private boolean computeInnerJoinCostAsFilter = true;
 
   public long getMetadataSegmentPollPeriod()
   {
@@ -120,6 +124,11 @@ public class PlannerConfig
     return serializeComplexValues;
   }
 
+  public boolean isComputeInnerJoinCostAsFilter()
+  {
+    return computeInnerJoinCostAsFilter;
+  }
+
   public PlannerConfig withOverrides(final Map<String, Object> context)
   {
     if (context == null) {
@@ -150,6 +159,9 @@ public class PlannerConfig
     newConfig.metadataSegmentCacheEnable = isMetadataSegmentCacheEnable();
     newConfig.metadataSegmentPollPeriod = getMetadataSegmentPollPeriod();
     newConfig.serializeComplexValues = shouldSerializeComplexValues();
+    newConfig.computeInnerJoinCostAsFilter = getContextBoolean(context,
+                                                               CTX_COMPUTE_INNER_JOIN_COST_AS_FILTER,
+                                                               computeInnerJoinCostAsFilter);
     return newConfig;
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -316,6 +316,9 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
       cost = CostEstimates.COST_JOIN_SUBQUERY;
     } else {
       cost = partialQuery.estimateCost();
+      if (joinRel.getJoinType() == JoinRelType.INNER) {
+        cost *= CostEstimates.MULTIPLIER_FILTER; // treating inner join like a filter on left table
+      }
     }
 
     if (computeRightRequiresSubquery(getSomeDruidChild(right))) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -354,7 +354,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
     return !DruidRels.isScanOrMapping(left, true);
   }
 
-  private static boolean computeRightRequiresSubquery(final DruidRel<?> right)
+  public static boolean computeRightRequiresSubquery(final DruidRel<?> right)
   {
     // Right requires a subquery unless it's a scan or mapping on top of a global datasource.
     // ideally this would involve JoinableFactory.isDirectlyJoinable to check that the global datasources
@@ -388,7 +388,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
     return Pair.of(rightPrefix, signatureBuilder.build());
   }
 
-  private static DruidRel<?> getSomeDruidChild(final RelNode child)
+  public static DruidRel<?> getSomeDruidChild(final RelNode child)
   {
     if (child instanceof DruidRel) {
       return (DruidRel<?>) child;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -53,6 +53,7 @@ import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.table.RowSignatures;
 
@@ -72,6 +73,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
   private final Filter leftFilter;
   private final PartialDruidQuery partialQuery;
   private final Join joinRel;
+  private final PlannerConfig plannerConfig;
   private RelNode left;
   private RelNode right;
 
@@ -90,6 +92,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
     this.right = joinRel.getRight();
     this.leftFilter = leftFilter;
     this.partialQuery = partialQuery;
+    this.plannerConfig = queryMaker.getPlannerContext().getPlannerConfig();
   }
 
   /**
@@ -316,7 +319,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
       cost = CostEstimates.COST_JOIN_SUBQUERY;
     } else {
       cost = partialQuery.estimateCost();
-      if (joinRel.getJoinType() == JoinRelType.INNER) {
+      if (joinRel.getJoinType() == JoinRelType.INNER && plannerConfig.isComputeInnerJoinCostAsFilter()) {
         cost *= CostEstimates.MULTIPLIER_FILTER; // treating inner join like a filter on left table
       }
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRule.java
@@ -37,25 +37,29 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.druid.java.util.common.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This class is a copy (with modification) of {@link FilterJoinRule}. Specifically, this class contains a
  * subset of code from {@link FilterJoinRule} for the codepath involving {@link FilterJoinRule#FILTER_ON_JOIN}
- * Everything has been keep as-is from {@link FilterJoinRule} except for the modification
- * of {@link #classifyFilters(List, JoinRelType, boolean, List)} method called in the
+ * Everything has been keep as-is from {@link FilterJoinRule} except for :
+ * 1. the modification of {@link #classifyFilters(List, JoinRelType, boolean, List)} method called in the
  * {@link #perform(RelOptRuleCall, Filter, Join)} method of this class.
+ * 2. removing redundant 'IS NOT NULL' filters from inner join filter condition
  * The {@link #classifyFilters(List, JoinRelType, boolean, List)} method is based of {@link RelOptUtil#classifyFilters}.
  * The difference is that the modfied method use in thsi class will not not push filters to the children.
  * Hence, filters will either stay where they are or are pushed to the join (if they originated from above the join).
  *
- * This modification is needed due to the bug described in https://github.com/apache/druid/pull/9773
- * This class and it's modification can be removed, switching back to the default Rule provided in Calcite's
- * {@link FilterJoinRule} when https://github.com/apache/druid/issues/9843 is resolved.
+ * The modification of {@link #classifyFilters(List, JoinRelType, boolean, List)} is needed due to the bug described in
+ * https://github.com/apache/druid/pull/9773. This class and it's modification can be removed, switching back to the
+ * default Rule provided in Calcite's {@link FilterJoinRule} when https://github.com/apache/druid/issues/9843 is resolved.
  */
 
 public abstract class FilterJoinExcludePushToChildRule extends FilterJoinRule
@@ -180,6 +184,9 @@ public abstract class FilterJoinExcludePushToChildRule extends FilterJoinRule
       filterPushed = true;
     }
 
+    // once the filters are pushed to join from top, try to remove redudant 'IS NOT NULL' filters
+    removeRedundantIsNotNullFilters(joinFilters, joinType);
+
     // if nothing actually got pushed and there is nothing leftover,
     // then this rule is a no-op
     if ((!filterPushed && joinType == join.getJoinType()) || joinFilters.isEmpty()) {
@@ -291,5 +298,51 @@ public abstract class FilterJoinExcludePushToChildRule extends FilterJoinRule
 
     // Did anything change?
     return !filtersToRemove.isEmpty();
+  }
+
+  /**
+   * This tries to find all the 'IS NOT NULL' filters in an inner join whose checking column is also
+   * a part of an equi-condition between the two tables. It removes such 'IS NOT NULL' filters from join since
+   * the equi-condition will never return true for null input, thus making the 'IS NOT NULL' filter a no-op.
+   * @param joinFilters
+   * @param joinType
+   */
+  private void removeRedundantIsNotNullFilters(List<RexNode> joinFilters, JoinRelType joinType)
+  {
+    if (joinType != JoinRelType.INNER) {
+      return; // only works for inner joins
+    }
+
+    ImmutableList.Builder<RexNode> isNotNullFiltersBuilder = ImmutableList.builder();
+    ImmutableList.Builder<Pair<RexNode, RexNode>> equalityFiltersOperandBuilder = ImmutableList.builder();
+
+    joinFilters.stream().filter(joinFilter -> joinFilter instanceof RexCall).forEach(joinFilter -> {
+      if (joinFilter.isA(SqlKind.IS_NOT_NULL)) {
+        isNotNullFiltersBuilder.add(joinFilter);
+      } else if (joinFilter.isA(SqlKind.EQUALS)) {
+        List<RexNode> operands = ((RexCall) joinFilter).getOperands();
+        if (operands.size() == 2 && operands.stream().noneMatch(Objects::isNull)) {
+          equalityFiltersOperandBuilder.add(new Pair<>(operands.get(0), operands.get(1)));
+        }
+      }
+    });
+
+    List<Pair<RexNode, RexNode>> equalityFilters = equalityFiltersOperandBuilder.build();
+    ImmutableList.Builder<RexNode> removableFilters = ImmutableList.builder();
+    for (RexNode isNotNullFilter : isNotNullFiltersBuilder.build()) {
+      List<RexNode> operands = ((RexCall) isNotNullFilter).getOperands();
+      boolean canDrop = false;
+      for (Pair<RexNode, RexNode> equalityFilterOperands : equalityFilters) {
+        if ((equalityFilterOperands.lhs != null && equalityFilterOperands.lhs.equals(operands.get(0))) ||
+            (equalityFilterOperands.rhs != null && equalityFilterOperands.rhs.equals(operands.get(0)))) {
+          canDrop = true;
+          break;
+        }
+      }
+      if (canDrop) {
+        removableFilters.add(isNotNullFilter);
+      }
+    }
+    joinFilters.removeAll(removableFilters.build());
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRule.java
@@ -186,7 +186,7 @@ public abstract class FilterJoinExcludePushToChildRule extends FilterJoinRule
     }
 
     // once the filters are pushed to join from top, try to remove redudant 'IS NOT NULL' filters
-    removeRedundantIsNotNullFilters(joinFilters, joinType);
+    removeRedundantIsNotNullFilters(joinFilters, joinType, NullHandling.sqlCompatible());
 
     // if nothing actually got pushed and there is nothing leftover,
     // then this rule is a no-op
@@ -307,10 +307,11 @@ public abstract class FilterJoinExcludePushToChildRule extends FilterJoinRule
    * the equi-condition will never return true for null input, thus making the 'IS NOT NULL' filter a no-op.
    * @param joinFilters
    * @param joinType
+   * @param isSqlCompatible
    */
-  private void removeRedundantIsNotNullFilters(List<RexNode> joinFilters, JoinRelType joinType)
+  static void removeRedundantIsNotNullFilters(List<RexNode> joinFilters, JoinRelType joinType, boolean isSqlCompatible)
   {
-    if (joinType != JoinRelType.INNER || !NullHandling.sqlCompatible()) {
+    if (joinType != JoinRelType.INNER || !isSqlCompatible) {
       return; // only works for inner joins in SQL mode
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRule.java
@@ -40,6 +40,7 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Pair;
 
 import java.util.ArrayList;
@@ -309,8 +310,8 @@ public abstract class FilterJoinExcludePushToChildRule extends FilterJoinRule
    */
   private void removeRedundantIsNotNullFilters(List<RexNode> joinFilters, JoinRelType joinType)
   {
-    if (joinType != JoinRelType.INNER) {
-      return; // only works for inner joins
+    if (joinType != JoinRelType.INNER || !NullHandling.sqlCompatible()) {
+      return; // only works for inner joins in SQL mode
     }
 
     ImmutableList.Builder<RexNode> isNotNullFiltersBuilder = ImmutableList.builder();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -958,6 +958,13 @@ public class BaseCalciteQueryTest extends CalciteTestBase
               .build(),
           };
     }
+
+    public static Map<String, Object> withOverrides(Map<String, Object> originalContext, Map<String, Object> overrides)
+    {
+      Map<String, Object> contextWithOverrides = new HashMap<>(originalContext);
+      contextWithOverrides.putAll(overrides);
+      return contextWithOverrides;
+    }
   }
 
   protected Map<String, Object> withLeftDirectAccessEnabled(Map<String, Object> context)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidJoinRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidJoinRuleTest.java
@@ -67,7 +67,8 @@ public class DruidJoinRuleTest
                 rexBuilder.makeInputRef(joinType, 0),
                 rexBuilder.makeInputRef(joinType, 1)
             ),
-            leftType
+            leftType,
+            null
         )
     );
   }
@@ -86,7 +87,8 @@ public class DruidJoinRuleTest
                 ),
                 rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1)
             ),
-            leftType
+            leftType,
+            null
         )
     );
   }
@@ -105,7 +107,8 @@ public class DruidJoinRuleTest
                     rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1)
                 )
             ),
-            leftType
+            leftType,
+            null
         )
     );
   }
@@ -120,7 +123,8 @@ public class DruidJoinRuleTest
                 rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0),
                 rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0)
             ),
-            leftType
+            leftType,
+            null
         )
     );
   }
@@ -135,7 +139,8 @@ public class DruidJoinRuleTest
                 rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1),
                 rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1)
             ),
-            leftType
+            leftType,
+            null
         )
     );
   }
@@ -146,7 +151,8 @@ public class DruidJoinRuleTest
     Assert.assertTrue(
         DruidJoinRule.canHandleCondition(
             rexBuilder.makeLiteral(true),
-            leftType
+            leftType,
+            null
         )
     );
   }
@@ -157,7 +163,8 @@ public class DruidJoinRuleTest
     Assert.assertTrue(
         DruidJoinRule.canHandleCondition(
             rexBuilder.makeLiteral(false),
-            leftType
+            leftType,
+            null
         )
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rule/FilterJoinExcludePushToChildRuleTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.sql.calcite.planner.DruidTypeSystem;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.IS_NOT_NULL;
+
+public class FilterJoinExcludePushToChildRuleTest
+{
+  private final RexBuilder rexBuilder = new RexBuilder(new JavaTypeFactoryImpl());
+  private final RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(DruidTypeSystem.INSTANCE);
+
+  @Test
+  public void testRemoveRedundantIsNotNullFiltersWithSQLCompatibility()
+  {
+    RexNode equalityFilter = rexBuilder.makeCall(
+        SqlStdOperatorTable.EQUALS,
+        rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0),
+        rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1));
+    RexNode isNotNullFilterOnJoinColumn = rexBuilder.makeCall(IS_NOT_NULL,
+                                                  ImmutableList.of(rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1)));
+    RexNode isNotNullFilterOnNonJoinColumn = rexBuilder.makeCall(IS_NOT_NULL,
+                                                  ImmutableList.of(rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 2)));
+    List<RexNode> joinFilters = new ArrayList<>();
+    joinFilters.add(equalityFilter);
+
+    FilterJoinExcludePushToChildRule.removeRedundantIsNotNullFilters(joinFilters, JoinRelType.INNER, true);
+    Assert.assertEquals(joinFilters.size(), 1);
+    Assert.assertEquals("Equality Filter changed", joinFilters.get(0), equalityFilter);
+
+    // add IS NOT NULL filter on a join column
+    joinFilters.add(isNotNullFilterOnNonJoinColumn);
+    joinFilters.add(isNotNullFilterOnJoinColumn);
+    Assert.assertEquals(joinFilters.size(), 3);
+    FilterJoinExcludePushToChildRule.removeRedundantIsNotNullFilters(joinFilters, JoinRelType.INNER, true);
+    Assert.assertEquals(joinFilters.size(), 2);
+    Assert.assertEquals("Equality Filter changed", joinFilters.get(0), equalityFilter);
+    Assert.assertEquals("IS NOT NULL filter on non-join column changed", joinFilters.get(1), isNotNullFilterOnNonJoinColumn);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->
This PR fixes the incorrect results for query : `SELECT dim1, l1.k FROM foo LEFT JOIN (select k || '' as k from lookup.lookyloo group by 1) l1 ON foo.dim1 = l1.k WHERE l1.k IS NOT NULL` (in `CalciteQueryTests`)
In the current code, the `WHERE` clause gets removed from the top of the left join and is pushed to the table `foo` 
leading to incorrect results.
The fix for such a situation is done by : 
1. Converting such left joins into inner joins (since logically the mentioned left join query is equivalent to an inner join) using Calcite while maintaining that the druid execution layer can execute such inner joins.
2. Preferring converted inner joins over original left joins in our cost model
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
