### PR TITLE
update dependency-check cron job to purge cache before checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -713,7 +713,7 @@ jobs:
       stage: cron
       install: skip
       script: |-
-        ${MVN} dependency-check:aggregate -pl '!integration-tests' || { echo "
+        ${MVN} dependency-check:purge dependency-check:aggregate -pl '!integration-tests' || { echo "
 
         The OWASP dependency check has found security vulnerabilities. Please use a newer version
         of the dependency that does not have vulnerabilities. To see a report run


### PR DESCRIPTION
The dependency-check cron job now purges any caches NVD before performing dependency check. Without this, a high CVE vulernability was reported in this job a few months after the nvd was updated for it.