### PR TITLE
Improve Auto scaler pendingTaskBased provisioning strategy to handle when there are no currently running worker node better

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1015,6 +1015,7 @@ There are additional configs for autoscaling (if it is enabled):
 |`druid.indexer.autoscale.pendingTaskTimeout`|How long a task can be in "pending" state before the Overlord tries to scale up.|PT30S|
 |`druid.indexer.autoscale.workerVersion`|If set, will only create nodes of set version during autoscaling. Overrides dynamic configuration. |null|
 |`druid.indexer.autoscale.workerPort`|The port that MiddleManagers will run on.|8080|
+|`druid.indexer.autoscale.workerCapacityFallback`| Worker capcity for determining number of workers needed for auto scaling when there are currently no worker running. If unset or null, auto scaler will scale to `minNumWorkers` in autoScaler config instead. Note: this config is only applicable to `pendingTaskBased` provisioning strategy|null|
 
 ##### Supervisors
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1015,7 +1015,7 @@ There are additional configs for autoscaling (if it is enabled):
 |`druid.indexer.autoscale.pendingTaskTimeout`|How long a task can be in "pending" state before the Overlord tries to scale up.|PT30S|
 |`druid.indexer.autoscale.workerVersion`|If set, will only create nodes of set version during autoscaling. Overrides dynamic configuration. |null|
 |`druid.indexer.autoscale.workerPort`|The port that MiddleManagers will run on.|8080|
-|`druid.indexer.autoscale.workerCapacityFallback`| Worker capacity for determining the number of workers needed for auto scaling when there is currently no worker running. If unset or null, auto scaler will scale to `minNumWorkers` in autoScaler config instead. Note: this config is only applicable to `pendingTaskBased` provisioning strategy|null|
+|`druid.indexer.autoscale.workerCapacityFallback`| Worker capacity for determining the number of workers needed for auto scaling when there is currently no worker running. If unset or set to value of 0 or less, auto scaler will scale to `minNumWorkers` in autoScaler config instead. Note: this config is only applicable to `pendingTaskBased` provisioning strategy|-1|
 
 ##### Supervisors
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1015,7 +1015,7 @@ There are additional configs for autoscaling (if it is enabled):
 |`druid.indexer.autoscale.pendingTaskTimeout`|How long a task can be in "pending" state before the Overlord tries to scale up.|PT30S|
 |`druid.indexer.autoscale.workerVersion`|If set, will only create nodes of set version during autoscaling. Overrides dynamic configuration. |null|
 |`druid.indexer.autoscale.workerPort`|The port that MiddleManagers will run on.|8080|
-|`druid.indexer.autoscale.workerCapacityFallback`| Worker capacity for determining the number of workers needed for auto scaling when there is currently no worker running. If unset or set to value of 0 or less, auto scaler will scale to `minNumWorkers` in autoScaler config instead. Note: this config is only applicable to `pendingTaskBased` provisioning strategy|-1|
+|`druid.indexer.autoscale.workerCapacityHint`| Worker capacity for determining the number of workers needed for auto scaling when there is currently no worker running. If unset or set to value of 0 or less, auto scaler will scale to `minNumWorkers` in autoScaler config instead. This value should typically be equal to `druid.worker.capacity` when you have a homogeneous cluster and the average of `druid.worker.capacity` across the workers when you have a heterogeneous cluster. Note: this config is only applicable to `pendingTaskBased` provisioning strategy|-1|
 
 ##### Supervisors
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1015,7 +1015,7 @@ There are additional configs for autoscaling (if it is enabled):
 |`druid.indexer.autoscale.pendingTaskTimeout`|How long a task can be in "pending" state before the Overlord tries to scale up.|PT30S|
 |`druid.indexer.autoscale.workerVersion`|If set, will only create nodes of set version during autoscaling. Overrides dynamic configuration. |null|
 |`druid.indexer.autoscale.workerPort`|The port that MiddleManagers will run on.|8080|
-|`druid.indexer.autoscale.workerCapacityFallback`| Worker capcity for determining number of workers needed for auto scaling when there are currently no worker running. If unset or null, auto scaler will scale to `minNumWorkers` in autoScaler config instead. Note: this config is only applicable to `pendingTaskBased` provisioning strategy|null|
+|`druid.indexer.autoscale.workerCapacityFallback`| Worker capacity for determining the number of workers needed for auto scaling when there is currently no worker running. If unset or null, auto scaler will scale to `minNumWorkers` in autoScaler config instead. Note: this config is only applicable to `pendingTaskBased` provisioning strategy|null|
 
 ##### Supervisors
 

--- a/extensions-contrib/gce-extensions/src/main/java/org/apache/druid/indexing/overlord/autoscaling/gce/GceAutoScaler.java
+++ b/extensions-contrib/gce-extensions/src/main/java/org/apache/druid/indexing/overlord/autoscaling/gce/GceAutoScaler.java
@@ -80,8 +80,8 @@ public class GceAutoScaler implements AutoScaler<GceEnvironmentConfig>
           @JsonProperty("envConfig") GceEnvironmentConfig envConfig
   )
   {
-    Preconditions.checkArgument(minNumWorkers > 0,
-                                "minNumWorkers must be greater than 0");
+    Preconditions.checkArgument(minNumWorkers >= 0,
+                                "minNumWorkers must be greater than or equal to 0");
     this.minNumWorkers = minNumWorkers;
     Preconditions.checkArgument(maxNumWorkers > 0,
                                 "maxNumWorkers must be greater than 0");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningConfig.java
@@ -30,7 +30,7 @@ public class PendingTaskBasedWorkerProvisioningConfig extends SimpleWorkerProvis
   private int maxScalingStep = 10;
 
   @JsonProperty
-  private Integer workerCapacityFallback = null;
+  private int workerCapacityFallback = -1;
 
   public int getMaxScalingStep()
   {
@@ -78,12 +78,12 @@ public class PendingTaskBasedWorkerProvisioningConfig extends SimpleWorkerProvis
     return this;
   }
 
-  public Integer getWorkerCapacityFallback()
+  public int getWorkerCapacityFallback()
   {
     return workerCapacityFallback;
   }
 
-  public PendingTaskBasedWorkerProvisioningConfig setWorkerCapacityFallback(Integer workerCapacityFallback)
+  public PendingTaskBasedWorkerProvisioningConfig setWorkerCapacityFallback(int workerCapacityFallback)
   {
     this.workerCapacityFallback = workerCapacityFallback;
     return this;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningConfig.java
@@ -30,7 +30,7 @@ public class PendingTaskBasedWorkerProvisioningConfig extends SimpleWorkerProvis
   private int maxScalingStep = 10;
 
   @JsonProperty
-  private int workerCapacityFallback = -1;
+  private int workerCapacityHint = -1;
 
   public int getMaxScalingStep()
   {
@@ -78,14 +78,14 @@ public class PendingTaskBasedWorkerProvisioningConfig extends SimpleWorkerProvis
     return this;
   }
 
-  public int getWorkerCapacityFallback()
+  public int getWorkerCapacityHint()
   {
-    return workerCapacityFallback;
+    return workerCapacityHint;
   }
 
-  public PendingTaskBasedWorkerProvisioningConfig setWorkerCapacityFallback(int workerCapacityFallback)
+  public PendingTaskBasedWorkerProvisioningConfig setWorkerCapacityHint(int workerCapacityHint)
   {
-    this.workerCapacityFallback = workerCapacityFallback;
+    this.workerCapacityHint = workerCapacityHint;
     return this;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningConfig.java
@@ -29,6 +29,8 @@ public class PendingTaskBasedWorkerProvisioningConfig extends SimpleWorkerProvis
   @JsonProperty
   private int maxScalingStep = 10;
 
+  @JsonProperty
+  private Integer workerCapacityFallback = null;
 
   public int getMaxScalingStep()
   {
@@ -76,4 +78,14 @@ public class PendingTaskBasedWorkerProvisioningConfig extends SimpleWorkerProvis
     return this;
   }
 
+  public Integer getWorkerCapacityFallback()
+  {
+    return workerCapacityFallback;
+  }
+
+  public PendingTaskBasedWorkerProvisioningConfig setWorkerCapacityFallback(Integer workerCapacityFallback)
+  {
+    this.workerCapacityFallback = workerCapacityFallback;
+    return this;
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -246,20 +246,16 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       log.info("Min/max workers: %d/%d", minWorkerCount, maxWorkerCount);
       final int currValidWorkers = getCurrValidWorkers(workers);
 
-      // If there are no worker, try to determine worker capacity from config.
-      Integer workerCapacityFromConfig = null;
-      if (currValidWorkers == 0) {
-        workerCapacityFromConfig = config.getWorkerCapacityFallback();
-      }
-
-      // If there are no worker and workerCapacityFallback is not set in config then spin up minWorkerCount,
-      // as we cannot determine the exact capacity here to fulfill the need
-      int moreWorkersNeeded = currValidWorkers == 0 && workerCapacityFromConfig == null ? minWorkerCount : getWorkersNeededToAssignTasks(
+      // If there are no worker and workerCapacityFallback config is not set (-1) then spin up minWorkerCount
+      // as we cannot determine the exact capacity here to fulfill the need.
+      // However, if there are no worker but workerCapacityFallback config is set (>0), then we can
+      // determine the number of workers needed using workerCapacityFallback config as expected worker capacity
+      int moreWorkersNeeded = currValidWorkers == 0 && config.getWorkerCapacityFallback() > 0 ? minWorkerCount : getWorkersNeededToAssignTasks(
           remoteTaskRunnerConfig,
           workerConfig,
           pendingTasks,
           workers,
-          workerCapacityFromConfig
+          config.getWorkerCapacityFallback()
       );
       log.debug("More workers needed: %d", moreWorkersNeeded);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -246,11 +246,11 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       log.info("Min/max workers: %d/%d", minWorkerCount, maxWorkerCount);
       final int currValidWorkers = getCurrValidWorkers(workers);
 
-      // If there are no worker and workerCapacityFallback config is not set (-1) then spin up minWorkerCount
+      // If there are no worker and workerCapacityFallback config is not set (-1) or invalid (<= 0), then spin up minWorkerCount
       // as we cannot determine the exact capacity here to fulfill the need.
       // However, if there are no worker but workerCapacityFallback config is set (>0), then we can
       // determine the number of workers needed using workerCapacityFallback config as expected worker capacity
-      int moreWorkersNeeded = currValidWorkers == 0 && config.getWorkerCapacityFallback() > 0 ? minWorkerCount : getWorkersNeededToAssignTasks(
+      int moreWorkersNeeded = currValidWorkers == 0 && config.getWorkerCapacityFallback() <= 0 ? minWorkerCount : getWorkersNeededToAssignTasks(
           remoteTaskRunnerConfig,
           workerConfig,
           pendingTasks,
@@ -284,7 +284,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
         final DefaultWorkerBehaviorConfig workerConfig,
         final Collection<Task> pendingTasks,
         final Collection<ImmutableWorkerInfo> workers,
-        final Integer workerCapacityFallback
+        final int workerCapacityFallback
     )
     {
       final Collection<ImmutableWorkerInfo> validWorkers = Collections2.filter(
@@ -445,12 +445,12 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
     return currValidWorkers;
   }
 
-  private static int getExpectedWorkerCapacity(final Collection<ImmutableWorkerInfo> workers, final Integer workerCapacityFallback)
+  private static int getExpectedWorkerCapacity(final Collection<ImmutableWorkerInfo> workers, final int workerCapacityFallback)
   {
     int size = workers.size();
     if (size == 0) {
       // No existing workers
-      if (workerCapacityFallback != null) {
+      if (workerCapacityFallback > 0) {
         // Return workerCapacityFallback if it is set in config
         return workerCapacityFallback;
       } else {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -172,7 +172,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
       log.debug("Workers: %d %s", workers.size(), workers);
       boolean didProvision = false;
-      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, config,"provision", log);
+      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, config, "provision", log);
       if (workerConfig == null) {
         return false;
       }
@@ -354,7 +354,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
     {
       Collection<ImmutableWorkerInfo> zkWorkers = runner.getWorkers();
       log.debug("Workers: %d [%s]", zkWorkers.size(), zkWorkers);
-      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, config,"terminate", log);
+      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, config, "terminate", log);
       if (workerConfig == null) {
         return false;
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord.autoscaling;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
@@ -60,11 +61,14 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
 {
   private static final EmittingLogger log = new EmittingLogger(PendingTaskBasedWorkerProvisioningStrategy.class);
 
+  public static final String ERROR_MESSAGE_MIN_WORKER_ZERO_HINT_UNSET = "As minNumWorkers is set to 0, workerCapacityHint must be greater than 0. workerCapacityHint value set is %d";
   private static final String SCHEME = "http";
 
+  @VisibleForTesting
   @Nullable
-  static DefaultWorkerBehaviorConfig getDefaultWorkerBehaviorConfig(
+  public static DefaultWorkerBehaviorConfig getDefaultWorkerBehaviorConfig(
       Supplier<WorkerBehaviorConfig> workerConfigRef,
+      SimpleWorkerProvisioningConfig config,
       String action,
       EmittingLogger log
   )
@@ -86,6 +90,17 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
     if (workerConfig.getAutoScaler() == null) {
       log.error("No autoScaler available, cannot %s workers", action);
       return null;
+    }
+    if (workerConfig.getAutoScaler().getMinNumWorkers() == 0) {
+      if (!(config instanceof PendingTaskBasedWorkerProvisioningConfig)) {
+        log.error("PendingTaskBasedWorkerProvisioningConfig must be provided");
+        return null;
+      }
+      int workerCapacityHint = ((PendingTaskBasedWorkerProvisioningConfig) config).getWorkerCapacityHint();
+      if (workerCapacityHint <= 0) {
+        log.error(ERROR_MESSAGE_MIN_WORKER_ZERO_HINT_UNSET, workerCapacityHint);
+        return null;
+      }
     }
     return workerConfig;
   }
@@ -157,7 +172,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
       log.debug("Workers: %d %s", workers.size(), workers);
       boolean didProvision = false;
-      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, "provision", log);
+      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, config,"provision", log);
       if (workerConfig == null) {
         return false;
       }
@@ -246,17 +261,19 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       log.info("Min/max workers: %d/%d", minWorkerCount, maxWorkerCount);
       final int currValidWorkers = getCurrValidWorkers(workers);
 
-      // If there are no worker and workerCapacityFallback config is not set (-1) or invalid (<= 0), then spin up minWorkerCount
+      // If there are no worker and workerCapacityHint config is not set (-1) or invalid (<= 0), then spin up minWorkerCount
       // as we cannot determine the exact capacity here to fulfill the need.
-      // However, if there are no worker but workerCapacityFallback config is set (>0), then we can
-      // determine the number of workers needed using workerCapacityFallback config as expected worker capacity
-      int moreWorkersNeeded = currValidWorkers == 0 && config.getWorkerCapacityFallback() <= 0 ? minWorkerCount : getWorkersNeededToAssignTasks(
-          remoteTaskRunnerConfig,
-          workerConfig,
-          pendingTasks,
-          workers,
-          config.getWorkerCapacityFallback()
-      );
+      // However, if there are no worker but workerCapacityHint config is set (>0), then we can
+      // determine the number of workers needed using workerCapacityHint config as expected worker capacity
+      int moreWorkersNeeded = currValidWorkers == 0 && config.getWorkerCapacityHint() <= 0
+                              ? minWorkerCount
+                              : getWorkersNeededToAssignTasks(
+                                  remoteTaskRunnerConfig,
+                                  workerConfig,
+                                  pendingTasks,
+                                  workers,
+                                  config.getWorkerCapacityHint()
+                              );
       log.debug("More workers needed: %d", moreWorkersNeeded);
 
       int want = Math.max(
@@ -284,7 +301,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
         final DefaultWorkerBehaviorConfig workerConfig,
         final Collection<Task> pendingTasks,
         final Collection<ImmutableWorkerInfo> workers,
-        final int workerCapacityFallback
+        final int workerCapacityHint
     )
     {
       final Collection<ImmutableWorkerInfo> validWorkers = Collections2.filter(
@@ -299,7 +316,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       }
       WorkerSelectStrategy workerSelectStrategy = workerConfig.getSelectStrategy();
       int need = 0;
-      int capacity = getExpectedWorkerCapacity(workers, workerCapacityFallback);
+      int capacity = getExpectedWorkerCapacity(workers, workerCapacityHint);
       log.info("Expected worker capacity: %d", capacity);
 
       // Simulate assigning tasks to dummy workers using configured workerSelectStrategy
@@ -337,7 +354,7 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
     {
       Collection<ImmutableWorkerInfo> zkWorkers = runner.getWorkers();
       log.debug("Workers: %d [%s]", zkWorkers.size(), zkWorkers);
-      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, "terminate", log);
+      final DefaultWorkerBehaviorConfig workerConfig = getDefaultWorkerBehaviorConfig(workerConfigRef, config,"terminate", log);
       if (workerConfig == null) {
         return false;
       }
@@ -445,14 +462,14 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
     return currValidWorkers;
   }
 
-  private static int getExpectedWorkerCapacity(final Collection<ImmutableWorkerInfo> workers, final int workerCapacityFallback)
+  private static int getExpectedWorkerCapacity(final Collection<ImmutableWorkerInfo> workers, final int workerCapacityHint)
   {
     int size = workers.size();
     if (size == 0) {
       // No existing workers
-      if (workerCapacityFallback > 0) {
-        // Return workerCapacityFallback if it is set in config
-        return workerCapacityFallback;
+      if (workerCapacityHint > 0) {
+        // Return workerCapacityHint if it is set in config
+        return workerCapacityHint;
       } else {
         // Assume capacity per worker as 1
         return 1;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedWorkerProvisioningStrategy.java
@@ -91,16 +91,12 @@ public class PendingTaskBasedWorkerProvisioningStrategy extends AbstractWorkerPr
       log.error("No autoScaler available, cannot %s workers", action);
       return null;
     }
-    if (workerConfig.getAutoScaler().getMinNumWorkers() == 0) {
-      if (!(config instanceof PendingTaskBasedWorkerProvisioningConfig)) {
-        log.error("PendingTaskBasedWorkerProvisioningConfig must be provided");
-        return null;
-      }
-      int workerCapacityHint = ((PendingTaskBasedWorkerProvisioningConfig) config).getWorkerCapacityHint();
-      if (workerCapacityHint <= 0) {
-        log.error(ERROR_MESSAGE_MIN_WORKER_ZERO_HINT_UNSET, workerCapacityHint);
-        return null;
-      }
+    if (config instanceof PendingTaskBasedWorkerProvisioningConfig
+        && workerConfig.getAutoScaler().getMinNumWorkers() == 0
+        && ((PendingTaskBasedWorkerProvisioningConfig) config).getWorkerCapacityHint() <= 0
+    ) {
+      log.error(ERROR_MESSAGE_MIN_WORKER_ZERO_HINT_UNSET, ((PendingTaskBasedWorkerProvisioningConfig) config).getWorkerCapacityHint());
+      return null;
     }
     return workerConfig;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
@@ -121,7 +121,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
       Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
       boolean didProvision = false;
       final DefaultWorkerBehaviorConfig workerConfig =
-          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, "provision", log);
+          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, config,"provision", log);
       if (workerConfig == null) {
         return false;
       }
@@ -186,7 +186,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
     {
       Collection<? extends TaskRunnerWorkItem> pendingTasks = runner.getPendingTasks();
       final DefaultWorkerBehaviorConfig workerConfig =
-          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, "terminate", log);
+          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, config,"terminate", log);
       if (workerConfig == null) {
         return false;
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/autoscaling/SimpleWorkerProvisioningStrategy.java
@@ -121,7 +121,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
       Collection<ImmutableWorkerInfo> workers = runner.getWorkers();
       boolean didProvision = false;
       final DefaultWorkerBehaviorConfig workerConfig =
-          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, config,"provision", log);
+          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, config, "provision", log);
       if (workerConfig == null) {
         return false;
       }
@@ -186,7 +186,7 @@ public class SimpleWorkerProvisioningStrategy extends AbstractWorkerProvisioning
     {
       Collection<? extends TaskRunnerWorkItem> pendingTasks = runner.getPendingTasks();
       final DefaultWorkerBehaviorConfig workerConfig =
-          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, config,"terminate", log);
+          PendingTaskBasedWorkerProvisioningStrategy.getDefaultWorkerBehaviorConfig(workerConfigRef, config, "terminate", log);
       if (workerConfig == null) {
         return false;
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/autoscaling/PendingTaskBasedProvisioningStrategyTest.java
@@ -647,7 +647,9 @@ public class PendingTaskBasedProvisioningStrategyTest
 
     RemoteTaskRunner runner = EasyMock.createMock(RemoteTaskRunner.class);
     EasyMock.expect(runner.getWorkers()).andReturn(
-        Collections.singletonList(
+        ImmutableList.of(
+            new TestZkWorker(testTask).toImmutable(),
+            new TestZkWorker(testTask).toImmutable(),
             new TestZkWorker(testTask).toImmutable()
         )
     ).times(2);


### PR DESCRIPTION
Improve Auto scaler pendingTaskBased provisioning strategy to handle when there are no currently running worker node better

### Description

As described in https://github.com/apache/druid/issues/10918, the PendingTaskBasedWorkerProvisioningStrategy of the Auto scaler does not work well when there are 0 worker node running. The problems are the following:
1. When there are 0 worker node running, currently the auto scaler will first scale up to minWorkerCount and only in the next provisioning cycle would be able to determine the correct number of workers needed to run all pending tasks. This is inefficient as we will have to go through two provisioning cycle plus the time it takes for the worker nodes in the first provisioning to be up and running before being able to scale to the correct number (basically it would take twice as long as needed)
2. When the minWorkerCount is set to 0 and there are 0 worker node running, the autoscaler will never attempts to add more instances. This is because the auto scaler will try to scale to minWorkerCount (which is 0). Hence, pending task will not be able to run. 

The reason for the auto scaler scaling to minWorkerCount first is because without any running worker node, the auto scaler will not be able to determine the capacity per worker. (note even when there are running worker nodes, that the auto scaler assume that all worker nodes have the same capacity and use the capacity of the first running node). 

To fix this problem, I introduce a new config in the PendingTaskBasedWorkerProvisioningConfig under `druid.indexer.autoscale.workerCapacityFallback`. This config tells the auto scaler the worker capcity for determining number of workers needed when there are currently no worker running. If unset or null, auto scaler will scale to `minNumWorkers` in autoScaler config instead. Note: this config is only applicable to `pendingTaskBased` provisioning strategy. Even if this config value is not accurate (i.e. if your worker node capacity changed over time) it is still useful for solving problem # 2 above, as the auto scaler will at least provision some nodes and in the next providing cycle will be able to determine the correct number of workers needed (rather than being stuck at 0 workers forever). 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
