### PR TITLE
Bump commons-io to 2.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,3 @@ updates:
       # pin ZooKeeper dependencies to 3.5.x
       - dependency-name: "org.apache.zookeeper"
         versions: "[3.6,)"
-      # Keep commons-io at 2.6 until https://issues.apache.org/jira/browse/IO-741 is resolved
-      - dependency-name: "commons-io:commons-io"

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <confluent.version>6.0.1</confluent.version>
-    <commons-io.version>2.6</commons-io.version>
+    <commons-io.version>2.11.0</commons-io.version>
   </properties>
 
   <repositories>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -545,13 +545,13 @@ name: Apache Commons IO
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.6
+version: 2.11.0
 libraries:
   - commons-io: commons-io
 notices:
   - commons-io: |
       Apache Commons IO
-      Copyright 2002-2017 The Apache Software Foundation
+      Copyright 2002-2021 The Apache Software Foundation
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>2.11.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehose.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehose.java
@@ -41,7 +41,7 @@ public class InlineFirehose implements Firehose
   private final StringInputRowParser parser;
   private final LineIterator lineIterator;
 
-  InlineFirehose(String data, StringInputRowParser parser) throws IOException
+  InlineFirehose(String data, StringInputRowParser parser)
   {
     this.parser = parser;
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
@@ -56,7 +56,7 @@ public class InlineFirehoseFactory implements FiniteFirehoseFactory<StringInputR
   }
 
   @Override
-  public Firehose connect(StringInputRowParser parser, @Nullable File temporaryDirectory) throws IOException
+  public Firehose connect(StringInputRowParser parser, @Nullable File temporaryDirectory)
   {
     return new InlineFirehose(data, parser);
   }

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
@@ -31,7 +31,6 @@ import org.apache.druid.data.input.impl.StringInputRowParser;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.IOException;
 import java.util.Objects;
 import java.util.stream.Stream;
 

--- a/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
@@ -153,7 +153,7 @@ public class LocalDataSegmentPusherTest
   public void testPushCannotCreateDirectory() throws IOException
   {
     exception.expect(IOException.class);
-    exception.expectMessage("Unable to create directory");
+    exception.expectMessage("Cannot create directory");
     config.storageDirectory = new File(config.storageDirectory, "xxx");
     Assert.assertTrue(config.storageDirectory.mkdir());
     config.storageDirectory.setWritable(false);

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseTest.java
@@ -208,12 +208,7 @@ public class InlineFirehoseTest
 
   private static InlineFirehose create(String data)
   {
-    try {
-      return new InlineFirehose(data, PARSER);
-    }
-    catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return new InlineFirehose(data, PARSER);
   }
 
   private static void assertRowValue(String expected, InputRow row)


### PR DESCRIPTION
### Description

https://github.com/apache/druid/pull/11338 upgraded `commons-io` from 2.6 to 2.9.
https://github.com/apache/druid/pull/11392 reverted it back due to https://issues.apache.org/jira/browse/IO-741 .

Since commons-io 2.11.0 fixed IO-741, this PR aims to retry the upgrade and remove the commons-io pinning from Dependabot.

BTW, the integration test (https://github.com/apache/druid/issues/11393) is not added yet because it isn't easy.

#### Fixed the bug ...

This will bring the bug fixes of 2.7 ~ 2.11
- https://commons.apache.org/proper/commons-io/changes-report.html
    - 2.11: 2021-07-09
    - 2.10: 2021-06-10
    - 2.9: 2021-05-22
    - 2.8: 2020-09-05
    - 2.7: 2020-05-24

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
