### PR TITLE
Updates to source and doc build pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 Druid is a high performance real-time analytics database. Druid's main value add is to reduce time to insight and action.
 
-Druid is designed for workflows where fast queries and ingest really matter. Druid excels at powering UIs, running operational (ad-hoc) queries, or handling high concurrency. Consider Druid as an open source alternative to data warehouses for a variety of use cases.
+Druid is designed for workflows where fast queries and ingest really matter. Druid excels at powering UIs, running operational (ad-hoc) queries, or handling high concurrency. Consider Druid as an open source alternative to data warehouses for a variety of use cases. The [design documentation](https://druid.apache.org/docs/latest/design/architecture.html) explains the key concepts.
 
 ### Getting started
 

--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -23,30 +23,32 @@ title: "Build from source"
   -->
 
 
-You can build Apache Druid directly from source. Please note that these instructions are for building the latest stable version of Druid.
-For building the latest code in master, follow the instructions [here](https://github.com/apache/druid/blob/master/docs/development/build.md).
-
+You can build Apache Druid directly from source. Use the version of this page
+that matches the version you want to build.
+For building the latest code in master, follow the latest version of this page
+[here](https://github.com/apache/druid/blob/master/docs/development/build.md):
+make sure it has `/master/` in the URL.
 
 #### Prerequisites
 
-##### Installing Java and Maven:
+##### Installing Java and Maven
+
 - JDK 8, 8u92+. We recommend using an OpenJDK distribution that provides long-term support and open-source licensing,
   like [Amazon Corretto](https://aws.amazon.com/corretto/) or [Azul Zulu](https://www.azul.com/downloads/zulu/).
 - [Maven version 3.x](http://maven.apache.org/download.cgi)
 
-##### Other Dependencies
-- for distribution build, Python and yaml module are required
+##### Other dependencies
 
+- Distribution builds require Python 3.x and the `pyyaml` module
 
-##### Downloading the source:
+##### Downloading the source
 
 ```bash
 git clone git@github.com:apache/druid.git
 cd druid
 ```
 
-
-#### Building the source
+#### Building from source
 
 The basic command to build Druid from source is:
 
@@ -71,13 +73,21 @@ mvn clean install -Papache-release,dist,rat -DskipTests
 ```
 #### Potential issues
 
-##### Issue
+##### Missing pyyaml
+
 You are building Druid from source following the instructions on this page but you get
 ```
 [ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.6.0:exec (generate-binary-license) on project distribution: Command execution failed.: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
 ```
 
 Resolution: Make sure you have Python installed as well as the `yaml` module:
-```
+
+```bash
 pip install pyyaml
+```
+
+On some systems, ensure you use the Python 3.x version of `pip`:
+
+```bash
+pip3 install pyyaml
 ```

--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -73,7 +73,7 @@ mvn clean install -Papache-release,dist,rat -DskipTests
 ```
 #### Potential issues
 
-##### Missing pyyaml
+##### Missing `pyyaml`
 
 You are building Druid from source following the instructions on this page but you get
 ```

--- a/website/README.md
+++ b/website/README.md
@@ -56,3 +56,17 @@ creating links to files of the same version on GitHub.
 
 The variables are not replaced when running the web site locally using the
 `start` command above.
+
+## Spellcheck
+
+Please run a spellcheck before issuing a pull request to avoid a build failure
+due to spelling issues. Run:
+
+```bash
+npm run link-lint
+npm run spellcheck
+```
+
+If you introduce new (correctly spelled) project names or technical terms, add
+them to the dictionary in the `.spelling` file in this directory. Also, terms
+enclosed in backticks are not spell checked. Example: \``symbolName`\`

--- a/website/README.md
+++ b/website/README.md
@@ -21,10 +21,38 @@
 
 This website was created with [Docusaurus](https://docusaurus.io/).
 
-To edit this documentation run:
+To view documentation run:
 
 `npm install`
 
-Then run
+Then run:
 
 `npm start`
+
+The current version of the web site appears in your browser. Edit pages with
+your favorite editor. Refresh the web page after each edit to review your changes.
+
+## Dependencies
+
+* [NodeJS](https://nodejs.org/en/download/). Use the version Docusaurus specifies, not a
+newer one. (For example, if 12.x is requested, don't install 16.x.)
+Docusaurus may require a version
+newer than that available in your Linux package repository, but older than the
+latest version. See
+[this page](https://github.com/nodesource/distributions/blob/master/README.md) to
+find the version required by Docusaurus.
+* The [Yarn](https://classic.yarnpkg.com/en/) dependency from Docusaurus is optional.
+(This Yarn is not the Hadoop resource manager, it is a package manager for Node.js).
+* [Docusaurus](https://docusaurus.io/docs/installation). Installed automatically
+as part of the the above `npm` commands.
+
+## Variables
+
+Documentation pages can refer to a number of special variables using the
+`{{var}}` syntax:
+
+* `DRUIDVERSION` - the version of Druid in which the page appears. Allows
+creating links to files of the same version on GitHub.
+
+The variables are not replaced when running the web site locally using the
+`start` command above.


### PR DESCRIPTION
### Description

The "build from source" and "build website" pages are very useful but miss a few details needed by newbies. This PR adds those details from the perspective of someone familiar with Apache projects in general, but not Druid in particular.

The top-level `README.md` provides a good overview of features, but we often want to know what Druid *is* before we dive into the UI and how to run it. So, added a link to the excellent architecture page.

Added more hints to the website `README.md`, including how to run a spellcheck.

Cleaned up a few spacing and capitalization style issues to use the most prevalent style.

This doc-only PR has:
- [x] been self-reviewed.
- [x] been reviewed using the Markdown viewer of VS Code (`README.md` files)
- [x] been reviewed using Docusaurus web tool (doc pages)
- [x] been checked with `npm run spellcheck`