### PR TITLE
Docs - Metrics docs layout and info about query/bytes

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -353,7 +353,7 @@ You can configure Druid processes to emit [metrics](../operations/metrics.md) re
 
 #### Metrics monitors
 
-The following monitors are available:
+Metric monitoring is an essential part of Druid operations.  The following monitors are available:
 
 |Name|Description|
 |----|-----------|
@@ -370,11 +370,11 @@ The following monitors are available:
 |`org.apache.druid.server.emitter.HttpEmittingMonitor`|Reports internal metrics of `http` or `parametrized` emitter (see below). Must not be used with another emitter type. See the description of the metrics here: https://github.com/apache/druid/pull/4973.|
 |`org.apache.druid.server.metrics.TaskCountStatsMonitor`|Reports how many ingestion tasks are currently running/pending/waiting and also the number of successful/failed tasks per emission period.|
 
-> Metric monitoring is an essential part of Druid operations.  For example, you might configure monitors on all processes for system and JVM information as follows:
->
->`druid.monitoring.monitors=["org.apache.druid.java.util.metrics.SysMonitor","org.apache.druid.java.util.metrics.JvmMonitor"]`
+For example, you might configure monitors on all processes for system and JVM information within `common.runtime.properties` as follows:
 
-> You can overwrite the default list of monitors with the configurations of individual processes.
+`druid.monitoring.monitors=["org.apache.druid.java.util.metrics.SysMonitor","org.apache.druid.java.util.metrics.JvmMonitor"]`
+
+You can override cluster-wide configuration by amending the `runtime.properties` of individual processes.
 
 #### Metrics emitters
 
@@ -394,7 +394,7 @@ There are several emitters available:
 |`druid.emitter.logging.loggerClass`|Choices: HttpPostEmitter, LoggingEmitter, NoopServiceEmitter, ServiceEmitter. The class used for logging.|LoggingEmitter|
 |`druid.emitter.logging.logLevel`|Choices: debug, info, warn, error. The log level at which message are logged.|info|
 
-##### Http Emitter Module
+##### HTTP Emitter Module
 
 |Property|Description|Default|
 |--------|-----------|-------|
@@ -408,27 +408,27 @@ There are several emitters available:
 |`druid.emitter.http.minHttpTimeoutMillis`|If the speed of filling batches imposes timeout smaller than that, not even trying to send batch to endpoint, because it will likely fail, not being able to send the data that fast. Configure this depending based on emitter/successfulSending/minTimeMs metric. Reasonable values are 10ms..100ms.|0|
 |`druid.emitter.http.recipientBaseUrl`|The base URL to emit messages to. Druid will POST JSON to be consumed at the HTTP endpoint specified by this property.|none, required config|
 
-##### Http Emitter Module TLS Overrides
+##### HTTP Emitter Module TLS Overrides
 
-When emitting events to a TLS-enabled receiver, the Http Emitter will by default use an SSLContext obtained via the process described at [Druid's internal communication over TLS](../operations/tls-support.md), i.e., the same
+When emitting events to a TLS-enabled receiver, the HTTP Emitter will by default use an SSLContext obtained via the process described at [Druid's internal communication over TLS](../operations/tls-support.md), i.e., the same
 SSLContext that would be used for internal communications between Druid processes.
 
-In some use cases it may be desirable to have the Http Emitter use its own separate truststore configuration. For example, there may be organizational policies that prevent the TLS-enabled metrics receiver's certificate from being added to the same truststore used by Druid's internal HTTP client.
+In some use cases it may be desirable to have the HTTP Emitter use its own separate truststore configuration. For example, there may be organizational policies that prevent the TLS-enabled metrics receiver's certificate from being added to the same truststore used by Druid's internal HTTP client.
 
-The following properties allow the Http Emitter to use its own truststore configuration when building its SSLContext.
+The following properties allow the HTTP Emitter to use its own truststore configuration when building its SSLContext.
 
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.emitter.http.ssl.useDefaultJavaContext`|If set to true, the HttpEmitter will use `SSLContext.getDefault()`, the default Java SSLContext, and all other properties below are ignored.|false|
-|`druid.emitter.http.ssl.trustStorePath`|The file path or URL of the TLS/SSL Key store where trusted root certificates are stored. If this is unspecified, the Http Emitter will use the same SSLContext as Druid's internal HTTP client, as described in the beginning of this section, and all other properties below are ignored.|null|
+|`druid.emitter.http.ssl.trustStorePath`|The file path or URL of the TLS/SSL Key store where trusted root certificates are stored. If this is unspecified, the HTTP Emitter will use the same SSLContext as Druid's internal HTTP client, as described in the beginning of this section, and all other properties below are ignored.|null|
 |`druid.emitter.http.ssl.trustStoreType`|The type of the key store where trusted root certificates are stored.|`java.security.KeyStore.getDefaultType()`|
 |`druid.emitter.http.ssl.trustStoreAlgorithm`|Algorithm to be used by TrustManager to validate certificate chains|`javax.net.ssl.TrustManagerFactory.getDefaultAlgorithm()`|
 |`druid.emitter.http.ssl.trustStorePassword`|The [Password Provider](../operations/password-provider.md) or String password for the Trust Store.|none|
 |`druid.emitter.http.ssl.protocol`|TLS protocol to use.|"TLSv1.2"|
 
-##### Parametrized Http Emitter Module
+##### Parametrized HTTP Emitter Module
 
-`druid.emitter.parametrized.httpEmitting.*` configs correspond to the configs of Http Emitter Modules, see above.
+`druid.emitter.parametrized.httpEmitting.*` configs correspond to the configs of HTTP Emitter Modules, see above.
 Except `recipientBaseUrl`. E.g., `druid.emitter.parametrized.httpEmitting.flushMillis`,
 `druid.emitter.parametrized.httpEmitting.flushCount`, `druid.emitter.parametrized.httpEmitting.ssl.trustStorePath`, etc.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -410,7 +410,7 @@ There are several emitters available:
 
 ##### HTTP Emitter Module TLS Overrides
 
-When emitting events to a TLS-enabled receiver, the HTTP Emitter will by default use an SSLContext obtained via the process described at [Druid's internal communication over TLS](../operations/tls-support.md), i.e., the same
+By default, when sending events to a TLS-enabled receiver, the HTTP Emitter uses an SSLContext obtained from the process described at [Druid's internal communication over TLS](../operations/tls-support.md), i.e., the same
 SSLContext that would be used for internal communications between Druid processes.
 
 In some use cases it may be desirable to have the HTTP Emitter use its own separate truststore configuration. For example, there may be organizational policies that prevent the TLS-enabled metrics receiver's certificate from being added to the same truststore used by Druid's internal HTTP client.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -349,7 +349,7 @@ You can configure Druid processes to emit [metrics](../operations/metrics.md) re
 |--------|-----------|-------|
 |`druid.monitoring.emissionPeriod`| Frequency that Druid emits metrics.|`PT1M`|
 |[`druid.monitoring.monitors`](#metrics-monitors)|Sets list of Druid monitors used by a process.|none (no monitors)|
-|[`druid.emitter`](#metrics-emitters)|Setting this value will initialize one of the emitter modules.|`noop`|
+|[`druid.emitter`](#metrics-emitters)|Setting this value initializes one of the emitter modules.|`noop`|
 
 #### Metrics monitors
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -347,7 +347,7 @@ You can configure Druid processes to emit [metrics](../operations/metrics.md) re
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.monitoring.emissionPeriod`|How often metrics are emitted.|`PT1M`|
+|`druid.monitoring.emissionPeriod`| Frequency that Druid emits metrics.|`PT1M`|
 |[`druid.monitoring.monitors`](#metrics-monitors)|Sets list of Druid monitors used by a process.|none (no monitors)|
 |[`druid.emitter`](#metrics-emitters)|Setting this value will initialize one of the emitter modules.|`noop`|
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -343,7 +343,7 @@ Coordinator and Overlord log changes to lookups, segment load/drop rules, dynami
 
 ### Enabling Metrics
 
-Druid processes can be configured to emit [metrics](../operations/metrics.md) regularly from a number of [monitors](#metrics-monitors) via [emitters](#metrics-emitters).
+You can configure Druid processes to emit [metrics](../operations/metrics.md) regularly from a number of [monitors](#metrics-monitors) via [emitters](#metrics-emitters).
 
 |Property|Description|Default|
 |--------|-----------|-------|

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -23,9 +23,7 @@ title: "Metrics"
   -->
 
 
-Druid generates metrics related to queries, ingestion, and coordination.
-
-Metrics are emitted as JSON objects to a runtime log file or over HTTP (to a service such as Apache Kafka). Metric emission is disabled by default.
+Druid can be [configured](../configuration/index.html#enabling-metrics) to emit metrics that are essential for monitoring query execution, ingestion, coordination, and so on.
 
 All Druid metrics share a common set of fields:
 
@@ -37,7 +35,7 @@ All Druid metrics share a common set of fields:
 
 Metrics may have additional dimensions beyond those listed above.
 
-Most metric values reset each emission period. By default druid emission period is 1 minute, this can be changed by setting the property `druid.monitoring.emissionPeriod`.
+> Most metric values reset each emission period, as specified in [`druid.monitoring.emissionPeriod`](../configuration/index.html#enabling-metrics).
 
 Available Metrics
 -----------------
@@ -49,7 +47,7 @@ Available Metrics
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|
 |`query/time`|Milliseconds taken to complete a query.|Common: dataSource, type, interval, hasFilters, duration, context, remoteAddress, id. Aggregation Queries: numMetrics, numComplexMetrics. GroupBy: numDimensions. TopN: threshold, dimension.|< 1s|
-|`query/bytes`|number of bytes returned in query response.|Common: dataSource, type, interval, hasFilters, duration, context, remoteAddress, id. Aggregation Queries: numMetrics, numComplexMetrics. GroupBy: numDimensions. TopN: threshold, dimension.| |
+|`query/bytes`|The total number of bytes returned in the query response back to the requesting client by the broker.  (Other services report the total bytes for their portion of the query.)|Common: dataSource, type, interval, hasFilters, duration, context, remoteAddress, id. Aggregation Queries: numMetrics, numComplexMetrics. GroupBy: numDimensions. TopN: threshold, dimension.| |
 |`query/node/time`|Milliseconds taken to query individual historical/realtime processes.|id, status, server.|< 1s|
 |`query/node/bytes`|number of bytes returned from querying individual historical/realtime processes.|id, status, server.| |
 |`query/node/ttfb`|Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.|id, status, server.|< 1s|

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -23,7 +23,7 @@ title: "Metrics"
   -->
 
 
-Druid can be [configured](../configuration/index.html#enabling-metrics) to emit metrics that are essential for monitoring query execution, ingestion, coordination, and so on.
+You can configure Druid to [emit metrics](../configuration/index.html#enabling-metrics) that are essential for monitoring query execution, ingestion, coordination, and so on.
 
 All Druid metrics share a common set of fields:
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -35,7 +35,7 @@ All Druid metrics share a common set of fields:
 
 Metrics may have additional dimensions beyond those listed above.
 
-> Most metric values reset each emission period, as specified in [`druid.monitoring.emissionPeriod`](../configuration/index.html#enabling-metrics).
+> Most metric values reset each emission period, as specified in `druid.monitoring.emissionPeriod`.
 
 Available Metrics
 -----------------

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -47,7 +47,7 @@ Available Metrics
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|
 |`query/time`|Milliseconds taken to complete a query.|Common: dataSource, type, interval, hasFilters, duration, context, remoteAddress, id. Aggregation Queries: numMetrics, numComplexMetrics. GroupBy: numDimensions. TopN: threshold, dimension.|< 1s|
-|`query/bytes`|The total number of bytes returned in the query response back to the requesting client by the broker.  (Other services report the total bytes for their portion of the query.)|Common: dataSource, type, interval, hasFilters, duration, context, remoteAddress, id. Aggregation Queries: numMetrics, numComplexMetrics. GroupBy: numDimensions. TopN: threshold, dimension.| |
+|`query/bytes`|The total number of bytes returned to the requesting client in the query response from the broker.  Other services report the total bytes for their portion of the query. |Common: `dataSource`, `type`, `interval`, `hasFilters`, `duration`, `context`, `remoteAddress`, `id`. Aggregation Queries: `numMetrics`, `numComplexMetrics`. GroupBy: `numDimensions`. TopN: `threshold`, `dimension`.| |
 |`query/node/time`|Milliseconds taken to query individual historical/realtime processes.|id, status, server.|< 1s|
 |`query/node/bytes`|number of bytes returned from querying individual historical/realtime processes.|id, status, server.| |
 |`query/node/ttfb`|Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.|id, status, server.|< 1s|


### PR DESCRIPTION
Knowledge transfer from https://groups.google.com/g/druid-user/c/8fiflmSEoTQ to note that the metric reports differently broker versus historical - also updated the layout of the Metrics part of the config doc, and added links between this and the metrics page itself.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] been tested in a test Druid cluster.

cc: @sthetland @techdocsmith 

@2bethere I haven't added the `query/bytes` entry to the tables for the other processes – should it be there?