### PR TITLE
Add error msg to parallel task's TaskStatus

### DIFF
--- a/core/src/main/java/org/apache/druid/indexer/TaskStatus.java
+++ b/core/src/main/java/org/apache/druid/indexer/TaskStatus.java
@@ -59,14 +59,7 @@ public class TaskStatus
 
   /**
    * All failed task status must have a non-null error message.
-   * Use {@link #failure(String, String)} instead.
    */
-  @Deprecated
-  public static TaskStatus failure(String taskId)
-  {
-    return new TaskStatus(taskId, TaskState.FAILED, -1, null, null);
-  }
-
   public static TaskStatus failure(String taskId, String errorMsg)
   {
     return new TaskStatus(taskId, TaskState.FAILED, -1, errorMsg, null);

--- a/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
+++ b/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
@@ -257,7 +257,7 @@ public class MaterializedViewSupervisorTest
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.absent()).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.of()).anyTimes();
     EasyMock.expect(taskStorage.getStatus("test_task1"))
-            .andReturn(Optional.of(TaskStatus.failure("test_task1")))
+            .andReturn(Optional.of(TaskStatus.failure("test_task1", "Dummy task status failure err message")))
             .anyTimes();
     EasyMock.expect(taskStorage.getStatus("test_task2"))
             .andReturn(Optional.of(TaskStatus.running("test_task2")))

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClientTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClientTest.java
@@ -170,7 +170,7 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
             .andReturn(new TaskLocation(TEST_HOST, TEST_PORT, TEST_TLS_PORT))
             .anyTimes();
     EasyMock.expect(taskInfoProvider.getTaskStatus(TEST_ID))
-            .andReturn(Optional.of(TaskStatus.failure(TEST_ID)))
+            .andReturn(Optional.of(TaskStatus.failure(TEST_ID, "Dummy task status failure err message")))
             .anyTimes();
     replayAll();
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1188,7 +1188,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
       EasyMock.expect(taskStorage.getTask(task.getId())).andReturn(Optional.of(task)).anyTimes();
     }
     EasyMock.expect(taskStorage.getStatus(iHaveFailed.getId()))
-            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId())));
+            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId(), "Dummy task status failure err message")));
     EasyMock.expect(taskStorage.getTask(iHaveFailed.getId())).andReturn(Optional.of(iHaveFailed)).anyTimes();
     EasyMock.expect(taskQueue.add(EasyMock.capture(aNewTaskCapture))).andReturn(true);
     EasyMock.replay(taskStorage);
@@ -1277,7 +1277,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .andReturn(ImmutableList.of(captured.getValue()))
             .anyTimes();
     EasyMock.expect(taskStorage.getStatus(iHaveFailed.getId()))
-            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId())));
+            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId(), "Dummy task status failure err message")));
     EasyMock.expect(taskStorage.getStatus(runningTaskId))
             .andReturn(Optional.of(TaskStatus.running(runningTaskId)))
             .anyTimes();

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
@@ -171,7 +171,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
             .andReturn(new TaskLocation(TEST_HOST, TEST_PORT, TEST_TLS_PORT))
             .anyTimes();
     EasyMock.expect(taskInfoProvider.getTaskStatus(TEST_ID))
-            .andReturn(Optional.of(TaskStatus.failure(TEST_ID)))
+            .andReturn(Optional.of(TaskStatus.failure(TEST_ID, "Dummy task status failure err message")))
             .anyTimes();
     replayAll();
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -1029,7 +1029,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
       EasyMock.expect(taskStorage.getTask(task.getId())).andReturn(Optional.of(task)).anyTimes();
     }
     EasyMock.expect(taskStorage.getStatus(iHaveFailed.getId()))
-            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId())));
+            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId(), "Dummy task status failure err message")));
     EasyMock.expect(taskStorage.getTask(iHaveFailed.getId())).andReturn(Optional.of(iHaveFailed)).anyTimes();
     EasyMock.expect(taskQueue.add(EasyMock.capture(aNewTaskCapture))).andReturn(true);
     EasyMock.replay(taskStorage);
@@ -1147,7 +1147,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(captured.getValue())).anyTimes();
     EasyMock.expect(taskStorage.getStatus(iHaveFailed.getId()))
-            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId())));
+            .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId(), "Dummy task status failure err message")));
     EasyMock.expect(taskStorage.getStatus(runningTaskId))
             .andReturn(Optional.of(TaskStatus.running(runningTaskId)))
             .anyTimes();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -142,7 +142,8 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
 
     synchronized (this) {
       if (stopped) {
-        return TaskStatus.failure(getId());
+        String errMsg = "Attempting to run a task that has been stopped. See overlord & task logs for more details.";
+        return TaskStatus.failure(getId(), errMsg);
       } else {
         // Register the cleaner to interrupt the current thread first.
         // Since the resource closer cleans up the registered resources in LIFO order,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -405,13 +405,15 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
         if (specVersion.compareTo(version) < 0) {
           version = specVersion;
         } else {
-          log.error(
-              "Spec version can not be greater than or equal to the lock version, Spec version: [%s] Lock version: [%s].",
-              specVersion,
-              version
-          );
+          String errMsg =
+              StringUtils.format(
+                  "Spec version can not be greater than or equal to the lock version, Spec version: [%s] Lock version: [%s].",
+                  specVersion,
+                  version
+              );
+          log.error(errMsg);
           toolbox.getTaskReportFileWriter().write(getId(), null);
-          return TaskStatus.failure(getId());
+          return TaskStatus.failure(getId(), errMsg);
         }
       }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -736,7 +736,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       Preconditions.checkState(state.isFailure());
       String errMsg = StringUtils.format(
           TASK_PHASE_FAILURE_MSG,
-          indexingRunner.getName()
+          mergeRunner.getName()
       );
       taskStatus = TaskStatus.failure(getId(), errMsg);
     }
@@ -748,7 +748,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     return taskStatus;
   }
 
-  private TaskStatus runRangePartitionMultiPhaseParallel(TaskToolbox toolbox) throws Exception
+  @VisibleForTesting
+  TaskStatus runRangePartitionMultiPhaseParallel(TaskToolbox toolbox) throws Exception
   {
     ParallelIndexIngestionSpec ingestionSchemaToUse = ingestionSchema;
     ParallelIndexTaskRunner<PartialDimensionDistributionTask, DimensionDistributionReport> distributionRunner =
@@ -759,7 +760,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
     TaskState distributionState = runNextPhase(distributionRunner);
     if (distributionState.isFailure()) {
-      return TaskStatus.failure(getId(), PartialDimensionDistributionTask.TYPE + " failed");
+      String errMsg = StringUtils.format(TASK_PHASE_FAILURE_MSG,distributionRunner.getName());
+      return TaskStatus.failure(getId(), errMsg);
     }
 
     Map<Interval, PartitionBoundaries> intervalToPartitions =

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -760,7 +760,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
     TaskState distributionState = runNextPhase(distributionRunner);
     if (distributionState.isFailure()) {
-      String errMsg = StringUtils.format(TASK_PHASE_FAILURE_MSG,distributionRunner.getName());
+      String errMsg = StringUtils.format(TASK_PHASE_FAILURE_MSG, distributionRunner.getName());
       return TaskStatus.failure(getId(), errMsg);
     }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -569,7 +569,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.success(getId());
     } else {
       // there is only success or failure after running....
-      Preconditions.checkState(state.isFailure());
+      Preconditions.checkState(state.isFailure(), "Unrecognized state after task is complete[%s]", state);
       final String errorMessage = StringUtils.format(
           TASK_PHASE_FAILURE_MSG,
           runner.getName()
@@ -733,7 +733,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.success(getId());
     } else {
       // there is only success or failure after running....
-      Preconditions.checkState(state.isFailure());
+      Preconditions.checkState(state.isFailure(), "Unrecognized state after task is complete[%s]", state);
       String errMsg = StringUtils.format(
           TASK_PHASE_FAILURE_MSG,
           mergeRunner.getName()
@@ -818,7 +818,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.success(getId());
     } else {
       // there is only success or failure after running....
-      Preconditions.checkState(mergeState.isFailure());
+      Preconditions.checkState(mergeState.isFailure(), "Unrecognized state after task is complete[%s]", mergeState);
       String errMsg = StringUtils.format(
           TASK_PHASE_FAILURE_MSG,
           mergeRunner.getName()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -564,12 +564,11 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         waitForSegmentAvailability(runner.getReports());
       }
       taskStatus = TaskStatus.success(getId());
-    } else if (state.isFailure()) {
+    } else {
+      // there is only success or failure after running....
+      Preconditions.checkState(state.isFailure());
       final String errorMessage = "Failed while running single phase parallel. See task logs for more details.";
       taskStatus = TaskStatus.failure(getId(), errorMessage);
-    } else {
-      final String errorMessage = "Task is in an invalid state after running.";
-      throw new ISE(errorMessage, state);
     }
     toolbox.getTaskReportFileWriter().write(
         getId(),
@@ -722,11 +721,11 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         waitForSegmentAvailability(mergeRunner.getReports());
       }
       taskStatus = TaskStatus.success(getId());
-    } else if (state.isFailure()) {
-      String errMsg = "Hash partition task failed while in partial segment merge phase. See task logs for details";
-      taskStatus = TaskStatus.fromCode(getId(), state);
     } else {
-      throw new ISE("Invalid state for Hash paritiion task while in partial segment merge phase[%s]", state);
+      // there is only success or failure after running....
+      Preconditions.checkState(state.isFailure());
+      String errMsg = "Hash partition task failed while in partial segment merge phase. See task logs for details";
+      taskStatus = TaskStatus.failure(getId(), errMsg);
     }
 
     toolbox.getTaskReportFileWriter().write(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -251,7 +251,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   }
 
   @Nullable
-  private <T extends Task, R extends SubTaskReport> ParallelIndexTaskRunner<T, R> createRunner(
+  @VisibleForTesting
+  <T extends Task, R extends SubTaskReport> ParallelIndexTaskRunner<T, R> createRunner(
       TaskToolbox toolbox,
       Function<TaskToolbox, ParallelIndexTaskRunner<T, R>> runnerCreator
   )
@@ -615,7 +616,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
   }
 
-  private TaskStatus runHashPartitionMultiPhaseParallel(TaskToolbox toolbox) throws Exception
+  @VisibleForTesting
+  TaskStatus runHashPartitionMultiPhaseParallel(TaskToolbox toolbox) throws Exception
   {
     TaskState state;
     ParallelIndexIngestionSpec ingestionSchemaToUse = ingestionSchema;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TestTasks.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TestTasks.java
@@ -113,8 +113,7 @@ public class TestTasks
       while (!Thread.currentThread().isInterrupted()) {
         Thread.sleep(1000);
       }
-
-      return TaskStatus.failure(getId());
+      return TaskStatus.failure(getId(), "Dummy task status failure for testing");
     }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
@@ -173,7 +173,7 @@ abstract class AbstractMultiPhaseParallelIndexingTest extends AbstractParallelIn
     return getIndexingServiceClient().getPublishedSegments(task);
   }
 
-  private ParallelIndexSupervisorTask newTask(
+  protected ParallelIndexSupervisorTask newTask(
       @Nullable TimestampSpec timestampSpec,
       @Nullable DimensionsSpec dimensionsSpec,
       @Nullable InputFormat inputFormat,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -443,7 +443,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
               if (task.isReady(toolbox.getTaskActionClient())) {
                 return task.run(toolbox);
               } else {
-                getTaskStorage().setStatus(TaskStatus.failure(task.getId()));
+                getTaskStorage().setStatus(TaskStatus.failure(task.getId(), "Dummy task status failure for testing"));
                 throw new ISE("task[%s] is not ready", task.getId());
               }
             }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Imply Data, Inc. All rights reserved.
+ *
+ * This software is the confidential and proprietary information
+ * of Imply Data, Inc. You shall not disclose such Confidential
+ * Information and shall use it only in accordance with the terms
+ * of the license agreement you entered into with Imply.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.impl.CSVParseSpec;
+import org.apache.druid.data.input.impl.CsvInputFormat;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.ParseSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexing.common.LockGranularity;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.guava.Comparators;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexingTest
+{
+  private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec("ts", "auto", null);
+  private static final DimensionsSpec DIMENSIONS_SPEC = new DimensionsSpec(
+      DimensionsSpec.getDefaultSchemas(Arrays.asList("ts", "dim1", "dim2"))
+  );
+  private static final ParseSpec PARSE_SPEC = new CSVParseSpec(
+      TIMESTAMP_SPEC,
+      DIMENSIONS_SPEC,
+      null,
+      Arrays.asList("ts", "dim1", "dim2", "val"),
+      false,
+      0
+  );
+  private static final InputFormat INPUT_FORMAT = new CsvInputFormat(
+      Arrays.asList("ts", "dim1", "dim2", "val"),
+      null,
+      false,
+      false,
+      0
+  );
+  private static final Interval INTERVAL_TO_INDEX = Intervals.of("2017-12/P1M");
+
+  private File inputDir;
+  // sorted input intervals
+  private List<Interval> inputIntervals;
+
+
+  public HashPartitionTaskKillTest()
+  {
+    super(LockGranularity.TIME_CHUNK, true, 0, 0);
+  }
+
+
+  @Before
+  public void setup() throws IOException
+  {
+    inputDir = temporaryFolder.newFolder("data");
+    final Set<Interval> intervals = new HashSet<>();
+    // set up data
+    for (int i = 0; i < 10; i++) {
+      try (final Writer writer =
+               Files.newBufferedWriter(new File(inputDir, "test_" + i).toPath(), StandardCharsets.UTF_8)) {
+        for (int j = 0; j < 10; j++) {
+          writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 1, i + 10, i));
+          writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 2, i + 11, i));
+          intervals.add(SEGMENT_GRANULARITY.bucket(DateTimes.of(StringUtils.format("2017-12-%d", j + 1))));
+          intervals.add(SEGMENT_GRANULARITY.bucket(DateTimes.of(StringUtils.format("2017-12-%d", j + 2))));
+        }
+      }
+    }
+
+    for (int i = 0; i < 5; i++) {
+      try (final Writer writer =
+               Files.newBufferedWriter(new File(inputDir, "filtered_" + i).toPath(), StandardCharsets.UTF_8)) {
+        writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", i + 1, i + 10, i));
+      }
+    }
+    inputIntervals = new ArrayList<>(intervals);
+    inputIntervals.sort(Comparators.intervalsByStartThenEnd());
+  }
+
+  @Test(timeout = 5000L)
+  public void testSubTaskFail() throws Exception
+  {
+
+    final ParallelIndexSupervisorTask task =
+        newTask(TIMESTAMP_SPEC, DIMENSIONS_SPEC, INPUT_FORMAT, null, INTERVAL_TO_INDEX, inputDir,
+                "test_*",
+                new HashedPartitionsSpec(null, 3,
+                                         ImmutableList.of("dim1", "dim2")
+                ),
+                1, false
+        );
+
+    final TaskActionClient actionClient = createActionClient(task);
+    final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
+
+    prepareTaskForLocking(task);
+    Assert.assertTrue(task.isReady(actionClient));
+
+    final TaskStatus taskStatus = task.run(toolbox);
+
+    Assert.assertTrue(taskStatus.isSuccess());
+
+
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -19,27 +19,42 @@
 
 package org.apache.druid.indexing.common.task.batch.parallel;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.impl.CSVParseSpec;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.data.input.impl.ParseSpec;
+import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Comparators;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.indexing.granularity.GranularitySpec;
+import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
+import org.apache.druid.segment.realtime.firehose.LocalFirehoseFactory;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
@@ -47,9 +62,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexingTest
 {
@@ -114,42 +132,15 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
   }
 
   @Test(timeout = 5000L)
-  public void testSubTaskFailsAtPartialSegmentGeneration() throws Exception
+  public void failsInDetermineIntervalsPhase() throws Exception
   {
-
     final ParallelIndexSupervisorTask task =
         newTask(TIMESTAMP_SPEC, DIMENSIONS_SPEC, INPUT_FORMAT, null, INTERVAL_TO_INDEX, inputDir,
                 "test_*",
-                new HashedPartitionsSpec(null, 3,
+                new HashedPartitionsSpec(null, null, // num shards is null to force it to go to first phase
                                          ImmutableList.of("dim1", "dim2")
                 ),
-                2, false
-        );
-
-    final TaskActionClient actionClient = createActionClient(task);
-    final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
-
-    prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
-
-    final TaskStatus taskStatus = task.run(toolbox);
-
-    Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals("Hash partition task failed while in partial segment generation phase. See task logs for details",
-                        taskStatus.getErrorMsg());
-  }
-
-  @Test(timeout = 5000L)
-  public void testSubTaskFailsWhenAttemptedToRunWhileStopped() throws Exception
-  {
-
-    final ParallelIndexSupervisorTask task =
-        newTask(TIMESTAMP_SPEC, DIMENSIONS_SPEC, INPUT_FORMAT, null, INTERVAL_TO_INDEX, inputDir,
-                "test_*",
-                new HashedPartitionsSpec(null, 3,
-                                         ImmutableList.of("dim1", "dim2")
-                ),
-                2, false
+                2, false, true, 0
         );
 
     final TaskActionClient actionClient = createActionClient(task);
@@ -158,12 +149,292 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     prepareTaskForLocking(task);
     Assert.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
-    final TaskStatus taskStatus = task.run(toolbox);
+
+
+    TaskStatus taskStatus = task.runHashPartitionMultiPhaseParallel(toolbox);
 
     Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals("Attempting to run a task that has been stopped. See overlord & task logs for more details.",
-                        taskStatus.getErrorMsg());
+    Assert.assertEquals(
+        "Hash partition task failed while in phase[partial_dimension_cardinality]. See task logs for details",
+        taskStatus.getErrorMsg()
+    );
+  }
 
+  @Test(timeout = 5000L)
+  public void failsInPartialSegmentGeneratePhase() throws Exception
+  {
+    final ParallelIndexSupervisorTask task =
+        newTask(TIMESTAMP_SPEC, DIMENSIONS_SPEC, INPUT_FORMAT, null, INTERVAL_TO_INDEX, inputDir,
+                "test_*",
+                new HashedPartitionsSpec(null, 3,
+                                         ImmutableList.of("dim1", "dim2")
+                ),
+                2, false, true, 0
+        );
+
+    final TaskActionClient actionClient = createActionClient(task);
+    final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
+
+    prepareTaskForLocking(task);
+    Assert.assertTrue(task.isReady(actionClient));
+    task.stopGracefully(null);
+
+    TaskStatus taskStatus = task.runHashPartitionMultiPhaseParallel(toolbox);
+
+    Assert.assertTrue(taskStatus.isFailure());
+    Assert.assertEquals(
+        "Hash partition task failed while in partial segment generation phase. See task logs for details",
+        taskStatus.getErrorMsg()
+    );
+  }
+
+  @Test(timeout = 5000L)
+  public void failsInPartialSegmentMergePhase() throws Exception
+  {
+    final ParallelIndexSupervisorTask task =
+        newTask(TIMESTAMP_SPEC, DIMENSIONS_SPEC, INPUT_FORMAT, null, INTERVAL_TO_INDEX, inputDir,
+                "test_*",
+                new HashedPartitionsSpec(null, 3,
+                                         ImmutableList.of("dim1", "dim2")
+                ),
+                2, false, true, 1
+        );
+
+    final TaskActionClient actionClient = createActionClient(task);
+    final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
+
+    prepareTaskForLocking(task);
+    Assert.assertTrue(task.isReady(actionClient));
+    task.stopGracefully(null);
+
+
+    TaskStatus taskStatus = task.runHashPartitionMultiPhaseParallel(toolbox);
+
+    Assert.assertTrue(taskStatus.isFailure());
+    Assert.assertEquals(
+        "Hash partition task failed while in partial segment merge phase. See task logs for details",
+        taskStatus.getErrorMsg()
+    );
+  }
+
+  static class ParallelIndexSupervisorTaskTest extends ParallelIndexSupervisorTask
+  {
+    private final int succeedsBeforeFailing;
+
+    public ParallelIndexSupervisorTaskTest(
+        String id,
+        @Nullable String groupId,
+        TaskResource taskResource,
+        ParallelIndexIngestionSpec ingestionSchema,
+        @Nullable String baseSubtaskSpecName,
+        Map<String, Object> context,
+        int succedsBeforeFailing
+
+    )
+    {
+      super(id, groupId, taskResource, ingestionSchema, baseSubtaskSpecName, context);
+      this.succeedsBeforeFailing = succedsBeforeFailing;
+    }
+
+    @Override
+    <T extends Task, R extends SubTaskReport> ParallelIndexTaskRunner<T, R> createRunner(
+        TaskToolbox toolbox,
+        Function<TaskToolbox, ParallelIndexTaskRunner<T, R>> runnerCreator
+    )
+    {
+      return (ParallelIndexTaskRunner<T, R>)
+          new TestRunner(succeedsBeforeFailing);
+    }
+
+  }
+
+  static class TestRunner
+      implements ParallelIndexTaskRunner<PartialDimensionCardinalityTask, DimensionCardinalityReport>
+  {
+
+    // These variables are at the class level since they are used to control after how many invocations of
+    // run the runner should fail
+    private static int succeedsBeforeFailing;
+    private static int numRuns = 0;
+
+    TestRunner(int succeedsBeforeFailing)
+    {
+      TestRunner.succeedsBeforeFailing = succeedsBeforeFailing;
+    }
+
+    @Override
+    public String getName()
+    {
+      return null;
+    }
+
+    @Override
+    public TaskState run() throws Exception
+    {
+      if (numRuns < succeedsBeforeFailing) {
+        numRuns++;
+        return TaskState.SUCCESS;
+      }
+      return TaskState.FAILED;
+    }
+
+    @Override
+    public void stopGracefully()
+    {
+
+    }
+
+    @Override
+    public void collectReport(DimensionCardinalityReport report)
+    {
+
+    }
+
+    @Override
+    public Map<String, DimensionCardinalityReport> getReports()
+    {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public ParallelIndexingPhaseProgress getProgress()
+    {
+      return null;
+    }
+
+    @Override
+    public Set<String> getRunningTaskIds()
+    {
+      return null;
+    }
+
+    @Override
+    public List<SubTaskSpec<PartialDimensionCardinalityTask>> getSubTaskSpecs()
+    {
+      return null;
+    }
+
+    @Override
+    public List<SubTaskSpec<PartialDimensionCardinalityTask>> getRunningSubTaskSpecs()
+    {
+      return null;
+    }
+
+    @Override
+    public List<SubTaskSpec<PartialDimensionCardinalityTask>> getCompleteSubTaskSpecs()
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public SubTaskSpec<PartialDimensionCardinalityTask> getSubTaskSpec(String subTaskSpecId)
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public SubTaskSpecStatus getSubTaskState(String subTaskSpecId)
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TaskHistory<PartialDimensionCardinalityTask> getCompleteSubTaskSpecAttemptHistory(String subTaskSpecId)
+    {
+      return null;
+    }
+
+  }
+
+  protected ParallelIndexSupervisorTask newTask(
+      @Nullable TimestampSpec timestampSpec,
+      @Nullable DimensionsSpec dimensionsSpec,
+      @Nullable InputFormat inputFormat,
+      @Nullable ParseSpec parseSpec,
+      Interval interval,
+      File inputDir,
+      String filter,
+      PartitionsSpec partitionsSpec,
+      int maxNumConcurrentSubTasks,
+      boolean appendToExisting,
+      boolean useInputFormatApi,
+      int succeedsBeforeFailing
+
+  )
+  {
+    GranularitySpec granularitySpec = new UniformGranularitySpec(
+        SEGMENT_GRANULARITY,
+        Granularities.MINUTE,
+        interval == null ? null : Collections.singletonList(interval)
+    );
+
+    ParallelIndexTuningConfig tuningConfig = newTuningConfig(
+        partitionsSpec,
+        maxNumConcurrentSubTasks,
+        !appendToExisting
+    );
+
+    final ParallelIndexIngestionSpec ingestionSpec;
+
+    if (useInputFormatApi) {
+      Preconditions.checkArgument(parseSpec == null);
+      ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(
+          null,
+          new LocalInputSource(inputDir, filter),
+          inputFormat,
+          appendToExisting,
+          null
+      );
+      ingestionSpec = new ParallelIndexIngestionSpec(
+          new DataSchema(
+              DATASOURCE,
+              timestampSpec,
+              dimensionsSpec,
+              new AggregatorFactory[]{new LongSumAggregatorFactory("val", "val")},
+              granularitySpec,
+              null
+          ),
+          ioConfig,
+          tuningConfig
+      );
+    } else {
+      Preconditions.checkArgument(inputFormat == null);
+      ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(
+          new LocalFirehoseFactory(inputDir, filter, null),
+          appendToExisting
+      );
+      //noinspection unchecked
+      ingestionSpec = new ParallelIndexIngestionSpec(
+          new DataSchema(
+              "dataSource",
+              getObjectMapper().convertValue(
+                  new StringInputRowParser(parseSpec, null),
+                  Map.class
+              ),
+              new AggregatorFactory[]{
+                  new LongSumAggregatorFactory("val", "val")
+              },
+              granularitySpec,
+              null,
+              getObjectMapper()
+          ),
+          ioConfig,
+          tuningConfig
+      );
+    }
+
+    return new ParallelIndexSupervisorTaskTest(
+        null,
+        null,
+        null,
+        ingestionSpec,
+        null,
+        Collections.emptyMap(),
+        succeedsBeforeFailing
+    );
   }
 
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -269,7 +269,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     }
 
     @Override
-    public TaskState run() throws Exception
+    public TaskState run() 
     {
       if (numRuns < succeedsBeforeFailing) {
         numRuns++;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -155,7 +155,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
 
     Assert.assertTrue(taskStatus.isFailure());
     Assert.assertEquals(
-        "Hash partition task failed while in phase[partial_dimension_cardinality]. See task logs for details",
+        "Failed in phase[TestRunner[0]]. See task logs for details.",
         taskStatus.getErrorMsg()
     );
   }
@@ -183,7 +183,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
 
     Assert.assertTrue(taskStatus.isFailure());
     Assert.assertEquals(
-        "Hash partition task failed while in partial segment generation phase. See task logs for details",
+        "Failed in phase[TestRunner[0]]. See task logs for details.",
         taskStatus.getErrorMsg()
     );
   }
@@ -212,7 +212,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
 
     Assert.assertTrue(taskStatus.isFailure());
     Assert.assertEquals(
-        "Hash partition task failed while in partial segment merge phase. See task logs for details",
+        "Failed in phase[TestRunner[1]]. See task logs for details.",
         taskStatus.getErrorMsg()
     );
   }
@@ -265,7 +265,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     @Override
     public String getName()
     {
-      return null;
+      return StringUtils.format("TestRunner[%s]", numRuns);
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -1,10 +1,20 @@
 /*
- * Copyright (c) Imply Data, Inc. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * This software is the confidential and proprietary information
- * of Imply Data, Inc. You shall not disclose such Confidential
- * Information and shall use it only in accordance with the terms
- * of the license agreement you entered into with Imply.
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.druid.indexing.common.task.batch.parallel;
@@ -113,7 +123,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
                 new HashedPartitionsSpec(null, 3,
                                          ImmutableList.of("dim1", "dim2")
                 ),
-                1, false
+                2, false
         );
 
     final TaskActionClient actionClient = createActionClient(task);
@@ -124,7 +134,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
 
     final TaskStatus taskStatus = task.run(toolbox);
 
-    Assert.assertTrue(taskStatus.isSuccess());
+    Assert.assertTrue(taskStatus.isFailure());
 
 
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -126,8 +126,10 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
     prepareTaskForLocking(task);
     Assert.assertTrue(task.isReady(actionClient));
 
-    final TaskState state = task.run(toolbox).getStatusCode();
-    Assert.assertEquals(TaskState.FAILED, state);
+    final TaskStatus taskStatus = task.run(toolbox);
+    Assert.assertEquals("Failed while running single phase parallel. See task logs for more details.",
+                        taskStatus.getErrorMsg());
+    Assert.assertEquals(TaskState.FAILED, taskStatus.getStatusCode());
 
     final SinglePhaseParallelIndexTaskRunner runner = (SinglePhaseParallelIndexTaskRunner) task.getCurrentRunner();
     Assert.assertTrue(runner.getRunningTaskIds().isEmpty());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -127,7 +127,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
     Assert.assertTrue(task.isReady(actionClient));
 
     final TaskStatus taskStatus = task.run(toolbox);
-    Assert.assertEquals("Failed while running single phase parallel. See task logs for more details.",
+    Assert.assertEquals("Failed in phase[segment generation]. See task logs for details.",
                         taskStatus.getErrorMsg());
     Assert.assertEquals(TaskState.FAILED, taskStatus.getStatusCode());
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
@@ -345,7 +345,7 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
 
       this.firstMap = new HashMap<>();
       Map<Interval, StringDistribution> intervalToDistribution = new HashMap<>();
-      intervalToDistribution.put(new Interval(0, 1000), new StringSketch());
+      intervalToDistribution.put(Intervals.of("2011-04-01/2011-04-02"), new StringSketch());
       this.firstMap.put("A", new DimensionDistributionReport("id", intervalToDistribution));
 
       this.secondMap = Collections.emptyMap();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
@@ -501,26 +501,26 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
 
     final ParallelIndexIngestionSpec ingestionSpec;
 
-      Preconditions.checkArgument(parseSpec == null);
-      ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(
-          null,
-          new LocalInputSource(inputDir, filter),
-          inputFormat,
-          appendToExisting,
-          null
-      );
-      ingestionSpec = new ParallelIndexIngestionSpec(
-          new DataSchema(
-              DATASOURCE,
-              timestampSpec,
-              dimensionsSpec,
-              new AggregatorFactory[]{new LongSumAggregatorFactory("val", "val")},
-              granularitySpec,
-              null
-          ),
-          ioConfig,
-          tuningConfig
-      );
+    Preconditions.checkArgument(parseSpec == null);
+    ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(
+        null,
+        new LocalInputSource(inputDir, filter),
+        inputFormat,
+        appendToExisting,
+        null
+    );
+    ingestionSpec = new ParallelIndexIngestionSpec(
+        new DataSchema(
+            DATASOURCE,
+            timestampSpec,
+            dimensionsSpec,
+            new AggregatorFactory[]{new LongSumAggregatorFactory("val", "val")},
+            granularitySpec,
+            null
+        ),
+        ioConfig,
+        tuningConfig
+    );
 
     return new ParallelIndexSupervisorTaskTest(
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
@@ -1,0 +1,536 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
+import org.apache.druid.common.config.NullValueHandlingConfig;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.impl.CSVParseSpec;
+import org.apache.druid.data.input.impl.CsvInputFormat;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LocalInputSource;
+import org.apache.druid.data.input.impl.ParseSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
+import org.apache.druid.indexing.common.LockGranularity;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringDistribution;
+import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringSketch;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.indexing.granularity.GranularitySpec;
+import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexingTest
+{
+  private static final int NUM_PARTITION = 2;
+  private static final int NUM_FILE = 10;
+  private static final int NUM_ROW = 20;
+  private static final int DIM_FILE_CARDINALITY = 2;
+  private static final int YEAR = 2017;
+  private static final Interval INTERVAL_TO_INDEX = Intervals.of("%s-12/P1M", YEAR);
+  private static final String TIME = "ts";
+  private static final String DIM1 = "dim1";
+  private static final String DIM2 = "dim2";
+  private static final String LIST_DELIMITER = "|";
+  private static final List<String> DIMS = ImmutableList.of(DIM1, DIM2);
+  private static final String TEST_FILE_NAME_PREFIX = "test_";
+  private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec(TIME, "auto", null);
+  private static final DimensionsSpec DIMENSIONS_SPEC = new DimensionsSpec(
+      DimensionsSpec.getDefaultSchemas(Arrays.asList(TIME, DIM1, DIM2))
+  );
+  private static final ParseSpec PARSE_SPEC = new CSVParseSpec(
+      TIMESTAMP_SPEC,
+      DIMENSIONS_SPEC,
+      LIST_DELIMITER,
+      Arrays.asList(TIME, DIM1, DIM2, "val"),
+      false,
+      0
+  );
+  private static final InputFormat INPUT_FORMAT = new CsvInputFormat(
+      Arrays.asList(TIME, DIM1, DIM2, "val"),
+      LIST_DELIMITER,
+      false,
+      false,
+      0
+  );
+
+  // Interpret empty values in CSV as null
+  @Rule
+  public final ProvideSystemProperty noDefaultNullValue = new ProvideSystemProperty(
+      NullValueHandlingConfig.NULL_HANDLING_CONFIG_STRING,
+      "false"
+  );
+
+  private File inputDir;
+  private SetMultimap<Interval, List<Object>> intervalToDims;
+
+  private final int maxNumConcurrentSubTasks;
+  private final boolean useMultivalueDim;
+  @Nullable
+  private final Interval intervalToIndex;
+
+  public RangePartitionTaskKillTest()
+  {
+    super(LockGranularity.SEGMENT, true, DEFAULT_TRANSIENT_TASK_FAILURE_RATE, DEFAULT_TRANSIENT_API_FAILURE_RATE);
+    this.maxNumConcurrentSubTasks = 1;
+    this.useMultivalueDim = false;
+    this.intervalToIndex = INTERVAL_TO_INDEX;
+  }
+
+  @Before
+  public void setup() throws IOException
+  {
+    inputDir = temporaryFolder.newFolder("data");
+    intervalToDims = createInputFiles(inputDir, useMultivalueDim);
+  }
+
+  private static SetMultimap<Interval, List<Object>> createInputFiles(File inputDir, boolean useMultivalueDim)
+      throws IOException
+  {
+    SetMultimap<Interval, List<Object>> intervalToDims = HashMultimap.create();
+
+    for (int fileIndex = 0; fileIndex < NUM_FILE; fileIndex++) {
+      Path path = new File(inputDir, TEST_FILE_NAME_PREFIX + fileIndex).toPath();
+      try (final Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+        for (int i = 0; i < (NUM_ROW / DIM_FILE_CARDINALITY); i++) {
+          for (int d = 0; d < DIM_FILE_CARDINALITY; d++) {
+            int rowIndex = i * DIM_FILE_CARDINALITY + d;
+            String dim1Value = createDim1Value(rowIndex, fileIndex, useMultivalueDim);
+
+            // This is the original row
+            writeRow(writer, i + d, dim1Value, fileIndex, intervalToDims);
+
+            // This row should get rolled up with original row
+            writeRow(writer, i + d, dim1Value, fileIndex, intervalToDims);
+
+            // This row should not get rolled up with original row
+            writeRow(writer, i + d, dim1Value, fileIndex + NUM_FILE, intervalToDims);
+          }
+        }
+      }
+    }
+
+    return intervalToDims;
+  }
+
+  @Nullable
+  private static String createDim1Value(int rowIndex, int fileIndex, boolean useMultivalueDim)
+  {
+    if (rowIndex == fileIndex) {
+      return null;
+    }
+
+    String dim1Value = String.valueOf(fileIndex);
+    return useMultivalueDim ? dim1Value + LIST_DELIMITER + dim1Value : dim1Value;
+  }
+
+  private static void writeRow(
+      Writer writer,
+      int day,
+      @Nullable String dim1Value,
+      int fileIndex,
+      Multimap<Interval, List<Object>> intervalToDims
+  ) throws IOException
+  {
+    Interval interval = Intervals.of("%s-12-%d/%s-12-%d", YEAR, day + 1, YEAR, day + 2);
+    String startDate = interval.getStart().toString("y-M-d");
+    String dim2Value = "test file " + fileIndex;
+    String row = startDate + ",";
+    if (dim1Value != null) {
+      row += dim1Value;
+    }
+    row += "," + dim2Value + "\n";
+    writer.write(row);
+    intervalToDims.put(interval, Arrays.asList(dim1Value, dim2Value));
+  }
+
+  @Test(timeout = 5000L)
+  public void failsFirstPhase() throws Exception
+  {
+    int targetRowsPerSegment = NUM_ROW * 2 / DIM_FILE_CARDINALITY / NUM_PARTITION;
+    final ParallelIndexSupervisorTask task =
+        newTask(TIMESTAMP_SPEC,
+                DIMENSIONS_SPEC,
+                INPUT_FORMAT,
+                null,
+                INTERVAL_TO_INDEX,
+                inputDir,
+                TEST_FILE_NAME_PREFIX + "*",
+                new SingleDimensionPartitionsSpec(
+                    targetRowsPerSegment,
+                    null,
+                    DIM1,
+                    false
+                ),
+                2,
+                false,
+                0
+        );
+
+    final TaskActionClient actionClient = createActionClient(task);
+    final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
+
+    prepareTaskForLocking(task);
+    Assert.assertTrue(task.isReady(actionClient));
+    task.stopGracefully(null);
+
+
+    TaskStatus taskStatus = task.runRangePartitionMultiPhaseParallel(toolbox);
+
+    Assert.assertTrue(taskStatus.isFailure());
+    Assert.assertEquals(
+        "Failed in phase[TestRunner[false]]. See task logs for details.",
+        taskStatus.getErrorMsg()
+    );
+  }
+
+  @Test(timeout = 5000L)
+  public void failsSecondPhase() throws Exception
+  {
+    int targetRowsPerSegment = NUM_ROW * 2 / DIM_FILE_CARDINALITY / NUM_PARTITION;
+    final ParallelIndexSupervisorTask task =
+        newTask(TIMESTAMP_SPEC,
+                DIMENSIONS_SPEC,
+                INPUT_FORMAT,
+                null,
+                INTERVAL_TO_INDEX,
+                inputDir,
+                TEST_FILE_NAME_PREFIX + "*",
+                new SingleDimensionPartitionsSpec(
+                    targetRowsPerSegment,
+                    null,
+                    DIM1,
+                    false
+                ),
+                2,
+                false,
+                1
+        );
+
+    final TaskActionClient actionClient = createActionClient(task);
+    final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
+
+    prepareTaskForLocking(task);
+    Assert.assertTrue(task.isReady(actionClient));
+    task.stopGracefully(null);
+
+
+    TaskStatus taskStatus = task.runRangePartitionMultiPhaseParallel(toolbox);
+
+    Assert.assertTrue(taskStatus.isFailure());
+    Assert.assertEquals(
+        "Failed in phase[TestRunner[false]]. See task logs for details.",
+        taskStatus.getErrorMsg()
+    );
+  }
+
+  @Test(timeout = 5000L)
+  public void failsThirdPhase() throws Exception
+  {
+    int targetRowsPerSegment = NUM_ROW * 2 / DIM_FILE_CARDINALITY / NUM_PARTITION;
+    final ParallelIndexSupervisorTask task =
+        newTask(TIMESTAMP_SPEC,
+                DIMENSIONS_SPEC,
+                INPUT_FORMAT,
+                null,
+                INTERVAL_TO_INDEX,
+                inputDir,
+                TEST_FILE_NAME_PREFIX + "*",
+                new SingleDimensionPartitionsSpec(
+                    targetRowsPerSegment,
+                    null,
+                    DIM1,
+                    false
+                ),
+                2,
+                false,
+                2
+        );
+
+    final TaskActionClient actionClient = createActionClient(task);
+    final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
+
+    prepareTaskForLocking(task);
+    Assert.assertTrue(task.isReady(actionClient));
+    task.stopGracefully(null);
+
+
+    TaskStatus taskStatus = task.runRangePartitionMultiPhaseParallel(toolbox);
+
+    Assert.assertTrue(taskStatus.isFailure());
+    Assert.assertEquals(
+        "Failed in phase[TestRunner[false]]. See task logs for details.",
+        taskStatus.getErrorMsg()
+    );
+  }
+
+
+  static class ParallelIndexSupervisorTaskTest extends ParallelIndexSupervisorTask
+  {
+    // These variables control how many runners get created until it fails:
+    private final int succeedsBeforeFailing;
+    private int numRuns;
+
+    // These maps are a hacky way to provide some sort of mock object in the runner to make the run continue
+    // until it fails:
+    private Map<String, DimensionDistributionReport> firstMap;
+    private Map<Interval, StringDistribution> secondMap;
+
+    public ParallelIndexSupervisorTaskTest(
+        String id,
+        @Nullable String groupId,
+        TaskResource taskResource,
+        ParallelIndexIngestionSpec ingestionSchema,
+        @Nullable String baseSubtaskSpecName,
+        Map<String, Object> context,
+        int succedsBeforeFailing
+
+    )
+    {
+      super(id, groupId, taskResource, ingestionSchema, baseSubtaskSpecName, context);
+      this.succeedsBeforeFailing = succedsBeforeFailing;
+
+      this.firstMap = new HashMap<>();
+      Map<Interval, StringDistribution> intervalToDistribution = new HashMap<>();
+      intervalToDistribution.put(new Interval(0, 1000), new StringSketch());
+      this.firstMap.put("A", new DimensionDistributionReport("id", intervalToDistribution));
+
+      this.secondMap = Collections.emptyMap();
+
+    }
+
+    @Override
+    <T extends Task, R extends SubTaskReport> ParallelIndexTaskRunner<T, R> createRunner(
+        TaskToolbox toolbox,
+        Function<TaskToolbox, ParallelIndexTaskRunner<T, R>> runnerCreator
+    )
+    {
+      ParallelIndexTaskRunner<T, R> runner;
+      if (numRuns < succeedsBeforeFailing && numRuns == 0) {
+        runner = (ParallelIndexTaskRunner<T, R>) new TestRunner(true, firstMap);
+      } else if (numRuns < succeedsBeforeFailing && numRuns == 2) {
+        runner = (ParallelIndexTaskRunner<T, R>) new TestRunner(true, secondMap);
+      } else {
+        runner = (ParallelIndexTaskRunner<T, R>) new TestRunner(false, secondMap);
+      }
+      numRuns++;
+      return runner;
+    }
+
+  }
+
+  static class TestRunner
+      implements ParallelIndexTaskRunner<PartialDimensionDistributionTask, DimensionDistributionReport>
+  {
+
+    private boolean succeeds;
+
+    private Map<String, DimensionDistributionReport> distributionMap;
+    private static boolean firstMapDone = false;
+
+    TestRunner(boolean succeeds, Map distributionMap)
+    {
+      this.succeeds = succeeds;
+      this.distributionMap = distributionMap;
+    }
+
+    @Override
+    public String getName()
+    {
+      return StringUtils.format("TestRunner[%s]", succeeds);
+    }
+
+    @Override
+    public TaskState run() 
+    {
+      if (succeeds) {
+        return TaskState.SUCCESS;
+      }
+      return TaskState.FAILED;
+    }
+
+    @Override
+    public void stopGracefully()
+    {
+
+    }
+
+    @Override
+    public void collectReport(DimensionDistributionReport report)
+    {
+
+    }
+
+    @Override
+    public Map<String, DimensionDistributionReport> getReports()
+    {
+      return distributionMap;
+    }
+
+    @Override
+    public ParallelIndexingPhaseProgress getProgress()
+    {
+      return null;
+    }
+
+    @Override
+    public Set<String> getRunningTaskIds()
+    {
+      return null;
+    }
+
+    @Override
+    public List<SubTaskSpec<PartialDimensionDistributionTask>> getSubTaskSpecs()
+    {
+      return null;
+    }
+
+    @Override
+    public List<SubTaskSpec<PartialDimensionDistributionTask>> getRunningSubTaskSpecs()
+    {
+      return null;
+    }
+
+    @Override
+    public List<SubTaskSpec<PartialDimensionDistributionTask>> getCompleteSubTaskSpecs()
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public SubTaskSpec<PartialDimensionDistributionTask> getSubTaskSpec(String subTaskSpecId)
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public SubTaskSpecStatus getSubTaskState(String subTaskSpecId)
+    {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TaskHistory<PartialDimensionDistributionTask> getCompleteSubTaskSpecAttemptHistory(String subTaskSpecId)
+    {
+      return null;
+    }
+
+  }
+
+  protected ParallelIndexSupervisorTask newTask(
+      @Nullable TimestampSpec timestampSpec,
+      @Nullable DimensionsSpec dimensionsSpec,
+      @Nullable InputFormat inputFormat,
+      @Nullable ParseSpec parseSpec,
+      Interval interval,
+      File inputDir,
+      String filter,
+      PartitionsSpec partitionsSpec,
+      int maxNumConcurrentSubTasks,
+      boolean appendToExisting,
+      int succeedsBeforeFailing
+  )
+  {
+    GranularitySpec granularitySpec = new UniformGranularitySpec(
+        SEGMENT_GRANULARITY,
+        Granularities.MINUTE,
+        interval == null ? null : Collections.singletonList(interval)
+    );
+
+    ParallelIndexTuningConfig tuningConfig = newTuningConfig(
+        partitionsSpec,
+        maxNumConcurrentSubTasks,
+        !appendToExisting
+    );
+
+    final ParallelIndexIngestionSpec ingestionSpec;
+
+      Preconditions.checkArgument(parseSpec == null);
+      ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(
+          null,
+          new LocalInputSource(inputDir, filter),
+          inputFormat,
+          appendToExisting,
+          null
+      );
+      ingestionSpec = new ParallelIndexIngestionSpec(
+          new DataSchema(
+              DATASOURCE,
+              timestampSpec,
+              dimensionsSpec,
+              new AggregatorFactory[]{new LongSumAggregatorFactory("val", "val")},
+              granularitySpec,
+              null
+          ),
+          ioConfig,
+          tuningConfig
+      );
+
+    return new ParallelIndexSupervisorTaskTest(
+        null,
+        null,
+        null,
+        ingestionSpec,
+        null,
+        Collections.emptyMap(),
+        succeedsBeforeFailing
+    );
+  }
+
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitorTest.java
@@ -240,7 +240,7 @@ public class TaskMonitorTest
       monitor.collectReport(new SimpleSubTaskReport(getId()));
       if (shouldFail) {
         Thread.sleep(getRunTime());
-        return TaskStatus.failure(getId());
+        return TaskStatus.failure(getId(), "Dummy task status failure for testing");
       } else {
         return super.run(toolbox);
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -200,8 +200,16 @@ public class RemoteTaskRunnerTestUtils
 
   void mockWorkerCompleteFailedTask(final String workerId, final Task task) throws Exception
   {
-    TaskAnnouncement taskAnnouncement = TaskAnnouncement.create(task, TaskStatus.failure(task.getId()), DUMMY_LOCATION);
-    cf.setData().forPath(JOINER.join(STATUS_PATH, workerId, task.getId()), jsonMapper.writeValueAsBytes(taskAnnouncement));
+    TaskAnnouncement taskAnnouncement = TaskAnnouncement.create(
+        task,
+        TaskStatus.failure(
+            task.getId(),
+            "Dummy task status failure for testing"
+        ),
+        DUMMY_LOCATION
+    );
+    cf.setData()
+      .forPath(JOINER.join(STATUS_PATH, workerId, task.getId()), jsonMapper.writeValueAsBytes(taskAnnouncement));
   }
 
   boolean workerRunningTask(final String workerId, final String taskId)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -1380,7 +1380,7 @@ public class TaskLockboxTest
     @Override
     public TaskStatus run(TaskToolbox toolbox)
     {
-      return TaskStatus.failure("how?");
+      return TaskStatus.failure("how?", "Dummy task status err msg");
     }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TestTaskRunner.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TestTaskRunner.java
@@ -176,11 +176,15 @@ public class TestTaskRunner implements TaskRunner, QuerySegmentWalker
           TaskRunnerUtils.notifyStatusChanged(listeners, task.getId(), taskStatus);
         }
         catch (Exception e) {
-          TaskRunnerUtils.notifyStatusChanged(listeners, task.getId(), TaskStatus.failure(task.getId()));
+          String errMsg = "Graceful shutdown of task aborted with exception, see task logs for more information";
+          TaskRunnerUtils.notifyStatusChanged(listeners, task.getId(), TaskStatus.failure(task.getId(), errMsg));
           throw new RE(e, "Graceful shutdown of task[%s] aborted with exception", task.getId());
         }
       } else {
-        TaskRunnerUtils.notifyStatusChanged(listeners, task.getId(), TaskStatus.failure(task.getId()));
+        TaskRunnerUtils.notifyStatusChanged(listeners, task.getId(), TaskStatus.failure(
+            task.getId(),
+            "Task failure while shutting down gracefully"
+        ));
       }
     }
 
@@ -416,11 +420,11 @@ public class TestTaskRunner implements TaskRunner, QuerySegmentWalker
           log.warn(e, "Interrupted while running task[%s]", task);
         }
 
-        status = TaskStatus.failure(task.getId());
+        status = TaskStatus.failure(task.getId(), "Task failed due to its thread being interrupted");
       }
       catch (Exception e) {
         log.error(e, "Exception while running task[%s]", task);
-        status = TaskStatus.failure(task.getId());
+        status = TaskStatus.failure(task.getId(), "Task failed");
       }
       catch (Throwable t) {
         throw new RE(t, "Uncaught Throwable while running task[%s]", task);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
@@ -1084,7 +1084,7 @@ public class HttpRemoteTaskRunnerTest
     EasyMock.replay(rogueWorkerHolder);
     taskRunner.taskAddedOrUpdated(TaskAnnouncement.create(
         task,
-        TaskStatus.failure(task.getId()),
+        TaskStatus.failure(task.getId(), "Dummy task status failure err message"),
         TaskLocation.create("rogue-worker", 1, 2)
     ), rogueWorkerHolder);
     Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getRunningTasks()).getTaskId());
@@ -1122,7 +1122,7 @@ public class HttpRemoteTaskRunnerTest
     EasyMock.replay(rogueWorkerHolder);
     taskRunner.taskAddedOrUpdated(TaskAnnouncement.create(
         task,
-        TaskStatus.failure(task.getId()),
+        TaskStatus.failure(task.getId(), "Dummy task status failure for testing"),
         TaskLocation.create("rogue-worker", 1, 2)
     ), rogueWorkerHolder);
     Assert.assertEquals(task.getId(), Iterables.getOnlyElement(taskRunner.getCompletedTasks()).getTaskId());


### PR DESCRIPTION
Description
The parallel task currently reports the null error message in taskStatus in most cases. The users are required to look up the parallel task logs to see why the task failed.

The parallel task can fail because of these reasons:

- Subtask failures. This is most common.

- The task is canceled.

- Bugs in the system, such as OOM.

This issue addresses the first 2 cases. For the subtask failures, the parallel task should report the last ingestion status in the error message in taskStatus, such as the phase where the ingestion failed, number of tasks succeeded/failed/running/total, and retry subtaskIds of the failed subtaskSpec. More details about the subtask failure will be in both the subtask report and the parallel task report. For canceled tasks, the error message should say something like "This task is canceled".

In general, the error message should meet these criteria.

Error should not show the node details.

Error should be understandable to basic users. For internal errors, it should lead users to reading task logs and task reports instead of putting too much information in taskStatus because the errorMsg field in taskStatus is truncated.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
