### PR TITLE
Fix integration test credential resource path handling

### DIFF
--- a/integration-tests/script/copy_resources.sh
+++ b/integration-tests/script/copy_resources.sh
@@ -14,12 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo "Copying integration test resources."
+
 set -e
 
 # setup client keystore
 ./docker/tls/generate-client-certs-and-keystores.sh
 rm -rf docker/client_tls
 cp -r client_tls docker/client_tls
+
+# install druid jars
+rm -rf $SHARED_DIR/docker
+cp -R docker $SHARED_DIR/docker
+mvn -B dependency:copy-dependencies -DoutputDirectory=$SHARED_DIR/docker/lib
 
 # Make directories if they dont exist
 mkdir -p $SHARED_DIR/hadoop_xml
@@ -28,11 +35,6 @@ mkdir -p $SHARED_DIR/logs
 mkdir -p $SHARED_DIR/tasklogs
 mkdir -p $SHARED_DIR/docker/extensions
 mkdir -p $SHARED_DIR/docker/credentials
-
-# install druid jars
-rm -rf $SHARED_DIR/docker
-cp -R docker $SHARED_DIR/docker
-mvn -B dependency:copy-dependencies -DoutputDirectory=$SHARED_DIR/docker/lib
 
 # install logging config
 cp src/main/resources/log4j2.xml $SHARED_DIR/docker/lib/log4j2.xml

--- a/integration-tests/script/copy_resources.sh
+++ b/integration-tests/script/copy_resources.sh
@@ -25,6 +25,7 @@ cp -r client_tls docker/client_tls
 
 # install druid jars
 rm -rf $SHARED_DIR/docker
+mkdir -p $SHARED_DIR
 cp -R docker $SHARED_DIR/docker
 mvn -B dependency:copy-dependencies -DoutputDirectory=$SHARED_DIR/docker/lib
 


### PR DESCRIPTION
This PR fixes an issue with the integration test `copy_resources.sh` script. 

The "install druid jars" portion was removing the `$SHARED_DIR/docker` directory, which wipes out the `$SHARED_DIR/docker/extensions` and `$SHARED_DIR/docker/credentials` directories created just before, which leads to issues later in the script when copying resources to the `$SHARED_DIR/docker/credentials/` dir.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [ ] been tested in a test Druid cluster.
