### PR TITLE
Docs - clarify datasource API sources

### DIFF
--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -187,9 +187,7 @@ Returns a list of all segments for one or more specific datasources with the ful
 
 * `/druid/coordinator/v1/metadata/datasources`
 
-Returns a list of the names of datasources with at least one used segment in the cluster.
-
-This method reads from the metadata database, whereas `/druid/coordinator/v1/datasources` reads from the cached server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation).
+Returns a list of the names of datasources with at least one used segment in the cluster, retrieved from the metadata database. Users should call this API to get the eventual state that the system will be in.
 
 * `/druid/coordinator/v1/metadata/datasources?includeUnused`
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -189,6 +189,8 @@ Returns a list of all segments for one or more specific datasources with the ful
 
 Returns a list of the names of datasources with at least one used segment in the cluster.
 
+This method reads from the server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation), whereas `/druid/coordinator/v1/datasources` reads from metadata database.
+
 * `/druid/coordinator/v1/metadata/datasources?includeUnused`
 
 Returns a list of the names of datasources, regardless of whether there are used segments belonging to those datasources in the cluster or not.
@@ -240,6 +242,8 @@ Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` 
 * `/druid/coordinator/v1/datasources`
 
 Returns a list of datasource names found in the cluster.
+
+This method reads from the metadata database, whereas `/druid/coordinator/v1/metadata/datasources` reads from the cached server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation).
 
 * `/druid/coordinator/v1/datasources?simple`
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -239,9 +239,7 @@ Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` 
 
 * `/druid/coordinator/v1/datasources`
 
-Returns a list of datasource names found in the cluster.
-
-This method reads from the server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation), whereas `/druid/coordinator/v1/metadata/datasources` reads from metadata database.
+Returns a list of datasource names found in the cluster as seen by the coordinator. This view is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation).
 
 * `/druid/coordinator/v1/datasources?simple`
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -189,7 +189,7 @@ Returns a list of all segments for one or more specific datasources with the ful
 
 Returns a list of the names of datasources with at least one used segment in the cluster.
 
-This method reads from the metadata database, whereas `/druid/coordinator/v1/metadata/datasources` reads from the cached server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation).
+This method reads from the metadata database, whereas `/druid/coordinator/v1/datasources` reads from the cached server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation).
 
 * `/druid/coordinator/v1/metadata/datasources?includeUnused`
 
@@ -243,7 +243,7 @@ Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` 
 
 Returns a list of datasource names found in the cluster.
 
-This method reads from the server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation), whereas `/druid/coordinator/v1/datasources` reads from metadata database.
+This method reads from the server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation), whereas `/druid/coordinator/v1/metadata/datasources` reads from metadata database.
 
 * `/druid/coordinator/v1/datasources?simple`
 

--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -189,7 +189,7 @@ Returns a list of all segments for one or more specific datasources with the ful
 
 Returns a list of the names of datasources with at least one used segment in the cluster.
 
-This method reads from the server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation), whereas `/druid/coordinator/v1/datasources` reads from metadata database.
+This method reads from the metadata database, whereas `/druid/coordinator/v1/metadata/datasources` reads from the cached server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation).
 
 * `/druid/coordinator/v1/metadata/datasources?includeUnused`
 
@@ -243,7 +243,7 @@ Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` 
 
 Returns a list of datasource names found in the cluster.
 
-This method reads from the metadata database, whereas `/druid/coordinator/v1/metadata/datasources` reads from the cached server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation).
+This method reads from the server view held by the coordinator that is updated every [`druid.coordinator.period`](../configuration/index.html#coordinator-operation), whereas `/druid/coordinator/v1/datasources` reads from metadata database.
 
 * `/druid/coordinator/v1/datasources?simple`
 


### PR DESCRIPTION
OTBO Druid Slack conversations, added clarification of the source of the information from the `datasources` APIs.

@jihoonson there seems to be an alternative view on which source is used by which API.  I believe this is the right way round now (reflecting what you have posted previously) but if you could confirm this change I'd be grateful.

This PR has:
- [x] been self-reviewed.
- [ ] been tested in a test Druid cluster.

cc @sthetland @techdocsmith 