### PR TITLE
Docs - S3 masking and nav update to S3 page

### DIFF
--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -64,7 +64,8 @@ In addition to this you need to set additional configuration, specific for [deep
 ### S3 authentication methods
 
 Druid uses the following credentials provider chain to connect to your S3 bucket (whether a deep storage bucket or source bucket).
-**Note :** *You can override the default credentials provider chain for connecting to source bucket by specifying an access key and secret key using [Properties Object](../../ingestion/native-batch.md#s3-input-source) parameters in the ingestionSpec.*
+
+> You can override the default credentials provider chain for connecting to source bucket by specifying an access key and secret key using [Properties Object](../../ingestion/native-batch.md#s3-input-source) parameters in the ingestion specification.
 
 |order|type|details|
 |--------|-----------|-------|
@@ -76,14 +77,17 @@ Druid uses the following credentials provider chain to connect to your S3 bucket
 |6|ECS container credentials|Based on environment variables available on AWS ECS (AWS_CONTAINER_CREDENTIALS_RELATIVE_URI or AWS_CONTAINER_CREDENTIALS_FULL_URI) as described in the [EC2ContainerCredentialsProviderWrapper documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EC2ContainerCredentialsProviderWrapper.html)|
 |7|Instance profile information|Based on the instance profile you may have attached to your druid instance|
 
-You can find more information about authentication method [here](https://docs.aws.amazon.com/fr_fr/sdk-for-java/v1/developer-guide/credentials)<br/>
-**Note :** *Order is important here as it indicates the precedence of authentication methods.<br/>
-So if you are trying to use Instance profile information, you **must not** set `druid.s3.accessKey` and `druid.s3.secretKey` in your Druid runtime.properties*
+> You can find more information about authentication methods in the [Amazon Developer Guide](https://docs.aws.amazon.com/fr_fr/sdk-for-java/v1/developer-guide/credentials).
 
+> **Order is important here as it indicates the precedence of authentication methods**
+>
+> If you are trying to use Instance profile information, you **must not** set `druid.s3.accessKey` and `druid.s3.secretKey` in your Druid runtime.properties
+
+> You can use the property [`druid.startup.logging.maskProperties`](../../configuration/index.html#startup-logging) to mask credentials information in Druid logs.  For example, `["password", "secretKey", "awsSecretAccessKey"]`.
 
 ### S3 permissions settings
 
-`s3:GetObject` and `s3:PutObject` are basically required for pushing/loading segments to/from S3.
+`s3:GetObject` and `s3:PutObject` are required for pushing / pulling segments to / from S3.
 If `druid.storage.disableAcl` is set to `false`, then `s3:GetBucketAcl` and `s3:PutObjectAcl` are additionally required to set ACL for objects.
 
 ### AWS region

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -79,9 +79,7 @@ Druid uses the following credentials provider chain to connect to your S3 bucket
 
 > You can find more information about authentication methods in the [Amazon Developer Guide](https://docs.aws.amazon.com/fr_fr/sdk-for-java/v1/developer-guide/credentials).
 
-> **Order is important here as it indicates the precedence of authentication methods**
->
-> If you are trying to use Instance profile information, you **must not** set `druid.s3.accessKey` and `druid.s3.secretKey` in your Druid runtime.properties
+> Order is important here as it indicates the precedence of authentication methods. If you are trying to use Instance profile information, you **must not** set `druid.s3.accessKey` and `druid.s3.secretKey` in your Druid runtime.properties.
 
 > You can use the property [`druid.startup.logging.maskProperties`](../../configuration/index.html#startup-logging) to mask credentials information in Druid logs.  For example, `["password", "secretKey", "awsSecretAccessKey"]`.
 


### PR DESCRIPTION
OTBO community discussion at https://groups.google.com/g/druid-user/c/FydcpFrA688 - tip on masking credentials in logs
"Note" section changed to > mimic style of other "notes" on other pages
`[click here]` nav replaced with name of the resource that will open (Amazon Developer Guide)
Nav changes on the S3 page with links to appropriate sections
"Basically" removed
"Loaded" changed to "Pulled" for term consistency
Introductory text added to each ingestion spec example
Explicit link to the S3 extension doc added

This PR has:
- [x] been self-reviewed.
- [ ] been tested in a test Druid cluster.

cc @sthetland @techdocsmith for checks on how I've structured the nav / stylistics