### PR TITLE
Make `buildQueryRunnerForSegment` protected in `ServerManager`

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ServerManager.java
@@ -238,7 +238,7 @@ public class ServerManager implements QuerySegmentWalker
     );
   }
 
-  <T> QueryRunner<T> buildQueryRunnerForSegment(
+  protected <T> QueryRunner<T> buildQueryRunnerForSegment(
       final Query<T> query,
       final SegmentDescriptor descriptor,
       final QueryRunnerFactory<T, Query<T>> factory,


### PR DESCRIPTION
This is a minor change in `ServerManager`. Any sub-class can access the `buildQueryRunnerForSegment` in an extension if required. 

This PR has:
- [x] been self-reviewed.
