### PR TITLE
CliIndexer: respect serverConfig.getTier

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -209,7 +209,7 @@ public class CliIndexer extends ServerRunnable
           public DataNodeService getDataNodeService(DruidServerConfig serverConfig)
           {
             return new DataNodeService(
-                DruidServer.DEFAULT_TIER,
+                serverConfig.getTier(),
                 serverConfig.getMaxSize(),
                 ServerType.INDEXER_EXECUTOR,
                 DruidServer.DEFAULT_PRIORITY


### PR DESCRIPTION
### Description

Not quite sure what the impact is; at a minimum the tier does not appear correctly in the router UI.

This PR has:
- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
