### PR TITLE
Adding custom callback url for pac4j config to support ssl termination at ELB

### DIFF
--- a/docs/development/extensions-core/druid-pac4j.md
+++ b/docs/development/extensions-core/druid-pac4j.md
@@ -44,3 +44,4 @@ druid.auth.authenticator.pac4j.type=pac4j
 |`druid.auth.pac4j.oidc.clientID`|OAuth Client Application id.|none|Yes|
 |`druid.auth.pac4j.oidc.clientSecret`|OAuth Client Application secret. It can be provided as plaintext string or The [Password Provider](../../operations/password-provider.md).|none|Yes|
 |`druid.auth.pac4j.oidc.discoveryURI`|discovery URI for fetching OP metadata [see this](http://openid.net/specs/openid-connect-discovery-1_0.html).|none|Yes|
+|`druid.server.http.enableForwardedRequestCustomizer`|If enabled, adds Jetty ForwardedRequestCustomizer which reads X-Forwarded-* request headers to manipulate servlet request object when Druid is used behind a proxy.|false|No|


### PR DESCRIPTION
Fixes #11437 

### Description

In order to support setups where SSL termination happens at the ELB and the communication from ELB to druid is on plain HTTP protocol, we would need some way to represent proper call back url which is based on HTTPS protocol.

Currently NoParameterCallbackUrlResolver picks up the current webserver configuration, which in this case happens to be http, but the actual communication goes out from an https connection and okta ends up barfing out with the following error.,

Error code - 400 bad request (Invalid request)
Error message - The 'redirect_uri' parameter must be a Login redirect URI in the client app settings: https://something-admin.okta.com/admin/app/oidc_client/instance/xxxxxxxxxxxxxxx#tab-general

If there was configuration that allows users to manually specify a custom callback url, then we can easily override the current jetty webserver config on druid and proxy the ELB's url. 

This is similar to what knox provides in some sense using the following parameter
"knoxJwtRealm.redirectParam = originalUrl"

Tested the changes locally using dev.okta account.

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
