### PR TITLE
adding expressions url_encode() and url_decode()

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/expression/UrlDecodeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/UrlDecodeExprMacro.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.ExprType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class UrlDecodeExprMacro implements ExprMacroTable.ExprMacro
+{
+
+  public static final String FN_NAME = "urldecode";
+
+  private static class UrlDecodeExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+  {
+    private UrlDecodeExpr(Expr arg)
+    {
+      super(FN_NAME, arg);
+    }
+
+    @Nonnull
+    @Override
+    public ExprEval eval(final ObjectBinding bindings)
+    {
+      ExprEval eval = arg.eval(bindings);
+      switch (eval.type()) {
+        case STRING:
+          return ExprEval.of(decode(eval.asString()));
+        default:
+          return ExprEval.of(null);
+      }
+    }
+
+    @Override
+    public Expr visit(Shuttle shuttle)
+    {
+      Expr newArg = arg.visit(shuttle);
+      return shuttle.visit(new UrlDecodeExpr(newArg));
+    }
+
+    @Nullable
+    @Override
+    public ExprType getOutputType(InputBindingInspector inspector)
+    {
+      return ExprType.STRING;
+    }
+  }
+
+
+  @Override
+  public String name()
+  {
+    return FN_NAME;
+  }
+
+  @Override
+  public Expr apply(final List<Expr> args)
+  {
+    if (args.size() != 1) {
+      throw new IAE(ExprUtils.createErrMsg(name(), "must have 1 argument"));
+    }
+
+    return new UrlDecodeExpr(args.get(0));
+  }
+
+  private static String decode(String s)
+  {
+    if (s == null) {
+      return null;
+    }
+
+    try {
+      return URLDecoder.decode(s, StandardCharsets.UTF_8.name());
+    }
+    catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("unable to decode the application/x-www-form-urlencoded string", e);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/expression/UrlEncodeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/UrlEncodeExprMacro.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.ExprType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class UrlEncodeExprMacro implements ExprMacroTable.ExprMacro
+{
+  public static final String FN_NAME = "urlencode";
+
+  private static class UrlEncodeExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+  {
+    private UrlEncodeExpr(Expr arg)
+    {
+      super(FN_NAME, arg);
+    }
+
+    @Nonnull
+    @Override
+    public ExprEval eval(final ObjectBinding bindings)
+    {
+      ExprEval eval = arg.eval(bindings);
+      switch (eval.type()) {
+        case STRING:
+          return ExprEval.of(encode(eval.asString()));
+        default:
+          return ExprEval.of(null);
+      }
+    }
+
+    @Override
+    public Expr visit(Shuttle shuttle)
+    {
+      Expr newArg = arg.visit(shuttle);
+      return shuttle.visit(new UrlEncodeExpr(newArg));
+    }
+
+    @Nullable
+    @Override
+    public ExprType getOutputType(InputBindingInspector inspector)
+    {
+      return ExprType.STRING;
+    }
+  }
+
+  @Override
+  public String name()
+  {
+    return FN_NAME;
+  }
+
+  @Override
+  public Expr apply(final List<Expr> args)
+  {
+    if (args.size() != 1) {
+      throw new IAE(ExprUtils.createErrMsg(name(), "must have 1 argument"));
+    }
+
+    return new UrlEncodeExpr(args.get(0));
+  }
+
+  private static String encode(final String s)
+  {
+    if (s == null) {
+      return null;
+    }
+
+    try {
+      return URLEncoder.encode(s, StandardCharsets.UTF_8.name());
+    }
+    catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("unable to encode to an application/x-www-form-urlencoded string", e);
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/expression/UrlDecodeExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/UrlDecodeExprMacroTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class UrlDecodeExprMacroTest extends MacroTestBase
+{
+
+  public UrlDecodeExprMacroTest()
+  {
+    super(new UrlDecodeExprMacro());
+  }
+
+  @Test
+  public void testNull()
+  {
+    Assert.assertNull(eval(null));
+  }
+
+  @Test
+  public void testEmpty()
+  {
+    Assert.assertNull(eval(""));
+  }
+
+  @Test
+  public void testBlank()
+  {
+    Assert.assertEquals(" ", eval(" "));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPercent()
+  {
+    eval("%");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPercentAndOne()
+  {
+    eval("%2");
+  }
+
+  @Test
+  public void testValid()
+  {
+    Assert.assertEquals("druid", eval("druid"));
+    Assert.assertEquals("http://druid.apache.org", eval("http://druid.apache.org"));
+    Assert.assertEquals("http://druid.apache.org/a/b/c", eval("http://druid.apache.org/a/b/c"));
+    Assert.assertEquals("http://druid.apache.org/a/b/c c", eval("http://druid.apache.org/a/b/c%20c"));
+    Assert.assertEquals("http://druid.apache.org/a/b/c", eval("http:%2F%2Fdruid.apache.org/a/b/c"));
+    Assert.assertEquals("http://druid.apache.org/a/b/c", eval("http%3A%2F%2Fdruid.apache.org/a/b/c"));
+    Assert.assertEquals("%", eval("%25"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalid()
+  {
+    Assert.assertEquals("http://druid.apache.org/", eval("http://druid.apache.org/%"));
+  }
+
+  private Object eval(String url)
+  {
+    Expr expr = apply(Collections.singletonList(toExpr(url)));
+    ExprEval eval = expr.eval(ExprUtils.nilBindings());
+    return eval.value();
+  }
+
+  private Expr toExpr(String url)
+  {
+    return ExprEval.of(url).toExpr();
+  }
+
+}

--- a/processing/src/test/java/org/apache/druid/query/expression/UrlEncodeExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/UrlEncodeExprMacroTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.expression;
+
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class UrlEncodeExprMacroTest extends MacroTestBase
+{
+
+  public UrlEncodeExprMacroTest()
+  {
+    super(new UrlEncodeExprMacro());
+  }
+
+  @Test
+  public void testNull()
+  {
+    Assert.assertNull(eval(null));
+  }
+
+  @Test
+  public void testEmpty()
+  {
+    Assert.assertNull(eval(""));
+  }
+
+  @Test
+  public void testBlank()
+  {
+    Assert.assertEquals("+", eval(" "));
+  }
+
+  @Test
+  public void testPercent()
+  {
+    Assert.assertEquals("%25", eval("%"));
+    Assert.assertEquals("%25%25", eval("%%"));
+  }
+
+  @Test
+  public void testUrls()
+  {
+    Assert.assertEquals("http%3A%2F%2Fdruid.apache.org", eval("http://druid.apache.org"));
+    Assert.assertEquals("http%3A%2F%2Fdruid.apache.org%2Fa+b%3Fc%3D%25", eval("http://druid.apache.org/a b?c=%"));
+    Assert.assertEquals("a+b", eval("a b"));
+  }
+
+
+  private Object eval(String url)
+  {
+    Expr expr = apply(Collections.singletonList(toExpr(url)));
+    ExprEval eval = expr.eval(ExprUtils.nilBindings());
+    return eval.value();
+  }
+
+  private Expr toExpr(String url)
+  {
+    return ExprEval.of(url).toExpr();
+  }
+
+}

--- a/server/src/main/java/org/apache/druid/guice/ExpressionModule.java
+++ b/server/src/main/java/org/apache/druid/guice/ExpressionModule.java
@@ -41,6 +41,8 @@ import org.apache.druid.query.expression.TimestampFormatExprMacro;
 import org.apache.druid.query.expression.TimestampParseExprMacro;
 import org.apache.druid.query.expression.TimestampShiftExprMacro;
 import org.apache.druid.query.expression.TrimExprMacro;
+import org.apache.druid.query.expression.UrlDecodeExprMacro;
+import org.apache.druid.query.expression.UrlEncodeExprMacro;
 
 import java.util.List;
 
@@ -65,6 +67,8 @@ public class ExpressionModule implements DruidModule
           .add(TrimExprMacro.BothTrimExprMacro.class)
           .add(TrimExprMacro.LeftTrimExprMacro.class)
           .add(TrimExprMacro.RightTrimExprMacro.class)
+          .add(UrlEncodeExprMacro.class)
+          .add(UrlDecodeExprMacro.class)
           .build();
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/UrlDecodeOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/UrlDecodeOperatorConversion.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.expression.builtin;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.expression.UrlDecodeExprMacro;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+
+public class UrlDecodeOperatorConversion extends DirectOperatorConversion
+{
+  private static final SqlFunction SQL_FUNCTION = OperatorConversions
+      .operatorBuilder(StringUtils.toUpperCase(UrlDecodeExprMacro.FN_NAME))
+      .operandTypeChecker(OperandTypes.family(SqlTypeFamily.STRING))
+      .returnTypeNullable(SqlTypeName.CHAR)
+      .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
+      .build();
+
+  public UrlDecodeOperatorConversion()
+  {
+    super(SQL_FUNCTION, UrlDecodeExprMacro.FN_NAME);
+  }
+
+  @Override
+  public SqlOperator calciteOperator()
+  {
+    return SQL_FUNCTION;
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/UrlEncodeOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/UrlEncodeOperatorConversion.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.expression.builtin;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.expression.UrlEncodeExprMacro;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+
+public class UrlEncodeOperatorConversion extends DirectOperatorConversion
+{
+  private static final SqlFunction SQL_FUNCTION = OperatorConversions
+      .operatorBuilder(StringUtils.toUpperCase(UrlEncodeExprMacro.FN_NAME))
+      .operandTypeChecker(OperandTypes.family(SqlTypeFamily.STRING))
+      .returnTypeNullable(SqlTypeName.CHAR)
+      .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
+      .build();
+
+  public UrlEncodeOperatorConversion()
+  {
+    super(SQL_FUNCTION, UrlEncodeExprMacro.FN_NAME);
+  }
+
+  @Override
+  public SqlOperator calciteOperator()
+  {
+    return SQL_FUNCTION;
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -110,6 +110,8 @@ import org.apache.druid.sql.calcite.expression.builtin.TimeShiftOperatorConversi
 import org.apache.druid.sql.calcite.expression.builtin.TimestampToMillisOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.TrimOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.TruncateOperatorConversion;
+import org.apache.druid.sql.calcite.expression.builtin.UrlDecodeOperatorConversion;
+import org.apache.druid.sql.calcite.expression.builtin.UrlEncodeOperatorConversion;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -250,6 +252,12 @@ public class DruidOperatorTable implements SqlOperatorTable
                    .add(new IPv4AddressStringifyOperatorConversion())
                    .build();
 
+  private static final List<SqlOperatorConversion> URL_OPERATOR_CONVERSIONS =
+      ImmutableList.<SqlOperatorConversion>builder()
+                   .add(new UrlEncodeOperatorConversion())
+                   .add(new UrlDecodeOperatorConversion())
+                   .build();
+
   private static final List<SqlOperatorConversion> BITWISE_OPERATOR_CONVERSIONS =
       ImmutableList.<SqlOperatorConversion>builder()
                    .add(OperatorConversions.druidBinaryLongFn("BITWISE_AND", "bitwiseAnd"))
@@ -342,6 +350,7 @@ public class DruidOperatorTable implements SqlOperatorTable
                    .addAll(MULTIVALUE_STRING_OPERATOR_CONVERSIONS)
                    .addAll(REDUCTION_OPERATOR_CONVERSIONS)
                    .addAll(IPV4ADDRESS_OPERATOR_CONVERSIONS)
+                   .addAll(URL_OPERATOR_CONVERSIONS)
                    .addAll(BITWISE_OPERATOR_CONVERSIONS)
                    .build();
 


### PR DESCRIPTION
provide expressions url_encode and url_decode to allow for those transformations to be done at ingestion and query within druid.

The default URL encoding/decoding functions of Java (java.net.URLEncoder and java.net.URLDecoder) were used. 

Followed how IPv4Address macros was built as guideline for organization and naming.

The alternate design of leveraging 3rd party library was rejected to avoid any additional dependencies.

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
