### PR TITLE
docs fix for doubleMean description

### DIFF
--- a/docs/querying/aggregations.md
+++ b/docs/querying/aggregations.md
@@ -128,6 +128,8 @@ Computes and stores the sum of values as 32-bit floating point value. Similar to
 
 Computes and returns arithmetic mean of a column values as 64 bit float value. `doubleMean` is a query time aggregator only. It is not available for indexing.
 
+To accomplish mean aggregation on ingestion, refer to the [Quantiles aggregator](https://druid.apache.org/docs/latest/development/extensions-core/datasketches-quantiles.html#aggregator) from the DataSketches extension.
+
 ```json
 { "type" : "doubleMean", "name" : <output_name>, "fieldName" : <metric_name> }
 ```

--- a/docs/querying/aggregations.md
+++ b/docs/querying/aggregations.md
@@ -128,7 +128,7 @@ Computes and stores the sum of values as 32-bit floating point value. Similar to
 
 Computes and returns arithmetic mean of a column values as 64 bit float value. `doubleMean` is a query time aggregator only. It is not available for indexing.
 
-To accomplish mean aggregation on ingestion, refer to the [Quantiles aggregator](https://druid.apache.org/docs/latest/development/extensions-core/datasketches-quantiles.html#aggregator) from the DataSketches extension.
+To accomplish mean aggregation on ingestion, refer to the [Quantiles aggregator](../development/extensions-core/datasketches-quantiles.md#aggregator) from the DataSketches extension.
 
 ```json
 { "type" : "doubleMean", "name" : <output_name>, "fieldName" : <metric_name> }

--- a/docs/querying/aggregations.md
+++ b/docs/querying/aggregations.md
@@ -126,7 +126,7 @@ Computes and stores the sum of values as 32-bit floating point value. Similar to
 
 ### `doubleMean` aggregator
 
-Computes and returns arithmetic mean of a column values as 64 bit float value. This is a query time aggregator only and should not be used during indexing.
+Computes and returns arithmetic mean of a column values as 64 bit float value. `doubleMean` is a query time aggregator only. It is not available for indexing.
 
 ```json
 { "type" : "doubleMean", "name" : <output_name>, "fieldName" : <metric_name> }


### PR DESCRIPTION
Fixes description for `doubleMean` aggregator.

This PR has:
- [x] been self-reviewed.

@sthetland @techdocsmith 