### PR TITLE
Upgrade ORC to 1.6.9

### DIFF
--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -31,7 +31,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <orc.version>1.5.10</orc.version>
+        <orc.version>1.6.9</orc.version>
     </properties>
     <dependencies>
         <dependency>

--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -118,6 +118,33 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.orc</groupId>
+            <artifactId>orc-core</artifactId>
+            <version>${orc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-hdfs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <scope>provided</scope>

--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -118,33 +118,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.orc</groupId>
-            <artifactId>orc-core</artifactId>
-            <version>${orc.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-lang</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-hdfs</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <scope>provided</scope>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4507,6 +4507,16 @@ notices:
 
 ---
 
+name: Jetbrains Annotations
+license_category: binary
+module: extensions/druid-orc-extensions
+license_name: Apache License version 2.0
+version: 17.0.0
+libraries:
+  - org.jetbrains: annotations
+
+---
+
 name: Google Cloud Storage JSON API
 license_category: binary
 module: extensions/druid-google-extensions

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4451,7 +4451,7 @@ name: Apache ORC libraries
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 1.5.10
+version: 1.6.9
 libraries:
   - org.apache.orc: orc-mapreduce
   - org.apache.orc: orc-core
@@ -4459,13 +4459,13 @@ libraries:
 notices:
   - orc-mapreduce: |
       ORC MapReduce
-      Copyright 2013-2019 The Apache Software Foundation
+      Copyright 2013-2021 The Apache Software Foundation
   - orc-core: |
       ORC Core
-      Copyright 2013-2019 The Apache Software Foundation
+      Copyright 2013-2021 The Apache Software Foundation
   - orc-shims: |
       ORC Shims
-      Copyright 2013-2019 The Apache Software Foundation
+      Copyright 2013-2021 The Apache Software Foundation
 
 ---
 
@@ -4487,7 +4487,7 @@ name: aircompressor
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: "0.10"
+version: "0.19"
 libraries:
   - io.airlift: aircompressor
 


### PR DESCRIPTION
### Description

This PR aims to upgrade Apache ORC from 1.5.10 to 1.6.9 and `licenses.yaml` correspondingly to bring the latest bug fixes and updates.

- https://orc.apache.org/docs/releases.html#current-release---169

Apache ORC 1.5.10 is too old and the following versions are available. Apache ORC community highly recommends to use 1.6.9.
- 1.6.9: https://orc.apache.org/news/2021/07/02/ORC-1.6.9/
- 1.5.12: https://orc.apache.org/news/2020/09/30/ORC-1.5.12/

<hr>

This PR has:
- [v] been self-reviewed.
- [v] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)