### PR TITLE
Add vavr dependency to benchmarks pom.xml

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -181,6 +181,11 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vavr</groupId>
+      <artifactId>vavr</artifactId>
+      <version>0.10.2</version>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
This PR adds an undeclared `io.vavr` dependency to the benchmarks pom.xml, which was referenced in the changes from https://github.com/apache/druid/pull/11257

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
