### PR TITLE
Fix document about pi in sql

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -376,6 +376,7 @@ to FLOAT. At runtime, Druid will widen 32-bit floats to 64-bit for most expressi
 
 |Function|Notes|
 |--------|-----|
+|`PI`|Constant Pi.|
 |`ABS(expr)`|Absolute value.|
 |`CEIL(expr)`|Ceiling.|
 |`EXP(expr)`|e to the power of expr.|


### PR DESCRIPTION
Fix PI in document. I test PI in sql, and it works. In source code, this `SqlFunction` is bound to its implementation. But I can not find it in document. I think it should be added in document.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
