### PR TITLE
Better logs for lookups

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -69,7 +69,7 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
       }
       dbQueryStart = System.currentTimeMillis();
 
-      LOG.debug("Updating %s", entryId);
+      LOG.info("Updating %s", entryId);
       pairs = getLookupPairs(entryId, namespace);
     }
     catch (UnableToObtainConnectionException e) {

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/UriCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/UriCacheGenerator.java
@@ -144,6 +144,7 @@ public final class UriCacheGenerator implements CacheGenerator<UriExtractionName
           final CacheScheduler.VersionedCache versionedCache = scheduler.createVersionedCache(entryId, version);
           try {
             final long startNs = System.nanoTime();
+            log.info("Updating %s", entryId);
             final MapPopulator.PopulateResult populateResult = new MapPopulator<>(
                 extractionNamespace.getNamespaceParseSpec().getParser()
             ).populate(source, versionedCache.getCache());

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/CacheScheduler.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/CacheScheduler.java
@@ -235,10 +235,10 @@ public final class CacheScheduler
             if (previousCacheState instanceof VersionedCache) {
               ((VersionedCache) previousCacheState).close();
             }
-            log.debug("%s: the cache was successfully updated", this);
+            log.info("%s: the cache was successfully updated", this);
           } else {
             newVersionedCache.close();
-            log.debug("%s was closed while the cache was being updated, discarding the update", this);
+            log.info("%s was closed while the cache was being updated, discarding the update", this);
           }
         } else {
           log.debug("%s: Version `%s` not updated, the cache is not updated", this, currentVersion);


### PR DESCRIPTION
Update log levels for cache refreshes of lookups to INFO

This is helpful for debugging when a process might crash because of running
out of memory when trying to load a lookup. It's also helpful for an operator
to be able to look at the logs and tell when the lookups were updated since
this could impact query results.