### PR TITLE
Lazy processing of spill files to avoid "Too many open files" errors

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LazyCloseableIterator.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LazyCloseableIterator.java
@@ -38,7 +38,15 @@ public class LazyCloseableIterator<T> implements CloseableIterator<T>
       }
     }
     
-    return iterator.hasNext();
+    boolean hasNext = iterator.hasNext();
+    if (!hasNext) {
+      try {
+        close();
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+    return hasNext;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LazyCloseableIterator.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LazyCloseableIterator.java
@@ -1,0 +1,62 @@
+package org.apache.druid.query.groupby.epinephelinae;
+
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Iterator;
+
+import javax.inject.Provider;
+
+/**
+ * Instance of CloseableIterator that can lazily allocate its iterator based
+ * on a Provider and ensure it is closed when close() is called.
+ * 
+ * @param <T> Type of item to return from the iterator
+ */
+public class LazyCloseableIterator<T> implements CloseableIterator<T>
+{
+  private Provider<Iterator<T>> provider;
+  private Iterator<T> iterator;
+  private Closeable closeable;
+  private boolean closed;
+  
+  public LazyCloseableIterator(Provider<Iterator<T>> innerIteratorProvider) {
+    provider = innerIteratorProvider;
+  }
+
+  @Override
+  public boolean hasNext()
+  {
+    if (closed) {
+      return false;
+    } 
+    if (iterator == null) {
+      iterator = provider.get();
+      if (iterator instanceof Closeable) {
+        closeable = (Closeable) iterator;
+      }
+    }
+    
+    return iterator.hasNext();
+  }
+
+  @Override
+  public T next()
+  {
+    return iterator.next();
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if(!closed) {
+      closed = true;
+      if (closeable != null) {
+        closeable.close();
+      }
+      iterator = null;
+      closeable = null;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #11558.

### Description

Solve the "Too many open files" problem in some groupBy queries by lazily opening spill files instead of opening them all at once.

Changing `SpillingGrouper` to use a new `LazyCloseableIterator` to lazily open spill files only when actually ready to consume their contents. In `SpillingGrouper.read()`, return a `Provider` that constructs the necessary `MappingIterator` instead of returning the `MappingIterator` itself. This allows a lambda to be used to capture the file, but postpone processing it until actually needed.

#### Fixed the bug #11558 

<hr>

##### Key changed/added classes in this PR
 * `SpillingGrouper`
 * `LazyCloseableIterator`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
