### PR TITLE
Cleanup test dependencies in hdfs-storage extension

### DIFF
--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -373,13 +373,6 @@
 
         <!-- Tests -->
         <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
-          <version>${hadoop.compile.version}</version>
-          <classifier>tests</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
           <scope>test</scope>
@@ -395,19 +388,6 @@
           <artifactId>druid-processing</artifactId>
           <version>${project.parent.version}</version>
           <type>test-jar</type>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-hdfs</artifactId>
-          <version>${hadoop.compile.version}</version>
-          <classifier>tests</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-hdfs</artifactId>
-          <version>${hadoop.compile.version}</version>
           <scope>test</scope>
         </dependency>
       <dependency>

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HdfsClasspathSetupTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HdfsClasspathSetupTest.java
@@ -79,14 +79,15 @@ public class HdfsClasspathSetupTest
     conf = new Configuration(true);
     localFS = new LocalFileSystem();
     localFS.initialize(hdfsTmpDir.toURI(), conf);
+    localFS.setWorkingDirectory(new Path(hdfsTmpDir.toURI()));
   }
 
   @Before
   public void setUp() throws IOException
   {
     // intermedatePath and finalClasspath are relative to hdfsTmpDir directory.
-    intermediatePath = new Path(StringUtils.format("/tmp/classpath/%s", UUIDUtils.generateUuid()));
-    finalClasspath = new Path(StringUtils.format("/tmp/intermediate/%s", UUIDUtils.generateUuid()));
+    intermediatePath = new Path(StringUtils.format("tmp/classpath/%s", UUIDUtils.generateUuid()));
+    finalClasspath = new Path(StringUtils.format("tmp/intermediate/%s", UUIDUtils.generateUuid()));
     dummyJarFile = tempFolder.newFile("dummy-test.jar");
     Files.copy(
         new ByteArrayInputStream(StringUtils.toUtf8(dummyJarString)),
@@ -116,7 +117,7 @@ public class HdfsClasspathSetupTest
   public void testAddSnapshotJarToClasspath() throws IOException
   {
     Job job = Job.getInstance(conf, "test-job");
-    Path intermediatePath = new Path("/tmp/classpath");
+    Path intermediatePath = new Path("tmp/classpath");
     JobHelper.addSnapshotJarToClassPath(dummyJarFile, intermediatePath, localFS, job);
     Path expectedJarPath = new Path(intermediatePath, dummyJarFile.getName());
     // check file gets uploaded to HDFS


### PR DESCRIPTION
This removes the dependency on `mini-dfs-cluster` from UTs in `hdfs-storage` module. The tests now use `LocalFileSystem` for the Hadoop's FileSystem API. The hdfs specific testing is left for the ITs which fully test the ingestion/deep-storage using hadoop servers on docker.