### PR TITLE
Suppress CVEs for jdom2, kafka-clients, libthrift, solr-solrj

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -264,6 +264,18 @@
   </suppress>
   <suppress>
     <!--
+      ~ TODO: Fix when Apache Ranger 2.1 is released
+      - transitive dep from apache-ranger, upgrading to 2.1.0 adds other CVEs, staying at ranger 2.0.0 for now
+      -->
+    <notes><![CDATA[
+    file name: kafka-clients-2.0.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka-clients@2.0.0$</packageUrl>
+    <cve>CVE-2019-12399</cve>
+    <cve>CVE-2018-17196</cve>
+  </suppress>
+  <suppress>
+    <!--
       ~ TODO: Fix when Apache Ranger is released with updated log4j
       -->
     <notes><![CDATA[
@@ -344,13 +356,35 @@
   </suppress>
 
   <suppress>
-     <notes><![CDATA[
+    <!-- Transitive dependency from apache-ranger, latest ranger version 2.1.0 still uses solr 7.7.1-->
+    <notes><![CDATA[
      file name: solr-solrj-7.7.1.jar
      ]]></notes>
-     <packageUrl regex="true">^pkg:maven/org\.apache\.solr/solr-solrj@7.7.1$</packageUrl>
-     <cve>CVE-2020-13957</cve>
-     <cve>CVE-2019-17558</cve>
-     <cve>CVE-2019-0193</cve>
-     <cve>CVE-2020-13941</cve>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.solr/solr-solrj@7.7.1$</packageUrl>
+    <cve>CVE-2020-13957</cve>
+    <cve>CVE-2019-17558</cve>
+    <cve>CVE-2019-0193</cve>
+    <cve>CVE-2020-13941</cve>
+    <cve>CVE-2021-29943</cve>
+    <cve>CVE-2021-27905</cve>
+    <cve>CVE-2021-29262</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Transitive dependency from aliyun-sdk-oss, there is currently no newer version of jdom2 as well-->
+    <notes><![CDATA[
+     file name: jdom2-2.0.6.jar
+     ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jdom/jdom2@2.0.6$</packageUrl>
+    <cve>CVE-2021-33813</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Upgrading to libthrift-0.14.2 adds many tomcat CVEs, suppress and stay at 0.13.0 for now-->
+    <notes><![CDATA[
+     file name: libthrift-0.13.0.jar
+     ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@0.13.0$</packageUrl>
+    <cve>CVE-2020-13949</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
This PR suppresses the current reported CVEs, with reasoning in the suppression file:

```
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
[ERROR] 
[ERROR] jdom2-2.0.6.jar: CVE-2021-33813
[ERROR] kafka-clients-2.0.0.jar: CVE-2019-12399, CVE-2018-17196
[ERROR] libthrift-0.13.0.jar: CVE-2020-13949
[ERROR] solr-solrj-7.7.1.jar: CVE-2021-29943, CVE-2021-27905, CVE-2021-29262
```

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
