### PR TITLE
Fix FileIteratingFirehoseTest to extend NullHandlingTest

### DIFF
--- a/core/src/test/java/org/apache/druid/data/input/impl/FileIteratingFirehoseTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/FileIteratingFirehoseTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.impl;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.LineIterator;
+import org.apache.druid.common.config.NullHandlingTest;
 import org.apache.druid.data.input.InputRow;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,7 +42,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @RunWith(Parameterized.class)
-public class FileIteratingFirehoseTest
+public class FileIteratingFirehoseTest extends NullHandlingTest
 {
   @Parameters(name = "{0}, {1}")
   public static Collection<Object[]> constructorFeeder()


### PR DESCRIPTION
## Problem
FileIteratingFirehoseTest was failing with the ERROR
[ERROR] Tests run: 192, Failures: 0, Errors: 180, Skipped: 0, Time elapsed: 1.021 s <<< FAILURE! - in org.apache.druid.data.input.impl.FileIteratingFirehoseTest00:19
[ERROR] testClose[[2000,foo], 0](org.apache.druid.data.input.impl.FileIteratingFirehoseTest)  Time elapsed: 0.017 s  <<< ERROR!00:19
java.lang.Exception: Unexpected exception, expected<java.lang.RuntimeException> but was<java.lang.ExceptionInInitializerError>
....
Caused by: java.lang.IllegalStateException: NullHandling module not initialized, call NullHandling.initializeForTests()00:19
	at org.apache.druid.common.config.NullHandling.replaceWithDefault(NullHandling.java:71)00:19
	at org.apache.druid.data.input.impl.CsvInputFormat.createOpenCsvParser(CsvInputFormat.java:84)00:19
	at org.apache.druid.data.input.impl.CsvInputFormat.<clinit>(CsvInputFormat.java:41)

## Fix
Made FileIteratingFirehoseTest extend NullHandlingTest 