### PR TITLE
Lock hadoop dependencies to 2.8.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,4 @@ updates:
       # pin Jetty dependencies to 9.4.x
       - dependency-name: "org.eclipse.jetty"
         versions: "[9.5,)"
+      - dependency-name: "org.apache.hadoop"


### PR DESCRIPTION
Adds hadoop's artifact group to the ignore list on dependabot to avoid continuous tries and accidental upgrades.