### PR TITLE
resultFormat name in camel case

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/http/ResultFormat.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/ResultFormat.java
@@ -20,6 +20,7 @@
 package org.apache.druid.sql.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
 
@@ -32,7 +33,7 @@ import java.util.List;
 
 public enum ResultFormat
 {
-  ARRAY {
+  ARRAY("array") {
     @Override
     public String contentType()
     {
@@ -46,7 +47,7 @@ public enum ResultFormat
     }
   },
 
-  ARRAYLINES {
+  ARRAYLINES("arrayLines") {
     @Override
     public String contentType()
     {
@@ -60,7 +61,7 @@ public enum ResultFormat
     }
   },
 
-  CSV {
+  CSV("csv") {
     @Override
     public String contentType()
     {
@@ -74,7 +75,7 @@ public enum ResultFormat
     }
   },
 
-  OBJECT {
+  OBJECT("object") {
     @Override
     public String contentType()
     {
@@ -88,7 +89,7 @@ public enum ResultFormat
     }
   },
 
-  OBJECTLINES {
+  OBJECTLINES("objectLines") {
     @Override
     public String contentType()
     {
@@ -102,11 +103,25 @@ public enum ResultFormat
     }
   };
 
+  private final String name;
+
+  ResultFormat(final String name)
+  {
+    this.name = name;
+  }
+
   public abstract String contentType();
 
   public abstract Writer createFormatter(OutputStream outputStream, ObjectMapper jsonMapper) throws IOException;
 
-  interface Writer extends Closeable
+  @Override
+  @JsonValue
+  public String toString()
+  {
+    return name;
+  }
+
+  public interface Writer extends Closeable
   {
     /**
      * Start of the response, called once per writer.

--- a/sql/src/test/java/org/apache/druid/sql/http/ResultFormatTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/ResultFormatTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.EnumSet;
+import java.util.stream.Collectors;
+
+@RunWith(Parameterized.class)
+public class ResultFormatTest
+{
+  @Parameters(name = "{0}")
+  public static Iterable<Object[]> constructorFeeder()
+  {
+    return EnumSet.allOf(ResultFormat.class)
+                  .stream()
+                  .map(format -> new Object[]{format})
+                  .collect(Collectors.toList());
+  }
+
+  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  private final ResultFormat target;
+
+  public ResultFormatTest(ResultFormat target)
+  {
+    this.target = target;
+  }
+
+  @Test
+  public void testSerde() throws JsonProcessingException
+  {
+    final String json = jsonMapper.writeValueAsString(target);
+    Assert.assertEquals(StringUtils.format("\"%s\"", target.toString()), json);
+    Assert.assertEquals(target, jsonMapper.readValue(json, ResultFormat.class));
+  }
+}


### PR DESCRIPTION
### Description

This PR simply adds a camel-case name for `ResultFormat` which will be used in its `toString`.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
