### PR TITLE
Fixes a HTTP 500 error in lookup endpoint

### DIFF
--- a/server/src/main/java/org/apache/druid/query/lookup/LookupListeningResource.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupListeningResource.java
@@ -110,7 +110,7 @@ class LookupListeningResource extends ListenerResource
           @Override
           public Object get(String id)
           {
-            return manager.get(id);
+            return manager.get(id).orElse(null);
           }
 
           @Override


### PR DESCRIPTION
Fixes #11499

### Description

The lookup API for a specified lookup id throws exception when serializing the returned object into json due to fail to serialize `java.util.Optional` object.

This PR fixes this bug by returning the underlying object holded by that `Optional` object.

Since the problem exists in the HTTP module, UT does not help.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
