### PR TITLE
Make ldap group attribute id configurable

### DIFF
--- a/docs/development/extensions-core/druid-basic-security.md
+++ b/docs/development/extensions-core/druid-basic-security.md
@@ -121,6 +121,7 @@ If Druid uses the default credentials validator (i.e., `credentialsValidator.typ
 |`druid.auth.authenticator.MyBasicLDAPAuthenticator.credentialsValidator.baseDn`|The point from where the LDAP server will search for users.|null|Yes|
 |`druid.auth.authenticator.MyBasicLDAPAuthenticator.credentialsValidator.userSearch`|The filter/expression to use for the search. For example, (&(sAMAccountName=%s)(objectClass=user))|null|Yes|
 |`druid.auth.authenticator.MyBasicLDAPAuthenticator.credentialsValidator.userAttribute`|The attribute id identifying the attribute that will be returned as part of the search. For example, sAMAccountName. |null|Yes|
+|`druid.auth.authenticator.MyBasicLDAPAuthenticator.credentialsValidator.ldapGroupAttribute`|The attribute id identifying the attribute used for LDAP groups by LDAP server that will be returned as part of the search. For example, memberOf. |memberOf|No|
 |`druid.auth.authenticator.MyBasicLDAPAuthenticator.credentialsValidator.credentialVerifyDuration`|The duration in seconds for how long valid credentials are verifiable within the cache when not requested.|600|No|
 |`druid.auth.authenticator.MyBasicLDAPAuthenticator.credentialsValidator.credentialMaxDuration`|The max duration in seconds for valid credentials that can reside in cache regardless of how often they are requested.|3600|No|
 |`druid.auth.authenticator.MyBasicLDAPAuthenticator.credentialsValidator.credentialCacheSize`|The valid credentials cache size. The cache uses a LRU policy.|100|No|
@@ -181,6 +182,7 @@ The authorizer configuration examples in the rest of this document will use "MyB
 |`druid.auth.authorizer.MyBasicLDAPAuthorizer.initialAdminGroupMapping`|The initial admin group mapping with role defined in initialAdminRole property if specified, otherwise the default admin role will be assigned. The name of this initial admin group mapping will be set to adminGroupMapping|null|No|
 |`druid.auth.authorizer.MyBasicLDAPAuthorizer.roleProvider.type`|The type of role provider (ldap) to authorize requests credentials.|metadata|No
 |`druid.auth.authorizer.MyBasicLDAPAuthorizer.roleProvider.groupFilters`|Array of LDAP group filters used to filter out the allowed set of groups returned from LDAP search. Filters can be begin with *, or end with ,* to provide configurational flexibility to limit or filter allowed set of groups available to LDAP Authorizer.|null|No|
+|`druid.auth.authorizer.MyBasicLDAPAuthorizer.roleProvider.ldapGroupAttribute`|The attribute id identifying the attribute used for LDAP groups by LDAP server. It should be same as druid.auth.authenticator.<ldap-authenticator-name>.ldapGroupAttribute|memberOf|No|
 
 ## Usage
 

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthLDAPConfig.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthLDAPConfig.java
@@ -29,6 +29,7 @@ public class BasicAuthLDAPConfig
   private final String baseDn;
   private final String userSearch;
   private final String userAttribute;
+  private final String ldapGroupAttribute;
   private final int credentialIterations;
   private final Integer credentialVerifyDuration;
   private final Integer credentialMaxDuration;
@@ -41,6 +42,7 @@ public class BasicAuthLDAPConfig
       final String baseDn,
       final String userSearch,
       final String userAttribute,
+      final String ldapGroupAttribute,
       final int credentialIterations,
       final Integer credentialVerifyDuration,
       final Integer credentialMaxDuration,
@@ -53,6 +55,7 @@ public class BasicAuthLDAPConfig
     this.baseDn = baseDn;
     this.userSearch = userSearch;
     this.userAttribute = userAttribute;
+    this.ldapGroupAttribute = ldapGroupAttribute;
     this.credentialIterations = credentialIterations;
     this.credentialVerifyDuration = credentialVerifyDuration;
     this.credentialMaxDuration = credentialMaxDuration;
@@ -87,6 +90,11 @@ public class BasicAuthLDAPConfig
   public String getUserAttribute()
   {
     return userAttribute;
+  }
+
+  public String getLdapGroupAttribute()
+  {
+    return ldapGroupAttribute;
   }
 
   public int getCredentialIterations()

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthUtils.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthUtils.java
@@ -55,6 +55,7 @@ public class BasicAuthUtils
   public static final String ADMIN_GROUP_MAPPING_NAME = "adminGroupMapping";
   public static final String INTERNAL_USER_NAME = "druid_system";
   public static final String SEARCH_RESULT_CONTEXT_KEY = "searchResult";
+  public static final String LDAP_GROUP_ATTRIBUTE_ID = "memberOf";
 
   // PBKDF2WithHmacSHA512 is chosen since it has built-in support in Java8.
   // Argon2 (https://github.com/p-h-c/phc-winner-argon2) is newer but the only presently

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/validator/LDAPCredentialsValidator.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/validator/LDAPCredentialsValidator.java
@@ -66,6 +66,7 @@ public class LDAPCredentialsValidator implements CredentialsValidator
       @JsonProperty("bindPassword") PasswordProvider bindPassword,
       @JsonProperty("baseDn") String baseDn,
       @JsonProperty("userSearch") String userSearch,
+      @JsonProperty("ldapGroupAttribute") String ldapGroupAttribute,
       @JsonProperty("userAttribute") String userAttribute,
       @JsonProperty("credentialIterations") Integer credentialIterations,
       @JsonProperty("credentialVerifyDuration") Integer credentialVerifyDuration,
@@ -80,6 +81,7 @@ public class LDAPCredentialsValidator implements CredentialsValidator
         baseDn,
         userSearch,
         userAttribute,
+        ldapGroupAttribute == null ? BasicAuthUtils.LDAP_GROUP_ATTRIBUTE_ID : ldapGroupAttribute,
         credentialIterations == null ? BasicAuthUtils.DEFAULT_KEY_ITERATIONS : credentialIterations,
         credentialVerifyDuration == null ? BasicAuthUtils.DEFAULT_CREDENTIAL_VERIFY_DURATION_SECONDS : credentialVerifyDuration,
         credentialMaxDuration == null ? BasicAuthUtils.DEFAULT_CREDENTIAL_MAX_DURATION_SECONDS : credentialMaxDuration,
@@ -188,7 +190,7 @@ public class LDAPCredentialsValidator implements CredentialsValidator
     try {
       SearchControls sc = new SearchControls();
       sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
-      sc.setReturningAttributes(new String[] {ldapConfig.getUserAttribute(), "memberOf" });
+      sc.setReturningAttributes(new String[] {ldapConfig.getUserAttribute(), ldapConfig.getLdapGroupAttribute()});
       String encodedUsername = encodeForLDAP(username, true);
       NamingEnumeration<SearchResult> results = context.search(
           ldapConfig.getBaseDn(),

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/LDAPRoleProvider.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/LDAPRoleProvider.java
@@ -54,15 +54,18 @@ public class LDAPRoleProvider implements RoleProvider
   private static final Logger LOG = new Logger(LDAPRoleProvider.class);
 
   private final BasicAuthorizerCacheManager cacheManager;
+  private final String ldapGroupAttribute;
   private final String[] groupFilters;
 
   @JsonCreator
   public LDAPRoleProvider(
       @JacksonInject BasicAuthorizerCacheManager cacheManager,
+      @JsonProperty("ldapGroupAttribute") String ldapGroupAttribute,
       @JsonProperty("groupFilters") String[] groupFilters
   )
   {
     this.cacheManager = cacheManager;
+    this.ldapGroupAttribute = ldapGroupAttribute == null ? BasicAuthUtils.LDAP_GROUP_ATTRIBUTE_ID : ldapGroupAttribute;
     this.groupFilters = groupFilters;
   }
 
@@ -166,7 +169,7 @@ public class LDAPRoleProvider implements RoleProvider
   {
     Set<LdapName> groups = new TreeSet<>();
 
-    Attribute memberOf = userResult.getAttributes().get("memberOf");
+    Attribute memberOf = userResult.getAttributes().get(this.ldapGroupAttribute);
     if (memberOf == null) {
       LOG.debug("No memberOf attributes");
       return groups; // not part of any groups

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/LDAPRoleProvider.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/LDAPRoleProvider.java
@@ -171,7 +171,7 @@ public class LDAPRoleProvider implements RoleProvider
 
     Attribute memberOf = userResult.getAttributes().get(this.ldapGroupAttribute);
     if (memberOf == null) {
-      LOG.debug("No memberOf attributes");
+      LOG.debug("No " + this.ldapGroupAttribute + " attributes");
       return groups; // not part of any groups
     }
 

--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authorization/BasicRoleBasedAuthorizerTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authorization/BasicRoleBasedAuthorizerTest.java
@@ -83,11 +83,11 @@ public class BasicRoleBasedAuthorizerTest
 
     BasicAttributes userAttrs = new BasicAttributes(true);
     userAttrs.put(new BasicAttribute("sAMAccountName", "druiduser"));
-    userAttrs.put(new BasicAttribute("memberOf", "CN=user,OU=Druid,OU=Application,OU=Groupings,DC=corp,DC=apache,DC=org"));
+    userAttrs.put(new BasicAttribute(BasicAuthUtils.LDAP_GROUP_ATTRIBUTE_ID, "CN=user,OU=Druid,OU=Application,OU=Groupings,DC=corp,DC=apache,DC=org"));
 
     BasicAttributes adminAttrs = new BasicAttributes(true);
     adminAttrs.put(new BasicAttribute("sAMAccountName", "druidadmin"));
-    adminAttrs.put(new BasicAttribute("memberOf", "CN=admin,OU=Platform,OU=Groupings,DC=corp,DC=apache,DC=org"));
+    adminAttrs.put(new BasicAttribute(BasicAuthUtils.LDAP_GROUP_ATTRIBUTE_ID, "CN=admin,OU=Platform,OU=Groupings,DC=corp,DC=apache,DC=org"));
 
     userSearchResult = new SearchResult("CN=1234,OU=Employees,OU=People", null, userAttrs);
     adminSearchResult = new SearchResult("CN=9876,OU=Employees,OU=People", null, adminAttrs);
@@ -113,7 +113,7 @@ public class BasicRoleBasedAuthorizerTest
                     null,
                     null, null,
                     null,
-                    new LDAPRoleProvider(null, groupFilters)
+                    new LDAPRoleProvider(null, BasicAuthUtils.LDAP_GROUP_ATTRIBUTE_ID, groupFilters)
                 )
             )
         ),
@@ -144,7 +144,7 @@ public class BasicRoleBasedAuthorizerTest
         null,
         null, null,
         null,
-        new LDAPRoleProvider(new MetadataStoragePollingBasicAuthorizerCacheManager(updater), groupFilters)
+        new LDAPRoleProvider(new MetadataStoragePollingBasicAuthorizerCacheManager(updater), BasicAuthUtils.LDAP_GROUP_ATTRIBUTE_ID, groupFilters)
     );
   }
 


### PR DESCRIPTION
Fixes #11605 .

### Description
Added two new properties in ```LDAPCredentialsValidator``` and ```LDAPRoleProvider```
These two properties can be set in runtime properties in following way
```druid.auth.authenticator.<ldapauthenticatorname>.credentialsValidator.ldapGroupAttribute```
```druid.auth.authorizer.<ldapauthorizername>.roleProvider.ldapGroupAttribute```

Both properties will have default value of ```membeOf```.

If these properties are set by users explicitly, it should have same values.

<hr>

##### Key changed/added classes in this PR
 * `BasicAuthLDAPConfig`
 * `BasicAuthUtils`
 * `LDAPCredentialsValidator`
 * `LDAPRoleProvider`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
