### PR TITLE
Fix bug in Variance Buffer Aggregator resulting in intermittent NaN when druid.generic.useDefaultValueForNull=false

### DIFF
--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceBufferAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceBufferAggregator.java
@@ -231,14 +231,14 @@ public abstract class VarianceBufferAggregator implements BufferAggregator
     {
       VarianceAggregatorCollector holder2 = (VarianceAggregatorCollector) selector.getObject();
       Preconditions.checkState(holder2 != null);
+      if (holder2.count == 0) {
+        return;
+      }
       long count = getCount(buf, position);
       if (count == 0) {
         buf.putLong(position, holder2.count);
         buf.putDouble(position + SUM_OFFSET, holder2.sum);
         buf.putDouble(position + NVARIANCE_OFFSET, holder2.nvariance);
-        return;
-      }
-      if (holder2.count == 0) {
         return;
       }
       double sum = getSum(buf, position);

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceBufferAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceBufferAggregator.java
@@ -238,7 +238,9 @@ public abstract class VarianceBufferAggregator implements BufferAggregator
         buf.putDouble(position + NVARIANCE_OFFSET, holder2.nvariance);
         return;
       }
-
+      if (holder2.count == 0) {
+        return;
+      }
       double sum = getSum(buf, position);
       double nvariance = buf.getDouble(position + NVARIANCE_OFFSET);
 

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorTest.java
@@ -22,7 +22,11 @@ package org.apache.druid.query.aggregation.variance;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.TestFloatColumnSelector;
+import org.apache.druid.query.aggregation.TestObjectColumnSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -123,6 +127,34 @@ public class VarianceAggregatorTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testObjectVarianceBufferAggregatorWithZeroCount()
+  {
+    VarianceAggregatorCollector holder1 = new VarianceAggregatorCollector().add(1.1f);
+    VarianceAggregatorCollector holder2 = new VarianceAggregatorCollector().add(2.7f);
+    VarianceAggregatorCollector holder3 = new VarianceAggregatorCollector();
+    VarianceAggregatorCollector[] values = {holder1, holder2, holder3};
+    TestObjectColumnSelector<VarianceAggregatorCollector> selector = new TestObjectColumnSelector(values);
+    colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    EasyMock.expect(colSelectorFactory.makeColumnValueSelector("nilly")).andReturn(selector);
+    EasyMock.expect(colSelectorFactory.getColumnCapabilities("nilly")).andReturn(new ColumnCapabilitiesImpl().setType(ValueType.COMPLEX));
+    EasyMock.replay(colSelectorFactory);
+
+    VarianceBufferAggregator agg = (VarianceBufferAggregator) aggFactory.factorizeBuffered(
+        colSelectorFactory
+    );
+
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[aggFactory.getMaxIntermediateSizeWithNulls()]);
+    agg.init(buffer, 0);
+    assertValues((VarianceAggregatorCollector) agg.get(buffer, 0), 0, 0d, 0d);
+    aggregate(selector, agg, buffer, 0);
+    assertValues((VarianceAggregatorCollector) agg.get(buffer, 0), 1, 1.1d, 0d);
+    aggregate(selector, agg, buffer, 0);
+    assertValues((VarianceAggregatorCollector) agg.get(buffer, 0), 2, 3.8d, 1.28d);
+    aggregate(selector, agg, buffer, 0);
+    assertValues((VarianceAggregatorCollector) agg.get(buffer, 0), 2, 3.8d, 1.28d);
+  }
+
+  @Test
   public void testCombine()
   {
     VarianceAggregatorCollector holder1 = new VarianceAggregatorCollector().add(1.1f).add(2.7f);
@@ -152,6 +184,17 @@ public class VarianceAggregatorTest extends InitializedNullHandlingTest
 
   private void aggregate(
       TestFloatColumnSelector selector,
+      VarianceBufferAggregator agg,
+      ByteBuffer buff,
+      int position
+  )
+  {
+    agg.aggregate(buff, position);
+    selector.increment();
+  }
+
+  private void aggregate(
+      TestObjectColumnSelector<VarianceAggregatorCollector> selector,
       VarianceBufferAggregator agg,
       ByteBuffer buff,
       int position

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorTest.java
@@ -24,7 +24,6 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.TestFloatColumnSelector;
 import org.apache.druid.query.aggregation.TestObjectColumnSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
-import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.testing.InitializedNullHandlingTest;


### PR DESCRIPTION
Fix bug in Variance Buffer Aggregator resulting in intermittent NaN when druid.generic.useDefaultValueForNull=false

### Description

In aggregate method of the Buffer ObjectVarianceAggregator, we should skip merging the ObjectVarianceAggregators when the other ObjectVarianceAggregator has count == 0

Here is an example of how NaN can be returned:
Imagine two Buffer ObjectVarianceAggregators, 
the current ObjectVarianceAggregator has count = 2, sum = 0, var =0
and other ObjectVarianceAggregator (holder2) has count =0, sum=0, var = 0
The aggregate method would run as follows:
`final double ratio = count / (double) holder2.count;`
ratio becomes infinity
then
`final double t = sum / ratio - holder2.sum;`
t becomes 0
and finally
`nvariance += holder2.nvariance + (ratio / (count + holder2.count) * t * t);`
is the same as
`holder2.nvariance + (infinity / 2 * 0 * 0);`
and infinity / 2 is NaN
Hence, variance will be NaN

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
