### PR TITLE
Fix TRIM help broken in Console SQL Editor

### DIFF
--- a/web-console/script/create-sql-docs.js
+++ b/web-console/script/create-sql-docs.js
@@ -30,6 +30,10 @@ function unwrapMarkdownLinks(str) {
   return str.replace(/\[([^\]]+)\]\([^)]+\)/g, (_, s) => s);
 }
 
+function deleteBackticks(str) {
+  return str.replace(/`/g, "");
+}
+
 const readDoc = async () => {
   const data = await fs.readFile(readfile, 'utf-8');
   const lines = data.split('\n');
@@ -41,8 +45,8 @@ const readDoc = async () => {
     if (functionMatch) {
       functionDocs.push([
         functionMatch[1],
-        functionMatch[2],
-        unwrapMarkdownLinks(functionMatch[3]),
+        deleteBackticks(functionMatch[2]),
+        deleteBackticks(unwrapMarkdownLinks(functionMatch[3])),
         // functionMatch[4] would be the default column but we ignore it for now
       ]);
     }

--- a/web-console/src/views/query-view/query-input/query-input.tsx
+++ b/web-console/src/views/query-view/query-input/query-input.tsx
@@ -126,7 +126,7 @@ export class QueryInput extends React.PureComponent<QueryInputProps, QueryInputS
   static makeDocHtml(item: any) {
     return `
 <div class="doc-name">${escape(item.caption)}</div>
-<div class="doc-syntax">${escape(item.syntax)}</div>
+<div class="doc-syntax">${item.syntax}</div>
 <div class="doc-description">${escape(item.description)}</div>`;
   }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes [11625](https://github.com/apache/druid/issues/11625). One escape cause this trouble. I'm not very sure if is safe to delete escape, but I don't think this escape is necessary. Now it will display like this:
<img width="490" alt="Screen Shot 2021-08-24 at 2 03 21 PM" src="https://user-images.githubusercontent.com/24642075/130565202-a9a57df6-c47d-4faf-b52c-0a7d025d19e0.png">


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
