### PR TITLE
Add functionality for integration test to run command inside the Docker container

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -316,6 +316,11 @@
             <version>3.2.0</version>
         </dependency>
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-core</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-kqueue</artifactId>
             <classifier>osx-x86_64</classifier>

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/DruidClusterAdminClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/DruidClusterAdminClient.java
@@ -45,6 +45,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -215,7 +216,7 @@ public class DruidClusterAdminClient
                 .exec(new ExecStartResultCallback(stdout, stderr))
                 .awaitCompletion();
 
-    return new Pair<>(stdout.toString(), stderr.toString());
+    return new Pair<>(stdout.toString(StandardCharsets.UTF_8.name()), stderr.toString(StandardCharsets.UTF_8.name()));
   }
 
   private void restartDockerContainer(String serviceName)


### PR DESCRIPTION
Add functionality for integration test to run command inside the Docker container

### Description

Add functionality for integration test to run command inside the Docker container. This is useful for when integration test needs to interact with the system that is running Druid for testing/verification purposes. For example, verifying that file on local disk was created or deleted by Druid can be done by running `test -f /some/file/on/local/disk/inside/container` using this new functionality. 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
