### PR TITLE
Fix custom coordinator duty integration test

### DIFF
--- a/integration-tests/docker/environment-configs/common-custom-coordinator-duties
+++ b/integration-tests/docker/environment-configs/common-custom-coordinator-duties
@@ -74,7 +74,8 @@ druid_request_logging_type=slf4j
 druid_indexer_task_ignoreTimestampSpecForDruidInputSource=true
 
 #Testing kill supervisor custom coordinator duty
-druid.coordinator.dutyGroups=["cleanupMetadata"]
-druid.coordinator.cleanupMetadata.duties=["killSupervisors"]
-druid.coordinator.cleanupMetadata.duty.killSupervisors.retainDuration=PT0M
-druid.coordinator.cleanupMetadata.period=PT10S
+druid_coordinator_kill_supervisor_on=false
+druid_coordinator_dutyGroups=["cleanupMetadata"]
+druid_coordinator_cleanupMetadata_duties=["killSupervisors"]
+druid_coordinator_cleanupMetadata_duty_killSupervisors_retainDuration=PT0M
+druid_coordinator_cleanupMetadata_period=PT10S

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -435,7 +435,7 @@ public class CliCoordinator extends ServerRunnable
           if (Strings.isNullOrEmpty(props.getProperty(groupPeriodPropKey))) {
             throw new IAE("Run period for coordinator custom duty group must be set for group %s", coordinatorCustomDutyGroupName);
           }
-          Duration groupPeriod = jsonMapper.readValue(props.getProperty(groupPeriodPropKey), Duration.class);
+          Duration groupPeriod = new Duration(props.getProperty(groupPeriodPropKey));
           coordinatorCustomDutyGroups.add(new CoordinatorCustomDutyGroup(coordinatorCustomDutyGroupName, groupPeriod, coordinatorCustomDuties));
         }
         return new CoordinatorCustomDutyGroups(coordinatorCustomDutyGroups);


### PR DESCRIPTION
Fix custom coordinator duty integration test

### Description
This is a follow to https://github.com/apache/druid/pull/11601
The integration test for the custom coordinator duty was actually not correct. The config to setup custom coordinator duty was not done correctly and hence the custom coordinator duty, KillSupervisorsCustomDuty, was not running. The test did still pass because the normal KillSupervisors coordinator was running. This PR make sure that the custom coordinator duty integration test (in the custom-coordinator-duties group) was the correct config set.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
