### PR TITLE
Improve error message when buckets are null for cloud objects

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
@@ -60,7 +60,8 @@ public class CloudObjectLocation
   @JsonCreator
   public CloudObjectLocation(@JsonProperty("bucket") String bucket, @JsonProperty("path") String path)
   {
-    this.bucket = Preconditions.checkNotNull(StringUtils.maybeRemoveTrailingSlash(bucket));
+    this.bucket = Preconditions.checkNotNull(StringUtils.maybeRemoveTrailingSlash(bucket),
+                 "bucket name cannot be null. Please verify if bucket name adheres to naming rules");
     this.path = Preconditions.checkNotNull(StringUtils.maybeRemoveLeadingSlash(path));
     Preconditions.checkArgument(
         this.bucket.equals(StringUtils.urlEncode(this.bucket)),

--- a/core/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
@@ -121,7 +121,7 @@ public class CloudObjectLocationTest
     expectedException.expectMessage("bucket name cannot be null. Please verify if bucket name adheres to naming rules");
     // Underscore(_) character is not valid for bucket names
     CloudObjectLocation invalidBucket1 = new CloudObjectLocation("test_bucket", "path/to/path");
-    CloudObjectLocation  invalidBucket2 = new CloudObjectLocation(invalidBucket1.toUri(SCHEME));
+    CloudObjectLocation invalidBucket2 = new CloudObjectLocation(invalidBucket1.toUri(SCHEME));
     Assert.assertEquals("test_bucket", new CloudObjectLocation(invalidBucket2.toUri(SCHEME)));
   }
 }

--- a/core/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
@@ -113,4 +113,15 @@ public class CloudObjectLocationTest
     // will never get here
     Assert.assertEquals(invalidBucket, new CloudObjectLocation(invalidBucket.toUri(SCHEME)));
   }
+
+  @Test
+  public void testInvalidBucketName()
+  {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("bucket name cannot be null. Please verify if bucket name adheres to naming rules");
+    // Underscore(_) character is not valid for bucket names
+    CloudObjectLocation invalidBucket1 = new CloudObjectLocation("test_bucket", "path/to/path");
+    CloudObjectLocation  invalidBucket2 = new CloudObjectLocation(invalidBucket1.toUri(SCHEME));
+    Assert.assertEquals("test_bucket", new CloudObjectLocation(invalidBucket2.toUri(SCHEME)));
+  }
 }


### PR DESCRIPTION
### Description

Pulling segments from cloud based deep storages like S3 can fail with a NullPointer exception if the bucket name does not adhere to bucket naming rules. This PR attempts to improve the error message for this case.
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
