### PR TITLE
fix goldilocks bug with HashVectorGrouper improperly initializing memory

### DIFF
--- a/extensions-core/datasketches/src/test/resources/simple_test_data_group_by_query.json
+++ b/extensions-core/datasketches/src/test/resources/simple_test_data_group_by_query.json
@@ -102,6 +102,5 @@
         "direction": "ASC"
       }
     ]
-  },
-  "context": {"forceHashAggregation": true}
+  }
 }

--- a/extensions-core/datasketches/src/test/resources/simple_test_data_group_by_query.json
+++ b/extensions-core/datasketches/src/test/resources/simple_test_data_group_by_query.json
@@ -102,5 +102,6 @@
         "direction": "ASC"
       }
     ]
-  }
+  },
+  "context": {"forceHashAggregation": true}
 }

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouperTest.java
@@ -160,7 +160,6 @@ public class HashVectorGrouperTest
     // two keys should not cause buffer to grow
     fillKeyspace(keySpace, maxVectorSize, 2);
     AggregateResult result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
-
     Assert.assertTrue(result.isOk());
     Assert.assertEquals(tableStart, grouper.getTableStart());
 
@@ -170,7 +169,6 @@ public class HashVectorGrouperTest
     result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
     Assert.assertTrue(result.isOk());
     Assert.assertTrue(grouper.getTableStart() > tableStart);
-
 
     // this time should be all the way
     fillKeyspace(keySpace, maxVectorSize, 6);
@@ -209,16 +207,13 @@ public class HashVectorGrouperTest
     // two keys should cause buffer to grow
     fillKeyspace(keySpace, maxVectorSize, 2);
     AggregateResult result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
-
-    // buffer should grow to maximum size
     Assert.assertTrue(result.isOk());
     Assert.assertEquals(tableStart, grouper.getTableStart());
 
     // 3rd key should cause buffer to grow
+    // buffer should grow to next size, but is not full
     fillKeyspace(keySpace, maxVectorSize, 3);
     result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
-
-    // buffer should grow to next size, but is not full
     Assert.assertTrue(result.isOk());
     Assert.assertTrue(grouper.getTableStart() > tableStart);
     tableStart = grouper.getTableStart();
@@ -228,7 +223,6 @@ public class HashVectorGrouperTest
     result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
     Assert.assertTrue(result.isOk());
     Assert.assertTrue(grouper.getTableStart() > tableStart);
-    tableStart = grouper.getTableStart();
 
     // this time should be all the way
     fillKeyspace(keySpace, maxVectorSize, 14);
@@ -267,16 +261,13 @@ public class HashVectorGrouperTest
     // two keys should cause buffer to grow
     fillKeyspace(keySpace, maxVectorSize, 2);
     AggregateResult result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
-
-    // buffer should grow to maximum size
     Assert.assertTrue(result.isOk());
     Assert.assertEquals(tableStart, grouper.getTableStart());
 
     // 3rd key should cause buffer to grow
+    // buffer should grow to next size, but is not full
     fillKeyspace(keySpace, maxVectorSize, 3);
     result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
-
-    // buffer should grow to next size, but is not full
     Assert.assertTrue(result.isOk());
     Assert.assertTrue(grouper.getTableStart() > tableStart);
     tableStart = grouper.getTableStart();
@@ -284,15 +275,15 @@ public class HashVectorGrouperTest
     // grow it again
     fillKeyspace(keySpace, maxVectorSize, 6);
     result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
-
+    Assert.assertTrue(result.isOk());
     Assert.assertTrue(grouper.getTableStart() > tableStart);
     tableStart = grouper.getTableStart();
 
+    // more
     fillKeyspace(keySpace, maxVectorSize, 14);
     result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
     Assert.assertTrue(result.isOk());
     Assert.assertTrue(grouper.getTableStart() > tableStart);
-    tableStart = grouper.getTableStart();
 
     // this time should be all the way
     fillKeyspace(keySpace, maxVectorSize, 25);

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouperTest.java
@@ -20,7 +20,9 @@
 package org.apache.druid.query.groupby.epinephelinae;
 
 import com.google.common.base.Suppliers;
+import org.apache.datasketches.memory.WritableMemory;
 import org.apache.druid.query.aggregation.AggregatorAdapters;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -44,5 +46,266 @@ public class HashVectorGrouperTest
     grouper.initVectorized(512);
     grouper.close();
     Mockito.verify(aggregatorAdapters, Mockito.times(1)).close();
+  }
+
+  @Test
+  public void testTableStartIsNotMemoryStartIfNotMaxSized()
+  {
+    final int maxVectorSize = 512;
+    final int keySize = 4;
+    final int bufferSize = 100 * 1024;
+    final WritableMemory keySpace = WritableMemory.allocate(keySize * maxVectorSize);
+    final ByteBuffer buffer = ByteBuffer.wrap(new byte[bufferSize]);
+    final AggregatorAdapters aggregatorAdapters = Mockito.mock(AggregatorAdapters.class);
+    final HashVectorGrouper grouper = new HashVectorGrouper(
+        Suppliers.ofInstance(buffer),
+        keySize,
+        aggregatorAdapters,
+        8,
+        0.f,
+        4
+    );
+    grouper.initVectorized(maxVectorSize);
+    Assert.assertNotEquals(0, grouper.getTableStart());
+  }
+
+  @Test
+  public void testTableStartIsNotMemoryStartIfIsMaxSized()
+  {
+    final int maxVectorSize = 512;
+    final int keySize = 10000;
+    final int bufferSize = 100 * 1024;
+    final ByteBuffer buffer = ByteBuffer.wrap(new byte[bufferSize]);
+    final AggregatorAdapters aggregatorAdapters = Mockito.mock(AggregatorAdapters.class);
+    final HashVectorGrouper grouper = new HashVectorGrouper(
+        Suppliers.ofInstance(buffer),
+        keySize,
+        aggregatorAdapters,
+        4,
+        0.f,
+        4
+    );
+    grouper.initVectorized(maxVectorSize);
+    Assert.assertEquals(0, grouper.getTableStart());
+  }
+
+  @Test
+  public void testGrowOnce()
+  {
+    final int maxVectorSize = 512;
+    final int keySize = 4;
+    final int aggSize = 8;
+    final WritableMemory keySpace = WritableMemory.allocate(keySize * maxVectorSize);
+
+    final AggregatorAdapters aggregatorAdapters = Mockito.mock(AggregatorAdapters.class);
+    Mockito.when(aggregatorAdapters.spaceNeeded()).thenReturn(aggSize);
+
+    int startingNumBuckets = 4;
+    int maxBuckets = 16;
+    final int bufferSize = (keySize + aggSize) * maxBuckets;
+    final ByteBuffer buffer = ByteBuffer.wrap(new byte[bufferSize]);
+    final HashVectorGrouper grouper = new HashVectorGrouper(
+        Suppliers.ofInstance(buffer),
+        keySize,
+        aggregatorAdapters,
+        maxBuckets,
+        0.f,
+        startingNumBuckets
+    );
+    grouper.initVectorized(maxVectorSize);
+
+    int tableStart = grouper.getTableStart();
+
+    // two keys should not cause buffer to grow
+    fillKeyspace(keySpace, maxVectorSize, 2);
+    AggregateResult result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(tableStart, grouper.getTableStart());
+
+    // 3rd key should cause buffer to grow
+    // buffer should grow to maximum size
+    fillKeyspace(keySpace, maxVectorSize, 3);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(0, grouper.getTableStart());
+  }
+
+  @Test
+  public void testGrowTwice()
+  {
+    final int maxVectorSize = 512;
+    final int keySize = 4;
+    final int aggSize = 8;
+    final WritableMemory keySpace = WritableMemory.allocate(keySize * maxVectorSize);
+
+    final AggregatorAdapters aggregatorAdapters = Mockito.mock(AggregatorAdapters.class);
+    Mockito.when(aggregatorAdapters.spaceNeeded()).thenReturn(aggSize);
+
+    int startingNumBuckets = 4;
+    int maxBuckets = 32;
+    final int bufferSize = (keySize + aggSize) * maxBuckets;
+    final ByteBuffer buffer = ByteBuffer.wrap(new byte[bufferSize]);
+    final HashVectorGrouper grouper = new HashVectorGrouper(
+        Suppliers.ofInstance(buffer),
+        keySize,
+        aggregatorAdapters,
+        maxBuckets,
+        0.f,
+        startingNumBuckets
+    );
+    grouper.initVectorized(maxVectorSize);
+
+    int tableStart = grouper.getTableStart();
+
+    // two keys should not cause buffer to grow
+    fillKeyspace(keySpace, maxVectorSize, 2);
+    AggregateResult result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(tableStart, grouper.getTableStart());
+
+    // 3rd key should cause buffer to grow
+    // buffer should grow to next size, but is not full
+    fillKeyspace(keySpace, maxVectorSize, 3);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertTrue(grouper.getTableStart() > tableStart);
+
+
+    // this time should be all the way
+    fillKeyspace(keySpace, maxVectorSize, 6);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(0, grouper.getTableStart());
+  }
+
+  @Test
+  public void testGrowThreeTimes()
+  {
+    final int maxVectorSize = 512;
+    final int keySize = 4;
+    final int aggSize = 8;
+    final WritableMemory keySpace = WritableMemory.allocate(keySize * maxVectorSize);
+
+    final AggregatorAdapters aggregatorAdapters = Mockito.mock(AggregatorAdapters.class);
+    Mockito.when(aggregatorAdapters.spaceNeeded()).thenReturn(aggSize);
+
+    int startingNumBuckets = 4;
+    int maxBuckets = 64;
+    final int bufferSize = (keySize + aggSize) * maxBuckets;
+    final ByteBuffer buffer = ByteBuffer.wrap(new byte[bufferSize]);
+    final HashVectorGrouper grouper = new HashVectorGrouper(
+        Suppliers.ofInstance(buffer),
+        keySize,
+        aggregatorAdapters,
+        maxBuckets,
+        0.f,
+        startingNumBuckets
+    );
+    grouper.initVectorized(maxVectorSize);
+
+    int tableStart = grouper.getTableStart();
+
+    // two keys should cause buffer to grow
+    fillKeyspace(keySpace, maxVectorSize, 2);
+    AggregateResult result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+
+    // buffer should grow to maximum size
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(tableStart, grouper.getTableStart());
+
+    // 3rd key should cause buffer to grow
+    fillKeyspace(keySpace, maxVectorSize, 3);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+
+    // buffer should grow to next size, but is not full
+    Assert.assertTrue(result.isOk());
+    Assert.assertTrue(grouper.getTableStart() > tableStart);
+    tableStart = grouper.getTableStart();
+
+    // grow it again
+    fillKeyspace(keySpace, maxVectorSize, 6);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertTrue(grouper.getTableStart() > tableStart);
+    tableStart = grouper.getTableStart();
+
+    // this time should be all the way
+    fillKeyspace(keySpace, maxVectorSize, 14);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(0, grouper.getTableStart());
+  }
+
+  @Test
+  public void testGrowFourTimes()
+  {
+    final int maxVectorSize = 512;
+    final int keySize = 4;
+    final int aggSize = 8;
+    final WritableMemory keySpace = WritableMemory.allocate(keySize * maxVectorSize);
+
+    final AggregatorAdapters aggregatorAdapters = Mockito.mock(AggregatorAdapters.class);
+    Mockito.when(aggregatorAdapters.spaceNeeded()).thenReturn(aggSize);
+
+    int startingNumBuckets = 4;
+    int maxBuckets = 128;
+    final int bufferSize = (keySize + aggSize) * maxBuckets;
+    final ByteBuffer buffer = ByteBuffer.wrap(new byte[bufferSize]);
+    final HashVectorGrouper grouper = new HashVectorGrouper(
+        Suppliers.ofInstance(buffer),
+        keySize,
+        aggregatorAdapters,
+        maxBuckets,
+        0.f,
+        startingNumBuckets
+    );
+    grouper.initVectorized(maxVectorSize);
+
+    int tableStart = grouper.getTableStart();
+
+    // two keys should cause buffer to grow
+    fillKeyspace(keySpace, maxVectorSize, 2);
+    AggregateResult result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+
+    // buffer should grow to maximum size
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(tableStart, grouper.getTableStart());
+
+    // 3rd key should cause buffer to grow
+    fillKeyspace(keySpace, maxVectorSize, 3);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+
+    // buffer should grow to next size, but is not full
+    Assert.assertTrue(result.isOk());
+    Assert.assertTrue(grouper.getTableStart() > tableStart);
+    tableStart = grouper.getTableStart();
+
+    // grow it again
+    fillKeyspace(keySpace, maxVectorSize, 6);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+
+    Assert.assertTrue(grouper.getTableStart() > tableStart);
+    tableStart = grouper.getTableStart();
+
+    fillKeyspace(keySpace, maxVectorSize, 14);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertTrue(grouper.getTableStart() > tableStart);
+    tableStart = grouper.getTableStart();
+
+    // this time should be all the way
+    fillKeyspace(keySpace, maxVectorSize, 25);
+    result = grouper.aggregateVector(keySpace, 0, maxVectorSize);
+    Assert.assertTrue(result.isOk());
+    Assert.assertEquals(0, grouper.getTableStart());
+  }
+
+  private void fillKeyspace(WritableMemory keySpace, int maxVectorSize, int distinctKeys)
+  {
+    for (int i = 0; i < maxVectorSize; i++) {
+      int bucket = i % distinctKeys;
+      keySpace.putInt(((long) Integer.BYTES * i), bucket);
+    }
   }
 }


### PR DESCRIPTION
### Description
This PR fixes an issue I found by accident in `HashVectorGrouper`, which was incorrectly initializing a hashtable at the starting position of the memory rather than the penultimate table ending position.

This doesn't cause an issue, _except_ in the case where there is only enough room to grow a single time, because it results in overlapping memory regions for the tables when the max sized table tries to use the same position 0. This causes a query failure because initializing the new hashtable clears out the buckets from the overlapping old table, causing copy to do nothing and explode with an error of the form:

```
    ...
Caused by: org.apache.druid.java.util.common.ISE: New table size[0] != old table size[2] after copying
    at org.apache.druid.query.groupby.epinephelinae.collection.MemoryOpenHashTable.copyTo(MemoryOpenHashTable.java:201) ~[classes/:?]
    at org.apache.druid.query.groupby.epinephelinae.HashVectorGrouper.grow(HashVectorGrouper.java:322) ~[classes/:?]
    at org.apache.druid.query.groupby.epinephelinae.HashVectorGrouper.aggregateVector(HashVectorGrouper.java:164) ~[classes/:?]
    at org.apache.druid.query.groupby.epinephelinae.vector.VectorGroupByEngine$VectorGroupByEngineIterator.initNewDelegate(VectorGroupByEngine.java:393) ~[classes/:?]
    at org.apache.druid.query.groupby.epinephelinae.vector.VectorGroupByEngine$VectorGroupByEngineIterator.hasNext(VectorGroupByEngine.java:304) ~[classes/:?]
```

Of the added test cases, only `testGrowOnce` fails prior to the fix in this PR. Im sure there is a more clever way to test this than explicit 'testGrowN` methods, but it was not immediately obvious to me so maybe a future improvement.

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

