### PR TITLE
Fix moving average extension loading in middle manager and overlord

### DIFF
--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryModule.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryModule.java
@@ -23,15 +23,25 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.name.Named;
+import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.DruidBinders;
 import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.query.Query;
+import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.QueryToolChest;
+import org.apache.druid.server.NoopQuerySegmentWalker;
+import org.apache.druid.server.log.NoopRequestLogger;
+import org.apache.druid.server.log.RequestLogger;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class MovingAverageQueryModule implements DruidModule
 {
@@ -58,4 +68,25 @@ public class MovingAverageQueryModule implements DruidModule
                                                  )));
   }
 
+  @Provides
+  @LazySingleton
+  @Named("movingAverage")
+  public QuerySegmentWalker createQueryWalker(@Self Set<NodeRole> nodeRoles, Injector injector)
+  {
+    if (!nodeRoles.contains(NodeRole.BROKER)) {
+      return new NoopQuerySegmentWalker();
+    }
+    return injector.getInstance(QuerySegmentWalker.class);
+  }
+
+  @Provides
+  @LazySingleton
+  @Named("movingAverage")
+  public RequestLogger createRequestLogger(@Self Set<NodeRole> nodeRoles, Injector injector)
+  {
+    if (!nodeRoles.contains(NodeRole.BROKER)) {
+      return new NoopRequestLogger();
+    }
+    return injector.getInstance(RequestLogger.class);
+  }
 }

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryToolChest.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryToolChest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.name.Named;
 import org.apache.druid.data.input.MapBasedRow;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.query.QueryMetrics;
@@ -57,7 +58,8 @@ public class MovingAverageQueryToolChest extends QueryToolChest<Row, MovingAvera
    * @param requestLogger
    */
   @Inject
-  public MovingAverageQueryToolChest(Provider<QuerySegmentWalker> walkerProvider, RequestLogger requestLogger)
+  public MovingAverageQueryToolChest(@Named("movingAverage") Provider<QuerySegmentWalker> walkerProvider,
+                                     @Named("movingAverage") RequestLogger requestLogger)
   {
     this.walkerProvider = walkerProvider;
     this.requestLogger = requestLogger;

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.google.inject.util.Providers;
 import org.apache.druid.client.CachingClusteredClient;
@@ -40,10 +41,12 @@ import org.apache.druid.client.cache.ForegroundCachePopulator;
 import org.apache.druid.client.cache.MapCache;
 import org.apache.druid.client.selector.ServerSelector;
 import org.apache.druid.data.input.MapBasedRow;
+import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.DruidProcessingModule;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
 import org.apache.druid.guice.QueryableModule;
+import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.guice.http.DruidHttpClientConfig;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.guava.Accumulators;
@@ -153,6 +156,7 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
               return getQueryRunnerForIntervals(query, null);
             }
           }));
+          Multibinder.newSetBinder(binder, NodeRole.class, Self.class).addBinding().toInstance(NodeRole.BROKER);
         }
     );
 

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -30,6 +30,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import io.airlift.airline.Arguments;
@@ -416,6 +417,7 @@ public class CliPeon extends GuiceRunnable
         .in(LazySingleton.class);
 
     binder.bind(NodeRole.class).annotatedWith(Self.class).toInstance(NodeRole.PEON);
+    Multibinder.newSetBinder(binder, NodeRole.class, Self.class).addBinding().toInstance(NodeRole.PEON);
   }
 
   static void bindTaskConfigAndClients(Binder binder)


### PR DESCRIPTION
This change fixes loading issue with movingAverage on middle manager and overlord. Now, a common script for all worker types can be used to load moving average extension.