### PR TITLE
Support passing query context params via JDBC URL

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandler.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandler.java
@@ -55,6 +55,7 @@ public class DruidAvaticaJsonHandler extends AvaticaJsonHandler
       final HttpServletResponse response
   ) throws IOException, ServletException
   {
+    DruidURLContext.populateContext(baseRequest.getParameterMap());
     if (request.getRequestURI().equals(AVATICA_PATH)) {
       super.handle(target, baseRequest, request, response);
     }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaProtobufHandler.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidAvaticaProtobufHandler.java
@@ -55,6 +55,7 @@ public class DruidAvaticaProtobufHandler extends AvaticaProtobufHandler
       final HttpServletResponse response
   ) throws IOException, ServletException
   {
+    DruidURLContext.populateContext(baseRequest.getParameterMap());
     if (request.getRequestURI().equals(AVATICA_PATH)) {
       super.handle(target, baseRequest, request, response);
     }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
@@ -54,6 +54,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
@@ -110,6 +111,14 @@ public class DruidMeta extends MetaImpl
         context.put(entry);
       }
     }
+
+    Properties currentContext = DruidURLContext.getCurrentContext();
+    if (currentContext != null) {
+      for (String property : currentContext.stringPropertyNames()) {
+        context.put(property, currentContext.getProperty(property));
+      }
+    }
+
     // we don't want to stringify arrays for JDBC ever because avatica needs to handle this
     context.put(PlannerContext.CTX_SQL_STRINGIFY_ARRAYS, false);
     openDruidConnection(ch.id, context.build());

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidURLContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidURLContext.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.avatica;
+
+import com.google.common.base.Strings;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Properties;
+
+public class DruidURLContext
+{
+  private static final ThreadLocal<Properties> PROPERTIES_THREAD_LOCAL = ThreadLocal.withInitial(() -> null);
+  private static final Logger LOG = new Logger(DruidURLContext.class);
+
+  @Nullable
+  public static Properties getCurrentContext()
+  {
+    return PROPERTIES_THREAD_LOCAL.get();
+  }
+
+  public static void populateContext(Map<String, String[]> urlParams)
+  {
+    PROPERTIES_THREAD_LOCAL.set(getProperties(urlParams));
+  }
+
+  @Nullable
+  private static Properties getProperties(Map<String, String[]> urlParams)
+  {
+    try {
+      if (null == urlParams) {
+        return null;
+      }
+
+      Properties urlContext = new Properties();
+      for (Map.Entry<String, String[]> entry : urlParams.entrySet()) {
+        for (String value : entry.getValue()) {
+          if (Strings.isNullOrEmpty(value)) {
+            continue;
+          }
+          urlContext.setProperty(entry.getKey(), value);
+        }
+      }
+      return urlContext;
+    }
+    catch (Exception ex) {
+      // let the query proceed even if we cannot parse the context parameters
+      LOG.warn(ex, "Failed to get the context parameters from URL params [%s]", urlParams);
+      return null;
+    }
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -225,8 +225,10 @@ public abstract class DruidAvaticaHandlerTest extends CalciteTestBase
     propertiesLosAngeles.setProperty("sqlQueryId", DUMMY_SQL_QUERY_ID);
     clientLosAngeles = DriverManager.getConnection(url, propertiesLosAngeles);
 
-    clientLosAngelesOther = DriverManager.getConnection(
-        url + "?sqlTimeZone=America/Los_Angeles&user=regularUserLA&sqlQueryId=" + DUMMY_SQL_QUERY_ID);
+    String parameterizedURL = this.getParameterizedJdbcConnectionString(
+        port,
+        "sqlTimeZone=America/Los_Angeles&user=regularUserLA&sqlQueryId=" + DUMMY_SQL_QUERY_ID);
+    clientLosAngelesOther = DriverManager.getConnection(parameterizedURL);
   }
 
   @After
@@ -1370,6 +1372,8 @@ public abstract class DruidAvaticaHandlerTest extends CalciteTestBase
   }
 
   protected abstract String getJdbcConnectionString(int port);
+
+  protected abstract String getParameterizedJdbcConnectionString(int port, String paramString);
 
   protected abstract AbstractAvaticaHandler getAvaticaHandler(DruidMeta druidMeta);
 

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaJsonHandlerTest.java
@@ -36,6 +36,12 @@ public class DruidAvaticaJsonHandlerTest extends DruidAvaticaHandlerTest
   }
 
   @Override
+  protected String getParameterizedJdbcConnectionString(int port, String paramString)
+  {
+    return getJdbcConnectionString(port) + "?" + paramString;
+  }
+
+  @Override
   protected AbstractAvaticaHandler getAvaticaHandler(final DruidMeta druidMeta)
   {
     return new DruidAvaticaJsonHandler(

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaProtobufHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaProtobufHandlerTest.java
@@ -36,6 +36,17 @@ public class DruidAvaticaProtobufHandlerTest extends DruidAvaticaHandlerTest
   }
 
   @Override
+  protected String getParameterizedJdbcConnectionString(int port, String paramString)
+  {
+    return StringUtils.format(
+        "jdbc:avatica:remote:url=http://127.0.0.1:%d%s?%s;serialization=protobuf",
+        port,
+        DruidAvaticaProtobufHandler.AVATICA_PATH,
+        paramString
+    );
+  }
+
+  @Override
   protected AbstractAvaticaHandler getAvaticaHandler(final DruidMeta druidMeta)
   {
     return new DruidAvaticaProtobufHandler(


### PR DESCRIPTION
This PR adds support for passing context parameters via JDBC URL. The server will parse the query parameters out of the URL and store them in a thread-local state object that can be later used by `DruidMeta` to build the query context. 

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
