### PR TITLE
improved JDBC logging

### DIFF
--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -229,7 +229,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       targetServer = hostFinder.findServerAvatica(connectionId);
       byte[] requestBytes = objectMapper.writeValueAsBytes(requestMap);
       request.setAttribute(AVATICA_QUERY_ATTRIBUTE, requestBytes);
-      LOG.debug("Forwarding JDBC connection [%s] to broker [%s]", connectionId, targetServer);
+      LOG.debug("Forwarding JDBC connection [%s] to broker [%s]", connectionId, targetServer.getHost());
     } else if (HttpMethod.DELETE.is(method)) {
       // query cancellation request
       targetServer = hostFinder.pickDefaultServer();
@@ -244,10 +244,10 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
           if (inputQuery.getId() == null) {
             inputQuery = inputQuery.withId(UUID.randomUUID().toString());
           }
-          LOG.debug("Forwarding JSON query [%s] to broker [%s]", inputQuery.getId(), targetServer);
+          LOG.debug("Forwarding JSON query [%s] to broker [%s]", inputQuery.getId(), targetServer.getHost());
         } else {
           targetServer = hostFinder.pickDefaultServer();
-          LOG.debug("Forwarding JSON request to broker [%s]", targetServer);
+          LOG.debug("Forwarding JSON request to broker [%s]", targetServer.getHost());
         }
         request.setAttribute(QUERY_ATTRIBUTE, inputQuery);
       }
@@ -264,7 +264,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         SqlQuery inputSqlQuery = objectMapper.readValue(request.getInputStream(), SqlQuery.class);
         request.setAttribute(SQL_QUERY_ATTRIBUTE, inputSqlQuery);
         targetServer = hostFinder.findServerSql(inputSqlQuery);
-        LOG.debug("Forwarding SQL query to broker [%s]", targetServer);
+        LOG.debug("Forwarding SQL query to broker [%s]", targetServer.getHost());
       }
       catch (IOException e) {
         handleQueryParseException(request, response, objectMapper, e, false);
@@ -276,6 +276,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       }
     } else {
       targetServer = hostFinder.pickDefaultServer();
+      LOG.debug("Forwarding query to broker [%s]", targetServer.getHost());
     }
 
     request.setAttribute(HOST_ATTRIBUTE, targetServer.getHost());

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -79,7 +79,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements QueryCountStatsProvider
 {
-  private static final EmittingLogger log = new EmittingLogger(AsyncQueryForwardingServlet.class);
+  private static final EmittingLogger LOG = new EmittingLogger(AsyncQueryForwardingServlet.class);
   @Deprecated // use SmileMediaTypes.APPLICATION_JACKSON_SMILE
   private static final String APPLICATION_SMILE = "application/smile";
 
@@ -189,7 +189,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       broadcastClient.stop();
     }
     catch (Exception e) {
-      log.warn(e, "Error stopping servlet");
+      LOG.warn(e, "Error stopping servlet");
     }
   }
 
@@ -219,6 +219,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       String connectionId = getAvaticaProtobufConnectionId(protobufRequest);
       targetServer = hostFinder.findServerAvatica(connectionId);
       request.setAttribute(AVATICA_QUERY_ATTRIBUTE, requestBytes);
+      LOG.debug("Forwarding protobuf JDBC connection [%s] to broker [%s]", connectionId, targetServer);
     } else if (isAvaticaJson) {
       Map<String, Object> requestMap = objectMapper.readValue(
           request.getInputStream(),
@@ -228,10 +229,12 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       targetServer = hostFinder.findServerAvatica(connectionId);
       byte[] requestBytes = objectMapper.writeValueAsBytes(requestMap);
       request.setAttribute(AVATICA_QUERY_ATTRIBUTE, requestBytes);
+      LOG.debug("Forwarding JDBC connection [%s] to broker [%s]", connectionId, targetServer);
     } else if (HttpMethod.DELETE.is(method)) {
       // query cancellation request
       targetServer = hostFinder.pickDefaultServer();
       broadcastQueryCancelRequest(request, targetServer);
+      LOG.debug("Broadcasting cancellation request to all brokers");
     } else if (isNativeQueryEndpoint && HttpMethod.POST.is(method)) {
       // query request
       try {
@@ -241,8 +244,10 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
           if (inputQuery.getId() == null) {
             inputQuery = inputQuery.withId(UUID.randomUUID().toString());
           }
+          LOG.debug("Forwarding JSON query [%s] to broker [%s]", inputQuery.getId(), targetServer);
         } else {
           targetServer = hostFinder.pickDefaultServer();
+          LOG.debug("Forwarding JSON request to broker [%s]", targetServer);
         }
         request.setAttribute(QUERY_ATTRIBUTE, inputQuery);
       }
@@ -259,6 +264,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         SqlQuery inputSqlQuery = objectMapper.readValue(request.getInputStream(), SqlQuery.class);
         request.setAttribute(SQL_QUERY_ATTRIBUTE, inputSqlQuery);
         targetServer = hostFinder.findServerSql(inputSqlQuery);
+        LOG.debug("Forwarding SQL query to broker [%s]", targetServer);
       }
       catch (IOException e) {
         handleQueryParseException(request, response, objectMapper, e, false);
@@ -293,7 +299,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       // issue async requests
       Response.CompleteListener completeListener = result -> {
         if (result.isFailed()) {
-          log.warn(
+          LOG.warn(
               result.getFailure(),
               "Failed to forward cancellation request to [%s]",
               server.getHost()
@@ -321,7 +327,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       boolean isNativeQuery
   ) throws IOException
   {
-    log.warn(parseException, "Exception parsing query");
+    LOG.warn(parseException, "Exception parsing query");
 
     // Log the error message
     final String errorMessage = parseException.getMessage() == null
@@ -407,7 +413,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
             proxyRequest
         );
       } else {
-        log.error("Can not find Authenticator with Name [%s]", authenticationResult.getAuthenticatedBy());
+        LOG.error("Can not find Authenticator with Name [%s]", authenticationResult.getAuthenticatedBy());
       }
     }
     super.sendProxyRequest(
@@ -682,7 +688,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         );
       }
       catch (Exception e) {
-        log.error(e, "Unable to log query [%s]!", query);
+        LOG.error(e, "Unable to log query [%s]!", query);
       }
 
       super.onComplete(result);
@@ -712,10 +718,10 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         );
       }
       catch (IOException logError) {
-        log.error(logError, "Unable to log query [%s]!", query);
+        LOG.error(logError, "Unable to log query [%s]!", query);
       }
 
-      log.makeAlert(failure, "Exception handling request")
+      LOG.makeAlert(failure, "Exception handling request")
          .addData("exception", failure.toString())
          .addData("query", query)
          .addData("peer", req.getRemoteAddr())

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
@@ -84,11 +84,11 @@ public class DruidConnection
       if (statements.containsKey(statementId)) {
         // Will only happen if statementCounter rolls over before old statements are cleaned up. If this
         // ever happens then something fishy is going on, because we shouldn't have billions of statements.
-        throw new ISE("Uh oh, too many statements");
+        throw DruidMeta.logError(new ISE("Uh oh, too many statements"));
       }
 
       if (statements.size() >= maxStatements) {
-        throw new ISE("Too many open statements, limit is[%,d]", maxStatements);
+        throw DruidMeta.logError(new ISE("Too many open statements, limit is[%,d]", maxStatements));
       }
 
       // remove sensitive fields from the context, only the connection's context needs to have authentication

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class DruidConnection
 {
-  private static final Logger log = new Logger(DruidConnection.class);
+  private static final Logger LOG = new Logger(DruidConnection.class);
   private static final Set<String> SENSITIVE_CONTEXT_FIELDS = Sets.newHashSet(
       "user", "password"
   );
@@ -69,6 +69,11 @@ public class DruidConnection
     this.maxStatements = maxStatements;
     this.context = ImmutableMap.copyOf(context);
     this.statements = new ConcurrentHashMap<>();
+  }
+
+  public String getConnectionId()
+  {
+    return connectionId;
   }
 
   public DruidStatement createStatement(SqlLifecycleFactory sqlLifecycleFactory)
@@ -101,14 +106,14 @@ public class DruidConnection
           sqlLifecycleFactory.factorize(),
           () -> {
             // onClose function for the statement
-            log.debug("Connection[%s] closed statement[%s].", connectionId, statementId);
+            LOG.debug("Connection[%s] closed statement[%s].", connectionId, statementId);
             // statements will be accessed unsynchronized to avoid deadlock
             statements.remove(statementId);
           }
       );
 
       statements.put(statementId, statement);
-      log.debug("Connection[%s] opened statement[%s].", connectionId, statementId);
+      LOG.debug("Connection[%s] opened statement[%s].", connectionId, statementId);
       return statement;
     }
   }
@@ -146,11 +151,11 @@ public class DruidConnection
           statement.close();
         }
         catch (Exception e) {
-          log.warn("Connection[%s] failed to close statement[%s]!", connectionId, statement.getStatementId());
+          LOG.warn("Connection[%s] failed to close statement[%s]!", connectionId, statement.getStatementId());
         }
       }
 
-      log.debug("Connection[%s] closed.", connectionId);
+      LOG.debug("Connection[%s] closed.", connectionId);
       open = false;
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
@@ -84,11 +84,11 @@ public class DruidConnection
       if (statements.containsKey(statementId)) {
         // Will only happen if statementCounter rolls over before old statements are cleaned up. If this
         // ever happens then something fishy is going on, because we shouldn't have billions of statements.
-        throw DruidMeta.logError(new ISE("Uh oh, too many statements"));
+        throw DruidMeta.logFailure(new ISE("Uh oh, too many statements"));
       }
 
       if (statements.size() >= maxStatements) {
-        throw DruidMeta.logError(new ISE("Too many open statements, limit is[%,d]", maxStatements));
+        throw DruidMeta.logFailure(new ISE("Too many open statements, limit is[%,d]", maxStatements));
       }
 
       // remove sensitive fields from the context, only the connection's context needs to have authentication

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
@@ -72,7 +72,7 @@ public class DruidMeta extends MetaImpl
 
   public static <T extends Throwable> T logFailure(T error)
   {
-    LOG.noStackTrace().error(error, error.getMessage());
+    LOG.error(error, error.getMessage());
     return error;
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidStatement.java
@@ -360,6 +360,8 @@ public class DruidStatement implements Closeable
           synchronized (lock) {
             sqlLifecycle.finalizeStateAndEmitLogsAndMetrics(this.throwable, null, -1);
           }
+        } else {
+          DruidMeta.logError(this.throwable);
         }
         onClose.run();
       }
@@ -388,6 +390,7 @@ public class DruidStatement implements Closeable
   private DruidStatement closeAndPropagateThrowable(Throwable t)
   {
     this.throwable = t;
+    DruidMeta.logError(t);
     try {
       close();
     }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidStatement.java
@@ -361,7 +361,7 @@ public class DruidStatement implements Closeable
             sqlLifecycle.finalizeStateAndEmitLogsAndMetrics(this.throwable, null, -1);
           }
         } else {
-          DruidMeta.logError(this.throwable);
+          DruidMeta.logFailure(this.throwable);
         }
         onClose.run();
       }
@@ -390,7 +390,7 @@ public class DruidStatement implements Closeable
   private DruidStatement closeAndPropagateThrowable(Throwable t)
   {
     this.throwable = t;
-    DruidMeta.logError(t);
+    DruidMeta.logFailure(t);
     try {
       close();
     }


### PR DESCRIPTION
### Description
This started out as a quest to make JDBC debug level logging slightly more verbose to get a better idea of what is happening, but in the process realized that there are quite a lot of cases where we actually aren't logging any exceptions at all whenever jdbc queries fail; all that is visible is the debug logs indicate that a connection was closed and the client might get a useful error message if it is lucky, but good luck beyond that.

I couldn't find an easy way to add any sort of centralized error logging for any caught exception in the `DruidAvaticaJsonHandler`, so, I added utility methods to `DruidMeta` to slightly make the 'log and throw' pattern a bit more concise. I don't love it, but at least it makes exceptions actually be logged in the broker in a lot of cases we were missing. To err on the side of caution i essentially went through and looked for places where we were throwing some exception to the wind without any obvious catcher in Druid code (hopefully there should be no duplicates).

Additionally, I made router debug logs slightly more chatty, including printing query ids when used with a broker selection strategy that parses the query at the router. This log really doesn't add much, since `AsyncQueryForwardingServlet` is quite chatty already from the base class structure it picks up by being a `AsyncProxyServlet`, but does at least print some things in Druid terms I guess.

This will probably fail CI because its all log messages and didn't add any tests...

<hr>


This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
