### PR TITLE
Require DATASOURCE WRITE access in SupervisorResourceFilter and TaskResourceFilter

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilter.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.indexing.overlord.http.security;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -31,11 +30,9 @@ import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.http.security.AbstractResourceFilter;
 import org.apache.druid.server.security.Access;
-import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.ForbiddenException;
-import org.apache.druid.server.security.ResourceAction;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.PathSegment;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilter.java
@@ -91,13 +91,11 @@ public class SupervisorResourceFilter extends AbstractResourceFilter
         "No dataSources found to perform authorization checks"
     );
 
-    Function<String, ResourceAction> resourceActionFunction = getAction(request) == Action.READ ?
-                                                              AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR :
-                                                              AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR;
-
+    // Supervisor APIs should always require DATASOURCE WRITE access
+    // as they deal with ingestion related information
     Access authResult = AuthorizationUtils.authorizeAllResourceActions(
         getReq(),
-        Iterables.transform(spec.getDataSources(), resourceActionFunction),
+        Iterables.transform(spec.getDataSources(), AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR),
         getAuthorizerMapper()
     );
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/TaskResourceFilter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/TaskResourceFilter.java
@@ -30,6 +30,7 @@ import org.apache.druid.indexing.overlord.TaskStorageQueryAdapter;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.http.security.AbstractResourceFilter;
 import org.apache.druid.server.security.Access;
+import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.ForbiddenException;
@@ -85,9 +86,11 @@ public class TaskResourceFilter extends AbstractResourceFilter
     }
     final String dataSourceName = Preconditions.checkNotNull(taskOptional.get().getDataSource());
 
+    // Task APIs should always require DATASOURCE WRITE access
+    // as they deal with ingestion related information
     final ResourceAction resourceAction = new ResourceAction(
         new Resource(dataSourceName, ResourceType.DATASOURCE),
-        getAction(request)
+        Action.WRITE
     );
 
     final Access authResult = AuthorizationUtils.authorizeResourceAction(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilterTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.http.security;
+
+import com.google.common.base.Optional;
+import com.sun.jersey.spi.container.ContainerRequest;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
+import org.apache.druid.server.security.Access;
+import org.apache.druid.server.security.Action;
+import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.server.security.Authorizer;
+import org.apache.druid.server.security.AuthorizerMapper;
+import org.apache.druid.server.security.ForbiddenException;
+import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.ResourceType;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+
+public class SupervisorResourceFilterTest
+{
+
+  private AuthorizerMapper authorizerMapper;
+  private SupervisorManager supervisorManager;
+  private SupervisorResourceFilter resourceFilter;
+
+  private ContainerRequest containerRequest;
+
+  @Before
+  public void setup()
+  {
+    supervisorManager = EasyMock.createMock(SupervisorManager.class);
+    authorizerMapper = EasyMock.createMock(AuthorizerMapper.class);
+    resourceFilter = new SupervisorResourceFilter(authorizerMapper, supervisorManager);
+
+    containerRequest = EasyMock.createMock(ContainerRequest.class);
+  }
+
+  @Test
+  public void testGetWhenUserHasWriteAccess()
+  {
+    setExpectations("/druid/indexer/v1/supervisor/datasource1", "GET", "datasource1", Action.WRITE, true);
+    ContainerRequest filteredRequest = resourceFilter.filter(containerRequest);
+    Assert.assertNotNull(filteredRequest);
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void testGetWhenUserHasNoWriteAccess()
+  {
+    setExpectations("/druid/indexer/v1/supervisor/datasource1", "GET", "datasource1", Action.WRITE, false);
+    resourceFilter.filter(containerRequest);
+  }
+
+  @Test
+  public void testPostWhenUserHasWriteAccess()
+  {
+    setExpectations("/druid/indexer/v1/supervisor/datasource1", "POST", "datasource1", Action.WRITE, true);
+    ContainerRequest filteredRequest = resourceFilter.filter(containerRequest);
+    Assert.assertNotNull(filteredRequest);
+  }
+
+  @Test(expected = ForbiddenException.class)
+  public void testPostWhenUserHasNoWriteAccess()
+  {
+    setExpectations("/druid/indexer/v1/supervisor/datasource1", "POST", "datasource1", Action.WRITE, false);
+    resourceFilter.filter(containerRequest);
+  }
+
+  private void setExpectations(
+      String path,
+      String requestMethod,
+      String datasource,
+      Action expectedAction,
+      boolean userHasAccess
+  )
+  {
+    expect(containerRequest.getPathSegments())
+        .andReturn(getPathSegments("/druid/indexer/v1/supervisor/datasource1"))
+        .anyTimes();
+    expect(containerRequest.getMethod()).andReturn(requestMethod).anyTimes();
+
+    SupervisorSpec supervisorSpec = EasyMock.createMock(SupervisorSpec.class);
+    expect(supervisorSpec.getDataSources())
+        .andReturn(Collections.singletonList(datasource))
+        .anyTimes();
+    expect(supervisorManager.getSupervisorSpec(datasource))
+        .andReturn(Optional.of(supervisorSpec))
+        .atLeastOnce();
+
+    HttpServletRequest servletRequest = EasyMock.createMock(HttpServletRequest.class);
+    expect(servletRequest.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH))
+        .andReturn(null).anyTimes();
+    expect(servletRequest.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED))
+        .andReturn(null).anyTimes();
+    servletRequest.setAttribute(isA(String.class), anyObject());
+
+    final String authorizerName = "authorizer";
+    AuthenticationResult authResult = EasyMock.createMock(AuthenticationResult.class);
+    expect(authResult.getAuthorizerName()).andReturn(authorizerName).anyTimes();
+
+    Authorizer authorizer = EasyMock.createMock(Authorizer.class);
+    expect(
+        authorizer.authorize(
+            authResult,
+            new Resource(datasource, ResourceType.DATASOURCE),
+            expectedAction
+        )
+    ).andReturn(new Access(userHasAccess)).anyTimes();
+
+    expect(authorizerMapper.getAuthorizer(authorizerName))
+        .andReturn(authorizer)
+        .atLeastOnce();
+
+    expect(servletRequest.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+        .andReturn(authResult)
+        .atLeastOnce();
+    resourceFilter.setReq(servletRequest);
+
+    EasyMock.replay(authorizerMapper);
+    EasyMock.replay(supervisorSpec);
+    EasyMock.replay(supervisorManager);
+    EasyMock.replay(servletRequest);
+    EasyMock.replay(authorizer);
+    EasyMock.replay(authResult);
+    EasyMock.replay(containerRequest);
+  }
+
+  private List<PathSegment> getPathSegments(String path)
+  {
+    String[] segments = path.split("/");
+
+    List<PathSegment> pathSegments = new ArrayList<>();
+    for (final String segment : segments) {
+      pathSegments.add(new PathSegment()
+      {
+        @Override
+        public String getPath()
+        {
+          return segment;
+        }
+
+        @Override
+        public MultivaluedMap<String, String> getMatrixParameters()
+        {
+          return null;
+        }
+      });
+    }
+    return pathSegments;
+  }
+}


### PR DESCRIPTION
### Description
Users with DATASOURCE READ access can currently call GET and HEAD APIs
on Supervisor and Task resources. These resources respond with ingestion related
information, which should be visible only to DATASOURCE WRITE users.

### Changes
- Always require DATASOURCE WRITE access in `SupervisorResourceFilter` and `TaskResourceFilter`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
