### PR TITLE
add missing stuff to docs sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -242,7 +242,7 @@
       "development/extensions-contrib/time-min-max",
       "development/extensions-contrib/gce-extensions",
       "development/extensions-contrib/aliyun-oss",
-      "development/extensions-contrib/prometheus-emitter",
+      "development/extensions-contrib/prometheus",
       "operations/kubernetes",
       "querying/hll-old",
       "querying/select-query",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -126,6 +126,7 @@
           "operations/security-user-auth",
           "operations/auth-ldap",
           "operations/password-provider",
+          "operations/dynamic-config-provider",
           "design/auth",
           "operations/tls-support"
 
@@ -219,6 +220,8 @@
       "development/extensions-core/simple-client-sslcontext",
       "development/extensions-core/stats",
       "development/extensions-core/test-stats",
+      "development/extensions-core/druid-aws-rds",
+      "development/extensions-core/kubernetes",
       "development/extensions-contrib/ambari-metrics-emitter",
       "development/extensions-contrib/cassandra",
       "development/extensions-contrib/cloudfiles",
@@ -239,6 +242,8 @@
       "development/extensions-contrib/time-min-max",
       "development/extensions-contrib/gce-extensions",
       "development/extensions-contrib/aliyun-oss",
+      "development/extensions-contrib/prometheus-emitter",
+      "operations/kubernetes",
       "querying/hll-old",
       "querying/select-query",
       "ingestion/standalone-realtime"


### PR DESCRIPTION
You lose sidebar navigation to other pages and stuff renders funny screen region if it isn't added to the sidebar.js, example:

<img width="1454" alt="Screen Shot 2021-09-08 at 10 16 29 PM" src="https://user-images.githubusercontent.com/1577461/132627089-a5fbb46e-1940-41af-ab25-5f82d203b420.png">


Maybe there is some way we could automate this as part of docs checks similar to missing links? (Not really looking to take that on with this PR though)