### PR TITLE
Add lane strategy for mergeBuffer pool

### DIFF
--- a/core/src/main/java/org/apache/druid/collections/BlockingPool.java
+++ b/core/src/main/java/org/apache/druid/collections/BlockingPool.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.collections;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public interface BlockingPool<T>
@@ -31,17 +32,35 @@ public interface BlockingPool<T>
    *
    * @param elementNum number of resources to take
    * @param timeoutMs  maximum time to wait for resources, in milliseconds.
-   *
    * @return a list of resource holders. An empty list is returned if {@code elementNum} resources aren't available.
    */
   List<ReferenceCountingResourceHolder<T>> takeBatch(int elementNum, long timeoutMs);
 
   /**
+   * Take resources from the special group pool, waiting up to the
+   * specified wait time if necessary for elements of the given number to become available.
+   *
+   * @param group resources group
+   * @param elementNum number of resources to take
+   * @param timeoutMs  maximum time to wait for resources, in milliseconds.
+   * @return a list of resource holders. An empty list is returned if {@code elementNum} resources aren't available.
+   */
+  List<ReferenceCountingResourceHolder<T>> takeBatch(@Nullable String group, int elementNum, long timeoutMs);
+
+  /**
    * Take resources from the pool, waiting if necessary until the elements of the given number become available.
    *
    * @param elementNum number of resources to take
-   *
    * @return a list of resource holders. An empty list is returned if {@code elementNum} resources aren't available.
    */
   List<ReferenceCountingResourceHolder<T>> takeBatch(int elementNum);
+
+  /**
+   * Take resources from the special group  pool, waiting if necessary until the elements of the given number become available.
+   *
+   * @param group resources group
+   * @param elementNum number of resources to take
+   * @return a list of resource holders. An empty list is returned if {@code elementNum} resources aren't available.
+   */
+  List<ReferenceCountingResourceHolder<T>> takeBatch(@Nullable String group, int elementNum);
 }

--- a/core/src/main/java/org/apache/druid/collections/DummyBlockingPool.java
+++ b/core/src/main/java/org/apache/druid/collections/DummyBlockingPool.java
@@ -51,7 +51,19 @@ public final class DummyBlockingPool<T> implements BlockingPool<T>
   }
 
   @Override
+  public List<ReferenceCountingResourceHolder<T>> takeBatch(String group, int elementNum, long timeoutMs)
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public List<ReferenceCountingResourceHolder<T>> takeBatch(int elementNum)
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<ReferenceCountingResourceHolder<T>> takeBatch(String group, int elementNum)
   {
     throw new UnsupportedOperationException();
   }

--- a/core/src/main/java/org/apache/druid/collections/ResourceGroupScheduler.java
+++ b/core/src/main/java/org/apache/druid/collections/ResourceGroupScheduler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public interface ResourceGroupScheduler
+{
+  int getGroupAvailableCapacity(String resourceGroup);
+
+  int getGroupCapacity(String resourceGroup);
+
+  int getTotalCapacity();
+
+  default void accquire(String group) throws InterruptedException
+  {
+    accquire(group, 1);
+  }
+
+  void accquire(String resourceGroup, int permits) throws InterruptedException;
+
+  default boolean tryAcquire(String group)
+  {
+    return tryAcquire(group, 1);
+  }
+
+  boolean tryAcquire(String resourceGroup, int permits);
+
+  default boolean tryAcquire(String group, long timeout, TimeUnit unit) throws InterruptedException
+  {
+    return tryAcquire(group, 1, timeout, unit);
+  }
+
+  boolean tryAcquire(String resourceGroup, int permits, long timeout, TimeUnit unit)
+      throws InterruptedException;
+
+  default void release(String group)
+  {
+    release(group, 1);
+  }
+
+  void release(String resourceGroup, int permits);
+
+  Set<String> getAllGroup();
+}

--- a/core/src/main/java/org/apache/druid/collections/SemaphoreResourceGroupScheduler.java
+++ b/core/src/main/java/org/apache/druid/collections/SemaphoreResourceGroupScheduler.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections;
+
+import org.apache.druid.java.util.common.IAE;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+public class SemaphoreResourceGroupScheduler implements ResourceGroupScheduler
+{
+  private final int capacity;
+  private final Map<String, Integer> configMap;
+  private final Map<String, Semaphore> groupSemaphoreRegistry;
+  private final boolean ignoreUnknownGroup;
+
+  public SemaphoreResourceGroupScheduler(int capacity, Map<String, Integer> config, boolean ignoreUnknownGroup)
+  {
+    this.capacity = capacity;
+    this.configMap = config;
+    this.ignoreUnknownGroup = ignoreUnknownGroup;
+    this.groupSemaphoreRegistry = new HashMap<>();
+    configMap.forEach((group, permits) -> {
+      Semaphore semaphore = new Semaphore(permits, true);
+      groupSemaphoreRegistry.put(group, semaphore);
+    });
+  }
+
+  @Override
+  public int getGroupAvailableCapacity(String resourceGroup)
+  {
+    if (ignoreResourceGroup(resourceGroup)) {
+      return capacity;
+    } else {
+      return getGroupSemaphore(resourceGroup).availablePermits();
+    }
+  }
+
+  @Override
+  public int getGroupCapacity(String resourceGroup)
+  {
+    if (ignoreResourceGroup(resourceGroup)) {
+      return capacity;
+    } else {
+      return configMap.getOrDefault(resourceGroup, -1);
+    }
+  }
+
+  @Override
+  public int getTotalCapacity()
+  {
+    return capacity;
+  }
+
+  @Override
+  public Set<String> getAllGroup()
+  {
+    return configMap.keySet();
+  }
+
+  @Override
+  public void accquire(String resourceGroup, int permits) throws InterruptedException
+  {
+    if (!ignoreResourceGroup(resourceGroup)) {
+      getGroupSemaphore(resourceGroup).acquire(permits);
+    }
+  }
+
+  @Override
+  public boolean tryAcquire(String resourceGroup, int permits)
+  {
+    if (ignoreResourceGroup(resourceGroup)) {
+      return true;
+    }
+    return getGroupSemaphore(resourceGroup).tryAcquire(permits);
+  }
+
+  @Override
+  public boolean tryAcquire(String resourceGroup, int permits, long timeout, TimeUnit unit) throws InterruptedException
+  {
+    if (ignoreResourceGroup(resourceGroup)) {
+      return true;
+    }
+    return getGroupSemaphore(resourceGroup).tryAcquire(permits, timeout, unit);
+  }
+
+  @Override
+  public void release(String resourceGroup, int permits)
+  {
+    if (!ignoreResourceGroup(resourceGroup)) {
+      getGroupSemaphore(resourceGroup).release(permits);
+    }
+  }
+
+  private boolean ignoreResourceGroup(String resourceGroup)
+  {
+    return resourceGroup == null || (ignoreUnknownGroup && configMap.get(resourceGroup) == null);
+  }
+
+  private Semaphore getGroupSemaphore(String group)
+  {
+    Semaphore semaphore = groupSemaphoreRegistry.get(group);
+    if (semaphore == null) {
+      throw new IAE("resource group %s not exists", group);
+    }
+    return semaphore;
+  }
+}

--- a/core/src/test/java/org/apache/druid/collections/BlockingPoolTest.java
+++ b/core/src/test/java/org/apache/druid/collections/BlockingPoolTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.collections;
 
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.junit.After;
@@ -40,8 +41,10 @@ public class BlockingPoolTest
 {
   private ExecutorService service;
 
-  private CloseableDefaultBlockingPool<Integer> pool;
+  private CloseableDefaultBlockingPool<Integer> nonGroupingPool;
   private CloseableDefaultBlockingPool<Integer> emptyPool;
+  private CloseableDefaultBlockingPool<Integer> groupingPool;
+  private final String firstResourceGroup = "group1";
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -50,15 +53,21 @@ public class BlockingPoolTest
   public void setup()
   {
     service = Execs.multiThreaded(2, "blocking-pool-test");
-    pool = new CloseableDefaultBlockingPool<>(Suppliers.ofInstance(1), 10);
+    nonGroupingPool = new CloseableDefaultBlockingPool<>(Suppliers.ofInstance(1), 10);
     emptyPool = new CloseableDefaultBlockingPool<>(Suppliers.ofInstance(1), 0);
+    groupingPool = new CloseableDefaultBlockingPool<>(
+        Suppliers.ofInstance(1),
+        ImmutableMap.of(firstResourceGroup, 5),
+        10
+    );
   }
 
   @After
   public void teardown()
   {
-    pool.close();
+    nonGroupingPool.close();
     emptyPool.close();
+    groupingPool.close();
     service.shutdownNow();
   }
 
@@ -81,7 +90,20 @@ public class BlockingPoolTest
   @Test(timeout = 60_000L)
   public void testTake()
   {
-    final ReferenceCountingResourceHolder<Integer> holder = Iterables.getOnlyElement(pool.takeBatch(1, 100), null);
+    take(nonGroupingPool, null);
+    take(groupingPool, null);
+    take(groupingPool, firstResourceGroup);
+  }
+
+  private void take(
+      CloseableDefaultBlockingPool<Integer> pool,
+      String group
+  )
+  {
+    final ReferenceCountingResourceHolder<Integer> holder = Iterables.getOnlyElement(
+        pool.takeBatch(group, 1, 100),
+        null
+    );
     Assert.assertNotNull(holder);
     Assert.assertEquals(9, pool.getPoolSize());
     holder.close();
@@ -91,8 +113,22 @@ public class BlockingPoolTest
   @Test(timeout = 60_000L)
   public void testTakeTimeout()
   {
-    final List<ReferenceCountingResourceHolder<Integer>> batchHolder = pool.takeBatch(10, 100L);
-    final ReferenceCountingResourceHolder<Integer> holder = Iterables.getOnlyElement(pool.takeBatch(1, 100), null);
+    takeTimeout(nonGroupingPool, null, 10);
+    takeTimeout(groupingPool, null, 10);
+    takeTimeout(groupingPool, firstResourceGroup, 5);
+  }
+
+  private void takeTimeout(
+      CloseableDefaultBlockingPool<Integer> pool,
+      String group,
+      int groupCapacity
+  )
+  {
+    final List<ReferenceCountingResourceHolder<Integer>> batchHolder = pool.takeBatch(group, groupCapacity, 100L);
+    final ReferenceCountingResourceHolder<Integer> holder = Iterables.getOnlyElement(
+        pool.takeBatch(group, 1, 100),
+        null
+    );
     Assert.assertNull(holder);
     batchHolder.forEach(ReferenceCountingResourceHolder::close);
   }
@@ -100,55 +136,97 @@ public class BlockingPoolTest
   @Test(timeout = 60_000L)
   public void testTakeBatch()
   {
-    final List<ReferenceCountingResourceHolder<Integer>> holder = pool.takeBatch(6, 100L);
+    takeBatch(nonGroupingPool, null, 6);
+    takeBatch(groupingPool, null, 6);
+    takeBatch(groupingPool, firstResourceGroup, 2);
+  }
+
+  private void takeBatch(
+      CloseableDefaultBlockingPool<Integer> pool,
+      String group,
+      int batch1
+  )
+  {
+    final List<ReferenceCountingResourceHolder<Integer>> holder = pool.takeBatch(group, batch1, 100L);
     Assert.assertNotNull(holder);
-    Assert.assertEquals(6, holder.size());
-    Assert.assertEquals(4, pool.getPoolSize());
+    Assert.assertEquals(batch1, holder.size());
+    Assert.assertEquals(pool.maxSize() - batch1, pool.getPoolSize());
     holder.forEach(ReferenceCountingResourceHolder::close);
-    Assert.assertEquals(10, pool.getPoolSize());
+    Assert.assertEquals(pool.maxSize(), pool.getPoolSize());
   }
 
   @Test(timeout = 60_000L)
   public void testWaitAndTakeBatch() throws InterruptedException, ExecutionException
   {
-    List<ReferenceCountingResourceHolder<Integer>> batchHolder = pool.takeBatch(10, 10);
+    waitAndTakeBatch(nonGroupingPool, null, 10, 8);
+    waitAndTakeBatch(groupingPool, null, 10, 8);
+    waitAndTakeBatch(groupingPool, firstResourceGroup, 5, 3);
+  }
+
+  private void waitAndTakeBatch(
+      CloseableDefaultBlockingPool<Integer> pool,
+      String group,
+      int groupCapacity,
+      int batchSize
+  )
+      throws InterruptedException, ExecutionException
+  {
+    List<ReferenceCountingResourceHolder<Integer>> batchHolder = pool.takeBatch(group, groupCapacity, 10);
     Assert.assertNotNull(batchHolder);
-    Assert.assertEquals(10, batchHolder.size());
-    Assert.assertEquals(0, pool.getPoolSize());
+    Assert.assertEquals(groupCapacity, batchHolder.size());
+    Assert.assertEquals(pool.maxSize() - groupCapacity, pool.getPoolSize());
 
     final Future<List<ReferenceCountingResourceHolder<Integer>>> future = service.submit(
-        () -> pool.takeBatch(8, 100)
+        () -> pool.takeBatch(group, batchSize, 100)
     );
     Thread.sleep(20);
     batchHolder.forEach(ReferenceCountingResourceHolder::close);
 
     batchHolder = future.get();
     Assert.assertNotNull(batchHolder);
-    Assert.assertEquals(8, batchHolder.size());
-    Assert.assertEquals(2, pool.getPoolSize());
+    Assert.assertEquals(batchSize, batchHolder.size());
+    Assert.assertEquals(pool.maxSize() - batchSize, pool.getPoolSize());
 
     batchHolder.forEach(ReferenceCountingResourceHolder::close);
-    Assert.assertEquals(10, pool.getPoolSize());
+    Assert.assertEquals(pool.maxSize(), pool.getPoolSize());
   }
 
   @Test(timeout = 60_000L)
   public void testTakeBatchTooManyObjects()
   {
-    final List<ReferenceCountingResourceHolder<Integer>> holder = pool.takeBatch(100, 100L);
+    takeBatchTooManyObjects(nonGroupingPool, null);
+    takeBatchTooManyObjects(groupingPool, null);
+    takeBatchTooManyObjects(groupingPool, firstResourceGroup);
+  }
+
+  private void takeBatchTooManyObjects(CloseableDefaultBlockingPool<Integer> pool, String group)
+  {
+    final List<ReferenceCountingResourceHolder<Integer>> holder = pool.takeBatch(group, 100, 100L);
     Assert.assertTrue(holder.isEmpty());
   }
 
   @Test(timeout = 60_000L)
   public void testConcurrentTake() throws ExecutionException, InterruptedException
   {
-    final int limit1 = pool.maxSize() / 2;
-    final int limit2 = pool.maxSize() - limit1 + 1;
+    concurrentTake(nonGroupingPool, null, 10, 5, 6);
+    concurrentTake(groupingPool, null, 10, 5, 6);
+    concurrentTake(groupingPool, firstResourceGroup, 5, 2, 4);
+  }
 
+  private void concurrentTake(
+      CloseableDefaultBlockingPool<Integer> pool,
+      String group,
+      int groupCapacity,
+      int limit1,
+      int limit2
+  )
+      throws ExecutionException, InterruptedException
+  {
     final Future<List<ReferenceCountingResourceHolder<Integer>>> f1 = service.submit(
         () -> {
           List<ReferenceCountingResourceHolder<Integer>> result = new ArrayList<>();
           for (int i = 0; i < limit1; i++) {
-            result.add(Iterables.getOnlyElement(pool.takeBatch(1, 10), null));
+            result.add(Iterables.getOnlyElement(pool.takeBatch(group, 1, 10), null));
           }
           return result;
         }
@@ -157,7 +235,7 @@ public class BlockingPoolTest
         () -> {
           List<ReferenceCountingResourceHolder<Integer>> result = new ArrayList<>();
           for (int i = 0; i < limit2; i++) {
-            result.add(Iterables.getOnlyElement(pool.takeBatch(1, 10), null));
+            result.add(Iterables.getOnlyElement(pool.takeBatch(group, 1, 10), null));
           }
           return result;
         }
@@ -166,7 +244,7 @@ public class BlockingPoolTest
     final List<ReferenceCountingResourceHolder<Integer>> r1 = f1.get();
     final List<ReferenceCountingResourceHolder<Integer>> r2 = f2.get();
 
-    Assert.assertEquals(0, pool.getPoolSize());
+    Assert.assertEquals(pool.getPoolSize(), pool.maxSize() - groupCapacity);
     Assert.assertTrue(r1.contains(null) || r2.contains(null));
 
     int nonNullCount = 0;
@@ -181,7 +259,7 @@ public class BlockingPoolTest
         nonNullCount++;
       }
     }
-    Assert.assertEquals(pool.maxSize(), nonNullCount);
+    Assert.assertEquals(groupCapacity, nonNullCount);
 
     final Future future1 = service.submit(() -> {
       for (ReferenceCountingResourceHolder<Integer> holder : r1) {
@@ -207,11 +285,16 @@ public class BlockingPoolTest
   @Test(timeout = 60_000L)
   public void testConcurrentTakeBatch() throws ExecutionException, InterruptedException
   {
-    final int batch1 = pool.maxSize() / 2;
-    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c1 = () -> pool.takeBatch(batch1, 10);
+    concurrentTakeBatch(nonGroupingPool, null, 5, 6);
+    concurrentTakeBatch(groupingPool, null, 5, 6);
+    concurrentTakeBatch(groupingPool, firstResourceGroup, 2, 4);
+  }
 
-    final int batch2 = pool.maxSize() - batch1 + 1;
-    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c2 = () -> pool.takeBatch(batch2, 10);
+  private void concurrentTakeBatch(CloseableDefaultBlockingPool<Integer> pool, String group, int batch1, int batch2)
+      throws ExecutionException, InterruptedException
+  {
+    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c1 = () -> pool.takeBatch(group, batch1, 10);
+    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c2 = () -> pool.takeBatch(group, batch2, 10);
 
     final Future<List<ReferenceCountingResourceHolder<Integer>>> f1 = service.submit(c1);
     final Future<List<ReferenceCountingResourceHolder<Integer>>> f2 = service.submit(c2);
@@ -237,11 +320,25 @@ public class BlockingPoolTest
   @Test(timeout = 60_000L)
   public void testConcurrentBatchClose() throws ExecutionException, InterruptedException
   {
-    final int batch1 = pool.maxSize() / 2;
-    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c1 = () -> pool.takeBatch(batch1, 10);
+    concurrentBatchClose(nonGroupingPool, null, 10, 5);
+    concurrentBatchClose(groupingPool, null, 10, 5);
+    concurrentBatchClose(groupingPool, firstResourceGroup, 5, 2);
+  }
 
-    final int batch2 = pool.maxSize() - batch1;
-    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c2 = () -> pool.takeBatch(batch2, 10);
+  private void concurrentBatchClose(
+      CloseableDefaultBlockingPool<Integer> pool,
+      String group,
+      int groupCapacity,
+      int batchSize
+  )
+      throws ExecutionException, InterruptedException
+  {
+    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c1 = () -> pool.takeBatch(group, batchSize, 10);
+    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c2 = () -> pool.takeBatch(
+        group,
+        groupCapacity - batchSize,
+        10
+    );
 
     final Future<List<ReferenceCountingResourceHolder<Integer>>> f1 = service.submit(c1);
     final Future<List<ReferenceCountingResourceHolder<Integer>>> f2 = service.submit(c2);
@@ -251,9 +348,9 @@ public class BlockingPoolTest
 
     Assert.assertNotNull(r1);
     Assert.assertNotNull(r2);
-    Assert.assertEquals(batch1, r1.size());
-    Assert.assertEquals(batch2, r2.size());
-    Assert.assertEquals(0, pool.getPoolSize());
+    Assert.assertEquals(batchSize, r1.size());
+    Assert.assertEquals(groupCapacity - batchSize, r2.size());
+    Assert.assertEquals(pool.maxSize() - groupCapacity, pool.getPoolSize());
 
     final Future future1 = service.submit(() -> r1.forEach(ReferenceCountingResourceHolder::close));
     final Future future2 = service.submit(() -> r2.forEach(ReferenceCountingResourceHolder::close));
@@ -268,9 +365,26 @@ public class BlockingPoolTest
   @Test(timeout = 60_000L)
   public void testConcurrentTakeBatchClose() throws ExecutionException, InterruptedException
   {
-    final List<ReferenceCountingResourceHolder<Integer>> r1 = pool.takeBatch(1, 10);
+    concurrentTakeBatchClose(nonGroupingPool, null, null, 10);
+    concurrentTakeBatchClose(groupingPool, null, null, 10);
+    concurrentTakeBatchClose(groupingPool, firstResourceGroup, firstResourceGroup, 5);
+    concurrentTakeBatchClose(groupingPool, firstResourceGroup, null, 10);
+  }
 
-    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c2 = () -> pool.takeBatch(10, 100);
+  private void concurrentTakeBatchClose(
+      CloseableDefaultBlockingPool<Integer> pool,
+      String group1,
+      String group2,
+      int group2Capcity
+  )
+      throws ExecutionException, InterruptedException
+  {
+    final List<ReferenceCountingResourceHolder<Integer>> r1 = pool.takeBatch(group1, 1, 10);
+    final Callable<List<ReferenceCountingResourceHolder<Integer>>> c2 = () -> pool.takeBatch(
+        group2,
+        group2Capcity,
+        100
+    );
 
     final Future<List<ReferenceCountingResourceHolder<Integer>>> f2 = service.submit(c2);
     final Future f1 = service.submit(() -> {
@@ -286,8 +400,8 @@ public class BlockingPoolTest
     final List<ReferenceCountingResourceHolder<Integer>> r2 = f2.get();
     f1.get();
     Assert.assertNotNull(r2);
-    Assert.assertEquals(10, r2.size());
-    Assert.assertEquals(0, pool.getPoolSize());
+    Assert.assertEquals(group2Capcity, r2.size());
+    Assert.assertEquals(pool.maxSize() - group2Capcity, pool.getPoolSize());
 
     r2.forEach(ReferenceCountingResourceHolder::close);
     Assert.assertEquals(pool.maxSize(), pool.getPoolSize());

--- a/core/src/test/java/org/apache/druid/collections/CloseableDefaultBlockingPool.java
+++ b/core/src/test/java/org/apache/druid/collections/CloseableDefaultBlockingPool.java
@@ -22,12 +22,18 @@ package org.apache.druid.collections;
 import com.google.common.base.Supplier;
 
 import java.io.Closeable;
+import java.util.Map;
 
 public class CloseableDefaultBlockingPool<T> extends DefaultBlockingPool<T> implements Closeable
 {
   public CloseableDefaultBlockingPool(Supplier<T> generator, int limit)
   {
     super(generator, limit);
+  }
+
+  public CloseableDefaultBlockingPool(Supplier<T> generator, Map<String, Integer> permits, int limit)
+  {
+    super(new SemaphoreResourceGroupScheduler(limit, permits, false), generator);
   }
 
   @Override

--- a/core/src/test/java/org/apache/druid/collections/SemaphoreResourceGroupSchedulerTest.java
+++ b/core/src/test/java/org/apache/druid/collections/SemaphoreResourceGroupSchedulerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class SemaphoreResourceGroupSchedulerTest
+{
+  private final String lane1 = "lane1";
+  private final String lane2 = "lane2";
+  private final int capacity = 10;
+  private final Map<String, Integer> config = ImmutableMap.of(lane1, 5, lane2, 1);
+  private final ResourceGroupScheduler resourceGroupScheduler = new SemaphoreResourceGroupScheduler(
+      capacity,
+      config,
+      false
+  );
+
+  private final ResourceGroupScheduler dummyResourceGroupScheduler = new SemaphoreResourceGroupScheduler(
+      capacity,
+      ImmutableMap.of(),
+      true
+  );
+
+
+  @Test
+  public void testGetGroupAvailableCapacity() throws InterruptedException
+  {
+    Assert.assertEquals(capacity, resourceGroupScheduler.getGroupAvailableCapacity(null));
+    Assert.assertEquals(5, resourceGroupScheduler.getGroupAvailableCapacity(lane1));
+    Assert.assertEquals(1, resourceGroupScheduler.getGroupAvailableCapacity(lane2));
+
+    resourceGroupScheduler.accquire(lane1, 3);
+    Assert.assertEquals(capacity, resourceGroupScheduler.getGroupAvailableCapacity(null));
+    Assert.assertEquals(2, resourceGroupScheduler.getGroupAvailableCapacity(lane1));
+    Assert.assertEquals(1, resourceGroupScheduler.getGroupAvailableCapacity(lane2));
+
+    resourceGroupScheduler.release(lane1, 3);
+    Assert.assertEquals(capacity, resourceGroupScheduler.getGroupAvailableCapacity(null));
+    Assert.assertEquals(5, resourceGroupScheduler.getGroupAvailableCapacity(lane1));
+    Assert.assertEquals(1, resourceGroupScheduler.getGroupAvailableCapacity(lane2));
+
+    resourceGroupScheduler.tryAcquire(lane2, 1, 1, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(5, resourceGroupScheduler.getGroupAvailableCapacity(lane1));
+    Assert.assertEquals(0, resourceGroupScheduler.getGroupAvailableCapacity(lane2));
+
+    Assert.assertFalse(resourceGroupScheduler.tryAcquire(lane2));
+    Assert.assertFalse(resourceGroupScheduler.tryAcquire(lane2, 1));
+
+
+    resourceGroupScheduler.release(lane2, 1);
+    Assert.assertEquals(5, resourceGroupScheduler.getGroupAvailableCapacity(lane1));
+    Assert.assertEquals(1, resourceGroupScheduler.getGroupAvailableCapacity(lane2));
+  }
+
+  @Test
+  public void testGetGroupCapacity()
+  {
+    Assert.assertEquals(capacity, resourceGroupScheduler.getGroupCapacity(null));
+    Assert.assertEquals(5, resourceGroupScheduler.getGroupCapacity(lane1));
+    Assert.assertEquals(1, resourceGroupScheduler.getGroupCapacity(lane2));
+
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupCapacity(null));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupCapacity(""));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupCapacity("lane"));
+  }
+
+  @Test
+  public void testGetTotalCapacity()
+  {
+    Assert.assertEquals(capacity, resourceGroupScheduler.getTotalCapacity());
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getTotalCapacity());
+  }
+
+  @Test
+  public void testGetAllGroup()
+  {
+    Assert.assertEquals(config.keySet(), resourceGroupScheduler.getAllGroup());
+    Assert.assertTrue(dummyResourceGroupScheduler.getAllGroup().isEmpty());
+  }
+
+  @Test
+  public void testDummyGetGroupAvailableCapacity() throws InterruptedException
+  {
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity(null));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity(""));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity("lane"));
+
+    dummyResourceGroupScheduler.tryAcquire("lane", 1, 1, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity(null));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity(""));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity("lane"));
+
+    dummyResourceGroupScheduler.release("lane", 1);
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity(null));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity(""));
+    Assert.assertEquals(capacity, dummyResourceGroupScheduler.getGroupAvailableCapacity("lane"));
+  }
+}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1691,6 +1691,8 @@ These Broker configurations can be defined in the `broker/runtime.properties` fi
 |`druid.query.scheduler.numThreads`|Maximum number of HTTP threads to dedicate to query processing. To save HTTP thread capacity, this should be lower than `druid.server.http.numThreads`, but it is worth noting that like `druid.server.http.enableRequestLimit` is set that query requests over this limit will be denied instead of waiting in the Jetty HTTP request queue.|Unbounded|
 |`druid.query.scheduler.laning.strategy`|Query laning strategy to use to assign queries to a lane in order to control capacities for certain classes of queries.|`none`|
 |`druid.query.scheduler.prioritization.strategy`|Query prioritization strategy to automatically assign priorities.|`manual`|
+|`druid.query.scheduler.mergeBuffer.strategy`|Strategy to schedule merge buffer pool. With `arbitrary` strategy, every query can require all of the merge buffer pool. On the contrary, `lane` strategy will limit a query with a lane to require partial resource according to the lane configuration, and only the query without a lane can require all of the merge buffer pool.|`arbitrary`|
+|`druid.query.scheduler.mergeBuffer.ignoreUnknownLane`|If a query has a lane but the lane cannot be found from configuration, set this to be false will make the query fail directly, while set this to be true will ignore the lane and let the query require all of the merge buffer pool just as if it is not with a lane.|`true`|
 
 ##### Prioritization strategies
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/strategy/GroupByStrategyV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/strategy/GroupByStrategyV2.java
@@ -130,10 +130,11 @@ public class GroupByStrategyV2 implements GroupByStrategy
       return new GroupByQueryResource();
     } else {
       final List<ReferenceCountingResourceHolder<ByteBuffer>> mergeBufferHolders;
+      final String lane = QueryContexts.getLane(query);
       if (QueryContexts.hasTimeout(query)) {
-        mergeBufferHolders = mergeBufferPool.takeBatch(requiredMergeBufferNum, QueryContexts.getTimeout(query));
+        mergeBufferHolders = mergeBufferPool.takeBatch(lane, requiredMergeBufferNum, QueryContexts.getTimeout(query));
       } else {
-        mergeBufferHolders = mergeBufferPool.takeBatch(requiredMergeBufferNum);
+        mergeBufferHolders = mergeBufferPool.takeBatch(lane, requiredMergeBufferNum);
       }
       if (mergeBufferHolders.isEmpty()) {
         throw QueryCapacityExceededException.withErrorMessageAndResolvedHost(

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryMergeBufferTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryMergeBufferTest.java
@@ -72,9 +72,13 @@ public class GroupByQueryMergeBufferTest extends InitializedNullHandlingTest
     }
 
     @Override
-    public List<ReferenceCountingResourceHolder<ByteBuffer>> takeBatch(final int maxElements, final long timeout)
+    public List<ReferenceCountingResourceHolder<ByteBuffer>> takeBatch(
+        final String group,
+        final int maxElements,
+        final long timeout
+    )
     {
-      final List<ReferenceCountingResourceHolder<ByteBuffer>> holder = super.takeBatch(maxElements, timeout);
+      final List<ReferenceCountingResourceHolder<ByteBuffer>> holder = super.takeBatch(group, maxElements, timeout);
       final int poolSize = getPoolSize();
       if (minRemainBufferNum > poolSize) {
         minRemainBufferNum = poolSize;

--- a/server/src/main/java/org/apache/druid/guice/QueryRunnerFactoryModule.java
+++ b/server/src/main/java/org/apache/druid/guice/QueryRunnerFactoryModule.java
@@ -46,6 +46,7 @@ import org.apache.druid.query.timeseries.TimeseriesQueryRunnerFactory;
 import org.apache.druid.query.topn.TopNQuery;
 import org.apache.druid.query.topn.TopNQueryRunnerFactory;
 import org.apache.druid.server.QueryScheduler;
+import org.apache.druid.server.QuerySchedulerConfig;
 import org.apache.druid.server.QuerySchedulerProvider;
 
 import java.util.Map;
@@ -76,7 +77,9 @@ public class QueryRunnerFactoryModule extends QueryToolChestModule
           .in(LazySingleton.class);
     binder.bind(QuerySchedulerProvider.class).in(LazySingleton.class);
     JsonConfigProvider.bind(binder, "druid.query.scheduler", QuerySchedulerProvider.class, Global.class);
-
+    binder.bind(QuerySchedulerConfig.class)
+          .to(Key.get(QuerySchedulerProvider.class, Global.class))
+          .in(LazySingleton.class);
     final MapBinder<Class<? extends Query>, QueryRunnerFactory> queryFactoryBinder = DruidBinders.queryRunnerFactoryBinder(
         binder
     );

--- a/server/src/main/java/org/apache/druid/server/QuerySchedulerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/QuerySchedulerConfig.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.server.scheduling.ArbitraryResourceScheduleStrategy;
 import org.apache.druid.server.scheduling.ManualQueryPrioritizationStrategy;
 import org.apache.druid.server.scheduling.NoQueryLaningStrategy;
 
@@ -30,6 +31,9 @@ public class QuerySchedulerConfig
 
   @JsonProperty("laning")
   private QueryLaningStrategy laningStrategy = NoQueryLaningStrategy.INSTANCE;
+
+  @JsonProperty("mergeBuffer")
+  private ResourceScheduleStrategy mergeBufferStrategy = new ArbitraryResourceScheduleStrategy();
 
   @JsonProperty("prioritization")
   private QueryPrioritizationStrategy prioritizationStrategy = ManualQueryPrioritizationStrategy.INSTANCE;
@@ -42,6 +46,11 @@ public class QuerySchedulerConfig
   public QueryLaningStrategy getLaningStrategy()
   {
     return laningStrategy;
+  }
+
+  public ResourceScheduleStrategy getMergeBufferStrategy()
+  {
+    return mergeBufferStrategy;
   }
 
   public QueryPrioritizationStrategy getPrioritizationStrategy()

--- a/server/src/main/java/org/apache/druid/server/ResourceScheduleStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/ResourceScheduleStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.query.DruidProcessingConfig;
+import org.apache.druid.server.initialization.ServerConfig;
+import org.apache.druid.server.scheduling.ArbitraryResourceScheduleStrategy;
+import org.apache.druid.server.scheduling.LaningResourceScheduleStrategy;
+
+import java.nio.ByteBuffer;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "strategy", defaultImpl = ArbitraryResourceScheduleStrategy.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "arbitrary", value = ArbitraryResourceScheduleStrategy.class),
+    @JsonSubTypes.Type(name = "lane", value = LaningResourceScheduleStrategy.class)
+})
+public interface ResourceScheduleStrategy
+{
+  BlockingPool<ByteBuffer> getMergeBufferPool(
+      ServerConfig serverConfig,
+      QuerySchedulerConfig querySchedulerConfig,
+      DruidProcessingConfig config
+  );
+}

--- a/server/src/main/java/org/apache/druid/server/scheduling/ArbitraryResourceScheduleStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ArbitraryResourceScheduleStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.scheduling;
+
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.collections.DefaultBlockingPool;
+import org.apache.druid.offheap.OffheapBufferGenerator;
+import org.apache.druid.query.DruidProcessingConfig;
+import org.apache.druid.server.QuerySchedulerConfig;
+import org.apache.druid.server.ResourceScheduleStrategy;
+import org.apache.druid.server.initialization.ServerConfig;
+
+import java.nio.ByteBuffer;
+
+public class ArbitraryResourceScheduleStrategy implements ResourceScheduleStrategy
+{
+  @Override
+  public BlockingPool<ByteBuffer> getMergeBufferPool(
+      ServerConfig serverConfig,
+      QuerySchedulerConfig querySchedulerConfig,
+      DruidProcessingConfig config
+  )
+  {
+    return new DefaultBlockingPool<>(
+        new OffheapBufferGenerator("result merging", config.intermediateComputeSizeBytes()),
+        config.getNumMergeBuffers()
+    );
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/scheduling/LaningResourceScheduleStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/LaningResourceScheduleStrategy.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.scheduling;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.collections.DefaultBlockingPool;
+import org.apache.druid.collections.ResourceGroupScheduler;
+import org.apache.druid.collections.SemaphoreResourceGroupScheduler;
+import org.apache.druid.offheap.OffheapBufferGenerator;
+import org.apache.druid.query.DruidProcessingConfig;
+import org.apache.druid.server.QueryLaningStrategy;
+import org.apache.druid.server.QuerySchedulerConfig;
+import org.apache.druid.server.ResourceScheduleStrategy;
+import org.apache.druid.server.initialization.ServerConfig;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LaningResourceScheduleStrategy implements ResourceScheduleStrategy
+{
+  private final boolean ignoreUnknownLane;
+
+  @JsonCreator
+  public LaningResourceScheduleStrategy(@JsonProperty("ignoreUnknownLane") Boolean ignoreUnknownLane)
+  {
+    this.ignoreUnknownLane = !Boolean.FALSE.equals(ignoreUnknownLane);
+  }
+
+  @Override
+  public BlockingPool<ByteBuffer> getMergeBufferPool(
+      ServerConfig serverConfig,
+      QuerySchedulerConfig querySchedulerConfig,
+      DruidProcessingConfig config
+  )
+  {
+    QueryLaningStrategy laningStrategy = querySchedulerConfig.getLaningStrategy();
+    int totalLimit = config.getNumMergeBuffers();
+    ResourceGroupScheduler laneCapacityScheduler = getResourceGroupScheduler(
+        serverConfig,
+        laningStrategy,
+        querySchedulerConfig,
+        totalLimit
+    );
+    OffheapBufferGenerator bufferGenerator = new OffheapBufferGenerator(
+        "result merging",
+        config.intermediateComputeSizeBytes()
+    );
+    return new DefaultBlockingPool<>(
+        laneCapacityScheduler,
+        bufferGenerator
+    );
+  }
+
+  private ResourceGroupScheduler getResourceGroupScheduler(
+      ServerConfig serverConfig,
+      QueryLaningStrategy laningStrategy,
+      QuerySchedulerConfig querySchedulerConfig,
+      int totalLimit
+  )
+  {
+    int serverQueryThreadCapacity;
+    if (querySchedulerConfig.getNumThreads() > 0
+        && querySchedulerConfig.getNumThreads() < serverConfig.getNumThreads()) {
+      serverQueryThreadCapacity = querySchedulerConfig.getNumThreads();
+    } else {
+      serverQueryThreadCapacity = serverConfig.getNumThreads();
+    }
+    Object2IntMap<String> serverQueryThreadPermitMap = laningStrategy.getLaneLimits(serverQueryThreadCapacity);
+    Map<String, Integer> newResourceGroupPermits = new HashMap<>();
+
+    serverQueryThreadPermitMap.forEach((group, serverQueryGroupCapacity) -> {
+      double doubleCapacityValue = (double) serverQueryGroupCapacity * totalLimit / serverQueryThreadCapacity;
+      int intCapacityValue = Math.max((int) Math.ceil(doubleCapacityValue), 1);
+      newResourceGroupPermits.put(group, intCapacityValue);
+    });
+    return new SemaphoreResourceGroupScheduler(
+        totalLimit,
+        newResourceGroupPermits,
+        ignoreUnknownLane
+    );
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/scheduling/ArbitraryResourceScheduleStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ArbitraryResourceScheduleStrategyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.scheduling;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.collections.ReferenceCountingResourceHolder;
+import org.apache.druid.common.exception.AllowedRegexErrorResponseTransformStrategy;
+import org.apache.druid.query.DruidProcessingConfig;
+import org.apache.druid.server.QueryLaningStrategy;
+import org.apache.druid.server.QuerySchedulerConfig;
+import org.apache.druid.server.initialization.ServerConfig;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.HttpMethod;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class ArbitraryResourceScheduleStrategyTest
+{
+  private BlockingPool<ByteBuffer> pool;
+
+  @Before
+  public void setup()
+  {
+    ServerConfig defaultConfig = new ServerConfig();
+    ServerConfig serverConfig = new ServerConfig(
+        200,
+        1000,
+        defaultConfig.isEnableRequestLimit(),
+        defaultConfig.getMaxIdleTime(),
+        defaultConfig.getDefaultQueryTimeout(),
+        defaultConfig.getMaxScatterGatherBytes(),
+        defaultConfig.getMaxSubqueryRows(),
+        defaultConfig.getMaxQueryTimeout(),
+        defaultConfig.getMaxRequestHeaderSize(),
+        defaultConfig.getGracefulShutdownTimeout(),
+        defaultConfig.getUnannouncePropagationDelay(),
+        defaultConfig.getInflateBufferSize(),
+        defaultConfig.getCompressionLevel(),
+        true,
+        ImmutableList.of(HttpMethod.OPTIONS),
+        true,
+        new AllowedRegexErrorResponseTransformStrategy(ImmutableList.of(".*"))
+    );
+    QuerySchedulerConfig querySchedulerConfig = new QuerySchedulerConfig()
+    {
+      @Override
+      public QueryLaningStrategy getLaningStrategy()
+      {
+        return new ManualQueryLaningStrategy(ImmutableMap.of("lane1", 50), true);
+      }
+    };
+    DruidProcessingConfig processingConfig = new DruidProcessingConfig()
+    {
+      @Override
+      public String getFormatString()
+      {
+        return null;
+      }
+
+      @Override
+      public int getNumMergeBuffersConfigured()
+      {
+        return 4;
+      }
+    };
+    pool = querySchedulerConfig.getMergeBufferStrategy()
+                               .getMergeBufferPool(serverConfig, querySchedulerConfig, processingConfig);
+  }
+
+  @Test
+  public void testTotalCapacity()
+  {
+    Assert.assertEquals(4, pool.maxSize());
+  }
+
+  @Test
+  public void testNotExistLane()
+  {
+    List<ReferenceCountingResourceHolder<ByteBuffer>> holders = pool.takeBatch("not exist", 1);
+    Assert.assertEquals(1, holders.size());
+    holders.forEach(ReferenceCountingResourceHolder::close);
+  }
+
+  @Test
+  public void testDefaultLane()
+  {
+    List<ReferenceCountingResourceHolder<ByteBuffer>> holders = pool.takeBatch(null, 1);
+    Assert.assertEquals(1, holders.size());
+    holders.forEach(ReferenceCountingResourceHolder::close);
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/scheduling/LaningResourceScheduleStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/LaningResourceScheduleStrategyTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.scheduling;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.collections.ReferenceCountingResourceHolder;
+import org.apache.druid.common.exception.AllowedRegexErrorResponseTransformStrategy;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.query.DruidProcessingConfig;
+import org.apache.druid.server.QueryLaningStrategy;
+import org.apache.druid.server.QuerySchedulerConfig;
+import org.apache.druid.server.ResourceScheduleStrategy;
+import org.apache.druid.server.initialization.ServerConfig;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.ws.rs.HttpMethod;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class LaningResourceScheduleStrategyTest
+{
+  private ResourceScheduleStrategy strategy;
+  private BlockingPool<ByteBuffer> pool;
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Before
+  public void setup()
+  {
+    this.strategy = new LaningResourceScheduleStrategy(false);
+    ServerConfig defaultConfig = new ServerConfig();
+    ServerConfig serverConfig = new ServerConfig(
+        200,
+        1000,
+        defaultConfig.isEnableRequestLimit(),
+        defaultConfig.getMaxIdleTime(),
+        defaultConfig.getDefaultQueryTimeout(),
+        defaultConfig.getMaxScatterGatherBytes(),
+        defaultConfig.getMaxSubqueryRows(),
+        defaultConfig.getMaxQueryTimeout(),
+        defaultConfig.getMaxRequestHeaderSize(),
+        defaultConfig.getGracefulShutdownTimeout(),
+        defaultConfig.getUnannouncePropagationDelay(),
+        defaultConfig.getInflateBufferSize(),
+        defaultConfig.getCompressionLevel(),
+        true,
+        ImmutableList.of(HttpMethod.OPTIONS),
+        true,
+        new AllowedRegexErrorResponseTransformStrategy(ImmutableList.of(".*"))
+    );
+    QuerySchedulerConfig querySchedulerConfig = new QuerySchedulerConfig()
+    {
+      @Override
+      public QueryLaningStrategy getLaningStrategy()
+      {
+        return new ManualQueryLaningStrategy(ImmutableMap.of("lane1", 8), false);
+      }
+
+      @Override
+      public ResourceScheduleStrategy getMergeBufferStrategy()
+      {
+        return strategy;
+      }
+
+      @Override
+      public int getNumThreads()
+      {
+        return 16;
+      }
+    };
+    DruidProcessingConfig processingConfig = new DruidProcessingConfig()
+    {
+      @Override
+      public String getFormatString()
+      {
+        return null;
+      }
+
+      @Override
+      public int getNumMergeBuffersConfigured()
+      {
+        return 4;
+      }
+
+      @Override
+      public int getNumThreadsConfigured()
+      {
+        return 8;
+      }
+    };
+    pool = strategy.getMergeBufferPool(serverConfig, querySchedulerConfig, processingConfig);
+  }
+
+  @Test
+  public void testNotExistLane()
+  {
+    exception.expect(IAE.class);
+    List<ReferenceCountingResourceHolder<ByteBuffer>> holders = pool.takeBatch("not exist", 1);
+    Assert.assertEquals(1, holders.size());
+    holders.forEach(ReferenceCountingResourceHolder::close);
+  }
+
+  @Test
+  public void testTotalCapacity()
+  {
+    Assert.assertEquals(4, pool.maxSize());
+  }
+
+  @Test
+  public void testExistLane()
+  {
+    List<ReferenceCountingResourceHolder<ByteBuffer>> holders = pool.takeBatch("lane1", 2);
+    Assert.assertEquals(2, holders.size());
+    Assert.assertTrue(pool.takeBatch("lane1", 1, 1).isEmpty());
+    holders.forEach(ReferenceCountingResourceHolder::close);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

From the proposal [Dynamic prioritization and laning #6993] raised,  there seems only the HTTP client connection limit from brokers to historicals has been solved. In this pr, I would like to add laning stragegy for the merge buffer pool on historicals and brokers.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

The idea is simple, I just limit each lane use only partial mergeBuffer pool according to the lane configuration. For example, if we use hilo laning strategy and maxLowPercent is 50%, then the low lane can only use 50% of the mergeBuffer pool, while the high can use all of it.


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

I have come to this idea when I try to use the http connection lane strategy to protect our short running queries from long running queries,  it helps but not enough. Without laning the mergeBuffers, we can only limit the http connections for the long running queries. However, if the long running connections are more than the mergeBuffers, the heavy queries will still block later group by queries, no matter they are short or long running, then blocked short running group by queries may use out of the connections, which surely block other timeseries and topn queries. On the other side, make the connections smaller than mergeBuffers may reject timeseries and topn queries directly, which do not need the mergeBuffer.

Add a laning strategy for mergeBuffer pool seems a better approach for me. I try to implement this feature and make some test on my mac. Here is result.

Test1.  priority is same and without lane strategy.

|query_type|status|query_count|cost_mean|cost_std|cost_min|cost_max|
|--------|-------|-------|--------|-------|-------|-------|
|big_groupby | fail | 9 | 120086 | 119 | 120005 | 120248|
|big_groupby | success | 1 | 61732 | 0 | 61732 | 61732|
|medium_groupby | fail | 7 | 120110 | 127 | 120004 | 120248|
|medium_groupby | success | 3 | 102166 | 10275 | 95709 | 114016|
|small_groupby | fail | 17 | 120090 | 117 | 120002 | 120247|
|small_groupby | success | 83 | 35681 | 43282 | 5314 | 119543|
|small_timeseries | fail | 6 | 120245 | 1 | 120244 | 120247|
|small_timeseries | success | 94 | 4459 | 11714 | 253 | 56474|


Test2.  heavy queries has low priority and only limit connections for heavy queries, 
the connections is more than mergeBuffers

|query_type|status|query_count|cost_mean|cost_std|cost_min|cost_max|
|--------|-----------|-------|--------|-----------|-------|-------|
|big_groupby | fail | 7 | 120080 | 119 | 120003 | 120256|
|big_groupby | success | 3 | 100590 | 14663 | 83659 | 109058|
|medium_groupby | fail | 9 | 120117 | 131 | 120002 | 120256|
|medium_groupby | success | 1 | 83373 | 0 | 83373 | 83373|
|small_groupby | fail | 11 | 120120 | 129 | 120003 | 120257|
|small_groupby | success | 89 | 48602 | 49882 | 3069 | 119887|
|small_timeseries | success | 100 | 4205 | 15012 | 271 | 103966|


Test3.  heavy queries has low priority and limit both connections and mergeBuffer capacity for heavy queries, 
the connections is more than mergeBuffers

|query_type|status|query_count|cost_mean|cost_std|cost_min|cost_max|
|--------|-----------|-------|--------|-----------|-------|-------|
|big_groupby | fail | 9 | 120096 | 132 | 120002 | 120273|
|big_groupby | success | 1 | 106489 | 0 | 106489 | 106489|
|medium_groupby | fail | 6 | 120141 | 143 | 120007 | 120276|
|medium_groupby | success | 4 | 85114 | 34123 | 37190 | 113508|
|small_groupby | success | 100 | 34663 | 9976 | 2872 | 50173|
|small_timeseries | success | 100 | 2196 | 1494 | 368 | 7309|

As you can see, all of the small group by of test3 is succeed, while test1 and test2 have some failed small  groupby queries, which are blocked by big grouby and medium groupby when requiring mergeBuffer. The cpu is also a problem as priority is same in test1, causing some timeseries queries failed.

So here comes my final approach to protect the short running queries from the long running queries, and make the throughout higher.
1. make the long running queries with low  priority, to make they acquire the cpu after short running queries, especially when scheduling the processing thread.
2. put the long running queries to low lane, and always keep some mergeBuffers for short running queries.

Besides, I have run these tests many times on my mac book, the mergeBuffer laning strategy as test3 surely makes small group by queries succeed more. But it is not that obviously when comparing how many long running queries succeed and how much time the short and long cost.  However, at most time, higher priority almost make short running queries finish faster and succeed more, and low parallelism may make more long running queries succeed as cpu competition is less. 

Here is my test parameters:
1. I use the yellow_tripdata dataset to make this test and the cost unit is millisecond. 
2. The big group by scan  two year data, the medium group by scan  one year data, and the small scan only one month data.
3. timeout is 120 seconds. 
4. historical server has 2 merge buffers, 8 processing thread and 100 http thread.
5. connections between broker and historical server is 50 
6. maxLowPercent is 50% when use hilo lane strategy, so there is only one merge buffer for heavy queries.
7. submit short running queries with 16 parallelism and 8 for long running queries

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `ResourceGroupScheduler`
 * `SemaphoreResourceGroupScheduler`
 * `DefaultBlockingPool`
 * `ResourceScheduleStrategy`
 * `LaningResourceScheduleStrategy`
 * `ArbitraryResourceScheduleStrategy`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
