### PR TITLE
suppress false positive cve

### DIFF
--- a/check_test_suite.py
+++ b/check_test_suite.py
@@ -29,7 +29,7 @@ always_run_jobs = ['license checks', '(openjdk8) packaging check', '(openjdk11) 
 ignore_prefixes = ['.github', '.idea', '.asf.yaml', '.backportrc.json', '.codecov.yml', '.dockerignore', '.gitignore',
                    '.lgtm.yml', 'CONTRIBUTING.md', 'setup-hooks.sh', 'upload.sh', 'dev', 'distribution/docker',
                    'distribution/asf-release-process-guide.md', '.travis.yml', 'check_test_suite.py',
-                   'check_test_suite_test.py']
+                   'check_test_suite_test.py', 'owasp-dependency-check-suppressions.xml']
 
 # these files are docs changes
 # if changes are limited to this set then we can skip web-console and java

--- a/check_test_suite_test.py
+++ b/check_test_suite_test.py
@@ -77,7 +77,7 @@ class CheckTestSuite(unittest.TestCase):
             ['check_test_suite_test.py'],
             ['website/core/Footer.js'],
             ['web-console/src/views/index.ts'],
-            ['check_test_suite_test.py', 'website/core/Footer.js', 'web-console/unified-console.html']
+            ['check_test_suite_test.py', 'website/core/Footer.js', 'web-console/unified-console.html', 'owasp-dependency-check-suppressions.xml']
         ]
         some_java_diffs = [
             ['core/src/main/java/org/apache/druid/math/expr/Expr.java'],

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -26,6 +26,7 @@
     <packageUrl regex="true">^pkg:maven/org\.apache\.druid/druid\-indexing\-hadoop@.*$</packageUrl>
     <cve>CVE-2012-4449</cve>
     <cve>CVE-2017-3162</cve>
+    <cve>CVE-2018-8009</cve>
   </suppress>
   <suppress>
     <!-- druid-processing.jar is mistaken for org.processing:processing -->
@@ -386,5 +387,9 @@
      ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@0.13.0$</packageUrl>
     <cve>CVE-2020-13949</cve>
+  </suppress>
+  <suppress>
+    <!-- misattributed to datasketches, actual vulnerability affects some collaboration tool called sketch -->
+    <cve>CVE-2021-40531</cve>
   </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -389,7 +389,12 @@
     <cve>CVE-2020-13949</cve>
   </suppress>
   <suppress>
-    <!-- misattributed to datasketches, actual vulnerability affects some collaboration tool called sketch -->
+    <!--
+    the scanner misattributes this to Apache DataSketches
+    the actual vulnerability affects some collaboration tool called Sketch, and impacts some 'library feeds' feature
+    which seems to relate to how the tool handles sharing designs or something, so we are doing a blanket ignore
+    because it seems nearly impossible for us to be affected by this
+     -->
     <cve>CVE-2021-40531</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
DatasSketches is getting flagged, but the CVE appears to belong to an unrelated design collaboration tool called Sketch. Also `druid-indexing-hadoop` seems to have picked up another Hadoop CVE.