### PR TITLE
Web console: fix segment timeline in Firefox

### DIFF
--- a/web-console/src/components/segment-timeline/bar-group.tsx
+++ b/web-console/src/components/segment-timeline/bar-group.tsx
@@ -52,7 +52,7 @@ export class BarGroup extends React.Component<BarGroupProps> {
 
     return dataToRender.map((entry: BarUnitData, i: number) => {
       const y0 = yScale(entry.y0 || 0) || 0;
-      const x = xScale(new Date(entry.x + 'Z'));
+      const x = xScale(new Date(entry.x + 'T00:00:00Z'));
       const y = yScale((entry.y0 || 0) + entry.y) || 0;
       const height = Math.max(y0 - y, 0);
       const barInfo: HoveredBarInfo = {


### PR DESCRIPTION
Fixes issue with segment timeline not rendering correctly in Firefox due to Firefox not being ok parsing `new Date('2017-09-01Z')` while Chrome is fine with it.

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
