### PR TITLE
[Backport] Web console: fix segment timeline in Firefox

### DIFF
--- a/web-console/src/components/segment-timeline/bar-group.tsx
+++ b/web-console/src/components/segment-timeline/bar-group.tsx
@@ -52,7 +52,7 @@ export class BarGroup extends React.Component<BarGroupProps> {
 
     return dataToRender.map((entry: BarUnitData, i: number) => {
       const y0 = yScale(entry.y0 || 0) || 0;
-      const x = xScale(new Date(entry.x + 'Z'));
+      const x = xScale(new Date(entry.x + 'T00:00:00Z'));
       const y = yScale((entry.y0 || 0) + entry.y) || 0;
       const height = Math.max(y0 - y, 0);
       const barInfo: HoveredBarInfo = {


### PR DESCRIPTION
Backport of #11701 to 0.22.0.