### PR TITLE
dependency check with inherit instead of aggregate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -725,7 +725,7 @@ jobs:
       stage: cron
       install: skip
       script: |-
-        ${MVN} dependency-check:purge dependency-check:aggregate -pl '!integration-tests' || { echo "
+        ${MVN} dependency-check:purge dependency-check:check || { echo "
 
         The OWASP dependency check has found security vulnerabilities. Please use a newer version
         of the dependency that does not have vulnerabilities. To see a report run

--- a/pom.xml
+++ b/pom.xml
@@ -1493,7 +1493,6 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>6.0.3</version>
-                <inherited>false</inherited>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
@@ -1505,9 +1504,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>aggregate</goal>
-                        </goals>
                         <phase>none</phase>  <!-- TODO: Consider enabling so part of dev flow instead of just CI -->
                     </execution>
                 </executions>


### PR DESCRIPTION
I'm having some trouble building release artifacts due to the dependency check failing because it tries to find CVE in `druid-integration-tests` (which is unnecessary). This is just undoing the change to use `aggregate` from #10883 and switching back to using inheritance so that benchmarks/distribution/integration-tests are all skipped.

Hopefully the cron job isn't too flaky this way...