### PR TITLE
Avoid primary key violation in segment tables under certain conditions when appending data to same interval

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -958,7 +958,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
       @Nullable final String versionOfExistingChunks;
       if (!existingChunks.isEmpty()) {
         versionOfExistingChunks = existingChunks.get(0).getVersion();
-      } else if (!segmentsForMaxId.isEmpty()) {
+      } else if (!segmentsForMaxId.isEmpty() && maxId != null) {
         versionOfExistingChunks = maxId.getVersion();
       } else {
         versionOfExistingChunks = null;

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -843,15 +843,30 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
           .execute();
   }
 
+  /**
+   * This function creates a new segment for the given datasource/interval/etc. A critical
+   * aspect of the creation is to make sure that the new version & new partition number will make
+   * sense given the existing segments & pending segments also very important is to avoid
+   * clashes with existing pending & used/unused segments.
+   * @param handle Database handle
+   * @param dataSource datasource for the new segment
+   * @param interval interval for the new segment
+   * @param partialShardSpec Shard spec info minus segment id stuff
+   * @param existingVersion Version of segments in interval, used to compute the version of the very first segment in
+   *                        interval
+   * @return
+   * @throws IOException
+   */
   @Nullable
   private SegmentIdWithShardSpec createNewSegment(
       final Handle handle,
       final String dataSource,
       final Interval interval,
       final PartialShardSpec partialShardSpec,
-      final String maxVersion
+      final String existingVersion
   ) throws IOException
   {
+    // Get the time chunk and associated data segments for the given interval, if any
     final List<TimelineObjectHolder<String, DataSegment>> existingChunks = getTimelineForIntervalsWithHandle(
         handle,
         dataSource,
@@ -884,36 +899,43 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
             // See PartitionIds.
             .filter(segment -> segment.getShardSpec().sharePartitionSpace(partialShardSpec))) {
           // Don't use the stream API for performance.
+          // Note that this will compute the max id of existing, visible, data segments in the time chunk:
           if (maxId == null || maxId.getShardSpec().getPartitionNum() < segment.getShardSpec().getPartitionNum()) {
             maxId = SegmentIdWithShardSpec.fromDataSegment(segment);
           }
         }
       }
 
+      // Get the version of the existing chunk, we might need it in some of the cases below
+      // to compute the new identifier's version
+      @Nullable
+      final String versionOfExistingChunk;
+      if (!existingChunks.isEmpty()) {
+        // remember only one chunk possible for given interval so get the first & only one
+        versionOfExistingChunk = existingChunks.get(0).getVersion();
+      } else {
+        versionOfExistingChunk = null;
+      }
+
+      // next, we need to enrich the maxId computed before with the information of the pending segments
+      // it is possible that a pending segment has a higher id in which case we need that, it will work,
+      // and it will avoid clashes when inserting the new pending segment later in the caller of this method
       final Set<SegmentIdWithShardSpec> pendings = getPendingSegmentsForIntervalWithHandle(
           handle,
           dataSource,
           interval
       );
-
+      // Make sure we add the maxId we obtained from the segments table:
       if (maxId != null) {
         pendings.add(maxId);
       }
-
-      @Nullable
-      final String versionOfExistingChunks;
-      if (!existingChunks.isEmpty()) {
-        versionOfExistingChunks = existingChunks.get(0).getVersion();
-      } else {
-        versionOfExistingChunks = null;
-      }
-
-      // the versionOfExistingChunks filter is ensure that we pick the max id with the version of the existing chunk
+      //  Now compute the maxId with all the information: pendings + segments:
+      // The versionOfExistingChunks filter is ensure that we pick the max id with the version of the existing chunk
       // in the case that there may be a pending segment with a higher version but no corresponding used segments
       // which may generate a clash with an existing segment once the new id is generated
       maxId = pendings.stream()
                       .filter(id -> id.getShardSpec().sharePartitionSpace(partialShardSpec))
-                      .filter(id -> versionOfExistingChunks == null ? true : id.getVersion().equals(versionOfExistingChunks))
+                      .filter(id -> versionOfExistingChunk == null ? true : id.getVersion().equals(versionOfExistingChunk))
                       .max((id1, id2) -> {
                         final int versionCompare = id1.getVersion().compareTo(id2.getVersion());
                         if (versionCompare != 0) {
@@ -927,38 +949,44 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
                       })
                       .orElse(null);
 
-      // Find the major version of existing segments
-      final String majorVersion;
-      if (versionOfExistingChunks != null) {
-        majorVersion = versionOfExistingChunks;
+      // The following code attempts to compute the new version, if this
+      // new version is not null at the end of next block then it will be
+      // used as the new version in the case for initial or appended segment
+      final String newSegmentVersion;
+      if (versionOfExistingChunk != null) {
+        // segment version overrides, so pick that now that we know it exists
+        newSegmentVersion = versionOfExistingChunk;
       } else if (!pendings.isEmpty() && maxId != null) {
-        majorVersion = maxId.getVersion();
+        // there is no visible segments in the time chunk, so pick the maxId of pendings, as computed above
+        newSegmentVersion = maxId.getVersion();
       } else {
-        majorVersion = null;
+        // no segments, no pendings, so this must be the very first segment created for this interval
+        newSegmentVersion = null;
       }
 
       if (maxId == null) {
+        // When appending segments, null maxId means that we are allocating the very initial
+        // segment for this time chunk.
         // This code is executed when the Overlord coordinates segment allocation, which is either you append segments
-        // or you use segment lock. When appending segments, null maxId means that we are allocating the very initial
-        // segment for this time chunk. Since the core partitions set is not determined for appended segments, we set
+        // or you use segment lock. Since the core partitions set is not determined for appended segments, we set
         // it 0. When you use segment lock, the core partitions set doesn't work with it. We simply set it 0 so that the
         // OvershadowableManager handles the atomic segment update.
         final int newPartitionId = partialShardSpec.useNonRootGenerationPartitionSpace()
                                    ? PartitionIds.NON_ROOT_GEN_START_PARTITION_ID
                                    : PartitionIds.ROOT_GEN_START_PARTITION_ID;
-        String version = majorVersion == null ? maxVersion : majorVersion;
+        String version = newSegmentVersion == null ? existingVersion : newSegmentVersion;
         return new SegmentIdWithShardSpec(
             dataSource,
             interval,
             version,
             partialShardSpec.complete(jsonMapper, newPartitionId, 0)
         );
-      } else if (!maxId.getInterval().equals(interval) || maxId.getVersion().compareTo(maxVersion) > 0) {
+      } else if (!maxId.getInterval().equals(interval) || maxId.getVersion().compareTo(existingVersion) > 0) {
         log.warn(
-            "Cannot allocate new segment for dataSource[%s], interval[%s], maxVersion[%s]: conflicting segment[%s].",
+            "Cannot allocate new segment for dataSource[%s], interval[%s], existingVersion[%s]: conflicting segment[%s].",
             dataSource,
             interval,
-            maxVersion,
+            existingVersion,
             maxId
         );
         return null;
@@ -973,7 +1001,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
         return new SegmentIdWithShardSpec(
             dataSource,
             maxId.getInterval(),
-            Preconditions.checkNotNull(majorVersion, "majorVersion"),
+            Preconditions.checkNotNull(newSegmentVersion, "newSegmentVersion"),
             partialShardSpec.complete(
                 jsonMapper,
                 maxId.getShardSpec().getPartitionNum() + 1,

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
@@ -383,7 +383,7 @@ public abstract class BaseAppenderatorDriver implements Closeable
    * @param sequenceName             sequenceName for this row's segment
    * @param committerSupplier        supplier of a committer associated with all data that has been added, including this row
    *                                 if {@param allowIncrementalPersists} is set to false then this will not be used
-   * @param skipSegmentLineageCheck  if true, perform lineage validation using previousSegmentId for this sequence.
+   * @param skipSegmentLineageCheck  if false, perform lineage validation using previousSegmentId for this sequence.
    *                                 Should be set to false if replica tasks would index events in same order
    * @param allowIncrementalPersists whether to allow persist to happen when maxRowsInMemory or intermediate persist period
    *                                 threshold is hit

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SegmentAllocator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SegmentAllocator.java
@@ -37,7 +37,7 @@ public interface SegmentAllocator
    *                                When skipSegmentLineageCheck is false, this can be null if it is the first call
    *                                for the same sequenceName.
    *                                When skipSegmentLineageCheck is true, this will be ignored.
-   * @param skipSegmentLineageCheck if true, perform lineage validation using previousSegmentId for this sequence.
+   * @param skipSegmentLineageCheck if false, perform lineage validation using previousSegmentId for this sequence.
    *                                Should be set to false if replica tasks would index events in same order
    *
    * @return the pending segment identifier, or null if it was impossible to allocate a new segment

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
@@ -167,8 +167,10 @@ public class StreamAppenderatorDriver extends BaseAppenderatorDriver
    * @param sequenceName             sequenceName for this row's segment
    * @param committerSupplier        supplier of a committer associated with all data that has been added, including this row
    *                                 if {@param allowIncrementalPersists} is set to false then this will not be used
-   * @param skipSegmentLineageCheck  if true, perform lineage validation using previousSegmentId for this sequence.
-   *                                 Should be set to false if replica tasks would index events in same order
+   * @param skipSegmentLineageCheck  Should be set {@code false} to perform lineage validation using previousSegmentId for this sequence.
+   *                                 Note that for Kafka Streams we should disable this check and set this parameter to
+   *                                 {@code true}.
+   *                                 if {@code true}, skips, does not enforce, lineage validation.
    * @param allowIncrementalPersists whether to allow persist to happen when maxRowsInMemory or intermediate persist period
    *                                 threshold is hit
    *


### PR DESCRIPTION
Fix issue of duplicate key  under certain conditions when loading late data in streaming. Also fixes a documentation issue with skipSegmentLineageCheck.

<hr>
Scope: the scope is preventing primary key violations in the pending segments and segments table as a result of
normal Druid operation and API actions. Another permitted operation within scope is reverting compaction/overwrite
by dropping the compacted segment (i.e. killing the compacted segment id allowing for previously overshadowed segments to become available again). This fix covers the existing issue (see repro below) and makes some effort to cover other potential uses. However, the coordinator API is pretty liberal to what can be done to segment table state so more issues might 
still be lurking.
<hr>

<hr>
##### Key changed/added classes in this PR
 * `IndexerSQLMetadataStorageCoordinator`
<hr>

<hr>

You can reproduce this bug as follows:

States:

1) Append wiki three times:
Pending: A, A_1,A_2
Used Segments: A, A_1, A_2
Unused:

2) Compact:
Pending: A, A_1,A_2
Used Segments: A, A_1, A_2, B <- A_* are overshadowed by B!, will be marked as unused later by the coordinator when it notices this
Unused:

3) One more append:
Pending: A, A_1,A_2, B_1
Used Segments: B, B_1
Unused: A, A_1, A_2,  <- Coordinator marked them as unused since they were overshadowed by B

4) Mark all segments as unused (directly on web console or using coordinator using HTTP API)
Pending: A, A_1,A_2, B_1
Used Segments: 
Unused: A, A_1, A_2,  B, B_1

5) One more append
Current algorithm in IndexerSQLMetadataStorageCoordinator#createNewSegment will pick the version and partition num of new segment id as follows:
Version = version of first segment in pending for the datasource/interval: A
Partition num = partition num of max_id  + 1
Where max_id is the max id of the used and pending segments, since there are no used then it will be max of pending which is B_1 thus partnum is 1 + 1 = 2
Therefore final id returned will be A_2, then later on this id needs to be inserted in pending which clashes with existing id so bug!

Then in after last step above you should get something like the following in the overlord logs:
<code>
Caused by: org.apache.derby.shared.common.error.DerbySQLIntegrityConstraintViolationException: The statement was aborted because it would have caused a duplicate key value in a unique or primary key constraint or unique index identified by 'SQL210921173037040' defined on 'DRUID_PENDINGSEGMENTS'.
	at org.apache.derby.client.am.SQLExceptionFactory.getSQLException(Unknown Source) ~[derbyclient-10.14.2.0.jar:?]
	at org.apache.derby.client.am.SqlException.getSQLException(Unknown Source) ~[derbyclient-10.14.2.0.jar:?]
	at org.apache.derby.client.am.ClientPreparedStatement.execute(Unknown Source) ~[derbyclient-10.14.2.0.jar:?]
	at org.apache.commons.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:198) ~[commons-dbcp2-2.0.1.jar:2.0.1]
	at org.apache.commons.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:198) ~[commons-dbcp2-2.0.1.jar:2.0.1]
	at org.skife.jdbi.v2.SQLStatement.internalExecute(SQLStatement.java:1328) ~[jdbi-2.63.1.jar:2.63.1]
	at org.skife.jdbi.v2.Update.execute(Update.java:56) ~[jdbi-2.63.1.jar:2.63.1]
	at org.apache.druid.metadata.IndexerSQLMetadataStorageCoordinator.insertToMetastore(IndexerSQLMetadataStorageCoordinator.java:843) ~[druid-server-2021.09.0-iap-SNAPSHOT.jar:2021.09.0-iap-SNAPSHOT]
	at org.apache.druid.metadata.IndexerSQLMetadataStorageCoordinator.allocatePendingSegmentWithSegmentLineageCheck(IndexerSQLMetadataStorageCoordinator.java:656) ~[druid-server-2021.09.0-iap-SNAPSHOT.jar:2021.09.0-iap-SNAPSHOT]
	at org.apache.druid.metadata.IndexerSQLMetadataStorageCoordinator.lambda$allocatePendingSegment$8(IndexerSQLMetadataStorageCoordinator.java:579) ~[druid-server-2021.09.0-iap-SNAPSHOT.jar:2021.09.0-iap-SNAPSHOT]
	at org.skife.jdbi.v2.DBI.withHandle(DBI.java:281) ~[jdbi-2.63.1.jar:2.63.1]
	... 96 more
</code>

<hr>
<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X ] been tested in a test Druid cluster.
