### PR TITLE
Suppress stacktrace of InterruptedException in CommonCacheNotifier

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
@@ -141,9 +141,7 @@ public class CommonCacheNotifier
               LOG.debug(callerName + ":Received responses for cache update notifications.");
             }
             catch (InterruptedException e) {
-              LOG.noStackTrace()
-                 .makeAlert(e, callerName + ":Interrupted while handling updates for cachedUserMaps.")
-                 .emit();
+              LOG.info(e, "%s: Interrupted while handling updates for cachedUserMaps.", callerName);
             }
             catch (Throwable t) {
               LOG.makeAlert(t, callerName + ":Error occured while handling updates for cachedUserMaps.").emit();

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
@@ -140,6 +140,11 @@ public class CommonCacheNotifier
 
               LOG.debug(callerName + ":Received responses for cache update notifications.");
             }
+            catch (InterruptedException e) {
+              LOG.noStackTrace()
+                 .makeAlert(e, callerName + ":Interrupted while handling updates for cachedUserMaps.")
+                 .emit();
+            }
             catch (Throwable t) {
               LOG.makeAlert(t, callerName + ":Error occured while handling updates for cachedUserMaps.").emit();
             }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
@@ -141,7 +141,7 @@ public class CommonCacheNotifier
               LOG.debug(callerName + ":Received responses for cache update notifications.");
             }
             catch (InterruptedException e) {
-              LOG.info(e, "%s: Interrupted while handling updates for cachedUserMaps.", callerName);
+              LOG.noStackTrace().info(e, "%s: Interrupted while handling updates for cachedUserMaps.", callerName);
             }
             catch (Throwable t) {
               LOG.makeAlert(t, callerName + ":Error occured while handling updates for cachedUserMaps.").emit();


### PR DESCRIPTION
Addresses #10709

### Description

When `CommonCachedNotifier` is being stopped while the thread is waiting on `updateQueue.take()`,
an InterruptedException is thrown. The stack trace from this exception gives the wrong idea that something went wrong with the shutdown.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
