### PR TITLE
Fix router documentation for `druid.router.sql.enable`

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2054,7 +2054,7 @@ Supported query contexts:
 |`druid.router.tierToBrokerMap`|Queries for a certain tier of data are routed to their appropriate Broker. This value should be an ordered JSON map of tiers to Broker names. The priority of Brokers is based on the ordering.|{"_default_tier": "<defaultBrokerServiceName>"}|
 |`druid.router.defaultRule`|The default rule for all datasources.|"_default"|
 |`druid.router.pollPeriod`|How often to poll for new rules.|PT1M|
-|`druid.router.sql.enable`|Enable routing of SQL queries. Possible values are `true` and `false`. When set to `true`, the Router uses the provided strategies to determine the broker service for a given SQL query.|`false`|
+|`druid.router.sql.enable`|Enable routing of SQL queries using strategies. Possible values are `true` and `false`. When set to `true`, the Router uses the provided strategies to determine the broker service for a given SQL query.|`false`|
 |`druid.router.strategies`|Please see [Router Strategies](../design/router.md#router-strategies) for details.|[{"type":"timeBoundary"},{"type":"priority"}]|
 |`druid.router.avatica.balancer.type`|Class to use for balancing Avatica queries across Brokers. Please see [Avatica Query Balancing](../design/router.md#avatica-query-balancing).|rendezvousHash|
 |`druid.router.managementProxy.enabled`|Enables the Router's [management proxy](../design/router.md#router-as-management-proxy) functionality.|false|

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2054,7 +2054,7 @@ Supported query contexts:
 |`druid.router.tierToBrokerMap`|Queries for a certain tier of data are routed to their appropriate Broker. This value should be an ordered JSON map of tiers to Broker names. The priority of Brokers is based on the ordering.|{"_default_tier": "<defaultBrokerServiceName>"}|
 |`druid.router.defaultRule`|The default rule for all datasources.|"_default"|
 |`druid.router.pollPeriod`|How often to poll for new rules.|PT1M|
-|`druid.router.sql.enable`|Enable routing of SQL queries using strategies. Possible values are `true` and `false`. When set to `true`, the Router uses the provided strategies to determine the broker service for a given SQL query. When set to `false`, the Router uses the `defaultBrokerServiceName`.|`false`|
+|`druid.router.sql.enable`|Enable routing of SQL queries using strategies. When`true`, the Router uses the  strategies defined in `druid.router.strategies` to determine the broker service for a given SQL query. When `false`, the Router uses the `defaultBrokerServiceName`.|`false`|
 |`druid.router.strategies`|Please see [Router Strategies](../design/router.md#router-strategies) for details.|[{"type":"timeBoundary"},{"type":"priority"}]|
 |`druid.router.avatica.balancer.type`|Class to use for balancing Avatica queries across Brokers. Please see [Avatica Query Balancing](../design/router.md#avatica-query-balancing).|rendezvousHash|
 |`druid.router.managementProxy.enabled`|Enables the Router's [management proxy](../design/router.md#router-as-management-proxy) functionality.|false|

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2054,7 +2054,7 @@ Supported query contexts:
 |`druid.router.tierToBrokerMap`|Queries for a certain tier of data are routed to their appropriate Broker. This value should be an ordered JSON map of tiers to Broker names. The priority of Brokers is based on the ordering.|{"_default_tier": "<defaultBrokerServiceName>"}|
 |`druid.router.defaultRule`|The default rule for all datasources.|"_default"|
 |`druid.router.pollPeriod`|How often to poll for new rules.|PT1M|
-|`druid.router.sql.enable`|Enable routing of SQL queries using strategies. Possible values are `true` and `false`. When set to `true`, the Router uses the provided strategies to determine the broker service for a given SQL query.|`false`|
+|`druid.router.sql.enable`|Enable routing of SQL queries using strategies. Possible values are `true` and `false`. When set to `true`, the Router uses the provided strategies to determine the broker service for a given SQL query. When set to `false`, the Router uses the `defaultBrokerServiceName`.|`false`|
 |`druid.router.strategies`|Please see [Router Strategies](../design/router.md#router-strategies) for details.|[{"type":"timeBoundary"},{"type":"priority"}]|
 |`druid.router.avatica.balancer.type`|Class to use for balancing Avatica queries across Brokers. Please see [Avatica Query Balancing](../design/router.md#avatica-query-balancing).|rendezvousHash|
 |`druid.router.managementProxy.enabled`|Enables the Router's [management proxy](../design/router.md#router-as-management-proxy) functionality.|false|

--- a/docs/design/router.md
+++ b/docs/design/router.md
@@ -138,7 +138,7 @@ Allows defining arbitrary routing rules using a JavaScript function. The functio
 
 > JavaScript-based functionality is disabled by default. Please refer to the Druid [JavaScript programming guide](../development/javascript.md) for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 
-### Routing of SQL queries using Strategies
+### Routing of SQL queries using strategies
 
 To enable routing of SQL queries using strategies, set `druid.router.sql.enable` to `true`. The broker service for a
 given SQL query is resolved using only the provided Router strategies. If not resolved using any of the strategies, the
@@ -147,9 +147,9 @@ first tries to resolve the broker service using strategies, then load rules and 
 if still not resolved. When `druid.router.sql.enable` is set to `false` (default value), the Router uses the
 `defaultBrokerServiceName`.
 
-Setting `druid.router.sql.enable` does not affect either Avatica JDBC requests or Native Queries.
-Native queries are always routed using strategies and load rules as explained above.
-Avatica JDBC requests are always routed based on connection ID as explained in the next section.
+Setting `druid.router.sql.enable` does not affect either Avatica JDBC requests or native queries.
+Druid always routes native queries using the strategies and load rules as documented.
+Druid always routes Avatica JDBC requests based on connection ID.
 
 ### Avatica query balancing
 

--- a/docs/design/router.md
+++ b/docs/design/router.md
@@ -138,18 +138,17 @@ Allows defining arbitrary routing rules using a JavaScript function. The functio
 
 > JavaScript-based functionality is disabled by default. Please refer to the Druid [JavaScript programming guide](../development/javascript.md) for guidelines about using Druid's JavaScript functionality, including instructions on how to enable it.
 
-### Routing of SQL queries
+### Routing of SQL queries using Strategies
 
-To enable routing of SQL queries, set `druid.router.sql.enable` to `true` (`false` by default). The broker service for a
+To enable routing of SQL queries using strategies, set `druid.router.sql.enable` to `true` (`false` by default). The broker service for a
 given SQL query is resolved using only the provided Router strategies. If not resolved using any of the strategies, the
 Router uses the `defaultBrokerServiceName`. This behavior is slightly different from native queries where the Router
 first tries to resolve the broker service using strategies, then load rules and finally using the `defaultBrokerServiceName`
 if still not resolved.
 
-Routing of native queries is always enabled.
-
-Setting `druid.router.sql.enable` does not affect Avatica JDBC requests. They are routed based on connection ID as
-explained in the next section.
+Setting `druid.router.sql.enable` does not affect either Avatica JDBC requests or Native Queries.
+Native queries are always routed using strategies and load rules as explained above.
+Avatica JDBC requests are always routed based on connection ID as explained in the next section.
 
 ### Avatica query balancing
 

--- a/docs/design/router.md
+++ b/docs/design/router.md
@@ -140,11 +140,12 @@ Allows defining arbitrary routing rules using a JavaScript function. The functio
 
 ### Routing of SQL queries using Strategies
 
-To enable routing of SQL queries using strategies, set `druid.router.sql.enable` to `true` (`false` by default). The broker service for a
+To enable routing of SQL queries using strategies, set `druid.router.sql.enable` to `true`. The broker service for a
 given SQL query is resolved using only the provided Router strategies. If not resolved using any of the strategies, the
 Router uses the `defaultBrokerServiceName`. This behavior is slightly different from native queries where the Router
 first tries to resolve the broker service using strategies, then load rules and finally using the `defaultBrokerServiceName`
-if still not resolved.
+if still not resolved. When `druid.router.sql.enable` is set to `false` (default value), the Router uses the
+`defaultBrokerServiceName`.
 
 Setting `druid.router.sql.enable` does not affect either Avatica JDBC requests or Native Queries.
 Native queries are always routed using strategies and load rules as explained above.

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -130,7 +130,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   private final AuthenticatorMapper authenticatorMapper;
   private final ProtobufTranslation protobufTranslation;
 
-  private final boolean routeSqlQueries;
+  private final boolean routeSqlByStrategy;
 
   private HttpClient broadcastClient;
 
@@ -160,7 +160,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     this.queryMetricsFactory = queryMetricsFactory;
     this.authenticatorMapper = authenticatorMapper;
     this.protobufTranslation = new ProtobufTranslationImpl();
-    this.routeSqlQueries = Boolean.parseBoolean(
+    this.routeSqlByStrategy = Boolean.parseBoolean(
         properties.getProperty(PROPERTY_SQL_ENABLE, PROPERTY_SQL_ENABLE_DEFAULT)
     );
   }
@@ -254,7 +254,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         handleException(response, objectMapper, e);
         return;
       }
-    } else if (routeSqlQueries && isSqlQueryEndpoint && HttpMethod.POST.is(method)) {
+    } else if (routeSqlByStrategy && isSqlQueryEndpoint && HttpMethod.POST.is(method)) {
       try {
         SqlQuery inputSqlQuery = objectMapper.readValue(request.getInputStream(), SqlQuery.class);
         request.setAttribute(SQL_QUERY_ATTRIBUTE, inputSqlQuery);


### PR DESCRIPTION
### Changes
- Rename field `AsyncQueryForwardingServlet.routeSqlQueries` to `routeSqlByStrategy`
- Fix router documentation to remove ambiguity

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
