### PR TITLE
[WIP] Require Datasource WRITE authorization for Supervisor and Task access

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -531,7 +531,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
       @Context final HttpServletRequest req
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     Map<String, Object> returnMap = new HashMap<>();
     Map<String, Object> totalsMap = new HashMap<>();
     Map<String, Object> averagesMap = new HashMap<>();
@@ -557,7 +557,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
       @Context final HttpServletRequest req
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     List<String> events = IndexTaskUtils.getMessagesFromSavedParseExceptions(
         parseExceptionHandler.getSavedParseExceptions()
     );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -634,7 +634,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
       @QueryParam("windows") List<Integer> windows
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     Map<String, Object> returnMap = new HashMap<>();
     Map<String, Object> totalsMap = new HashMap<>();
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -285,7 +285,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     return Response.ok(doGetUnparseableEvents(full)).build();
   }
 
@@ -394,7 +394,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     return Response.ok(doGetRowStats(full)).build();
   }
 
@@ -406,7 +406,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     Map<String, Object> returnMap = new HashMap<>();
     Map<String, Object> ingestionStatsAndErrors = new HashMap<>();
     Map<String, Object> payload = new HashMap<>();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1175,7 +1175,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       @Context final HttpServletRequest req
   )
   {
-    ChatHandlers.authorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
 
     if (toolbox == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1254,12 +1254,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       @Context final HttpServletRequest req
   )
   {
-    ChatHandlers.authorizationCheck(
-        req,
-        Action.WRITE,
-        getDataSource(),
-        authorizerMapper
-    );
+    datasourceWriteAuthCheck(req);
     if (currentSubTaskHolder == null || currentSubTaskHolder.getTask() == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
     } else {
@@ -1277,7 +1272,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getMode(@Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     return Response.ok(isParallelMode() ? "parallel" : "sequential").build();
   }
 
@@ -1286,7 +1281,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getPhaseName(@Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     if (isParallelMode()) {
       final ParallelIndexTaskRunner runner = getCurrentRunner();
       if (runner == null) {
@@ -1304,7 +1299,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getProgress(@Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1318,7 +1313,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getRunningTasks(@Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1332,7 +1327,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getSubTaskSpecs(@Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1346,7 +1341,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getRunningSubTaskSpecs(@Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1360,7 +1355,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getCompleteSubTaskSpecs(@Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1374,7 +1369,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getSubTaskSpec(@PathParam("id") String id, @Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
 
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
@@ -1394,7 +1389,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Produces(MediaType.APPLICATION_JSON)
   public Response getSubTaskState(@PathParam("id") String id, @Context final HttpServletRequest req)
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1416,7 +1411,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       @Context final HttpServletRequest req
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     final ParallelIndexTaskRunner currentRunner = getCurrentRunner();
     if (currentRunner == null) {
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("task is not running yet").build();
@@ -1568,7 +1563,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
     return Response.ok(doGetRowStatsAndUnparseableEvents(full, false).lhs).build();
   }
 
@@ -1613,8 +1608,16 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    datasourceWriteAuthCheck(req);
 
     return Response.ok(doGetLiveReports(full)).build();
+  }
+
+  /**
+   * Checks if the User has Datasource WRITE authorization on this datasource.
+   */
+  private void datasourceWriteAuthCheck(HttpServletRequest request)
+  {
+    IndexTaskUtils.datasourceAuthorizationCheck(request, Action.WRITE, getDataSource(), authorizerMapper);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -488,7 +488,7 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     Map<String, List<String>> events = new HashMap<>();
 
     boolean needsBuildSegments = false;
@@ -563,7 +563,7 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     return Response.ok(doGetRowStats(full)).build();
   }
 
@@ -595,7 +595,7 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
       @QueryParam("full") String full
   )
   {
-    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.READ, getDataSource(), authorizerMapper);
+    IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, getDataSource(), authorizerMapper);
     return Response.ok(doGetLiveReports(full)).build();
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
 @Path("/druid/indexer/v1/supervisor")
 public class SupervisorResource
 {
-  private static final Function<VersionedSupervisorSpec, Iterable<ResourceAction>> SPEC_DATASOURCE_READ_RA_GENERATOR =
+  private static final Function<VersionedSupervisorSpec, Iterable<ResourceAction>> SPEC_DATASOURCE_WRITE_RA_GENERATOR =
       supervisorSpec -> {
         if (supervisorSpec.getSpec() == null) {
           return null;
@@ -75,7 +75,7 @@ public class SupervisorResource
         }
         return Iterables.transform(
             supervisorSpec.getSpec().getDataSources(),
-            AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR
+            AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR
         );
       };
 
@@ -376,7 +376,7 @@ public class SupervisorResource
             AuthorizationUtils.filterAuthorizedResources(
                 req,
                 manager.getSupervisorHistory(),
-                SPEC_DATASOURCE_READ_RA_GENERATOR,
+                SPEC_DATASOURCE_WRITE_RA_GENERATOR,
                 authorizerMapper
             )
         ).build()
@@ -401,7 +401,7 @@ public class SupervisorResource
                     AuthorizationUtils.filterAuthorizedResources(
                         req,
                         historyForId,
-                        SPEC_DATASOURCE_READ_RA_GENERATOR,
+                        SPEC_DATASOURCE_WRITE_RA_GENERATOR,
                         authorizerMapper
                     )
                 );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1354,9 +1354,9 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
    *
    * @return authorization result
    */
-  private Access authorizationCheck(final HttpServletRequest req, Action action)
+  private Access datasourceWriteAuthCheck(final HttpServletRequest req)
   {
-    return IndexTaskUtils.datasourceAuthorizationCheck(req, action, task.getDataSource(), authorizerMapper);
+    return IndexTaskUtils.datasourceAuthorizationCheck(req, Action.WRITE, task.getDataSource(), authorizerMapper);
   }
 
   public Appenderator getAppenderator()
@@ -1433,7 +1433,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   @Path("/stop")
   public Response stop(@Context final HttpServletRequest req)
   {
-    authorizationCheck(req, Action.WRITE);
+    datasourceWriteAuthCheck(req);
     stopGracefully();
     return Response.status(Response.Status.OK).build();
   }
@@ -1443,7 +1443,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   @Produces(MediaType.APPLICATION_JSON)
   public Status getStatusHTTP(@Context final HttpServletRequest req)
   {
-    authorizationCheck(req, Action.READ);
+    datasourceWriteAuthCheck(req);
     return status;
   }
 
@@ -1458,7 +1458,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   @Produces(MediaType.APPLICATION_JSON)
   public Map<PartitionIdType, SequenceOffsetType> getCurrentOffsets(@Context final HttpServletRequest req)
   {
-    authorizationCheck(req, Action.READ);
+    datasourceWriteAuthCheck(req);
     return getCurrentOffsets();
   }
 
@@ -1472,7 +1472,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   @Produces(MediaType.APPLICATION_JSON)
   public Map<PartitionIdType, SequenceOffsetType> getEndOffsetsHTTP(@Context final HttpServletRequest req)
   {
-    authorizationCheck(req, Action.READ);
+    datasourceWriteAuthCheck(req);
     return getEndOffsets();
   }
 
@@ -1492,7 +1492,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
       @Context final HttpServletRequest req
   ) throws InterruptedException
   {
-    authorizationCheck(req, Action.WRITE);
+    datasourceWriteAuthCheck(req);
     return setEndOffsets(sequences, finish);
   }
 
@@ -1542,7 +1542,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
       @Context final HttpServletRequest req
   )
   {
-    authorizationCheck(req, Action.READ);
+    datasourceWriteAuthCheck(req);
     return Response.ok(doGetRowStats()).build();
   }
 
@@ -1553,7 +1553,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
       @Context final HttpServletRequest req
   )
   {
-    authorizationCheck(req, Action.READ);
+    datasourceWriteAuthCheck(req);
     return Response.ok(doGetLiveReports()).build();
   }
 
@@ -1565,7 +1565,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
       @Context final HttpServletRequest req
   )
   {
-    authorizationCheck(req, Action.READ);
+    datasourceWriteAuthCheck(req);
     List<String> events = IndexTaskUtils.getMessagesFromSavedParseExceptions(
         parseExceptionHandler.getSavedParseExceptions()
     );
@@ -1716,7 +1716,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
       @Context final HttpServletRequest req
   )
   {
-    authorizationCheck(req, Action.READ);
+    datasourceWriteAuthCheck(req);
     return getCheckpoints();
   }
 
@@ -1743,7 +1743,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
       @Context final HttpServletRequest req
   ) throws InterruptedException
   {
-    authorizationCheck(req, Action.WRITE);
+    datasourceWriteAuthCheck(req);
     return pause();
   }
 
@@ -1798,7 +1798,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   @Path("/resume")
   public Response resumeHTTP(@Context final HttpServletRequest req) throws InterruptedException
   {
-    authorizationCheck(req, Action.WRITE);
+    datasourceWriteAuthCheck(req);
     resume();
     return Response.status(Response.Status.OK).build();
   }
@@ -1831,7 +1831,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   @Produces(MediaType.APPLICATION_JSON)
   public DateTime getStartTime(@Context final HttpServletRequest req)
   {
-    authorizationCheck(req, Action.WRITE);
+    datasourceWriteAuthCheck(req);
     return startTime;
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilterTest.java
@@ -130,7 +130,7 @@ public class SupervisorResourceFilterTest
   )
   {
     expect(containerRequest.getPathSegments())
-        .andReturn(getPathSegments("/druid/indexer/v1/supervisor/datasource1"))
+        .andReturn(getPathSegments(path))
         .anyTimes();
     expect(containerRequest.getMethod()).andReturn(requestMethod).anyTimes();
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -872,7 +872,7 @@ public class SystemSchema extends AbstractSchema
       );
 
       Function<TaskStatusPlus, Iterable<ResourceAction>> raGenerator = task -> Collections.singletonList(
-          AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(task.getDataSource()));
+          AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR.apply(task.getDataSource()));
 
       final Iterable<TaskStatusPlus> authorizedTasks = AuthorizationUtils.filterAuthorizedResources(
           authenticationResult,
@@ -1014,7 +1014,7 @@ public class SystemSchema extends AbstractSchema
       );
 
       Function<SupervisorStatus, Iterable<ResourceAction>> raGenerator = supervisor -> Collections.singletonList(
-          AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(supervisor.getSource()));
+          AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR.apply(supervisor.getSource()));
 
       final Iterable<SupervisorStatus> authorizedSupervisors = AuthorizationUtils.filterAuthorizedResources(
           authenticationResult,


### PR DESCRIPTION
Follow up PR for #11680 

### Description
Supervisor and Task APIs are related to ingestion and must always require Datasource WRITE
authorization even if they are purely informative.

### Changes
- Check Datasource WRITE in `SystemSchema` for tables "supervisors" and "tasks"
- Check Datasource WRITE for APIs `/supervisor/history` and `/supervisor/{id}/history`
- Check Datasource for all Indexing Task APIs

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
