### PR TITLE
Improve exception message when loading data from web-console

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -29,14 +29,17 @@ import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecor
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.metadata.PasswordProvider;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -267,6 +270,9 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long, KafkaR
       Deserializer valueDeserializerObject = getKafkaDeserializer(props, "value.deserializer");
 
       return new KafkaConsumer<>(props, keyDeserializerObject, valueDeserializerObject);
+    }
+    catch (ConfigException e) {
+      throw new IAE("Unable to construct Kafka Consumer: %s", e.getMessage());
     }
     finally {
       Thread.currentThread().setContextClassLoader(currCtxCl);

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -29,17 +29,14 @@ import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecor
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
-import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.metadata.PasswordProvider;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -270,9 +267,6 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long, KafkaR
       Deserializer valueDeserializerObject = getKafkaDeserializer(props, "value.deserializer");
 
       return new KafkaConsumer<>(props, keyDeserializerObject, valueDeserializerObject);
-    }
-    catch (ConfigException e) {
-      throw new IAE("Unable to construct Kafka Consumer: %s", e.getMessage());
     }
     finally {
       Thread.currentThread().setContextClassLoader(currCtxCl);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerException.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerException.java
@@ -21,6 +21,9 @@ package org.apache.druid.indexing.overlord.sampler;
 
 import org.apache.druid.java.util.common.StringUtils;
 
+/**
+ * This exception will be mapped to a JSON object that will be returned to the client by {@link SamplerExceptionMapper}
+ */
 public class SamplerException extends RuntimeException
 {
   public SamplerException(Throwable cause, String formatText, Object... arguments)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
@@ -37,8 +37,8 @@ public class SamplerExceptionMapper implements ExceptionMapper<SamplerException>
     String message = exception.getMessage() == null ? "The sampler encountered an issue" : exception.getMessage();
 
     // stack trace is not returned to the client,
-    // so the cause of the exception should be logged so that we know where the exception is thrown
-    LOG.error(exception.getCause(), message);
+    // so the exception should be logged so that we know where the exception is thrown
+    LOG.error(exception, message);
 
     return Response.status(Response.Status.BAD_REQUEST)
                    .entity(ImmutableMap.of(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
@@ -36,7 +36,6 @@ public class SamplerExceptionMapper implements ExceptionMapper<SamplerException>
   {
     String message = exception.getMessage() == null ? "The sampler encountered an issue" : exception.getMessage();
 
-    // stack trace is not returned to the client,
     // Logging the stack trace and returning the exception message in the response
     LOG.error(exception, message);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexing.overlord.sampler;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.logger.Logger;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -28,13 +29,21 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class SamplerExceptionMapper implements ExceptionMapper<SamplerException>
 {
+  private static final Logger LOG = new Logger(SamplerExceptionMapper.class);
+
   @Override
   public Response toResponse(SamplerException exception)
   {
+    String message = exception.getMessage() == null ? "The sampler encountered an issue" : exception.getMessage();
+
+    // stack trace is not returned to the client,
+    // so the cause of the exception should be logged so that we know where the exception is thrown
+    LOG.error(exception.getCause(), message);
+
     return Response.status(Response.Status.BAD_REQUEST)
                    .entity(ImmutableMap.of(
                        "error",
-                       exception.getMessage() == null ? "The sampler encountered an issue" : exception.getMessage()
+                       message
                    ))
                    .build();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerExceptionMapper.java
@@ -37,7 +37,7 @@ public class SamplerExceptionMapper implements ExceptionMapper<SamplerException>
     String message = exception.getMessage() == null ? "The sampler encountered an issue" : exception.getMessage();
 
     // stack trace is not returned to the client,
-    // so the exception should be logged so that we know where the exception is thrown
+    // Logging the stack trace and returning the exception message in the response
     LOG.error(exception, message);
 
     return Response.status(Response.Status.BAD_REQUEST)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexing.seekablestream;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import org.apache.druid.client.indexing.SamplerResponse;
 import org.apache.druid.client.indexing.SamplerSpec;
 import org.apache.druid.data.input.ByteBufferInputRowParser;
@@ -99,11 +100,7 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
         recordSupplier = createRecordSupplier();
       }
       catch (Exception e) {
-        if (e.getCause() != null) {
-          throw new SamplerException(e, "Unable to create RecordSupplier: %s. Cause: %s", e.getMessage(), e.getCause().getMessage());
-        } else {
-          throw new SamplerException(e, "Unable to create RecordSupplier: %s", e.getMessage());
-        }
+        throw new SamplerException(e, "Unable to create RecordSupplier: %s", Throwables.getRootCause(e).getMessage());
       }
 
       inputSource = new RecordSupplierInputSource<>(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -100,9 +100,9 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
       }
       catch (Exception e) {
         if (e.getCause() != null) {
-          throw new SamplerException(e, "Unable to sample data: %s. Cause: %s", e.getMessage(), e.getCause().getMessage());
+          throw new SamplerException(e, "Unable to create RecordSupplier: %s. Cause: %s", e.getMessage(), e.getCause().getMessage());
         } else {
-          throw new SamplerException(e, "Unable to sample data: %s", e.getMessage());
+          throw new SamplerException(e, "Unable to create RecordSupplier: %s", e.getMessage());
         }
       }
 


### PR DESCRIPTION
Fixes #11651 

### Description

This PR improves the exception message when using the web console wizard to load data by:
1. catching exception that is thrown when constructing kafka consumer object and then re-throwing a SamplerException which will be automatically mapped to a JSON object by existing `SamplerExceptionMapper`

2. since `SamplerExceptionMapper` returns the exception message to the client without any stack trace, it's not able to know where the exception comes from, so we also loges the cause of SamplerException to log so that we know where the exception is thrown from server side log

Now the web-console showes the error as followes:
![image](https://user-images.githubusercontent.com/6525742/133927769-9988e63b-7958-45d5-a74e-5065d36e4100.png)


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
