### PR TITLE
Web console: update typescript 4.4 for faster build speeds

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -21679,9 +21679,9 @@
       }
     },
     "tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -21761,9 +21761,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -97,7 +97,7 @@
     "react-splitter-layout": "^4.0.0",
     "react-table": "~6.10.3",
     "regenerator-runtime": "^0.13.7",
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@awesome-code-style/eslint-config": "^3.2.0",
@@ -163,7 +163,7 @@
     "ts-jest": "^26.5.5",
     "ts-loader": "^8.1.0",
     "ts-node": "^8.4.1",
-    "typescript": "^4.2.4",
+    "typescript": "^4.4.3",
     "uuid": "^7.0.2",
     "webpack": "^5.33.2",
     "webpack-bundle-analyzer": "^4.4.1",

--- a/web-console/src/components/refresh-button/refresh-button.tsx
+++ b/web-console/src/components/refresh-button/refresh-button.tsx
@@ -41,6 +41,7 @@ export const RefreshButton = React.memo(function RefreshButton(props: RefreshBut
 
   return (
     <TimedButton
+      className="refresh-button"
       defaultDelay={30000}
       label="Auto refresh every"
       delays={DELAYS}

--- a/web-console/src/components/timed-button/timed-button.tsx
+++ b/web-console/src/components/timed-button/timed-button.tsx
@@ -19,6 +19,7 @@
 import { Button, ButtonGroup, ButtonProps, Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
+import classNames from 'classnames';
 import React, { useState } from 'react';
 
 import { useInterval } from '../../hooks';
@@ -39,6 +40,7 @@ export interface TimedButtonProps extends ButtonProps {
 
 export const TimedButton = React.memo(function TimedButton(props: TimedButtonProps) {
   const {
+    className,
     label,
     delays,
     onRefresh,
@@ -68,7 +70,7 @@ export const TimedButton = React.memo(function TimedButton(props: TimedButtonPro
   }
 
   return (
-    <ButtonGroup className="timed-button">
+    <ButtonGroup className={classNames('timed-button', className)}>
       <Button {...other} text={text} icon={icon} onClick={() => onRefresh(false)} />
       <Popover2
         content={

--- a/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
@@ -283,7 +283,7 @@ exports[`LookupEditDialog matches snapshot 1`] = `
                 The table which contains the key value pairs. This will become the table value in the SQL query:
               </p>
               <p>
-                SELECT keyColumn, valueColumn, tsColumn? FROM namespace.
+                SELECT keyColumn, valueColumn, tsColumn? FROM 
                 <strong>
                   table
                 </strong>
@@ -306,7 +306,7 @@ exports[`LookupEditDialog matches snapshot 1`] = `
                 <strong>
                   keyColumn
                 </strong>
-                , valueColumn, tsColumn? FROM namespace.table WHERE filter
+                , valueColumn, tsColumn? FROM table WHERE filter
               </p>
             </React.Fragment>,
             "name": "extractionNamespace.keyColumn",
@@ -325,7 +325,7 @@ exports[`LookupEditDialog matches snapshot 1`] = `
                 <strong>
                   valueColumn
                 </strong>
-                , tsColumn? FROM namespace.table WHERE filter
+                , tsColumn? FROM table WHERE filter
               </p>
             </React.Fragment>,
             "name": "extractionNamespace.valueColumn",
@@ -344,7 +344,7 @@ exports[`LookupEditDialog matches snapshot 1`] = `
                 <strong>
                   tsColumn
                 </strong>
-                ? FROM namespace.table WHERE filter
+                ? FROM table WHERE filter
               </p>
             </React.Fragment>,
             "label": "Timestamp column",
@@ -359,8 +359,7 @@ exports[`LookupEditDialog matches snapshot 1`] = `
                 The filter to be used when selecting lookups, this is used to create a where clause on lookup population. This will become the expression filter in the SQL query:
               </p>
               <p>
-                SELECT keyColumn, valueColumn, tsColumn? FROM namespace.table WHERE
-                 
+                SELECT keyColumn, valueColumn, tsColumn? FROM table WHERE 
                 <strong>
                   filter
                 </strong>

--- a/web-console/src/druid-models/lookup-spec.tsx
+++ b/web-console/src/druid-models/lookup-spec.tsx
@@ -295,8 +295,7 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
           query:
         </p>
         <p>
-          SELECT keyColumn, valueColumn, tsColumn? FROM namespace.<strong>table</strong> WHERE
-          filter
+          SELECT keyColumn, valueColumn, tsColumn? FROM <strong>table</strong> WHERE filter
         </p>
       </>
     ),
@@ -314,8 +313,7 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
           the SQL query:
         </p>
         <p>
-          SELECT <strong>keyColumn</strong>, valueColumn, tsColumn? FROM namespace.table WHERE
-          filter
+          SELECT <strong>keyColumn</strong>, valueColumn, tsColumn? FROM table WHERE filter
         </p>
       </>
     ),
@@ -333,8 +331,7 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
           the SQL query:
         </p>
         <p>
-          SELECT keyColumn, <strong>valueColumn</strong>, tsColumn? FROM namespace.table WHERE
-          filter
+          SELECT keyColumn, <strong>valueColumn</strong>, tsColumn? FROM table WHERE filter
         </p>
       </>
     ),
@@ -352,8 +349,7 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
           the SQL query:
         </p>
         <p>
-          SELECT keyColumn, valueColumn, <strong>tsColumn</strong>? FROM namespace.table WHERE
-          filter
+          SELECT keyColumn, valueColumn, <strong>tsColumn</strong>? FROM table WHERE filter
         </p>
       </>
     ),
@@ -370,8 +366,7 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
           lookup population. This will become the expression filter in the SQL query:
         </p>
         <p>
-          SELECT keyColumn, valueColumn, tsColumn? FROM namespace.table WHERE{' '}
-          <strong>filter</strong>
+          SELECT keyColumn, valueColumn, tsColumn? FROM table WHERE <strong>filter</strong>
         </p>
       </>
     ),

--- a/web-console/tsconfig.json
+++ b/web-console/tsconfig.json
@@ -19,6 +19,7 @@
     "rootDirs": ["lib", "src"],
     "skipLibCheck": true,
     "strict": true,
+    "useUnknownInCatchVariables": false,
     "target": "es2016"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "e2e-tests/**/*.ts"]


### PR DESCRIPTION
Updates to TS4.4 which offers [perf improvements to the build speed](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#perf-improvements)

Also fixes two small bugs:
- the customary class was not applied to the refresh button
- there was an unnecessary `namespace.` describing how lookup JDBC queries are generated

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
