### PR TITLE
Fix broken build due to https://github.com/apache/druid/pull/11090

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -624,7 +624,8 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
                 getTaskCompletionUnparseableEvents(),
                 getTaskCompletionRowStats(),
                 errorMsg,
-                false // not applicable for parallel subtask
+                false, // not applicable for parallel subtask
+                segmentAvailabilityWaitTimeMs
             )
         )
     );


### PR DESCRIPTION
Fix broken build due to https://github.com/apache/druid/pull/11090

### Description

This change in https://github.com/apache/druid/pull/11090 that was merged a few hours ago is causing build to fail. This is because the change https://github.com/apache/druid/pull/11688 that went in a few days ago use the IngestionStatsAndErrorsTaskReportData constructor which was changed in https://github.com/apache/druid/pull/11090. Note that when https://github.com/apache/druid/pull/11090 got merged in, the Travis green check in that PR was from 25 days ago.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
