### PR TITLE
Update Apache Kafka client libraries to 3.0.0

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -150,7 +150,7 @@ public class TestKafkaExtractionCluster
   private Map<String, String> getConsumerProperties()
   {
     final Map<String, String> props = new HashMap<>(KAFKA_PROPERTIES);
-    int port = kafkaServer.socketServer().config().port();
+    int port = kafkaServer.socketServer().config().advertisedListeners().apply(0).port();
     props.put("bootstrap.servers", StringUtils.format("127.0.0.1:%d", port));
     return props;
   }
@@ -194,7 +194,7 @@ public class TestKafkaExtractionCluster
   {
     final Properties kafkaProducerProperties = new Properties();
     kafkaProducerProperties.putAll(KAFKA_PROPERTIES);
-    int port = kafkaServer.socketServer().config().port();
+    int port = kafkaServer.socketServer().config().advertisedListeners().apply(0).port();
     kafkaProducerProperties.put("bootstrap.servers", StringUtils.format("127.0.0.1:%d", port));
     kafkaProducerProperties.put("key.serializer", ByteArraySerializer.class.getName());
     kafkaProducerProperties.put("value.serializer", ByteArraySerializer.class.getName());

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/TestBroker.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/TestBroker.java
@@ -95,7 +95,7 @@ public class TestBroker implements Closeable
 
   public int getPort()
   {
-    return server.socketServer().config().port();
+    return server.socketServer().config().advertisedListeners().apply(0).port();
   }
 
   public KafkaProducer<byte[], byte[]> newProducer()

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3654,7 +3654,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 2.8.0
+version: 3.0.0
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -4564,7 +4564,7 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 2.8.0
+version: 3.0.0
 libraries:
   - org.apache.kafka: kafka-clients
 notices:

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>4.3.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
-        <apache.kafka.version>2.8.0</apache.kafka.version>
+        <apache.kafka.version>3.0.0</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
         <avatica.version>1.17.0</avatica.version>


### PR DESCRIPTION
Release notes:
https://downloads.apache.org/kafka/3.0.0/RELEASE_NOTES.html
https://blogs.apache.org/kafka/entry/what-s-new-in-apache6

On the consumer side, I did not see anything notable that would affect Kafka ingestion,
other than maybe the consumer group timeout increase.

On the producer side the client now defaults to acks=all and idempotent producer which
could affect the KafkaEmitter extension