### PR TITLE
Support real query cancelling for web console

### DIFF
--- a/web-console/README.md
+++ b/web-console/README.md
@@ -117,9 +117,10 @@ development mode of the web console (started via `npm start`), which runs on por
 
 Like so: `DRUID_E2E_TEST_UNIFIED_CONSOLE_PORT=18081 npm run test-e2e`
 
-#### Running a single e2e test using Jest and Playwright
+#### Running and debugging a single e2e test using Jest and Playwright
 
-For example, `jest --config jest.e2e.config.js e2e-tests/tutorial-batch.spec.ts`.
+- Run - `jest --config jest.e2e.config.js e2e-tests/tutorial-batch.spec.ts`.
+- Debug - `PWDEBUG=console jest --config jest.e2e.config.js e2e-tests/tutorial-batch.spec.ts`.
 
 ## Description of the directory structure
 

--- a/web-console/README.md
+++ b/web-console/README.md
@@ -115,6 +115,12 @@ The environment variable `DRUID_E2E_TEST_UNIFIED_CONSOLE_PORT` can be used to ta
 non-default port (i.e., not port `8888`). For example, this environment variable can be used to target the
 development mode of the web console (started via `npm start`), which runs on port `18081`.
 
+Like so: `DRUID_E2E_TEST_UNIFIED_CONSOLE_PORT=18081 npm run test-e2e`
+
+#### Running a single e2e test using Jest and Playwright
+
+For example, `jest --config jest.e2e.config.js e2e-tests/tutorial-batch.spec.ts`.
+
 ## Description of the directory structure
 
 As part of this directory:

--- a/web-console/e2e-tests/cancel-query.spec.ts
+++ b/web-console/e2e-tests/cancel-query.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as playwright from 'playwright-chromium';
+
+import { QueryOverview } from './component/query/overview';
+import { saveScreenshotIfError } from './util/debug';
+import { UNIFIED_CONSOLE_URL } from './util/druid';
+import { createBrowser, createPage } from './util/playwright';
+import { waitTillWebConsoleReady } from './util/setup';
+
+jest.setTimeout(5 * 60 * 1000);
+
+describe('Cancel query', () => {
+  let browser: playwright.Browser;
+  let page: playwright.Page;
+
+  beforeAll(async () => {
+    await waitTillWebConsoleReady();
+    browser = await createBrowser();
+  });
+
+  beforeEach(async () => {
+    page = await createPage(browser);
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('delete accepted', async () => {
+    const testName = 'cancel-query';
+    await saveScreenshotIfError(testName, page, async () => {
+      await validateCancelQuery(page);
+    });
+  });
+});
+
+async function validateCancelQuery(page: playwright.Page) {
+  const queryOverview = new QueryOverview(page, UNIFIED_CONSOLE_URL);
+  const query = 'SELECT sleep(20)';
+  const results = await queryOverview.cancelQuery(query);
+  expect(results).toBeDefined();
+  expect(results).toBeGreaterThan(0);
+  expect(results).toStrictEqual(202);
+}

--- a/web-console/e2e-tests/cancel-query.spec.ts
+++ b/web-console/e2e-tests/cancel-query.spec.ts
@@ -53,7 +53,7 @@ describe('Cancel query', () => {
 
 async function validateCancelQuery(page: playwright.Page) {
   const queryOverview = new QueryOverview(page, UNIFIED_CONSOLE_URL);
-  const query = 'SELECT sleep(20)';
+  const query = 'SELECT sleep(40)';
   const results = await queryOverview.cancelQuery(query);
   expect(results).toBeDefined();
   expect(results).toBeGreaterThan(0);

--- a/web-console/e2e-tests/component/query/overview.ts
+++ b/web-console/e2e-tests/component/query/overview.ts
@@ -54,9 +54,6 @@ export class QueryOverview {
 
     await setInput(input!, query);
 
-    this.page.on('request', request => console.log('>>', request.method(), request.url()));
-    this.page.on('response', response => console.log('<<', response.status(), response.url()));
-
     await Promise.all([
       this.page.waitForRequest(
         request => request.url().includes('druid/v2') && request.method() === 'POST',

--- a/web-console/e2e-tests/component/query/overview.ts
+++ b/web-console/e2e-tests/component/query/overview.ts
@@ -18,7 +18,7 @@
 
 import * as playwright from 'playwright-chromium';
 
-import { clickButton, setInput } from '../../util/playwright';
+import { clickButton, clickText, setInput } from '../../util/playwright';
 import { extractTable } from '../../util/table';
 
 /**
@@ -43,5 +43,32 @@ export class QueryOverview {
     await this.page.waitForSelector('div.query-info');
 
     return await extractTable(this.page, 'div.query-output div.rt-tr-group', 'div.rt-td');
+  }
+
+  async cancelQuery(query: string): Promise<number> {
+    await this.page.goto(this.baseUrl);
+    await this.page.reload({ waitUntil: 'networkidle' });
+
+    await this.page.waitForSelector('div.query-input textarea');
+    const input = await this.page.$('div.query-input textarea');
+    await setInput(input!, query);
+
+    await Promise.all([
+      this.page.waitForRequest(
+        request => request.url().includes('druid/v2') && request.method() === 'POST',
+      ),
+      clickButton(this.page, 'Run'),
+      await this.page.waitForSelector('.cancel-label'),
+    ]);
+
+    const [resp] = await Promise.all([
+      this.page.waitForResponse(
+        response => response.url().includes('druid/v2') && response.request().method() === 'DELETE',
+      ),
+
+      clickText(this.page, 'Cancel query'),
+    ]);
+
+    return resp.status();
   }
 }

--- a/web-console/e2e-tests/util/playwright.ts
+++ b/web-console/e2e-tests/util/playwright.ts
@@ -100,6 +100,10 @@ export async function clickLabeledButton(
   await page.click(`//*[text()="${label}"]/following-sibling::div${buttonSelector(text)}`);
 }
 
+export async function clickText(page: playwright.Page, text: string): Promise<void> {
+  await page.click(`//*[text()="${text}"]`);
+}
+
 export async function selectSuggestibleInput(
   page: playwright.Page,
   label: string,

--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -59,7 +59,10 @@ function _build_distribution() {
     && mvn -Pdist,skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -q -T1C install \
     && cd distribution/target \
     && tar xzf "apache-druid-$(_get_druid_version)-bin.tar.gz" \
-    && echo -e "\n\ndruid.server.http.allowedHttpMethods=[\"HEAD\"]" >> apache-druid-$(_get_druid_version)/conf/druid/single-server/micro-quickstart/_common/common.runtime.properties
+    && cd apache-druid-$(_get_druid_version) \
+    && java -classpath "lib/*" org.apache.druid.cli.Main tools pull-deps -c org.apache.druid.extensions:druid-testing-tools \
+    && echo -e "\n\ndruid.extensions.loadList=[\"druid-hdfs-storage\", \"druid-kafka-indexing-service\", \"druid-datasketches\", \"druid-testing-tools\"]" >> conf/druid/single-server/micro-quickstart/_common/common.runtime.properties \
+    && echo -e "\n\ndruid.server.http.allowedHttpMethods=[\"HEAD\"]" >> conf/druid/single-server/micro-quickstart/_common/common.runtime.properties \
   )
 }
 

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -231,12 +231,9 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
 
         cancelToken.promise
           .then(() => {
-            Api.instance
-              .delete(`/druid/v2/${isSql ? '/sql' : ''}/${queryId}`)
-              .then()
-              .catch(e => {
-                throw new DruidError(e);
-              });
+            Api.instance.delete(`/druid/v2/${isSql ? '/sql' : ''}/${queryId}`).catch(e => {
+              throw new DruidError(e);
+            });
           })
           .catch(e => {
             throw new DruidError(e);

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -137,7 +137,6 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
   private readonly queryManager: QueryManager<QueryWithContext, QueryResult>;
 
   private readonly queryInputRef: RefObject<QueryInput>;
-  // private id = 0;
 
   constructor(props: QueryViewProps, context: any) {
     super(props, context);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->



<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

This is a follow up to #11643 When a user presses the cancel query button in the web-console, a query cancel request should be sent to Druid to cancel the already running query

Generating queryId, added queryId in context when submitting POST request.
After cancelToken, check `isSql` then call DELETE request with the corresponding queryId URL

`DELETE https://ROUTER:8888/druid/v2/{queryId}`
`DELETE https://ROUTER:8888/druid/v2/sql/{sqlQueryId}`

Return status `202` shows running query deleted successfully

<hr>

##### Key changed/added classes in this PR
 * `Druid SQL's HTTP DELETE method`
 * `query-view`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.

