### PR TITLE
Fix IT test script failure when host machine has multiple IP addresses

### DIFF
--- a/integration-tests/docker/tls/set-docker-host-ip.sh
+++ b/integration-tests/docker/tls/set-docker-host-ip.sh
@@ -24,7 +24,7 @@ fi
 
 if [ -z "$DOCKER_HOST_IP" ]; then
   # Another Mac specific way, when the machine isn't able to resolve its own name
-  DOCKER_HOST_IP="$(ifconfig | fgrep 'inet ' | fgrep -v 127.0.0.1 | awk '{print $2}')"
+  DOCKER_HOST_IP="$(ifconfig | fgrep 'inet ' | fgrep -v 127.0.0.1 | awk '{print $2}' | tail -n1)"
 fi
 
 if [ -z "$DOCKER_HOST_IP" ]; then


### PR DESCRIPTION

Fixes #11663 

If the host machine has multiple IP addresses, the integration test project fails to build, shows following exception message
```bash
error on line 23 of expired_csr.conf
4585021100:error:0EFFF065:configuration file routines:CRYPTO_internal:missing equal sign:/System/Volumes/Data/SWE/macOS/BuildRoots/38cf1d983f/Library/Caches/com.apple.xbs/Sources/libressl/libressl-56.60.2/libressl-2.8/crypto/conf/conf_def.c:344:line 23
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
```

And we can see from the file 'expired_csr.conf' on line 23, there're multiple addresses which is a ill-formed script

```bash
[ alt_names ]
IP.1 = 192.168.2.10
192.168.2.241
10.2.56.244
IP.2 = 127.0.0.1
IP.3 = 172.172.172.1
IP.4 = 127.0.0.1
DNS.1 = D32E529ME5A
DNS.2 = localhost
```

There're 3 IP addresses for the `IP.1` variable. The first two addresses are my local LAN and wireless network IP addresses respectively, while the 3rd is the address on my VPN network. 

The build script should pick any one of local network addresses as DOCKER_HOST_IP. And as a fix, the last IP address returned by ifconfig command is picked. 


This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
