### PR TITLE
Web console: auto refresh in foreground only

### DIFF
--- a/web-console/src/components/refresh-button/refresh-button.tsx
+++ b/web-console/src/components/refresh-button/refresh-button.tsx
@@ -47,6 +47,7 @@ export const RefreshButton = React.memo(function RefreshButton(props: RefreshBut
       icon={IconNames.REFRESH}
       text="Refresh"
       onRefresh={onRefresh}
+      foregroundOnly
       localStorageKey={localStorageKey}
     />
   );

--- a/web-console/src/components/timed-button/timed-button.tsx
+++ b/web-console/src/components/timed-button/timed-button.tsx
@@ -22,7 +22,7 @@ import { Popover2 } from '@blueprintjs/popover2';
 import React, { useState } from 'react';
 
 import { useInterval } from '../../hooks';
-import { localStorageGet, LocalStorageKeys, localStorageSet } from '../../utils';
+import { isInBackground, localStorageGet, LocalStorageKeys, localStorageSet } from '../../utils';
 
 export interface DelayLabel {
   label: string;
@@ -35,6 +35,7 @@ export interface TimedButtonProps extends ButtonProps {
   localStorageKey?: LocalStorageKeys;
   label: string;
   defaultDelay: number;
+  foregroundOnly?: boolean;
 }
 
 export const TimedButton = React.memo(function TimedButton(props: TimedButtonProps) {
@@ -46,6 +47,7 @@ export const TimedButton = React.memo(function TimedButton(props: TimedButtonPro
     text,
     icon,
     defaultDelay,
+    foregroundOnly,
     localStorageKey,
     ...other
   } = props;
@@ -57,6 +59,7 @@ export const TimedButton = React.memo(function TimedButton(props: TimedButtonPro
   );
 
   useInterval(() => {
+    if (foregroundOnly && isInBackground()) return;
     onRefresh(true);
   }, selectedDelay);
 

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -404,3 +404,7 @@ export function stringifyValue(value: unknown): string {
       return String(value);
   }
 }
+
+export function isInBackground(): boolean {
+  return document.visibilityState === 'hidden';
+}


### PR DESCRIPTION
This tiny PR makes it so that the auto refresh buttons only refresh if the tab is in the foreground. This prevents people who have 10s of background web console tabs (you know who you are!) from hogging resources they are not even using.

![image](https://user-images.githubusercontent.com/177816/135152954-41730541-7503-44e4-8d73-32408eab39ad.png)

In the screenshot above notice the timing gap between the last 3 `sql` requests and the one before them - I had the tab in the background.

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
