### PR TITLE
Add killAndRestart for container for integration tests

### DIFF
--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/SqlQueryWithResults.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/SqlQueryWithResults.java
@@ -20,6 +20,7 @@
 package org.apache.druid.testing.utils;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.sql.http.SqlQuery;
 
 import java.util.Collections;
@@ -31,8 +32,8 @@ public class SqlQueryWithResults extends AbstractQueryWithResults<SqlQuery>
 
   @JsonCreator
   public SqlQueryWithResults(
-      SqlQuery query,
-      List<Map<String, Object>> expectedResults
+      @JsonProperty("query") SqlQuery query,
+      @JsonProperty("expectedResults") List<Map<String, Object>> expectedResults
   )
   {
     super(query, expectedResults, Collections.emptyList());


### PR DESCRIPTION
### Description

#9576 added utility functions for integration tests including restarting docker containers. This PR adds a new utility method to kill a container with `SIGKILL` and restart the container. This could be useful for testing certain edge cases where some node is forced to exit without graceful shutdown. I made this method public along with others since the current way providing utility methods for each node doesn't seem scalable. This PR also fixes a bug in `SqlQueryWithResults` that `JsonProperty` annotations are missing for parameters.

<hr>

This PR has:
- [x] been self-reviewed.