### PR TITLE
update docs with X-Druid-SQL-Query-Id

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -871,13 +871,13 @@ Submit your query as the value of a "query" field in the JSON object within the 
 {"query" : "SELECT COUNT(*) FROM data_source WHERE foo = 'bar'"}
 ```
 
-##### Request
+##### Request body
       
 |Property|Description|Default|
 |--------|----|-----------|
 |`query`|SQL query string.| none (required)|
 |`resultFormat`|Format of query results. See [Responses](#responses) for details.|`"object"`|
-|`header`|Whether or not to include a header. See [Responses] for details.|`false`|
+|`header`|Whether or not to include a header. See [Responses](#responses) for details.|`false`|
 |`context`|JSON object containing [connection context parameters](#connection-context).|`{}` (empty)|
 |`parameters`|List of query parameters for parameterized queries. Each parameter in the list should be a JSON object like `{"type": "VARCHAR", "value": "foo"}`. The type should be a SQL type; see [Data types](#data-types) for a list of supported SQL types.|`[]` (empty)|
 
@@ -952,6 +952,8 @@ You can additionally request a header by setting "header" to true in your reques
 In this case, the first result returned will be a header. For the `csv`, `array`, and `arrayLines` formats, the header
 will be a list of column names. For the `object` and `objectLines` formats, the header will be an object where the
 keys are column names, and the values are null.
+If you specified `sqlQueryId` in the [connection context parameters](#connection-context),
+the SQL query identifier will be returned in the header labeled `X-Druid-SQL-Query-Id`.
 
 Errors that occur before the response body is sent will be reported in JSON, with an HTTP 500 status code, in the
 same format as [native Druid query errors](../querying/querying.md#query-errors). If an error occurs while the response body is

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -949,7 +949,7 @@ You can additionally request a header by setting "header" to true in your reques
 }
 ```
 
-In this case, the first result of the response body returned will be a header. For the `csv`, `array`, and `arrayLines` formats, the header
+In this case, the first result of the response body is the header row. For the `csv`, `array`, and `arrayLines` formats, the header
 will be a list of column names. For the `object` and `objectLines` formats, the header will be an object where the
 keys are column names, and the values are null.
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -877,7 +877,7 @@ Submit your query as the value of a "query" field in the JSON object within the 
 |--------|----|-----------|
 |`query`|SQL query string.| none (required)|
 |`resultFormat`|Format of query results. See [Responses](#responses) for details.|`"object"`|
-|`header`|Whether or not to include a header. See [Responses](#responses) for details.|`false`|
+|`header`|Whether or not to include a header for the query response. See [Responses](#responses) for details.|`false`|
 |`context`|JSON object containing [connection context parameters](#connection-context).|`{}` (empty)|
 |`parameters`|List of query parameters for parameterized queries. Each parameter in the list should be a JSON object like `{"type": "VARCHAR", "value": "foo"}`. The type should be a SQL type; see [Data types](#data-types) for a list of supported SQL types.|`[]` (empty)|
 
@@ -949,11 +949,13 @@ You can additionally request a header by setting "header" to true in your reques
 }
 ```
 
-In this case, the first result returned will be a header. For the `csv`, `array`, and `arrayLines` formats, the header
+In this case, the first result of the response body returned will be a header. For the `csv`, `array`, and `arrayLines` formats, the header
 will be a list of column names. For the `object` and `objectLines` formats, the header will be an object where the
 keys are column names, and the values are null.
-If you specified `sqlQueryId` in the [connection context parameters](#connection-context),
-the SQL query identifier will be returned in the header labeled `X-Druid-SQL-Query-Id`.
+
+Druid returns the SQL query identifier in the `X-Druid-SQL-Query-Id` HTTP header.
+This query id will be assigned the value of `sqlQueryId` from the [connection context parameters](#connection-context)
+if specified, else Druid will generate a SQL query id for you.
 
 Errors that occur before the response body is sent will be reported in JSON, with an HTTP 500 status code, in the
 same format as [native Druid query errors](../querying/querying.md#query-errors). If an error occurs while the response body is

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -877,7 +877,7 @@ Submit your query as the value of a "query" field in the JSON object within the 
 |--------|----|-----------|
 |`query`|SQL query string.| none (required)|
 |`resultFormat`|Format of query results. See [Responses](#responses) for details.|`"object"`|
-|`header`|Whether or not to include a header for the query response. See [Responses](#responses) for details.|`false`|
+|`header`|Whether or not to include a header for the query result. See [Responses](#responses) for details.|`false`|
 |`context`|JSON object containing [connection context parameters](#connection-context).|`{}` (empty)|
 |`parameters`|List of query parameters for parameterized queries. Each parameter in the list should be a JSON object like `{"type": "VARCHAR", "value": "foo"}`. The type should be a SQL type; see [Data types](#data-types) for a list of supported SQL types.|`[]` (empty)|
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -877,7 +877,7 @@ Submit your query as the value of a "query" field in the JSON object within the 
 |--------|----|-----------|
 |`query`|SQL query string.| none (required)|
 |`resultFormat`|Format of query results. See [Responses](#responses) for details.|`"object"`|
-|`header`|Whether or not to include a header for the query result. See [Responses](#responses) for details.|`false`|
+|`header`|Whether or not to include a header row for the query result. See [Responses](#responses) for details.|`false`|
 |`context`|JSON object containing [connection context parameters](#connection-context).|`{}` (empty)|
 |`parameters`|List of query parameters for parameterized queries. Each parameter in the list should be a JSON object like `{"type": "VARCHAR", "value": "foo"}`. The type should be a SQL type; see [Data types](#data-types) for a list of supported SQL types.|`[]` (empty)|
 


### PR DESCRIPTION
This PR documents the "X-Druid-SQL-Query-Id" header.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
