### PR TITLE
Add option to JSON input format for ingesting arrays of rows

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
@@ -63,28 +63,8 @@ public class JsonInputFormat extends NestedInputFormat
       @JsonProperty("rowArray") @Nullable Boolean rowArray
   )
   {
-    this(flattenSpec, featureSpec, keepNullColumns, rowArray, true);
+    this(flattenSpec, featureSpec, keepNullColumns, rowArray, !rowArray);
   }
-
-  public JsonInputFormat(
-      JSONPathSpec flattenSpec,
-      Map<String, Boolean> featureSpec,
-      Boolean keepNullColumns
-  )
-  {
-    this(flattenSpec, featureSpec, keepNullColumns, false, true);
-  }
-
-  public JsonInputFormat(
-      JSONPathSpec flattenSpec,
-      Map<String, Boolean> featureSpec,
-      Boolean keepNullColumns,
-      boolean lineSplittable
-  )
-  {
-    this(flattenSpec, featureSpec, keepNullColumns, false, lineSplittable);
-  }
-
 
   public JsonInputFormat(
       JSONPathSpec flattenSpec,
@@ -113,7 +93,7 @@ public class JsonInputFormat extends NestedInputFormat
   }
 
   @JsonProperty
-  public boolean isRowArray()
+  public Boolean getRowArray()
   {
     return rowArray;
   }
@@ -142,8 +122,8 @@ public class JsonInputFormat extends NestedInputFormat
     return new JsonInputFormat(this.getFlattenSpec(),
                                this.getFeatureSpec(),
                                this.keepNullColumns,
-                               lineSplittable,
-                               this.rowArray);
+                               this.rowArray,
+                               lineSplittable);
   }
 
   public JsonInputFormat withRowArray(boolean rowArray)
@@ -151,8 +131,8 @@ public class JsonInputFormat extends NestedInputFormat
     return new JsonInputFormat(this.getFlattenSpec(),
                                this.getFeatureSpec(),
                                this.keepNullColumns,
-                               this.lineSplittable,
-                               rowArray);
+                               rowArray,
+                               this.lineSplittable);
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/data/input/impl/JsonReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/JsonReader.java
@@ -22,8 +22,8 @@ package org.apache.druid.data.input.impl;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterators;
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * In constract to {@link JsonLineReader} which processes input text line by line independently,
@@ -139,15 +140,30 @@ public class JsonReader extends IntermediateRowParsingReader<String>
   protected List<Map<String, Object>> toMap(String intermediateRow) throws IOException
   {
     try (JsonParser parser = new JsonFactory().createParser(intermediateRow)) {
-      final MappingIterator<Map> delegate = mapper.readValues(parser, Map.class);
+      final Iterator<Map> delegate;
+      if (rowArray) {
+        final JsonNode inputNode = mapper.readTree(parser);
+        delegate = Stream
+          .generate(inputNode.elements()::next)
+          .map(elem -> {
+            try {
+              return mapper.treeToValue(elem, Map.class);
+            }
+            catch (JsonProcessingException e) {
+              throw new RuntimeException(e);
+            }
+          }).iterator();
+      } else {
+        delegate = mapper.readValues(parser, Map.class);
+      }
       return FluentIterable.from(() -> delegate)
                            .transform(map -> (Map<String, Object>) map)
                            .toList();
     }
     catch (RuntimeException e) {
-      //convert Jackson's JsonParseException into druid's exception for further processing
+      //convert Jackson's JsonParseException/JsonProcessingException into druid's exception for further processing
       //JsonParseException will be thrown from MappingIterator#hasNext or MappingIterator#next when input json text is ill-formed
-      if (e.getCause() instanceof JsonParseException) {
+      if (e.getCause() instanceof JsonProcessingException) {
         throw new ParseException(e, "Unable to parse row [%s]", intermediateRow);
       }
 

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
@@ -52,6 +52,7 @@ public class JsonInputFormatTest
             )
         ),
         ImmutableMap.of(Feature.ALLOW_COMMENTS.name(), true, Feature.ALLOW_UNQUOTED_FIELD_NAMES.name(), false),
+        false,
         false
     );
     final byte[] bytes = mapper.writeValueAsBytes(format);

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonLineReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonLineReaderTest.java
@@ -56,7 +56,8 @@ public class JsonLineReaderTest
             )
         ),
         null,
-        null
+        null,
+        false
     );
 
     final ByteEntity source = new ByteEntity(
@@ -106,7 +107,8 @@ public class JsonLineReaderTest
             )
         ),
         null,
-        null
+        null,
+        false
     );
 
     final ByteEntity source = new ByteEntity(
@@ -148,7 +150,8 @@ public class JsonLineReaderTest
             )
         ),
         null,
-        true
+        true,
+        false
     );
 
     final ByteEntity source = new ByteEntity(
@@ -190,7 +193,8 @@ public class JsonLineReaderTest
             )
         ),
         null,
-        true
+        true,
+        false
     );
 
     final ByteEntity source = new ByteEntity(
@@ -232,6 +236,7 @@ public class JsonLineReaderTest
             )
         ),
         null,
+        false,
         false
     );
 

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
@@ -45,6 +45,7 @@ public class JsonReaderTest
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  @Test
   public void testParseRowArray() throws IOException
   {
     final JsonInputFormat format = new JsonInputFormat(
@@ -61,8 +62,8 @@ public class JsonReaderTest
         ),
         null,
         null,
-        false, //make sure JsonReader is used
-        true //make sure Arrays are used
+        true, //make sure Arrays are used
+        false
     );
     final ByteEntity source = new ByteEntity(
         StringUtils.toUtf8("[{\"timestamp\":\"2019-01-01\",\"bar\":null,\"foo\":\"x\",\"baz\":4,\"o\":{\"mg\":1}}"
@@ -120,6 +121,7 @@ public class JsonReaderTest
         ),
         null,
         null,
+        false,
         false //make sure JsonReader is used
     );
 
@@ -180,6 +182,7 @@ public class JsonReaderTest
         ),
         null,
         null,
+        false,
         false //make sure JsonReader is used
     );
 
@@ -247,6 +250,7 @@ public class JsonReaderTest
         ),
         null,
         null,
+        false,
         false //make sure JsonReader is used
     );
 
@@ -301,6 +305,7 @@ public class JsonReaderTest
         ),
         null,
         null,
+        false,
         false //make sure JsonReader is used
     );
 
@@ -367,6 +372,7 @@ public class JsonReaderTest
         ),
         null,
         null,
+        false,
         false //make sure JsonReader is used
     );
 
@@ -423,6 +429,7 @@ public class JsonReaderTest
         ),
         null,
         null,
+        false,
         false //make sure JsonReader is used
     );
 
@@ -479,6 +486,7 @@ public class JsonReaderTest
         ),
         null,
         null,
+        false,
         false //make sure JsonReader is used
     );
 

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
@@ -45,6 +45,64 @@ public class JsonReaderTest
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  public void testParseRowArray() throws IOException
+  {
+    final JsonInputFormat format = new JsonInputFormat(
+        new JSONPathSpec(
+            true,
+            ImmutableList.of(
+                new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz", "baz"),
+                new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz2", "baz2"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+            )
+        ),
+        null,
+        null,
+        false, //make sure JsonReader is used
+        true //make sure Arrays are used
+    );
+    final ByteEntity source = new ByteEntity(
+        StringUtils.toUtf8("[{\"timestamp\":\"2019-01-01\",\"bar\":null,\"foo\":\"x\",\"baz\":4,\"o\":{\"mg\":1}}"
+                           + ",{\"timestamp\":\"2019-01-01\",\"bar\":null,\"foo\":\"x\",\"baz\":4,\"o\":{\"mg\":2}}\n"
+                           + ",{\"timestamp\":\"2019-01-01\",\"bar\":null,\"foo\":\"x\",\"baz\":4,\"o\":{\"mg\":3}}\n]")
+    );
+    final InputEntityReader reader = format.createReader(
+        new InputRowSchema(
+            new TimestampSpec("timestamp", "iso", null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo"))),
+            ColumnsFilter.all()
+        ),
+        source,
+        null
+    );
+    final int numExpectedIterations = 3;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      int numActualIterations = 0;
+      while (iterator.hasNext()) {
+
+        final InputRow row = iterator.next();
+
+        final String msgId = String.valueOf(++numActualIterations);
+        Assert.assertEquals(DateTimes.of("2019-01-01"), row.getTimestamp());
+        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("jq_omg")));
+
+        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+      }
+
+      Assert.assertEquals(numExpectedIterations, numActualIterations);
+    }
+
+  }
+
   @Test
   public void testParseMultipleRows() throws IOException
   {

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -43,6 +43,18 @@ _JSON_
 {"timestamp": "2013-08-31T12:41:27Z", "page": "Coyote Tango", "language" : "ja", "user" : "cancer", "unpatrolled" : "true", "newPage" : "false", "robot": "true", "anonymous": "false", "namespace":"wikipedia", "continent":"Asia", "country":"Japan", "region":"Kanto", "city":"Tokyo", "added": 1, "deleted": 10, "delta": -9}
 ```
 
+or
+
+```json
+[
+{"timestamp": "2013-08-31T01:02:33Z", "page": "Gypsy Danger", "language" : "en", "user" : "nuclear", "unpatrolled" : "true", "newPage" : "true", "robot": "false", "anonymous": "false", "namespace":"article", "continent":"North America", "country":"United States", "region":"Bay Area", "city":"San Francisco", "added": 57, "deleted": 200, "delta": -143},
+{"timestamp": "2013-08-31T03:32:45Z", "page": "Striker Eureka", "language" : "en", "user" : "speed", "unpatrolled" : "false", "newPage" : "true", "robot": "true", "anonymous": "false", "namespace":"wikipedia", "continent":"Australia", "country":"Australia", "region":"Cantebury", "city":"Syndey", "added": 459, "deleted": 129, "delta": 330},
+{"timestamp": "2013-08-31T07:11:21Z", "page": "Cherno Alpha", "language" : "ru", "user" : "masterYi", "unpatrolled" : "false", "newPage" : "true", "robot": "true", "anonymous": "false", "namespace":"article", "continent":"Asia", "country":"Russia", "region":"Oblast", "city":"Moscow", "added": 123, "deleted": 12, "delta": 111},
+{"timestamp": "2013-08-31T11:58:39Z", "page": "Crimson Typhoon", "language" : "zh", "user" : "triplets", "unpatrolled" : "true", "newPage" : "false", "robot": "true", "anonymous": "false", "namespace":"wikipedia", "continent":"Asia", "country":"China", "region":"Shanxi", "city":"Taiyuan", "added": 905, "deleted": 5, "delta": 900},
+{"timestamp": "2013-08-31T12:41:27Z", "page": "Coyote Tango", "language" : "ja", "user" : "cancer", "unpatrolled" : "true", "newPage" : "false", "robot": "true", "anonymous": "false", "namespace":"wikipedia", "continent":"Asia", "country":"Japan", "region":"Kanto", "city":"Tokyo", "added": 1, "deleted": 10, "delta": -9}
+]
+```
+
 _CSV_
 
 ```
@@ -90,6 +102,7 @@ Configure the JSON `inputFormat` to load JSON data as follows:
 | type | String | Set value to `json`. | yes |
 | flattenSpec | JSON Object | Specifies flattening configuration for nested JSON data. See [`flattenSpec`](#flattenspec) for more info. | no |
 | featureSpec | JSON Object | [JSON parser features](https://github.com/FasterXML/jackson-core/wiki/JsonParser-Features) supported by Jackson library. Those features will be applied when parsing the input JSON data. | no |
+| rowArray | Boolean | If true, interpret data as an array of rows. If false, interpret data as individual objects. (default = false)  | no |
 
 For example:
 ```json

--- a/web-console/src/druid-models/ingestion-spec.spec.ts
+++ b/web-console/src/druid-models/ingestion-spec.spec.ts
@@ -148,6 +148,14 @@ describe('ingestion-spec', () => {
       expect(guessInputFormat(['{"a":1}']).type).toEqual('json');
     });
 
+    it('works for JSON Arrays', () => {
+      expect(guessInputFormat(['[{"a":1}]']).type).toEqual('json');
+    });
+
+    it('works for JSON Arrays w/ newlines', () => {
+      expect(guessInputFormat(['[\n{"a":1}\n]']).type).toEqual('json');
+    });
+
     it('works for TSV', () => {
       expect(guessInputFormat(['A\tB\tX\tY']).type).toEqual('tsv');
     });

--- a/web-console/src/druid-models/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec.tsx
@@ -2049,16 +2049,6 @@ export function issueWithSampleData(sampleData: string[]): JSX.Element | undefin
         </>
       );
     }
-
-    if (oneOf(firstData, '[', '[]')) {
-      return (
-        <>
-          This data looks like a multi-line JSON array. For Druid to parse a text file it must have
-          one row per event. Maybe look at{' '}
-          <ExternalLink href="http://ndjson.org/">newline delimited JSON</ExternalLink> instead.
-        </>
-      );
-    }
   }
 
   return;
@@ -2095,7 +2085,10 @@ export function guessInputFormat(sampleData: string[]): InputFormat {
     // After checking for magic byte sequences perform heuristics to deduce string formats
 
     // If the string starts and ends with curly braces assume JSON
-    if (sampleDatum.startsWith('{') && sampleDatum.endsWith('}')) {
+    if (
+      (sampleDatum.startsWith('{') && sampleDatum.endsWith('}')) ||
+      (sampleDatum.startsWith('[') && sampleDatum.endsWith(']'))
+    ) {
       return inputFormatFromType('json');
     }
     // Contains more than 3 tabs assume TSV

--- a/web-console/src/druid-models/input-format.tsx
+++ b/web-console/src/druid-models/input-format.tsx
@@ -36,6 +36,7 @@ export interface InputFormat {
   readonly function?: string;
   readonly flattenSpec?: FlattenSpec;
   readonly keepNullColumns?: boolean;
+  readonly rowArray?: boolean;
 }
 
 export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
@@ -137,6 +138,13 @@ export const INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
         as a UTF-8 encoded string.
       </>
     ),
+  },
+  {
+    name: 'rowArray',
+    type: 'boolean',
+    defaultValue: false,
+    defined: typeIs('json'),
+    info: <>Specifies if the data is arrays of rows or individual row objects.</>,
   },
 ];
 

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -126,9 +126,13 @@ export function applyCache(sampleSpec: SampleSpec, cacheRows: CacheRows) {
   });
 
   const flattenSpec = deepGet(sampleSpec, 'spec.ioConfig.inputFormat.flattenSpec');
+  const rowArray = deepGet(sampleSpec, 'spec.ioConfig.inputFormat.rowArray');
   let inputFormat: InputFormat = { type: 'json', keepNullColumns: true };
   if (flattenSpec) {
     inputFormat = deepSet(inputFormat, 'flattenSpec', flattenSpec);
+  }
+  if (rowArray) {
+    inputFormat = deepSet(inputFormat, 'rowArray', true);
   }
   sampleSpec = deepSet(sampleSpec, 'spec.ioConfig.inputFormat', inputFormat);
 


### PR DESCRIPTION
Fixes #11789.

### Description

Added an optional flag `rowArray` to the JSON input format to treat the input as an array of row objects, rather than individual objects. This is meant to facilitate ingesting data from REST APIs, which often return single JSON elements instead of whitespace-separated objects.

Tested with the nano quickstart using both sample data sets in the documentation.

Note: I wasn't sure of the best name to give this flag. I am open to suggestions.

<hr>

##### Key changed/added classes in this PR
 * `JsonInputFormat`
 * `JsonReader`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
