### PR TITLE
Add thread count to pre-push hook to speed up checking

### DIFF
--- a/hooks/pre-push.sh
+++ b/hooks/pre-push.sh
@@ -14,4 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# set thread count to 2 times of cores to speed up checking
 mvn checkstyle:checkstyle -T 2C --fail-at-end

--- a/hooks/pre-push.sh
+++ b/hooks/pre-push.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mvn checkstyle:checkstyle --fail-at-end
+mvn checkstyle:checkstyle -T 2C --fail-at-end


### PR DESCRIPTION
Druid provides a pre-push hook to git to perform code style checking when pushing code branch to remote servers.Since there're more than 60 modules in Druid, the checking sometimes are a little bit slow. 

Since `mvn` command supports `-T` parameter to run tasks in multiple threads, by adding this parameter to the pre-push hook, we can save a lot of time when pushing code to remote servers.

Here's the time consumption using the old command

```bash
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.270 s
[INFO] Finished at: 2021-10-18T12:01:21+08:00
[INFO] ------------------------------------------------------------------------
```

and after adding thread count parameter to the checking command, the time is decreased by more than 50%.

```bash
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.037 s (Wall Clock)
[INFO] Finished at: 2021-10-18T13:16:37+08:00
[INFO] ------------------------------------------------------------------------
```

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
