### PR TITLE
Extract HyperLogLog into an interface

### DIFF
--- a/hll/src/main/java/org/apache/druid/hll/AbstractHyperLogLogCollector.java
+++ b/hll/src/main/java/org/apache/druid/hll/AbstractHyperLogLogCollector.java
@@ -1,0 +1,718 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.hll;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.primitives.UnsignedBytes;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+/**
+ * Implements the HyperLogLog cardinality estimator described in:
+ *
+ * http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
+ *
+ * Run this code to see a simple indication of expected errors based on different m values:
+ *
+ * <code>
+ * for (int i = 1; i &lt; 20; ++i) {
+ * System.out.printf("i[%,d], val[%,d] =&gt; error[%f%%]%n", i, 2 &lt;&lt; i, 104 / Math.sqrt(2 &lt;&lt; i));
+ * }
+ * </code>
+ *
+ * This class is *not* multi-threaded. It can be passed among threads, but it is written with the assumption that
+ * only one thread is ever calling methods on it.
+ *
+ * If you have multiple threads calling methods on this concurrently, I hope you manage to get correct behavior.
+ *
+ * Note that despite the non-thread-safety of this class, it is actually currently used by multiple threads during
+ * realtime indexing. HyperUniquesAggregator's "aggregate" and "get" methods can be called simultaneously by
+ * OnheapIncrementalIndex, since its "doAggregate" and "getMetricObjectValue" methods are not synchronized. So, watch
+ * out for that.
+ */
+abstract class AbstractHyperLogLogCollector implements HyperLogLogCollector
+{
+  public static final int DENSE_THRESHOLD = 128;
+  public static final int BITS_FOR_BUCKETS = 11;
+  public static final int NUM_BUCKETS = 1 << BITS_FOR_BUCKETS;
+  public static final int NUM_BYTES_FOR_BUCKETS = NUM_BUCKETS / 2;
+
+  private static final double TWO_TO_THE_SIXTY_FOUR = Math.pow(2, 64);
+  private static final double ALPHA = 0.7213 / (1 + 1.079 / NUM_BUCKETS);
+
+  public static final double LOW_CORRECTION_THRESHOLD = (5 * NUM_BUCKETS) / 2.0d;
+  public static final double HIGH_CORRECTION_THRESHOLD = TWO_TO_THE_SIXTY_FOUR / 30.0d;
+  public static final double CORRECTION_PARAMETER = ALPHA * NUM_BUCKETS * NUM_BUCKETS;
+
+  private static final int BUCKET_MASK = 0x7ff;
+  private static final int MIN_BYTES_REQUIRED = 10;
+  private static final int BITS_PER_BUCKET = 4;
+  private static final int RANGE = (int) Math.pow(2, BITS_PER_BUCKET) - 1;
+
+  private static final double[][] MIN_NUM_REGISTER_LOOKUP = new double[64][256];
+
+  static {
+    for (int registerOffset = 0; registerOffset < 64; ++registerOffset) {
+      for (int register = 0; register < 256; ++register) {
+        final int upper = ((register & 0xf0) >> 4) + registerOffset;
+        final int lower = (register & 0x0f) + registerOffset;
+        MIN_NUM_REGISTER_LOOKUP[registerOffset][register] = 1.0d / Math.pow(2, upper) + 1.0d / Math.pow(2, lower);
+      }
+    }
+  }
+
+  // we have to keep track of the number of zeroes in each of the two halves of the byte register (0, 1, or 2)
+  private static final int[] NUM_ZERO_LOOKUP = new int[256];
+
+  static {
+    for (int i = 0; i < NUM_ZERO_LOOKUP.length; ++i) {
+      NUM_ZERO_LOOKUP[i] = (((i & 0xf0) == 0) ? 1 : 0) + (((i & 0x0f) == 0) ? 1 : 0);
+    }
+  }
+
+  public static double applyCorrection(double e, int zeroCount)
+  {
+    e = CORRECTION_PARAMETER / e;
+
+    if (e <= LOW_CORRECTION_THRESHOLD) {
+      return zeroCount == 0 ? e : NUM_BUCKETS * Math.log(NUM_BUCKETS / (double) zeroCount);
+    }
+
+    if (e > HIGH_CORRECTION_THRESHOLD) {
+      final double ratio = e / TWO_TO_THE_SIXTY_FOUR;
+      if (ratio >= 1) {
+        // handle very unlikely case that value is > 2^64
+        return Double.POSITIVE_INFINITY;
+      } else {
+        return -TWO_TO_THE_SIXTY_FOUR * Math.log(1 - ratio);
+      }
+    }
+
+    return e;
+  }
+
+
+  @Override
+  public int getNumBuckets()
+  {
+    return NUM_BUCKETS;
+  }
+
+  private static double estimateSparse(
+      final ByteBuffer buf,
+      final byte minNum,
+      final byte overflowValue,
+      final short overflowPosition,
+      final boolean isUpperNibble
+  )
+  {
+    final ByteBuffer copy = buf.asReadOnlyBuffer();
+    double e = 0.0d;
+    int zeroCount = NUM_BUCKETS - 2 * (buf.remaining() / 3);
+    while (copy.hasRemaining()) {
+      short position = copy.getShort();
+      final int register = (int) copy.get() & 0xff;
+      if (overflowValue != 0 && position == overflowPosition) {
+        int upperNibble = ((register & 0xf0) >>> BITS_PER_BUCKET) + minNum;
+        int lowerNibble = (register & 0x0f) + minNum;
+        if (isUpperNibble) {
+          upperNibble = Math.max(upperNibble, overflowValue);
+        } else {
+          lowerNibble = Math.max(lowerNibble, overflowValue);
+        }
+        e += 1.0d / Math.pow(2, upperNibble) + 1.0d / Math.pow(2, lowerNibble);
+        zeroCount += (((upperNibble & 0xf0) == 0) ? 1 : 0) + (((lowerNibble & 0x0f) == 0) ? 1 : 0);
+      } else {
+        e += MIN_NUM_REGISTER_LOOKUP[minNum][register];
+        zeroCount += NUM_ZERO_LOOKUP[register];
+      }
+    }
+
+    e += zeroCount;
+    return applyCorrection(e, zeroCount);
+  }
+
+  private static double estimateDense(
+      final ByteBuffer buf,
+      final byte minNum,
+      final byte overflowValue,
+      final short overflowPosition,
+      final boolean isUpperNibble
+  )
+  {
+    final ByteBuffer copy = buf.asReadOnlyBuffer();
+    double e = 0.0d;
+    int zeroCount = 0;
+    int position = 0;
+    while (copy.hasRemaining()) {
+      final int register = (int) copy.get() & 0xff;
+      if (overflowValue != 0 && position == overflowPosition) {
+        int upperNibble = ((register & 0xf0) >>> BITS_PER_BUCKET) + minNum;
+        int lowerNibble = (register & 0x0f) + minNum;
+        if (isUpperNibble) {
+          upperNibble = Math.max(upperNibble, overflowValue);
+        } else {
+          lowerNibble = Math.max(lowerNibble, overflowValue);
+        }
+        e += 1.0d / Math.pow(2, upperNibble) + 1.0d / Math.pow(2, lowerNibble);
+        zeroCount += (((upperNibble & 0xf0) == 0) ? 1 : 0) + (((lowerNibble & 0x0f) == 0) ? 1 : 0);
+      } else {
+        e += MIN_NUM_REGISTER_LOOKUP[minNum][register];
+        zeroCount += NUM_ZERO_LOOKUP[register];
+      }
+      position++;
+    }
+
+    return applyCorrection(e, zeroCount);
+  }
+
+  /**
+   * Checks if the payload for the given ByteBuffer is sparse or not.
+   * The given buffer must be positioned at getPayloadBytePosition() prior to calling isSparse
+   */
+  private static boolean isSparse(ByteBuffer buffer)
+  {
+    return buffer.remaining() != NUM_BYTES_FOR_BUCKETS;
+  }
+
+  private ByteBuffer storageBuffer;
+  private int initPosition;
+  private Double estimatedCardinality;
+
+  public AbstractHyperLogLogCollector(ByteBuffer byteBuffer)
+  {
+    storageBuffer = byteBuffer;
+    initPosition = byteBuffer.position();
+    estimatedCardinality = null;
+  }
+
+  public abstract byte getVersion();
+
+  public abstract void setVersion(ByteBuffer buffer);
+
+  public abstract byte getRegisterOffset();
+
+  public abstract void setRegisterOffset(byte registerOffset);
+
+  public abstract void setRegisterOffset(ByteBuffer buffer, byte registerOffset);
+
+  public abstract short getNumNonZeroRegisters();
+
+  public abstract void setNumNonZeroRegisters(short numNonZeroRegisters);
+
+  public abstract void setNumNonZeroRegisters(ByteBuffer buffer, short numNonZeroRegisters);
+
+  public abstract byte getMaxOverflowValue();
+
+  public abstract void setMaxOverflowValue(byte value);
+
+  public abstract void setMaxOverflowValue(ByteBuffer buffer, byte value);
+
+  public abstract short getMaxOverflowRegister();
+
+  public abstract void setMaxOverflowRegister(short register);
+
+  public abstract void setMaxOverflowRegister(ByteBuffer buffer, short register);
+
+  public abstract int getNumHeaderBytes();
+
+  public abstract int getNumBytesForDenseStorage();
+
+  public abstract int getPayloadBytePosition();
+
+  public abstract int getPayloadBytePosition(ByteBuffer buffer);
+
+  protected int getInitPosition()
+  {
+    return initPosition;
+  }
+
+  protected final ByteBuffer getStorageBuffer()
+  {
+    return storageBuffer;
+  }
+
+  @Override
+  public void add(byte[] hashedValue)
+  {
+    if (hashedValue.length < MIN_BYTES_REQUIRED) {
+      throw new IAE("Insufficient bytes, need[%d] got [%d]", MIN_BYTES_REQUIRED, hashedValue.length);
+    }
+
+    estimatedCardinality = null;
+
+    final ByteBuffer buffer = ByteBuffer.wrap(hashedValue);
+
+    short bucket = (short) (buffer.getShort(hashedValue.length - 2) & BUCKET_MASK);
+
+    byte positionOf1 = 0;
+
+    for (int i = 0; i < 8; ++i) {
+      byte lookupVal = ByteBitLookup.LOOKUP[UnsignedBytes.toInt(hashedValue[i])];
+      switch (lookupVal) {
+        case 0:
+          positionOf1 += (byte) 8;
+          continue;
+        default:
+          positionOf1 += lookupVal;
+          i = 8;
+          break;
+      }
+    }
+
+    add(bucket, positionOf1);
+  }
+
+  public void add(short bucket, byte positionOf1)
+  {
+    if (storageBuffer.isReadOnly()) {
+      convertToMutableByteBuffer();
+    }
+
+    byte registerOffset = getRegisterOffset();
+
+    // discard everything outside of the range we care about
+    if (positionOf1 <= registerOffset) {
+      return;
+    } else if (positionOf1 > (registerOffset + RANGE)) {
+      final byte currMax = getMaxOverflowValue();
+      if (positionOf1 > currMax) {
+        if (currMax <= (registerOffset + RANGE)) {
+          // this could be optimized by having an add without sanity checks
+          add(getMaxOverflowRegister(), currMax);
+        }
+        setMaxOverflowValue(positionOf1);
+        setMaxOverflowRegister(bucket);
+      }
+      return;
+    }
+
+    // whatever value we add must be stored in 4 bits
+    short numNonZeroRegisters = addNibbleRegister(bucket, (byte) ((0xff & positionOf1) - registerOffset));
+    setNumNonZeroRegisters(numNonZeroRegisters);
+    if (numNonZeroRegisters == NUM_BUCKETS) {
+      setRegisterOffset((byte) (registerOffset + 1));
+      setNumNonZeroRegisters(decrementBuckets());
+    }
+  }
+
+  static AbstractHyperLogLogCollector makeLatestCollector()
+  {
+    return new VersionOneHyperLogLogCollector();
+  }
+
+  static AbstractHyperLogLogCollector makeCollector(ByteBuffer buffer)
+  {
+    int remaining = buffer.remaining();
+    if (remaining % 3 == 0 || remaining == 1027) {
+      return new VersionZeroHyperLogLogCollector(buffer);
+    } else {
+      return new VersionOneHyperLogLogCollector(buffer);
+    }
+  }
+
+  @Override
+  public AbstractHyperLogLogCollector fold(@Nullable HyperLogLogCollector o)
+  {
+    if (o == null || !(o instanceof AbstractHyperLogLogCollector)) {
+      return this;
+    }
+
+    AbstractHyperLogLogCollector other = (AbstractHyperLogLogCollector) o;
+    if (other.storageBuffer.remaining() == 0) {
+      return this;
+    }
+
+    if (storageBuffer.isReadOnly()) {
+      convertToMutableByteBuffer();
+    }
+
+    if (storageBuffer.remaining() != getNumBytesForDenseStorage()) {
+      convertToDenseStorage();
+    }
+
+    estimatedCardinality = null;
+
+    if (getRegisterOffset() < other.getRegisterOffset()) {
+      // "Swap" the buffers so that we are folding into the one with the higher offset
+      final ByteBuffer tmpBuffer = ByteBuffer.allocate(storageBuffer.remaining());
+      tmpBuffer.put(storageBuffer.asReadOnlyBuffer());
+      tmpBuffer.clear();
+
+      storageBuffer.duplicate().put(other.storageBuffer.asReadOnlyBuffer());
+
+      if (other.storageBuffer.remaining() != other.getNumBytesForDenseStorage()) {
+        // The other buffer was sparse, densify it
+        final int newLImit = storageBuffer.position() + other.storageBuffer.remaining();
+        storageBuffer.limit(newLImit);
+        convertToDenseStorage();
+      }
+
+      other = AbstractHyperLogLogCollector.makeCollector(tmpBuffer);
+    }
+
+    final ByteBuffer otherBuffer = other.storageBuffer;
+
+    // Save position and restore later to avoid allocations due to duplicating the otherBuffer object.
+    final int otherPosition = otherBuffer.position();
+
+    try {
+      final byte otherOffset = other.getRegisterOffset();
+
+      byte myOffset = getRegisterOffset();
+      short numNonZero = getNumNonZeroRegisters();
+
+      final int offsetDiff = myOffset - otherOffset;
+      if (offsetDiff < 0) {
+        throw new ISE("offsetDiff[%d] < 0, shouldn't happen because of swap.", offsetDiff);
+      }
+
+      final int myPayloadStart = getPayloadBytePosition();
+      otherBuffer.position(other.getPayloadBytePosition());
+
+      if (isSparse(otherBuffer)) {
+        while (otherBuffer.hasRemaining()) {
+          final int payloadStartPosition = otherBuffer.getShort() - other.getNumHeaderBytes();
+          numNonZero += mergeAndStoreByteRegister(
+              storageBuffer,
+              myPayloadStart + payloadStartPosition,
+              offsetDiff,
+              otherBuffer.get()
+          );
+        }
+        if (numNonZero == NUM_BUCKETS) {
+          numNonZero = decrementBuckets();
+          setRegisterOffset((byte) (myOffset + 1));
+          setNumNonZeroRegisters(numNonZero);
+        }
+      } else { // dense
+        int position = getPayloadBytePosition();
+        while (otherBuffer.hasRemaining()) {
+          numNonZero += mergeAndStoreByteRegister(
+              storageBuffer,
+              position,
+              offsetDiff,
+              otherBuffer.get()
+          );
+          position++;
+        }
+        if (numNonZero == NUM_BUCKETS) {
+          numNonZero = decrementBuckets();
+          setRegisterOffset((byte) (myOffset + 1));
+          setNumNonZeroRegisters(numNonZero);
+        }
+      }
+
+      // no need to call setRegisterOffset(myOffset) here, since it gets updated every time myOffset is incremented
+      setNumNonZeroRegisters(numNonZero);
+
+      // this will add the max overflow and also recheck if offset needs to be shifted
+      add(other.getMaxOverflowRegister(), other.getMaxOverflowValue());
+
+      return this;
+    }
+    finally {
+      otherBuffer.position(otherPosition);
+    }
+  }
+
+  @Override
+  public HyperLogLogCollector fold(ByteBuffer buffer)
+  {
+    return fold(makeCollector(buffer.duplicate()));
+  }
+
+  @Override
+  public ByteBuffer toByteBuffer()
+  {
+
+    final short numNonZeroRegisters = getNumNonZeroRegisters();
+
+    // store sparsely
+    if (storageBuffer.remaining() == getNumBytesForDenseStorage() && numNonZeroRegisters < DENSE_THRESHOLD) {
+      final ByteBuffer retVal = ByteBuffer.wrap(new byte[numNonZeroRegisters * 3 + getNumHeaderBytes()]);
+      setVersion(retVal);
+      setRegisterOffset(retVal, getRegisterOffset());
+      setNumNonZeroRegisters(retVal, numNonZeroRegisters);
+      setMaxOverflowValue(retVal, getMaxOverflowValue());
+      setMaxOverflowRegister(retVal, getMaxOverflowRegister());
+
+      final int startPosition = getPayloadBytePosition();
+      retVal.position(getPayloadBytePosition(retVal));
+
+      final byte[] zipperBuffer = new byte[NUM_BYTES_FOR_BUCKETS];
+      ByteBuffer roStorageBuffer = storageBuffer.asReadOnlyBuffer();
+      roStorageBuffer.position(startPosition);
+      roStorageBuffer.get(zipperBuffer);
+
+      for (int i = 0; i < NUM_BYTES_FOR_BUCKETS; ++i) {
+        if (zipperBuffer[i] != 0) {
+          final short val = (short) (0xffff & (i + startPosition - initPosition));
+          retVal.putShort(val);
+          retVal.put(zipperBuffer[i]);
+        }
+      }
+      retVal.rewind();
+      return retVal.asReadOnlyBuffer();
+    }
+
+    return storageBuffer.asReadOnlyBuffer();
+  }
+
+  @Override
+  @JsonValue
+  public byte[] toByteArray()
+  {
+    final ByteBuffer buffer = toByteBuffer();
+    byte[] theBytes = new byte[buffer.remaining()];
+    buffer.get(theBytes);
+
+    return theBytes;
+  }
+
+  @Override
+  public long estimateCardinalityRound()
+  {
+    return Math.round(estimateCardinality());
+  }
+
+  @Override
+  public double estimateCardinality()
+  {
+    if (estimatedCardinality == null) {
+      byte registerOffset = getRegisterOffset();
+      byte overflowValue = getMaxOverflowValue();
+      short overflowRegister = getMaxOverflowRegister();
+      short overflowPosition = (short) (overflowRegister >>> 1);
+      boolean isUpperNibble = ((overflowRegister & 0x1) == 0);
+
+      storageBuffer.position(getPayloadBytePosition());
+
+      if (isSparse(storageBuffer)) {
+        estimatedCardinality = estimateSparse(
+            storageBuffer,
+            registerOffset,
+            overflowValue,
+            overflowPosition,
+            isUpperNibble
+        );
+      } else {
+        estimatedCardinality = estimateDense(
+            storageBuffer,
+            registerOffset,
+            overflowValue,
+            overflowPosition,
+            isUpperNibble
+        );
+      }
+
+      storageBuffer.position(initPosition);
+    }
+    return estimatedCardinality;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ByteBuffer otherBuffer = ((AbstractHyperLogLogCollector) o).storageBuffer;
+
+    if (storageBuffer != null ? false : otherBuffer != null) {
+      return false;
+    }
+
+    if (storageBuffer == null && otherBuffer == null) {
+      return true;
+    }
+
+    final ByteBuffer denseStorageBuffer;
+    if (storageBuffer.remaining() != getNumBytesForDenseStorage()) {
+      AbstractHyperLogLogCollector denseCollector = AbstractHyperLogLogCollector.makeCollector(storageBuffer.duplicate());
+      denseCollector.convertToDenseStorage();
+      denseStorageBuffer = denseCollector.storageBuffer;
+    } else {
+      denseStorageBuffer = storageBuffer;
+    }
+
+    if (otherBuffer.remaining() != getNumBytesForDenseStorage()) {
+      AbstractHyperLogLogCollector otherCollector = AbstractHyperLogLogCollector.makeCollector(otherBuffer.duplicate());
+      otherCollector.convertToDenseStorage();
+      otherBuffer = otherCollector.storageBuffer;
+    }
+
+    return denseStorageBuffer.equals(otherBuffer);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = storageBuffer != null ? storageBuffer.hashCode() : 0;
+    result = 31 * result + initPosition;
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "HyperLogLogCollector{" +
+           "initPosition=" + initPosition +
+           ", version=" + getVersion() +
+           ", registerOffset=" + getRegisterOffset() +
+           ", numNonZeroRegisters=" + getNumNonZeroRegisters() +
+           ", maxOverflowValue=" + getMaxOverflowValue() +
+           ", maxOverflowRegister=" + getMaxOverflowRegister() +
+           '}';
+  }
+
+  private short decrementBuckets()
+  {
+    final int startPosition = getPayloadBytePosition();
+    short count = 0;
+    for (int i = startPosition; i < startPosition + NUM_BYTES_FOR_BUCKETS; i++) {
+      final byte val = (byte) (storageBuffer.get(i) - 0x11);
+      if ((val & 0xf0) != 0) {
+        ++count;
+      }
+      if ((val & 0x0f) != 0) {
+        ++count;
+      }
+      storageBuffer.put(i, val);
+    }
+    return count;
+  }
+
+  private void convertToMutableByteBuffer()
+  {
+    ByteBuffer tmpBuffer = ByteBuffer.allocate(storageBuffer.remaining());
+    tmpBuffer.put(storageBuffer.asReadOnlyBuffer());
+    tmpBuffer.position(0);
+    storageBuffer = tmpBuffer;
+    initPosition = 0;
+  }
+
+  private void convertToDenseStorage()
+  {
+    ByteBuffer tmpBuffer = ByteBuffer.allocate(getNumBytesForDenseStorage());
+    // put header
+    setVersion(tmpBuffer);
+    setRegisterOffset(tmpBuffer, getRegisterOffset());
+    setNumNonZeroRegisters(tmpBuffer, getNumNonZeroRegisters());
+    setMaxOverflowValue(tmpBuffer, getMaxOverflowValue());
+    setMaxOverflowRegister(tmpBuffer, getMaxOverflowRegister());
+
+    storageBuffer.position(getPayloadBytePosition());
+    tmpBuffer.position(getPayloadBytePosition(tmpBuffer));
+    // put payload
+    while (storageBuffer.hasRemaining()) {
+      tmpBuffer.put(storageBuffer.getShort(), storageBuffer.get());
+    }
+    tmpBuffer.rewind();
+    storageBuffer = tmpBuffer;
+    initPosition = 0;
+  }
+
+  private short addNibbleRegister(short bucket, byte positionOf1)
+  {
+    short numNonZeroRegs = getNumNonZeroRegisters();
+
+    final int position = getPayloadBytePosition() + (short) (bucket >> 1);
+    final boolean isUpperNibble = ((bucket & 0x1) == 0);
+
+    final byte shiftedPositionOf1 = (isUpperNibble) ? (byte) (positionOf1 << BITS_PER_BUCKET) : positionOf1;
+
+    if (storageBuffer.remaining() != getNumBytesForDenseStorage()) {
+      convertToDenseStorage();
+    }
+
+    final byte origVal = storageBuffer.get(position);
+    final byte newValueMask = (isUpperNibble) ? (byte) 0xf0 : (byte) 0x0f;
+    final byte originalValueMask = (byte) (newValueMask ^ 0xff);
+
+    // if something was at zero, we have to increase the numNonZeroRegisters
+    if ((origVal & newValueMask) == 0 && shiftedPositionOf1 != 0) {
+      numNonZeroRegs++;
+    }
+
+    storageBuffer.put(
+        position,
+        (byte) (UnsignedBytes.max((byte) (origVal & newValueMask), shiftedPositionOf1) | (origVal & originalValueMask))
+    );
+
+    return numNonZeroRegs;
+  }
+
+  /**
+   * Returns the number of registers that are no longer zero after the value was added
+   *
+   * @param position   The position into the byte buffer, this position represents two "registers"
+   * @param offsetDiff The difference in offset between the byteToAdd and the current HyperLogLogCollector
+   * @param byteToAdd  The byte to merge into the current HyperLogLogCollector
+   */
+  private static short mergeAndStoreByteRegister(
+      final ByteBuffer storageBuffer,
+      final int position,
+      final int offsetDiff,
+      final byte byteToAdd
+  )
+  {
+    if (byteToAdd == 0) {
+      return 0;
+    }
+
+    final byte currVal = storageBuffer.get(position);
+
+    final int upperNibble = currVal & 0xf0;
+    final int lowerNibble = currVal & 0x0f;
+
+    // subtract the differences so that the nibbles align
+    final int otherUpper = (byteToAdd & 0xf0) - (offsetDiff << BITS_PER_BUCKET);
+    final int otherLower = (byteToAdd & 0x0f) - offsetDiff;
+
+    final int newUpper = Math.max(upperNibble, otherUpper);
+    final int newLower = Math.max(lowerNibble, otherLower);
+
+    storageBuffer.put(position, (byte) ((newUpper | newLower) & 0xff));
+
+    short numNoLongerZero = 0;
+    if (upperNibble == 0 && newUpper > 0) {
+      ++numNoLongerZero;
+    }
+    if (lowerNibble == 0 && newLower > 0) {
+      ++numNoLongerZero;
+    }
+
+    return numNoLongerZero;
+  }
+
+  @Override
+  public int compareTo(HyperLogLogCollector other)
+  {
+    return Double.compare(this.estimateCardinality(), other.estimateCardinality());
+  }
+}

--- a/hll/src/main/java/org/apache/druid/hll/AbstractHyperLogLogCollector.java
+++ b/hll/src/main/java/org/apache/druid/hll/AbstractHyperLogLogCollector.java
@@ -316,6 +316,10 @@ abstract class AbstractHyperLogLogCollector implements HyperLogLogCollector
     }
   }
 
+  static double estimateByteBuffer(ByteBuffer buf)
+  {
+    return makeCollector(buf.duplicate()).estimateCardinality();
+  }
   static AbstractHyperLogLogCollector makeLatestCollector()
   {
     return new VersionOneHyperLogLogCollector();

--- a/hll/src/main/java/org/apache/druid/hll/ByteBitLookup.java
+++ b/hll/src/main/java/org/apache/druid/hll/ByteBitLookup.java
@@ -20,10 +20,15 @@
 package org.apache.druid.hll;
 
 /**
+ *
  */
 public class ByteBitLookup
 {
   public static final byte[] LOOKUP;
+
+  private ByteBitLookup()
+  {
+  }
 
   static {
     LOOKUP = new byte[256];

--- a/hll/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
+++ b/hll/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
@@ -19,102 +19,52 @@
 
 package org.apache.druid.hll;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.primitives.UnsignedBytes;
-import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.ISE;
-
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
-/**
- * Implements the HyperLogLog cardinality estimator described in:
- *
- * http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
- *
- * Run this code to see a simple indication of expected errors based on different m values:
- *
- * <code>
- * for (int i = 1; i &lt; 20; ++i) {
- * System.out.printf("i[%,d], val[%,d] =&gt; error[%f%%]%n", i, 2 &lt;&lt; i, 104 / Math.sqrt(2 &lt;&lt; i));
- * }
- * </code>
- *
- * This class is *not* multi-threaded. It can be passed among threads, but it is written with the assumption that
- * only one thread is ever calling methods on it.
- *
- * If you have multiple threads calling methods on this concurrently, I hope you manage to get correct behavior.
- *
- * Note that despite the non-thread-safety of this class, it is actually currently used by multiple threads during
- * realtime indexing. HyperUniquesAggregator's "aggregate" and "get" methods can be called simultaneously by
- * OnheapIncrementalIndex, since its "doAggregate" and "getMetricObjectValue" methods are not synchronized. So, watch
- * out for that.
- */
-public abstract class HyperLogLogCollector implements Comparable<HyperLogLogCollector>
+public interface HyperLogLogCollector extends Comparable<HyperLogLogCollector>
 {
-  public static final int DENSE_THRESHOLD = 128;
-  public static final int BITS_FOR_BUCKETS = 11;
-  public static final int NUM_BUCKETS = 1 << BITS_FOR_BUCKETS;
-  public static final int NUM_BYTES_FOR_BUCKETS = NUM_BUCKETS / 2;
 
-  private static final double TWO_TO_THE_SIXTY_FOUR = Math.pow(2, 64);
-  private static final double ALPHA = 0.7213 / (1 + 1.079 / NUM_BUCKETS);
+  long estimateCardinalityRound();
 
-  public static final double LOW_CORRECTION_THRESHOLD = (5 * NUM_BUCKETS) / 2.0d;
-  public static final double HIGH_CORRECTION_THRESHOLD = TWO_TO_THE_SIXTY_FOUR / 30.0d;
-  public static final double CORRECTION_PARAMETER = ALPHA * NUM_BUCKETS * NUM_BUCKETS;
+  double estimateCardinality();
 
-  private static final int BUCKET_MASK = 0x7ff;
-  private static final int MIN_BYTES_REQUIRED = 10;
-  private static final int BITS_PER_BUCKET = 4;
-  private static final int RANGE = (int) Math.pow(2, BITS_PER_BUCKET) - 1;
+  void add(byte[] hashedValue);
 
-  private static final double[][] MIN_NUM_REGISTER_LOOKUP = new double[64][256];
+  HyperLogLogCollector fold(@Nullable HyperLogLogCollector other);
 
-  static {
-    for (int registerOffset = 0; registerOffset < 64; ++registerOffset) {
-      for (int register = 0; register < 256; ++register) {
-        final int upper = ((register & 0xf0) >> 4) + registerOffset;
-        final int lower = (register & 0x0f) + registerOffset;
-        MIN_NUM_REGISTER_LOOKUP[registerOffset][register] = 1.0d / Math.pow(2, upper) + 1.0d / Math.pow(2, lower);
-      }
-    }
-  }
+  HyperLogLogCollector fold(ByteBuffer buffer);
 
-  // we have to keep track of the number of zeroes in each of the two halves of the byte register (0, 1, or 2)
-  private static final int[] NUM_ZERO_LOOKUP = new int[256];
+  ByteBuffer toByteBuffer();
 
-  static {
-    for (int i = 0; i < NUM_ZERO_LOOKUP.length; ++i) {
-      NUM_ZERO_LOOKUP[i] = (((i & 0xf0) == 0) ? 1 : 0) + (((i & 0x0f) == 0) ? 1 : 0);
-    }
-  }
+  byte[] toByteArray();
+
+  int getNumBuckets();
 
   // Methods to build the latest HLLC
-  public static HyperLogLogCollector makeLatestCollector()
+  static HyperLogLogCollector makeLatestCollector()
   {
-    return new VersionOneHyperLogLogCollector();
+    return AbstractHyperLogLogCollector.makeLatestCollector();
   }
 
   /**
    * Create a wrapper object around an HLL sketch contained within a buffer. The position and limit of
    * the buffer may be changed; if you do not want this to happen, you can duplicate the buffer before
    * passing it in.
-   *
+   * <p>
    * The mark and byte order of the buffer will not be modified.
    *
    * @param buffer buffer containing an HLL sketch starting at its position and ending at its limit
-   *
    * @return HLLC wrapper object
    */
-  public static HyperLogLogCollector makeCollector(ByteBuffer buffer)
+  static HyperLogLogCollector makeCollector(ByteBuffer buffer)
   {
-    int remaining = buffer.remaining();
-    if (remaining % 3 == 0 || remaining == 1027) {
-      return new VersionZeroHyperLogLogCollector(buffer);
-    } else {
-      return new VersionOneHyperLogLogCollector(buffer);
-    }
+    return AbstractHyperLogLogCollector.makeCollector(buffer);
+  }
+
+  static double estimateByteBuffer(ByteBuffer buf)
+  {
+    return makeCollector(buf.duplicate()).estimateCardinality();
   }
 
   /**
@@ -123,617 +73,21 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
    * @param otherCollector collector which buffer will be shared
    * @return collector
    */
-  public static HyperLogLogCollector makeCollectorSharingStorage(HyperLogLogCollector otherCollector)
+  static HyperLogLogCollector makeCollectorSharingStorage(HyperLogLogCollector otherCollector)
   {
-    return makeCollector(otherCollector.getStorageBuffer().duplicate());
+    AbstractHyperLogLogCollector collector = (AbstractHyperLogLogCollector) otherCollector;
+    return makeCollector(collector.getStorageBuffer().duplicate());
   }
 
-  public static int getLatestNumBytesForDenseStorage()
+  static int getLatestNumBytesForDenseStorage()
   {
     return VersionOneHyperLogLogCollector.NUM_BYTES_FOR_DENSE_STORAGE;
   }
 
-  public static byte[] makeEmptyVersionedByteArray()
+  static byte[] makeEmptyVersionedByteArray()
   {
     byte[] arr = new byte[getLatestNumBytesForDenseStorage()];
     arr[0] = VersionOneHyperLogLogCollector.VERSION;
     return arr;
-  }
-
-  public static double applyCorrection(double e, int zeroCount)
-  {
-    e = CORRECTION_PARAMETER / e;
-
-    if (e <= LOW_CORRECTION_THRESHOLD) {
-      return zeroCount == 0 ? e : NUM_BUCKETS * Math.log(NUM_BUCKETS / (double) zeroCount);
-    }
-
-    if (e > HIGH_CORRECTION_THRESHOLD) {
-      final double ratio = e / TWO_TO_THE_SIXTY_FOUR;
-      if (ratio >= 1) {
-        // handle very unlikely case that value is > 2^64
-        return Double.POSITIVE_INFINITY;
-      } else {
-        return -TWO_TO_THE_SIXTY_FOUR * Math.log(1 - ratio);
-      }
-    }
-
-    return e;
-  }
-
-  public static double estimateByteBuffer(ByteBuffer buf)
-  {
-    return makeCollector(buf.duplicate()).estimateCardinality();
-  }
-
-  private static double estimateSparse(
-      final ByteBuffer buf,
-      final byte minNum,
-      final byte overflowValue,
-      final short overflowPosition,
-      final boolean isUpperNibble
-  )
-  {
-    final ByteBuffer copy = buf.asReadOnlyBuffer();
-    double e = 0.0d;
-    int zeroCount = NUM_BUCKETS - 2 * (buf.remaining() / 3);
-    while (copy.hasRemaining()) {
-      short position = copy.getShort();
-      final int register = (int) copy.get() & 0xff;
-      if (overflowValue != 0 && position == overflowPosition) {
-        int upperNibble = ((register & 0xf0) >>> BITS_PER_BUCKET) + minNum;
-        int lowerNibble = (register & 0x0f) + minNum;
-        if (isUpperNibble) {
-          upperNibble = Math.max(upperNibble, overflowValue);
-        } else {
-          lowerNibble = Math.max(lowerNibble, overflowValue);
-        }
-        e += 1.0d / Math.pow(2, upperNibble) + 1.0d / Math.pow(2, lowerNibble);
-        zeroCount += (((upperNibble & 0xf0) == 0) ? 1 : 0) + (((lowerNibble & 0x0f) == 0) ? 1 : 0);
-      } else {
-        e += MIN_NUM_REGISTER_LOOKUP[minNum][register];
-        zeroCount += NUM_ZERO_LOOKUP[register];
-      }
-    }
-
-    e += zeroCount;
-    return applyCorrection(e, zeroCount);
-  }
-
-  private static double estimateDense(
-      final ByteBuffer buf,
-      final byte minNum,
-      final byte overflowValue,
-      final short overflowPosition,
-      final boolean isUpperNibble
-  )
-  {
-    final ByteBuffer copy = buf.asReadOnlyBuffer();
-    double e = 0.0d;
-    int zeroCount = 0;
-    int position = 0;
-    while (copy.hasRemaining()) {
-      final int register = (int) copy.get() & 0xff;
-      if (overflowValue != 0 && position == overflowPosition) {
-        int upperNibble = ((register & 0xf0) >>> BITS_PER_BUCKET) + minNum;
-        int lowerNibble = (register & 0x0f) + minNum;
-        if (isUpperNibble) {
-          upperNibble = Math.max(upperNibble, overflowValue);
-        } else {
-          lowerNibble = Math.max(lowerNibble, overflowValue);
-        }
-        e += 1.0d / Math.pow(2, upperNibble) + 1.0d / Math.pow(2, lowerNibble);
-        zeroCount += (((upperNibble & 0xf0) == 0) ? 1 : 0) + (((lowerNibble & 0x0f) == 0) ? 1 : 0);
-      } else {
-        e += MIN_NUM_REGISTER_LOOKUP[minNum][register];
-        zeroCount += NUM_ZERO_LOOKUP[register];
-      }
-      position++;
-    }
-
-    return applyCorrection(e, zeroCount);
-  }
-
-  /**
-   * Checks if the payload for the given ByteBuffer is sparse or not.
-   * The given buffer must be positioned at getPayloadBytePosition() prior to calling isSparse
-   */
-  private static boolean isSparse(ByteBuffer buffer)
-  {
-    return buffer.remaining() != NUM_BYTES_FOR_BUCKETS;
-  }
-
-  private ByteBuffer storageBuffer;
-  private int initPosition;
-  private Double estimatedCardinality;
-
-  public HyperLogLogCollector(ByteBuffer byteBuffer)
-  {
-    storageBuffer = byteBuffer;
-    initPosition = byteBuffer.position();
-    estimatedCardinality = null;
-  }
-
-  public abstract byte getVersion();
-
-  public abstract void setVersion(ByteBuffer buffer);
-
-  public abstract byte getRegisterOffset();
-
-  public abstract void setRegisterOffset(byte registerOffset);
-
-  public abstract void setRegisterOffset(ByteBuffer buffer, byte registerOffset);
-
-  public abstract short getNumNonZeroRegisters();
-
-  public abstract void setNumNonZeroRegisters(short numNonZeroRegisters);
-
-  public abstract void setNumNonZeroRegisters(ByteBuffer buffer, short numNonZeroRegisters);
-
-  public abstract byte getMaxOverflowValue();
-
-  public abstract void setMaxOverflowValue(byte value);
-
-  public abstract void setMaxOverflowValue(ByteBuffer buffer, byte value);
-
-  public abstract short getMaxOverflowRegister();
-
-  public abstract void setMaxOverflowRegister(short register);
-
-  public abstract void setMaxOverflowRegister(ByteBuffer buffer, short register);
-
-  public abstract int getNumHeaderBytes();
-
-  public abstract int getNumBytesForDenseStorage();
-
-  public abstract int getPayloadBytePosition();
-
-  public abstract int getPayloadBytePosition(ByteBuffer buffer);
-
-  protected int getInitPosition()
-  {
-    return initPosition;
-  }
-
-  protected ByteBuffer getStorageBuffer()
-  {
-    return storageBuffer;
-  }
-
-  public void add(byte[] hashedValue)
-  {
-    if (hashedValue.length < MIN_BYTES_REQUIRED) {
-      throw new IAE("Insufficient bytes, need[%d] got [%d]", MIN_BYTES_REQUIRED, hashedValue.length);
-    }
-
-    estimatedCardinality = null;
-
-    final ByteBuffer buffer = ByteBuffer.wrap(hashedValue);
-
-    short bucket = (short) (buffer.getShort(hashedValue.length - 2) & BUCKET_MASK);
-
-    byte positionOf1 = 0;
-
-    for (int i = 0; i < 8; ++i) {
-      byte lookupVal = ByteBitLookup.LOOKUP[UnsignedBytes.toInt(hashedValue[i])];
-      switch (lookupVal) {
-        case 0:
-          positionOf1 += (byte) 8;
-          continue;
-        default:
-          positionOf1 += lookupVal;
-          i = 8;
-          break;
-      }
-    }
-
-    add(bucket, positionOf1);
-  }
-
-  public void add(short bucket, byte positionOf1)
-  {
-    if (storageBuffer.isReadOnly()) {
-      convertToMutableByteBuffer();
-    }
-
-    byte registerOffset = getRegisterOffset();
-
-    // discard everything outside of the range we care about
-    if (positionOf1 <= registerOffset) {
-      return;
-    } else if (positionOf1 > (registerOffset + RANGE)) {
-      final byte currMax = getMaxOverflowValue();
-      if (positionOf1 > currMax) {
-        if (currMax <= (registerOffset + RANGE)) {
-          // this could be optimized by having an add without sanity checks
-          add(getMaxOverflowRegister(), currMax);
-        }
-        setMaxOverflowValue(positionOf1);
-        setMaxOverflowRegister(bucket);
-      }
-      return;
-    }
-
-    // whatever value we add must be stored in 4 bits
-    short numNonZeroRegisters = addNibbleRegister(bucket, (byte) ((0xff & positionOf1) - registerOffset));
-    setNumNonZeroRegisters(numNonZeroRegisters);
-    if (numNonZeroRegisters == NUM_BUCKETS) {
-      setRegisterOffset((byte) (registerOffset + 1));
-      setNumNonZeroRegisters(decrementBuckets());
-    }
-  }
-
-  public HyperLogLogCollector fold(@Nullable HyperLogLogCollector other)
-  {
-    if (other == null || other.storageBuffer.remaining() == 0) {
-      return this;
-    }
-
-    if (storageBuffer.isReadOnly()) {
-      convertToMutableByteBuffer();
-    }
-
-    if (storageBuffer.remaining() != getNumBytesForDenseStorage()) {
-      convertToDenseStorage();
-    }
-
-    estimatedCardinality = null;
-
-    if (getRegisterOffset() < other.getRegisterOffset()) {
-      // "Swap" the buffers so that we are folding into the one with the higher offset
-      final ByteBuffer tmpBuffer = ByteBuffer.allocate(storageBuffer.remaining());
-      tmpBuffer.put(storageBuffer.asReadOnlyBuffer());
-      tmpBuffer.clear();
-
-      storageBuffer.duplicate().put(other.storageBuffer.asReadOnlyBuffer());
-
-      if (other.storageBuffer.remaining() != other.getNumBytesForDenseStorage()) {
-        // The other buffer was sparse, densify it
-        final int newLImit = storageBuffer.position() + other.storageBuffer.remaining();
-        storageBuffer.limit(newLImit);
-        convertToDenseStorage();
-      }
-
-      other = HyperLogLogCollector.makeCollector(tmpBuffer);
-    }
-
-    final ByteBuffer otherBuffer = other.storageBuffer;
-
-    // Save position and restore later to avoid allocations due to duplicating the otherBuffer object.
-    final int otherPosition = otherBuffer.position();
-
-    try {
-      final byte otherOffset = other.getRegisterOffset();
-
-      byte myOffset = getRegisterOffset();
-      short numNonZero = getNumNonZeroRegisters();
-
-      final int offsetDiff = myOffset - otherOffset;
-      if (offsetDiff < 0) {
-        throw new ISE("offsetDiff[%d] < 0, shouldn't happen because of swap.", offsetDiff);
-      }
-
-      final int myPayloadStart = getPayloadBytePosition();
-      otherBuffer.position(other.getPayloadBytePosition());
-
-      if (isSparse(otherBuffer)) {
-        while (otherBuffer.hasRemaining()) {
-          final int payloadStartPosition = otherBuffer.getShort() - other.getNumHeaderBytes();
-          numNonZero += mergeAndStoreByteRegister(
-              storageBuffer,
-              myPayloadStart + payloadStartPosition,
-              offsetDiff,
-              otherBuffer.get()
-          );
-        }
-        if (numNonZero == NUM_BUCKETS) {
-          numNonZero = decrementBuckets();
-          setRegisterOffset((byte) (myOffset + 1));
-          setNumNonZeroRegisters(numNonZero);
-        }
-      } else { // dense
-        int position = getPayloadBytePosition();
-        while (otherBuffer.hasRemaining()) {
-          numNonZero += mergeAndStoreByteRegister(
-              storageBuffer,
-              position,
-              offsetDiff,
-              otherBuffer.get()
-          );
-          position++;
-        }
-        if (numNonZero == NUM_BUCKETS) {
-          numNonZero = decrementBuckets();
-          setRegisterOffset((byte) (myOffset + 1));
-          setNumNonZeroRegisters(numNonZero);
-        }
-      }
-
-      // no need to call setRegisterOffset(myOffset) here, since it gets updated every time myOffset is incremented
-      setNumNonZeroRegisters(numNonZero);
-
-      // this will add the max overflow and also recheck if offset needs to be shifted
-      add(other.getMaxOverflowRegister(), other.getMaxOverflowValue());
-
-      return this;
-    }
-    finally {
-      otherBuffer.position(otherPosition);
-    }
-  }
-
-  public HyperLogLogCollector fold(ByteBuffer buffer)
-  {
-    return fold(makeCollector(buffer.duplicate()));
-  }
-
-  public ByteBuffer toByteBuffer()
-  {
-
-    final short numNonZeroRegisters = getNumNonZeroRegisters();
-
-    // store sparsely
-    if (storageBuffer.remaining() == getNumBytesForDenseStorage() && numNonZeroRegisters < DENSE_THRESHOLD) {
-      final ByteBuffer retVal = ByteBuffer.wrap(new byte[numNonZeroRegisters * 3 + getNumHeaderBytes()]);
-      setVersion(retVal);
-      setRegisterOffset(retVal, getRegisterOffset());
-      setNumNonZeroRegisters(retVal, numNonZeroRegisters);
-      setMaxOverflowValue(retVal, getMaxOverflowValue());
-      setMaxOverflowRegister(retVal, getMaxOverflowRegister());
-
-      final int startPosition = getPayloadBytePosition();
-      retVal.position(getPayloadBytePosition(retVal));
-
-      final byte[] zipperBuffer = new byte[NUM_BYTES_FOR_BUCKETS];
-      ByteBuffer roStorageBuffer = storageBuffer.asReadOnlyBuffer();
-      roStorageBuffer.position(startPosition);
-      roStorageBuffer.get(zipperBuffer);
-
-      for (int i = 0; i < NUM_BYTES_FOR_BUCKETS; ++i) {
-        if (zipperBuffer[i] != 0) {
-          final short val = (short) (0xffff & (i + startPosition - initPosition));
-          retVal.putShort(val);
-          retVal.put(zipperBuffer[i]);
-        }
-      }
-      retVal.rewind();
-      return retVal.asReadOnlyBuffer();
-    }
-
-    return storageBuffer.asReadOnlyBuffer();
-  }
-
-  @JsonValue
-  public byte[] toByteArray()
-  {
-    final ByteBuffer buffer = toByteBuffer();
-    byte[] theBytes = new byte[buffer.remaining()];
-    buffer.get(theBytes);
-
-    return theBytes;
-  }
-
-  public long estimateCardinalityRound()
-  {
-    return Math.round(estimateCardinality());
-  }
-
-  public double estimateCardinality()
-  {
-    if (estimatedCardinality == null) {
-      byte registerOffset = getRegisterOffset();
-      byte overflowValue = getMaxOverflowValue();
-      short overflowRegister = getMaxOverflowRegister();
-      short overflowPosition = (short) (overflowRegister >>> 1);
-      boolean isUpperNibble = ((overflowRegister & 0x1) == 0);
-
-      storageBuffer.position(getPayloadBytePosition());
-
-      if (isSparse(storageBuffer)) {
-        estimatedCardinality = estimateSparse(
-            storageBuffer,
-            registerOffset,
-            overflowValue,
-            overflowPosition,
-            isUpperNibble
-        );
-      } else {
-        estimatedCardinality = estimateDense(
-            storageBuffer,
-            registerOffset,
-            overflowValue,
-            overflowPosition,
-            isUpperNibble
-        );
-      }
-
-      storageBuffer.position(initPosition);
-    }
-    return estimatedCardinality;
-  }
-
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    ByteBuffer otherBuffer = ((HyperLogLogCollector) o).storageBuffer;
-
-    if (storageBuffer != null ? false : otherBuffer != null) {
-      return false;
-    }
-
-    if (storageBuffer == null && otherBuffer == null) {
-      return true;
-    }
-
-    final ByteBuffer denseStorageBuffer;
-    if (storageBuffer.remaining() != getNumBytesForDenseStorage()) {
-      HyperLogLogCollector denseCollector = HyperLogLogCollector.makeCollector(storageBuffer.duplicate());
-      denseCollector.convertToDenseStorage();
-      denseStorageBuffer = denseCollector.storageBuffer;
-    } else {
-      denseStorageBuffer = storageBuffer;
-    }
-
-    if (otherBuffer.remaining() != getNumBytesForDenseStorage()) {
-      HyperLogLogCollector otherCollector = HyperLogLogCollector.makeCollector(otherBuffer.duplicate());
-      otherCollector.convertToDenseStorage();
-      otherBuffer = otherCollector.storageBuffer;
-    }
-
-    return denseStorageBuffer.equals(otherBuffer);
-  }
-
-  @Override
-  public int hashCode()
-  {
-    int result = storageBuffer != null ? storageBuffer.hashCode() : 0;
-    result = 31 * result + initPosition;
-    return result;
-  }
-
-  @Override
-  public String toString()
-  {
-    return "HyperLogLogCollector{" +
-           "initPosition=" + initPosition +
-           ", version=" + getVersion() +
-           ", registerOffset=" + getRegisterOffset() +
-           ", numNonZeroRegisters=" + getNumNonZeroRegisters() +
-           ", maxOverflowValue=" + getMaxOverflowValue() +
-           ", maxOverflowRegister=" + getMaxOverflowRegister() +
-           '}';
-  }
-
-  private short decrementBuckets()
-  {
-    final int startPosition = getPayloadBytePosition();
-    short count = 0;
-    for (int i = startPosition; i < startPosition + NUM_BYTES_FOR_BUCKETS; i++) {
-      final byte val = (byte) (storageBuffer.get(i) - 0x11);
-      if ((val & 0xf0) != 0) {
-        ++count;
-      }
-      if ((val & 0x0f) != 0) {
-        ++count;
-      }
-      storageBuffer.put(i, val);
-    }
-    return count;
-  }
-
-  private void convertToMutableByteBuffer()
-  {
-    ByteBuffer tmpBuffer = ByteBuffer.allocate(storageBuffer.remaining());
-    tmpBuffer.put(storageBuffer.asReadOnlyBuffer());
-    tmpBuffer.position(0);
-    storageBuffer = tmpBuffer;
-    initPosition = 0;
-  }
-
-  private void convertToDenseStorage()
-  {
-    ByteBuffer tmpBuffer = ByteBuffer.allocate(getNumBytesForDenseStorage());
-    // put header
-    setVersion(tmpBuffer);
-    setRegisterOffset(tmpBuffer, getRegisterOffset());
-    setNumNonZeroRegisters(tmpBuffer, getNumNonZeroRegisters());
-    setMaxOverflowValue(tmpBuffer, getMaxOverflowValue());
-    setMaxOverflowRegister(tmpBuffer, getMaxOverflowRegister());
-
-    storageBuffer.position(getPayloadBytePosition());
-    tmpBuffer.position(getPayloadBytePosition(tmpBuffer));
-    // put payload
-    while (storageBuffer.hasRemaining()) {
-      tmpBuffer.put(storageBuffer.getShort(), storageBuffer.get());
-    }
-    tmpBuffer.rewind();
-    storageBuffer = tmpBuffer;
-    initPosition = 0;
-  }
-
-  private short addNibbleRegister(short bucket, byte positionOf1)
-  {
-    short numNonZeroRegs = getNumNonZeroRegisters();
-
-    final int position = getPayloadBytePosition() + (short) (bucket >> 1);
-    final boolean isUpperNibble = ((bucket & 0x1) == 0);
-
-    final byte shiftedPositionOf1 = (isUpperNibble) ? (byte) (positionOf1 << BITS_PER_BUCKET) : positionOf1;
-
-    if (storageBuffer.remaining() != getNumBytesForDenseStorage()) {
-      convertToDenseStorage();
-    }
-
-    final byte origVal = storageBuffer.get(position);
-    final byte newValueMask = (isUpperNibble) ? (byte) 0xf0 : (byte) 0x0f;
-    final byte originalValueMask = (byte) (newValueMask ^ 0xff);
-
-    // if something was at zero, we have to increase the numNonZeroRegisters
-    if ((origVal & newValueMask) == 0 && shiftedPositionOf1 != 0) {
-      numNonZeroRegs++;
-    }
-
-    storageBuffer.put(
-        position,
-        (byte) (UnsignedBytes.max((byte) (origVal & newValueMask), shiftedPositionOf1) | (origVal & originalValueMask))
-    );
-
-    return numNonZeroRegs;
-  }
-
-  /**
-   * Returns the number of registers that are no longer zero after the value was added
-   *
-   * @param position   The position into the byte buffer, this position represents two "registers"
-   * @param offsetDiff The difference in offset between the byteToAdd and the current HyperLogLogCollector
-   * @param byteToAdd  The byte to merge into the current HyperLogLogCollector
-   */
-  private static short mergeAndStoreByteRegister(
-      final ByteBuffer storageBuffer,
-      final int position,
-      final int offsetDiff,
-      final byte byteToAdd
-  )
-  {
-    if (byteToAdd == 0) {
-      return 0;
-    }
-
-    final byte currVal = storageBuffer.get(position);
-
-    final int upperNibble = currVal & 0xf0;
-    final int lowerNibble = currVal & 0x0f;
-
-    // subtract the differences so that the nibbles align
-    final int otherUpper = (byteToAdd & 0xf0) - (offsetDiff << BITS_PER_BUCKET);
-    final int otherLower = (byteToAdd & 0x0f) - offsetDiff;
-
-    final int newUpper = Math.max(upperNibble, otherUpper);
-    final int newLower = Math.max(lowerNibble, otherLower);
-
-    storageBuffer.put(position, (byte) ((newUpper | newLower) & 0xff));
-
-    short numNoLongerZero = 0;
-    if (upperNibble == 0 && newUpper > 0) {
-      ++numNoLongerZero;
-    }
-    if (lowerNibble == 0 && newLower > 0) {
-      ++numNoLongerZero;
-    }
-
-    return numNoLongerZero;
-  }
-
-  @Override
-  public int compareTo(HyperLogLogCollector other)
-  {
-    return Double.compare(this.estimateCardinality(), other.estimateCardinality());
   }
 }

--- a/hll/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
+++ b/hll/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
@@ -22,26 +22,60 @@ package org.apache.druid.hll;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
+/**
+ * HyperLogLog cardinality estimator
+ */
 public interface HyperLogLogCollector extends Comparable<HyperLogLogCollector>
 {
 
+  /**
+   * Get the estimated cardinality rounded to the nearest long.
+   */
   long estimateCardinalityRound();
 
+  /**
+   * Get the estimated cardinality.
+   */
   double estimateCardinality();
 
+  /**
+   * Add hash value to the underlying HyperLogLog structure.
+   * @param hashedValue hashed value, using {@link com.google.common.hash.HashFunction}.
+   */
   void add(byte[] hashedValue);
 
+  /**
+   * Merge with another collector
+   * @param other another collector
+   * @return this collector
+   */
   HyperLogLogCollector fold(@Nullable HyperLogLogCollector other);
 
+  /**
+   * Merge with another collector represented by byte buffer
+   * @param buffer another collector
+   * @return this collector
+   */
   HyperLogLogCollector fold(ByteBuffer buffer);
 
+  /**
+   * Copy and return the underlying byte buffer
+   * @return the underlying byte buffer
+   */
   ByteBuffer toByteBuffer();
 
+  /**
+   * Copy and return the underlying byte buffer in array form
+   * @return the underlying byte buffer in array form
+   */
   byte[] toByteArray();
 
+  /**
+   * Get the number of buckets
+   */
   int getNumBuckets();
 
-  // Methods to build the latest HLLC
+  /** Methods to build the latest HLLC */
   static HyperLogLogCollector makeLatestCollector()
   {
     return AbstractHyperLogLogCollector.makeLatestCollector();
@@ -60,11 +94,6 @@ public interface HyperLogLogCollector extends Comparable<HyperLogLogCollector>
   static HyperLogLogCollector makeCollector(ByteBuffer buffer)
   {
     return AbstractHyperLogLogCollector.makeCollector(buffer);
-  }
-
-  static double estimateByteBuffer(ByteBuffer buf)
-  {
-    return makeCollector(buf.duplicate()).estimateCardinality();
   }
 
   /**

--- a/hll/src/main/java/org/apache/druid/hll/VersionOneHyperLogLogCollector.java
+++ b/hll/src/main/java/org/apache/druid/hll/VersionOneHyperLogLogCollector.java
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
 
 /**
  */
-public class VersionOneHyperLogLogCollector extends HyperLogLogCollector
+public class VersionOneHyperLogLogCollector extends AbstractHyperLogLogCollector
 {
   /**
    * Header:

--- a/hll/src/main/java/org/apache/druid/hll/VersionZeroHyperLogLogCollector.java
+++ b/hll/src/main/java/org/apache/druid/hll/VersionZeroHyperLogLogCollector.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 /**
  */
 @Deprecated
-public class VersionZeroHyperLogLogCollector extends HyperLogLogCollector
+public class VersionZeroHyperLogLogCollector extends AbstractHyperLogLogCollector
 {
   /**
    * Header:

--- a/hll/src/test/java/org/apache/druid/hll/AbstractHyperLogLogCollectorTest.java
+++ b/hll/src/test/java/org/apache/druid/hll/AbstractHyperLogLogCollectorTest.java
@@ -43,13 +43,14 @@ import java.util.function.Predicate;
 /**
  *
  */
-public class HyperLogLogCollectorTest
+@SuppressWarnings("UnstableApiUsage")
+public class AbstractHyperLogLogCollectorTest
 {
-  private static final Logger log = new Logger(HyperLogLogCollectorTest.class);
+  private static final Logger log = new Logger(AbstractHyperLogLogCollectorTest.class);
 
   private final HashFunction fn = Hashing.murmur3_128();
 
-  private static void fillBuckets(HyperLogLogCollector collector, byte startOffset, byte endOffset)
+  private static void fillBuckets(AbstractHyperLogLogCollector collector, byte startOffset, byte endOffset)
   {
     byte offset = startOffset;
     while (offset <= endOffset) {
@@ -67,9 +68,9 @@ public class HyperLogLogCollectorTest
     final Random random = new Random(0);
     final int[] numValsToCheck = {10, 20, 50, 100, 1000, 2000};
     for (int numThings : numValsToCheck) {
-      HyperLogLogCollector allCombined = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector oneHalf = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector otherHalf = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector allCombined = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector oneHalf = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector otherHalf = AbstractHyperLogLogCollector.makeLatestCollector();
 
       for (int i = 0; i < numThings; ++i) {
         byte[] hashedVal = fn.hashLong(random.nextLong()).asBytes();
@@ -82,7 +83,7 @@ public class HyperLogLogCollectorTest
         }
       }
 
-      HyperLogLogCollector folded = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector folded = AbstractHyperLogLogCollector.makeLatestCollector();
 
       folded.fold(oneHalf);
       Assert.assertEquals(oneHalf, folded);
@@ -109,11 +110,11 @@ public class HyperLogLogCollectorTest
   @Test
   public void testHighCardinalityRollingFold() throws Exception
   {
-    final HyperLogLogCollector rolling = HyperLogLogCollector.makeLatestCollector();
-    final HyperLogLogCollector simple = HyperLogLogCollector.makeLatestCollector();
+    final AbstractHyperLogLogCollector rolling = AbstractHyperLogLogCollector.makeLatestCollector();
+    final AbstractHyperLogLogCollector simple = AbstractHyperLogLogCollector.makeLatestCollector();
 
     MessageDigest md = MessageDigest.getInstance("SHA-1");
-    HyperLogLogCollector tmp = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector tmp = AbstractHyperLogLogCollector.makeLatestCollector();
 
     int count;
     for (count = 0; count < 100_000_000; ++count) {
@@ -126,7 +127,7 @@ public class HyperLogLogCollectorTest
 
       if (count % 100 == 0) {
         rolling.fold(tmp);
-        tmp = HyperLogLogCollector.makeLatestCollector();
+        tmp = AbstractHyperLogLogCollector.makeLatestCollector();
       }
     }
 
@@ -145,12 +146,12 @@ public class HyperLogLogCollectorTest
   @Test
   public void testHighCardinalityRollingFold2()
   {
-    final HyperLogLogCollector rolling = HyperLogLogCollector.makeLatestCollector();
+    final AbstractHyperLogLogCollector rolling = AbstractHyperLogLogCollector.makeLatestCollector();
     int count;
     long start = System.currentTimeMillis();
 
     for (count = 0; count < 50_000_000; ++count) {
-      HyperLogLogCollector theCollector = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector theCollector = AbstractHyperLogLogCollector.makeLatestCollector();
       theCollector.add(fn.hashLong(count).asBytes());
       rolling.fold(theCollector);
     }
@@ -171,9 +172,9 @@ public class HyperLogLogCollectorTest
     final Random random = new Random(0);
     final int[] numValsToCheck = {10, 20, 50, 100, 1000, 2000};
     for (int numThings : numValsToCheck) {
-      HyperLogLogCollector allCombined = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector oneHalf = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector otherHalf = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector allCombined = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector oneHalf = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector otherHalf = AbstractHyperLogLogCollector.makeLatestCollector();
 
       for (int i = 0; i < numThings; ++i) {
         byte[] hashedVal = fn.hashLong(random.nextLong()).asBytes();
@@ -186,7 +187,7 @@ public class HyperLogLogCollectorTest
         }
       }
 
-      HyperLogLogCollector folded = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector folded = AbstractHyperLogLogCollector.makeLatestCollector();
 
       folded.fold(oneHalf.toByteBuffer());
       Assert.assertEquals(oneHalf, folded);
@@ -204,9 +205,9 @@ public class HyperLogLogCollectorTest
     final Random random = new Random(0);
     final int[] numValsToCheck = {10, 20, 50, 100, 1000, 2000};
     for (int numThings : numValsToCheck) {
-      HyperLogLogCollector allCombined = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector oneHalf = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector otherHalf = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector allCombined = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector oneHalf = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector otherHalf = AbstractHyperLogLogCollector.makeLatestCollector();
 
       for (int i = 0; i < numThings; ++i) {
         byte[] hashedVal = fn.hashLong(random.nextLong()).asBytes();
@@ -219,7 +220,7 @@ public class HyperLogLogCollectorTest
         }
       }
 
-      HyperLogLogCollector folded = HyperLogLogCollector.makeCollector(
+      AbstractHyperLogLogCollector folded = AbstractHyperLogLogCollector.makeCollector(
           ByteBuffer.wrap(HyperLogLogCollector.makeEmptyVersionedByteArray())
                     .asReadOnlyBuffer()
       );
@@ -240,9 +241,9 @@ public class HyperLogLogCollectorTest
     final Random random = new Random(0);
     final int[] numValsToCheck = {10, 20, 50, 100, 1000, 2000};
     for (int numThings : numValsToCheck) {
-      HyperLogLogCollector allCombined = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector oneHalf = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector otherHalf = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector allCombined = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector oneHalf = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector otherHalf = AbstractHyperLogLogCollector.makeLatestCollector();
 
       for (int i = 0; i < numThings; ++i) {
         byte[] hashedVal = fn.hashLong(random.nextLong()).asBytes();
@@ -255,7 +256,7 @@ public class HyperLogLogCollectorTest
         }
       }
 
-      HyperLogLogCollector folded = HyperLogLogCollector.makeCollector(
+      AbstractHyperLogLogCollector folded = AbstractHyperLogLogCollector.makeCollector(
           shiftedBuffer(
               ByteBuffer.wrap(HyperLogLogCollector.makeEmptyVersionedByteArray())
                         .asReadOnlyBuffer(),
@@ -279,7 +280,7 @@ public class HyperLogLogCollectorTest
     ByteBuffer biggerOffset = makeCollectorBuffer(1, (byte) 0x00, 0x11);
     ByteBuffer smallerOffset = makeCollectorBuffer(0, (byte) 0x20, 0x00);
 
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(biggerOffset);
     collector.fold(smallerOffset);
 
@@ -295,7 +296,7 @@ public class HyperLogLogCollectorTest
       Assert.assertEquals(outBuffer.get(), 0x11);
     }
 
-    collector = HyperLogLogCollector.makeLatestCollector();
+    collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(smallerOffset);
     collector.fold(biggerOffset);
 
@@ -319,15 +320,15 @@ public class HyperLogLogCollectorTest
     ByteBuffer smallerOffset = makeCollectorBuffer(0, (byte) 0x20, 0x00);
 
     ByteBuffer buffer = ByteBuffer.allocate(HyperLogLogCollector.getLatestNumBytesForDenseStorage());
-    HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(buffer.duplicate());
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeCollector(buffer.duplicate());
 
     // make sure the original buffer gets modified
     collector.fold(biggerOffset);
-    Assert.assertEquals(collector, HyperLogLogCollector.makeCollector(buffer.duplicate()));
+    Assert.assertEquals(collector, AbstractHyperLogLogCollector.makeCollector(buffer.duplicate()));
 
     // make sure the original buffer gets modified
     collector.fold(smallerOffset);
-    Assert.assertEquals(collector, HyperLogLogCollector.makeCollector(buffer.duplicate()));
+    Assert.assertEquals(collector, AbstractHyperLogLogCollector.makeCollector(buffer.duplicate()));
   }
 
   @Test
@@ -336,7 +337,7 @@ public class HyperLogLogCollectorTest
     ByteBuffer biggerOffset = shiftedBuffer(makeCollectorBuffer(1, (byte) 0x00, 0x11), 10);
     ByteBuffer smallerOffset = shiftedBuffer(makeCollectorBuffer(0, (byte) 0x20, 0x00), 15);
 
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(biggerOffset);
     collector.fold(smallerOffset);
 
@@ -352,7 +353,7 @@ public class HyperLogLogCollectorTest
       Assert.assertEquals(outBuffer.get(), 0x11);
     }
 
-    collector = HyperLogLogCollector.makeLatestCollector();
+    collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(smallerOffset);
     collector.fold(biggerOffset);
 
@@ -384,7 +385,7 @@ public class HyperLogLogCollectorTest
     ByteBuffer biggerOffset = makeCollectorBuffer(1, (byte) 0x01, 0x11);
     ByteBuffer smallerOffset = makeCollectorBuffer(0, (byte) 0x20, 0x00);
 
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(biggerOffset);
     collector.fold(smallerOffset);
 
@@ -397,7 +398,7 @@ public class HyperLogLogCollectorTest
     outBuffer.getShort();
     Assert.assertFalse(outBuffer.hasRemaining());
 
-    collector = HyperLogLogCollector.makeLatestCollector();
+    collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(smallerOffset);
     collector.fold(biggerOffset);
 
@@ -429,7 +430,7 @@ public class HyperLogLogCollectorTest
     buffer2.put(1, (byte) 0);
     buffer2.putShort(2, (short) (2048));
 
-    HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(buffer1);
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeCollector(buffer1);
     collector.fold(buffer2);
 
     ByteBuffer outBuffer = collector.toByteBuffer();
@@ -446,10 +447,10 @@ public class HyperLogLogCollectorTest
   public void testSparseFoldWithDifferentOffsets1()
   {
     ByteBuffer biggerOffset = makeCollectorBuffer(1, new byte[]{0x11, 0x10}, 0x11);
-    ByteBuffer sparse = HyperLogLogCollector.makeCollector(makeCollectorBuffer(0, new byte[]{0x00, 0x02}, 0x00))
+    ByteBuffer sparse = AbstractHyperLogLogCollector.makeCollector(makeCollectorBuffer(0, new byte[]{0x00, 0x02}, 0x00))
                                             .toByteBuffer();
 
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(biggerOffset);
     collector.fold(sparse);
 
@@ -462,7 +463,7 @@ public class HyperLogLogCollectorTest
     Assert.assertEquals(outBuffer.getShort(), 0);
     Assert.assertFalse(outBuffer.hasRemaining());
 
-    collector = HyperLogLogCollector.makeLatestCollector();
+    collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.fold(sparse);
     collector.fold(biggerOffset);
 
@@ -489,7 +490,7 @@ public class HyperLogLogCollectorTest
     }
 
     final short numNonZeroInRemaining = computeNumNonZero((byte) remainingBytes);
-    numNonZero += (short) ((HyperLogLogCollector.NUM_BYTES_FOR_BUCKETS - initialBytes.length) * numNonZeroInRemaining);
+    numNonZero += (short) ((AbstractHyperLogLogCollector.NUM_BYTES_FOR_BUCKETS - initialBytes.length) * numNonZeroInRemaining);
 
     ByteBuffer biggerOffset = ByteBuffer.allocate(HyperLogLogCollector.getLatestNumBytesForDenseStorage());
     biggerOffset.put(VersionOneHyperLogLogCollector.VERSION);
@@ -524,9 +525,9 @@ public class HyperLogLogCollectorTest
     // final Random random = new Random(37); // this seed will cause this test to fail because of slightly larger errors
     final Random random = new Random(0);
     for (int j = 0; j < 10; j++) {
-      HyperLogLogCollector smallVals = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector bigVals = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector all = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector smallVals = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector bigVals = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector all = AbstractHyperLogLogCollector.makeLatestCollector();
 
       int numThings = 500000;
       for (int i = 0; i < numThings; i++) {
@@ -540,7 +541,7 @@ public class HyperLogLogCollectorTest
         all.add(hashedVal);
       }
 
-      HyperLogLogCollector folded = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector folded = AbstractHyperLogLogCollector.makeLatestCollector();
       folded.fold(smallVals);
       folded.fold(bigVals);
       final double expected = all.estimateCardinality();
@@ -557,9 +558,9 @@ public class HyperLogLogCollectorTest
     MessageDigest md = MessageDigest.getInstance("SHA-1");
 
     for (int j = 0; j < 1; j++) {
-      HyperLogLogCollector evenVals = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector oddVals = HyperLogLogCollector.makeLatestCollector();
-      HyperLogLogCollector all = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector evenVals = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector oddVals = AbstractHyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector all = AbstractHyperLogLogCollector.makeLatestCollector();
 
       int numThings = 500000;
       for (int i = 0; i < numThings; i++) {
@@ -574,7 +575,7 @@ public class HyperLogLogCollectorTest
         all.add(hashedVal);
       }
 
-      HyperLogLogCollector folded = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector folded = AbstractHyperLogLogCollector.makeLatestCollector();
       folded.fold(evenVals);
       folded.fold(oddVals);
       final double expected = all.estimateCardinality();
@@ -597,7 +598,7 @@ public class HyperLogLogCollectorTest
     };
 
     int valsToCheckIndex = 0;
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     for (int i = 0; i < valsToCheck[valsToCheck.length - 1]; ++i) {
       collector.add(fn.hashLong(random.nextLong()).asBytes());
       if (i == valsToCheck[valsToCheckIndex]) {
@@ -623,7 +624,7 @@ public class HyperLogLogCollectorTest
     };
 
     int valsToCheckIndex = 0;
-    HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeCollector(
         ByteBuffer.allocateDirect(
             HyperLogLogCollector.getLatestNumBytesForDenseStorage()
         )
@@ -653,7 +654,7 @@ public class HyperLogLogCollectorTest
     };
 
     int valsToCheckIndex = 0;
-    HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeCollector(
         (ByteBuffer) ByteBuffer.allocate(10000)
                                .position(0)
                                .limit(HyperLogLogCollector.getLatestNumBytesForDenseStorage())
@@ -673,7 +674,7 @@ public class HyperLogLogCollectorTest
   public void testSparseEstimation()
   {
     final Random random = new Random(0);
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
 
     for (int i = 0; i < 100; ++i) {
       collector.add(fn.hashLong(random.nextLong()).asBytes());
@@ -687,7 +688,7 @@ public class HyperLogLogCollectorTest
   @Test
   public void testHighBits()
   {
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
 
     // fill up all the buckets so we reach a registerOffset of 49
     fillBuckets(collector, (byte) 0, (byte) 49);
@@ -706,7 +707,7 @@ public class HyperLogLogCollectorTest
   @Test
   public void testMaxOverflow()
   {
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.add((short) 23, (byte) 16);
     Assert.assertEquals(23, collector.getMaxOverflowRegister());
     Assert.assertEquals(16, collector.getMaxOverflowValue());
@@ -727,16 +728,16 @@ public class HyperLogLogCollectorTest
   @Test
   public void testRegisterSwapWithSparse()
   {
-    final HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    final AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     // Skip the first bucket
-    for (int i = 1; i < HyperLogLogCollector.NUM_BUCKETS; i++) {
+    for (int i = 1; i < AbstractHyperLogLogCollector.NUM_BUCKETS; i++) {
       collector.add((short) i, (byte) 1);
       Assert.assertEquals(i, collector.getNumNonZeroRegisters());
       Assert.assertEquals(0, collector.getRegisterOffset());
     }
     Assert.assertEquals(
         15615.219683654448D,
-        HyperLogLogCollector.makeCollector(collector.toByteBuffer().asReadOnlyBuffer())
+        AbstractHyperLogLogCollector.makeCollector(collector.toByteBuffer().asReadOnlyBuffer())
                             .estimateCardinality(),
         1e-5D
     );
@@ -757,13 +758,13 @@ public class HyperLogLogCollectorTest
     final ByteBuffer buffer = collector.toByteBuffer();
     Assert.assertEquals(collector.getNumHeaderBytes(), buffer.remaining());
 
-    final HyperLogLogCollector denseCollector = HyperLogLogCollector.makeLatestCollector();
-    for (int i = 0; i < HyperLogLogCollector.NUM_BUCKETS - 1; i++) {
+    final AbstractHyperLogLogCollector denseCollector = AbstractHyperLogLogCollector.makeLatestCollector();
+    for (int i = 0; i < AbstractHyperLogLogCollector.NUM_BUCKETS - 1; i++) {
       denseCollector.add((short) i, (byte) 1);
     }
 
-    Assert.assertEquals(HyperLogLogCollector.NUM_BUCKETS - 1, denseCollector.getNumNonZeroRegisters());
-    final HyperLogLogCollector folded = denseCollector.fold(HyperLogLogCollector.makeCollector(buffer));
+    Assert.assertEquals(AbstractHyperLogLogCollector.NUM_BUCKETS - 1, denseCollector.getNumNonZeroRegisters());
+    final AbstractHyperLogLogCollector folded = denseCollector.fold(HyperLogLogCollector.makeCollector(buffer));
     Assert.assertNotNull(folded.toByteBuffer());
     Assert.assertEquals(folded.getStorageBuffer().remaining(), denseCollector.getNumBytesForDenseStorage());
   }
@@ -773,7 +774,7 @@ public class HyperLogLogCollectorTest
   public void testCanFillUpOnMod()
   {
     final HashFunction fn = Hashing.murmur3_128();
-    final HyperLogLogCollector hyperLogLogCollector = HyperLogLogCollector.makeLatestCollector();
+    final AbstractHyperLogLogCollector hyperLogLogCollector = AbstractHyperLogLogCollector.makeLatestCollector();
     final byte[] b = new byte[10];
     b[0] = 1;
     hyperLogLogCollector.add(b);
@@ -803,10 +804,10 @@ public class HyperLogLogCollectorTest
   public void testMergeMaxOverflow()
   {
     // no offset
-    HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.add((short) 23, (byte) 16);
 
-    HyperLogLogCollector other = HyperLogLogCollector.makeLatestCollector();
+    AbstractHyperLogLogCollector other = AbstractHyperLogLogCollector.makeLatestCollector();
     collector.add((short) 56, (byte) 17);
 
     collector.fold(other);
@@ -815,11 +816,11 @@ public class HyperLogLogCollectorTest
 
     // different offsets
     // fill up all the buckets so we reach a registerOffset of 49
-    collector = HyperLogLogCollector.makeLatestCollector();
+    collector = AbstractHyperLogLogCollector.makeLatestCollector();
     fillBuckets(collector, (byte) 0, (byte) 49);
     collector.add((short) 23, (byte) 65);
 
-    other = HyperLogLogCollector.makeLatestCollector();
+    other = AbstractHyperLogLogCollector.makeLatestCollector();
     fillBuckets(other, (byte) 0, (byte) 43);
     other.add((short) 47, (byte) 67);
 
@@ -846,7 +847,7 @@ public class HyperLogLogCollectorTest
     Collection<List<HyperLogLogCollector>> permutations = Collections2.permutations(collectors);
 
     for (List<HyperLogLogCollector> permutation : permutations) {
-      HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
 
       for (HyperLogLogCollector foldee : permutation) {
         collector.fold(foldee);
@@ -874,7 +875,7 @@ public class HyperLogLogCollectorTest
 
     for (int numThings : valsToCheck) {
       long startTime = System.currentTimeMillis();
-      HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+      AbstractHyperLogLogCollector collector = AbstractHyperLogLogCollector.makeLatestCollector();
 
       for (int i = 0; i < numThings; ++i) {
         if (i != 0 && i % 100000000 == 0) {
@@ -889,7 +890,7 @@ public class HyperLogLogCollectorTest
     }
   }
 
-  private double computeError(double error, int count, int numThings, long startTime, HyperLogLogCollector collector)
+  private double computeError(double error, int count, int numThings, long startTime, AbstractHyperLogLogCollector collector)
   {
     final double estimatedValue = collector.estimateCardinality();
     final double errorThisTime = Math.abs((double) numThings - estimatedValue) / numThings;

--- a/hll/src/test/java/org/apache/druid/hll/AbstractHyperLogLogCollectorTest.java
+++ b/hll/src/test/java/org/apache/druid/hll/AbstractHyperLogLogCollectorTest.java
@@ -681,7 +681,7 @@ public class AbstractHyperLogLogCollectorTest
     }
 
     Assert.assertEquals(
-        collector.estimateCardinality(), HyperLogLogCollector.estimateByteBuffer(collector.toByteBuffer()), 0.0d
+        collector.estimateCardinality(), AbstractHyperLogLogCollector.estimateByteBuffer(collector.toByteBuffer()), 0.0d
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/query/aggregation/MetricManipulatorFnsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/MetricManipulatorFnsTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation;
 
+import com.google.common.hash.Hashing;
 import org.apache.druid.hll.HyperLogLogCollector;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
@@ -72,7 +73,7 @@ public class MetricManipulatorFnsTest
 
     HyperUniquesAggregatorFactory hyperUniquesAggregatorFactory = new HyperUniquesAggregatorFactory(NAME, FIELD);
     HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
-    collector.add((short) 1, (byte) 5);
+    collector.add(Hashing.murmur3_128().hashLong(123).asBytes());
 
     constructorArrays.add(
         new Object[]{


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Related to #11824 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Extract HyperLogLog file into an interface and an abstract class to hide implementation details

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->
added interface `org.apache.druid.hll.HyperLogLogCollector`, all current class users are not affected.

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
