### PR TITLE
Refactor ResponseContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ README
 **/.pmd
 **/.pmdruleset.xml
 .java-version
+integration-tests/gen-scripts/

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryRunner.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryRunner.java
@@ -123,8 +123,7 @@ public class MovingAverageQueryRunner implements QueryRunner<Row>
 
       ResponseContext gbqResponseContext = ResponseContext.createEmpty();
       gbqResponseContext.merge(responseContext);
-      gbqResponseContext.put(
-          ResponseContext.Key.QUERY_FAIL_DEADLINE_MILLIS,
+      gbqResponseContext.putQueryFailDeadlineMs(
           System.currentTimeMillis() + QueryContexts.getTimeout(gbq)
       );
 
@@ -164,8 +163,7 @@ public class MovingAverageQueryRunner implements QueryRunner<Row>
       );
       ResponseContext tsqResponseContext = ResponseContext.createEmpty();
       tsqResponseContext.merge(responseContext);
-      tsqResponseContext.put(
-          ResponseContext.Key.QUERY_FAIL_DEADLINE_MILLIS,
+      tsqResponseContext.putQueryFailDeadlineMs(
           System.currentTimeMillis() + QueryContexts.getTimeout(tsq)
       );
 

--- a/processing/src/main/java/org/apache/druid/jackson/DruidDefaultSerializersModule.java
+++ b/processing/src/main/java/org/apache/druid/jackson/DruidDefaultSerializersModule.java
@@ -31,15 +31,20 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.guava.Accumulator;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Yielder;
+import org.apache.druid.query.context.ResponseContext;
+import org.apache.druid.query.context.ResponseContextDeserializer;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
 
 /**
+ *
  */
+@SuppressWarnings("serial")
 public class DruidDefaultSerializersModule extends SimpleModule
 {
+  @SuppressWarnings("rawtypes")
   public DruidDefaultSerializersModule()
   {
     super("Druid default serializers");
@@ -78,6 +83,7 @@ public class DruidDefaultSerializersModule extends SimpleModule
         Sequence.class,
         new JsonSerializer<Sequence>()
         {
+          @SuppressWarnings("unchecked")
           @Override
           public void serialize(Sequence value, final JsonGenerator jgen, SerializerProvider provider)
               throws IOException
@@ -108,6 +114,7 @@ public class DruidDefaultSerializersModule extends SimpleModule
         Yielder.class,
         new JsonSerializer<Yielder>()
         {
+          @SuppressWarnings("unchecked")
           @Override
           public void serialize(Yielder yielder, final JsonGenerator jgen, SerializerProvider provider)
               throws IOException
@@ -142,5 +149,6 @@ public class DruidDefaultSerializersModule extends SimpleModule
           }
         }
     );
+    addDeserializer(ResponseContext.class, new ResponseContextDeserializer());
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/CPUTimeMetricQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/CPUTimeMetricQueryRunner.java
@@ -56,7 +56,6 @@ public class CPUTimeMetricQueryRunner<T> implements QueryRunner<T>
     this.report = report;
   }
 
-
   @Override
   public Sequence<T> run(final QueryPlus<T> queryPlus, final ResponseContext responseContext)
   {
@@ -88,7 +87,7 @@ public class CPUTimeMetricQueryRunner<T> implements QueryRunner<T>
             if (report) {
               final long cpuTimeNs = cpuTimeAccumulator.get();
               if (cpuTimeNs > 0) {
-                responseContext.add(ResponseContext.Key.CPU_CONSUMED_NANOS, cpuTimeNs);
+                responseContext.addCpuNanos(cpuTimeNs);
                 queryWithMetrics.getQueryMetrics().reportCpuTime(cpuTimeNs).emit(emitter);
               }
             }

--- a/processing/src/main/java/org/apache/druid/query/ReportTimelineMissingSegmentQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/ReportTimelineMissingSegmentQueryRunner.java
@@ -49,7 +49,7 @@ public class ReportTimelineMissingSegmentQueryRunner<T> implements QueryRunner<T
   public Sequence<T> run(QueryPlus<T> queryPlus, ResponseContext responseContext)
   {
     LOG.debug("Reporting a missing segments[%s] for query[%s]", descriptors, queryPlus.getQuery().getId());
-    responseContext.add(ResponseContext.Key.MISSING_SEGMENTS, descriptors);
+    responseContext.addMissingSegments(descriptors);
     return Sequences.empty();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/context/ConcurrentResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ConcurrentResponseContext.java
@@ -35,10 +35,10 @@ public class ConcurrentResponseContext extends ResponseContext
     return new ConcurrentResponseContext();
   }
 
-  private final ConcurrentHashMap<BaseKey, Object> delegate = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Key, Object> delegate = new ConcurrentHashMap<>();
 
   @Override
-  protected Map<BaseKey, Object> getDelegate()
+  protected Map<Key, Object> getDelegate()
   {
     return delegate;
   }

--- a/processing/src/main/java/org/apache/druid/query/context/DefaultResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/DefaultResponseContext.java
@@ -35,10 +35,10 @@ public class DefaultResponseContext extends ResponseContext
     return new DefaultResponseContext();
   }
 
-  private final HashMap<BaseKey, Object> delegate = new HashMap<>();
+  private final HashMap<Key, Object> delegate = new HashMap<>();
 
   @Override
-  protected Map<BaseKey, Object> getDelegate()
+  protected Map<Key, Object> getDelegate()
   {
     return delegate;
   }

--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
@@ -462,7 +462,7 @@ public abstract class ResponseContext
      * Thread-safe structure is required since there is no guarantee that {@link #registerKey(Key)}
      * would be called only from class static blocks.
      */
-    private final ConcurrentMap<String, Key> registered_keys = new ConcurrentSkipListMap<>();
+    private final ConcurrentMap<String, Key> registeredKeys = new ConcurrentSkipListMap<>();
 
     static {
       instance().registerKeys(new Key[]
@@ -503,7 +503,7 @@ public abstract class ResponseContext
      */
     public void registerKey(Key key)
     {
-      if (registered_keys.putIfAbsent(key.getName(), key) != null) {
+      if (registeredKeys.putIfAbsent(key.getName(), key) != null) {
         throw new IAE("Key [%s] has already been registered as a context key", key.getName());
       }
     }
@@ -525,7 +525,7 @@ public abstract class ResponseContext
      */
     public Key keyOf(String name)
     {
-      Key key = registered_keys.get(name);
+      Key key = registeredKeys.get(name);
       if (key == null) {
         throw new ISE("Key [%s] is not registered as a context key", name);
       }
@@ -539,7 +539,7 @@ public abstract class ResponseContext
      */
     public Key find(String name)
     {
-      return registered_keys.get(name);
+      return registeredKeys.get(name);
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
@@ -19,38 +19,80 @@
 
 package org.apache.druid.query.context;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
+import org.apache.druid.guice.annotations.ExtensionPoint;
 import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.NonnullPair;
-import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.query.SegmentDescriptor;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.function.BiFunction;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * The context for storing and passing data between chains of {@link org.apache.druid.query.QueryRunner}s.
  * The context is also transferred between Druid nodes with all the data it contains.
- */
+ * <p>
+ * The response context consists of a set of key/value pairs. Keys are those defined in
+ * the {@code Keys} registry. Keys are indexed by key instance, not by name. The
+ * key defines the type of the associated value, including logic to merge values and
+ * to deserialize JSON values for that key.
+ *
+ * <h4>Structure</h4>
+ * The context has evolved to perform multiple tasks. First, it holds two kinds
+ * of information:
+ * <ul>
+ * <li>Information to be returned in the query response header.
+ * (These are values tagged as {@link Visibility#HEADER}.)</li>
+ * <li>Values passed within a single server. These are tagged with
+ * visibility {@link Visibility#NONE}.)</li>
+ * </ul>
+ * Second, it performs multiple tasks:
+ * <ul>
+ * <li>Registers the keys to be used in the header. But, since it also holds
+ * internal information, the internal information also needs keys, though the
+ * corresponding values are never serialized.</li>
+ * <li>Gathers information for the query as a whole.</li>
+ * <li>Merges information back up the query tree: from multiple segments,
+ * from multiple servers, etc.</li>
+ * <li>Manages headers size by dropping fields when the header would get too
+ * large.</li>
+ * </ul>
+ *
+ * A result is that the information the context, when inspected by a calling
+ * query, may be incomplete if some of it was previously dropped by the
+ * called query.
+ *
+ * <h4>API</h4>
+ *
+ * The query profile needs to obtain the full, untruncated information. To do this
+ * it piggy-backs on the set operations to obtain the full value. To ensure this
+ * is possible, code that works with standard values should call the set (or add)
+ * functions provided which will do the needed map update.
+  */
 @PublicApi
 public abstract class ResponseContext
 {
@@ -58,65 +100,261 @@ public abstract class ResponseContext
    * The base interface of a response context key.
    * Should be implemented by every context key.
    */
-  public interface BaseKey
+  @ExtensionPoint
+  public interface Key
   {
     @JsonValue
     String getName();
+
     /**
-     * Merge function associated with a key: Object (Object oldValue, Object newValue)
+     * The phase (header, trailer, none) where this key is emitted.
      */
-    BiFunction<Object, Object, Object> getMergeFunction();
+    Visibility getPhase();
+
+    /**
+     * Reads a value of this key from a JSON stream. Used by {@link ResponseContextDeserializer}.
+     */
+    Object readValue(JsonParser jp);
+
+    /**
+     * Merges two values of type T.
+     *
+     * This method may modify "oldValue" but must not modify "newValue".
+     */
+    Object mergeValues(Object oldValue, Object newValue);
+
+    /**
+     * Returns true if this key can be removed to reduce header size when the
+     * header would otherwise be too large.
+     */
+    @JsonIgnore
+    boolean canDrop();
   }
 
   /**
-   * Keys associated with objects in the context.
+   * Where the key is emitted, if at all. Values in the context can be for internal
+   * use only: for return before the query results (header) or only after query
+   * results (trailer).
+   */
+  public enum Visibility
+  {
+    /**
+     * Keys to include in in the "X-Druid-Response-Context" header.
+     */
+    HEADER,
+
+    /**
+     * Keys that are not present in query responses at all. Generally used for internal state tracking within a
+     * single server.
+     */
+    NONE
+  }
+
+  /**
+   * Abstract key class which provides most functionality except the
+   * type-specific merge logic. Parsing is provided by an associated
+   * parse function.
+   */
+  public abstract static class AbstractKey implements Key
+  {
+    private final String name;
+    private final Visibility visibility;
+    private final boolean canDrop;
+    private final Function<JsonParser, Object> parseFunction;
+
+    AbstractKey(String name, Visibility visibility, boolean canDrop, Class<?> serializedClass)
+    {
+      this.name = name;
+      this.visibility = visibility;
+      this.canDrop = canDrop;
+      this.parseFunction = jp -> {
+        try {
+          return jp.readValueAs(serializedClass);
+        }
+        catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      };
+    }
+
+    AbstractKey(String name, Visibility visibility, boolean canDrop, TypeReference<?> serializedTypeReference)
+    {
+      this.name = name;
+      this.visibility = visibility;
+      this.canDrop = canDrop;
+      this.parseFunction = jp -> {
+        try {
+          return jp.readValueAs(serializedTypeReference);
+        }
+        catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      };
+    }
+
+    @Override
+    public String getName()
+    {
+      return name;
+    }
+
+    @Override
+    public Visibility getPhase()
+    {
+      return visibility;
+    }
+
+    @Override
+    public boolean canDrop()
+    {
+      return canDrop;
+    }
+
+    @Override
+    public Object readValue(JsonParser jp)
+    {
+      return parseFunction.apply(jp);
+    }
+
+    @Override
+    public String toString()
+    {
+      return name;
+    }
+  }
+
+  /**
+   * String valued attribute that holds the latest value assigned.
+   */
+  public static class StringKey extends AbstractKey
+  {
+    StringKey(String name, Visibility visibility, boolean canDrop)
+    {
+      super(name, visibility, canDrop, String.class);
+    }
+
+    @Override
+    public Object mergeValues(Object oldValue, Object newValue)
+    {
+      return newValue;
+    }
+  }
+
+  /**
+   * Boolean valued attribute with the semantics that once the flag is
+   * set true, it stays true.
+   */
+  public static class BooleanKey extends AbstractKey
+  {
+    BooleanKey(String name, Visibility visibility)
+    {
+      super(name, visibility, false, Boolean.class);
+    }
+
+    @Override
+    public Object mergeValues(Object oldValue, Object newValue)
+    {
+      return (boolean) oldValue || (boolean) newValue;
+    }
+  }
+
+  /**
+   * Long valued attribute that holds the latest value assigned.
+   */
+  public static class LongKey extends AbstractKey
+  {
+    LongKey(String name, Visibility visibility)
+    {
+      super(name, visibility, false, Long.class);
+    }
+
+    @Override
+    public Object mergeValues(Object oldValue, Object newValue)
+    {
+      return newValue;
+    }
+  }
+
+  /**
+   * Long valued attribute that holds the accumulation of values assigned.
+   */
+  public static class CounterKey extends AbstractKey
+  {
+    CounterKey(String name, Visibility visibility)
+    {
+      super(name, visibility, false, Long.class);
+    }
+
+    @Override
+    public Object mergeValues(Object oldValue, Object newValue)
+    {
+      if (oldValue == null) {
+        return newValue;
+      }
+      if (newValue == null) {
+        return oldValue;
+      }
+      return (Long) oldValue + (Long) newValue;
+    }
+  }
+
+  /**
+   * Global registry of response context keys. Also defines the standard keys
+   * associated with objects in the context.
    * <p>
-   * If it's necessary to have some new keys in the context then they might be listed in a separate enum:
+   * If it's necessary to add new keys in the context then they should be listed
+   * in a separate class:
    * <pre>{@code
-   * public enum ExtensionResponseContextKey implements BaseKey
+   * public class SomeClass
    * {
-   *   EXTENSION_KEY_1("extension_key_1"), EXTENSION_KEY_2("extension_key_2");
+   *   static final Key EXTENSION_KEY_1 = new StringKey(
+   *      "extension_key_1", Visibility.HEADER_AND_TRAILER, true),
+   *   static final Key EXTENSION_KEY_2 = new CounterKey(
+   *      "extension_key_2", Visibility.None);
    *
    *   static {
-   *     for (BaseKey key : values()) ResponseContext.Key.registerKey(key);
+   *     Keys.instance().registerKeys(new Key[] {
+   *        EXTENSION_KEY_1,
+   *        EXTENSION_KEY_2
+   *     });
    *   }
-   *
-   *   private final String name;
-   *   private final BiFunction<Object, Object, Object> mergeFunction;
-   *
-   *   ExtensionResponseContextKey(String name)
-   *   {
-   *     this.name = name;
-   *     this.mergeFunction = (oldValue, newValue) -> newValue;
-   *   }
-   *
-   *   @Override public String getName() { return name; }
-   *
-   *   @Override public BiFunction<Object, Object, Object> getMergeFunction() { return mergeFunction; }
-   * }
    * }</pre>
-   * Make sure all extension enum values added with {@link Key#registerKey} method.
+   * Make sure all extension keys are added with the {@link #registerKey(Key)} or
+   * {@link #registerKeys(Key[])} methods.
+   * <p>
+   * Create custom keys in one of two ways. As shown above, predefined key types
+   * exist for common values. Custom values can be created as shown in the code
+   * for this class.
    */
-  public enum Key implements BaseKey
+  public static class Keys
   {
     /**
      * Lists intervals for which NO segment is present.
      */
-    UNCOVERED_INTERVALS(
+    public static final Key UNCOVERED_INTERVALS = new AbstractKey(
         "uncoveredIntervals",
-            (oldValue, newValue) -> {
-              final ArrayList<Interval> result = new ArrayList<Interval>((List) oldValue);
-              result.addAll((List) newValue);
-              return result;
-            }
-    ),
+        Visibility.HEADER, true,
+        new TypeReference<List<Interval>>()
+        {
+        })
+    {
+      @Override
+      @SuppressWarnings("unchecked")
+      public Object mergeValues(Object oldValue, Object newValue)
+      {
+        final List<Interval> result = new ArrayList<Interval>((List<Interval>) oldValue);
+        result.addAll((List<Interval>) newValue);
+        return result;
+      }
+    };
+
     /**
      * Indicates if the number of uncovered intervals exceeded the limit (true/false).
      */
-    UNCOVERED_INTERVALS_OVERFLOWED(
+    public static final Key UNCOVERED_INTERVALS_OVERFLOWED = new BooleanKey(
         "uncoveredIntervalsOverflowed",
-            (oldValue, newValue) -> (boolean) oldValue || (boolean) newValue
-    ),
+        Visibility.HEADER);
+
     /**
      * Map of most relevant query ID to remaining number of responses from query nodes.
      * The value is initialized in {@code CachingClusteredClient} when it initializes the connection to the query nodes,
@@ -129,156 +367,203 @@ public abstract class ResponseContext
      *
      * @see org.apache.druid.query.Query#getMostSpecificId
      */
-    REMAINING_RESPONSES_FROM_QUERY_SERVERS(
+    public static final Key REMAINING_RESPONSES_FROM_QUERY_SERVERS = new AbstractKey(
         "remainingResponsesFromQueryServers",
-            (totalRemainingPerId, idAndNumResponses) -> {
-              final ConcurrentHashMap<String, Integer> map = (ConcurrentHashMap<String, Integer>) totalRemainingPerId;
-              final NonnullPair<String, Integer> pair = (NonnullPair<String, Integer>) idAndNumResponses;
-              map.compute(
-                  pair.lhs,
-                  (id, remaining) -> remaining == null ? pair.rhs : remaining + pair.rhs
-              );
-              return map;
-            }
-    ),
+        Visibility.NONE, true,
+        Object.class)
+    {
+      @Override
+      @SuppressWarnings("unchecked")
+      public Object mergeValues(Object totalRemainingPerId, Object idAndNumResponses)
+      {
+        final ConcurrentHashMap<String, Integer> map = (ConcurrentHashMap<String, Integer>) totalRemainingPerId;
+        final NonnullPair<String, Integer> pair = (NonnullPair<String, Integer>) idAndNumResponses;
+        map.compute(
+            pair.lhs,
+            (id, remaining) -> remaining == null ? pair.rhs : remaining + pair.rhs);
+        return map;
+      }
+    };
+
     /**
      * Lists missing segments.
      */
-    MISSING_SEGMENTS(
+    public static final Key MISSING_SEGMENTS = new AbstractKey(
         "missingSegments",
-            (oldValue, newValue) -> {
-              final ArrayList<SegmentDescriptor> result = new ArrayList<SegmentDescriptor>((List) oldValue);
-              result.addAll((List) newValue);
-              return result;
-            }
-    ),
+        Visibility.HEADER, true,
+        new TypeReference<List<SegmentDescriptor>>() {})
+    {
+      @Override
+      @SuppressWarnings("unchecked")
+      public Object mergeValues(Object oldValue, Object newValue)
+      {
+        final List<SegmentDescriptor> result = new ArrayList<SegmentDescriptor>((List<SegmentDescriptor>) oldValue);
+        result.addAll((List<SegmentDescriptor>) newValue);
+        return result;
+      }
+    };
+
     /**
      * Entity tag. A part of HTTP cache validation mechanism.
      * Is being removed from the context before sending and used as a separate HTTP header.
      */
-    ETAG("ETag"),
-    /**
-     * Query fail time (current time + timeout).
-     * It is not updated continuously as {@link Key#TIMEOUT_AT}.
-     */
-    QUERY_FAIL_DEADLINE_MILLIS("queryFailTime"),
+    public static final Key ETAG = new StringKey("ETag", Visibility.NONE, true);
+
     /**
      * Query total bytes gathered.
      */
-    QUERY_TOTAL_BYTES_GATHERED("queryTotalBytesGathered"),
+    public static final Key QUERY_TOTAL_BYTES_GATHERED = new AbstractKey(
+        "queryTotalBytesGathered",
+        Visibility.NONE, false,
+        new TypeReference<AtomicLong>() {})
+    {
+      @Override
+      public Object mergeValues(Object oldValue, Object newValue)
+      {
+        return ((AtomicLong) newValue).addAndGet(((AtomicLong) newValue).get());
+      }
+    };
+
+    /**
+     * Query fail time (current time + timeout).
+     * It is not updated continuously as {@link Keys#TIMEOUT_AT}.
+     */
+    public static final Key QUERY_FAIL_DEADLINE_MILLIS = new LongKey(
+        "queryFailTime",
+        Visibility.NONE);
+
     /**
      * This variable indicates when a running query should be expired,
      * and is effective only when 'timeout' of queryContext has a positive value.
      * Continuously updated by {@link org.apache.druid.query.scan.ScanQueryEngine}
      * by reducing its value on the time of every scan iteration.
      */
-    TIMEOUT_AT("timeoutAt"),
+    public static final Key TIMEOUT_AT = new LongKey(
+        "timeoutAt",
+        Visibility.NONE);
+
     /**
-     * The number of scanned rows.
-     * For backward compatibility the context key name still equals to "count".
+     * The number of rows scanned by {@link org.apache.druid.query.scan.ScanQueryEngine}.
+     *
+     * Named "count" for backwards compatibility with older data servers that still send this, even though it's now
+     * marked with {@link Visibility#NONE}.
      */
-    NUM_SCANNED_ROWS(
+    public static final Key NUM_SCANNED_ROWS = new CounterKey(
         "count",
-            (oldValue, newValue) -> ((Number) oldValue).longValue() + ((Number) newValue).longValue()
-    ),
+        Visibility.NONE);
+
     /**
      * The total CPU time for threads related to Sequence processing of the query.
      * Resulting value on a Broker is a sum of downstream values from historicals / realtime nodes.
      * For additional information see {@link org.apache.druid.query.CPUTimeMetricQueryRunner}
      */
-    CPU_CONSUMED_NANOS(
+    public static final Key CPU_CONSUMED_NANOS = new CounterKey(
         "cpuConsumed",
-            (oldValue, newValue) -> ((Number) oldValue).longValue() + ((Number) newValue).longValue()
-    ),
+        Visibility.NONE);
+
     /**
      * Indicates if a {@link ResponseContext} was truncated during serialization.
      */
-    TRUNCATED(
+    public static final Key TRUNCATED = new BooleanKey(
         "truncated",
-            (oldValue, newValue) -> (boolean) oldValue || (boolean) newValue
-    );
+        Visibility.HEADER);
+
+    /**
+     * One and only global list of keys. This is a semi-constant: it is mutable
+     * at start-up time, but then is not thread-safe, and must remain unchanged
+     * for the duration of the server run.
+     */
+    public static final Keys INSTANCE = new Keys();
 
     /**
      * ConcurrentSkipListMap is used to have the natural ordering of its keys.
-     * Thread-safe structure is required since there is no guarantee that {@link #registerKey(BaseKey)}
+     * Thread-safe structure is required since there is no guarantee that {@link #registerKey(Key)}
      * would be called only from class static blocks.
      */
-    private static final ConcurrentMap<String, BaseKey> REGISTERED_KEYS = new ConcurrentSkipListMap<>();
+    private final ConcurrentMap<String, Key> registered_keys = new ConcurrentSkipListMap<>();
 
     static {
-      for (BaseKey key : values()) {
-        registerKey(key);
-      }
+      instance().registerKeys(new Key[]
+      {
+          UNCOVERED_INTERVALS,
+          UNCOVERED_INTERVALS_OVERFLOWED,
+          REMAINING_RESPONSES_FROM_QUERY_SERVERS,
+          MISSING_SEGMENTS,
+          ETAG,
+          QUERY_TOTAL_BYTES_GATHERED,
+          QUERY_FAIL_DEADLINE_MILLIS,
+          TIMEOUT_AT,
+          NUM_SCANNED_ROWS,
+          CPU_CONSUMED_NANOS,
+          TRUNCATED,
+      });
+    }
+
+    /**
+     * Use {@link #instance()} to obtain the singleton instance of this class.
+     */
+    private Keys()
+    {
+    }
+
+    /**
+     * Returns the single, global key registry for this server.
+     */
+    public static Keys instance()
+    {
+      return INSTANCE;
     }
 
     /**
      * Primary way of registering context keys.
+     *
      * @throws IllegalArgumentException if the key has already been registered.
      */
-    public static void registerKey(BaseKey key)
+    public void registerKey(Key key)
     {
-      if (REGISTERED_KEYS.putIfAbsent(key.getName(), key) != null) {
+      if (registered_keys.putIfAbsent(key.getName(), key) != null) {
         throw new IAE("Key [%s] has already been registered as a context key", key.getName());
       }
     }
 
     /**
-     * Returns a registered key associated with the name {@param name}.
-     * @throws IllegalStateException if a corresponding key has not been registered.
+     * Register a group of keys.
      */
-    public static BaseKey keyOf(String name)
+    public void registerKeys(Key[] keys)
     {
-      BaseKey key = REGISTERED_KEYS.get(name);
-      if (key == null) {
-        throw new ISE("Key [%s] has not yet been registered as a context key", name);
+      for (Key key : keys) {
+        registerKey(key);
       }
-      return key;
     }
 
     /**
-     * Returns all keys registered via {@link Key#registerKey}.
+     * Returns a registered key associated with the name {@param name}.
+     *
+     * @throws IllegalStateException if a corresponding key has not been registered.
      */
-    public static Collection<BaseKey> getAllRegisteredKeys()
+    public Key keyOf(String name)
     {
-      return Collections.unmodifiableCollection(REGISTERED_KEYS.values());
-    }
-
-    private final String name;
-
-    private final BiFunction<Object, Object, Object> mergeFunction;
-
-    Key(String name)
-    {
-      this.name = name;
-      this.mergeFunction = (oldValue, newValue) -> newValue;
-    }
-
-    Key(String name, BiFunction<Object, Object, Object> mergeFunction)
-    {
-      this.name = name;
-      this.mergeFunction = mergeFunction;
-    }
-
-    @Override
-    public String getName()
-    {
-      return name;
-    }
-
-    @Override
-    public BiFunction<Object, Object, Object> getMergeFunction()
-    {
-      return mergeFunction;
+      Key key = registered_keys.get(name);
+      if (key == null) {
+        throw new ISE("Key [%s] is not registered as a context key", name);
+      }
+      return key;
     }
   }
 
-  protected abstract Map<BaseKey, Object> getDelegate();
+  protected abstract Map<Key, Object> getDelegate();
+
+  public Map<String, Object> toMap()
+  {
+    return CollectionUtils.mapKeys(getDelegate(), k -> k.getName());
+  }
 
   private static final Comparator<Map.Entry<String, JsonNode>> VALUE_LENGTH_REVERSED_COMPARATOR =
       Comparator.comparing((Map.Entry<String, JsonNode> e) -> e.getValue().toString().length()).reversed();
 
   /**
    * Create an empty DefaultResponseContext instance
+   *
    * @return empty DefaultResponseContext instance
    */
   public static ResponseContext createEmpty()
@@ -287,39 +572,129 @@ public abstract class ResponseContext
   }
 
   /**
+   * Initialize fields for a query context. Not needed when merging.
+   */
+  public void initialize()
+  {
+    putValue(Keys.QUERY_TOTAL_BYTES_GATHERED, new AtomicLong());
+    initializeRemainingResponses();
+  }
+
+  public void initializeRemainingResponses()
+  {
+    putValue(Keys.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new ConcurrentHashMap<>());
+  }
+
+  public void initializeMissingSegments()
+  {
+    putValue(Keys.MISSING_SEGMENTS, new ArrayList<>());
+  }
+
+  public void initializeRowScanCount()
+  {
+    putValue(Keys.NUM_SCANNED_ROWS, 0L);
+  }
+
+  /**
    * Deserializes a string into {@link ResponseContext} using given {@link ObjectMapper}.
+   *
    * @throws IllegalStateException if one of the deserialized map keys has not been registered.
    */
   public static ResponseContext deserialize(String responseContext, ObjectMapper objectMapper) throws IOException
   {
-    final Map<String, Object> keyNameToObjects = objectMapper.readValue(
-        responseContext,
-        JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
-    );
-    final ResponseContext context = ResponseContext.createEmpty();
-    keyNameToObjects.forEach((keyName, value) -> {
-      final BaseKey key = Key.keyOf(keyName);
-      context.add(key, value);
-    });
-    return context;
+    return objectMapper.readValue(responseContext, ResponseContext.class);
   }
 
   /**
-   * Associates the specified object with the specified key.
+   * Associates the specified object with the specified extension key.
+   *
    * @throws IllegalStateException if the key has not been registered.
    */
-  public Object put(BaseKey key, Object value)
+  public Object put(Key key, Object value)
   {
-    final BaseKey registeredKey = Key.keyOf(key.getName());
-    return getDelegate().put(registeredKey, value);
+    final Key registeredKey = Keys.instance().keyOf(key.getName());
+    return putValue(registeredKey, value);
   }
 
-  public Object get(BaseKey key)
+  public void putUncoveredIntervals(List<Interval> intervals, boolean overflowed)
+  {
+    putValue(Keys.UNCOVERED_INTERVALS, intervals);
+    putValue(Keys.UNCOVERED_INTERVALS_OVERFLOWED, overflowed);
+  }
+
+  public void putEntityTag(String eTag)
+  {
+    putValue(Keys.ETAG, eTag);
+  }
+
+  public void putTimeoutTime(long time)
+  {
+    putValue(Keys.TIMEOUT_AT, time);
+  }
+
+  public void putQueryFailDeadlineMs(long deadlineMs)
+  {
+    putValue(Keys.QUERY_FAIL_DEADLINE_MILLIS, deadlineMs);
+  }
+
+  /**
+   * Associates the specified object with the specified key. Assumes that
+   * the key is validated.
+   */
+  private Object putValue(Key key, Object value)
+  {
+    return getDelegate().put(key, value);
+  }
+
+  public Object get(Key key)
   {
     return getDelegate().get(key);
   }
 
-  public Object remove(BaseKey key)
+  @SuppressWarnings("unchecked")
+  public ConcurrentHashMap<String, Integer> getRemainingResponses()
+  {
+    return (ConcurrentHashMap<String, Integer>) get(Keys.REMAINING_RESPONSES_FROM_QUERY_SERVERS);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Interval> getUncoveredIntervals()
+  {
+    return (List<Interval>) get(Keys.UNCOVERED_INTERVALS);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<SegmentDescriptor> getMissingSegments()
+  {
+    return (List<SegmentDescriptor>) get(Keys.MISSING_SEGMENTS);
+  }
+
+  public String getEntityTag()
+  {
+    return (String) get(Keys.ETAG);
+  }
+
+  public AtomicLong getTotalBytes()
+  {
+    return (AtomicLong) get(Keys.QUERY_TOTAL_BYTES_GATHERED);
+  }
+
+  public Long getTimeoutTime()
+  {
+    return (Long) get(Keys.TIMEOUT_AT);
+  }
+
+  public Long getRowScanCount()
+  {
+    return (Long) get(Keys.NUM_SCANNED_ROWS);
+  }
+
+  public Long getCpuNanos()
+  {
+    return (Long) get(Keys.CPU_CONSUMED_NANOS);
+  }
+
+  public Object remove(Key key)
   {
     return getDelegate().remove(key);
   }
@@ -327,16 +702,44 @@ public abstract class ResponseContext
   /**
    * Adds (merges) a new value associated with a key to an old value.
    * See merge function of a context key for a specific implementation.
+   *
    * @throws IllegalStateException if the key has not been registered.
    */
-  public Object add(BaseKey key, Object value)
+  public Object add(Key key, Object value)
   {
-    final BaseKey registeredKey = Key.keyOf(key.getName());
-    return getDelegate().merge(registeredKey, value, key.getMergeFunction());
+    final Key registeredKey = Keys.instance().keyOf(key.getName());
+    return addValue(registeredKey, value);
+  }
+
+  public void addRemainingResponse(String id, int count)
+  {
+    addValue(Keys.REMAINING_RESPONSES_FROM_QUERY_SERVERS,
+        new NonnullPair<>(id, count));
+  }
+
+  public void addMissingSegments(List<SegmentDescriptor> descriptors)
+  {
+    addValue(Keys.MISSING_SEGMENTS, descriptors);
+  }
+
+  public void addRowScanCount(long count)
+  {
+    addValue(Keys.NUM_SCANNED_ROWS, count);
+  }
+
+  public void addCpuNanos(long ns)
+  {
+    addValue(Keys.CPU_CONSUMED_NANOS, ns);
+  }
+
+  private Object addValue(Key key, Object value)
+  {
+    return getDelegate().merge(key, value, key::mergeValues);
   }
 
   /**
    * Merges a response context into the current.
+   *
    * @throws IllegalStateException If a key of the {@code responseContext} has not been registered.
    */
   public void merge(ResponseContext responseContext)
@@ -351,87 +754,101 @@ public abstract class ResponseContext
   /**
    * Serializes the context given that the resulting string length is less than the provided limit.
    * This method removes some elements from context collections if it's needed to satisfy the limit.
-   * There is no explicit priorities of keys which values are being truncated because for now there are only
-   * two potential limit breaking keys ({@link Key#UNCOVERED_INTERVALS}
-   * and {@link Key#MISSING_SEGMENTS}) and their values are arrays.
-   * Thus current implementation considers these arrays as equal prioritized and starts removing elements from
+   * There is no explicit priorities of keys which values are being truncated.
+   * Any kind of key can be removed, the key's @{code canDrop()} attribute indicates
+   * which can be dropped. (The unit tests use a string key.)
+   * Thus keys as equally prioritized and starts removing elements from
    * the array which serialized value length is the biggest.
-   * The resulting string might be correctly deserialized to {@link ResponseContext}.
+   * The resulting string will be correctly deserialized to {@link ResponseContext}.
    */
-  public SerializationResult serializeWith(ObjectMapper objectMapper, int maxCharsNumber) throws JsonProcessingException
+  public SerializationResult serializeWith(ObjectMapper objectMapper, int maxCharsNumber)
+      throws JsonProcessingException
   {
-    final String fullSerializedString = objectMapper.writeValueAsString(getDelegate());
+    final Map<Key, Object> headerMap =
+        getDelegate().entrySet()
+                     .stream()
+                     .filter(entry -> entry.getKey().getPhase() == Visibility.HEADER)
+                     .collect(
+                         Collectors.toMap(
+                             Map.Entry::getKey,
+                             Map.Entry::getValue
+                         )
+                     );
+
+    final String fullSerializedString = objectMapper.writeValueAsString(headerMap);
     if (fullSerializedString.length() <= maxCharsNumber) {
       return new SerializationResult(null, fullSerializedString);
-    } else {
-      // Indicates that the context is truncated during serialization.
-      add(Key.TRUNCATED, true);
-      final ObjectNode contextJsonNode = objectMapper.valueToTree(getDelegate());
-      final ArrayList<Map.Entry<String, JsonNode>> sortedNodesByLength = Lists.newArrayList(contextJsonNode.fields());
-      sortedNodesByLength.sort(VALUE_LENGTH_REVERSED_COMPARATOR);
-      int needToRemoveCharsNumber = fullSerializedString.length() - maxCharsNumber;
-      // The complexity of this block is O(n*m*log(m)) where n - context size, m - context's array size
-      for (Map.Entry<String, JsonNode> e : sortedNodesByLength) {
-        final String fieldName = e.getKey();
-        final JsonNode node = e.getValue();
-        if (node.isArray()) {
-          if (needToRemoveCharsNumber >= node.toString().length()) {
-            // We need to remove more chars than the field's length so removing it completely
-            contextJsonNode.remove(fieldName);
-            // Since the field is completely removed (name + value) we need to do a recalculation
-            needToRemoveCharsNumber = contextJsonNode.toString().length() - maxCharsNumber;
-          } else {
-            final ArrayNode arrayNode = (ArrayNode) node;
-            needToRemoveCharsNumber -= removeNodeElementsToSatisfyCharsLimit(arrayNode, needToRemoveCharsNumber);
-            if (arrayNode.size() == 0) {
-              // The field is empty, removing it because an empty array field may be misleading
-              // for the recipients of the truncated response context.
-              contextJsonNode.remove(fieldName);
-              // Since the field is completely removed (name + value) we need to do a recalculation
-              needToRemoveCharsNumber = contextJsonNode.toString().length() - maxCharsNumber;
-            }
-          } // node is not an array
-        } else {
-          // A context should not contain nulls so we completely remove the field.
+    }
+
+    int needToRemoveCharsNumber = fullSerializedString.length() - maxCharsNumber;
+    // Indicates that the context is truncated during serialization.
+    headerMap.put(Keys.TRUNCATED, true);
+    // Account for the extra field just added: "truncated: true,
+    // The length of ": true," is 7.
+    needToRemoveCharsNumber += Keys.TRUNCATED.getName().length() + 7;
+    final ObjectNode contextJsonNode = objectMapper.valueToTree(headerMap);
+    final List<Map.Entry<String, JsonNode>> sortedNodesByLength = Lists.newArrayList(contextJsonNode.fields());
+    sortedNodesByLength.sort(VALUE_LENGTH_REVERSED_COMPARATOR);
+    // The complexity of this block is O(n*m*log(m)) where n - context size, m - context's array size
+    for (Map.Entry<String, JsonNode> e : sortedNodesByLength) {
+      final String fieldName = e.getKey();
+      if (!Keys.instance().keyOf(fieldName).canDrop()) {
+        continue;
+      }
+      final JsonNode node = e.getValue();
+      int removeLength = fieldName.length() + node.toString().length();
+      if (removeLength < needToRemoveCharsNumber || !node.isArray()) {
+        // Remove the field
+        contextJsonNode.remove(fieldName);
+        needToRemoveCharsNumber -= removeLength;
+      } else {
+        final ArrayNode arrayNode = (ArrayNode) node;
+        int removed = removeNodeElementsToSatisfyCharsLimit(arrayNode, needToRemoveCharsNumber);
+        if (arrayNode.size() == 0) {
+          // The field is now empty, removing it because an empty array field may be misleading
+          // for the recipients of the truncated response context.
           contextJsonNode.remove(fieldName);
-          // Since the field is completely removed (name + value) we need to do a recalculation
-          needToRemoveCharsNumber = contextJsonNode.toString().length() - maxCharsNumber;
-        }
-        if (needToRemoveCharsNumber <= 0) {
-          break;
+          needToRemoveCharsNumber -= removeLength;
+        } else {
+          needToRemoveCharsNumber -= removed;
         }
       }
-      return new SerializationResult(contextJsonNode.toString(), fullSerializedString);
+
+      if (needToRemoveCharsNumber <= 0) {
+        break;
+      }
     }
+    return new SerializationResult(contextJsonNode.toString(), fullSerializedString);
   }
 
   /**
    * Removes {@code node}'s elements which total length of serialized values is greater or equal to the passed limit.
    * If it is impossible to satisfy the limit the method removes all {@code node}'s elements.
    * On every iteration it removes exactly half of the remained elements to reduce the overall complexity.
-   * @param node {@link ArrayNode} which elements are being removed.
-   * @param needToRemoveCharsNumber the number of chars need to be removed.
+   *
+   * @param node   {@link ArrayNode} which elements are being removed.
+   * @param target the number of chars need to be removed.
+   *
    * @return the number of removed chars.
    */
-  private static int removeNodeElementsToSatisfyCharsLimit(ArrayNode node, int needToRemoveCharsNumber)
+  private static int removeNodeElementsToSatisfyCharsLimit(ArrayNode node, int target)
   {
-    int removedCharsNumber = 0;
-    while (node.size() > 0 && needToRemoveCharsNumber > removedCharsNumber) {
-      final int lengthBeforeRemove = node.toString().length();
+    int nodeLen = node.toString().length();
+    final int startLen = nodeLen;
+    while (node.size() > 0 && target > startLen - nodeLen) {
       // Reducing complexity by removing half of array's elements
       final int removeUntil = node.size() / 2;
       for (int removeAt = node.size() - 1; removeAt >= removeUntil; removeAt--) {
         node.remove(removeAt);
       }
-      final int lengthAfterRemove = node.toString().length();
-      removedCharsNumber += lengthBeforeRemove - lengthAfterRemove;
+      nodeLen = node.toString().length();
     }
-    return removedCharsNumber;
+    return startLen - nodeLen;
   }
 
   /**
    * Serialization result of {@link ResponseContext}.
-   * Response context might be serialized using max legth limit, in this case the context might be reduced
+   * Response context might be serialized using max length limit, in this case the context might be reduced
    * by removing max-length fields one by one unless serialization result length is less than the limit.
    * This structure has a reduced serialization result along with full result and boolean property
    * indicating if some fields were removed from the context.

--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
@@ -66,9 +66,9 @@ import java.util.stream.Collectors;
  * of information:
  * <ul>
  * <li>Information to be returned in the query response header.
- * (These are values tagged as {@link Visibility#HEADER}.)</li>
+ * These are values tagged as being in the header.</li>
  * <li>Values passed within a single server. These are tagged with
- * visibility {@link Visibility#NONE}.)</li>
+ * not being in the header.</li>
  * </ul>
  * Second, it performs multiple tasks:
  * <ul>
@@ -428,7 +428,7 @@ public abstract class ResponseContext
      * The number of rows scanned by {@link org.apache.druid.query.scan.ScanQueryEngine}.
      *
      * Named "count" for backwards compatibility with older data servers that still send this, even though it's now
-     * marked with {@link Visibility#NONE}.
+     * marked as internal.
      */
     public static final Key NUM_SCANNED_ROWS = new CounterKey(
         "count",

--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContextDeserializer.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContextDeserializer.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.context;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Deserialize a response context. The response context is created for single-thread use.
+ * (That is, it is non-concurrent.) Clients of this code should convert the
+ * context to concurrent if it will be used across threads.
+ */
+@SuppressWarnings("serial")
+public class ResponseContextDeserializer extends StdDeserializer<ResponseContext>
+{
+  public ResponseContextDeserializer()
+  {
+    super(ResponseContext.class);
+  }
+
+  @Override
+  public ResponseContext deserialize(
+      final JsonParser jp,
+      final DeserializationContext ctxt
+  ) throws IOException
+  {
+    if (jp.currentToken() != JsonToken.START_OBJECT) {
+      throw ctxt.wrongTokenException(jp, ResponseContext.class, JsonToken.START_OBJECT, null);
+    }
+
+    // TODO(gianm): Check if we need concurrent response context here
+    final ResponseContext retVal = ResponseContext.createEmpty();
+
+    jp.nextToken();
+
+    ResponseContext.Keys keys = ResponseContext.Keys.instance();
+    while (jp.currentToken() == JsonToken.FIELD_NAME) {
+      final ResponseContext.Key key = keys.keyOf(jp.getText());
+
+      jp.nextToken();
+      final Object value = key.readValue(jp);
+      retVal.add(key, value);
+
+      jp.nextToken();
+    }
+
+    if (jp.currentToken() != JsonToken.END_OBJECT) {
+      throw ctxt.wrongTokenException(jp, ResponseContext.class, JsonToken.END_OBJECT, null);
+    }
+
+    return retVal;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContextDeserializer.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContextDeserializer.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.context;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-
 import java.io.IOException;
 
 /**
@@ -49,18 +49,24 @@ public class ResponseContextDeserializer extends StdDeserializer<ResponseContext
       throw ctxt.wrongTokenException(jp, ResponseContext.class, JsonToken.START_OBJECT, null);
     }
 
-    // TODO(gianm): Check if we need concurrent response context here
     final ResponseContext retVal = ResponseContext.createEmpty();
 
     jp.nextToken();
 
     ResponseContext.Keys keys = ResponseContext.Keys.instance();
     while (jp.currentToken() == JsonToken.FIELD_NAME) {
-      final ResponseContext.Key key = keys.keyOf(jp.getText());
+      // Get the key. Since this is a deserialization, the sender may
+      // be a different version of Druid with a different set of keys.
+      // Ignore any keys which the sender knows about but this node
+      // does not know about.
+      final ResponseContext.Key key = keys.find(jp.getText());
 
       jp.nextToken();
-      final Object value = key.readValue(jp);
-      retVal.add(key, value);
+      if (key == null) {
+        skipValue(jp, jp.getText());
+      } else {
+        retVal.add(key, key.readValue(jp));
+      }
 
       jp.nextToken();
     }
@@ -70,5 +76,53 @@ public class ResponseContextDeserializer extends StdDeserializer<ResponseContext
     }
 
     return retVal;
+  }
+
+  /**
+   * Skip over a single JSON value: scalar or composite.
+   */
+  private void skipValue(final JsonParser jp, String key) throws IOException
+  {
+    final JsonToken token = jp.currentToken();
+    switch (token) {
+      case START_OBJECT:
+        skipTo(jp, JsonToken.END_OBJECT);
+        break;
+      case START_ARRAY:
+        skipTo(jp, JsonToken.END_ARRAY);
+        break;
+      default:
+        if (token.isScalarValue()) {
+          return;
+        }
+        throw new JsonMappingException(jp, "Invalid JSON inside unknown key: " + key);
+    }
+  }
+
+  /**
+   * Freewheel over the contents of a structured object, including any
+   * nested structured objects, until the given end token.
+   */
+  private void skipTo(final JsonParser jp, JsonToken end) throws IOException
+  {
+    while (true) {
+      jp.nextToken();
+      final JsonToken token = jp.currentToken();
+      if (token == null) {
+        throw new JsonMappingException(jp, "Premature EOF");
+      }
+      switch (token) {
+        case START_OBJECT:
+          skipTo(jp, JsonToken.END_OBJECT);
+          break;
+        case START_ARRAY:
+          skipTo(jp, JsonToken.END_ARRAY);
+          break;
+        default:
+          if (token == end) {
+            return;
+          }
+      }
+    }
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
@@ -67,15 +67,12 @@ public class ScanQueryEngine
     // "legacy" should be non-null due to toolChest.mergeResults
     final boolean legacy = Preconditions.checkNotNull(query.isLegacy(), "Expected non-null 'legacy' parameter");
 
-    final Object numScannedRows = responseContext.get(ResponseContext.Key.NUM_SCANNED_ROWS);
-    if (numScannedRows != null) {
-      long count = (long) numScannedRows;
-      if (count >= query.getScanRowsLimit() && query.getTimeOrder().equals(ScanQuery.Order.NONE)) {
-        return Sequences.empty();
-      }
+    final Long numScannedRows = responseContext.getRowScanCount();
+    if (numScannedRows != null && numScannedRows >= query.getScanRowsLimit() && query.getTimeOrder().equals(ScanQuery.Order.NONE)) {
+      return Sequences.empty();
     }
     final boolean hasTimeout = QueryContexts.hasTimeout(query);
-    final long timeoutAt = (long) responseContext.get(ResponseContext.Key.TIMEOUT_AT);
+    final Long timeoutAt = responseContext.getTimeoutTime();
     final long start = System.currentTimeMillis();
     final StorageAdapter adapter = segment.asStorageAdapter();
 
@@ -122,7 +119,8 @@ public class ScanQueryEngine
 
     final Filter filter = Filters.convertToCNFFromQueryContext(query, Filters.toFilter(query.getFilter()));
 
-    responseContext.add(ResponseContext.Key.NUM_SCANNED_ROWS, 0L);
+    // If the row count is not set, set it to 0, else do nothing.
+    responseContext.addRowScanCount(0);
     final long limit = calculateRemainingScanRowsLimit(query, responseContext);
     return Sequences.concat(
             adapter
@@ -186,10 +184,9 @@ public class ScanQueryEngine
                             } else {
                               throw new UOE("resultFormat[%s] is not supported", resultFormat.toString());
                             }
-                            responseContext.add(ResponseContext.Key.NUM_SCANNED_ROWS, offset - lastOffset);
+                            responseContext.addRowScanCount(offset - lastOffset);
                             if (hasTimeout) {
-                              responseContext.put(
-                                  ResponseContext.Key.TIMEOUT_AT,
+                              responseContext.putTimeoutTime(
                                   timeoutAt - (System.currentTimeMillis() - start)
                               );
                             }
@@ -262,7 +259,7 @@ public class ScanQueryEngine
   private long calculateRemainingScanRowsLimit(ScanQuery query, ResponseContext responseContext)
   {
     if (query.getTimeOrder().equals(ScanQuery.Order.NONE)) {
-      return query.getScanRowsLimit() - (long) responseContext.get(ResponseContext.Key.NUM_SCANNED_ROWS);
+      return query.getScanRowsLimit() - (Long) responseContext.getRowScanCount();
     }
     return query.getScanRowsLimit();
   }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryRunnerFactory.java
@@ -87,7 +87,7 @@ public class ScanQueryRunnerFactory implements QueryRunnerFactory<ScanResultValu
       final Iterable<QueryRunner<ScanResultValue>> queryRunners
   )
   {
-    // in single thread and in jetty thread instead of processing thread
+    // in single thread and in Jetty thread instead of processing thread
     return (queryPlus, responseContext) -> {
       ScanQuery query = (ScanQuery) queryPlus.getQuery();
       ScanQuery.verifyOrderByForNativeExecution(query);
@@ -95,7 +95,7 @@ public class ScanQueryRunnerFactory implements QueryRunnerFactory<ScanResultValu
       // Note: this variable is effective only when queryContext has a timeout.
       // See the comment of ResponseContext.Key.TIMEOUT_AT.
       final long timeoutAt = System.currentTimeMillis() + QueryContexts.getTimeout(queryPlus.getQuery());
-      responseContext.put(ResponseContext.Key.TIMEOUT_AT, timeoutAt);
+      responseContext.putTimeoutTime(timeoutAt);
 
       if (query.getTimeOrder().equals(ScanQuery.Order.NONE)) {
         // Use normal strategy
@@ -369,9 +369,9 @@ public class ScanQueryRunnerFactory implements QueryRunnerFactory<ScanResultValu
       ScanQuery.verifyOrderByForNativeExecution((ScanQuery) query);
 
       // it happens in unit tests
-      final Number timeoutAt = (Number) responseContext.get(ResponseContext.Key.TIMEOUT_AT);
-      if (timeoutAt == null || timeoutAt.longValue() == 0L) {
-        responseContext.put(ResponseContext.Key.TIMEOUT_AT, JodaUtils.MAX_INSTANT);
+      final Long timeoutAt = responseContext.getTimeoutTime();
+      if (timeoutAt == null || timeoutAt == 0L) {
+        responseContext.putTimeoutTime(JodaUtils.MAX_INSTANT);
       }
       return engine.process((ScanQuery) query, segment, responseContext);
     }

--- a/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
@@ -157,8 +157,7 @@ public class SpecificSegmentQueryRunner<T> implements QueryRunner<T>
 
   private void appendMissingSegment(ResponseContext responseContext)
   {
-    responseContext.add(
-        ResponseContext.Key.MISSING_SEGMENTS,
+    responseContext.addMissingSegments(
         Collections.singletonList(specificSpec.getDescriptor())
     );
   }

--- a/processing/src/test/java/org/apache/druid/query/ReportTimelineMissingSegmentQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/ReportTimelineMissingSegmentQueryRunnerTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.query.context.DefaultResponseContext;
 import org.apache.druid.query.context.ResponseContext;
-import org.apache.druid.query.context.ResponseContext.Key;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.spec.MultipleSpecificSegmentSpec;
 import org.apache.druid.query.spec.QuerySegmentSpec;
@@ -47,8 +46,8 @@ public class ReportTimelineMissingSegmentQueryRunnerTest
         = new ReportTimelineMissingSegmentQueryRunner<>(missingSegment);
     final ResponseContext responseContext = DefaultResponseContext.createEmpty();
     runner.run(QueryPlus.wrap(new TestQuery()), responseContext);
-    Assert.assertNotNull(responseContext.get(Key.MISSING_SEGMENTS));
-    Assert.assertEquals(Collections.singletonList(missingSegment), responseContext.get(Key.MISSING_SEGMENTS));
+    Assert.assertNotNull(responseContext.getMissingSegments());
+    Assert.assertEquals(Collections.singletonList(missingSegment), responseContext.getMissingSegments());
   }
 
   @Test
@@ -63,8 +62,8 @@ public class ReportTimelineMissingSegmentQueryRunnerTest
         = new ReportTimelineMissingSegmentQueryRunner<>(missingSegments);
     final ResponseContext responseContext = DefaultResponseContext.createEmpty();
     runner.run(QueryPlus.wrap(new TestQuery()), responseContext);
-    Assert.assertNotNull(responseContext.get(Key.MISSING_SEGMENTS));
-    Assert.assertEquals(missingSegments, responseContext.get(Key.MISSING_SEGMENTS));
+    Assert.assertNotNull(responseContext.getMissingSegments());
+    Assert.assertEquals(missingSegments, responseContext.getMissingSegments());
   }
 
   private static class TestQuery extends BaseQuery<Object>

--- a/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
@@ -20,12 +20,18 @@
 package org.apache.druid.query.context;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.NonnullPair;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.SegmentDescriptor;
+import org.apache.druid.query.context.ResponseContext.CounterKey;
 import org.apache.druid.query.context.ResponseContext.Key;
+import org.apache.druid.query.context.ResponseContext.Keys;
+import org.apache.druid.query.context.ResponseContext.StringKey;
+import org.apache.druid.query.context.ResponseContext.Visibility;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,177 +39,170 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
 
 public class ResponseContextTest
 {
+  // Droppable header key
+  static final Key EXTN_STRING_KEY = new StringKey(
+      "extn_string_key", Visibility.HEADER, true);
+  // Non-droppable header key
+  static final Key EXTN_COUNTER_KEY = new CounterKey(
+      "extn_counter_key", Visibility.HEADER);
 
-  enum ExtensionResponseContextKey implements ResponseContext.BaseKey
-  {
-    EXTENSION_KEY_1("extension_key_1"),
-    EXTENSION_KEY_2("extension_key_2", (oldValue, newValue) -> (long) oldValue + (long) newValue);
-
-    static {
-      for (ResponseContext.BaseKey key : values()) {
-        ResponseContext.Key.registerKey(key);
-      }
-    }
-
-    private final String name;
-    private final BiFunction<Object, Object, Object> mergeFunction;
-
-    ExtensionResponseContextKey(String name)
-    {
-      this.name = name;
-      this.mergeFunction = (oldValue, newValue) -> newValue;
-    }
-
-    ExtensionResponseContextKey(String name, BiFunction<Object, Object, Object> mergeFunction)
-    {
-      this.name = name;
-      this.mergeFunction = mergeFunction;
-    }
-
-    @Override
-    public String getName()
-    {
-      return name;
-    }
-
-    @Override
-    public BiFunction<Object, Object, Object> getMergeFunction()
-    {
-      return mergeFunction;
-    }
+  static {
+    Keys.instance().registerKeys(new Key[] {
+        EXTN_STRING_KEY,
+        EXTN_COUNTER_KEY
+    });
   }
 
-  private final ResponseContext.BaseKey nonregisteredKey = new ResponseContext.BaseKey()
-  {
-    @Override
-    public String getName()
-    {
-      return "non-registered-key";
-    }
-
-    @Override
-    public BiFunction<Object, Object, Object> getMergeFunction()
-    {
-      return (Object a, Object b) -> a;
-    }
-  };
+  static final Key UNREGISTERED_KEY = new StringKey(
+      "unregistered-key", Visibility.HEADER, true);
 
   @Test(expected = IllegalStateException.class)
   public void putISETest()
   {
-    ResponseContext.createEmpty().put(nonregisteredKey, new Object());
+    ResponseContext.createEmpty().put(UNREGISTERED_KEY, new Object());
   }
 
   @Test(expected = IllegalStateException.class)
   public void addISETest()
   {
-    ResponseContext.createEmpty().add(nonregisteredKey, new Object());
+    ResponseContext.createEmpty().add(UNREGISTERED_KEY, new Object());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void registerKeyIAETest()
   {
-    ResponseContext.Key.registerKey(ResponseContext.Key.NUM_SCANNED_ROWS);
+    Keys.INSTANCE.registerKey(Keys.NUM_SCANNED_ROWS);
   }
 
   @Test
-  public void mergeValueTest()
+  public void mergeETagTest()
   {
     final ResponseContext ctx = ResponseContext.createEmpty();
-    ctx.add(ResponseContext.Key.ETAG, "dummy-etag");
-    Assert.assertEquals("dummy-etag", ctx.get(ResponseContext.Key.ETAG));
-    ctx.add(ResponseContext.Key.ETAG, "new-dummy-etag");
-    Assert.assertEquals("new-dummy-etag", ctx.get(ResponseContext.Key.ETAG));
+    ctx.putEntityTag("dummy-etag");
+    Assert.assertEquals("dummy-etag", ctx.getEntityTag());
+    ctx.putEntityTag("new-dummy-etag");
+    Assert.assertEquals("new-dummy-etag", ctx.getEntityTag());
+  }
 
-    final Interval interval01 = Intervals.of("2019-01-01/P1D");
-    ctx.add(ResponseContext.Key.UNCOVERED_INTERVALS, Collections.singletonList(interval01));
-    Assert.assertArrayEquals(
-        Collections.singletonList(interval01).toArray(),
-        ((List) ctx.get(ResponseContext.Key.UNCOVERED_INTERVALS)).toArray()
-    );
-    final Interval interval12 = Intervals.of("2019-01-02/P1D");
-    final Interval interval23 = Intervals.of("2019-01-03/P1D");
-    ctx.add(ResponseContext.Key.UNCOVERED_INTERVALS, Arrays.asList(interval12, interval23));
-    Assert.assertArrayEquals(
-        Arrays.asList(interval01, interval12, interval23).toArray(),
-        ((List) ctx.get(ResponseContext.Key.UNCOVERED_INTERVALS)).toArray()
-    );
+  private static final Interval INTERVAL_01 = Intervals.of("2019-01-01/P1D");
+  private static final Interval INTERVAL_12 = Intervals.of("2019-01-02/P1D");
+  private static final Interval INTERVAL_23 = Intervals.of("2019-01-03/P1D");
 
+  @Test
+  public void mergeUncoveredIntervalsTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
+    ctx.putUncoveredIntervals(Collections.singletonList(INTERVAL_01), false);
+    Assert.assertArrayEquals(
+        Collections.singletonList(INTERVAL_01).toArray(),
+        ctx.getUncoveredIntervals().toArray()
+    );
+    ctx.add(Keys.UNCOVERED_INTERVALS, Arrays.asList(INTERVAL_12, INTERVAL_23));
+    Assert.assertArrayEquals(
+        Arrays.asList(INTERVAL_01, INTERVAL_12, INTERVAL_23).toArray(),
+        ctx.getUncoveredIntervals().toArray()
+    );
+  }
+
+  @Test
+  public void mergeRemainingResponseTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
     final String queryId = "queryId";
     final String queryId2 = "queryId2";
-    ctx.put(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new ConcurrentHashMap<>());
-    ctx.add(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new NonnullPair<>(queryId, 3));
-    ctx.add(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new NonnullPair<>(queryId2, 4));
-    ctx.add(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new NonnullPair<>(queryId, -1));
-    ctx.add(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new NonnullPair<>(queryId, -2));
+    ctx.initialize();
+    ctx.addRemainingResponse(queryId, 3);
+    ctx.addRemainingResponse(queryId2, 4);
+    ctx.addRemainingResponse(queryId, -1);
+    ctx.addRemainingResponse(queryId, -2);
     Assert.assertEquals(
         ImmutableMap.of(queryId, 0, queryId2, 4),
-        ctx.get(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS)
+        ctx.get(Keys.REMAINING_RESPONSES_FROM_QUERY_SERVERS)
     );
+  }
 
-    final SegmentDescriptor sd01 = new SegmentDescriptor(interval01, "01", 0);
-    ctx.add(ResponseContext.Key.MISSING_SEGMENTS, Collections.singletonList(sd01));
+  @Test
+  public void mergeMissingSegmentsTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
+    final SegmentDescriptor sd01 = new SegmentDescriptor(INTERVAL_01, "01", 0);
+    ctx.addMissingSegments(Collections.singletonList(sd01));
     Assert.assertArrayEquals(
         Collections.singletonList(sd01).toArray(),
-        ((List) ctx.get(ResponseContext.Key.MISSING_SEGMENTS)).toArray()
+        ctx.getMissingSegments().toArray()
     );
-    final SegmentDescriptor sd12 = new SegmentDescriptor(interval12, "12", 1);
-    final SegmentDescriptor sd23 = new SegmentDescriptor(interval23, "23", 2);
-    ctx.add(ResponseContext.Key.MISSING_SEGMENTS, Arrays.asList(sd12, sd23));
+    final SegmentDescriptor sd12 = new SegmentDescriptor(INTERVAL_12, "12", 1);
+    final SegmentDescriptor sd23 = new SegmentDescriptor(INTERVAL_23, "23", 2);
+    ctx.addMissingSegments(Arrays.asList(sd12, sd23));
     Assert.assertArrayEquals(
         Arrays.asList(sd01, sd12, sd23).toArray(),
-        ((List) ctx.get(ResponseContext.Key.MISSING_SEGMENTS)).toArray()
+        ctx.getMissingSegments().toArray()
     );
+  }
 
-    ctx.add(ResponseContext.Key.NUM_SCANNED_ROWS, 0L);
-    Assert.assertEquals(0L, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
-    ctx.add(ResponseContext.Key.NUM_SCANNED_ROWS, 1L);
-    Assert.assertEquals(1L, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
-    ctx.add(ResponseContext.Key.NUM_SCANNED_ROWS, 3L);
-    Assert.assertEquals(4L, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
+  @Test
+  public void initScannedRowsTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
+    Assert.assertNull(ctx.getRowScanCount());
+    ctx.initializeRowScanCount();
+    Assert.assertEquals((Long) 0L, ctx.getRowScanCount());
+  }
 
-    ctx.add(ResponseContext.Key.UNCOVERED_INTERVALS_OVERFLOWED, false);
-    Assert.assertEquals(false, ctx.get(ResponseContext.Key.UNCOVERED_INTERVALS_OVERFLOWED));
-    ctx.add(ResponseContext.Key.UNCOVERED_INTERVALS_OVERFLOWED, true);
-    Assert.assertEquals(true, ctx.get(ResponseContext.Key.UNCOVERED_INTERVALS_OVERFLOWED));
-    ctx.add(ResponseContext.Key.UNCOVERED_INTERVALS_OVERFLOWED, false);
-    Assert.assertEquals(true, ctx.get(ResponseContext.Key.UNCOVERED_INTERVALS_OVERFLOWED));
+  @Test
+  public void mergeScannedRowsTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
+    Assert.assertNull(ctx.getRowScanCount());
+    ctx.addRowScanCount(0L);
+    Assert.assertEquals((Long) 0L, ctx.getRowScanCount());
+    ctx.addRowScanCount(1L);
+    Assert.assertEquals((Long) 1L, ctx.getRowScanCount());
+    ctx.addRowScanCount(3L);
+    Assert.assertEquals((Long) 4L, ctx.getRowScanCount());
+  }
+
+  @Test
+  public void mergeUncoveredIntervalsOverflowedTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
+    ctx.add(Keys.UNCOVERED_INTERVALS_OVERFLOWED, false);
+    Assert.assertEquals(false, ctx.get(Keys.UNCOVERED_INTERVALS_OVERFLOWED));
+    ctx.add(Keys.UNCOVERED_INTERVALS_OVERFLOWED, true);
+    Assert.assertEquals(true, ctx.get(Keys.UNCOVERED_INTERVALS_OVERFLOWED));
+    ctx.add(Keys.UNCOVERED_INTERVALS_OVERFLOWED, false);
+    Assert.assertEquals(true, ctx.get(Keys.UNCOVERED_INTERVALS_OVERFLOWED));
   }
 
   @Test
   public void mergeResponseContextTest()
   {
     final ResponseContext ctx1 = ResponseContext.createEmpty();
-    ctx1.put(ResponseContext.Key.ETAG, "dummy-etag-1");
-    final Interval interval01 = Intervals.of("2019-01-01/P1D");
-    ctx1.put(ResponseContext.Key.UNCOVERED_INTERVALS, Collections.singletonList(interval01));
-    ctx1.put(ResponseContext.Key.NUM_SCANNED_ROWS, 1L);
+    ctx1.putEntityTag("dummy-etag-1");
+    ctx1.putUncoveredIntervals(Collections.singletonList(INTERVAL_01), false);
+    ctx1.addRowScanCount(1L);
 
     final ResponseContext ctx2 = ResponseContext.createEmpty();
-    ctx2.put(ResponseContext.Key.ETAG, "dummy-etag-2");
-    final Interval interval12 = Intervals.of("2019-01-02/P1D");
-    ctx2.put(ResponseContext.Key.UNCOVERED_INTERVALS, Collections.singletonList(interval12));
-    final SegmentDescriptor sd01 = new SegmentDescriptor(interval01, "01", 0);
-    ctx2.put(ResponseContext.Key.MISSING_SEGMENTS, Collections.singletonList(sd01));
-    ctx2.put(ResponseContext.Key.NUM_SCANNED_ROWS, 2L);
+    ctx2.putEntityTag("dummy-etag-2");
+    ctx2.putUncoveredIntervals(Collections.singletonList(INTERVAL_12), false);
+    final SegmentDescriptor sd01 = new SegmentDescriptor(INTERVAL_01, "01", 0);
+    ctx2.addMissingSegments(Collections.singletonList(sd01));
+    ctx2.addRowScanCount(2L);
 
     ctx1.merge(ctx2);
-    Assert.assertEquals("dummy-etag-2", ctx1.get(ResponseContext.Key.ETAG));
-    Assert.assertEquals(3L, ctx1.get(ResponseContext.Key.NUM_SCANNED_ROWS));
+    Assert.assertEquals("dummy-etag-2", ctx1.getEntityTag());
+    Assert.assertEquals((Long) 3L, ctx1.getRowScanCount());
     Assert.assertArrayEquals(
-        Arrays.asList(interval01, interval12).toArray(),
-        ((List) ctx1.get(ResponseContext.Key.UNCOVERED_INTERVALS)).toArray()
+        Arrays.asList(INTERVAL_01, INTERVAL_12).toArray(),
+        ctx1.getUncoveredIntervals().toArray()
     );
     Assert.assertArrayEquals(
         Collections.singletonList(sd01).toArray(),
-        ((List) ctx1.get(ResponseContext.Key.MISSING_SEGMENTS)).toArray()
+        ctx1.getMissingSegments().toArray()
     );
   }
 
@@ -213,9 +212,9 @@ public class ResponseContextTest
     final ResponseContext ctx = new ResponseContext()
     {
       @Override
-      protected Map<BaseKey, Object> getDelegate()
+      protected Map<Key, Object> getDelegate()
       {
-        return ImmutableMap.of(nonregisteredKey, "non-registered-key");
+        return ImmutableMap.of(UNREGISTERED_KEY, "non-registered-key");
       }
     };
     ResponseContext.createEmpty().merge(ctx);
@@ -225,68 +224,92 @@ public class ResponseContextTest
   public void serializeWithCorrectnessTest() throws JsonProcessingException
   {
     final ResponseContext ctx1 = ResponseContext.createEmpty();
-    ctx1.add(ResponseContext.Key.ETAG, "string-value");
+    ctx1.add(EXTN_STRING_KEY, "string-value");
     final DefaultObjectMapper mapper = new DefaultObjectMapper();
     Assert.assertEquals(
-        mapper.writeValueAsString(ImmutableMap.of("ETag", "string-value")),
-        ctx1.serializeWith(mapper, Integer.MAX_VALUE).getResult()
-    );
+        mapper.writeValueAsString(ImmutableMap.of(
+            EXTN_STRING_KEY.getName(),
+            "string-value")),
+        ctx1.serializeWith(mapper, Integer.MAX_VALUE).getResult());
 
     final ResponseContext ctx2 = ResponseContext.createEmpty();
-    ctx2.add(ResponseContext.Key.NUM_SCANNED_ROWS, 100);
+    // Add two non-header fields, and one that will be in the header
+    ctx2.putEntityTag("not in header");
+    ctx2.addCpuNanos(100);
+    ctx2.add(EXTN_COUNTER_KEY, 100);
     Assert.assertEquals(
-        mapper.writeValueAsString(ImmutableMap.of("count", 100)),
-        ctx2.serializeWith(mapper, Integer.MAX_VALUE).getResult()
-    );
+        mapper.writeValueAsString(ImmutableMap.of(
+            EXTN_COUNTER_KEY.getName(), 100)),
+        ctx2.serializeWith(mapper, Integer.MAX_VALUE).getResult());
+  }
+
+  private Map<ResponseContext.Key, Object> deserializeContext(String input, ObjectMapper mapper) throws IOException
+  {
+    return ResponseContext.deserialize(input, mapper).getDelegate();
   }
 
   @Test
   public void serializeWithTruncateValueTest() throws IOException
   {
     final ResponseContext ctx = ResponseContext.createEmpty();
-    ctx.put(ResponseContext.Key.NUM_SCANNED_ROWS, 100);
-    ctx.put(ResponseContext.Key.ETAG, "long-string-that-is-supposed-to-be-removed-from-result");
+    ctx.put(EXTN_COUNTER_KEY, 100L);
+    ctx.put(EXTN_STRING_KEY, "long-string-that-is-supposed-to-be-removed-from-result");
     final DefaultObjectMapper objectMapper = new DefaultObjectMapper();
-    final String fullString = objectMapper.writeValueAsString(ctx.getDelegate());
     final ResponseContext.SerializationResult res1 = ctx.serializeWith(objectMapper, Integer.MAX_VALUE);
-    Assert.assertEquals(fullString, res1.getResult());
+    Assert.assertEquals(ctx.getDelegate(), deserializeContext(res1.getResult(), objectMapper));
     final ResponseContext ctxCopy = ResponseContext.createEmpty();
     ctxCopy.merge(ctx);
-    final ResponseContext.SerializationResult res2 = ctx.serializeWith(objectMapper, 30);
-    ctxCopy.remove(ResponseContext.Key.ETAG);
-    ctxCopy.put(ResponseContext.Key.TRUNCATED, true);
+    final int target = EXTN_COUNTER_KEY.getName().length() + 3 +
+                       Keys.TRUNCATED.getName().length() + 5 +
+                       15; // Fudge factor for quotes, separators, etc.
+    final ResponseContext.SerializationResult res2 = ctx.serializeWith(objectMapper, target);
+    ctxCopy.remove(EXTN_STRING_KEY);
+    ctxCopy.put(Keys.TRUNCATED, true);
     Assert.assertEquals(
         ctxCopy.getDelegate(),
-        ResponseContext.deserialize(res2.getResult(), objectMapper).getDelegate()
+        deserializeContext(res2.getResult(), objectMapper)
     );
   }
+
+  // Interval value for the test. Must match the deserialized value.
+  private static Interval interval(int n)
+  {
+    return Intervals.of(StringUtils.format("2021-01-%02d/PT1M", n));
+  }
+
+  // Length of above with quotes and comma.
+  private static final int INTERVAL_LEN = 52;
 
   @Test
   public void serializeWithTruncateArrayTest() throws IOException
   {
     final ResponseContext ctx = ResponseContext.createEmpty();
-    ctx.put(ResponseContext.Key.NUM_SCANNED_ROWS, 100);
     ctx.put(
-        ResponseContext.Key.UNCOVERED_INTERVALS,
-        Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+        Keys.UNCOVERED_INTERVALS,
+        Arrays.asList(interval(1), interval(2), interval(3), interval(4),
+                      interval(5), interval(6))
     );
+    // This value should be longer than the above so it is fully removed
+    // before we truncate the above.
     ctx.put(
-        ResponseContext.Key.MISSING_SEGMENTS,
-        Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+        EXTN_STRING_KEY,
+        Strings.repeat("x", INTERVAL_LEN * 7)
     );
     final DefaultObjectMapper objectMapper = new DefaultObjectMapper();
     final String fullString = objectMapper.writeValueAsString(ctx.getDelegate());
     final ResponseContext.SerializationResult res1 = ctx.serializeWith(objectMapper, Integer.MAX_VALUE);
     Assert.assertEquals(fullString, res1.getResult());
+    final int maxLen = INTERVAL_LEN * 4 + Keys.UNCOVERED_INTERVALS.getName().length() + 4 +
+                       Keys.TRUNCATED.getName().length() + 6;
+    final ResponseContext.SerializationResult res2 = ctx.serializeWith(objectMapper, maxLen);
     final ResponseContext ctxCopy = ResponseContext.createEmpty();
-    ctxCopy.merge(ctx);
-    final ResponseContext.SerializationResult res2 = ctx.serializeWith(objectMapper, 70);
-    ctxCopy.put(ResponseContext.Key.UNCOVERED_INTERVALS, Arrays.asList(0, 1, 2, 3, 4));
-    ctxCopy.remove(ResponseContext.Key.MISSING_SEGMENTS);
-    ctxCopy.put(ResponseContext.Key.TRUNCATED, true);
+    // The resulting key array length will be half the start
+    // length.
+    ctxCopy.put(Keys.UNCOVERED_INTERVALS, Arrays.asList(interval(1), interval(2), interval(3)));
+    ctxCopy.put(Keys.TRUNCATED, true);
     Assert.assertEquals(
         ctxCopy.getDelegate(),
-        ResponseContext.deserialize(res2.getResult(), objectMapper).getDelegate()
+        deserializeContext(res2.getResult(), objectMapper)
     );
   }
 
@@ -297,20 +320,20 @@ public class ResponseContextTest
     final ResponseContext ctx = ResponseContext.deserialize(
         mapper.writeValueAsString(
             ImmutableMap.of(
-                "ETag", "string-value",
-                "count", 100L,
-                "cpuConsumed", 100000L
+                Keys.ETAG.getName(), "string-value",
+                Keys.NUM_SCANNED_ROWS.getName(), 100L,
+                Keys.CPU_CONSUMED_NANOS.getName(), 100000L
             )
         ),
         mapper
     );
-    Assert.assertEquals("string-value", ctx.get(ResponseContext.Key.ETAG));
-    Assert.assertEquals(100, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
-    Assert.assertEquals(100000, ctx.get(ResponseContext.Key.CPU_CONSUMED_NANOS));
-    ctx.add(ResponseContext.Key.NUM_SCANNED_ROWS, 10L);
-    Assert.assertEquals(110L, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
-    ctx.add(ResponseContext.Key.CPU_CONSUMED_NANOS, 100);
-    Assert.assertEquals(100100L, ctx.get(ResponseContext.Key.CPU_CONSUMED_NANOS));
+    Assert.assertEquals("string-value", ctx.getEntityTag());
+    Assert.assertEquals((Long) 100L, ctx.getRowScanCount());
+    Assert.assertEquals((Long) 100000L, ctx.getCpuNanos());
+    ctx.addRowScanCount(10L);
+    Assert.assertEquals((Long) 110L, ctx.getRowScanCount());
+    ctx.addCpuNanos(100L);
+    Assert.assertEquals((Long) 100100L, ctx.getCpuNanos());
   }
 
   @Test(expected = IllegalStateException.class)
@@ -324,35 +347,28 @@ public class ResponseContextTest
   }
 
   @Test
-  public void extensionEnumIntegrityTest()
-  {
-    Assert.assertEquals(
-        ExtensionResponseContextKey.EXTENSION_KEY_1,
-        ResponseContext.Key.keyOf(ExtensionResponseContextKey.EXTENSION_KEY_1.getName())
-    );
-    Assert.assertEquals(
-        ExtensionResponseContextKey.EXTENSION_KEY_2,
-        ResponseContext.Key.keyOf(ExtensionResponseContextKey.EXTENSION_KEY_2.getName())
-    );
-    for (ResponseContext.BaseKey key : ExtensionResponseContextKey.values()) {
-      Assert.assertTrue(ResponseContext.Key.getAllRegisteredKeys().contains(key));
-    }
-  }
-
-  @Test
   public void extensionEnumMergeTest()
   {
     final ResponseContext ctx = ResponseContext.createEmpty();
-    ctx.add(ResponseContext.Key.ETAG, "etag");
-    ctx.add(ExtensionResponseContextKey.EXTENSION_KEY_1, "string-value");
-    ctx.add(ExtensionResponseContextKey.EXTENSION_KEY_2, 2L);
+    ctx.putEntityTag("etag");
+    ctx.add(EXTN_STRING_KEY, "string-value");
+    ctx.add(EXTN_COUNTER_KEY, 2L);
     final ResponseContext ctxFinal = ResponseContext.createEmpty();
-    ctxFinal.add(ResponseContext.Key.ETAG, "old-etag");
-    ctxFinal.add(ExtensionResponseContextKey.EXTENSION_KEY_1, "old-string-value");
-    ctxFinal.add(ExtensionResponseContextKey.EXTENSION_KEY_2, 1L);
+    ctxFinal.putEntityTag("old-etag");
+    ctxFinal.add(EXTN_STRING_KEY, "old-string-value");
+    ctxFinal.add(EXTN_COUNTER_KEY, 1L);
     ctxFinal.merge(ctx);
-    Assert.assertEquals("etag", ctxFinal.get(ResponseContext.Key.ETAG));
-    Assert.assertEquals("string-value", ctxFinal.get(ExtensionResponseContextKey.EXTENSION_KEY_1));
-    Assert.assertEquals(1L + 2L, ctxFinal.get(ExtensionResponseContextKey.EXTENSION_KEY_2));
+    Assert.assertEquals("etag", ctxFinal.getEntityTag());
+    Assert.assertEquals("string-value", ctxFinal.get(EXTN_STRING_KEY));
+    Assert.assertEquals(1L + 2L, ctxFinal.get(EXTN_COUNTER_KEY));
+  }
+
+  @Test
+  public void toMapTest()
+  {
+    final ResponseContext ctx = ResponseContext.createEmpty();
+    ctx.putEntityTag("etag");
+    Map<String, Object> map = ctx.toMap();
+    Assert.assertEquals(map.get(ResponseContext.Keys.ETAG.getName()), "etag");
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -50,7 +50,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +139,7 @@ public class DataSourceMetadataQueryTest
                                                             .dataSource("testing")
                                                             .build();
     ResponseContext context = ConcurrentResponseContext.createEmpty();
-    context.put(ResponseContext.Key.MISSING_SEGMENTS, new ArrayList<>());
+    context.initializeMissingSegments();
     Iterable<Result<DataSourceMetadataResultValue>> results =
         runner.run(QueryPlus.wrap(dataSourceMetadataQuery), context).toList();
     DataSourceMetadataResultValue val = results.iterator().next().getValue();

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryRunnerTest.java
@@ -913,7 +913,7 @@ public class ScanQueryRunnerTest extends InitializedNullHandlingTest
         .context(ImmutableMap.of(QueryContexts.TIMEOUT_KEY, 1))
         .build();
     ResponseContext responseContext = DefaultResponseContext.createEmpty();
-    responseContext.add(ResponseContext.Key.TIMEOUT_AT, System.currentTimeMillis());
+    responseContext.putTimeoutTime(System.currentTimeMillis());
     try {
       runner.run(QueryPlus.wrap(query), responseContext).toList();
     }

--- a/processing/src/test/java/org/apache/druid/query/spec/SpecificSegmentQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/spec/SpecificSegmentQueryRunnerTest.java
@@ -197,17 +197,11 @@ public class SpecificSegmentQueryRunnerTest
   private void validate(ObjectMapper mapper, SegmentDescriptor descriptor, ResponseContext responseContext)
       throws IOException
   {
-    Object missingSegments = responseContext.get(ResponseContext.Key.MISSING_SEGMENTS);
-
+    List<SegmentDescriptor> missingSegments = responseContext.getMissingSegments();
     Assert.assertTrue(missingSegments != null);
-    Assert.assertTrue(missingSegments instanceof List);
 
-    Object segmentDesc = ((List) missingSegments).get(0);
-
-    Assert.assertTrue(segmentDesc instanceof SegmentDescriptor);
-
+    SegmentDescriptor segmentDesc = missingSegments.get(0);
     SegmentDescriptor newDesc = mapper.readValue(mapper.writeValueAsString(segmentDesc), SegmentDescriptor.class);
-
     Assert.assertEquals(descriptor, newDesc);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -225,7 +225,7 @@ public class TimeBoundaryQueryRunnerTest
                                                 .bound(TimeBoundaryQuery.MAX_TIME)
                                                 .build();
     ResponseContext context = ConcurrentResponseContext.createEmpty();
-    context.put(ResponseContext.Key.MISSING_SEGMENTS, new ArrayList<>());
+    context.initializeMissingSegments();
     Iterable<Result<TimeBoundaryResultValue>> results = runner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
     TimeBoundaryResultValue val = results.iterator().next().getValue();
     DateTime minTime = val.getMinTime();
@@ -244,7 +244,7 @@ public class TimeBoundaryQueryRunnerTest
                                                 .bound(TimeBoundaryQuery.MIN_TIME)
                                                 .build();
     ResponseContext context = ConcurrentResponseContext.createEmpty();
-    context.put(ResponseContext.Key.MISSING_SEGMENTS, new ArrayList<>());
+    context.initializeMissingSegments();
     Iterable<Result<TimeBoundaryResultValue>> results = runner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
     TimeBoundaryResultValue val = results.iterator().next().getValue();
     DateTime minTime = val.getMinTime();

--- a/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
@@ -97,7 +97,7 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
           QueryPlus.wrap(query),
           responseContext
       );
-      String newResultSetId = (String) responseContext.get(ResponseContext.Key.ETAG);
+      String newResultSetId = responseContext.getEntityTag();
 
       if (useResultCache && newResultSetId != null && newResultSetId.equals(existingResultSetId)) {
         log.debug("Return cached result set as there is no change in identifiers for query %s ", query.getId());

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -128,7 +128,7 @@ public class CachingClusteredClientFunctionalityTest
 
     ResponseContext responseContext = ResponseContext.createEmpty();
     runQuery(client, builder.build(), responseContext);
-    Assert.assertNull(responseContext.get(ResponseContext.Key.UNCOVERED_INTERVALS));
+    Assert.assertNull(responseContext.getUncoveredIntervals());
 
     builder.intervals("2015-01-01/2015-01-03");
     responseContext = ResponseContext.createEmpty();
@@ -177,8 +177,8 @@ public class CachingClusteredClientFunctionalityTest
     for (String interval : intervals) {
       expectedList.add(Intervals.of(interval));
     }
-    Assert.assertEquals((Object) expectedList, context.get(ResponseContext.Key.UNCOVERED_INTERVALS));
-    Assert.assertEquals(uncoveredIntervalsOverflowed, context.get(ResponseContext.Key.UNCOVERED_INTERVALS_OVERFLOWED));
+    Assert.assertEquals((Object) expectedList, context.getUncoveredIntervals());
+    Assert.assertEquals(uncoveredIntervalsOverflowed, context.get(ResponseContext.Keys.UNCOVERED_INTERVALS_OVERFLOWED));
   }
 
   private void addToTimeline(Interval interval, String version)

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -88,7 +88,6 @@ import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
 import org.apache.druid.query.aggregation.post.ConstantPostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.apache.druid.query.context.ResponseContext;
-import org.apache.druid.query.context.ResponseContext.Key;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.filter.AndDimFilter;
 import org.apache.druid.query.filter.BoundDimFilter;
@@ -168,7 +167,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
@@ -3292,7 +3290,7 @@ public class CachingClusteredClientTest
     final ResponseContext responseContext = initializeResponseContext();
 
     getDefaultQueryRunner().run(QueryPlus.wrap(query), responseContext);
-    Assert.assertEquals("MDs2yIUvYLVzaG6zmwTH1plqaYE=", responseContext.get(ResponseContext.Key.ETAG));
+    Assert.assertEquals("MDs2yIUvYLVzaG6zmwTH1plqaYE=", responseContext.getEntityTag());
   }
 
   @Test
@@ -3340,9 +3338,9 @@ public class CachingClusteredClientTest
     final ResponseContext responseContext = initializeResponseContext();
 
     getDefaultQueryRunner().run(QueryPlus.wrap(query), responseContext);
-    final Object etag1 = responseContext.get(ResponseContext.Key.ETAG);
+    final String etag1 = responseContext.getEntityTag();
     getDefaultQueryRunner().run(QueryPlus.wrap(query2), responseContext);
-    final Object etag2 = responseContext.get(ResponseContext.Key.ETAG);
+    final String etag2 = responseContext.getEntityTag();
     Assert.assertNotEquals(etag1, etag2);
   }
 
@@ -3363,7 +3361,7 @@ public class CachingClusteredClientTest
   private static ResponseContext initializeResponseContext()
   {
     final ResponseContext context = ResponseContext.createEmpty();
-    context.put(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new ConcurrentHashMap<>());
+    context.initializeRemainingResponses();
     return context;
   }
 }

--- a/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
+++ b/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
@@ -44,7 +44,6 @@ import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.context.ConcurrentResponseContext;
 import org.apache.druid.query.context.ResponseContext;
-import org.apache.druid.query.context.ResponseContext.Key;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.segment.QueryableIndex;
@@ -65,7 +64,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -247,7 +245,7 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
   protected static ResponseContext responseContext()
   {
     final ResponseContext responseContext = ConcurrentResponseContext.createEmpty();
-    responseContext.put(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new ConcurrentHashMap<>());
+    responseContext.initializeRemainingResponses();
     return responseContext;
   }
 

--- a/server/src/test/java/org/apache/druid/server/QueryDetailsTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryDetailsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server;
+
+import org.apache.druid.query.context.ResponseContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+/**
+ * Tests for low-level bits of the query resource mechanism.
+ */
+public class QueryDetailsTest
+{
+  @Test
+  public void testEtag()
+  {
+    // No ETAG
+    {
+      ResponseContext responseContext = ResponseContext.createEmpty();
+      Response.ResponseBuilder responseBuilder = Response.ok();
+      QueryResource.transferEntityTag(responseContext, responseBuilder);
+      Response response = responseBuilder.build();
+      MultivaluedMap<String, Object> metadata = response.getMetadata();
+      Assert.assertNull(metadata.get(QueryResource.HEADER_ETAG));
+    }
+
+    // Provided ETAG is passed along.
+    {
+      ResponseContext responseContext = ResponseContext.createEmpty();
+      String etagValue = "myTag";
+      responseContext.putEntityTag(etagValue);
+      Response.ResponseBuilder responseBuilder = Response.ok();
+      QueryResource.transferEntityTag(responseContext, responseBuilder);
+      Response response = responseBuilder.build();
+      MultivaluedMap<String, Object> metadata = response.getMetadata();
+      Assert.assertEquals(etagValue, metadata.getFirst(QueryResource.HEADER_ETAG));
+    }
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -893,9 +893,9 @@ public class QueryResourceTest
     final String queryString = "{\"queryType\":\"timeBoundary\", \"dataSource\":\"allow\","
                                + "\"context\":{\"queryId\":\"id_1\"}}";
     ObjectMapper mapper = new DefaultObjectMapper();
-    Query query = mapper.readValue(queryString, Query.class);
+    Query<?> query = mapper.readValue(queryString, Query.class);
 
-    ListenableFuture future = MoreExecutors.listeningDecorator(
+    ListenableFuture<?> future = MoreExecutors.listeningDecorator(
         Execs.singleThreaded("test_query_resource_%s")
     ).submit(
         new Runnable()
@@ -1017,9 +1017,9 @@ public class QueryResourceTest
     final String queryString = "{\"queryType\":\"timeBoundary\", \"dataSource\":\"allow\","
                                + "\"context\":{\"queryId\":\"id_1\"}}";
     ObjectMapper mapper = new DefaultObjectMapper();
-    Query query = mapper.readValue(queryString, Query.class);
+    Query<?> query = mapper.readValue(queryString, Query.class);
 
-    ListenableFuture future = MoreExecutors.listeningDecorator(
+    ListenableFuture<?> future = MoreExecutors.listeningDecorator(
         Execs.singleThreaded("test_query_resource_%s")
     ).submit(
         new Runnable()

--- a/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
+++ b/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.druid.client.SegmentServerSelector;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.java.util.common.NonnullPair;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.guava.FunctionalIterable;
 import org.apache.druid.java.util.common.guava.LazySequence;
@@ -41,7 +40,6 @@ import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.ReferenceCountingSegmentQueryRunner;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.query.TableDataSource;
-import org.apache.druid.query.context.ResponseContext.Key;
 import org.apache.druid.query.planning.DataSourceAnalysis;
 import org.apache.druid.query.spec.SpecificSegmentQueryRunner;
 import org.apache.druid.query.spec.SpecificSegmentSpec;
@@ -62,7 +60,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
@@ -167,11 +164,9 @@ public class TestClusterQuerySegmentWalker implements QuerySegmentWalker
     // the LocalQuerySegmentWalker constructor instead since this walker is not mimic remote DruidServer objects
     // to actually serve the queries
     return (theQuery, responseContext) -> {
-      responseContext.put(Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS, new ConcurrentHashMap<>());
-      responseContext.add(
-          Key.REMAINING_RESPONSES_FROM_QUERY_SERVERS,
-          new NonnullPair<>(theQuery.getQuery().getMostSpecificId(), 0)
-      );
+      responseContext.initializeRemainingResponses();
+      responseContext.addRemainingResponse(
+          theQuery.getQuery().getMostSpecificId(), 0);
       if (scheduler != null) {
         Set<SegmentServerSelector> segments = new HashSet<>();
         specs.forEach(spec -> segments.add(new SegmentServerSelector(spec)));

--- a/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
@@ -63,7 +63,6 @@ import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.aggregation.MetricManipulationFn;
 import org.apache.druid.query.context.DefaultResponseContext;
 import org.apache.druid.query.context.ResponseContext;
-import org.apache.druid.query.context.ResponseContext.Key;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.planning.DataSourceAnalysis;
@@ -456,8 +455,8 @@ public class ServerManagerTest
     final ResponseContext responseContext = DefaultResponseContext.createEmpty();
     final List<Result<SearchResultValue>> results = queryRunner.run(QueryPlus.wrap(query), responseContext).toList();
     Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.get(Key.MISSING_SEGMENTS));
-    Assert.assertEquals(unknownSegments, responseContext.get(Key.MISSING_SEGMENTS));
+    Assert.assertNotNull(responseContext.getMissingSegments());
+    Assert.assertEquals(unknownSegments, responseContext.getMissingSegments());
   }
 
   @Test
@@ -475,8 +474,8 @@ public class ServerManagerTest
     final ResponseContext responseContext = DefaultResponseContext.createEmpty();
     final List<Result<SearchResultValue>> results = queryRunner.run(QueryPlus.wrap(query), responseContext).toList();
     Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.get(Key.MISSING_SEGMENTS));
-    Assert.assertEquals(unknownSegments, responseContext.get(Key.MISSING_SEGMENTS));
+    Assert.assertNotNull(responseContext.getMissingSegments());
+    Assert.assertEquals(unknownSegments, responseContext.getMissingSegments());
   }
 
   @Test
@@ -495,8 +494,8 @@ public class ServerManagerTest
     final ResponseContext responseContext = DefaultResponseContext.createEmpty();
     final List<Result<SearchResultValue>> results = queryRunner.run(QueryPlus.wrap(query), responseContext).toList();
     Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.get(Key.MISSING_SEGMENTS));
-    Assert.assertEquals(unknownSegments, responseContext.get(Key.MISSING_SEGMENTS));
+    Assert.assertNotNull(responseContext.getMissingSegments());
+    Assert.assertEquals(unknownSegments, responseContext.getMissingSegments());
   }
 
   @Test
@@ -526,8 +525,8 @@ public class ServerManagerTest
     final ResponseContext responseContext = DefaultResponseContext.createEmpty();
     final List<Result<SearchResultValue>> results = queryRunner.run(QueryPlus.wrap(query), responseContext).toList();
     Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.get(Key.MISSING_SEGMENTS));
-    Assert.assertEquals(closedSegments, responseContext.get(Key.MISSING_SEGMENTS));
+    Assert.assertNotNull(responseContext.getMissingSegments());
+    Assert.assertEquals(closedSegments, responseContext.getMissingSegments());
   }
 
   @Test


### PR DESCRIPTION
### Description

Fixes a number of annoying issues in preparation for request trailers and the query profile.

* Converts keys from an enum to classes for smaller code
* Wraps stored values in functions for easier capture for other uses
* Reworks the "header squeezer" to handle types other than arrays.
* Uses metadata for visibility, and ability to compress, to replace ad-hoc code.
* Cleans up JSON serialization for the response context.
* Other miscellaneous cleanup.

Based on a prototype by Gian.

#### Preparing for response trailers and query profile

The query profile work needs a way to return profile information at the completion of a query. It turns out Gian had prototyped just such a mechanism. To do that, he modified the response context to make it clear which fields are returned in the trailer vs. the header. vs. not at all.

The query profile will use the response context as a "back door" to sneak metrics information out of each `QueryRunner.run()` call. This PR contains just the refactoring done by those projects without the additional complexity of the actual trailer or profile code.

#### Key metadata

`ResponseContext` provides a set of key values that define the values allowed in the the context. It seems that those values were originally for a small set of request header values, but grew over time to include internal-only values. With the addition of the response trailer (coming in a later PR), we'll also have footer values.

We have code that knows which names should be in the header and picks those out. However, extensions can add keys, which makes a hard-code approach brittle. This PR adds metadata to each key to identify its visibility. (Based on work originally done by Gian.)

#### Expanded header truncation support

The code can drop (or truncate) header fields. The code hard-codes those fields that can be truncated, and assumes they are arrays. This PR adds the "droppable" state as metadata in the key, and handles non-array fields when dropping. This ensures that extensions get the same "droppable" behavior as core code.

#### Keys as classes, not enums

Keys are defined as an enum. Enums define a fixed set of values. Yet, we allow extensions to "extend" the set of keys. In this case, it is easier to define keys as objects not in an enum.

With this move, we can simplify key definitions. Enum values can't be instances of a class. But, with the additional responsibilities placed on keys, the enum structured forced quite a bit of redundant code. Changing keys to objects let's us use the usual code reuse techniques to avoid redundancy.

#### Explicit accessors

The code to use the response context usually looks like this:

```java
responseContext.add(ResponseContext.Key.CPU_CONSUMED_NANOS, cpuTimeNs);
```

That is rather verbose. And, if we wanted to capture the value for use in, say, metrics, we'd have to hunt down all the places that update the response context and add code to update metrics. This PR provides accessors instead:

```java
responseContext.addCpuNanos(cpuTimeNs);
```

#### Release notes

This PR changes the the `ResponseContext` and it's keys in a breaking way. Any extension that used the prior way to add keys to the response context will need to change the code a bit. However, such changes should be simple.

The prior version of the response context suggested that keys be defined in an enum, then registered. This version suggests that keys be defined as objects, then registered. See the `ResponseContext` class itself for the details.

Note that this change *does not* impact any extension unless that extension adds customer response context keys.

### Summary

This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [X] been tested in a local Druid cluster.
- [X] release note explanation listed above
