### PR TITLE
Optimize Method VersionedIntervalTimeline.isOvershadowed from O(N) to O(logN).

### DIFF
--- a/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
+++ b/core/src/main/java/org/apache/druid/timeline/VersionedIntervalTimeline.java
@@ -466,12 +466,12 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
       if (entry != null) {
         final int majorVersionCompare = versionComparator.compare(version, entry.getVersion());
         if (majorVersionCompare == 0) {
-          for (PartitionChunk<ObjectType> chunk : entry.partitionHolder) {
-            if (chunk.getObject().overshadows(object)) {
-              return true;
-            }
-          }
-          return false;
+          PartitionHolder<ObjectType> partitionHolder = entry.getPartitionHolder();
+          return partitionHolder.isMinorOvershadowed(
+              object.getStartRootPartitionId(),
+              object.getEndRootPartitionId(),
+              object.getMinorVersion()
+          );
         } else {
           return majorVersionCompare < 0;
         }
@@ -502,11 +502,10 @@ public class VersionedIntervalTimeline<VersionType, ObjectType extends Overshado
         if (versionCompare > 0) {
           return false;
         } else if (versionCompare == 0) {
-          // Intentionally use the Iterators API instead of the stream API for performance.
-          //noinspection ConstantConditions
-          final boolean nonOvershadowedObject = Iterators.all(
-              timelineEntry.partitionHolder.iterator(), chunk -> !chunk.getObject().overshadows(object)
-          );
+          PartitionHolder<ObjectType> partitionHolder = timelineEntry.getPartitionHolder();
+          final boolean nonOvershadowedObject = !partitionHolder.isMinorOvershadowed(object.getStartRootPartitionId(),
+                                                                                     object.getEndRootPartitionId(),
+                                                                                     object.getMinorVersion());
           if (nonOvershadowedObject) {
             return false;
           }

--- a/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
@@ -119,6 +119,14 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
     return overshadowableManager.getChunk(partitionNum);
   }
 
+  public boolean isMinorOvershadowed(int startRootPartitionId, int endRootPartitionId, short minorVersion)
+  {
+    return overshadowableManager.isOvershadowedByVisibleGroup(
+        OvershadowableManager.RootPartitionRange.of(startRootPartitionId, endRootPartitionId),
+        minorVersion
+    );
+  }
+
   @Override
   public Iterator<PartitionChunk<T>> iterator()
   {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Before this work, the method VersionedIntervalTimeline.isOvershadowed will traversal all the visible chunks in PartitionHolder, so the cost is O(N). This PR simply reuse exist method OvershadowableManager.isOvershadowedByVisibleGroup to get better performace , which has a cost of O(logN).

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `VersionedIntervalTimeline`
 * `PartitionHolder`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
