### PR TITLE
SqlAggregationModuleTest now extends CalciteTestBase to ensure consistent string encoding

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/aggregation/SqlAggregationModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/aggregation/SqlAggregationModuleTest.java
@@ -24,6 +24,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import org.apache.druid.sql.calcite.aggregation.builtin.CountSqlAggregator;
+import org.apache.druid.sql.calcite.util.CalciteTestBase;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,7 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class SqlAggregationModuleTest
+public class SqlAggregationModuleTest extends CalciteTestBase
 {
   private SqlAggregationModule target;
   private Injector injector;


### PR DESCRIPTION
running SQL unit tests with maven encounters a large number of errors of the form:

```
Cannot apply = to the two different charsets UTF-16LE and ISO-8859-1
```

Adding `SqlAggregationModuleTest extends CalciteTestBase` to ensure that test also sets the correct system properties seems to resolve the issue for me, though not sure what about (i'm guessing) the changes in #11181 caused the issue to start happening.