### PR TITLE
Fix quickstart link

### DIFF
--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -90,6 +90,6 @@ background batch jobs.
 taking a long time to complete.
 
 ## Learn more
-- Try the Druid [Quickstart](../design/index.md).
+- Try the Druid [Quickstart](../tutorials/index.md).
 - Learn more about Druid components in [Design](../design/architecture.md).
 - Read about new features and other details of [Druid Releases](https://github.com/apache/druid/releases).


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description

Druid Quickstart link points to a wrong URL. This PR updates the link.

#### Fixed the Quickstart link.

This PR has:
- [x] been self-reviewed.

