### PR TITLE
Migrate File.mkdirs to FileUtils.mkdirp.

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromGeneratorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromGeneratorBenchmark.java
@@ -20,6 +20,7 @@
 package org.apache.druid.benchmark.compression;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.generator.ColumnValueGenerator;
@@ -29,6 +30,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 @State(Scope.Benchmark)
@@ -385,11 +387,11 @@ public class BaseColumnarLongsFromGeneratorBenchmark extends BaseColumnarLongsBe
     return StringUtils.format("%s-%s-%s-%s.bin", encoding, distribution, rows, nullProbability);
   }
 
-  static File getTmpDir()
+  static File getTmpDir() throws IOException
   {
     final String dirPath = "tmp/encoding/longs/";
     File dir = new File(dirPath);
-    dir.mkdirs();
+    FileUtils.mkdirp(dir);
     return dir;
   }
 }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromSegmentsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsFromSegmentsBenchmark.java
@@ -19,12 +19,14 @@
 
 package org.apache.druid.benchmark.compression;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import java.io.File;
+import java.io.IOException;
 
 @State(Scope.Benchmark)
 public class BaseColumnarLongsFromSegmentsBenchmark extends BaseColumnarLongsBenchmark
@@ -78,11 +80,11 @@ public class BaseColumnarLongsFromSegmentsBenchmark extends BaseColumnarLongsBen
     return StringUtils.format("%s-%s-longs-%s.bin", encoding, segmentName, columnName);
   }
 
-  File getTmpDir()
+  File getTmpDir() throws IOException
   {
     final String dirPath = StringUtils.format("tmp/encoding/%s", segmentName);
     File dir = new File(dirPath);
-    dir.mkdirs();
+    FileUtils.mkdirp(dir);
     return dir;
   }
 }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -157,7 +157,7 @@ public class IndexMergeBenchmark
   {
     File tmpFile = File.createTempFile("IndexMergeBenchmark-MERGEDFILE-V9-" + System.currentTimeMillis(), ".TEMPFILE");
     tmpFile.delete();
-    tmpFile.mkdirs();
+    FileUtils.mkdirp(tmpFile);
     try {
       log.info(tmpFile.getAbsolutePath() + " isFile: " + tmpFile.isFile() + " isDir:" + tmpFile.isDirectory());
 

--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -22,6 +22,7 @@ com.google.common.collect.Sets#newTreeSet() @ Create java.util.TreeSet directly
 com.google.common.collect.Sets#newTreeSet(java.util.Comparator) @ Create java.util.TreeSet directly
 com.google.common.io.Files#createTempDir() @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
 com.google.common.util.concurrent.MoreExecutors#sameThreadExecutor() @ Use org.apache.druid.java.util.common.concurrent.Execs#directExecutor()
+java.io.File#mkdirs() @ Use org.apache.druid.java.util.common.FileUtils.mkdirp instead
 java.io.File#toURL() @ Use java.io.File#toURI() and java.net.URI#toURL() instead
 java.lang.String#matches(java.lang.String) @ Use startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 java.lang.String#replace(java.lang.CharSequence,java.lang.CharSequence) @ Use one of the appropriate methods in StringUtils instead

--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -44,6 +44,7 @@ java.lang.Math#random() @ Use ThreadLocalRandom.current()
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead
 org.apache.commons.io.FileUtils#deleteDirectory(java.io.File) @ Use org.apache.druid.java.util.common.FileUtils#deleteDirectory()
+org.apache.commons.io.FileUtils#forceMkdir(java.io.File) @ Use org.apache.druid.java.util.common.FileUtils.mkdirp instead
 java.lang.Class#getCanonicalName() @ Class.getCanonicalName can return null for anonymous types, use Class.getName instead.
 com.google.common.base.Objects#firstNonNull(java.lang.Object, java.lang.Object) @ Use org.apache.druid.common.guava.GuavaUtils#firstNonNull(java.lang.Object, java.lang.Object) instead (probably... the GuavaUtils method return object is nullable)
 

--- a/core/src/main/java/org/apache/druid/java/util/common/FileUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/FileUtils.java
@@ -380,6 +380,27 @@ public class FileUtils
   }
 
   /**
+   * Create "directory" and all intermediate directories as needed. If the directory is successfully created, or already
+   * exists, returns quietly. Otherwise, throws an IOException.
+   *
+   * Simpler to use than {@link File#mkdirs()}, and more reliable since it is safe from races where two threads try
+   * to create the same directory at the same time.
+   *
+   * The name is inspired by UNIX {@code mkdir -p}, which has the same behavior.
+   */
+  @SuppressForbidden(reason = "File#mkdirs")
+  public static void mkdirp(final File directory) throws IOException
+  {
+    // Second isDirectory check is necessary in case of races.
+    //noinspection DuplicateBooleanBranch
+    final boolean success = directory.isDirectory() || directory.mkdirs() || directory.isDirectory();
+
+    if (!success) {
+      throw new IOE("Cannot create directory [%s]", directory);
+    }
+  }
+
+  /**
    * Equivalent to {@link org.apache.commons.io.FileUtils#deleteDirectory(File)}. Exists here mostly so callers
    * can avoid dealing with our FileUtils and the Commons FileUtils having the same name.
    */

--- a/core/src/main/java/org/apache/druid/java/util/common/FileUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/FileUtils.java
@@ -391,11 +391,9 @@ public class FileUtils
   @SuppressForbidden(reason = "File#mkdirs")
   public static void mkdirp(final File directory) throws IOException
   {
-    // Second isDirectory check is necessary in case of races.
-    //noinspection DuplicateBooleanBranch
-    final boolean success = directory.isDirectory() || directory.mkdirs() || directory.isDirectory();
-
-    if (!success) {
+    // isDirectory check after mkdirs is necessary in case of concurrent calls to mkdirp, because two concurrent
+    // calls to mkdirs cannot both succeed.
+    if (!directory.mkdirs() && !directory.isDirectory()) {
       throw new IOE("Cannot create directory [%s]", directory);
     }
   }

--- a/core/src/main/java/org/apache/druid/java/util/common/StreamUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/StreamUtils.java
@@ -49,7 +49,7 @@ public class StreamUtils
    */
   public static long copyToFileAndClose(InputStream is, File file) throws IOException
   {
-    file.getParentFile().mkdirs();
+    FileUtils.mkdirp(file.getParentFile());
     try (OutputStream os = new BufferedOutputStream(new FileOutputStream(file))) {
       final long result = ByteStreams.copy(is, os);
       // Workarround for http://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/759aa847dcaf

--- a/core/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
@@ -163,7 +163,7 @@ public class FileUtilsTest
   {
     final File tmpFile = folder.newFile();
 
-    expectedException.expect(IllegalStateException.class);
+    expectedException.expect(IOException.class);
     expectedException.expectMessage("Cannot create directory");
     FileUtils.mkdirp(tmpFile);
   }
@@ -175,10 +175,7 @@ public class FileUtilsTest
     final File testDirectory = new File(tmpDir, "test");
     tmpDir.setWritable(false);
     try {
-      final IllegalStateException e = Assert.assertThrows(
-          IllegalStateException.class,
-          () -> FileUtils.mkdirp(testDirectory)
-      );
+      final IOException e = Assert.assertThrows(IOException.class, () -> FileUtils.mkdirp(testDirectory));
 
       MatcherAssert.assertThat(
           e,

--- a/core/src/test/java/org/apache/druid/java/util/metrics/CgroupCpuMonitorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/CgroupCpuMonitorTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.metrics;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.metrics.cgroups.CgroupDiscoverer;
 import org.apache.druid.java.util.metrics.cgroups.ProcCgroupDiscoverer;
@@ -58,7 +59,7 @@ public class CgroupCpuMonitorTest
         "cpu,cpuacct/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
     );
 
-    Assert.assertTrue((cpuDir.isDirectory() && cpuDir.exists()) || cpuDir.mkdirs());
+    FileUtils.mkdirp(cpuDir);
     TestUtils.copyOrReplaceResource("/cpu.shares", new File(cpuDir, "cpu.shares"));
     TestUtils.copyOrReplaceResource("/cpu.cfs_quota_us", new File(cpuDir, "cpu.cfs_quota_us"));
     TestUtils.copyOrReplaceResource("/cpu.cfs_period_us", new File(cpuDir, "cpu.cfs_period_us"));

--- a/core/src/test/java/org/apache/druid/java/util/metrics/CgroupCpuSetMonitorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/CgroupCpuSetMonitorTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.metrics;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.metrics.cgroups.CgroupDiscoverer;
 import org.apache.druid.java.util.metrics.cgroups.ProcCgroupDiscoverer;
@@ -57,8 +58,8 @@ public class CgroupCpuSetMonitorTest
         cgroupDir,
         "cpuset/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
     );
-    Assert.assertTrue((cpusetDir.isDirectory() && cpusetDir.exists()) || cpusetDir.mkdirs());
 
+    FileUtils.mkdirp(cpusetDir);
     TestUtils.copyOrReplaceResource("/cpuset.cpus", new File(cpusetDir, "cpuset.cpus"));
     TestUtils.copyOrReplaceResource("/cpuset.effective_cpus.complex", new File(cpusetDir, "cpuset.effective_cpus"));
     TestUtils.copyOrReplaceResource("/cpuset.mems", new File(cpusetDir, "cpuset.mems"));

--- a/core/src/test/java/org/apache/druid/java/util/metrics/CgroupMemoryMonitorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/CgroupMemoryMonitorTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.metrics;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.metrics.cgroups.CgroupDiscoverer;
 import org.apache.druid.java.util.metrics.cgroups.ProcCgroupDiscoverer;
@@ -56,7 +57,8 @@ public class CgroupMemoryMonitorTest
         cgroupDir,
         "memory/system.slice/some.service"
     );
-    Assert.assertTrue((memoryDir.isDirectory() && memoryDir.exists()) || memoryDir.mkdirs());
+
+    FileUtils.mkdirp(memoryDir);
     TestUtils.copyResource("/memory.stat", new File(memoryDir, "memory.stat"));
     TestUtils.copyResource("/memory.numa_stat", new File(memoryDir, "memory.numa_stat"));
   }

--- a/core/src/test/java/org/apache/druid/java/util/metrics/CpuAcctDeltaMonitorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/CpuAcctDeltaMonitorTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.metrics;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.metrics.cgroups.TestUtils;
 import org.junit.Assert;
@@ -53,7 +54,8 @@ public class CpuAcctDeltaMonitorTest
         cgroupDir,
         "cpu,cpuacct/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
     );
-    Assert.assertTrue((cpuacctDir.isDirectory() && cpuacctDir.exists()) || cpuacctDir.mkdirs());
+
+    FileUtils.mkdirp(cpuacctDir);
     TestUtils.copyResource("/cpuacct.usage_all", new File(cpuacctDir, "cpuacct.usage_all"));
   }
 

--- a/core/src/test/java/org/apache/druid/java/util/metrics/ProcFsReaderTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/ProcFsReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.metrics;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.metrics.cgroups.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,7 +45,8 @@ public class ProcFsReaderTest
         procDir,
         "sys/kernel/random"
     );
-    Assert.assertTrue(kernelDir.mkdirs());
+
+    FileUtils.mkdirp(kernelDir);
     TestUtils.copyResource("/cpuinfo", new File(procDir, "cpuinfo"));
     TestUtils.copyResource("/boot_id", new File(kernelDir, "boot_id"));
   }

--- a/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/CpuAcctTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/CpuAcctTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.metrics.cgroups;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,7 +55,8 @@ public class CpuAcctTest
         cgroupDir,
         "cpu,cpuacct/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
     );
-    Assert.assertTrue((cpuacctDir.isDirectory() && cpuacctDir.exists()) || cpuacctDir.mkdirs());
+
+    FileUtils.mkdirp(cpuacctDir);
     TestUtils.copyResource("/cpuacct.usage_all", new File(cpuacctDir, "cpuacct.usage_all"));
   }
 

--- a/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/CpuSetTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/CpuSetTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.metrics.cgroups;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -47,8 +48,8 @@ public class CpuSetTest
         cgroupDir,
         "cpuset/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
     );
-    Assert.assertTrue((cpusetDir.isDirectory() && cpusetDir.exists()) || cpusetDir.mkdirs());
 
+    FileUtils.mkdirp(cpusetDir);
     TestUtils.copyOrReplaceResource("/cpuset.cpus", new File(cpusetDir, "cpuset.cpus"));
     TestUtils.copyOrReplaceResource("/cpuset.mems", new File(cpusetDir, "cpuset.mems"));
     TestUtils.copyOrReplaceResource("/cpuset.effective_mems", new File(cpusetDir, "cpuset.effective_mems"));

--- a/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/CpuTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/CpuTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.metrics.cgroups;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +47,8 @@ public class CpuTest
         cgroupDir,
         "cpu,cpuacct/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
     );
-    Assert.assertTrue((cpuDir.isDirectory() && cpuDir.exists()) || cpuDir.mkdirs());
+
+    FileUtils.mkdirp(cpuDir);
     TestUtils.copyOrReplaceResource("/cpu.shares", new File(cpuDir, "cpu.shares"));
     TestUtils.copyOrReplaceResource("/cpu.cfs_quota_us", new File(cpuDir, "cpu.cfs_quota_us"));
     TestUtils.copyOrReplaceResource("/cpu.cfs_period_us", new File(cpuDir, "cpu.cfs_period_us"));

--- a/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/MemoryTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/MemoryTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.metrics.cgroups;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,7 +53,8 @@ public class MemoryTest
         cgroupDir,
         "memory/system.slice/some.service"
     );
-    Assert.assertTrue((memoryDir.isDirectory() && memoryDir.exists()) || memoryDir.mkdirs());
+
+    FileUtils.mkdirp(memoryDir);
     TestUtils.copyResource("/memory.stat", new File(memoryDir, "memory.stat"));
     TestUtils.copyResource("/memory.numa_stat", new File(memoryDir, "memory.numa_stat"));
   }

--- a/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/TestUtils.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/cgroups/TestUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.metrics.cgroups;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.junit.Assert;
 
@@ -43,15 +44,15 @@ public class TestUtils
         StringUtils.toUtf8(StringUtils.replace(procMountsString, "/sys/fs/cgroup", cgroupDir.getAbsolutePath()))
     );
 
-    Assert.assertTrue(new File(
+    FileUtils.mkdirp(new File(
         cgroupDir,
         "cpu,cpuacct/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
-    ).mkdirs());
+    ));
 
-    Assert.assertTrue(new File(
+    FileUtils.mkdirp(new File(
         cgroupDir,
         "cpuset/system.slice/some.service/f12ba7e0-fa16-462e-bb9d-652ccc27f0ee"
-    ).mkdirs());
+    ));
     copyResource("/proc.pid.cgroup", new File(procDir, "cgroup"));
   }
 

--- a/extensions-contrib/aliyun-oss-extensions/src/main/java/org/apache/druid/storage/aliyun/OssDataSegmentPuller.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/main/java/org/apache/druid/storage/aliyun/OssDataSegmentPuller.java
@@ -80,7 +80,7 @@ public class OssDataSegmentPuller implements URIDataPuller
     }
 
     try {
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
 
       final URI uri = ossCoords.toUri(OssStorageDruidModule.SCHEME);
       final ByteSource byteSource = new ByteSource()

--- a/extensions-contrib/cassandra-storage/src/main/java/org/apache/druid/storage/cassandra/CassandraDataSegmentPuller.java
+++ b/extensions-contrib/cassandra-storage/src/main/java/org/apache/druid/storage/cassandra/CassandraDataSegmentPuller.java
@@ -52,7 +52,7 @@ public class CassandraDataSegmentPuller extends CassandraStorage
   {
     log.info("Pulling index from C* at path[%s] to outDir[%s]", key, outDir);
     try {
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
     }
     catch (IOException e) {
       throw new SegmentLoadingException(e, "");

--- a/extensions-contrib/cloudfiles-extensions/src/main/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPuller.java
+++ b/extensions-contrib/cloudfiles-extensions/src/main/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPuller.java
@@ -21,7 +21,6 @@ package org.apache.druid.storage.cloudfiles;
 
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.FileUtils;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.utils.CompressionUtils;
@@ -81,16 +80,4 @@ public class CloudFilesDataSegmentPuller
       }
     }
   }
-
-  private void prepareOutDir(final File outDir) throws ISE
-  {
-    if (!outDir.exists()) {
-      outDir.mkdirs();
-    }
-
-    if (!outDir.isDirectory()) {
-      throw new ISE("outDir[%s] must be a directory.", outDir);
-    }
-  }
-
 }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPuller.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPuller.java
@@ -53,7 +53,7 @@ public class AzureDataSegmentPuller
       throws SegmentLoadingException
   {
     try {
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
 
       log.info(
           "Loading container: [%s], with blobPath: [%s] and outDir: [%s]", containerName, blobPath, outDir

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
@@ -235,7 +235,7 @@ public class CoordinatorPollingBasicAuthenticatorCacheManager implements BasicAu
   private void writeUserMapToDisk(String prefix, byte[] userMapBytes) throws IOException
   {
     File cacheDir = new File(commonCacheConfig.getCacheDirectory());
-    cacheDir.mkdirs();
+    FileUtils.mkdirp(cacheDir);
     File userMapFile = new File(commonCacheConfig.getCacheDirectory(), getUserMapFilename(prefix));
     FileUtils.writeAtomically(
         userMapFile,

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
@@ -296,7 +296,7 @@ public class CoordinatorPollingBasicAuthorizerCacheManager implements BasicAutho
   private void writeUserMapToDisk(String prefix, byte[] userMapBytes) throws IOException
   {
     File cacheDir = new File(commonCacheConfig.getCacheDirectory());
-    cacheDir.mkdirs();
+    FileUtils.mkdirp(cacheDir);
     File userMapFile = new File(commonCacheConfig.getCacheDirectory(), getUserRoleMapFilename(prefix));
     FileUtils.writeAtomically(
         userMapFile,
@@ -310,7 +310,7 @@ public class CoordinatorPollingBasicAuthorizerCacheManager implements BasicAutho
   private void writeGroupMappingMapToDisk(String prefix, byte[] groupMappingBytes) throws IOException
   {
     File cacheDir = new File(commonCacheConfig.getCacheDirectory());
-    cacheDir.mkdirs();
+    FileUtils.mkdirp(cacheDir);
     File groupMapFile = new File(commonCacheConfig.getCacheDirectory(), getGroupMappingRoleMapFilename(prefix));
     FileUtils.writeAtomically(
         groupMapFile,

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPuller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPuller.java
@@ -51,7 +51,7 @@ public class GoogleDataSegmentPuller implements URIDataPuller
     LOG.info("Pulling index at bucket[%s] path[%s] to outDir[%s]", bucket, path, outDir.getAbsolutePath());
 
     try {
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
 
       final GoogleByteSource byteSource = new GoogleByteSource(storage, bucket, path);
       final FileUtils.FileCopyResult result = CompressionUtils.unzip(

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPuller.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPuller.java
@@ -187,7 +187,7 @@ public class HdfsDataSegmentPuller implements URIDataPuller
   FileUtils.FileCopyResult getSegmentFiles(final Path path, final File outDir) throws SegmentLoadingException
   {
     try {
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
     }
     catch (IOException e) {
       throw new SegmentLoadingException(e, "");

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPuller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPuller.java
@@ -81,7 +81,7 @@ public class S3DataSegmentPuller implements URIDataPuller
     }
 
     try {
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
 
       final URI uri = s3Coords.toUri(S3StorageDruidModule.SCHEME);
       final ByteSource byteSource = new ByteSource()

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/hadoop/FSSpideringIteratorTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/hadoop/FSSpideringIteratorTest.java
@@ -51,9 +51,9 @@ public class FSSpideringIteratorTest
       new File(baseDir, "dir1/file1").createNewFile();
       new File(baseDir, "dir1/file2").createNewFile();
 
-      new File(baseDir, "dir2/subDir1").mkdirs();
+      FileUtils.mkdirp(new File(baseDir, "dir2/subDir1"));
       new File(baseDir, "dir2/subDir1/file3").createNewFile();
-      new File(baseDir, "dir2/subDir2").mkdirs();
+      FileUtils.mkdirp(new File(baseDir, "dir2/subDir2"));
       new File(baseDir, "dir2/subDir2/file4").createNewFile();
       new File(baseDir, "dir2/subDir2/file5").createNewFile();
 
@@ -101,10 +101,9 @@ public class FSSpideringIteratorTest
     try {
       new File(baseDir, "dir1").mkdir();
 
-      new File(baseDir, "dir2/subDir1").mkdirs();
-      new File(baseDir, "dir2/subDir2").mkdirs();
-
-      new File(baseDir, "dir3/subDir1").mkdirs();
+      FileUtils.mkdirp(new File(baseDir, "dir2/subDir1"));
+      FileUtils.mkdirp(new File(baseDir, "dir2/subDir2"));
+      FileUtils.mkdirp(new File(baseDir, "dir3/subDir1"));
 
       List<String> files = Lists.newArrayList(
           Iterables.transform(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
@@ -20,7 +20,7 @@
 package org.apache.druid.indexing.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.FileUtils;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -47,7 +47,7 @@ public class MultipleFileTaskReportFileWriter implements TaskReportFileWriter
     try {
       final File reportsFileParent = reportsFile.getParentFile();
       if (reportsFileParent != null) {
-        FileUtils.forceMkdir(reportsFileParent);
+        FileUtils.mkdirp(reportsFileParent);
       }
       objectMapper.writeValue(reportsFile, reports);
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
@@ -20,7 +20,7 @@
 package org.apache.druid.indexing.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.FileUtils;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -44,7 +44,7 @@ public class SingleFileTaskReportFileWriter implements TaskReportFileWriter
     try {
       final File reportsFileParent = reportsFile.getParentFile();
       if (reportsFileParent != null) {
-        FileUtils.forceMkdir(reportsFileParent);
+        FileUtils.mkdirp(reportsFileParent);
       }
       objectMapper.writeValue(reportsFile, reports);
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.inject.Provider;
-import org.apache.commons.io.FileUtils;
 import org.apache.druid.client.cache.Cache;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.client.cache.CachePopulatorStats;
@@ -43,6 +42,7 @@ import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskClient;
 import org.apache.druid.indexing.common.task.batch.parallel.ShuffleClient;
 import org.apache.druid.indexing.worker.shuffle.IntermediaryDataManager;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.metrics.Monitor;
 import org.apache.druid.java.util.metrics.MonitorScheduler;
@@ -372,7 +372,7 @@ public class TaskToolbox
   {
     final File tmpDir = new File(taskWorkDir, "indexing-tmp");
     try {
-      FileUtils.forceMkdir(tmpDir);
+      FileUtils.mkdirp(tmpDir);
     }
     catch (IOException e) {
       throw new RuntimeException(e);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStorageShuffleClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStorageShuffleClient.java
@@ -21,7 +21,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
-import org.apache.commons.io.FileUtils;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.loading.LoadSpec;
@@ -47,7 +47,7 @@ public class DeepStorageShuffleClient implements ShuffleClient<DeepStoragePartit
   {
     final LoadSpec loadSpec = objectMapper.convertValue(location.getLoadSpec(), LoadSpec.class);
     final File unzippedDir = new File(partitionDir, StringUtils.format("unzipped_%s", location.getSubTaskId()));
-    FileUtils.forceMkdir(unzippedDir);
+    FileUtils.mkdirp(unzippedDir);
     try {
       loadSpec.loadSegment(unzippedDir);
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/HttpShuffleClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/HttpShuffleClient.java
@@ -88,7 +88,7 @@ public class HttpShuffleClient implements ShuffleClient<GenericPartitionLocation
     );
     final File unzippedDir = new File(partitionDir, StringUtils.format("unzipped_%s", location.getSubTaskId()));
     try {
-      org.apache.commons.io.FileUtils.forceMkdir(unzippedDir);
+      FileUtils.mkdirp(unzippedDir);
       CompressionUtils.unzip(zippedFile, unzippedDir);
     }
     finally {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
@@ -186,7 +186,7 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
     );
 
     final File persistDir = toolbox.getPersistDir();
-    org.apache.commons.io.FileUtils.forceDelete(persistDir);
+    org.apache.commons.io.FileUtils.deleteQuietly(persistDir);
     FileUtils.mkdirp(persistDir);
 
     final Set<DataSegment> pushedSegments = mergeAndPushSegments(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import org.apache.commons.io.FileUtils;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.TaskToolbox;
@@ -35,6 +34,7 @@ import org.apache.druid.indexing.common.actions.SurrogateAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.task.ClientBasedTaskInfoProvider;
 import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.RetryUtils;
@@ -186,8 +186,8 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
     );
 
     final File persistDir = toolbox.getPersistDir();
-    FileUtils.deleteQuietly(persistDir);
-    FileUtils.forceMkdir(persistDir);
+    org.apache.commons.io.FileUtils.forceDelete(persistDir);
+    org.apache.druid.java.util.common.FileUtils.mkdirp(taskTempDir);
 
     final Set<DataSegment> pushedSegments = mergeAndPushSegments(
         toolbox,
@@ -212,8 +212,8 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
   ) throws IOException
   {
     final File tempDir = toolbox.getIndexingTmpDir();
-    FileUtils.deleteQuietly(tempDir);
-    FileUtils.forceMkdir(tempDir);
+    org.apache.commons.io.FileUtils.deleteQuietly(tempDir);
+    FileUtils.mkdirp(tempDir);
 
     final Map<Interval, Int2ObjectMap<List<File>>> intervalToUnzippedFiles = new HashMap<>();
     // Fetch partition files
@@ -221,13 +221,13 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
       final Interval interval = entryPerInterval.getKey();
       for (Int2ObjectMap.Entry<List<PartitionLocation>> entryPerBucketId : entryPerInterval.getValue().int2ObjectEntrySet()) {
         final int bucketId = entryPerBucketId.getIntKey();
-        final File partitionDir = FileUtils.getFile(
+        final File partitionDir = org.apache.commons.io.FileUtils.getFile(
             tempDir,
             interval.getStart().toString(),
             interval.getEnd().toString(),
             Integer.toString(bucketId)
         );
-        FileUtils.forceMkdir(partitionDir);
+        FileUtils.mkdirp(partitionDir);
         for (PartitionLocation location : entryPerBucketId.getValue()) {
           final File unzippedDir = toolbox.getShuffleClient().fetchSegmentFile(partitionDir, supervisorTaskId, location);
           intervalToUnzippedFiles.computeIfAbsent(interval, k -> new Int2ObjectOpenHashMap<>())

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
@@ -187,7 +187,7 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
 
     final File persistDir = toolbox.getPersistDir();
     org.apache.commons.io.FileUtils.forceDelete(persistDir);
-    org.apache.druid.java.util.common.FileUtils.mkdirp(taskTempDir);
+    FileUtils.mkdirp(persistDir);
 
     final Set<DataSegment> pushedSegments = mergeAndPushSegments(
         toolbox,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogs.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogs.java
@@ -51,25 +51,19 @@ public class FileTaskLogs implements TaskLogs
   @Override
   public void pushTaskLog(final String taskid, File file) throws IOException
   {
-    if (config.getDirectory().exists() || config.getDirectory().mkdirs()) {
-      final File outputFile = fileForTask(taskid, file.getName());
-      Files.copy(file, outputFile);
-      log.info("Wrote task log to: %s", outputFile);
-    } else {
-      throw new IOE("Unable to create task log dir[%s]", config.getDirectory());
-    }
+    FileUtils.mkdirp(config.getDirectory());
+    final File outputFile = fileForTask(taskid, file.getName());
+    Files.copy(file, outputFile);
+    log.info("Wrote task log to: %s", outputFile);
   }
 
   @Override
   public void pushTaskReports(String taskid, File reportFile) throws IOException
   {
-    if (config.getDirectory().exists() || config.getDirectory().mkdirs()) {
-      final File outputFile = fileForTask(taskid, reportFile.getName());
-      Files.copy(reportFile, outputFile);
-      log.info("Wrote task report to: %s", outputFile);
-    } else {
-      throw new IOE("Unable to create task report dir[%s]", config.getDirectory());
-    }
+    FileUtils.mkdirp(config.getDirectory());
+    final File outputFile = fileForTask(taskid, reportFile.getName());
+    Files.copy(reportFile, outputFile);
+    log.info("Wrote task report to: %s", outputFile);
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -51,7 +51,6 @@ import org.apache.druid.indexing.overlord.config.ForkingTaskRunnerConfig;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.FileUtils;
-import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -161,9 +161,7 @@ public class ForkingTaskRunner
                   try {
                     final Closer closer = Closer.create();
                     try {
-                      if (!attemptDir.mkdirs()) {
-                        throw new IOE("Could not create directories: %s", attemptDir);
-                      }
+                      FileUtils.mkdirp(attemptDir);
 
                       final File taskFile = new File(taskDir, "task.json");
                       final File statusFile = new File(attemptDir, "status.json");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -165,9 +165,7 @@ public class ThreadingTaskRunner
                           final ThreadingTaskRunnerWorkItem taskWorkItem;
 
                           try {
-                            if (!attemptDir.mkdirs()) {
-                              throw new IOE("Could not create directories: %s", attemptDir);
-                            }
+                            FileUtils.mkdirp(attemptDir);
 
                             final File taskFile = new File(taskDir, "task.json");
                             final File reportsFile = new File(attemptDir, "report.json");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -43,7 +43,6 @@ import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.FileUtils;
-import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -312,10 +312,10 @@ public class WorkerTaskManager
     return new File(taskConfig.getBaseTaskDir(), "workerTaskManagerTmp");
   }
 
-  private void cleanupAndMakeTmpTaskDir()
+  private void cleanupAndMakeTmpTaskDir() throws IOException
   {
     File tmpDir = getTmpTaskDir();
-    tmpDir.mkdirs();
+    FileUtils.mkdirp(tmpDir);
     if (!tmpDir.isDirectory()) {
       throw new ISE("Tmp Tasks Dir [%s] does not exist/not-a-directory.", tmpDir);
     }
@@ -334,17 +334,13 @@ public class WorkerTaskManager
     return new File(taskConfig.getBaseTaskDir(), "assignedTasks");
   }
 
-  private void initAssignedTasks()
+  private void initAssignedTasks() throws IOException
   {
     File assignedTaskDir = getAssignedTaskDir();
 
     log.debug("Looking for any previously assigned tasks on disk[%s].", assignedTaskDir);
 
-    assignedTaskDir.mkdirs();
-
-    if (!assignedTaskDir.isDirectory()) {
-      throw new ISE("Assigned Tasks Dir [%s] does not exist/not-a-directory.", assignedTaskDir);
-    }
+    FileUtils.mkdirp(assignedTaskDir);
 
     for (File taskFile : assignedTaskDir.listFiles()) {
       try {
@@ -461,16 +457,12 @@ public class WorkerTaskManager
     }
   }
 
-  private void initCompletedTasks()
+  private void initCompletedTasks() throws IOException
   {
     File completedTaskDir = getCompletedTaskDir();
     log.debug("Looking for any previously completed tasks on disk[%s].", completedTaskDir);
 
-    completedTaskDir.mkdirs();
-
-    if (!completedTaskDir.isDirectory()) {
-      throw new ISE("Completed Tasks Dir [%s] does not exist/not-a-directory.", completedTaskDir);
-    }
+    FileUtils.mkdirp(completedTaskDir);
 
     for (File taskFile : completedTaskDir.listFiles()) {
       try {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycle.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycle.java
@@ -25,13 +25,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
-import org.apache.commons.io.FileUtils;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
@@ -192,7 +192,7 @@ public class ExecutorLifecycle
 
               final File statusFileParent = statusFile.getParentFile();
               if (statusFileParent != null) {
-                FileUtils.forceMkdir(statusFileParent);
+                FileUtils.mkdirp(statusFileParent);
               }
               jsonMapper.writeValue(statusFile, taskStatus);
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -777,7 +777,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
       );
       final File unzippedDir = new File(partitionDir, StringUtils.format("unzipped_%s", location.getSubTaskId()));
       try {
-        org.apache.commons.io.FileUtils.forceMkdir(unzippedDir);
+        FileUtils.mkdirp(unzippedDir);
         CompressionUtils.unzip(fetchedFile, unzippedDir);
       }
       finally {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
@@ -84,7 +84,7 @@ public class FileTaskLogsTest
     final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
 
     expectedException.expect(IOException.class);
-    expectedException.expectMessage("Unable to create task log dir");
+    expectedException.expectMessage("Cannot create directory");
     taskLogs.pushTaskLog("foo", logFile);
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -54,7 +54,6 @@ import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.indexing.overlord.TaskLockbox;
 import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.java.util.common.FileUtils;
-import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.StringUtils;
@@ -206,9 +205,7 @@ public class IngestSegmentFirehoseFactoryTest
       index.add(ROW_PARSER.parseBatch(buildRow(i.longValue())).get(0));
     }
 
-    if (!PERSIST_DIR.mkdirs() && !PERSIST_DIR.exists()) {
-      throw new IOE("Could not create directory at [%s]", PERSIST_DIR.getAbsolutePath());
-    }
+    FileUtils.mkdirp(PERSIST_DIR);
     INDEX_MERGER_V9.persist(index, PERSIST_DIR, indexSpec, null);
 
     final CoordinatorClient cc = new CoordinatorClient(null, null)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -89,6 +89,7 @@ import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
@@ -157,7 +158,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -925,7 +925,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
     List<File> segmentFiles = new ArrayList<>();
     for (DataSegment segment : mdc.retrieveUnusedSegmentsForInterval("test_kill_task", Intervals.of("2011-04-01/P4D"))) {
       File file = new File((String) segment.getLoadSpec().get("path"));
-      file.mkdirs();
+      FileUtils.mkdirp(file);
       segmentFiles.add(file);
     }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -181,8 +181,8 @@ public class WorkerTaskManagerTest
     Task task2 = createNoopTask("task2-completed-already");
     Task task3 = createNoopTask("task3-assigned-explicitly");
 
-    workerTaskManager.getAssignedTaskDir().mkdirs();
-    workerTaskManager.getCompletedTaskDir().mkdirs();
+    FileUtils.mkdirp(workerTaskManager.getAssignedTaskDir());
+    FileUtils.mkdirp(workerTaskManager.getCompletedTaskDir());
 
     // create a task in assigned task directory, to simulate MM shutdown right after a task was assigned.
     jsonMapper.writeValue(new File(workerTaskManager.getAssignedTaskDir(), task1.getId()), task1);

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/LimitedTemporaryStorage.java
@@ -20,7 +20,7 @@
 package org.apache.druid.query.groupby.epinephelinae;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.io.FileUtils;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -82,7 +82,7 @@ public class LimitedTemporaryStorage implements Closeable
         throw new ISE("Closed");
       }
 
-      FileUtils.forceMkdir(storageDirectory);
+      FileUtils.mkdirp(storageDirectory);
       if (!createdStorageDirectory) {
         createdStorageDirectory = true;
       }

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupSnapshotTaker.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupSnapshotTaker.java
@@ -54,12 +54,6 @@ public class LookupSnapshotTaker
         "can not work without specifying persistDirectory"
     );
     this.persistDirectory = new File(persistDirectory);
-    if (!this.persistDirectory.exists()) {
-      Preconditions.checkArgument(this.persistDirectory.mkdirs(), "Oups was not able to create persist directory");
-    }
-    if (!this.persistDirectory.isDirectory()) {
-      throw new ISE("Can only persist to directories, [%s] wasn't a directory", persistDirectory);
-    }
   }
 
   public synchronized List<LookupBean> pullExistingSnapshot(final String tier)

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -209,7 +209,7 @@ public class IndexMergerV9 implements IndexMerger
     Closer closer = Closer.create();
     try {
       final FileSmoosher v9Smoosher = new FileSmoosher(outDir);
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
 
       SegmentWriteOutMediumFactory omf = segmentWriteOutMediumFactory != null ? segmentWriteOutMediumFactory
                                                                               : defaultSegmentWriteOutMediumFactory;
@@ -859,7 +859,7 @@ public class IndexMergerV9 implements IndexMerger
       );
     }
 
-    org.apache.commons.io.FileUtils.forceMkdir(outDir);
+    FileUtils.mkdirp(outDir);
 
     log.debug("Starting persist for interval[%s], rows[%,d]", dataInterval, index.size());
     return multiphaseMerge(
@@ -985,7 +985,7 @@ public class IndexMergerV9 implements IndexMerger
   ) throws IOException
   {
     FileUtils.deleteDirectory(outDir);
-    org.apache.commons.io.FileUtils.forceMkdir(outDir);
+    FileUtils.mkdirp(outDir);
 
     List<File> tempDirs = new ArrayList<>();
 
@@ -1227,7 +1227,7 @@ public class IndexMergerV9 implements IndexMerger
   ) throws IOException
   {
     FileUtils.deleteDirectory(outDir);
-    org.apache.commons.io.FileUtils.forceMkdir(outDir);
+    FileUtils.mkdirp(outDir);
 
     final List<String> mergedDimensions = IndexMerger.getMergedDimensions(indexes, null);
 

--- a/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMedium.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMedium.java
@@ -35,7 +35,7 @@ public final class TmpFileSegmentWriteOutMedium implements SegmentWriteOutMedium
   TmpFileSegmentWriteOutMedium(File outDir) throws IOException
   {
     File tmpOutputFilesDir = new File(outDir, "tmpOutputFiles");
-    org.apache.commons.io.FileUtils.forceMkdir(tmpOutputFilesDir);
+    FileUtils.mkdirp(tmpOutputFilesDir);
     closer.register(() -> FileUtils.deleteDirectory(tmpOutputFilesDir));
     this.dir = tmpOutputFilesDir;
   }

--- a/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.data.input.impl.JSONParseSpec;
 import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.metadata.SegmentMetadataQueryConfig;
@@ -344,7 +345,7 @@ public class DoubleStorageTest
     }
     File someTmpFile = File.createTempFile("billy", "yay");
     someTmpFile.delete();
-    someTmpFile.mkdirs();
+    FileUtils.mkdirp(someTmpFile);
     INDEX_MERGER_V9.persist(index, someTmpFile, new IndexSpec(), null);
     someTmpFile.delete();
     return INDEX_IO.loadIndex(someTmpFile);

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerV9CompatibilityTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerV9CompatibilityTest.java
@@ -150,7 +150,7 @@ public class IndexMergerV9CompatibilityTest
     }
     tmpDir = FileUtils.createTempDir();
     persistTmpDir = new File(tmpDir, "persistDir");
-    org.apache.commons.io.FileUtils.forceMkdir(persistTmpDir);
+    FileUtils.mkdirp(persistTmpDir);
     String[] files = new String[] {"00000.smoosh", "meta.smoosh", "version.bin"};
     for (String file : files) {
       new ByteSource()

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -259,7 +259,7 @@ public class IndexMergerV9WithSpatialIndexTest extends InitializedNullHandlingTe
     IncrementalIndex theIndex = makeIncrementalIndex();
     File tmpFile = File.createTempFile("billy", "yay");
     tmpFile.delete();
-    tmpFile.mkdirs();
+    FileUtils.mkdirp(tmpFile);
 
     try {
       indexMergerV9.persist(theIndex, tmpFile, indexSpec, null);
@@ -488,10 +488,10 @@ public class IndexMergerV9WithSpatialIndexTest extends InitializedNullHandlingTe
       File thirdFile = new File(tmpFile, "third");
       File mergedFile = new File(tmpFile, "merged");
 
-      firstFile.mkdirs();
-      secondFile.mkdirs();
-      thirdFile.mkdirs();
-      mergedFile.mkdirs();
+      FileUtils.mkdirp(firstFile);
+      FileUtils.mkdirp(secondFile);
+      FileUtils.mkdirp(thirdFile);
+      FileUtils.mkdirp(mergedFile);
 
       indexMergerV9.persist(first, DATA_INTERVAL, firstFile, indexSpec, null);
       indexMergerV9.persist(second, DATA_INTERVAL, secondFile, indexSpec, null);

--- a/processing/src/test/java/org/apache/druid/segment/SchemalessIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessIndexTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -202,11 +203,11 @@ public class SchemalessIndexTest
         File bottomFile = new File(tmpFile, "bottom");
         File mergedFile = new File(tmpFile, "merged");
 
-        topFile.mkdirs();
+        FileUtils.mkdirp(topFile);
+        FileUtils.mkdirp(bottomFile);
+        FileUtils.mkdirp(mergedFile);
         topFile.deleteOnExit();
-        bottomFile.mkdirs();
         bottomFile.deleteOnExit();
-        mergedFile.mkdirs();
         mergedFile.deleteOnExit();
 
         indexMerger.persist(top, topFile, INDEX_SPEC, null);
@@ -257,7 +258,7 @@ public class SchemalessIndexTest
 
         File mergedFile = new File(tmpFile, "merged");
 
-        mergedFile.mkdirs();
+        FileUtils.mkdirp(mergedFile);
         mergedFile.deleteOnExit();
 
         QueryableIndex index = indexIO.loadIndex(
@@ -295,7 +296,7 @@ public class SchemalessIndexTest
 
         File mergedFile = new File(tmpFile, "merged");
 
-        mergedFile.mkdirs();
+        FileUtils.mkdirp(mergedFile);
         mergedFile.deleteOnExit();
 
         List<QueryableIndex> indexesToMerge = new ArrayList<>();
@@ -387,7 +388,7 @@ public class SchemalessIndexTest
 
           File tmpFile = File.createTempFile("billy", "yay");
           tmpFile.delete();
-          tmpFile.mkdirs();
+          FileUtils.mkdirp(tmpFile);
           tmpFile.deleteOnExit();
 
           indexMerger.persist(rowIndex, tmpFile, INDEX_SPEC, null);
@@ -453,7 +454,7 @@ public class SchemalessIndexTest
     for (Pair<String, AggregatorFactory[]> file : files) {
       IncrementalIndex index = makeIncrementalIndex(file.lhs, file.rhs);
       File theFile = new File(tmpFile, file.lhs);
-      theFile.mkdirs();
+      FileUtils.mkdirp(theFile);
       theFile.deleteOnExit();
       filesToMap.add(theFile);
       indexMerger.persist(index, theFile, INDEX_SPEC, null);
@@ -471,7 +472,7 @@ public class SchemalessIndexTest
       File tmpFile = File.createTempFile("yay", "boo");
       tmpFile.delete();
       File mergedFile = new File(tmpFile, "merged");
-      mergedFile.mkdirs();
+      FileUtils.mkdirp(mergedFile);
       mergedFile.deleteOnExit();
 
       List<File> filesToMap = makeFilesToMap(tmpFile, files);
@@ -536,7 +537,7 @@ public class SchemalessIndexTest
       File tmpFile = File.createTempFile("yay", "who");
       tmpFile.delete();
       File mergedFile = new File(tmpFile, "merged");
-      mergedFile.mkdirs();
+      FileUtils.mkdirp(mergedFile);
       mergedFile.deleteOnExit();
 
       List<File> filesToMap = makeFilesToMap(tmpFile, files);

--- a/processing/src/test/java/org/apache/druid/segment/TestIndex.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestIndex.java
@@ -34,6 +34,7 @@ import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -191,11 +192,11 @@ public class TestIndex
       File bottomFile = new File(tmpFile, "bottom");
       File mergedFile = new File(tmpFile, "merged");
 
-      topFile.mkdirs();
+      FileUtils.mkdirp(topFile);
+      FileUtils.mkdirp(bottomFile);
+      FileUtils.mkdirp(mergedFile);
       topFile.deleteOnExit();
-      bottomFile.mkdirs();
       bottomFile.deleteOnExit();
-      mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
       INDEX_MERGER.persist(top, DATA_INTERVAL, topFile, INDEX_SPEC, null);
@@ -377,7 +378,7 @@ public class TestIndex
     try {
       File someTmpFile = File.createTempFile("billy", "yay");
       someTmpFile.delete();
-      someTmpFile.mkdirs();
+      FileUtils.mkdirp(someTmpFile);
       someTmpFile.deleteOnExit();
 
       INDEX_MERGER.persist(index, someTmpFile, INDEX_SPEC, null);

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.SpatialDimensionSchema;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -248,7 +249,7 @@ public class SpatialFilterBonusTest
     IncrementalIndex theIndex = makeIncrementalIndex();
     File tmpFile = File.createTempFile("billy", "yay");
     tmpFile.delete();
-    tmpFile.mkdirs();
+    FileUtils.mkdirp(tmpFile);
     tmpFile.deleteOnExit();
 
     indexMerger.persist(theIndex, tmpFile, indexSpec, null);
@@ -433,13 +434,13 @@ public class SpatialFilterBonusTest
       File thirdFile = new File(tmpFile, "third");
       File mergedFile = new File(tmpFile, "merged");
 
-      firstFile.mkdirs();
+      FileUtils.mkdirp(firstFile);
+      FileUtils.mkdirp(secondFile);
+      FileUtils.mkdirp(thirdFile);
+      FileUtils.mkdirp(mergedFile);
       firstFile.deleteOnExit();
-      secondFile.mkdirs();
       secondFile.deleteOnExit();
-      thirdFile.mkdirs();
       thirdFile.deleteOnExit();
-      mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
       indexMerger.persist(first, DATA_INTERVAL, firstFile, indexSpec, null);

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.SpatialDimensionSchema;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.Druids;
@@ -270,7 +271,7 @@ public class SpatialFilterTest extends InitializedNullHandlingTest
     IncrementalIndex theIndex = makeIncrementalIndex();
     File tmpFile = File.createTempFile("billy", "yay");
     tmpFile.delete();
-    tmpFile.mkdirs();
+    FileUtils.mkdirp(tmpFile);
     tmpFile.deleteOnExit();
 
     INDEX_MERGER.persist(theIndex, tmpFile, indexSpec, null);
@@ -488,13 +489,13 @@ public class SpatialFilterTest extends InitializedNullHandlingTest
       File thirdFile = new File(tmpFile, "third");
       File mergedFile = new File(tmpFile, "merged");
 
-      firstFile.mkdirs();
+      FileUtils.mkdirp(firstFile);
+      FileUtils.mkdirp(secondFile);
+      FileUtils.mkdirp(thirdFile);
+      FileUtils.mkdirp(mergedFile);
       firstFile.deleteOnExit();
-      secondFile.mkdirs();
       secondFile.deleteOnExit();
-      thirdFile.mkdirs();
       thirdFile.deleteOnExit();
-      mergedFile.mkdirs();
       mergedFile.deleteOnExit();
 
       INDEX_MERGER.persist(first, DATA_INTERVAL, firstFile, indexSpec, null);

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -34,6 +34,7 @@ import org.apache.druid.concurrent.LifecycleLock;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
@@ -48,6 +49,7 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -147,13 +149,14 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
   }
 
   @LifecycleStart
-  public void start()
+  public void start() throws IOException
   {
     if (!lifecycleLock.canStart()) {
       throw new ISE("can't start.");
     }
     try {
       LOG.debug("LookupExtractorFactoryContainerProvider starting.");
+      FileUtils.mkdirp(new File(lookupConfig.getSnapshotWorkingDir()));
       loadAllLookupsAndInitStateRef();
       if (!testMode) {
         mainThread = Execs.makeThread(

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -156,7 +156,9 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
     }
     try {
       LOG.debug("LookupExtractorFactoryContainerProvider starting.");
-      FileUtils.mkdirp(new File(lookupConfig.getSnapshotWorkingDir()));
+      if (!Strings.isNullOrEmpty(lookupConfig.getSnapshotWorkingDir())) {
+        FileUtils.mkdirp(new File(lookupConfig.getSnapshotWorkingDir()));
+      }
       loadAllLookupsAndInitStateRef();
       if (!testMode) {
         mainThread = Execs.makeThread(

--- a/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusher.java
@@ -89,7 +89,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
 
     final File tmpOutDir = new File(config.getStorageDirectory(), makeIntermediateDir());
     log.debug("Creating intermediate directory[%s] for segment[%s].", tmpOutDir.toString(), segment.getId());
-    org.apache.commons.io.FileUtils.forceMkdir(tmpOutDir);
+    FileUtils.mkdirp(tmpOutDir);
 
     try {
       final File tmpIndexFile = new File(tmpOutDir, INDEX_FILENAME);
@@ -99,7 +99,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
                                              .withSize(size)
                                              .withBinaryVersion(SegmentUtils.getVersionFromDir(dataSegmentFile));
 
-      org.apache.commons.io.FileUtils.forceMkdir(outDir);
+      FileUtils.mkdirp(outDir);
       final File indexFileTarget = new File(outDir, tmpIndexFile.getName());
 
       if (!tmpIndexFile.renameTo(indexFileTarget)) {

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -300,10 +300,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     // the parent directories of the segment are removed
     final File downloadStartMarker = new File(storageDir, DOWNLOAD_START_MARKER_FILE_NAME);
     synchronized (directoryWriteRemoveLock) {
-      if (!storageDir.mkdirs()) {
-        log.debug("Unable to make parent file[%s]", storageDir);
-      }
       try {
+        FileUtils.mkdirp(storageDir);
+
         if (!downloadStartMarker.createNewFile()) {
           throw new SegmentLoadingException("Was not able to create new download marker for [%s]", storageDir);
         }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -1478,7 +1478,7 @@ public class AppenderatorImpl implements Appenderator
   private File createPersistDirIfNeeded(SegmentIdWithShardSpec identifier) throws IOException
   {
     final File persistDir = computePersistDir(identifier);
-    org.apache.commons.io.FileUtils.forceMkdir(persistDir);
+    FileUtils.mkdirp(persistDir);
 
     objectMapper.writeValue(computeIdentifierFile(identifier), identifier);
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -260,7 +260,6 @@ public class AppenderatorImpl implements Appenderator
   @Override
   public Object startJob()
   {
-    tuningConfig.getBasePersistDirectory().mkdirs();
     lockBasePersistDirectory();
     final Object retVal = bootstrapSinksFromDisk();
     initializeExecutors();
@@ -381,7 +380,8 @@ public class AppenderatorImpl implements Appenderator
           }
         }
 
-        if (!skipBytesInMemoryOverheadCheck && bytesCurrentlyInMemory.get() - bytesToBePersisted > maxBytesTuningConfig) {
+        if (!skipBytesInMemoryOverheadCheck
+            && bytesCurrentlyInMemory.get() - bytesToBePersisted > maxBytesTuningConfig) {
           // We are still over maxBytesTuningConfig even after persisting.
           // This means that we ran out of all available memory to ingest (due to overheads created as part of ingestion)
           final String alertMessage = StringUtils.format(
@@ -1099,6 +1099,8 @@ public class AppenderatorImpl implements Appenderator
   {
     if (basePersistDirLock == null) {
       try {
+        FileUtils.mkdirp(tuningConfig.getBasePersistDirectory());
+
         basePersistDirLockChannel = FileChannel.open(
             computeLockFile().toPath(),
             StandardOpenOption.CREATE,

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
@@ -193,7 +193,6 @@ public class BatchAppenderator implements Appenderator
   @Override
   public Object startJob()
   {
-    tuningConfig.getBasePersistDirectory().mkdirs();
     lockBasePersistDirectory();
     initializeExecutors();
     return null;
@@ -927,6 +926,8 @@ public class BatchAppenderator implements Appenderator
   {
     if (basePersistDirLock == null) {
       try {
+        FileUtils.mkdirp(tuningConfig.getBasePersistDirectory());
+
         basePersistDirLockChannel = FileChannel.open(
             computeLockFile().toPath(),
             StandardOpenOption.CREATE,

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
@@ -1100,7 +1100,7 @@ public class BatchAppenderator implements Appenderator
   private File createPersistDirIfNeeded(SegmentIdWithShardSpec identifier) throws IOException
   {
     final File persistDir = computePersistDir(identifier);
-    org.apache.commons.io.FileUtils.forceMkdir(persistDir);
+    FileUtils.mkdirp(persistDir);
 
     objectMapper.writeValue(computeIdentifierFile(identifier), identifier);
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
@@ -1398,7 +1398,7 @@ public class StreamAppenderator implements Appenderator
   private File createPersistDirIfNeeded(SegmentIdWithShardSpec identifier) throws IOException
   {
     final File persistDir = computePersistDir(identifier);
-    org.apache.commons.io.FileUtils.forceMkdir(persistDir);
+    FileUtils.mkdirp(persistDir);
 
     objectMapper.writeValue(computeIdentifierFile(identifier), identifier);
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
@@ -228,7 +228,6 @@ public class StreamAppenderator implements Appenderator
   @Override
   public Object startJob()
   {
-    tuningConfig.getBasePersistDirectory().mkdirs();
     lockBasePersistDirectory();
     final Object retVal = bootstrapSinksFromDisk();
     initializeExecutors();
@@ -1022,6 +1021,8 @@ public class StreamAppenderator implements Appenderator
   {
     if (basePersistDirLock == null) {
       try {
+        FileUtils.mkdirp(tuningConfig.getBasePersistDirectory());
+
         basePersistDirLockChannel = FileChannel.open(
             computeLockFile().toPath(),
             StandardOpenOption.CREATE,

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/FlushingPlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/FlushingPlumber.java
@@ -25,6 +25,7 @@ import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.client.cache.CachePopulatorStats;
 import org.apache.druid.common.guava.ThreadRenamingCallable;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
@@ -43,6 +44,7 @@ import org.apache.druid.server.coordination.DataSegmentAnnouncer;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +113,13 @@ public class FlushingPlumber extends RealtimePlumber
   {
     log.info("Starting job for %s", getSchema().getDataSource());
 
-    computeBaseDir(getSchema()).mkdirs();
+    try {
+      FileUtils.mkdirp(computeBaseDir(getSchema()));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
     initializeExecutors();
 
     if (flushScheduledExec == null) {

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -202,7 +202,13 @@ public class RealtimePlumber implements Plumber
   @Override
   public Object startJob()
   {
-    computeBaseDir(schema).mkdirs();
+    try {
+      FileUtils.mkdirp(computeBaseDir(schema));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
     initializeExecutors();
     handoffNotifier.start();
     Object retVal = bootstrapSinksFromDisk();

--- a/server/src/main/java/org/apache/druid/server/coordination/SegmentLoadDropHandler.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/SegmentLoadDropHandler.java
@@ -35,6 +35,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.inject.Inject;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.ServerTypeConfig;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
@@ -210,17 +211,11 @@ public class SegmentLoadDropHandler implements DataSegmentChangeHandler
     return started;
   }
 
-  private void loadLocalCache()
+  private void loadLocalCache() throws IOException
   {
     final long start = System.currentTimeMillis();
     File baseDir = config.getInfoDir();
-    if (!baseDir.isDirectory()) {
-      if (baseDir.exists()) {
-        throw new ISE("[%s] exists but not a directory.", baseDir);
-      } else if (!baseDir.mkdirs()) {
-        throw new ISE("Failed to create directory[%s].", baseDir);
-      }
-    }
+    FileUtils.mkdirp(baseDir);
 
     List<DataSegment> cachedSegments = new ArrayList<>();
     File[] segmentsToLoad = baseDir.listFiles();

--- a/server/src/main/java/org/apache/druid/server/log/FileRequestLogger.java
+++ b/server/src/main/java/org/apache/druid/server/log/FileRequestLogger.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.log;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
@@ -73,7 +74,7 @@ public class FileRequestLogger implements RequestLogger
   public void start()
   {
     try {
-      baseDir.mkdirs();
+      FileUtils.mkdirp(baseDir);
 
       MutableDateTime mutableDateTime = DateTimes.nowUtc().toMutableDateTime(ISOChronology.getInstanceUTC());
       mutableDateTime.setMillisOfDay(0);

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlInputSourceTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlInputSourceTest.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.io.FileUtils;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRow;
@@ -38,6 +37,7 @@ import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
@@ -102,7 +102,7 @@ public class SqlInputSourceTest
   public static void teardown() throws IOException
   {
     for (File dir : FIREHOSE_TMP_DIRS) {
-      FileUtils.forceDelete(dir);
+      org.apache.commons.io.FileUtils.forceDelete(dir);
     }
   }
 
@@ -131,8 +131,8 @@ public class SqlInputSourceTest
         SqlInputSourceTest.class.getSimpleName(),
         dirSuffix
     );
-    FileUtils.forceDelete(firehoseTempDir);
-    FileUtils.forceMkdir(firehoseTempDir);
+    org.apache.commons.io.FileUtils.forceDelete(firehoseTempDir);
+    FileUtils.mkdirp(firehoseTempDir);
     FIREHOSE_TMP_DIRS.add(firehoseTempDir);
     return firehoseTempDir;
   }

--- a/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentKillerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentKillerTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.loading;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
@@ -118,7 +119,7 @@ public class LocalDataSegmentKillerTest
 
   private void makePartitionDirWithIndex(File path) throws IOException
   {
-    Assert.assertTrue(path.mkdirs());
+    FileUtils.mkdirp(path);
     Assert.assertTrue(new File(path, "index.zip").createNewFile());
   }
 

--- a/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
@@ -22,7 +22,7 @@ package org.apache.druid.segment.loading;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.google.common.primitives.Ints;
-import org.apache.commons.io.FileUtils;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.timeline.DataSegment;
@@ -140,7 +140,7 @@ public class LocalDataSegmentPusherTest
     Assert.assertEquals(dataSegment2.getDimensions(), returnSegment2.getDimensions());
 
     File unzipDir = new File(config.storageDirectory, "unzip");
-    FileUtils.forceMkdir(unzipDir);
+    FileUtils.mkdirp(unzipDir);
     CompressionUtils.unzip(
         new File(config.storageDirectory, "/ds/1970-01-01T00:00:00.000Z_1970-01-01T00:00:00.001Z/v1/0/index.zip"),
         unzipDir

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -125,7 +126,7 @@ public class SegmentLocalCacheManagerConcurrencyTest
           localStorageFolder,
           segmentPath
       );
-      localSegmentFile.mkdirs();
+      FileUtils.mkdirp(localSegmentFile);
       final File indexZip = new File(localSegmentFile, "index.zip");
       indexZip.createNewFile();
 

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
@@ -37,6 +38,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -80,14 +82,14 @@ public class SegmentLocalCacheManagerTest
   }
 
   @Test
-  public void testIfSegmentIsLoaded()
+  public void testIfSegmentIsLoaded() throws IOException
   {
     final DataSegment cachedSegment = dataSegmentWithInterval("2014-10-20T00:00:00Z/P1D");
     final File cachedSegmentFile = new File(
         localSegmentCacheFolder,
         "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    cachedSegmentFile.mkdirs();
+    FileUtils.mkdirp(cachedSegmentFile);
 
     Assert.assertTrue("Expect cache hit", manager.isSegmentCached(cachedSegment));
 
@@ -117,7 +119,7 @@ public class SegmentLocalCacheManagerTest
         localStorageFolder,
         "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    localSegmentFile.mkdirs();
+    FileUtils.mkdirp(localSegmentFile);
     final File indexZip = new File(localSegmentFile, "index.zip");
     indexZip.createNewFile();
 
@@ -163,7 +165,7 @@ public class SegmentLocalCacheManagerTest
         segmentSrcFolder,
         "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    localSegmentFile.mkdirs();
+    FileUtils.mkdirp(localSegmentFile);
     final File indexZip = new File(localSegmentFile, "index.zip");
     indexZip.createNewFile();
 
@@ -211,7 +213,7 @@ public class SegmentLocalCacheManagerTest
         segmentSrcFolder,
         "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    localSegmentFile.mkdirs();
+    FileUtils.mkdirp(localSegmentFile);
     final File indexZip = new File(localSegmentFile, "index.zip");
     indexZip.createNewFile();
 
@@ -261,7 +263,7 @@ public class SegmentLocalCacheManagerTest
         segmentSrcFolder,
         "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    localSegmentFile.mkdirs();
+    FileUtils.mkdirp(localSegmentFile);
     final File indexZip = new File(localSegmentFile, "index.zip");
     indexZip.createNewFile();
 
@@ -310,7 +312,7 @@ public class SegmentLocalCacheManagerTest
         segmentSrcFolder,
         "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    localSegmentFile.mkdirs();
+    FileUtils.mkdirp(localSegmentFile);
     final File indexZip = new File(localSegmentFile, "index.zip");
     indexZip.createNewFile();
 
@@ -336,7 +338,7 @@ public class SegmentLocalCacheManagerTest
         segmentSrcFolder,
         "test_segment_loader/2014-11-20T00:00:00.000Z_2014-11-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    localSegmentFile2.mkdirs();
+    FileUtils.mkdirp(localSegmentFile2);
     final File indexZip2 = new File(localSegmentFile2, "index.zip");
     indexZip2.createNewFile();
 
@@ -504,7 +506,7 @@ public class SegmentLocalCacheManagerTest
   {
     // manually create a local segment under segmentSrcFolder
     final File localSegmentFile = new File(segmentSrcFolder, localSegmentPath);
-    localSegmentFile.mkdirs();
+    FileUtils.mkdirp(localSegmentFile);
     final File indexZip = new File(localSegmentFile, "index.zip");
     indexZip.createNewFile();
   }
@@ -746,7 +748,7 @@ public class SegmentLocalCacheManagerTest
         localStorageFolder,
         "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
     );
-    Assert.assertTrue(localSegmentFile.mkdirs());
+    FileUtils.mkdirp(localSegmentFile);
     final File indexZip = new File(localSegmentFile, "index.zip");
     Assert.assertTrue(indexZip.createNewFile());
 

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseFactoryTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.segment.realtime.firehose;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.io.FileUtils;
 import org.apache.druid.data.input.Firehose;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -29,6 +28,7 @@ import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.TimeAndDimsParseSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.metadata.input.SqlTestUtils;
@@ -82,16 +82,16 @@ public class SqlFirehoseFactoryTest
   public static void setup() throws IOException
   {
     TEST_DIR = File.createTempFile(SqlFirehoseFactoryTest.class.getSimpleName(), "testDir");
-    FileUtils.forceDelete(TEST_DIR);
-    FileUtils.forceMkdir(TEST_DIR);
+    org.apache.commons.io.FileUtils.forceDelete(TEST_DIR);
+    FileUtils.mkdirp(TEST_DIR);
   }
 
   @AfterClass
   public static void teardown() throws IOException
   {
-    FileUtils.forceDelete(TEST_DIR);
+    org.apache.commons.io.FileUtils.forceDelete(TEST_DIR);
     for (File dir : FIREHOSE_TMP_DIRS) {
-      FileUtils.forceDelete(dir);
+      org.apache.commons.io.FileUtils.forceDelete(dir);
     }
   }
 
@@ -127,8 +127,8 @@ public class SqlFirehoseFactoryTest
         SqlFirehoseFactoryTest.class.getSimpleName(),
         dirSuffix
     );
-    FileUtils.forceDelete(firehoseTempDir);
-    FileUtils.forceMkdir(firehoseTempDir);
+    org.apache.commons.io.FileUtils.forceDelete(firehoseTempDir);
+    FileUtils.mkdirp(firehoseTempDir);
     FIREHOSE_TMP_DIRS.add(firehoseTempDir);
     return firehoseTempDir;
   }

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/SqlFirehoseTest.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.io.FileUtils;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.InputRowParser;
@@ -34,6 +33,7 @@ import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.data.input.impl.TimeAndDimsParseSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.data.input.impl.prefetch.JsonIterator;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.transform.ExpressionTransform;
 import org.apache.druid.segment.transform.TransformSpec;
@@ -70,8 +70,8 @@ public class SqlFirehoseTest
   public void setup() throws IOException
   {
     TEST_DIR = File.createTempFile(SqlFirehose.class.getSimpleName(), "testDir");
-    FileUtils.forceDelete(TEST_DIR);
-    FileUtils.forceMkdir(TEST_DIR);
+    org.apache.commons.io.FileUtils.forceDelete(TEST_DIR);
+    FileUtils.mkdirp(TEST_DIR);
 
     final List<Map<String, Object>> inputTexts = ImmutableList.of(
         ImmutableMap.of("x", "foostring1", "timestamp", 2000),
@@ -249,7 +249,7 @@ public class SqlFirehoseTest
   @After
   public void teardown() throws IOException
   {
-    FileUtils.forceDelete(TEST_DIR);
+    org.apache.commons.io.FileUtils.forceDelete(TEST_DIR);
   }
 
   private static final class TestCloseable implements Closeable

--- a/server/src/test/java/org/apache/druid/server/SegmentManagerBroadcastJoinIndexedTableTest.java
+++ b/server/src/test/java/org/apache/druid/server/SegmentManagerBroadcastJoinIndexedTableTest.java
@@ -338,7 +338,7 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
     );
     final String storageDir = DataSegmentPusher.getDefaultStorageDir(tmpSegment, false);
     final File segmentDir = new File(segmentDeepStorageDir, storageDir);
-    org.apache.commons.io.FileUtils.forceMkdir(segmentDir);
+    FileUtils.mkdirp(segmentDir);
 
     IndexMerger indexMerger =
         new IndexMergerV9(objectMapper, indexIO, OffHeapMemorySegmentWriteOutMediumFactory.instance());

--- a/server/src/test/java/org/apache/druid/server/SegmentManagerThreadSafetyTest.java
+++ b/server/src/test/java/org/apache/druid/server/SegmentManagerThreadSafetyTest.java
@@ -58,7 +58,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -187,7 +186,7 @@ public class SegmentManagerThreadSafetyTest
     );
     final String storageDir = DataSegmentPusher.getDefaultStorageDir(tmpSegment, false);
     final File segmentDir = new File(segmentDeepStorageDir, storageDir);
-    org.apache.commons.io.FileUtils.forceMkdir(segmentDir);
+    FileUtils.mkdirp(segmentDir);
 
     final File factoryJson = new File(segmentDir, "factory.json");
     objectMapper.writeValue(factoryJson, new TestSegmentizerFactory());

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerCacheTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerCacheTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import org.apache.druid.guice.ServerTypeConfig;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.IndexIO;
@@ -188,7 +189,7 @@ public class SegmentLoadDropHandlerCacheTest
       File segmentFile = new File(destDir, "segment");
       File factoryJson = new File(destDir, "factory.json");
       try {
-        destDir.mkdirs();
+        FileUtils.mkdirp(destDir);
         segmentFile.createNewFile();
         factoryJson.createNewFile();
       }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
@@ -103,7 +103,7 @@ public class SegmentLoadDropHandlerTest
   }
 
   @Before
-  public void setUp()
+  public void setUp() throws IOException
   {
     try {
       testStorageLocation = new TestStorageLocation(temporaryFolder);

--- a/server/src/test/java/org/apache/druid/server/coordination/TestStorageLocation.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/TestStorageLocation.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.coordination;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.loading.StorageLocationConfig;
@@ -104,19 +105,15 @@ public class TestStorageLocation
     Assert.assertEquals(expectedSegments, segmentsInFiles);
   }
 
-  public StorageLocationConfig toStorageLocationConfig()
+  public StorageLocationConfig toStorageLocationConfig() throws IOException
   {
-    if (!cacheDir.exists()) {
-      cacheDir.mkdirs();
-    }
+    FileUtils.mkdirp(cacheDir);
     return new StorageLocationConfig(cacheDir, 100L, 100d);
   }
 
-  public StorageLocationConfig toStorageLocationConfig(long maxSize, Double freeSpacePercent)
+  public StorageLocationConfig toStorageLocationConfig(long maxSize, Double freeSpacePercent) throws IOException
   {
-    if (!cacheDir.exists()) {
-      cacheDir.mkdirs();
-    }
+    FileUtils.mkdirp(cacheDir);
     return new StorageLocationConfig(cacheDir, maxSize, freeSpacePercent);
   }
 }

--- a/services/src/main/java/org/apache/druid/cli/PullDependencies.java
+++ b/services/src/main/java/org/apache/druid/cli/PullDependencies.java
@@ -285,8 +285,8 @@ public class PullDependencies implements Runnable
         FileUtils.deleteDirectory(extensionsDir);
         FileUtils.deleteDirectory(hadoopDependenciesDir);
       }
-      org.apache.commons.io.FileUtils.forceMkdir(extensionsDir);
-      org.apache.commons.io.FileUtils.forceMkdir(hadoopDependenciesDir);
+      FileUtils.mkdirp(extensionsDir);
+      FileUtils.mkdirp(hadoopDependenciesDir);
     }
     catch (IOException e) {
       log.error(e, "Unable to clear or create extension directory at [%s]", extensionsDir);


### PR DESCRIPTION
The changes:

- Add `void mkdirp(File directory) throws IOException` to FileUtils, which has semantics like Unix `mkdir -p`. It creates a directory if it does not exist, returns quietly if it already exists, and generates an error if it could not be created.
- Migrate usages of File.mkdirs to the new function and add File.mkdirs to the forbidden functions list.

The new method is better for two reasons:

First, File.mkdirs makes it easy to ignore errors, since it returns a boolean. Unchecked usage is common and leads to confusing errors later, like "Cannot create file [dir/file]", instead of more-specific errors upfront like "Cannot create directory [dir]".

Second, File.mkdirs is not concurrency safe. "Natural" patterns like this with File.mkdirs are prone to race conditions, because two `dir.mkdirs()` that run concurrently cannot both succeed:

```
if (!dir.exists() && !dir.mkdirs()) {
  throw new IOException();
}
```