### PR TITLE
Fix: invalid JSON in ingestion spec doc example

### DIFF
--- a/docs/ingestion/ingestion-spec.md
+++ b/docs/ingestion/ingestion-spec.md
@@ -49,8 +49,8 @@ Example ingestion spec for task type `index_parallel` (native batch):
       },
       "dimensionsSpec": {
         "dimensions": [
-          { "page" },
-          { "language" },
+          "page",
+          "language",
           { "type": "long", "name": "userId" }
         ]
       },

--- a/docs/ingestion/ingestion-spec.md
+++ b/docs/ingestion/ingestion-spec.md
@@ -124,8 +124,8 @@ An example `dataSchema` is:
   },
   "dimensionsSpec": {
     "dimensions": [
-      { "page" },
-      { "language" },
+      "page",
+      "language",
       { "type": "long", "name": "userId" }
     ]
   },
@@ -402,8 +402,8 @@ An example `parser` is:
     },
     "dimensionsSpec": {
       "dimensions": [
-        { "page" },
-        { "language" },
+        "page",
+        "language",
         { "type": "long", "name": "userId" }
       ]
     }


### PR DESCRIPTION
### Description

Typo in docs: `{ "page" }` is not valid JSON. 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
