### PR TITLE
Add javadocs to StringUtils.fromUtf8.

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/StringUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/StringUtils.java
@@ -88,6 +88,10 @@ public class StringUtils
     }
   }
 
+  /**
+   * Decodes a UTF-8 String from {@code numBytes} bytes starting at the current position of a buffer.
+   * Advances the position of the buffer by {@code numBytes}.
+   */
   public static String fromUtf8(final ByteBuffer buffer, final int numBytes)
   {
     final byte[] bytes = new byte[numBytes];
@@ -95,6 +99,10 @@ public class StringUtils
     return fromUtf8(bytes);
   }
 
+  /**
+   * Decodes a UTF-8 string from the remaining bytes of a buffer.
+   * Advances the position of the buffer by {@link ByteBuffer#remaining()}.
+   */
   public static String fromUtf8(final ByteBuffer buffer)
   {
     return StringUtils.fromUtf8(buffer, buffer.remaining());


### PR DESCRIPTION
They clarify that the methods advance the position of the buffer.