### PR TITLE
Ensure backward compatibility of multi dimension partitioning

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/StringTuple.java
+++ b/core/src/main/java/org/apache/druid/data/input/StringTuple.java
@@ -39,6 +39,15 @@ public class StringTuple implements Comparable<StringTuple>
     return new StringTuple(values);
   }
 
+  /**
+   * Gets the first String from the given StringTuple if the tuple is non-null
+   * and non-empty, null otherwise.
+   */
+  public static String firstOrNull(StringTuple tuple)
+  {
+    return tuple == null || tuple.size() < 1 ? null : tuple.get(0);
+  }
+
   @JsonCreator
   public StringTuple(String[] values)
   {

--- a/core/src/main/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpec.java
@@ -29,7 +29,12 @@ import java.util.Objects;
 
 /**
  * See {@link BuildingShardSpec} for how this class is used.
+ * <p>
+ * Calling {@link #convert(int)} on an instance of this class creates a
+ * {@link SingleDimensionShardSpec} if there is a single dimension or a
+ * {@link DimensionRangeShardSpec} if there are multiple dimensions.
  *
+ * @see SingleDimensionShardSpec
  * @see DimensionRangeShardSpec
  */
 public class BuildingDimensionRangeShardSpec implements BuildingShardSpec<DimensionRangeShardSpec>
@@ -68,14 +73,14 @@ public class BuildingDimensionRangeShardSpec implements BuildingShardSpec<Dimens
 
   @Nullable
   @JsonProperty("start")
-  public StringTuple getStart()
+  public StringTuple getStartTuple()
   {
     return start;
   }
 
   @Nullable
   @JsonProperty("end")
-  public StringTuple getEnd()
+  public StringTuple getEndTuple()
   {
     return end;
   }
@@ -100,8 +105,8 @@ public class BuildingDimensionRangeShardSpec implements BuildingShardSpec<Dimens
     return dimensions != null && dimensions.size() == 1
            ? new SingleDimensionShardSpec(
         dimensions.get(0),
-        firstOrNull(start),
-        firstOrNull(end),
+        StringTuple.firstOrNull(start),
+        StringTuple.firstOrNull(end),
         partitionId,
         numCorePartitions
     ) : new DimensionRangeShardSpec(
@@ -111,11 +116,6 @@ public class BuildingDimensionRangeShardSpec implements BuildingShardSpec<Dimens
         partitionId,
         numCorePartitions
     );
-  }
-
-  private String firstOrNull(StringTuple tuple)
-  {
-    return tuple == null || tuple.size() < 1 ? null : tuple.get(0);
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpec.java
@@ -32,7 +32,12 @@ import java.util.Objects;
 
 /**
  * See {@link BucketNumberedShardSpec} for how this class is used.
+ * <p>
+ * Calling {@link #convert(int)} on an instance of this class creates a
+ * {@link BuildingSingleDimensionShardSpec} if there is a single dimension
+ * or {@link BuildingDimensionRangeShardSpec} if there are multiple dimensions.
  *
+ * @see BuildingSingleDimensionShardSpec
  * @see BuildingDimensionRangeShardSpec
  */
 public class DimensionRangeBucketShardSpec implements BucketNumberedShardSpec<BuildingDimensionRangeShardSpec>
@@ -100,7 +105,20 @@ public class DimensionRangeBucketShardSpec implements BucketNumberedShardSpec<Bu
   @Override
   public BuildingDimensionRangeShardSpec convert(int partitionId)
   {
-    return new BuildingDimensionRangeShardSpec(bucketId, dimensions, start, end, partitionId);
+    return dimensions != null && dimensions.size() == 1
+           ? new BuildingSingleDimensionShardSpec(
+        bucketId,
+        dimensions.get(0),
+        StringTuple.firstOrNull(start),
+        StringTuple.firstOrNull(end),
+        partitionId
+    ) : new BuildingDimensionRangeShardSpec(
+        bucketId,
+        dimensions,
+        start,
+        end,
+        partitionId
+    );
   }
 
   @Override

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpecTest.java
@@ -58,13 +58,7 @@ public class BuildingDimensionRangeShardSpecTest
   public void testConvert_withSingleDimension()
   {
     Assert.assertEquals(
-        new SingleDimensionShardSpec(
-            "dim",
-            "start",
-            "end",
-            5,
-            10
-        ),
+        new SingleDimensionShardSpec("dim", "start", "end", 5, 10),
         new BuildingDimensionRangeShardSpec(
             1,
             Collections.singletonList("dim"),

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues.Std;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -67,6 +66,9 @@ public class BuildingSingleDimensionShardSpecTest
   @Test
   public void testEquals()
   {
-    EqualsVerifier.forClass(BuildingSingleDimensionShardSpec.class).usingGetClass().verify();
+    Assert.assertEquals(
+        new BuildingSingleDimensionShardSpec(10, "dim", "start", "end", 4),
+        new BuildingSingleDimensionShardSpec(10, "dim", "start", "end", 4)
+    );
   }
 }

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
@@ -19,15 +19,19 @@
 
 package org.apache.druid.timeline.partition;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues.Std;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.apache.druid.java.util.common.ISE;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Map;
+
 public class BuildingSingleDimensionShardSpecTest
 {
+  private static final ObjectMapper OBJECT_MAPPER = setupObjectMapper();
+
   @Test
   public void testConvert()
   {
@@ -47,20 +51,48 @@ public class BuildingSingleDimensionShardSpecTest
   }
 
   @Test
-  public void testSerde() throws JsonProcessingException
+  public void testSerde()
   {
-    final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
-    mapper.registerSubtypes(
-        new NamedType(BuildingSingleDimensionShardSpec.class, BuildingSingleDimensionShardSpec.TYPE)
-    );
-    mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
-    final BuildingSingleDimensionShardSpec original = new BuildingSingleDimensionShardSpec(1, "dim", "start", "end", 5);
-    final String json = mapper.writeValueAsString(original);
-    final BuildingSingleDimensionShardSpec fromJson = (BuildingSingleDimensionShardSpec) mapper.readValue(
-        json,
-        ShardSpec.class
-    );
+    final BuildingSingleDimensionShardSpec original =
+        new BuildingSingleDimensionShardSpec(1, "dim", "start", "end", 5);
+    final String json = serialize(original);
+    final BuildingSingleDimensionShardSpec fromJson =
+        (BuildingSingleDimensionShardSpec) deserialize(json, ShardSpec.class);
     Assert.assertEquals(original, fromJson);
+  }
+
+  @Test
+  public void testGetSerializableObject()
+  {
+    BuildingSingleDimensionShardSpec shardSpec =
+        new BuildingSingleDimensionShardSpec(1, "dim", "abc", "xyz", 5);
+
+    // Verify the fields of the serializable object
+    Map<String, Object> jsonMap = shardSpec.getSerializableObject();
+    Assert.assertEquals(5, jsonMap.size());
+    Assert.assertEquals(1, jsonMap.get("bucketId"));
+    Assert.assertEquals("dim", jsonMap.get("dimension"));
+    Assert.assertEquals("abc", jsonMap.get("start"));
+    Assert.assertEquals("xyz", jsonMap.get("end"));
+    Assert.assertEquals(5, jsonMap.get("partitionNum"));
+  }
+
+  @Test
+  public void testDeserializeFromMap()
+  {
+    final String json = "{\"type\": \"" + BuildingSingleDimensionShardSpec.TYPE + "\","
+                        + " \"bucketId\":1,"
+                        + " \"dimension\": \"dim\","
+                        + " \"start\": \"abc\","
+                        + " \"end\": \"xyz\","
+                        + " \"partitionNum\": 5}";
+
+    BuildingSingleDimensionShardSpec shardSpec =
+        (BuildingSingleDimensionShardSpec) deserialize(json, ShardSpec.class);
+    Assert.assertEquals(
+        new BuildingSingleDimensionShardSpec(1, "dim", "abc", "xyz", 5),
+        shardSpec
+    );
   }
 
   @Test
@@ -71,4 +103,36 @@ public class BuildingSingleDimensionShardSpecTest
         new BuildingSingleDimensionShardSpec(10, "dim", "start", "end", 4)
     );
   }
+
+  private static ObjectMapper setupObjectMapper()
+  {
+    final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
+    mapper.registerSubtypes(
+        new NamedType(BuildingSingleDimensionShardSpec.class, BuildingSingleDimensionShardSpec.TYPE)
+    );
+    mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
+
+    return mapper;
+  }
+
+  private String serialize(Object object)
+  {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(object);
+    }
+    catch (Exception e) {
+      throw new ISE("Error while serializing");
+    }
+  }
+
+  private <T> T deserialize(String json, Class<T> clazz)
+  {
+    try {
+      return OBJECT_MAPPER.readValue(json, clazz);
+    }
+    catch (Exception e) {
+      throw new ISE(e, "Error while deserializing");
+    }
+  }
+
 }

--- a/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpecTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class DimensionRangeBucketShardSpecTest
@@ -61,6 +62,20 @@ public class DimensionRangeBucketShardSpecTest
             DIMENSIONS,
             StringTuple.create("start1", "start2"),
             StringTuple.create("end1", "end2")
+        ).convert(5)
+    );
+  }
+
+  @Test
+  public void testConvert_withSingleDimension()
+  {
+    Assert.assertEquals(
+        new BuildingSingleDimensionShardSpec(1, "dim", "start", "end", 5),
+        new DimensionRangeBucketShardSpec(
+            1,
+            Collections.singletonList("dim"),
+            StringTuple.create("start"),
+            StringTuple.create("end")
         ).convert(5)
     );
   }

--- a/core/src/test/java/org/apache/druid/timeline/partition/PartitionBoundariesTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/PartitionBoundariesTest.java
@@ -92,6 +92,22 @@ public class PartitionBoundariesTest
   }
 
   @Test
+  public void testSerdeWithMultiDimensions() throws JsonProcessingException
+  {
+    PartitionBoundaries original = new PartitionBoundaries(
+        StringTuple.create("a", "10"),
+        StringTuple.create("b", "7"),
+        StringTuple.create("c", "4")
+    );
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+    String json = objectMapper.writeValueAsString(original);
+
+    PartitionBoundaries deserialized = objectMapper.readValue(json, PartitionBoundaries.class);
+    Assert.assertEquals(original, deserialized);
+  }
+
+  @Test
   public void testGetNumBucketsOfNonEmptyPartitionBoundariesReturningCorrectSize()
   {
     Assert.assertEquals(2, target.getNumBuckets());

--- a/core/src/test/java/org/apache/druid/timeline/partition/PartitionBoundariesTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/PartitionBoundariesTest.java
@@ -19,10 +19,10 @@
 
 package org.apache.druid.timeline.partition;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.data.input.StringTuple;
+import org.apache.druid.java.util.common.ISE;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +34,8 @@ import java.util.List;
 
 public class PartitionBoundariesTest
 {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   private PartitionBoundaries target;
   private StringTuple[] values;
   private List<StringTuple> expected;
@@ -79,20 +81,26 @@ public class PartitionBoundariesTest
   @Test
   public void handlesRepeatedValue()
   {
-    Assert.assertEquals(Arrays.asList(null, null), new PartitionBoundaries(StringTuple.create("a"), StringTuple.create("a"), StringTuple.create("a")));
+    Assert.assertEquals(
+        Arrays.asList(null, null),
+        new PartitionBoundaries(
+            StringTuple.create("a"),
+            StringTuple.create("a"),
+            StringTuple.create("a")
+        )
+    );
   }
 
   @Test
-  public void serializesDeserializes() throws JsonProcessingException
+  public void serializesDeserializes()
   {
-    final ObjectMapper objectMapper = new ObjectMapper();
-    String serialized = objectMapper.writeValueAsString(target);
-    Object deserialized = objectMapper.readValue(serialized, target.getClass());
-    Assert.assertEquals(serialized, objectMapper.writeValueAsString(deserialized));
+    String serialized = serialize(target);
+    Object deserialized = deserialize(serialized, target.getClass());
+    Assert.assertEquals(serialized, serialize(deserialized));
   }
 
   @Test
-  public void testSerdeWithMultiDimensions() throws JsonProcessingException
+  public void testSerdeWithMultiDimensions()
   {
     PartitionBoundaries original = new PartitionBoundaries(
         StringTuple.create("a", "10"),
@@ -100,11 +108,81 @@ public class PartitionBoundariesTest
         StringTuple.create("c", "4")
     );
 
-    final ObjectMapper objectMapper = new ObjectMapper();
-    String json = objectMapper.writeValueAsString(original);
-
-    PartitionBoundaries deserialized = objectMapper.readValue(json, PartitionBoundaries.class);
+    String json = serialize(original);
+    PartitionBoundaries deserialized = deserialize(json, PartitionBoundaries.class);
     Assert.assertEquals(original, deserialized);
+  }
+
+  @Test
+  public void testGetSerializableObject_withMultiDimensions()
+  {
+    // Create a PartitionBoundaries for multiple dimensions
+    PartitionBoundaries multiDimBoundaries = new PartitionBoundaries(
+        StringTuple.create("a", "10"),
+        StringTuple.create("b", "7"),
+        StringTuple.create("c", "4")
+    );
+
+    // Verify that the serializable object is a List<StringTuple>
+    Object serializableObject = multiDimBoundaries.getSerializableObject();
+    Assert.assertTrue(serializableObject instanceof List);
+    assertThatItemsAreNullOr(StringTuple.class, (List<?>) serializableObject);
+
+    // Verify the output of getSerializableObject can be serialized/deserialized
+    String json = serialize(serializableObject);
+    PartitionBoundaries deserialized = deserialize(json, PartitionBoundaries.class);
+    Assert.assertEquals(multiDimBoundaries, deserialized);
+  }
+
+  @Test
+  public void testGetSerializableObject_withSingleDimension()
+  {
+    // Create a PartitionBoundaries for a single dimension
+    PartitionBoundaries singleDimBoundaries = new PartitionBoundaries(
+        StringTuple.create("a"),
+        StringTuple.create("b"),
+        StringTuple.create("c")
+    );
+
+    // Verify that the serializable object is a List<String>
+    Object serializableObject = singleDimBoundaries.getSerializableObject();
+    Assert.assertTrue(serializableObject instanceof List);
+    assertThatItemsAreNullOr(String.class, (List<?>) serializableObject);
+
+    // Verify the output of getSerializableObject can be serialized/deserialized
+    String json = serialize(serializableObject);
+    PartitionBoundaries deserialized = deserialize(json, PartitionBoundaries.class);
+    Assert.assertEquals(singleDimBoundaries, deserialized);
+  }
+
+  @Test
+  public void testDeserializeArrayOfString()
+  {
+    String json = "[null, \"a\", null]";
+    PartitionBoundaries deserialized = deserialize(json, PartitionBoundaries.class);
+    Assert.assertEquals(
+        new PartitionBoundaries(
+            null,
+            StringTuple.create("a"),
+            StringTuple.create("b")
+        ),
+        deserialized
+    );
+  }
+
+  @Test
+  public void testDeserializeArrayOfTuples()
+  {
+    String json = "[null, [\"a\",\"10\"], null]";
+    PartitionBoundaries deserialized = deserialize(json, PartitionBoundaries.class);
+    Assert.assertEquals(
+        new PartitionBoundaries(
+            null,
+            StringTuple.create("a", "10"),
+            StringTuple.create("a", "20")
+        ),
+        deserialized
+    );
   }
 
   @Test
@@ -117,5 +195,42 @@ public class PartitionBoundariesTest
   public void testEqualsContract()
   {
     EqualsVerifier.forClass(PartitionBoundaries.class).withNonnullFields("delegate").usingGetClass().verify();
+  }
+
+  /**
+   * Asserts that all the items in the given list are either null or of the
+   * specified class.
+   */
+  private <T> void assertThatItemsAreNullOr(Class<T> clazz, List<?> list)
+  {
+    if (list == null || list.isEmpty()) {
+      return;
+    }
+
+    for (Object item : list) {
+      if (item != null) {
+        Assert.assertSame(clazz, item.getClass());
+      }
+    }
+  }
+
+  private String serialize(Object object)
+  {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(object);
+    }
+    catch (Exception e) {
+      throw new ISE("Error while serializing");
+    }
+  }
+
+  private <T> T deserialize(String json, Class<T> clazz)
+  {
+    try {
+      return OBJECT_MAPPER.readValue(json, clazz);
+    }
+    catch (Exception e) {
+      throw new ISE(e, "Error while deserializing");
+    }
   }
 }

--- a/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionShardSpecTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.timeline.partition;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -161,6 +162,25 @@ public class SingleDimensionShardSpecTest
     testSerde(new SingleDimensionShardSpec("dim", "abc", null, 5, 10));
     testSerde(new SingleDimensionShardSpec("dim", null, "xyz", 10, 1));
     testSerde(new SingleDimensionShardSpec("dim", "abc", "xyz", 10, null));
+  }
+
+  @Test
+  public void testDeserialize() throws JsonProcessingException
+  {
+    final String json = "{\"type\": \"single\","
+                        + " \"dimension\": \"dim\","
+                        + " \"start\": \"abc\","
+                        + "\"end\": \"xyz\","
+                        + "\"partitionNum\": 5,"
+                        + "\"numCorePartitions\": 10}";
+    ShardSpec shardSpec = OBJECT_MAPPER.readValue(json, ShardSpec.class);
+    Assert.assertTrue(shardSpec instanceof SingleDimensionShardSpec);
+
+    SingleDimensionShardSpec singleDimShardSpec = (SingleDimensionShardSpec) shardSpec;
+    Assert.assertEquals(
+        new SingleDimensionShardSpec("dim", "abc", "xyz", 5, 10),
+        singleDimShardSpec
+    );
   }
 
   private void testSerde(SingleDimensionShardSpec shardSpec) throws IOException


### PR DESCRIPTION
### Description
This PR has changes to ensure backward compatibility of multi dimension partitioning
such that if some middle managers are upgraded to a newer version, the cluster still
functions normally for single_dim use cases.

### Changes
- Make `BuildingSingleDimensionShardSpec` extend `BuildingDimensionRangeShardSpec`
- Convert `DimensionRangeBucketShardSpec` to `BuildingSingleDim` or `BuildingDimRange`
   as applicable
- Serialize/deserialize `PartitionBoundaries` as an array of Strings instead of an array of `StringTuples`
   for single dimension use cases (i.e. when each boundary is either null or is a tuple of size 1)

### Testing
- Tested behaviour of single_dim on local cluster with a micro quickstart cluster on old version
   and a separate middle manager on new version (with multi dim)

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
