### PR TITLE
HashJoinEngine: Fix extraneous advance of left cursor.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/RowWalker.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowWalker.java
@@ -35,6 +35,7 @@ public class RowWalker<T>
   private final Iterable<T> rowIterable;
   private final ToLongFunction<T> timestampFunction;
 
+  @Nullable
   private Iterator<T> rowIterator;
 
   @Nullable
@@ -60,13 +61,16 @@ public class RowWalker<T>
 
   public void advance()
   {
-    if (rowIterator.hasNext()) {
+    if (rowIterator == null) {
+      throw new IllegalStateException("cannot call advance when isDone == true");
+    } else if (rowIterator.hasNext()) {
       current = rowIterator.next();
 
       if (current == null) {
         throw new NullPointerException("null row encountered in walker");
       }
     } else {
+      rowIterator = null;
       current = null;
     }
   }

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinEngine.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinEngine.java
@@ -181,6 +181,12 @@ public class HashJoinEngine
 
         assert !joinMatcher.hasMatch();
 
+        if (leftCursor.isDone()) {
+          // No right-hand matches and nothing on the left cursor. We're done; return.
+          assert isDone();
+          return;
+        }
+
         do {
           // No more right-hand side matches; advance the left-hand side.
           leftCursor.advanceUninterruptibly();


### PR DESCRIPTION
This could happen for right or full outer joins in certain cases. Tests
weren't catching this because existing Cursor implementations generally
ignore extraneous calls to "advance". So, to help catch this in tests,
extra state validations are also added to RowWalker, which is used by
RowBasedSegment.