### PR TITLE
Modifying index from druid_segments(datasource, used, end) to druid_segments(datasource, used, end, start) to support kill task

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -280,7 +280,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_used ON %1$s(used)", tableName),
             StringUtils.format(
-                "CREATE INDEX idx_%1$s_datasource_used_end ON %1$s(dataSource, used, %2$send%2$s)",
+                "CREATE INDEX idx_%1$s_datasource_used_end_start ON %1$s(dataSource, used, %2$send%2$s, start)",
                 tableName,
                 getQuoteString()
             )


### PR DESCRIPTION
This index helps in faster query results during kill task's query on interval based unused segment listing. This had become a bottleneck at our production loads causing coordinator to wait longer for metadata db replies and hence causing increased ingestion lag. The modified index has helped reduce the query times for such queries and has made it possible for us to use kill feature in production.


This PR has:
- [x] been self-reviewed.
- [x] been tested in a dev,stage and prod Druid clusters.
