### PR TITLE
revert ColumnAnalysis type, add typeSignature and use it for DruidSchema

### DIFF
--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -89,7 +89,7 @@ The format of the result is:
 
 All columns contain a `typeSignature` that Druid uses to represent the column type information internally. The `typeSignature` is typically the same value used to identify the JSON type information at query or ingest time. One of: `STRING`, `FLOAT`, `DOUBLE`, `LONG`, or `COMPLEX<typeName>`, e.g. `COMPLEX<hyperUnique>`.
 
-Columns will also have a legacy `type` name. For some column types, the value may match the `typeSignature`  (`STRING`, `FLOAT`, `DOUBLE`, or `LONG`). For `COMPLEX` columns, the `type` only contains the name of the underlying complex type such as `hyperUnique`.
+Columns also have a legacy `type` name. For some column types, the value may match the `typeSignature`  (`STRING`, `FLOAT`, `DOUBLE`, or `LONG`). For `COMPLEX` columns, the `type` only contains the name of the underlying complex type such as `hyperUnique`.
 
 New applications should use `typeSignature`, not `type`.
 

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -87,9 +87,11 @@ The format of the result is:
 } ]
 ```
 
-Dimension columns will have type `STRING`, `FLOAT`, `DOUBLE`, or `LONG`.
-Metric columns will have type `FLOAT`, `DOUBLE`, or `LONG`, or the name of the underlying complex type such as `hyperUnique` in case of COMPLEX metric.
-Timestamp column will have type `LONG`.
+All columns will contain a `typeSignature` which is the Druid internal representation of the type information for this column, is what is show in [`INFORMATION_SCHEMA.COLUMNS`](../querying/sql.md#columns-table) table in SQL, and is typically the value used to supply Druid with JSON type information at query or ingest time. This value will be `STRING`, `FLOAT`, `DOUBLE`, `LONG`, or `COMPLEX<typeName>` (e.g. `COMPLEX<hyperUnique>`).
+
+Additionally, columns will have a legacy friendly `type` name. This might match `typeSignature` for some column types (`STRING`, `FLOAT`, `DOUBLE`, or `LONG`) but for COMPLEX columns will only contain the name of the underlying complex type such as `hyperUnique`.
+
+The timestamp column will always have `typeSignature` and `type` as `LONG`.
 
 If the `errorMessage` field is non-null, you should not trust the other fields in the response. Their contents are
 undefined.

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -87,11 +87,11 @@ The format of the result is:
 } ]
 ```
 
-All columns will contain a `typeSignature` which is the Druid internal representation of the type information for this column, is what is show in [`INFORMATION_SCHEMA.COLUMNS`](../querying/sql.md#columns-table) table in SQL, and is typically the value used to supply Druid with JSON type information at query or ingest time. This value will be `STRING`, `FLOAT`, `DOUBLE`, `LONG`, or `COMPLEX<typeName>` (e.g. `COMPLEX<hyperUnique>`).
+All columns contain a `typeSignature` that Druid uses to represent the column type information internally. The `typeSignature` is typically the same value used to identify the JSON type information at query or ingest time. One of: STRING`, `FLOAT`, `DOUBLE`, `LONG`, or `COMPLEX<typeName>`, e.g. `COMPLEX<hyperUnique>`.
 
-Additionally, columns will have a legacy friendly `type` name. This might match `typeSignature` for some column types (`STRING`, `FLOAT`, `DOUBLE`, or `LONG`) but for COMPLEX columns will only contain the name of the underlying complex type such as `hyperUnique`.
+Columns will also have a legacy `type` name. For some column types, the value may match the `typeSignature`  (`STRING`, `FLOAT`, `DOUBLE`, or `LONG`). For `COMPLEX` columns, the `type` only contains the name of the underlying complex type such as `hyperUnique`.
 
-The timestamp column will always have `typeSignature` and `type` as `LONG`.
+New applications should use `typeSignature`, not `type`.
 
 If the `errorMessage` field is non-null, you should not trust the other fields in the response. Their contents are
 undefined.

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -87,7 +87,7 @@ The format of the result is:
 } ]
 ```
 
-All columns contain a `typeSignature` that Druid uses to represent the column type information internally. The `typeSignature` is typically the same value used to identify the JSON type information at query or ingest time. One of: STRING`, `FLOAT`, `DOUBLE`, `LONG`, or `COMPLEX<typeName>`, e.g. `COMPLEX<hyperUnique>`.
+All columns contain a `typeSignature` that Druid uses to represent the column type information internally. The `typeSignature` is typically the same value used to identify the JSON type information at query or ingest time. One of: `STRING`, `FLOAT`, `DOUBLE`, `LONG`, or `COMPLEX<typeName>`, e.g. `COMPLEX<hyperUnique>`.
 
 Columns will also have a legacy `type` name. For some column types, the value may match the `typeSignature`  (`STRING`, `FLOAT`, `DOUBLE`, or `LONG`). For `COMPLEX` columns, the `type` only contains the name of the underlying complex type such as `hyperUnique`.
 

--- a/integration-tests/src/test/resources/hadoop/batch_hadoop_queries.json
+++ b/integration-tests/src/test/resources/hadoop/batch_hadoop_queries.json
@@ -15,6 +15,7 @@
         "id": "merged",
         "columns": {
           "location": {
+            "typeSignature": "STRING",,
             "type": "STRING",
             "size": 0,
             "hasMultipleValues": false,
@@ -25,6 +26,7 @@
             "errorMessage": null
           },
           "user_id_sketch": {
+            "typeSignature": "COMPLEX<thetaSketch>",
             "type": "thetaSketch",
             "size": 0,
             "hasMultipleValues": false,
@@ -35,6 +37,7 @@
             "errorMessage": null
           },
           "other_metric": {
+            "typeSignature": "COMPLEX<thetaSketch>",
             "type": "thetaSketch",
             "size": 0,
             "hasMultipleValues": false,
@@ -45,6 +48,7 @@
             "errorMessage": null
           },
           "__time": {
+            "typeSignature": "LONG",
             "type": "LONG",
             "size": 0,
             "hasMultipleValues": false,
@@ -55,6 +59,7 @@
             "errorMessage": null
           },
           "product": {
+            "typeSignature": "STRING",
             "type": "STRING",
             "size": 0,
             "hasMultipleValues": false,

--- a/integration-tests/src/test/resources/hadoop/batch_hadoop_queries.json
+++ b/integration-tests/src/test/resources/hadoop/batch_hadoop_queries.json
@@ -15,7 +15,7 @@
         "id": "merged",
         "columns": {
           "location": {
-            "typeSignature": "STRING",,
+            "typeSignature": "STRING",
             "type": "STRING",
             "size": 0,
             "hasMultipleValues": false,

--- a/integration-tests/src/test/resources/queries/twitterstream_queries.json
+++ b/integration-tests/src/test/resources/queries/twitterstream_queries.json
@@ -596,6 +596,7 @@
                 "intervals":["2013-01-01T00:00:00.000Z/2013-01-02T00:00:00.000Z"],
                 "columns":{
                     "has_links":{
+                        "typeSignature": "STRING",
                         "type":"STRING",
                         "hasMultipleValues":false,
                         "size":0,
@@ -618,6 +619,7 @@
                 "intervals":["2013-01-02T00:00:00.000Z/2013-01-03T00:00:00.000Z"],
                 "columns":{
                     "has_links":{
+                        "typeSignature": "STRING",
                         "type":"STRING",
                         "hasMultipleValues":false,
                         "size":0,
@@ -640,6 +642,7 @@
                 "intervals":["2013-01-03T00:00:00.000Z/2013-01-04T00:00:00.000Z"],
                 "columns":{
                     "has_links":{
+                        "typeSignature": "STRING",
                         "type":"STRING",
                         "hasMultipleValues":false,
                         "size":0,

--- a/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
+++ b/integration-tests/src/test/resources/queries/wikipedia_editstream_queries.json
@@ -1402,6 +1402,7 @@
                 "intervals":["2012-12-29T00:00:00.000Z/2013-01-10T08:00:00.000Z"],
                 "columns":{
                     "country_name":{
+                        "typeSignature": "STRING",
                         "type":"STRING",
                         "hasMultipleValues":false,
                         "size":0,
@@ -1412,6 +1413,7 @@
                         "hasNulls":true
                     },
                     "language":{
+                        "typeSignature": "STRING",
                         "type":"STRING",
                         "hasMultipleValues":false,
                         "size":0,

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -192,7 +192,8 @@ public class SegmentAnalyzer
     }
 
     return new ColumnAnalysis(
-        capabilities.asTypeString(),
+        capabilities.toColumnType(),
+        capabilities.getType().name(),
         capabilities.hasMultipleValues().isTrue(),
         capabilities.hasNulls().isMaybeTrue(), // if we don't know for sure, then we should plan to check for nulls
         size,
@@ -248,7 +249,8 @@ public class SegmentAnalyzer
     }
 
     return new ColumnAnalysis(
-        capabilities.asTypeString(),
+        capabilities.toColumnType(),
+        capabilities.getType().name(),
         capabilities.hasMultipleValues().isTrue(),
         capabilities.hasNulls().isMaybeTrue(), // if we don't know for sure, then we should plan to check for nulls
         size,
@@ -326,7 +328,8 @@ public class SegmentAnalyzer
     }
 
     return new ColumnAnalysis(
-        capabilities.asTypeString(),
+        capabilities.toColumnType(),
+        capabilities.getType().name(),
         capabilities.hasMultipleValues().isTrue(),
         capabilities.hasNulls().isMaybeTrue(), // if we don't know for sure, then we should plan to check for nulls
         size,
@@ -343,8 +346,6 @@ public class SegmentAnalyzer
       final String typeName
   )
   {
-    // serialize using asTypeString (which is also used for JSON so can easily round-trip complex type info back into ColumnType)
-    final String serdeTypeName = ColumnType.ofComplex(typeName).asTypeString();
     try (final ComplexColumn complexColumn = columnHolder != null ? (ComplexColumn) columnHolder.getColumn() : null) {
       final boolean hasMultipleValues = capabilities != null && capabilities.hasMultipleValues().isTrue();
       final boolean hasNulls = capabilities != null && capabilities.hasNulls().isMaybeTrue();
@@ -359,7 +360,8 @@ public class SegmentAnalyzer
         final Function<Object, Long> inputSizeFn = serde.inputSizeFn();
         if (inputSizeFn == null) {
           return new ColumnAnalysis(
-              serdeTypeName,
+              capabilities.toColumnType(),
+              typeName,
               hasMultipleValues,
               hasNulls,
               0,
@@ -377,7 +379,8 @@ public class SegmentAnalyzer
       }
 
       return new ColumnAnalysis(
-          serdeTypeName,
+          capabilities.toColumnType(),
+          typeName,
           hasMultipleValues,
           hasNulls,
           size,

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -360,7 +360,7 @@ public class SegmentAnalyzer
         final Function<Object, Long> inputSizeFn = serde.inputSizeFn();
         if (inputSizeFn == null) {
           return new ColumnAnalysis(
-              capabilities.toColumnType(),
+              capabilities == null ? ColumnType.UNKNOWN_COMPLEX : capabilities.toColumnType(),
               typeName,
               hasMultipleValues,
               hasNulls,
@@ -379,7 +379,7 @@ public class SegmentAnalyzer
       }
 
       return new ColumnAnalysis(
-          capabilities.toColumnType(),
+          capabilities == null ? ColumnType.UNKNOWN_COMPLEX : capabilities.toColumnType(),
           typeName,
           hasMultipleValues,
           hasNulls,

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -43,6 +43,7 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.ColumnTypeFactory;
 import org.apache.druid.segment.column.ComplexColumn;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
 import org.apache.druid.segment.column.TypeSignature;
@@ -364,7 +365,7 @@ public class SegmentAnalyzer
         final Function<Object, Long> inputSizeFn = serde.inputSizeFn();
         if (inputSizeFn == null) {
           return new ColumnAnalysis(
-              capabilities.toColumnType(),
+              ColumnTypeFactory.ofType(typeSignature),
               typeName,
               hasMultipleValues,
               hasNulls,
@@ -383,7 +384,7 @@ public class SegmentAnalyzer
       }
 
       return new ColumnAnalysis(
-          capabilities.toColumnType(),
+          ColumnTypeFactory.ofType(typeSignature),
           typeName,
           hasMultipleValues,
           hasNulls,

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -360,7 +360,7 @@ public class SegmentAnalyzer
         final Function<Object, Long> inputSizeFn = serde.inputSizeFn();
         if (inputSizeFn == null) {
           return new ColumnAnalysis(
-              capabilities == null ? ColumnType.UNKNOWN_COMPLEX : capabilities.toColumnType(),
+              capabilities == null ? ColumnType.ofComplex(typeName) : capabilities.toColumnType(),
               typeName,
               hasMultipleValues,
               hasNulls,
@@ -379,7 +379,7 @@ public class SegmentAnalyzer
       }
 
       return new ColumnAnalysis(
-          capabilities == null ? ColumnType.UNKNOWN_COMPLEX : capabilities.toColumnType(),
+          capabilities == null ? ColumnType.ofComplex(typeName) : capabilities.toColumnType(),
           typeName,
           hasMultipleValues,
           hasNulls,

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -58,8 +57,6 @@ import org.apache.druid.timeline.LogicalSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -75,16 +72,10 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
   private static final TypeReference<SegmentAnalysis> TYPE_REFERENCE = new TypeReference<SegmentAnalysis>()
   {
   };
-  private static final byte[] SEGMENT_METADATA_CACHE_PREFIX = new byte[]{0x4};
+  private static final byte SEGMENT_METADATA_CACHE_PREFIX = 0x4;
   private static final byte SEGMENT_METADATA_QUERY = 0x16;
-  private static final Function<SegmentAnalysis, SegmentAnalysis> MERGE_TRANSFORM_FN = new Function<SegmentAnalysis, SegmentAnalysis>()
-  {
-    @Override
-    public SegmentAnalysis apply(SegmentAnalysis analysis)
-    {
-      return finalizeAnalysis(analysis);
-    }
-  };
+  private static final Function<SegmentAnalysis, SegmentAnalysis> MERGE_TRANSFORM_FN =
+      SegmentMetadataQueryQueryToolChest::finalizeAnalysis;
 
   private final SegmentMetadataQueryConfig config;
   private final GenericQueryMetricsFactory queryMetricsFactory;
@@ -195,13 +186,9 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
       public byte[] computeCacheKey(SegmentMetadataQuery query)
       {
         SegmentMetadataQuery updatedQuery = query.withFinalizedAnalysisTypes(config);
-        byte[] includerBytes = updatedQuery.getToInclude().getCacheKey();
-        byte[] analysisTypesBytes = updatedQuery.getAnalysisTypesCacheKey();
-        return ByteBuffer.allocate(1 + includerBytes.length + analysisTypesBytes.length)
-                         .put(SEGMENT_METADATA_CACHE_PREFIX)
-                         .put(includerBytes)
-                         .put(analysisTypesBytes)
-                         .array();
+        return new CacheKeyBuilder(SEGMENT_METADATA_CACHE_PREFIX).appendCacheable(updatedQuery.getToInclude())
+                                                                 .appendCacheables(updatedQuery.getAnalysisTypes())
+                                                                 .build();
       }
 
       @Override
@@ -223,27 +210,13 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
       @Override
       public Function<SegmentAnalysis, SegmentAnalysis> prepareForCache(boolean isResultLevelCache)
       {
-        return new Function<SegmentAnalysis, SegmentAnalysis>()
-        {
-          @Override
-          public SegmentAnalysis apply(@Nullable SegmentAnalysis input)
-          {
-            return input;
-          }
-        };
+        return input -> input;
       }
 
       @Override
       public Function<SegmentAnalysis, SegmentAnalysis> pullFromCache(boolean isResultLevelCache)
       {
-        return new Function<SegmentAnalysis, SegmentAnalysis>()
-        {
-          @Override
-          public SegmentAnalysis apply(@Nullable SegmentAnalysis input)
-          {
-            return input;
-          }
-        };
+        return input -> input;
       }
     };
   }
@@ -266,14 +239,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
     return Lists.newArrayList(
         Iterables.filter(
             segments,
-            new Predicate<T>()
-            {
-              @Override
-              public boolean apply(T input)
-              {
-                return (input.getInterval().overlaps(targetInterval));
-              }
-            }
+            input -> (input.getInterval().overlaps(targetInterval))
         )
     );
   }

--- a/processing/src/main/java/org/apache/druid/query/metadata/metadata/ColumnAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/metadata/ColumnAnalysis.java
@@ -73,15 +73,16 @@ public class ColumnAnalysis
   }
 
   @JsonProperty
-  public String getType()
-  {
-    return type;
-  }
-
-  @JsonProperty
   public ColumnType getTypeSignature()
   {
     return typeSignature;
+  }
+
+  @JsonProperty
+  @Deprecated
+  public String getType()
+  {
+    return type;
   }
 
   @JsonProperty
@@ -146,13 +147,13 @@ public class ColumnAnalysis
       return rhs;
     }
 
-    if (!type.equals(rhs.getType())) {
+    if (!Objects.equals(type, rhs.getType())) {
       return ColumnAnalysis.error(
           StringUtils.format("cannot_merge_diff_types: [%s] and [%s]", type, rhs.getType())
       );
     }
 
-    if (!typeSignature.equals(rhs.getTypeSignature())) {
+    if (!Objects.equals(typeSignature, rhs.getTypeSignature())) {
       return ColumnAnalysis.error(
           StringUtils.format(
               "cannot_merge_diff_types: [%s] and [%s]",
@@ -204,8 +205,8 @@ public class ColumnAnalysis
   public String toString()
   {
     return "ColumnAnalysis{" +
-           "type='" + type + '\'' +
-           ", columnType=" + typeSignature +
+           "typeSignature='" + typeSignature + '\'' +
+           ", type=" + type +
            ", hasMultipleValues=" + hasMultipleValues +
            ", hasNulls=" + hasNulls +
            ", size=" + size +
@@ -229,8 +230,8 @@ public class ColumnAnalysis
     return hasMultipleValues == that.hasMultipleValues &&
            hasNulls == that.hasNulls &&
            size == that.size &&
-           Objects.equals(type, that.type) &&
            Objects.equals(typeSignature, that.typeSignature) &&
+           Objects.equals(type, that.type) &&
            Objects.equals(cardinality, that.cardinality) &&
            Objects.equals(minValue, that.minValue) &&
            Objects.equals(maxValue, that.maxValue) &&
@@ -240,7 +241,16 @@ public class ColumnAnalysis
   @Override
   public int hashCode()
   {
-    return Objects.hash(type,
-                        typeSignature, hasMultipleValues, hasNulls, size, cardinality, minValue, maxValue, errorMessage);
+    return Objects.hash(
+        typeSignature,
+        type,
+        hasMultipleValues,
+        hasNulls,
+        size,
+        cardinality,
+        minValue,
+        maxValue,
+        errorMessage
+    );
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/metadata/metadata/ColumnIncluderator.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/metadata/ColumnIncluderator.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.metadata.metadata;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.java.util.common.Cacheable;
 
 /**
  */
@@ -30,8 +31,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(name = "all", value = AllColumnIncluderator.class),
     @JsonSubTypes.Type(name = "list", value = ListColumnIncluderator.class)
 })
-public interface ColumnIncluderator
+public interface ColumnIncluderator extends Cacheable
 {
   boolean include(String columnName);
-  byte[] getCacheKey();
 }

--- a/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DoubleStorageTest.java
@@ -51,6 +51,7 @@ import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
@@ -155,7 +156,8 @@ public class DoubleStorageTest
         ImmutableMap.of(
             TIME_COLUMN,
             new ColumnAnalysis(
-                ValueType.LONG.toString(),
+                ColumnType.LONG,
+                ValueType.LONG.name(),
                 false,
                 false,
                 100,
@@ -166,7 +168,8 @@ public class DoubleStorageTest
             ),
             DIM_NAME,
             new ColumnAnalysis(
-                ValueType.STRING.toString(),
+                ColumnType.STRING,
+                ValueType.STRING.name(),
                 false,
                 false,
                 120,
@@ -177,7 +180,8 @@ public class DoubleStorageTest
             ),
             DIM_FLOAT_NAME,
             new ColumnAnalysis(
-                ValueType.DOUBLE.toString(),
+                ColumnType.DOUBLE,
+                ValueType.DOUBLE.name(),
                 false,
                 false,
                 80,
@@ -200,7 +204,8 @@ public class DoubleStorageTest
         ImmutableMap.of(
             TIME_COLUMN,
             new ColumnAnalysis(
-                ValueType.LONG.toString(),
+                ColumnType.LONG,
+                ValueType.LONG.name(),
                 false,
                 false,
                 100,
@@ -211,7 +216,8 @@ public class DoubleStorageTest
             ),
             DIM_NAME,
             new ColumnAnalysis(
-                ValueType.STRING.toString(),
+                ColumnType.STRING,
+                ValueType.STRING.name(),
                 false,
                 false,
                 120,
@@ -222,7 +228,8 @@ public class DoubleStorageTest
             ),
             DIM_FLOAT_NAME,
             new ColumnAnalysis(
-                ValueType.FLOAT.toString(),
+                ColumnType.FLOAT,
+                ValueType.FLOAT.name(),
                 false,
                 false,
                 80,

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
@@ -295,7 +295,8 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
       Map<String, ColumnAnalysis> analyses = analyzer.analyze(segment);
       ColumnAnalysis columnAnalysis = analyses.get(invalid_aggregator);
       Assert.assertFalse(columnAnalysis.isError());
-      Assert.assertEquals("COMPLEX<invalid_complex_column_type>", columnAnalysis.getType());
+      Assert.assertEquals("invalid_complex_column_type", columnAnalysis.getType());
+      Assert.assertEquals(ColumnType.ofComplex("invalid_complex_column_type"), columnAnalysis.getTypeSignature());
     }
 
     // Persist the index.

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.query.spec.LegacySegmentSpec;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.timeline.LogicalSegment;
 import org.joda.time.Interval;
@@ -79,7 +80,8 @@ public class SegmentMetadataQueryQueryToolChestTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
-                ValueType.STRING.toString(),
+                ColumnType.STRING,
+                ValueType.STRING.name(),
                 true,
                 false,
                 10881,

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -70,7 +70,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         new SegmentMetadataQueryQueryToolChest(new SegmentMetadataQueryConfig()).getCacheStrategy(query);
 
     // Test cache key generation
-    byte[] expectedKey = {0x04, 0x01, (byte) 0xFF, 0x00, 0x02, 0x04};
+    byte[] expectedKey = {0x04, 0x09, 0x01, 0x0A, 0x00, 0x00, 0x00, 0x03, 0x00, 0x02, 0x04};
     byte[] actualKey = strategy.computeCacheKey(query);
     Assert.assertArrayEquals(expectedKey, actualKey);
 

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -52,6 +52,7 @@ import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.timeline.LogicalSegment;
@@ -207,6 +208,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "__time",
             new ColumnAnalysis(
+                ColumnType.LONG,
                 ValueType.LONG.toString(),
                 false,
                 false,
@@ -218,6 +220,7 @@ public class SegmentMetadataQueryTest
             ),
             "index",
             new ColumnAnalysis(
+                ColumnType.DOUBLE,
                 ValueType.DOUBLE.toString(),
                 false,
                 false,
@@ -229,6 +232,7 @@ public class SegmentMetadataQueryTest
             ),
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -251,6 +255,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "__time",
             new ColumnAnalysis(
+                ColumnType.LONG,
                 ValueType.LONG.toString(),
                 false,
                 false,
@@ -262,6 +267,7 @@ public class SegmentMetadataQueryTest
             ),
             "index",
             new ColumnAnalysis(
+                ColumnType.DOUBLE,
                 ValueType.DOUBLE.toString(),
                 false,
                 false,
@@ -273,6 +279,7 @@ public class SegmentMetadataQueryTest
             ),
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -310,6 +317,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -321,6 +329,7 @@ public class SegmentMetadataQueryTest
             ),
             "placementish",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 true,
                 false,
@@ -380,6 +389,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -391,6 +401,7 @@ public class SegmentMetadataQueryTest
             ),
             "placementish",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 true,
                 false,
@@ -450,6 +461,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -461,7 +473,8 @@ public class SegmentMetadataQueryTest
             ),
             "quality_uniques",
             new ColumnAnalysis(
-                "COMPLEX<hyperUnique>",
+                ColumnType.ofComplex("hyperUnique"),
+                "hyperUnique",
                 false,
                 true,
                 0,
@@ -521,6 +534,7 @@ public class SegmentMetadataQueryTest
       size2 = mmap2 ? 10881 : 10764;
     }
     ColumnAnalysis analysis = new ColumnAnalysis(
+        ColumnType.STRING,
         ValueType.STRING.toString(),
         false,
         false,
@@ -543,6 +557,7 @@ public class SegmentMetadataQueryTest
       size2 = mmap2 ? 6882 : 6808;
     }
     ColumnAnalysis analysis = new ColumnAnalysis(
+        ColumnType.STRING,
         ValueType.STRING.toString(),
         false,
         false,
@@ -565,6 +580,7 @@ public class SegmentMetadataQueryTest
       size2 = mmap2 ? 9765 : 9660;
     }
     ColumnAnalysis analysis = new ColumnAnalysis(
+        ColumnType.STRING,
         ValueType.STRING.toString(),
         false,
         false,
@@ -588,6 +604,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "__time",
             new ColumnAnalysis(
+                ColumnType.LONG,
                 ValueType.LONG.toString(),
                 false,
                 false,
@@ -599,6 +616,7 @@ public class SegmentMetadataQueryTest
             ),
             "index",
             new ColumnAnalysis(
+                ColumnType.DOUBLE,
                 ValueType.DOUBLE.toString(),
                 false,
                 false,
@@ -654,6 +672,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -717,6 +736,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -776,6 +796,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -835,6 +856,7 @@ public class SegmentMetadataQueryTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,
@@ -1299,6 +1321,7 @@ public class SegmentMetadataQueryTest
   public void testLongNullableColumn()
   {
     ColumnAnalysis analysis = new ColumnAnalysis(
+        ColumnType.LONG,
         ValueType.LONG.toString(),
         false,
         NullHandling.replaceWithDefault() ? false : true,
@@ -1315,6 +1338,7 @@ public class SegmentMetadataQueryTest
   public void testDoubleNullableColumn()
   {
     ColumnAnalysis analysis = new ColumnAnalysis(
+        ColumnType.DOUBLE,
         ValueType.DOUBLE.toString(),
         false,
         NullHandling.replaceWithDefault() ? false : true,
@@ -1332,6 +1356,7 @@ public class SegmentMetadataQueryTest
   public void testFloatNullableColumn()
   {
     ColumnAnalysis analysis = new ColumnAnalysis(
+        ColumnType.FLOAT,
         ValueType.FLOAT.toString(),
         false,
         NullHandling.replaceWithDefault() ? false : true,

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataUnionQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataUnionQueryTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Test;
@@ -101,6 +102,7 @@ public class SegmentMetadataUnionQueryTest extends InitializedNullHandlingTest
         ImmutableMap.of(
             "placement",
             new ColumnAnalysis(
+                ColumnType.STRING,
                 ValueType.STRING.toString(),
                 false,
                 false,

--- a/processing/src/test/java/org/apache/druid/query/metadata/metadata/ColumnAnalysisTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/metadata/ColumnAnalysisTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.metadata.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.column.ColumnType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,13 +37,43 @@ public class ColumnAnalysisTest
   @Test
   public void testFoldStringColumns() throws Exception
   {
-    final ColumnAnalysis analysis1 = new ColumnAnalysis("STRING", false, false, 1L, 2, "aaA", "Zzz", null);
-    final ColumnAnalysis analysis2 = new ColumnAnalysis("STRING", true, false, 3L, 4, "aAA", "ZZz", null);
+    final ColumnAnalysis analysis1 = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        false,
+        false,
+        1L,
+        2,
+        "aaA",
+        "Zzz",
+        null
+    );
+    final ColumnAnalysis analysis2 = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        true,
+        false,
+        3L,
+        4,
+        "aAA",
+        "ZZz",
+        null
+    );
 
     assertSerDe(analysis1);
     assertSerDe(analysis2);
 
-    final ColumnAnalysis expected = new ColumnAnalysis("STRING", true, false, 4L, 4, "aAA", "Zzz", null);
+    final ColumnAnalysis expected = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        true,
+        false,
+        4L,
+        4,
+        "aAA",
+        "Zzz",
+        null
+    );
 
     ColumnAnalysis fold1 = analysis1.fold(analysis2);
     ColumnAnalysis fold2 = analysis2.fold(analysis1);
@@ -56,7 +87,17 @@ public class ColumnAnalysisTest
   @Test
   public void testFoldWithNull() throws Exception
   {
-    final ColumnAnalysis analysis1 = new ColumnAnalysis("STRING", false, false, 1L, 2, null, null, null);
+    final ColumnAnalysis analysis1 = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        false,
+        false,
+        1L,
+        2,
+        null,
+        null,
+        null
+    );
     Assert.assertEquals(analysis1, analysis1.fold(null));
     assertSerDe(analysis1);
   }
@@ -64,13 +105,43 @@ public class ColumnAnalysisTest
   @Test
   public void testFoldComplexColumns() throws Exception
   {
-    final ColumnAnalysis analysis1 = new ColumnAnalysis("hyperUnique", false, false, 0L, null, null, null, null);
-    final ColumnAnalysis analysis2 = new ColumnAnalysis("hyperUnique", false, false, 0L, null, null, null, null);
+    final ColumnAnalysis analysis1 = new ColumnAnalysis(
+        ColumnType.ofComplex("hyperUnique"),
+        "hyperUnique",
+        false,
+        false,
+        0L,
+        null,
+        null,
+        null,
+        null
+    );
+    final ColumnAnalysis analysis2 = new ColumnAnalysis(
+        ColumnType.ofComplex("hyperUnique"),
+        "hyperUnique",
+        false,
+        false,
+        0L,
+        null,
+        null,
+        null,
+        null
+    );
 
     assertSerDe(analysis1);
     assertSerDe(analysis2);
 
-    final ColumnAnalysis expected = new ColumnAnalysis("hyperUnique", false, false, 0L, null, null, null, null);
+    final ColumnAnalysis expected = new ColumnAnalysis(
+        ColumnType.ofComplex("hyperUnique"),
+        "hyperUnique",
+        false,
+        false,
+        0L,
+        null,
+        null,
+        null,
+        null
+    );
 
     ColumnAnalysis fold1 = analysis1.fold(analysis2);
     ColumnAnalysis fold2 = analysis2.fold(analysis1);
@@ -84,26 +155,83 @@ public class ColumnAnalysisTest
   @Test
   public void testFoldDifferentTypes() throws Exception
   {
-    final ColumnAnalysis analysis1 = new ColumnAnalysis("hyperUnique", false, false, 1L, 1, null, null, null);
-    final ColumnAnalysis analysis2 = new ColumnAnalysis("COMPLEX", false, false, 2L, 2, null, null, null);
+    final ColumnAnalysis analysis1 = new ColumnAnalysis(
+        ColumnType.ofComplex("hyperUnique"),
+        "hyperUnique",
+        false,
+        false,
+        1L,
+        1,
+        null,
+        null,
+        null
+    );
+    final ColumnAnalysis analysis2 = new ColumnAnalysis(
+        ColumnType.UNKNOWN_COMPLEX,
+        "COMPLEX",
+        false,
+        false,
+        2L,
+        2,
+        null,
+        null,
+        null
+    );
 
     assertSerDe(analysis1);
     assertSerDe(analysis2);
 
-    final ColumnAnalysis expected = new ColumnAnalysis(
-        "STRING",
+    final ColumnAnalysis expected = ColumnAnalysis.error("cannot_merge_diff_types: [hyperUnique] and [COMPLEX]");
+    final ColumnAnalysis expected2 = ColumnAnalysis.error("cannot_merge_diff_types: [COMPLEX] and [hyperUnique]");
+    ColumnAnalysis fold1 = analysis1.fold(analysis2);
+    ColumnAnalysis fold2 = analysis2.fold(analysis1);
+    Assert.assertEquals(expected, fold1);
+    Assert.assertEquals(expected2, fold2);
+
+    assertSerDe(fold1);
+    assertSerDe(fold2);
+  }
+
+  @Test
+  public void testFoldDifferentTypeSignatures() throws Exception
+  {
+    // not sure that this should be able to happen in real life but if messages are artifically constructed
+    final ColumnAnalysis analysis1 = new ColumnAnalysis(
+        ColumnType.ofComplex("hyperUnique"),
+        "hyperUnique",
         false,
         false,
-        -1L,
+        1L,
+        1,
         null,
         null,
+        null
+    );
+    final ColumnAnalysis analysis2 = new ColumnAnalysis(
+        ColumnType.UNKNOWN_COMPLEX,
+        "hyperUnique",
+        false,
+        false,
+        2L,
+        2,
         null,
-        "error:cannot_merge_diff_types"
+        null,
+        null
+    );
+
+    assertSerDe(analysis1);
+    assertSerDe(analysis2);
+
+    final ColumnAnalysis expected = ColumnAnalysis.error(
+        "cannot_merge_diff_types: [COMPLEX<hyperUnique>] and [COMPLEX]"
+    );
+    final ColumnAnalysis expected2 = ColumnAnalysis.error(
+        "cannot_merge_diff_types: [COMPLEX] and [COMPLEX<hyperUnique>]"
     );
     ColumnAnalysis fold1 = analysis1.fold(analysis2);
     ColumnAnalysis fold2 = analysis2.fold(analysis1);
     Assert.assertEquals(expected, fold1);
-    Assert.assertEquals(expected, fold2);
+    Assert.assertEquals(expected2, fold2);
 
     assertSerDe(fold1);
     assertSerDe(fold2);
@@ -118,7 +246,17 @@ public class ColumnAnalysisTest
     assertSerDe(analysis1);
     assertSerDe(analysis2);
 
-    final ColumnAnalysis expected = new ColumnAnalysis("STRING", false, false, -1L, null, null, null, "error:foo");
+    final ColumnAnalysis expected = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        false,
+        false,
+        -1L,
+        null,
+        null,
+        null,
+        "error:foo"
+    );
     ColumnAnalysis fold1 = analysis1.fold(analysis2);
     ColumnAnalysis fold2 = analysis2.fold(analysis1);
     Assert.assertEquals(expected, fold1);
@@ -132,12 +270,32 @@ public class ColumnAnalysisTest
   public void testFoldErrorAndNoError() throws Exception
   {
     final ColumnAnalysis analysis1 = ColumnAnalysis.error("foo");
-    final ColumnAnalysis analysis2 = new ColumnAnalysis("STRING", false, false, 2L, 2, "a", "z", null);
+    final ColumnAnalysis analysis2 = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        false,
+        false,
+        2L,
+        2,
+        "a",
+        "z",
+        null
+    );
 
     assertSerDe(analysis1);
     assertSerDe(analysis2);
 
-    final ColumnAnalysis expected = new ColumnAnalysis("STRING", false, false, -1L, null, null, null, "error:foo");
+    final ColumnAnalysis expected = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        false,
+        false,
+        -1L,
+        null,
+        null,
+        null,
+        "error:foo"
+    );
     ColumnAnalysis fold1 = analysis1.fold(analysis2);
     ColumnAnalysis fold2 = analysis2.fold(analysis1);
     Assert.assertEquals(expected, fold1);
@@ -156,7 +314,17 @@ public class ColumnAnalysisTest
     assertSerDe(analysis1);
     assertSerDe(analysis2);
 
-    final ColumnAnalysis expected = new ColumnAnalysis("STRING", false, false, -1L, null, null, null, "error:multiple_errors");
+    final ColumnAnalysis expected = new ColumnAnalysis(
+        ColumnType.STRING,
+        "STRING",
+        false,
+        false,
+        -1L,
+        null,
+        null,
+        null,
+        "error:multiple_errors"
+    );
     ColumnAnalysis fold1 = analysis1.fold(analysis2);
     ColumnAnalysis fold2 = analysis2.fold(analysis1);
     Assert.assertEquals(expected, fold1);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -884,15 +884,9 @@ public class DruidSchema extends AbstractSchema
         continue;
       }
 
-      ColumnType valueType = null;
-      try {
-        valueType = ColumnType.fromString(entry.getValue().getType());
-      }
-      catch (IllegalArgumentException ignored) {
-      }
+      ColumnType valueType = entry.getValue().getTypeSignature();
 
-      // Assume unrecognized types are some flavor of COMPLEX. This throws away information about exactly
-      // what kind of complex column it is, which we may want to preserve some day.
+      // this shouldn't happen, but if it does assume types are some flavor of COMPLEX.
       if (valueType == null) {
         valueType = ColumnType.UNKNOWN_COMPLEX;
       }


### PR DESCRIPTION
### Description
#11713 changed the segment metadata query column analysis `type` field, but this might not be very friendly to actual users (e.g. not `DruidSchema`) who are calling this query directly because, merging query results of mixed versions of Druid would result in an error due to mismatched types. 

This PR reverts `type` to its original behavior, and adds a new `typeSignature` which is used by `DruidSchema`. Error messaging when merging `ColumnAnalysis` has also been improved to include the mismatched types involved in the merge.

<hr>

##### Key changed/added classes in this PR
 * `ColumnAnalysis`
 * `SegmentAnalyzer`

<hr>


This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
