### PR TITLE
Document expression post-aggregators

### DIFF
--- a/docs/querying/post-aggregations.md
+++ b/docs/querying/post-aggregations.md
@@ -42,7 +42,7 @@ Supported functions are `+`, `-`, `*`, `/`, and `quotient`.
 
 * `/` division always returns `0` if dividing by`0`, regardless of the numerator.
 * `quotient` division behaves like regular floating point division
-* Arithemtic post-aggregators always use floating point arithmetic.
+* Arithmetic post-aggregators always use floating point arithmetic.
 
 Arithmetic post-aggregators may also specify an `ordering`, which defines the order
 of resulting values when sorting results (this can be useful for topN queries for instance):

--- a/docs/querying/post-aggregations.md
+++ b/docs/querying/post-aggregations.md
@@ -42,6 +42,7 @@ Supported functions are `+`, `-`, `*`, `/`, and `quotient`.
 
 * `/` division always returns `0` if dividing by`0`, regardless of the numerator.
 * `quotient` division behaves like regular floating point division
+* Arithemtic post-aggregators always use floating point arithmetic.
 
 Arithmetic post-aggregators may also specify an `ordering`, which defines the order
 of resulting values when sorting results (this can be useful for topN queries for instance):
@@ -88,6 +89,20 @@ The constant post-aggregator always returns the specified value.
 ```json
 { "type"  : "constant", "name"  : <output_name>, "value" : <numerical_value> }
 ```
+
+
+### Expression post-aggregator
+The expression post-aggregator is defined using a Druid [expression](../misc/math-expr.md).
+
+```json
+{
+  "type": "expression",
+  "name": <output_name>,
+  "expression": <post-aggregation expression>,
+  "ordering" : <null (default), or "numericFirst">
+}
+```
+
 
 ### Greatest / Least post-aggregators
 
@@ -221,3 +236,21 @@ The format of the query JSON is as follows:
   ...
 }
 ```
+
+The same could be computed using an expression post-aggregator: 
+```json
+{
+  ...
+  "aggregations" : [
+    { "type" : "doubleSum", "name" : "tot", "fieldName" : "total" },
+    { "type" : "doubleSum", "name" : "part", "fieldName" : "part" }
+  ],
+  "postAggregations" : [{
+    "type"       : "expression",
+    "name"       : "part_percentage",
+    "expression" : "100 * (part / tot)"
+  }]
+  ...
+}
+```
+


### PR DESCRIPTION
### Description

There was no documentation about expression post-aggregators; adding that here. 

Also adding a note that the arithmetic post-aggregator always uses floating point arithmetic ( [per the latest commit](https://github.com/apache/druid/blob/a5bd0b8cc023b771ef95f1e46c19961f50e05900/processing/src/main/java/org/apache/druid/query/aggregation/post/ArithmeticPostAggregator.java#L209-L246).)

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster. (I didn't test exhaustively, but I verified that some queries with the syntax documented here work as expected). 