### PR TITLE
Removes Druid chart deprecation message and flag

### DIFF
--- a/helm/druid/Chart.yaml
+++ b/helm/druid/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 appVersion: 0.19.0
-description: DEPRECATED Apache Druid is a high performance real-time analytics database.
+description: Apache Druid is a high performance real-time analytics database.
 name: druid
 dependencies:
   - name: zookeeper
@@ -33,7 +33,6 @@ dependencies:
 version: 0.3.0
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png
-deprecated: true
 sources:
   - https://github.com/apache/druid
 keywords:


### PR DESCRIPTION
The Druid Chart was deprecated in [helm/charts](https://github.com/helm/charts/tree/master/incubator/druid) repo
> ⚠️ Repo Archive Notice
> As of Nov 13, 2020, charts in this repo will no longer be updated. For more information, see the Helm Charts Deprecation and Archive Notice, and Update.

Deprecation message and flag can be removed as Druid chart will be supported in Druid repo. 





<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
