### PR TITLE
Can reject row if parsing error

### DIFF
--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
@@ -199,7 +199,8 @@ public class MaterializedViewSupervisorSpec implements SupervisorSpec
         tuningConfig.isLogParseExceptions(),
         tuningConfig.getMaxParseExceptions(),
         tuningConfig.isUseYarnRMJobStatusFallback(),
-        tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis()
+        tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(),
+        tuningConfig.isRejectRowIfParseError()
     );
 
     // generate granularity

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTuningConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTuningConfig.java
@@ -52,7 +52,8 @@ public class KafkaIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningCon
       @JsonProperty("intermediateHandoffPeriod") @Nullable Period intermediateHandoffPeriod,
       @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
       @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
-      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions
+      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     super(
@@ -75,7 +76,8 @@ public class KafkaIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningCon
         intermediateHandoffPeriod,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        rejectRowIfParseError
     );
   }
 
@@ -101,7 +103,8 @@ public class KafkaIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningCon
         getIntermediateHandoffPeriod(),
         isLogParseExceptions(),
         getMaxParseExceptions(),
-        getMaxSavedParseExceptions()
+        getMaxSavedParseExceptions(),
+        isRejectRowIfParseError()
     );
   }
 
@@ -128,7 +131,7 @@ public class KafkaIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningCon
            ", logParseExceptions=" + isLogParseExceptions() +
            ", maxParseExceptions=" + getMaxParseExceptions() +
            ", maxSavedParseExceptions=" + getMaxSavedParseExceptions() +
+           ", rejectRowIfParseError=" + isRejectRowIfParseError() +
            '}';
   }
-
 }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
@@ -68,6 +68,7 @@ public class KafkaSupervisorTuningConfig extends KafkaIndexTaskTuningConfig
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -97,7 +98,8 @@ public class KafkaSupervisorTuningConfig extends KafkaIndexTaskTuningConfig
       @JsonProperty("intermediateHandoffPeriod") Period intermediateHandoffPeriod,
       @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
       @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
-      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions
+      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     super(
@@ -119,7 +121,8 @@ public class KafkaSupervisorTuningConfig extends KafkaIndexTaskTuningConfig
         intermediateHandoffPeriod,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        rejectRowIfParseError
     );
     this.workerThreads = workerThreads;
     this.chatThreads = chatThreads;
@@ -215,6 +218,7 @@ public class KafkaSupervisorTuningConfig extends KafkaIndexTaskTuningConfig
            ", logParseExceptions=" + isLogParseExceptions() +
            ", maxParseExceptions=" + getMaxParseExceptions() +
            ", maxSavedParseExceptions=" + getMaxSavedParseExceptions() +
+           ", rejectRowIfParseError=" + isRejectRowIfParseError() +
            '}';
   }
 
@@ -240,7 +244,8 @@ public class KafkaSupervisorTuningConfig extends KafkaIndexTaskTuningConfig
         getIntermediateHandoffPeriod(),
         isLogParseExceptions(),
         getMaxParseExceptions(),
-        getMaxSavedParseExceptions()
+        getMaxSavedParseExceptions(),
+        isRejectRowIfParseError()
     );
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -2780,7 +2780,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         intermediateHandoffPeriod,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        null
     );
     if (!context.containsKey(SeekableStreamSupervisor.CHECKPOINTS_CTX_KEY)) {
       final TreeMap<Integer, Map<Integer, Long>> checkpoints = new TreeMap<>();

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTuningConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTuningConfigTest.java
@@ -144,6 +144,7 @@ public class KafkaIndexTaskTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
     KafkaIndexTaskTuningConfig copy = (KafkaIndexTaskTuningConfig) original.convertToTaskTuningConfig();
@@ -183,7 +184,8 @@ public class KafkaIndexTaskTuningConfigTest
         null,
         true,
         42,
-        42
+        42,
+        null
     );
 
     String serialized = mapper.writeValueAsString(base);
@@ -233,6 +235,7 @@ public class KafkaIndexTaskTuningConfigTest
         true,
         42,
         42,
+        null,
         "extra string"
     );
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -324,6 +324,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null,
             null,
             null,
+            null,
             null
     );
 
@@ -449,6 +450,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             INPUT_FORMAT
         ),
         new KafkaIndexTaskTuningConfig(
+            null,
             null,
             null,
             null,
@@ -3291,6 +3293,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null,
             null,
             null,
+            null,
             null
         )
     );
@@ -3327,6 +3330,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         TEST_CHAT_RETRIES,
         TEST_HTTP_TIMEOUT,
         TEST_SHUTDOWN_TIMEOUT,
+        null,
         null,
         null,
         null,
@@ -3628,6 +3632,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
+        null,
         null
     );
 
@@ -3736,6 +3741,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         TEST_CHAT_RETRIES,
         TEST_HTTP_TIMEOUT,
         TEST_SHUTDOWN_TIMEOUT,
+        null,
         null,
         null,
         null,

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/TestModifiedKafkaIndexTaskTuningConfig.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/TestModifiedKafkaIndexTaskTuningConfig.java
@@ -57,6 +57,7 @@ public class TestModifiedKafkaIndexTaskTuningConfig extends KafkaIndexTaskTuning
       @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
       @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
       @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError,
       @JsonProperty("extra") String extra
   )
   {
@@ -79,7 +80,8 @@ public class TestModifiedKafkaIndexTaskTuningConfig extends KafkaIndexTaskTuning
         intermediateHandoffPeriod,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        rejectRowIfParseError
     );
     this.extra = extra;
   }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfig.java
@@ -76,7 +76,8 @@ public class KinesisIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningC
       @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
       @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
       @JsonProperty("maxRecordsPerPoll") @Nullable Integer maxRecordsPerPoll,
-      @JsonProperty("intermediateHandoffPeriod") @Nullable Period intermediateHandoffPeriod
+      @JsonProperty("intermediateHandoffPeriod") @Nullable Period intermediateHandoffPeriod,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     super(
@@ -99,7 +100,8 @@ public class KinesisIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningC
         intermediateHandoffPeriod,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        rejectRowIfParseError
     );
     this.recordBufferSize = recordBufferSize == null ? DEFAULT_RECORD_BUFFER_SIZE : recordBufferSize;
     this.recordBufferOfferTimeout = recordBufferOfferTimeout == null
@@ -182,7 +184,8 @@ public class KinesisIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningC
         getMaxParseExceptions(),
         getMaxSavedParseExceptions(),
         getMaxRecordsPerPoll(),
-        getIntermediateHandoffPeriod()
+        getIntermediateHandoffPeriod(),
+        isRejectRowIfParseError()
     );
   }
 
@@ -249,6 +252,7 @@ public class KinesisIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningC
            ", maxSavedParseExceptions=" + getMaxSavedParseExceptions() +
            ", maxRecordsPerPoll=" + maxRecordsPerPoll +
            ", intermediateHandoffPeriod=" + getIntermediateHandoffPeriod() +
+           ", rejectRowIfParseError=" + isRejectRowIfParseError() +
            '}';
   }
 }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
@@ -77,6 +77,7 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -114,7 +115,8 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
       @JsonProperty("maxRecordsPerPoll") @Nullable Integer maxRecordsPerPoll,
       @JsonProperty("intermediateHandoffPeriod") Period intermediateHandoffPeriod,
       @JsonProperty("repartitionTransitionDuration") Period repartitionTransitionDuration,
-      @JsonProperty("offsetFetchPeriod") Period offsetFetchPeriod
+      @JsonProperty("offsetFetchPeriod") Period offsetFetchPeriod,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     super(
@@ -143,7 +145,8 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
         maxParseExceptions,
         maxSavedParseExceptions,
         maxRecordsPerPoll,
-        intermediateHandoffPeriod
+        intermediateHandoffPeriod,
+        rejectRowIfParseError
     );
 
     this.workerThreads = workerThreads;
@@ -246,6 +249,7 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
            ", maxRecordsPerPoll=" + getMaxRecordsPerPoll() +
            ", intermediateHandoffPeriod=" + getIntermediateHandoffPeriod() +
            ", repartitionTransitionDuration=" + getRepartitionTransitionDuration() +
+           ", rejectRowIfParseError=" + isRejectRowIfParseError() +
            '}';
   }
 
@@ -278,7 +282,8 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
         getMaxParseExceptions(),
         getMaxSavedParseExceptions(),
         getMaxRecordsPerPoll(),
-        getIntermediateHandoffPeriod()
+        getIntermediateHandoffPeriod(),
+        isRejectRowIfParseError()
     );
   }
 }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
@@ -73,6 +73,7 @@ public class KinesisIndexTaskSerdeTest
       null,
       null,
       null,
+      null,
       null
   );
   private static final KinesisIndexTaskIOConfig IO_CONFIG = new KinesisIndexTaskIOConfig(

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -2781,7 +2781,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         maxParseExceptions,
         maxSavedParseExceptions,
         maxRecordsPerPoll,
-        intermediateHandoffPeriod
+        intermediateHandoffPeriod,
+        null
     );
     return createTask(taskId, dataSchema, ioConfig, tuningConfig, context);
   }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
@@ -163,7 +163,8 @@ public class KinesisIndexTaskTuningConfigTest
         500,
         500,
         6000,
-        new Period("P3D")
+        new Period("P3D"),
+        null
     );
 
     String serialized = mapper.writeValueAsString(base);
@@ -223,7 +224,8 @@ public class KinesisIndexTaskTuningConfigTest
         500,
         500,
         6000,
-        new Period("P3D")
+        new Period("P3D"),
+        null
     );
 
     String serialized = mapper.writeValueAsString(new TestModifiedKinesisIndexTaskTuningConfig(base, "loool"));
@@ -311,6 +313,7 @@ public class KinesisIndexTaskTuningConfigTest
         500,
         6000,
         2,
+        null,
         null,
         null,
         null,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -204,6 +204,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
+        null,
         null
     );
     rowIngestionMetersFactory = new TestUtils().getRowIngestionMetersFactory();
@@ -3941,6 +3942,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         42, // This property is different from tuningConfig
         null,
         null,
+        null,
         null
     );
 
@@ -4988,6 +4990,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         5000,
+        null,
         null,
         null,
         null,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/test/TestModifiedKinesisIndexTaskTuningConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/test/TestModifiedKinesisIndexTaskTuningConfig.java
@@ -64,6 +64,7 @@ public class TestModifiedKinesisIndexTaskTuningConfig extends KinesisIndexTaskTu
       @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
       @JsonProperty("maxRecordsPerPoll") @Nullable Integer maxRecordsPerPoll,
       @JsonProperty("intermediateHandoffPeriod") @Nullable Period intermediateHandoffPeriod,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError,
       @JsonProperty("extra") String extra
   )
   {
@@ -93,7 +94,8 @@ public class TestModifiedKinesisIndexTaskTuningConfig extends KinesisIndexTaskTu
         maxParseExceptions,
         maxSavedParseExceptions,
         maxRecordsPerPoll,
-        intermediateHandoffPeriod
+        intermediateHandoffPeriod,
+        rejectRowIfParseError
     );
     this.extra = extra;
   }
@@ -126,7 +128,8 @@ public class TestModifiedKinesisIndexTaskTuningConfig extends KinesisIndexTaskTu
         base.getMaxParseExceptions(),
         base.getMaxSavedParseExceptions(),
         base.getMaxRecordsPerPoll(),
-        base.getIntermediateHandoffPeriod()
+        base.getIntermediateHandoffPeriod(),
+        base.isRejectRowIfParseError()
     );
     this.extra = extra;
   }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -252,6 +252,7 @@ public class HadoopTuningConfig implements TuningConfig
     return maxBytesInMemory;
   }
 
+  @JsonProperty
   @Override
   public boolean isRejectRowIfParseError()
   {

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -74,7 +74,8 @@ public class HadoopTuningConfig implements TuningConfig
         null,
         null,
         null,
-        null
+        null,
+        TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR
     );
   }
   @Nullable
@@ -102,6 +103,7 @@ public class HadoopTuningConfig implements TuningConfig
   private final int maxParseExceptions;
   private final boolean useYarnRMJobStatusFallback;
   private final long awaitSegmentAvailabilityTimeoutMillis;
+  private final boolean rejectRowIfParseError;
 
   @JsonCreator
   public HadoopTuningConfig(
@@ -130,7 +132,8 @@ public class HadoopTuningConfig implements TuningConfig
       final @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
       final @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
       final @JsonProperty("useYarnRMJobStatusFallback") @Nullable Boolean useYarnRMJobStatusFallback,
-      final @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis
+      final @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis,
+      final @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     this.workingPath = workingPath;
@@ -182,6 +185,10 @@ public class HadoopTuningConfig implements TuningConfig
     } else {
       this.awaitSegmentAvailabilityTimeoutMillis = awaitSegmentAvailabilityTimeoutMillis;
     }
+
+    this.rejectRowIfParseError = rejectRowIfParseError == null
+                                 ? TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR :
+                                 rejectRowIfParseError;
   }
 
   @Nullable
@@ -243,6 +250,12 @@ public class HadoopTuningConfig implements TuningConfig
   public long getMaxBytesInMemory()
   {
     return maxBytesInMemory;
+  }
+
+  @Override
+  public boolean isRejectRowIfParseError()
+  {
+    return rejectRowIfParseError;
   }
 
   @JsonProperty
@@ -363,7 +376,8 @@ public class HadoopTuningConfig implements TuningConfig
         logParseExceptions,
         maxParseExceptions,
         useYarnRMJobStatusFallback,
-        awaitSegmentAvailabilityTimeoutMillis
+        awaitSegmentAvailabilityTimeoutMillis,
+        rejectRowIfParseError
     );
   }
 
@@ -394,7 +408,8 @@ public class HadoopTuningConfig implements TuningConfig
         logParseExceptions,
         maxParseExceptions,
         useYarnRMJobStatusFallback,
-        awaitSegmentAvailabilityTimeoutMillis
+        awaitSegmentAvailabilityTimeoutMillis,
+        rejectRowIfParseError
     );
   }
 
@@ -425,7 +440,8 @@ public class HadoopTuningConfig implements TuningConfig
         logParseExceptions,
         maxParseExceptions,
         useYarnRMJobStatusFallback,
-        awaitSegmentAvailabilityTimeoutMillis
+        awaitSegmentAvailabilityTimeoutMillis,
+        rejectRowIfParseError
     );
   }
 }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -400,7 +400,8 @@ public class IndexGeneratorJob implements Jobby
       ParseException pe = IncrementalIndex.getCombinedParseException(
           inputRow,
           serializeResult.getParseExceptionMessages(),
-          null
+          null,
+          config.getSchema().getTuningConfig().isRejectRowIfParseError()
       );
       if (pe != null) {
         throw pe;

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
@@ -489,6 +489,7 @@ public class BatchDeltaIngestionTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -235,6 +235,7 @@ public class DetermineHashedPartitionsJobTest
             null,
             null,
             null,
+            null,
             null
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
@@ -344,6 +344,7 @@ public class DeterminePartitionsJobTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -257,6 +257,7 @@ public class HadoopDruidIndexerConfigTest
           null,
           null,
           null,
+          null,
           null
       );
 

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
@@ -63,6 +63,7 @@ public class HadoopTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
@@ -547,6 +547,7 @@ public class IndexGeneratorJobTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
@@ -187,6 +187,7 @@ public class JobHelperTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
@@ -79,6 +79,7 @@ public class GranularityPathSpecTest
       null,
       null,
       null,
+      null,
       null
   );
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/index/RealtimeAppenderatorTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/index/RealtimeAppenderatorTuningConfig.java
@@ -169,6 +169,7 @@ public class RealtimeAppenderatorTuningConfig implements AppenderatorConfig
   }
 
   @Override
+  @JsonProperty
   public boolean isRejectRowIfParseError()
   {
     return rejectRowIfParseError;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/index/RealtimeAppenderatorTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/index/RealtimeAppenderatorTuningConfig.java
@@ -73,6 +73,7 @@ public class RealtimeAppenderatorTuningConfig implements AppenderatorConfig
   private final boolean logParseExceptions;
   private final int maxParseExceptions;
   private final int maxSavedParseExceptions;
+  private final boolean rejectRowIfParseError;
 
   @JsonCreator
   public RealtimeAppenderatorTuningConfig(
@@ -94,7 +95,8 @@ public class RealtimeAppenderatorTuningConfig implements AppenderatorConfig
       @JsonProperty("segmentWriteOutMediumFactory") @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
       @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
       @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
-      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions
+      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     this.appendableIndexSpec = appendableIndexSpec == null ? DEFAULT_APPENDABLE_INDEX : appendableIndexSpec;
@@ -140,6 +142,9 @@ public class RealtimeAppenderatorTuningConfig implements AppenderatorConfig
     this.logParseExceptions = logParseExceptions == null
                               ? TuningConfig.DEFAULT_LOG_PARSE_EXCEPTIONS
                               : logParseExceptions;
+    this.rejectRowIfParseError = rejectRowIfParseError == null
+                                 ? TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR
+                                 : rejectRowIfParseError;
   }
 
   @Override
@@ -161,6 +166,12 @@ public class RealtimeAppenderatorTuningConfig implements AppenderatorConfig
   public long getMaxBytesInMemory()
   {
     return maxBytesInMemory;
+  }
+
+  @Override
+  public boolean isRejectRowIfParseError()
+  {
+    return rejectRowIfParseError;
   }
 
   @JsonProperty
@@ -299,7 +310,8 @@ public class RealtimeAppenderatorTuningConfig implements AppenderatorConfig
         segmentWriteOutMediumFactory,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        rejectRowIfParseError
     );
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -275,7 +275,8 @@ public class CompactionTask extends AbstractBatchIndexTask
           parallelIndexTuningConfig.getMaxParseExceptions(),
           parallelIndexTuningConfig.getMaxSavedParseExceptions(),
           parallelIndexTuningConfig.getMaxColumnsToMerge(),
-          parallelIndexTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis()
+          parallelIndexTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(),
+          parallelIndexTuningConfig.isRejectRowIfParseError()
       );
     } else if (tuningConfig instanceof IndexTuningConfig) {
       final IndexTuningConfig indexTuningConfig = (IndexTuningConfig) tuningConfig;
@@ -309,7 +310,8 @@ public class CompactionTask extends AbstractBatchIndexTask
           indexTuningConfig.getMaxParseExceptions(),
           indexTuningConfig.getMaxSavedParseExceptions(),
           indexTuningConfig.getMaxColumnsToMerge(),
-          indexTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis()
+          indexTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(),
+          indexTuningConfig.isRejectRowIfParseError()
       );
     } else {
       throw new ISE(
@@ -1176,7 +1178,8 @@ public class CompactionTask extends AbstractBatchIndexTask
           null,
           null,
           null,
-          0L
+          0L,
+          null
       );
     }
 
@@ -1211,7 +1214,8 @@ public class CompactionTask extends AbstractBatchIndexTask
         @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
         @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
         @JsonProperty("maxColumnsToMerge") @Nullable Integer maxColumnsToMerge,
-        @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis
+        @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis,
+        @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
     )
     {
       super(
@@ -1244,7 +1248,8 @@ public class CompactionTask extends AbstractBatchIndexTask
           maxParseExceptions,
           maxSavedParseExceptions,
           maxColumnsToMerge,
-          awaitSegmentAvailabilityTimeoutMillis
+          awaitSegmentAvailabilityTimeoutMillis,
+          rejectRowIfParseError
       );
 
       Preconditions.checkArgument(
@@ -1286,7 +1291,8 @@ public class CompactionTask extends AbstractBatchIndexTask
           getMaxParseExceptions(),
           getMaxSavedParseExceptions(),
           getMaxColumnsToMerge(),
-          getAwaitSegmentAvailabilityTimeoutMillis()
+          getAwaitSegmentAvailabilityTimeoutMillis(),
+          isRejectRowIfParseError()
       );
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -1197,6 +1197,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
     private final int maxParseExceptions;
     private final int maxSavedParseExceptions;
     private final long awaitSegmentAvailabilityTimeoutMillis;
+    private final boolean rejectRowIfParseError;
 
     @Nullable
     private final SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
@@ -1267,7 +1268,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
         @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
         @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
         @JsonProperty("maxColumnsToMerge") @Nullable Integer maxColumnsToMerge,
-        @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis
+        @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis,
+        @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
     )
     {
       this(
@@ -1295,7 +1297,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           maxParseExceptions,
           maxSavedParseExceptions,
           maxColumnsToMerge,
-          awaitSegmentAvailabilityTimeoutMillis
+          awaitSegmentAvailabilityTimeoutMillis,
+          reportParseExceptions
       );
 
       Preconditions.checkArgument(
@@ -1306,7 +1309,27 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
 
     private IndexTuningConfig()
     {
-      this(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+      this(
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+      );
     }
 
     private IndexTuningConfig(
@@ -1327,7 +1350,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
         @Nullable Integer maxParseExceptions,
         @Nullable Integer maxSavedParseExceptions,
         @Nullable Integer maxColumnsToMerge,
-        @Nullable Long awaitSegmentAvailabilityTimeoutMillis
+        @Nullable Long awaitSegmentAvailabilityTimeoutMillis,
+        @Nullable Boolean rejectRowIfParseError
     )
     {
       this.appendableIndexSpec = appendableIndexSpec == null ? DEFAULT_APPENDABLE_INDEX : appendableIndexSpec;
@@ -1373,6 +1397,10 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       } else {
         this.awaitSegmentAvailabilityTimeoutMillis = awaitSegmentAvailabilityTimeoutMillis;
       }
+
+      this.rejectRowIfParseError = rejectRowIfParseError == null
+                                   ? TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR
+                                   : rejectRowIfParseError;
     }
 
     @Override
@@ -1396,7 +1424,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           maxParseExceptions,
           maxSavedParseExceptions,
           maxColumnsToMerge,
-          awaitSegmentAvailabilityTimeoutMillis
+          awaitSegmentAvailabilityTimeoutMillis,
+          rejectRowIfParseError
       );
     }
 
@@ -1420,7 +1449,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           maxParseExceptions,
           maxSavedParseExceptions,
           maxColumnsToMerge,
-          awaitSegmentAvailabilityTimeoutMillis
+          awaitSegmentAvailabilityTimeoutMillis,
+          rejectRowIfParseError
       );
     }
 
@@ -1443,6 +1473,12 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
     public long getMaxBytesInMemory()
     {
       return maxBytesInMemory;
+    }
+
+    @Override
+    public boolean isRejectRowIfParseError()
+    {
+      return rejectRowIfParseError;
     }
 
     @JsonProperty
@@ -1636,7 +1672,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
              Objects.equals(indexSpecForIntermediatePersists, that.indexSpecForIntermediatePersists) &&
              Objects.equals(basePersistDirectory, that.basePersistDirectory) &&
              Objects.equals(segmentWriteOutMediumFactory, that.segmentWriteOutMediumFactory) &&
-             Objects.equals(awaitSegmentAvailabilityTimeoutMillis, that.awaitSegmentAvailabilityTimeoutMillis);
+             Objects.equals(awaitSegmentAvailabilityTimeoutMillis, that.awaitSegmentAvailabilityTimeoutMillis) &&
+             rejectRowIfParseError == that.rejectRowIfParseError;
     }
 
     @Override
@@ -1660,7 +1697,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           maxParseExceptions,
           maxSavedParseExceptions,
           segmentWriteOutMediumFactory,
-          awaitSegmentAvailabilityTimeoutMillis
+          awaitSegmentAvailabilityTimeoutMillis,
+          rejectRowIfParseError
       );
     }
 
@@ -1685,6 +1723,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
              ", maxSavedParseExceptions=" + maxSavedParseExceptions +
              ", segmentWriteOutMediumFactory=" + segmentWriteOutMediumFactory +
              ", awaitSegmentAvailabilityTimeoutMillis=" + awaitSegmentAvailabilityTimeoutMillis +
+             ", rejectRowIfParseError=" + rejectRowIfParseError +
              '}';
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -1475,6 +1475,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       return maxBytesInMemory;
     }
 
+    @JsonProperty
     @Override
     public boolean isRejectRowIfParseError()
     {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -1298,7 +1298,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           maxSavedParseExceptions,
           maxColumnsToMerge,
           awaitSegmentAvailabilityTimeoutMillis,
-          reportParseExceptions
+          rejectRowIfParseError
       );
 
       Preconditions.checkArgument(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1156,7 +1156,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         tuningConfig.getMaxParseExceptions(),
         tuningConfig.getMaxSavedParseExceptions(),
         tuningConfig.getMaxColumnsToMerge(),
-        tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis()
+        tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(),
+        tuningConfig.isRejectRowIfParseError()
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
@@ -102,6 +102,7 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -137,7 +138,8 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
       @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
       @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
       @JsonProperty("maxColumnsToMerge") @Nullable Integer maxColumnsToMerge,
-      @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis
+      @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     super(
@@ -164,7 +166,8 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
         maxParseExceptions,
         maxSavedParseExceptions,
         maxColumnsToMerge,
-        awaitSegmentAvailabilityTimeoutMillis
+        awaitSegmentAvailabilityTimeoutMillis,
+        rejectRowIfParseError
     );
 
     if (maxNumSubTasks != null && maxNumConcurrentSubTasks != null) {
@@ -288,7 +291,8 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
         getMaxParseExceptions(),
         getMaxSavedParseExceptions(),
         getMaxColumnsToMerge(),
-        getAwaitSegmentAvailabilityTimeoutMillis()
+        getAwaitSegmentAvailabilityTimeoutMillis(),
+        isRejectRowIfParseError()
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
@@ -154,7 +154,7 @@ public class InputSourceSampler
 
             //keep the index of the row to be added to responseRows for further use
             final int rowIndex = responseRows.size();
-            IncrementalIndexAddResult addResult = index.add(new SamplerInputRow(row, rowIndex), true);
+            IncrementalIndexAddResult addResult = index.add(new SamplerInputRow(row, rowIndex), true, false);
             if (addResult.hasParseException()) {
               responseRows.add(new SamplerResponseRow(
                   rawColumns,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
@@ -154,7 +154,7 @@ public class InputSourceSampler
 
             //keep the index of the row to be added to responseRows for further use
             final int rowIndex = responseRows.size();
-            IncrementalIndexAddResult addResult = index.add(new SamplerInputRow(row, rowIndex), true, false);
+            IncrementalIndexAddResult addResult = index.add(new SamplerInputRow(row, rowIndex), true);
             if (addResult.hasParseException()) {
               responseRows.add(new SamplerResponseRow(
                   rawColumns,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTuningConfig.java
@@ -60,6 +60,7 @@ public abstract class SeekableStreamIndexTaskTuningConfig implements Appenderato
   private final boolean logParseExceptions;
   private final int maxParseExceptions;
   private final int maxSavedParseExceptions;
+  private final boolean rejectRowIfParseError;
 
   public SeekableStreamIndexTaskTuningConfig(
       @Nullable AppendableIndexSpec appendableIndexSpec,
@@ -81,7 +82,8 @@ public abstract class SeekableStreamIndexTaskTuningConfig implements Appenderato
       @Nullable Period intermediateHandoffPeriod,
       @Nullable Boolean logParseExceptions,
       @Nullable Integer maxParseExceptions,
-      @Nullable Integer maxSavedParseExceptions
+      @Nullable Integer maxSavedParseExceptions,
+      @Nullable Boolean rejectRowIfParseError
   )
   {
     // Cannot be a static because default basePersistDirectory is unique per-instance
@@ -134,6 +136,9 @@ public abstract class SeekableStreamIndexTaskTuningConfig implements Appenderato
     this.logParseExceptions = logParseExceptions == null
                               ? TuningConfig.DEFAULT_LOG_PARSE_EXCEPTIONS
                               : logParseExceptions;
+    this.rejectRowIfParseError = rejectRowIfParseError == null
+                                 ? TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR
+                                 : rejectRowIfParseError;
   }
 
   @Override
@@ -248,6 +253,13 @@ public abstract class SeekableStreamIndexTaskTuningConfig implements Appenderato
     return segmentWriteOutMediumFactory;
   }
 
+  @Override
+  @JsonProperty
+  public boolean isRejectRowIfParseError()
+  {
+    return rejectRowIfParseError;
+  }
+
   @JsonProperty
   public Period getIntermediateHandoffPeriod()
   {
@@ -309,7 +321,8 @@ public abstract class SeekableStreamIndexTaskTuningConfig implements Appenderato
            Objects.equals(indexSpec, that.indexSpec) &&
            Objects.equals(indexSpecForIntermediatePersists, that.indexSpecForIntermediatePersists) &&
            Objects.equals(segmentWriteOutMediumFactory, that.segmentWriteOutMediumFactory) &&
-           Objects.equals(intermediateHandoffPeriod, that.intermediateHandoffPeriod);
+           Objects.equals(intermediateHandoffPeriod, that.intermediateHandoffPeriod) &&
+           rejectRowIfParseError == that.rejectRowIfParseError;
   }
 
   @Override
@@ -334,7 +347,8 @@ public abstract class SeekableStreamIndexTaskTuningConfig implements Appenderato
         skipSequenceNumberAvailabilityCheck,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        rejectRowIfParseError
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -1413,7 +1413,8 @@ public class AppenderatorDriverRealtimeIndexTaskTest extends InitializedNullHand
         null,
         logParseExceptions,
         maxParseExceptions,
-        maxSavedParseExceptions
+        maxSavedParseExceptions,
+        null
     );
     return new AppenderatorDriverRealtimeIndexTask(
         taskId,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorsTest.java
@@ -175,7 +175,8 @@ public class AppenderatorsTest
           0L,
           OffHeapMemorySegmentWriteOutMediumFactory.instance(),
           IndexMerger.UNLIMITED_MAX_COLUMNS_TO_MERGE,
-          basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory
+          basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory,
+          null
       );
       metrics = new FireDepartmentMetrics();
 
@@ -347,6 +348,7 @@ public class AppenderatorsTest
       private final IndexSpec indexSpecForIntermediatePersists;
       @Nullable
       private final SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
+      private final boolean rejectRowIfParseError;
 
       public TestIndexTuningConfig(
           AppendableIndexSpec appendableIndexSpec,
@@ -359,7 +361,8 @@ public class AppenderatorsTest
           Long pushTimeout,
           @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
           Integer maxColumnsToMerge,
-          File basePersistDirectory
+          File basePersistDirectory,
+          Boolean rejectRowIfParseError
       )
       {
         this.appendableIndexSpec = appendableIndexSpec;
@@ -376,6 +379,9 @@ public class AppenderatorsTest
 
         this.partitionsSpec = null;
         this.indexSpecForIntermediatePersists = this.indexSpec;
+        this.rejectRowIfParseError = rejectRowIfParseError == null ?
+                                     TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR :
+                                     rejectRowIfParseError;
       }
 
       @Override
@@ -400,6 +406,12 @@ public class AppenderatorsTest
       public long getMaxBytesInMemory()
       {
         return maxBytesInMemory;
+      }
+
+      @Override
+      public boolean isRejectRowIfParseError()
+      {
+        return false;
       }
 
       @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
@@ -179,7 +179,8 @@ public class BatchAppenderatorsTest
           0L,
           OffHeapMemorySegmentWriteOutMediumFactory.instance(),
           IndexMerger.UNLIMITED_MAX_COLUMNS_TO_MERGE,
-          basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory
+          basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory,
+          null
       );
       metrics = new FireDepartmentMetrics();
 
@@ -375,6 +376,7 @@ public class BatchAppenderatorsTest
       private final IndexSpec indexSpecForIntermediatePersists;
       @Nullable
       private final SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
+      private final boolean rejectRowIfParseError;
 
       public TestIndexTuningConfig(
           AppendableIndexSpec appendableIndexSpec,
@@ -387,7 +389,8 @@ public class BatchAppenderatorsTest
           Long pushTimeout,
           @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
           Integer maxColumnsToMerge,
-          File basePersistDirectory
+          File basePersistDirectory,
+          Boolean rejectRowIfParseError
       )
       {
         this.appendableIndexSpec = appendableIndexSpec;
@@ -404,6 +407,9 @@ public class BatchAppenderatorsTest
 
         this.partitionsSpec = null;
         this.indexSpecForIntermediatePersists = this.indexSpec;
+        this.rejectRowIfParseError = rejectRowIfParseError == null ?
+                                     TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR :
+                                     rejectRowIfParseError;
       }
 
       @Override
@@ -428,6 +434,12 @@ public class BatchAppenderatorsTest
       public long getMaxBytesInMemory()
       {
         return maxBytesInMemory;
+      }
+
+      @Override
+      public boolean isRejectRowIfParseError()
+      {
+        return false;
       }
 
       @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -265,6 +265,7 @@ public class ClientCompactionTaskQuerySerdeTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -316,6 +316,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -346,6 +346,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -579,6 +580,7 @@ public class CompactionTaskTest
             null,
             null,
             null,
+            null,
             null
         ),
         null,
@@ -642,6 +644,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         null
     );
 
@@ -666,6 +669,7 @@ public class CompactionTaskTest
         null,
         true,
         false,
+        null,
         null,
         null,
         null,
@@ -725,6 +729,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         null
     );
 
@@ -750,6 +755,7 @@ public class CompactionTaskTest
         true,
         false,
         5000L,
+        null,
         null,
         null,
         null,
@@ -911,6 +917,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         null
     );
     final List<ParallelIndexIngestionSpec> ingestionSpecs = CompactionTask.createIngestionSchema(
@@ -972,6 +979,7 @@ public class CompactionTaskTest
         false,
         false,
         5000L,
+        null,
         null,
         null,
         null,
@@ -1049,6 +1057,7 @@ public class CompactionTaskTest
         null,
         null,
         10,
+        null,
         null,
         null,
         null,
@@ -1677,6 +1686,7 @@ public class CompactionTaskTest
             true,
             false,
             5000L,
+            null,
             null,
             null,
             null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTuningConfigTest.java
@@ -102,7 +102,8 @@ public class CompactionTuningConfigTest
         null,
         null,
         null,
-        5L
+        5L,
+        null
     );
   }
 
@@ -144,7 +145,8 @@ public class CompactionTuningConfigTest
         null,
         null,
         null,
-        0L
+        0L,
+        null
     );
     Assert.assertEquals(0L, tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }
@@ -184,6 +186,7 @@ public class CompactionTuningConfigTest
         null,
         null,
         false,
+        null,
         null,
         null,
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
@@ -85,7 +85,8 @@ public class IndexTaskSerdeTest
         10,
         100,
         1234,
-        0L
+        0L,
+        false
     );
     assertSerdeTuningConfig(tuningConfig);
   }
@@ -122,7 +123,8 @@ public class IndexTaskSerdeTest
         10,
         100,
         null,
-        -1L
+        -1L,
+        true
     );
     assertSerdeTuningConfig(tuningConfig);
   }
@@ -159,7 +161,8 @@ public class IndexTaskSerdeTest
         10,
         100,
         null,
-        1L
+        1L,
+        null
     );
     assertSerdeTuningConfig(tuningConfig);
   }
@@ -196,6 +199,7 @@ public class IndexTaskSerdeTest
         10,
         100,
         1234,
+        null,
         null
     );
     assertSerdeTuningConfig(tuningConfig);
@@ -235,6 +239,7 @@ public class IndexTaskSerdeTest
         10,
         100,
         null,
+        null,
         null
     );
   }
@@ -272,6 +277,7 @@ public class IndexTaskSerdeTest
         true,
         10,
         100,
+        null,
         null,
         null
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -1346,6 +1346,7 @@ public class IndexTaskTest extends IngestionTestBase
         7,
         7,
         null,
+        null,
         null
     );
 
@@ -1480,6 +1481,7 @@ public class IndexTaskTest extends IngestionTestBase
         2,
         5,
         null,
+        null,
         null
     );
 
@@ -1605,6 +1607,7 @@ public class IndexTaskTest extends IngestionTestBase
         true,
         2,
         5,
+        null,
         null,
         null
     );
@@ -2419,6 +2422,7 @@ public class IndexTaskTest extends IngestionTestBase
         null,
         null,
         1,
+        null,
         null,
         null
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -850,6 +850,7 @@ public class RealtimeIndexTaskTest extends InitializedNullHandlingTest
         handoffTimeout,
         null,
         null,
+        null,
         null
     );
     return new RealtimeIndexTask(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -270,7 +270,8 @@ public class TaskSerdeTest
                 null,
                 null,
                 null,
-                1L
+                1L,
+                null
             )
         ),
         null
@@ -355,6 +356,7 @@ public class TaskSerdeTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         ),
@@ -421,6 +423,7 @@ public class TaskSerdeTest
                 0,
                 0,
                 true,
+                null,
                 null,
                 null,
                 null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -179,6 +179,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
           null,
           5,
           null,
+          null,
           null
       );
 
@@ -288,6 +289,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         null,
         null,
         maxNumConcurrentSubTasks,
+        null,
         null,
         null,
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -201,6 +201,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
             null,
             null,
             null,
+            null,
             null
         )
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -448,6 +448,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
             null,
             null,
             null,
+            null,
             null
         )
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
@@ -275,6 +275,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
           null,
           null,
           null,
+          null,
           null
       );
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -251,6 +251,7 @@ public class ParallelIndexSupervisorTaskTest
           null,
           null,
           null,
+          null,
           null
       );
       final ParallelIndexIngestionSpec indexIngestionSpec = new ParallelIndexIngestionSpec(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
@@ -187,6 +187,7 @@ class ParallelIndexTestingFactory
           maxParseExceptions,
           25,
           null,
+          null,
           null
       );
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
@@ -102,6 +102,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
     final byte[] json = mapper.writeValueAsBytes(tuningConfig);
@@ -148,6 +149,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
     final byte[] json = mapper.writeValueAsBytes(tuningConfig);
@@ -191,6 +193,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         false,
+        null,
         null,
         null,
         null,
@@ -242,6 +245,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -284,6 +288,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         false,
+        null,
         null,
         null,
         null,
@@ -332,6 +337,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -374,6 +380,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         false,
+        null,
         null,
         null,
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -533,6 +533,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
             null,
             null,
             null,
+            null,
             null
         ),
         VALID_INPUT_SOURCE_FILTER

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -771,6 +771,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         ),
@@ -847,6 +848,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 null,
                 3,
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -1290,6 +1292,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         ),
@@ -1393,6 +1396,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 null,
                 3,
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -1564,6 +1568,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
         null,
         0,
         0,
+        null,
         null,
         null,
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -501,6 +501,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
                 null,
                 null,
                 null,
+                null,
                 null
         )
         {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -1012,6 +1012,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             null,
             null,
             null,
+            null,
             null
         )
         {

--- a/processing/src/main/java/org/apache/druid/segment/incremental/AppendableIndexBuilder.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/AppendableIndexBuilder.java
@@ -34,6 +34,7 @@ public abstract class AppendableIndexBuilder
   protected boolean sortFacts = true;
   protected int maxRowCount = 0;
   protected long maxBytesInMemory = 0;
+  protected boolean rejectRowIfParseError = false;
 
   protected final Logger log = new Logger(this.getClass());
 
@@ -103,6 +104,12 @@ public abstract class AppendableIndexBuilder
   public AppendableIndexBuilder setMaxBytesInMemory(final long maxBytesInMemory)
   {
     this.maxBytesInMemory = maxBytesInMemory;
+    return this;
+  }
+
+  public AppendableIndexBuilder setRejectRowIfParseError(boolean rejectRowIfParseError)
+  {
+    this.rejectRowIfParseError = rejectRowIfParseError;
     return this;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -454,7 +454,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
    */
   public IncrementalIndexAddResult add(InputRow row) throws IndexSizeExceededException
   {
-    return add(row, false);
+    return add(row, false, false);
   }
 
   /**
@@ -467,10 +467,12 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
    *
    * @param row the row of data to add
    * @param skipMaxRowsInMemoryCheck whether or not skip the check of rows exceeding the max rows limit
+   * @param rejectRowIfParseError whether ot not to skip adding a row for which a parsing error is found.
    * @return the number of rows in the data set after adding the InputRow. If any parse failure occurs, a {@link ParseException} is returned in {@link IncrementalIndexAddResult}.
    * @throws IndexSizeExceededException this exception is thrown once it reaches max rows limit and skipMaxRowsInMemoryCheck is set to false.
    */
-  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck) throws IndexSizeExceededException
+  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck, boolean rejectRowIfParseError)
+      throws IndexSizeExceededException
   {
     IncrementalIndexRowResult incrementalIndexRowResult = toIncrementalIndexRow(row);
     final AddToFactsResult addToFactsResult = addToFacts(

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -484,7 +484,10 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
         skipMaxRowsInMemoryCheck,
         rejectRowIfParseError
     );
-    updateMaxIngestedTime(row.getTimestamp());
+    if (!rejectRowIfParseError || (incrementalIndexRowResult.getParseExceptionMessages().isEmpty()
+                                   && addToFactsResult.parseExceptionMessages.isEmpty())) {
+      updateMaxIngestedTime(row.getTimestamp());
+    }
     @Nullable ParseException parseException = getCombinedParseException(
         row,
         incrementalIndexRowResult.getParseExceptionMessages(),

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -631,6 +631,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
       stringBuilder.delete(messageLen - 1, messageLen);
     }
     return new ParseException(
+
         true,
         "Found unparseable columns in row: [%s], exceptions: [%s]",
         row,

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -69,6 +69,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex
   private final long maxBytesPerRowForAggregators;
   protected final int maxRowCount;
   protected final long maxBytesInMemory;
+  protected final boolean rejectRowIfParseError;
 
   @Nullable
   private volatile Map<String, ColumnSelectorFactory> selectors;
@@ -81,12 +82,14 @@ public class OnheapIncrementalIndex extends IncrementalIndex
       boolean concurrentEventAdd,
       boolean sortFacts,
       int maxRowCount,
-      long maxBytesInMemory
+      long maxBytesInMemory,
+      boolean rejectRowIfParseError
   )
   {
     super(incrementalIndexSchema, deserializeComplexMetrics, concurrentEventAdd);
     this.maxRowCount = maxRowCount;
     this.maxBytesInMemory = maxBytesInMemory == 0 ? Long.MAX_VALUE : maxBytesInMemory;
+    this.rejectRowIfParseError = rejectRowIfParseError;
     this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator(), getDimensions())
                                                    : new PlainFactsHolder(sortFacts, dimsComparator());
     maxBytesPerRowForAggregators = getMaxBytesPerRowForAggregators(incrementalIndexSchema);
@@ -500,7 +503,8 @@ public class OnheapIncrementalIndex extends IncrementalIndex
           concurrentEventAdd,
           sortFacts,
           maxRowCount,
-          maxBytesInMemory
+          maxBytesInMemory,
+          rejectRowIfParseError
       );
     }
   }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -169,11 +169,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex
     final AtomicInteger numEntries = getNumEntries();
     final AtomicLong sizeInBytes = getBytesInMemory();
     if (rejectRowIfParseError && !incrementalIndexRowResult.getParseExceptionMessages().isEmpty()) {
-      return new AddToFactsResult(
-          numEntries.get(),
-          sizeInBytes.get(),
-          incrementalIndexRowResult.getParseExceptionMessages()
-      );
+      return new AddToFactsResult(numEntries.get(), sizeInBytes.get(), parseExceptionMessages);
     }
     if (IncrementalIndexRow.EMPTY_ROW_INDEX != priorIndex) {
       aggs = concurrentGet(priorIndex);

--- a/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -184,11 +184,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
       final AtomicInteger numEntries = getNumEntries();
       final AtomicLong sizeInBytes = getBytesInMemory();
       if (rejectRowIfParseError && !incrementalIndexRowResult.getParseExceptionMessages().isEmpty()) {
-        return new AddToFactsResult(
-            numEntries.get(),
-            sizeInBytes.get(),
-            incrementalIndexRowResult.getParseExceptionMessages()
-        );
+        return new AddToFactsResult(numEntries.get(), sizeInBytes.get(), new ArrayList<>());
       }
       if (null != priorIdex) {
         aggs = indexedMap.get(priorIdex);

--- a/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -172,8 +172,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
         IncrementalIndexRowResult incrementalIndexRowResult,
         ThreadLocal<InputRow> rowContainer,
         Supplier<InputRow> rowSupplier,
-        boolean skipMaxRowsInMemoryCheck, // ignore for benchmark
-        boolean rejectRowIfParseError
+        boolean skipMaxRowsInMemoryCheck // ignore for benchmark
     ) throws IndexSizeExceededException
     {
       IncrementalIndexRow key = incrementalIndexRowResult.getIncrementalIndexRow();
@@ -183,7 +182,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
       final AggregatorFactory[] metrics = getMetrics();
       final AtomicInteger numEntries = getNumEntries();
       final AtomicLong sizeInBytes = getBytesInMemory();
-      if (rejectRowIfParseError && !incrementalIndexRowResult.getParseExceptionMessages().isEmpty()) {
+      if (this.rejectRowIfParseError && !incrementalIndexRowResult.getParseExceptionMessages().isEmpty()) {
         return new AddToFactsResult(numEntries.get(), sizeInBytes.get(), new ArrayList<>());
       }
       if (null != priorIdex) {

--- a/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -114,7 +114,8 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
         boolean concurrentEventAdd,
         boolean sortFacts,
         int maxRowCount,
-        long maxBytesInMemory
+        long maxBytesInMemory,
+        boolean rejectRowIfParseError
     )
     {
       super(
@@ -123,7 +124,8 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
           concurrentEventAdd,
           sortFacts,
           maxRowCount,
-          maxBytesInMemory
+          maxBytesInMemory,
+          rejectRowIfParseError
       );
     }
 
@@ -132,7 +134,8 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
         Granularity gran,
         AggregatorFactory[] metrics,
         int maxRowCount,
-        long maxBytesInMemory
+        long maxBytesInMemory,
+        boolean rejectRowIfParseError
     )
     {
       super(
@@ -145,7 +148,8 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
           false,
           true,
           maxRowCount,
-          maxBytesInMemory
+          maxBytesInMemory,
+          rejectRowIfParseError
       );
     }
 

--- a/server/src/main/java/org/apache/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/RealtimeTuningConfig.java
@@ -84,7 +84,8 @@ public class RealtimeTuningConfig implements AppenderatorConfig
         DEFAULT_HANDOFF_CONDITION_TIMEOUT,
         DEFAULT_ALERT_TIMEOUT,
         null,
-        DEFAULT_DEDUP_COLUMN
+        DEFAULT_DEDUP_COLUMN,
+        DEFAULT_REJECT_ROW_IF_PARSE_ERROR
     );
   }
 
@@ -110,6 +111,7 @@ public class RealtimeTuningConfig implements AppenderatorConfig
   private final SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
   @Nullable
   private final String dedupColumn;
+  private final boolean rejectRowIfParseError;
 
   @JsonCreator
   public RealtimeTuningConfig(
@@ -132,7 +134,8 @@ public class RealtimeTuningConfig implements AppenderatorConfig
       @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout,
       @JsonProperty("alertTimeout") Long alertTimeout,
       @JsonProperty("segmentWriteOutMediumFactory") @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
-      @JsonProperty("dedupColumn") @Nullable String dedupColumn
+      @JsonProperty("dedupColumn") @Nullable String dedupColumn,
+      @JsonProperty("rejectRowIfParseError") @Nullable Boolean rejectRowIfParseError
   )
   {
     this.appendableIndexSpec = appendableIndexSpec == null ? DEFAULT_APPENDABLE_INDEX : appendableIndexSpec;
@@ -170,6 +173,9 @@ public class RealtimeTuningConfig implements AppenderatorConfig
     Preconditions.checkArgument(this.alertTimeout >= 0, "alertTimeout must be >= 0");
     this.segmentWriteOutMediumFactory = segmentWriteOutMediumFactory;
     this.dedupColumn = dedupColumn == null ? DEFAULT_DEDUP_COLUMN : dedupColumn;
+    this.rejectRowIfParseError = rejectRowIfParseError == null
+                                 ? TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR
+                                 : rejectRowIfParseError;
   }
 
   @Override
@@ -191,6 +197,12 @@ public class RealtimeTuningConfig implements AppenderatorConfig
   public long getMaxBytesInMemory()
   {
     return maxBytesInMemory;
+  }
+
+  @Override
+  public boolean isRejectRowIfParseError()
+  {
+    return rejectRowIfParseError;
   }
 
   @JsonProperty
@@ -333,7 +345,8 @@ public class RealtimeTuningConfig implements AppenderatorConfig
         handoffConditionTimeout,
         alertTimeout,
         segmentWriteOutMediumFactory,
-        dedupColumn
+        dedupColumn,
+        rejectRowIfParseError
     );
   }
 
@@ -360,7 +373,8 @@ public class RealtimeTuningConfig implements AppenderatorConfig
         handoffConditionTimeout,
         alertTimeout,
         segmentWriteOutMediumFactory,
-        dedupColumn
+        dedupColumn,
+        rejectRowIfParseError
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/RealtimeTuningConfig.java
@@ -200,6 +200,7 @@ public class RealtimeTuningConfig implements AppenderatorConfig
   }
 
   @Override
+  @JsonProperty
   public boolean isRejectRowIfParseError()
   {
     return rejectRowIfParseError;

--- a/server/src/main/java/org/apache/druid/segment/indexing/TuningConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/TuningConfig.java
@@ -41,6 +41,7 @@ public interface TuningConfig
   int DEFAULT_MAX_ROWS_IN_MEMORY = 1_000_000;
   boolean DEFAULT_SKIP_BYTES_IN_MEMORY_OVERHEAD_CHECK = false;
   long DEFAULT_AWAIT_SEGMENT_AVAILABILITY_TIMEOUT_MILLIS = 0L;
+  boolean DEFAULT_REJECT_ROW_IF_PARSE_ERROR = false;
 
   /**
    * The incremental index implementation to use
@@ -75,6 +76,8 @@ public interface TuningConfig
       return Long.MAX_VALUE;
     }
   }
+
+  boolean isRejectRowIfParseError();
 
   PartitionsSpec getPartitionsSpec();
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderator.java
@@ -204,6 +204,8 @@ public interface Appenderator extends QuerySegmentWalker
       boolean useUniquePath
   );
 
+  boolean isSegmentEmpty(SegmentIdWithShardSpec identifer);
+
   /**
    * Stop any currently-running processing and clean up after ourselves. This allows currently running persists and
    * pushes to finish. This will not remove any on-disk persisted data, but it will drop any data that has not yet been

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -304,7 +304,7 @@ public class AppenderatorImpl implements Appenderator
     final IncrementalIndexAddResult addResult;
 
     try {
-      addResult = sink.add(row, !allowIncrementalPersists);
+      addResult = sink.add(row, !allowIncrementalPersists, tuningConfig.isRejectRowIfParseError());
       sinkRowsInMemoryAfterAdd = addResult.getRowCount();
       bytesInMemoryAfterAdd = addResult.getBytesInMemory();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -304,7 +304,7 @@ public class AppenderatorImpl implements Appenderator
     final IncrementalIndexAddResult addResult;
 
     try {
-      addResult = sink.add(row, !allowIncrementalPersists, tuningConfig.isRejectRowIfParseError());
+      addResult = sink.add(row, !allowIncrementalPersists);
       sinkRowsInMemoryAfterAdd = addResult.getRowCount();
       bytesInMemoryAfterAdd = addResult.getBytesInMemory();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -145,6 +145,7 @@ public class AppenderatorImpl implements Appenderator
   private final Set<SegmentIdWithShardSpec> droppingSinks = Sets.newConcurrentHashSet();
   private final VersionedIntervalTimeline<String, Sink> sinkTimeline;
   private final long maxBytesTuningConfig;
+  private final boolean rejectRowIfParseError;
   private final boolean skipBytesInMemoryOverheadCheck;
 
   private final QuerySegmentWalker texasRanger;
@@ -236,6 +237,7 @@ public class AppenderatorImpl implements Appenderator
 
     maxBytesTuningConfig = tuningConfig.getMaxBytesInMemoryOrDefault();
     skipBytesInMemoryOverheadCheck = tuningConfig.isSkipBytesInMemoryOverheadCheck();
+    rejectRowIfParseError = tuningConfig.isRejectRowIfParseError();
 
     if (isOpenSegments) {
       log.info("Running open segments appenderator");
@@ -496,7 +498,8 @@ public class AppenderatorImpl implements Appenderator
           tuningConfig.getAppendableIndexSpec(),
           tuningConfig.getMaxRowsInMemory(),
           maxBytesTuningConfig,
-          null
+          null,
+          rejectRowIfParseError
       );
       bytesCurrentlyInMemory.addAndGet(calculateSinkMemoryInUsed(retVal));
 
@@ -1297,6 +1300,7 @@ public class AppenderatorImpl implements Appenderator
             tuningConfig.getMaxRowsInMemory(),
             maxBytesTuningConfig,
             null,
+            rejectRowIfParseError,
             hydrants
         );
         rowsSoFar += currSink.getNumRows();

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
@@ -491,7 +491,11 @@ public abstract class BaseAppenderatorDriver implements Closeable
               .map(SegmentIdWithShardSpec::fromDataSegment)
               .collect(Collectors.toSet());
 
-          if (!pushedSegments.equals(Sets.newHashSet(segmentIdentifiers))) {
+          Set<SegmentIdWithShardSpec> segmentsThatShouldBePushed = segmentIdentifiers
+              .stream()
+              .filter(s -> !appenderator.isSegmentEmpty(s))
+              .collect(Collectors.toSet());
+          if (!pushedSegments.equals(Sets.newHashSet(segmentsThatShouldBePushed))) {
             log.warn(
                 "Removing [%s] segments from deep storage because sanity check failed",
                 segmentsAndMetadata.getSegments().size()
@@ -506,7 +510,7 @@ public abstract class BaseAppenderatorDriver implements Closeable
             throw new ISE(
                 "Pushed different segments than requested. Pushed[%s], requested[%s].",
                 pushedSegments,
-                segmentIdentifiers
+                segmentsThatShouldBePushed
             );
           }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
@@ -280,7 +280,7 @@ public class BatchAppenderator implements Appenderator
     final IncrementalIndexAddResult addResult;
 
     try {
-      addResult = sink.add(row, false); // allow incrememtal persis is always true for batch
+      addResult = sink.add(row, false, tuningConfig.isRejectRowIfParseError()); // allow incrememtal persis is always true for batch
       sinkRowsInMemoryAfterAdd = addResult.getRowCount();
       bytesInMemoryAfterAdd = addResult.getBytesInMemory();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
@@ -465,7 +465,8 @@ public class BatchAppenderator implements Appenderator
           tuningConfig.getAppendableIndexSpec(),
           tuningConfig.getMaxRowsInMemory(),
           maxBytesTuningConfig,
-          null
+          null,
+          tuningConfig.isRejectRowIfParseError()
       );
       bytesCurrentlyInMemory += calculateSinkMemoryInUsed();
       sinks.put(identifier, retVal);
@@ -1029,6 +1030,7 @@ public class BatchAppenderator implements Appenderator
         tuningConfig.getMaxRowsInMemory(),
         maxBytesTuningConfig,
         null,
+        tuningConfig.isRejectRowIfParseError(),
         hydrants
     );
     retVal.finishWriting(); // this sink is not writable

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
@@ -280,7 +280,7 @@ public class BatchAppenderator implements Appenderator
     final IncrementalIndexAddResult addResult;
 
     try {
-      addResult = sink.add(row, false, tuningConfig.isRejectRowIfParseError()); // allow incrememtal persis is always true for batch
+      addResult = sink.add(row, false); // allow incrememtal persis is always true for batch
       sinkRowsInMemoryAfterAdd = addResult.getRowCount();
       bytesInMemoryAfterAdd = addResult.getBytesInMemory();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
@@ -270,7 +270,7 @@ public class StreamAppenderator implements Appenderator
     final IncrementalIndexAddResult addResult;
 
     try {
-      addResult = sink.add(row, !allowIncrementalPersists);
+      addResult = sink.add(row, !allowIncrementalPersists, tuningConfig.isRejectRowIfParseError());
       sinkRowsInMemoryAfterAdd = addResult.getRowCount();
       bytesInMemoryAfterAdd = addResult.getBytesInMemory();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
@@ -270,7 +270,7 @@ public class StreamAppenderator implements Appenderator
     final IncrementalIndexAddResult addResult;
 
     try {
-      addResult = sink.add(row, !allowIncrementalPersists, tuningConfig.isRejectRowIfParseError());
+      addResult = sink.add(row, !allowIncrementalPersists);
       sinkRowsInMemoryAfterAdd = addResult.getRowCount();
       bytesInMemoryAfterAdd = addResult.getBytesInMemory();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
@@ -464,7 +464,8 @@ public class StreamAppenderator implements Appenderator
           tuningConfig.getAppendableIndexSpec(),
           tuningConfig.getMaxRowsInMemory(),
           maxBytesTuningConfig,
-          null
+          null,
+          tuningConfig.isRejectRowIfParseError()
       );
       bytesCurrentlyInMemory.addAndGet(calculateSinkMemoryInUsed(retVal));
 
@@ -1220,6 +1221,7 @@ public class StreamAppenderator implements Appenderator
             tuningConfig.getMaxRowsInMemory(),
             maxBytesTuningConfig,
             null,
+            tuningConfig.isRejectRowIfParseError(),
             hydrants
         );
         rowsSoFar += currSink.getNumRows();

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
@@ -393,7 +393,11 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
   private AppenderatorConfig rewriteAppenderatorConfigMemoryLimits(AppenderatorConfig baseConfig)
   {
     long perWorkerLimit = workerConfig.getGlobalIngestionHeapLimitBytes() / workerConfig.getCapacity();
-    return new MemoryParameterOverridingAppenderatorConfig(baseConfig, perWorkerLimit);
+    return new MemoryParameterOverridingAppenderatorConfig(
+        baseConfig,
+        perWorkerLimit,
+        baseConfig.isRejectRowIfParseError()
+    );
   }
 
   @VisibleForTesting
@@ -452,14 +456,17 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
   {
     private final AppenderatorConfig baseConfig;
     private final long newMaxBytesInMemory;
+    private final boolean rejectRowIfParseError;
 
     public MemoryParameterOverridingAppenderatorConfig(
         AppenderatorConfig baseConfig,
-        long newMaxBytesInMemory
+        long newMaxBytesInMemory,
+        boolean rejectRowIfParseError
     )
     {
       this.baseConfig = baseConfig;
       this.newMaxBytesInMemory = newMaxBytesInMemory;
+      this.rejectRowIfParseError = rejectRowIfParseError;
     }
 
     @Override
@@ -484,6 +491,12 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
     public long getMaxBytesInMemory()
     {
       return newMaxBytesInMemory;
+    }
+
+    @Override
+    public boolean isRejectRowIfParseError()
+    {
+      return rejectRowIfParseError;
     }
 
     @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -224,7 +224,7 @@ public class RealtimePlumber implements Plumber
       return Plumber.THROWAWAY;
     }
 
-    final IncrementalIndexAddResult addResult = sink.add(row, false, config.isRejectRowIfParseError());
+    final IncrementalIndexAddResult addResult = sink.add(row, false);
     if (config.isReportParseExceptions() && addResult.getParseException() != null) {
       throw addResult.getParseException();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -264,7 +264,8 @@ public class RealtimePlumber implements Plumber
           config.getAppendableIndexSpec(),
           config.getMaxRowsInMemory(),
           config.getMaxBytesInMemoryOrDefault(),
-          config.getDedupColumn()
+          config.getDedupColumn(),
+          config.isRejectRowIfParseError()
       );
       addSink(retVal);
 
@@ -730,6 +731,7 @@ public class RealtimePlumber implements Plumber
           config.getMaxRowsInMemory(),
           config.getMaxBytesInMemoryOrDefault(),
           config.getDedupColumn(),
+          config.isRejectRowIfParseError(),
           hydrants
       );
       addSink(currSink);

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -224,7 +224,7 @@ public class RealtimePlumber implements Plumber
       return Plumber.THROWAWAY;
     }
 
-    final IncrementalIndexAddResult addResult = sink.add(row, false);
+    final IncrementalIndexAddResult addResult = sink.add(row, false, config.isRejectRowIfParseError());
     if (config.isReportParseExceptions() && addResult.getParseException() != null) {
       throw addResult.getParseException();
     }

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
@@ -67,6 +67,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
   private final AppendableIndexSpec appendableIndexSpec;
   private final int maxRowsInMemory;
   private final long maxBytesInMemory;
+  private final boolean rejectRowIfParseError;
   private final CopyOnWriteArrayList<FireHydrant> hydrants = new CopyOnWriteArrayList<>();
   private final LinkedHashSet<String> dimOrder = new LinkedHashSet<>();
   private final AtomicInteger numRowsExcludingCurrIndex = new AtomicInteger();
@@ -84,7 +85,8 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
       AppendableIndexSpec appendableIndexSpec,
       int maxRowsInMemory,
       long maxBytesInMemory,
-      String dedupColumn
+      String dedupColumn,
+      boolean rejectRowIfParseError
   )
   {
     this(
@@ -96,6 +98,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
         maxRowsInMemory,
         maxBytesInMemory,
         dedupColumn,
+        rejectRowIfParseError,
         Collections.emptyList()
     );
   }
@@ -109,6 +112,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
       int maxRowsInMemory,
       long maxBytesInMemory,
       String dedupColumn,
+      boolean rejectRowIfParseError,
       List<FireHydrant> hydrants
   )
   {
@@ -120,6 +124,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
     this.maxRowsInMemory = maxRowsInMemory;
     this.maxBytesInMemory = maxBytesInMemory;
     this.dedupColumn = dedupColumn;
+    this.rejectRowIfParseError = rejectRowIfParseError;
 
     int maxCount = -1;
     for (int i = 0; i < hydrants.size(); ++i) {
@@ -334,6 +339,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
         .setIndexSchema(indexSchema)
         .setMaxRowCount(maxRowsInMemory)
         .setMaxBytesInMemory(maxBytesInMemory)
+        .setRejectRowIfParseError(rejectRowIfParseError)
         .build();
 
     final FireHydrant old;

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
@@ -161,7 +161,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
     return currHydrant;
   }
 
-  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck) throws IndexSizeExceededException
+  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck, boolean rejectRowIfParseError) throws IndexSizeExceededException
   {
     if (currHydrant == null) {
       throw new IAE("No currHydrant but given row[%s]", row);
@@ -181,7 +181,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
         return Plumber.DUPLICATE;
       }
 
-      return index.add(row, skipMaxRowsInMemoryCheck);
+      return index.add(row, skipMaxRowsInMemoryCheck, rejectRowIfParseError);
     }
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
@@ -161,7 +161,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
     return currHydrant;
   }
 
-  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck, boolean rejectRowIfParseError) throws IndexSizeExceededException
+  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck) throws IndexSizeExceededException
   {
     if (currHydrant == null) {
       throw new IAE("No currHydrant but given row[%s]", row);
@@ -181,7 +181,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
         return Plumber.DUPLICATE;
       }
 
-      return index.add(row, skipMaxRowsInMemoryCheck, rejectRowIfParseError);
+      return index.add(row, skipMaxRowsInMemoryCheck);
     }
   }
 

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
@@ -81,6 +81,7 @@ public class AppenderatorPlumberTest
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/ClosedSegmensSinksBatchAppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/ClosedSegmensSinksBatchAppenderatorTester.java
@@ -179,7 +179,8 @@ public class ClosedSegmensSinksBatchAppenderatorTester implements AutoCloseable
         0L,
         OffHeapMemorySegmentWriteOutMediumFactory.instance(),
         IndexMerger.UNLIMITED_MAX_COLUMNS_TO_MERGE,
-        basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory
+        basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory,
+        null
     );
     metrics = new FireDepartmentMetrics();
 
@@ -315,6 +316,7 @@ public class ClosedSegmensSinksBatchAppenderatorTester implements AutoCloseable
     private final IndexSpec indexSpecForIntermediatePersists;
     @Nullable
     private final SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
+    private final boolean rejectRowIfParseError;
 
     public TestIndexTuningConfig(
          AppendableIndexSpec appendableIndexSpec,
@@ -327,7 +329,8 @@ public class ClosedSegmensSinksBatchAppenderatorTester implements AutoCloseable
          Long pushTimeout,
          @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
          Integer maxColumnsToMerge,
-         File basePersistDirectory
+         File basePersistDirectory,
+         Boolean rejectRowIfParseError
     )
     {
       this.appendableIndexSpec = appendableIndexSpec;
@@ -344,6 +347,9 @@ public class ClosedSegmensSinksBatchAppenderatorTester implements AutoCloseable
 
       this.partitionsSpec = null;
       this.indexSpecForIntermediatePersists = this.indexSpec;
+      this.rejectRowIfParseError = rejectRowIfParseError == null ?
+                                   TuningConfig.DEFAULT_REJECT_ROW_IF_PARSE_ERROR :
+                                   rejectRowIfParseError;
     }
 
     @Override
@@ -369,7 +375,13 @@ public class ClosedSegmensSinksBatchAppenderatorTester implements AutoCloseable
     {
       return maxBytesInMemory;
     }
-    
+
+    @Override
+    public boolean isRejectRowIfParseError()
+    {
+      return false;
+    }
+
     @Override
     public boolean isSkipBytesInMemoryOverheadCheck()
     {

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
@@ -151,6 +151,7 @@ public class DefaultOfflineAppenderatorFactoryTest
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/OpenAndClosedSegmentsAppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/OpenAndClosedSegmentsAppenderatorTester.java
@@ -150,7 +150,8 @@ public class OpenAndClosedSegmentsAppenderatorTester implements AutoCloseable
             0L,
             OffHeapMemorySegmentWriteOutMediumFactory.instance(),
             IndexMerger.UNLIMITED_MAX_COLUMNS_TO_MERGE,
-            basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory
+            basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory,
+            null
         );
 
     metrics = new FireDepartmentMetrics();

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriverFailTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriverFailTest.java
@@ -44,6 +44,7 @@ import org.apache.druid.segment.realtime.FireDepartmentMetrics;
 import org.apache.druid.segment.realtime.appenderator.StreamAppenderatorDriverTest.TestCommitterSupplier;
 import org.apache.druid.segment.realtime.appenderator.StreamAppenderatorDriverTest.TestSegmentAllocator;
 import org.apache.druid.segment.realtime.appenderator.StreamAppenderatorDriverTest.TestSegmentHandoffNotifierFactory;
+import org.apache.druid.segment.realtime.plumber.Sink;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.easymock.EasyMock;
@@ -520,6 +521,12 @@ public class StreamAppenderatorDriverFailTest extends EasyMockSupport
           return Futures.immediateFailedFuture(new ISE("Fail test while pushing segments[%s]", identifiers));
         }
       }
+    }
+
+    @Override
+    public boolean isSegmentEmpty(SegmentIdWithShardSpec identifier)
+    {
+      return false;
     }
 
     @Override

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTester.java
@@ -194,6 +194,7 @@ public class StreamAppenderatorTester implements AutoCloseable
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/org/apache/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -220,6 +220,7 @@ public class RealtimePlumberSchoolTest extends InitializedNullHandlingTest
         null,
         null,
         null,
+        null,
         null
     );
 
@@ -283,7 +284,8 @@ public class RealtimePlumberSchoolTest extends InitializedNullHandlingTest
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxBytesInMemoryOrDefault(),
-        tuningConfig.getDedupColumn()
+        tuningConfig.getDedupColumn(),
+        tuningConfig.isRejectRowIfParseError()
     );
     plumber.getSinks().put(0L, sink);
     Assert.assertNull(plumber.startJob());
@@ -329,7 +331,8 @@ public class RealtimePlumberSchoolTest extends InitializedNullHandlingTest
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxBytesInMemoryOrDefault(),
-        tuningConfig.getDedupColumn()
+        tuningConfig.getDedupColumn(),
+        tuningConfig.isRejectRowIfParseError()
     );
     plumber.getSinks().put(0L, sink);
     plumber.startJob();
@@ -380,7 +383,8 @@ public class RealtimePlumberSchoolTest extends InitializedNullHandlingTest
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxBytesInMemoryOrDefault(),
-        tuningConfig.getDedupColumn()
+        tuningConfig.getDedupColumn(),
+        tuningConfig.isRejectRowIfParseError()
     );
     plumber2.getSinks().put(0L, sink);
     Assert.assertNull(plumber2.startJob());

--- a/server/src/test/java/org/apache/druid/segment/realtime/plumber/SinkTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/plumber/SinkTest.java
@@ -144,7 +144,6 @@ public class SinkTest extends InitializedNullHandlingTest
             return 0;
           }
         },
-        false,
         false
     );
 
@@ -199,7 +198,6 @@ public class SinkTest extends InitializedNullHandlingTest
             return 0;
           }
         },
-        false,
         false
     );
 
@@ -263,7 +261,7 @@ public class SinkTest extends InitializedNullHandlingTest
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value1", "dedupColumn", "v1")
-    ), false, false).getRowCount();
+    ), false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     // dedupColumn is null
@@ -271,7 +269,7 @@ public class SinkTest extends InitializedNullHandlingTest
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value2")
-    ), false, false).getRowCount();
+    ), false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     // dedupColumn is null
@@ -279,21 +277,21 @@ public class SinkTest extends InitializedNullHandlingTest
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value3")
-    ), false, false).getRowCount();
+    ), false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     rows = sink.add(new MapBasedInputRow(
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value4", "dedupColumn", "v2")
-    ), false, false).getRowCount();
+    ), false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     rows = sink.add(new MapBasedInputRow(
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value5", "dedupColumn", "v1")
-    ), false, false).getRowCount();
+    ), false).getRowCount();
     Assert.assertTrue(rows == -2);
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/plumber/SinkTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/plumber/SinkTest.java
@@ -84,6 +84,7 @@ public class SinkTest extends InitializedNullHandlingTest
         null,
         null,
         null,
+        null,
         null
     );
     final Sink sink = new Sink(
@@ -94,7 +95,8 @@ public class SinkTest extends InitializedNullHandlingTest
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxBytesInMemoryOrDefault(),
-        tuningConfig.getDedupColumn()
+        tuningConfig.getDedupColumn(),
+        tuningConfig.isRejectRowIfParseError()
     );
 
     sink.add(
@@ -240,7 +242,8 @@ public class SinkTest extends InitializedNullHandlingTest
         null,
         null,
         null,
-        "dedupColumn"
+        "dedupColumn",
+        null
     );
     final Sink sink = new Sink(
         interval,
@@ -250,7 +253,8 @@ public class SinkTest extends InitializedNullHandlingTest
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxBytesInMemoryOrDefault(),
-        tuningConfig.getDedupColumn()
+        tuningConfig.getDedupColumn(),
+        tuningConfig.isRejectRowIfParseError()
     );
 
     int rows = sink.add(new MapBasedInputRow(

--- a/server/src/test/java/org/apache/druid/segment/realtime/plumber/SinkTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/plumber/SinkTest.java
@@ -144,6 +144,7 @@ public class SinkTest extends InitializedNullHandlingTest
             return 0;
           }
         },
+        false,
         false
     );
 
@@ -198,6 +199,7 @@ public class SinkTest extends InitializedNullHandlingTest
             return 0;
           }
         },
+        false,
         false
     );
 
@@ -261,7 +263,7 @@ public class SinkTest extends InitializedNullHandlingTest
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value1", "dedupColumn", "v1")
-    ), false).getRowCount();
+    ), false, false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     // dedupColumn is null
@@ -269,7 +271,7 @@ public class SinkTest extends InitializedNullHandlingTest
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value2")
-    ), false).getRowCount();
+    ), false, false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     // dedupColumn is null
@@ -277,21 +279,21 @@ public class SinkTest extends InitializedNullHandlingTest
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value3")
-    ), false).getRowCount();
+    ), false, false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     rows = sink.add(new MapBasedInputRow(
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value4", "dedupColumn", "v2")
-    ), false).getRowCount();
+    ), false, false).getRowCount();
     Assert.assertTrue(rows > 0);
 
     rows = sink.add(new MapBasedInputRow(
         DateTimes.of("2013-01-01"),
         ImmutableList.of("field", "dedupColumn"),
         ImmutableMap.of("field1", "value5", "dedupColumn", "v1")
-    ), false).getRowCount();
+    ), false, false).getRowCount();
     Assert.assertTrue(rows == -2);
   }
 }

--- a/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
@@ -175,6 +175,7 @@ public class DruidJsonValidatorTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         ),


### PR DESCRIPTION
### Description

Added a config, `rejectRowIfParsingError` parameter to tuningConfig, which allows a user to specify that any rows that are found during ingestion to have parsing errors, should be deemed `unparseable` and discarded, instead of the existing behavior of retaining the row, but filling the column(s) which caused parsing error to be null value. The new parameter is disabled by default, which will retain the existing behavior.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
