### PR TITLE
Reduce list operation calls when pulling segments from S3

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPuller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPuller.java
@@ -71,7 +71,8 @@ public class S3DataSegmentPuller implements URIDataPuller
     this.s3Client = s3Client;
   }
 
-  FileUtils.FileCopyResult getSegmentFiles(final CloudObjectLocation s3Coords, final File outDir) throws SegmentLoadingException
+  FileUtils.FileCopyResult getSegmentFiles(final CloudObjectLocation s3Coords, final File outDir)
+      throws SegmentLoadingException
   {
 
     log.info("Pulling index at path[%s] to outDir[%s]", s3Coords, outDir);
@@ -157,6 +158,7 @@ public class S3DataSegmentPuller implements URIDataPuller
     return new FileObject()
     {
       S3Object s3Object = null;
+      S3ObjectSummary objectSummary = null;
 
       @Override
       public URI toUri()
@@ -229,8 +231,13 @@ public class S3DataSegmentPuller implements URIDataPuller
       @Override
       public long getLastModified()
       {
-        final S3ObjectSummary objectSummary =
-            S3Utils.getSingleObjectSummary(s3Client, coords.getBucket(), coords.getPath());
+        if (s3Object != null) {
+          return s3Object.getObjectMetadata().getLastModified().getTime();
+        }
+        if (objectSummary == null) {
+          objectSummary =
+              S3Utils.getSingleObjectSummary(s3Client, coords.getBucket(), coords.getPath());
+        }
         return objectSummary.getLastModified().getTime();
       }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPuller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPuller.java
@@ -149,11 +149,9 @@ public class S3DataSegmentPuller implements URIDataPuller
     }
   }
 
-  private FileObject buildFileObject(final URI uri) throws AmazonServiceException
+  public FileObject buildFileObject(final URI uri) throws AmazonServiceException
   {
     final CloudObjectLocation coords = new CloudObjectLocation(S3Utils.checkURI(uri));
-    final S3ObjectSummary objectSummary =
-        S3Utils.getSingleObjectSummary(s3Client, coords.getBucket(), coords.getPath());
     final String path = uri.getPath();
 
     return new FileObject()
@@ -182,7 +180,7 @@ public class S3DataSegmentPuller implements URIDataPuller
         try {
           if (s3Object == null) {
             // lazily promote to full GET
-            s3Object = s3Client.getObject(objectSummary.getBucketName(), objectSummary.getKey());
+            s3Object = s3Client.getObject(coords.getBucket(), coords.getPath());
           }
 
           final InputStream in = s3Object.getObjectContent();
@@ -231,6 +229,8 @@ public class S3DataSegmentPuller implements URIDataPuller
       @Override
       public long getLastModified()
       {
+        final S3ObjectSummary objectSummary =
+            S3Utils.getSingleObjectSummary(s3Client, coords.getBucket(), coords.getPath());
         return objectSummary.getLastModified().getTime();
       }
 
@@ -252,9 +252,7 @@ public class S3DataSegmentPuller implements URIDataPuller
    * Returns the "version" (aka last modified timestamp) of the URI
    *
    * @param uri The URI to check the last timestamp
-   *
    * @return The time in ms of the last modification of the URI in String format
-   *
    * @throws IOException
    */
   @Override


### PR DESCRIPTION
While fetching segments from S3, it presently creates an object summary(LIST operation) for the segment before proceeding to GET the object and so the number of LIST ops are proportional to the number of segments. Since LIST ops are more expensive compared to GET, it is desirable to reduce the number of list ops especially if the LIST limit Is much smaller than for GETs.

This PR lazily creates the object summary  since it isn't really required for pulling segments since the bucket and prefix can be retrieved from the URI and the check to validate if the object is present in the bucket is already done before attempting to pull the segment. This reduces the list operations down to zero while pulling segments.

<hr>


This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
