### PR TITLE
Fix NPE for SQL queries when a query parameter is missing in the mid

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITJdbcQueryTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.tests.query;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import org.apache.calcite.avatica.AvaticaSqlException;
 import org.apache.druid.https.SSLClientConfig;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -163,7 +164,7 @@ public class ITJdbcQueryTest
         );
       }
       catch (SQLException throwables) {
-        Assert.assertFalse(true, throwables.getMessage());
+        Assert.fail(throwables.getMessage());
       }
     }
   }
@@ -185,7 +186,7 @@ public class ITJdbcQueryTest
         }
       }
       catch (SQLException throwables) {
-        Assert.assertFalse(true, throwables.getMessage());
+        Assert.fail(throwables.getMessage());
       }
     }
   }
@@ -208,7 +209,18 @@ public class ITJdbcQueryTest
         }
       }
       catch (SQLException throwables) {
-        Assert.assertFalse(true, throwables.getMessage());
+        Assert.fail(throwables.getMessage());
+      }
+    }
+  }
+
+  @Test(expectedExceptions = AvaticaSqlException.class, expectedExceptionsMessageRegExp = ".* Parameter at position\\[0] is not bound")
+  public void testJdbcPrepareStatementQueryMissingParameters() throws SQLException
+  {
+    for (String url : connections) {
+      try (Connection connection = DriverManager.getConnection(url, connectionProperties);
+           PreparedStatement statement = connection.prepareStatement(QUERY_PARAMETERIZED);
+           ResultSet resultSet = statement.executeQuery()) {
       }
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/SqlPlanningException.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlPlanningException.java
@@ -65,7 +65,7 @@ public class SqlPlanningException extends BadQueryException
     this(PlanningError.VALIDATION_ERROR, e.getMessage());
   }
 
-  private SqlPlanningException(PlanningError planningError, String errorMessage)
+  public SqlPlanningException(PlanningError planningError, String errorMessage)
   {
     this(planningError.errorCode, errorMessage, planningError.errorClass);
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/RelParameterizerShuttle.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/RelParameterizerShuttle.java
@@ -43,6 +43,7 @@ import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 
 /**
@@ -198,6 +199,9 @@ public class RelParameterizerShuttle implements RelShuttle
       // if we have a value for dynamic parameter, replace with a literal, else add to list of unbound parameters
       if (plannerContext.getParameters().size() > dynamicParam.getIndex()) {
         TypedValue param = plannerContext.getParameters().get(dynamicParam.getIndex());
+        if (param == null) {
+          throw new IAE("Parameter at position[%s] is not bound", dynamicParam.getIndex());
+        }
         if (param.value == null) {
           return builder.makeNullLiteral(typeFactory.createSqlType(SqlTypeName.NULL));
         }
@@ -208,7 +212,7 @@ public class RelParameterizerShuttle implements RelShuttle
             true
         );
       } else {
-        throw new ISE("Parameter: [%s] is not bound", dynamicParam.getName());
+        throw new IAE("Parameter at position[%s] is not bound", dynamicParam.getIndex());
       }
     }
     return node;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/RelParameterizerShuttle.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/RelParameterizerShuttle.java
@@ -44,7 +44,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.ISE;
 
 /**
  * Traverse {@link RelNode} tree and replaces all {@link RexDynamicParam} with {@link org.apache.calcite.rex.RexLiteral}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/RelParameterizerShuttle.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/RelParameterizerShuttle.java
@@ -43,7 +43,9 @@ import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.sql.SqlPlanningException;
+import org.apache.druid.sql.SqlPlanningException.PlanningError;
 
 /**
  * Traverse {@link RelNode} tree and replaces all {@link RexDynamicParam} with {@link org.apache.calcite.rex.RexLiteral}
@@ -199,7 +201,10 @@ public class RelParameterizerShuttle implements RelShuttle
       if (plannerContext.getParameters().size() > dynamicParam.getIndex()) {
         TypedValue param = plannerContext.getParameters().get(dynamicParam.getIndex());
         if (param == null) {
-          throw new IAE("Parameter at position[%s] is not bound", dynamicParam.getIndex());
+          throw new SqlPlanningException(
+              PlanningError.VALIDATION_ERROR,
+              StringUtils.format("Parameter at position[%s] is not bound", dynamicParam.getIndex())
+          );
         }
         if (param.value == null) {
           return builder.makeNullLiteral(typeFactory.createSqlType(SqlTypeName.NULL));
@@ -211,7 +216,10 @@ public class RelParameterizerShuttle implements RelShuttle
             true
         );
       } else {
-        throw new IAE("Parameter at position[%s] is not bound", dynamicParam.getIndex());
+        throw new SqlPlanningException(
+            PlanningError.VALIDATION_ERROR,
+            StringUtils.format("Parameter at position[%s] is not bound", dynamicParam.getIndex())
+        );
       }
     }
     return node;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/SqlParameterizerShuttle.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/SqlParameterizerShuttle.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.util.TimestampString;
+import org.apache.druid.java.util.common.IAE;
 
 /**
  * Replaces all {@link SqlDynamicParam} encountered in an {@link SqlNode} tree with a {@link SqlLiteral} if a value
@@ -51,6 +52,9 @@ public class SqlParameterizerShuttle extends SqlShuttle
     try {
       if (plannerContext.getParameters().size() > param.getIndex()) {
         TypedValue paramBinding = plannerContext.getParameters().get(param.getIndex());
+        if (paramBinding == null) {
+          throw new IAE("Parameter at position[%s] is not bound", param.getIndex());
+        }
         if (paramBinding.value == null) {
           return SqlLiteral.createNull(param.getParserPosition());
         }
@@ -67,6 +71,8 @@ public class SqlParameterizerShuttle extends SqlShuttle
         }
 
         return typeName.createLiteral(paramBinding.value, param.getParserPosition());
+      } else {
+        throw new IAE("Parameter at position[%s] is not bound", param.getIndex());
       }
     }
     catch (ClassCastException ignored) {

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -36,7 +36,10 @@ public class SqlQuery
   public static List<TypedValue> getParameterList(List<SqlParameter> parameters)
   {
     return parameters.stream()
-                     .map(SqlParameter::getTypedValue)
+                     // null params are not good!
+                     // we pass them to the planner, so that it can generate a proper error message.
+                     // see SqlParameterizerShuttle and RelParameterizerShuttle.
+                     .map(p -> p == null ? null : p.getTypedValue())
                      .collect(Collectors.toList());
   }
 
@@ -49,7 +52,7 @@ public class SqlQuery
   @JsonCreator
   public SqlQuery(
       @JsonProperty("query") final String query,
-      @JsonProperty("resultFormat") final ResultFormat resultFormat,
+      @JsonProperty("resultFormat") final ResultFormat   resultFormat,
       @JsonProperty("header") final boolean header,
       @JsonProperty("context") final Map<String, Object> context,
       @JsonProperty("parameters") final List<SqlParameter> parameters

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -52,7 +52,7 @@ public class SqlQuery
   @JsonCreator
   public SqlQuery(
       @JsonProperty("query") final String query,
-      @JsonProperty("resultFormat") final ResultFormat   resultFormat,
+      @JsonProperty("resultFormat") final ResultFormat resultFormat,
       @JsonProperty("header") final boolean header,
       @JsonProperty("context") final Map<String, Object> context,
       @JsonProperty("parameters") final List<SqlParameter> parameters


### PR DESCRIPTION
### Description

NPE can be thrown when there is a query parameter missing in the mid. Here is a stack trace.

```
Caused by: java.lang.NullPointerException
	at org.apache.druid.sql.calcite.planner.SqlParameterizerShuttle.visit(SqlParameterizerShuttle.java:54)
	at org.apache.druid.sql.calcite.planner.SqlParameterizerShuttle.visit(SqlParameterizerShuttle.java:39)
	at org.apache.calcite.sql.SqlDynamicParam.accept(SqlDynamicParam.java:76)
```

This PR adds a null check for parameters and returns a more user-friendly error message.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
