### PR TITLE
Add dimension partitioningType to metrics to track usage of different partitioning schemes

### DIFF
--- a/core/src/main/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpec.java
@@ -39,8 +39,6 @@ import java.util.Objects;
  */
 public class BuildingDimensionRangeShardSpec implements BuildingShardSpec<DimensionRangeShardSpec>
 {
-  public static final String TYPE = "building_range";
-
   private final int bucketId;
   private final List<String> dimensions;
   @Nullable
@@ -122,6 +120,12 @@ public class BuildingDimensionRangeShardSpec implements BuildingShardSpec<Dimens
   public <T> PartitionChunk<T> createChunk(T obj)
   {
     return new NumberedPartitionChunk<>(partitionId, 0, obj);
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.BUILDING_RANGE;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/BuildingHashBasedNumberedShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/BuildingHashBasedNumberedShardSpec.java
@@ -36,8 +36,6 @@ import java.util.Objects;
  */
 public class BuildingHashBasedNumberedShardSpec implements BuildingShardSpec<HashBasedNumberedShardSpec>
 {
-  public static final String TYPE = "building_hashed";
-
   private final int partitionId;
   private final int bucketId;
   private final int numBuckets;
@@ -118,6 +116,12 @@ public class BuildingHashBasedNumberedShardSpec implements BuildingShardSpec<Has
         partitionFunction,
         jsonMapper
     );
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.BUILDING_HASHED;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/BuildingNumberedShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/BuildingNumberedShardSpec.java
@@ -35,7 +35,6 @@ import java.util.Objects;
  */
 public class BuildingNumberedShardSpec implements BuildingShardSpec<NumberedShardSpec>
 {
-  public static final String TYPE = "building_numbered";
 
   private final int partitionId;
 
@@ -72,6 +71,12 @@ public class BuildingNumberedShardSpec implements BuildingShardSpec<NumberedShar
   public int getPartitionNum()
   {
     return partitionId;
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.BUILDING_NUMBERED;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpec.java
@@ -37,8 +37,6 @@ import java.util.Objects;
  */
 public class BuildingSingleDimensionShardSpec extends BuildingDimensionRangeShardSpec
 {
-  public static final String TYPE = "building_single_dim";
-
   private final String dimension;
 
   @Nullable
@@ -108,6 +106,12 @@ public class BuildingSingleDimensionShardSpec extends BuildingDimensionRangeShar
   public <T> PartitionChunk<T> createChunk(T obj)
   {
     return new NumberedPartitionChunk<>(getPartitionNum(), 0, obj);
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.BUILDING_SINGLE_DIM;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpec.java
@@ -42,8 +42,6 @@ import java.util.Objects;
  */
 public class DimensionRangeBucketShardSpec implements BucketNumberedShardSpec<BuildingDimensionRangeShardSpec>
 {
-  public static final String TYPE = "bucket_range";
-
   private final int bucketId;
   private final List<String> dimensions;
   @Nullable
@@ -137,6 +135,12 @@ public class DimensionRangeBucketShardSpec implements BucketNumberedShardSpec<Bu
   private boolean isInChunk(InputRow inputRow)
   {
     return DimensionRangeShardSpec.isInChunk(dimensions, start, end, inputRow);
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.BUCKET_RANGE;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeShardSpec.java
@@ -213,6 +213,12 @@ public class DimensionRangeShardSpec implements ShardSpec
   }
 
   @Override
+  public String getType()
+  {
+    return Type.RANGE;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/core/src/main/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpec.java
@@ -246,6 +246,12 @@ public class HashBasedNumberedShardSpec extends NumberedShardSpec
   }
 
   @Override
+  public String getType()
+  {
+    return Type.HASHED;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/core/src/main/java/org/apache/druid/timeline/partition/HashBucketShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/HashBucketShardSpec.java
@@ -35,8 +35,6 @@ import java.util.Objects;
  */
 public class HashBucketShardSpec implements BucketNumberedShardSpec<BuildingHashBasedNumberedShardSpec>
 {
-  public static final String TYPE = "bucket_hash";
-
   private final int bucketId;
   private final int numBuckets;
   private final List<String> partitionDimensions;
@@ -108,6 +106,12 @@ public class HashBucketShardSpec implements BucketNumberedShardSpec<BuildingHash
         partitionDimensions,
         numBuckets
     ).createHashLookup(shardSpecs);
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.BUCKET_HASH;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/LinearShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/LinearShardSpec.java
@@ -80,6 +80,12 @@ public final class LinearShardSpec implements ShardSpec
   }
 
   @Override
+  public String getType()
+  {
+    return Type.LINEAR;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/core/src/main/java/org/apache/druid/timeline/partition/NoneShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/NoneShardSpec.java
@@ -84,6 +84,12 @@ public class NoneShardSpec implements ShardSpec
   }
 
   @Override
+  public String getType()
+  {
+    return Type.NONE;
+  }
+
+  @Override
   public boolean equals(Object obj)
   {
     return obj instanceof NoneShardSpec;

--- a/core/src/main/java/org/apache/druid/timeline/partition/NumberedOverwriteShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/NumberedOverwriteShardSpec.java
@@ -53,7 +53,6 @@ import java.util.Objects;
  */
 public class NumberedOverwriteShardSpec implements OverwriteShardSpec
 {
-  public static final String TYPE = "numbered_overwrite";
   private final int partitionId;
 
   private final short startRootPartitionId;
@@ -197,6 +196,12 @@ public class NumberedOverwriteShardSpec implements OverwriteShardSpec
   public boolean possibleInDomain(Map<String, RangeSet<String>> domain)
   {
     return true;
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.NUMBERED_OVERWRITE;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/NumberedShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/NumberedShardSpec.java
@@ -107,6 +107,12 @@ public class NumberedShardSpec implements ShardSpec
   }
 
   @Override
+  public String getType()
+  {
+    return Type.NUMBERED;
+  }
+
+  @Override
   public String toString()
   {
     return "NumberedShardSpec{" +

--- a/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
@@ -162,7 +162,7 @@ public interface ShardSpec
     String BUILDING_RANGE = "building_range";
 
     String BUCKET_HASH = "bucket_hash";
-    String BUCKET_SINGLE_DIM = "single_dim";
+    String BUCKET_SINGLE_DIM = "bucket_single_dim";
     String BUCKET_RANGE = "bucket_range";
   }
 }

--- a/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
@@ -33,25 +33,25 @@ import java.util.Map;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-    @JsonSubTypes.Type(name = "none", value = NoneShardSpec.class),
-    @JsonSubTypes.Type(name = "single", value = SingleDimensionShardSpec.class),
-    @JsonSubTypes.Type(name = "range", value = DimensionRangeShardSpec.class),
-    @JsonSubTypes.Type(name = "linear", value = LinearShardSpec.class),
-    @JsonSubTypes.Type(name = "numbered", value = NumberedShardSpec.class),
-    @JsonSubTypes.Type(name = "hashed", value = HashBasedNumberedShardSpec.class),
-    @JsonSubTypes.Type(name = NumberedOverwriteShardSpec.TYPE, value = NumberedOverwriteShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.NONE, value = NoneShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.SINGLE_DIM, value = SingleDimensionShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.RANGE, value = DimensionRangeShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.LINEAR, value = LinearShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.NUMBERED, value = NumberedShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.HASHED, value = HashBasedNumberedShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.NUMBERED_OVERWRITE, value = NumberedOverwriteShardSpec.class),
     // BuildingShardSpecs are the shardSpec with missing numCorePartitions, and thus must not be published.
     // See BuildingShardSpec for more details.
-    @JsonSubTypes.Type(name = BuildingNumberedShardSpec.TYPE, value = BuildingNumberedShardSpec.class),
-    @JsonSubTypes.Type(name = BuildingHashBasedNumberedShardSpec.TYPE, value = BuildingHashBasedNumberedShardSpec.class),
-    @JsonSubTypes.Type(name = BuildingSingleDimensionShardSpec.TYPE, value = BuildingSingleDimensionShardSpec.class),
-    @JsonSubTypes.Type(name = BuildingDimensionRangeShardSpec.TYPE, value = BuildingDimensionRangeShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.BUILDING_NUMBERED, value = BuildingNumberedShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.BUILDING_HASHED, value = BuildingHashBasedNumberedShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.BUILDING_SINGLE_DIM, value = BuildingSingleDimensionShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.BUILDING_RANGE, value = BuildingDimensionRangeShardSpec.class),
     // BucketShardSpecs are the shardSpec with missing partitionId and numCorePartitions.
     // These shardSpecs must not be used in segment push.
     // See BucketShardSpec for more details.
-    @JsonSubTypes.Type(name = HashBucketShardSpec.TYPE, value = HashBucketShardSpec.class),
-    @JsonSubTypes.Type(name = SingleDimensionRangeBucketShardSpec.TYPE, value = SingleDimensionRangeBucketShardSpec.class),
-    @JsonSubTypes.Type(name = DimensionRangeBucketShardSpec.TYPE, value = DimensionRangeBucketShardSpec.class)
+    @JsonSubTypes.Type(name = ShardSpec.Type.BUCKET_HASH, value = HashBucketShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.BUCKET_SINGLE_DIM, value = SingleDimensionRangeBucketShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.BUCKET_RANGE, value = DimensionRangeBucketShardSpec.class)
 })
 public interface ShardSpec
 {
@@ -124,6 +124,12 @@ public interface ShardSpec
   boolean possibleInDomain(Map<String, RangeSet<String>> domain);
 
   /**
+   * Get the type name of this ShardSpec.
+   */
+  @JsonIgnore
+  String getType();
+
+  /**
    * Returns true if this shardSpec and the given {@link PartialShardSpec} share the same partition space.
    * All shardSpecs except {@link OverwriteShardSpec} use the root-generation partition space and thus share the same
    * space.
@@ -133,5 +139,30 @@ public interface ShardSpec
   default boolean sharePartitionSpace(PartialShardSpec partialShardSpec)
   {
     return !partialShardSpec.useNonRootGenerationPartitionSpace();
+  }
+
+  /**
+   * ShardSpec type names.
+   */
+  interface Type
+  {
+    String NONE = "none";
+
+    String SINGLE_DIM = "single";
+    String RANGE = "range";
+    String LINEAR = "linear";
+    String NUMBERED = "numbered";
+    String HASHED = "hashed";
+
+    String NUMBERED_OVERWRITE = "numbered_overwrite";
+
+    String BUILDING_NUMBERED = "building_numbered";
+    String BUILDING_HASHED = "building_hashed";
+    String BUILDING_SINGLE_DIM = "building_single_dim";
+    String BUILDING_RANGE = "building_range";
+
+    String BUCKET_HASH = "bucket_hash";
+    String BUCKET_SINGLE_DIM = "single_dim";
+    String BUCKET_RANGE = "bucket_range";
   }
 }

--- a/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
@@ -127,7 +127,10 @@ public interface ShardSpec
    * Get the type name of this ShardSpec.
    */
   @JsonIgnore
-  String getType();
+  default String getType()
+  {
+    return Type.UNKNOWN;
+  }
 
   /**
    * Returns true if this shardSpec and the given {@link PartialShardSpec} share the same partition space.
@@ -146,6 +149,7 @@ public interface ShardSpec
    */
   interface Type
   {
+    String UNKNOWN = "unknown";
     String NONE = "none";
 
     String SINGLE = "single";

--- a/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/ShardSpec.java
@@ -34,7 +34,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = ShardSpec.Type.NONE, value = NoneShardSpec.class),
-    @JsonSubTypes.Type(name = ShardSpec.Type.SINGLE_DIM, value = SingleDimensionShardSpec.class),
+    @JsonSubTypes.Type(name = ShardSpec.Type.SINGLE, value = SingleDimensionShardSpec.class),
     @JsonSubTypes.Type(name = ShardSpec.Type.RANGE, value = DimensionRangeShardSpec.class),
     @JsonSubTypes.Type(name = ShardSpec.Type.LINEAR, value = LinearShardSpec.class),
     @JsonSubTypes.Type(name = ShardSpec.Type.NUMBERED, value = NumberedShardSpec.class),
@@ -148,7 +148,7 @@ public interface ShardSpec
   {
     String NONE = "none";
 
-    String SINGLE_DIM = "single";
+    String SINGLE = "single";
     String RANGE = "range";
     String LINEAR = "linear";
     String NUMBERED = "numbered";

--- a/core/src/main/java/org/apache/druid/timeline/partition/SingleDimensionRangeBucketShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/SingleDimensionRangeBucketShardSpec.java
@@ -35,8 +35,6 @@ import java.util.Objects;
  */
 public class SingleDimensionRangeBucketShardSpec implements BucketNumberedShardSpec<BuildingSingleDimensionShardSpec>
 {
-  public static final String TYPE = "bucket_single_dim";
-
   private final int bucketId;
   private final String dimension;
   @Nullable
@@ -107,6 +105,12 @@ public class SingleDimensionRangeBucketShardSpec implements BucketNumberedShardS
       }
       throw new ISE("row[%s] doesn't fit in any shard[%s]", row, shardSpecs);
     };
+  }
+
+  @Override
+  public String getType()
+  {
+    return Type.BUCKET_SINGLE_DIM;
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/timeline/partition/SingleDimensionShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/SingleDimensionShardSpec.java
@@ -204,6 +204,12 @@ public class SingleDimensionShardSpec extends DimensionRangeShardSpec
   }
 
   @Override
+  public String getType()
+  {
+    return Type.SINGLE;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/core/src/test/java/org/apache/druid/timeline/DataSegmentTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/DataSegmentTest.java
@@ -93,6 +93,12 @@ public class DataSegmentTest
       {
         return true;
       }
+
+      @Override
+      public String getType()
+      {
+        return null;
+      }
     };
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/DataSegmentTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/DataSegmentTest.java
@@ -94,11 +94,6 @@ public class DataSegmentTest
         return true;
       }
 
-      @Override
-      public String getType()
-      {
-        return null;
-      }
     };
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpecTest.java
@@ -100,10 +100,10 @@ public class BuildingDimensionRangeShardSpecTest
         5
     );
     final String json = mapper.writeValueAsString(original);
-    final BuildingDimensionRangeShardSpec fromJson = (BuildingDimensionRangeShardSpec) mapper.readValue(
-        json,
-        ShardSpec.class
-    );
+    ShardSpec shardSpec = mapper.readValue(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.BUILDING_RANGE, shardSpec.getType());
+
+    final BuildingDimensionRangeShardSpec fromJson = (BuildingDimensionRangeShardSpec) shardSpec;
     Assert.assertEquals(original, fromJson);
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingDimensionRangeShardSpecTest.java
@@ -89,7 +89,7 @@ public class BuildingDimensionRangeShardSpecTest
   {
     final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
     mapper.registerSubtypes(
-        new NamedType(BuildingDimensionRangeShardSpec.class, BuildingDimensionRangeShardSpec.TYPE)
+        new NamedType(BuildingDimensionRangeShardSpec.class, ShardSpec.Type.BUILDING_RANGE)
     );
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
     final BuildingDimensionRangeShardSpec original = new BuildingDimensionRangeShardSpec(

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingHashBasedNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingHashBasedNumberedShardSpecTest.java
@@ -68,7 +68,7 @@ public class BuildingHashBasedNumberedShardSpecTest
   public void testSerde() throws JsonProcessingException
   {
     mapper.registerSubtypes(
-        new NamedType(BuildingHashBasedNumberedShardSpec.class, BuildingHashBasedNumberedShardSpec.TYPE)
+        new NamedType(BuildingHashBasedNumberedShardSpec.class, ShardSpec.Type.BUILDING_HASHED)
     );
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
     final BuildingHashBasedNumberedShardSpec original = new BuildingHashBasedNumberedShardSpec(

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingHashBasedNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingHashBasedNumberedShardSpecTest.java
@@ -80,10 +80,9 @@ public class BuildingHashBasedNumberedShardSpecTest
         mapper
     );
     final String json = mapper.writeValueAsString(original);
-    final BuildingHashBasedNumberedShardSpec fromJson = (BuildingHashBasedNumberedShardSpec) mapper.readValue(
-        json,
-        ShardSpec.class
-    );
+    ShardSpec shardSpec = mapper.readValue(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.BUILDING_HASHED, shardSpec.getType());
+    final BuildingHashBasedNumberedShardSpec fromJson = (BuildingHashBasedNumberedShardSpec) shardSpec;
     Assert.assertEquals(original, fromJson);
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingNumberedShardSpecTest.java
@@ -49,7 +49,7 @@ public class BuildingNumberedShardSpecTest
   {
     final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    mapper.registerSubtypes(new NamedType(BuildingNumberedShardSpec.class, BuildingNumberedShardSpec.TYPE));
+    mapper.registerSubtypes(new NamedType(BuildingNumberedShardSpec.class, ShardSpec.Type.BUILDING_NUMBERED));
     final BuildingNumberedShardSpec original = new BuildingNumberedShardSpec(5);
     final String json = mapper.writeValueAsString(original);
     final BuildingNumberedShardSpec fromJson = (BuildingNumberedShardSpec) mapper.readValue(json, ShardSpec.class);

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingNumberedShardSpecTest.java
@@ -52,7 +52,9 @@ public class BuildingNumberedShardSpecTest
     mapper.registerSubtypes(new NamedType(BuildingNumberedShardSpec.class, ShardSpec.Type.BUILDING_NUMBERED));
     final BuildingNumberedShardSpec original = new BuildingNumberedShardSpec(5);
     final String json = mapper.writeValueAsString(original);
-    final BuildingNumberedShardSpec fromJson = (BuildingNumberedShardSpec) mapper.readValue(json, ShardSpec.class);
+    ShardSpec shardSpec = mapper.readValue(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.BUILDING_NUMBERED, shardSpec.getType());
+    final BuildingNumberedShardSpec fromJson = (BuildingNumberedShardSpec) shardSpec;
     Assert.assertEquals(original, fromJson);
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
@@ -56,8 +56,10 @@ public class BuildingSingleDimensionShardSpecTest
     final BuildingSingleDimensionShardSpec original =
         new BuildingSingleDimensionShardSpec(1, "dim", "start", "end", 5);
     final String json = serialize(original);
-    final BuildingSingleDimensionShardSpec fromJson =
-        (BuildingSingleDimensionShardSpec) deserialize(json, ShardSpec.class);
+    ShardSpec shardSpec = deserialize(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.BUILDING_SINGLE_DIM, shardSpec.getType());
+
+    final BuildingSingleDimensionShardSpec fromJson = (BuildingSingleDimensionShardSpec) shardSpec;
     Assert.assertEquals(original, fromJson);
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/BuildingSingleDimensionShardSpecTest.java
@@ -80,7 +80,7 @@ public class BuildingSingleDimensionShardSpecTest
   @Test
   public void testDeserializeFromMap()
   {
-    final String json = "{\"type\": \"" + BuildingSingleDimensionShardSpec.TYPE + "\","
+    final String json = "{\"type\": \"" + ShardSpec.Type.BUILDING_SINGLE_DIM + "\","
                         + " \"bucketId\":1,"
                         + " \"dimension\": \"dim\","
                         + " \"start\": \"abc\","
@@ -108,7 +108,7 @@ public class BuildingSingleDimensionShardSpecTest
   {
     final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
     mapper.registerSubtypes(
-        new NamedType(BuildingSingleDimensionShardSpec.class, BuildingSingleDimensionShardSpec.TYPE)
+        new NamedType(BuildingSingleDimensionShardSpec.class, ShardSpec.Type.BUILDING_SINGLE_DIM)
     );
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpecTest.java
@@ -158,11 +158,9 @@ public class DimensionRangeBucketShardSpecTest
         StringTuple.create("end1", "end2")
     );
     final String json = mapper.writeValueAsString(original);
-    final DimensionRangeBucketShardSpec fromJson = (DimensionRangeBucketShardSpec) mapper.readValue(
-        json,
-        ShardSpec.class
-    );
-    Assert.assertEquals(original, fromJson);
+    ShardSpec shardSpec = mapper.readValue(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.BUCKET_RANGE, shardSpec.getType());
+    Assert.assertEquals(original, shardSpec);
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeBucketShardSpecTest.java
@@ -148,7 +148,7 @@ public class DimensionRangeBucketShardSpecTest
     final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
     mapper.registerSubtypes(new NamedType(
         DimensionRangeBucketShardSpec.class,
-        DimensionRangeBucketShardSpec.TYPE
+        ShardSpec.Type.BUCKET_RANGE
     ));
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
     final DimensionRangeBucketShardSpec original = new DimensionRangeBucketShardSpec(

--- a/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/HashBasedNumberedShardSpecTest.java
@@ -99,6 +99,7 @@ public class HashBasedNumberedShardSpecTest
         "{\"type\": \"hashed\", \"partitions\": 2, \"partitionNum\": 1, \"partitionDimensions\":[\"visitor_id\"]}",
         ShardSpec.class
     );
+    Assert.assertEquals(ShardSpec.Type.HASHED, specWithPartitionDimensions.getType());
     Assert.assertEquals(1, specWithPartitionDimensions.getPartitionNum());
     Assert.assertEquals(2, specWithPartitionDimensions.getNumCorePartitions());
     Assert.assertEquals(2, ((HashBasedNumberedShardSpec) specWithPartitionDimensions).getNumBuckets());

--- a/core/src/test/java/org/apache/druid/timeline/partition/HashBucketShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/HashBucketShardSpecTest.java
@@ -113,7 +113,7 @@ public class HashBucketShardSpecTest
   @Test
   public void testSerde() throws JsonProcessingException
   {
-    mapper.registerSubtypes(new NamedType(HashBucketShardSpec.class, HashBucketShardSpec.TYPE));
+    mapper.registerSubtypes(new NamedType(HashBucketShardSpec.class, ShardSpec.Type.BUCKET_HASH));
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
 
     final HashBucketShardSpec original = new HashBucketShardSpec(

--- a/core/src/test/java/org/apache/druid/timeline/partition/HashBucketShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/HashBucketShardSpecTest.java
@@ -124,7 +124,10 @@ public class HashBucketShardSpecTest
         mapper
     );
     final String json = mapper.writeValueAsString(original);
-    final HashBucketShardSpec fromJson = (HashBucketShardSpec) mapper.readValue(json, ShardSpec.class);
+    ShardSpec shardSpec = mapper.readValue(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.BUCKET_HASH, shardSpec.getType());
+
+    final HashBucketShardSpec fromJson = (HashBucketShardSpec) shardSpec;
     Assert.assertEquals(original, fromJson);
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/NoneShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/NoneShardSpecTest.java
@@ -48,6 +48,7 @@ public class NoneShardSpecTest
     // Serde should return same object instead of creating new one every time.
     Assert.assertTrue(serde1 == serde2);
     Assert.assertTrue(one == serde1);
+    Assert.assertEquals(ShardSpec.Type.NONE, serde1.getType());
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/timeline/partition/NumberedOverwriteShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/NumberedOverwriteShardSpecTest.java
@@ -47,7 +47,9 @@ public class NumberedOverwriteShardSpecTest
         (short) 3
     );
     final String json = mapper.writeValueAsString(original);
-    final NumberedOverwriteShardSpec fromJson = (NumberedOverwriteShardSpec) mapper.readValue(json, ShardSpec.class);
+    ShardSpec shardSpec = mapper.readValue(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.NUMBERED_OVERWRITE, shardSpec.getType());
+    final NumberedOverwriteShardSpec fromJson = (NumberedOverwriteShardSpec) shardSpec;
     Assert.assertEquals(original, fromJson);
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/NumberedOverwriteShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/NumberedOverwriteShardSpecTest.java
@@ -38,7 +38,7 @@ public class NumberedOverwriteShardSpecTest
   public void testSerde() throws JsonProcessingException
   {
     final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
-    mapper.registerSubtypes(new NamedType(NumberedOverwriteShardSpec.class, NumberedOverwriteShardSpec.TYPE));
+    mapper.registerSubtypes(new NamedType(NumberedOverwriteShardSpec.class, ShardSpec.Type.NUMBERED_OVERWRITE));
     final NumberedOverwriteShardSpec original = new NumberedOverwriteShardSpec(
         PartitionIds.NON_ROOT_GEN_START_PARTITION_ID + 2,
         0,

--- a/core/src/test/java/org/apache/druid/timeline/partition/NumberedShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/NumberedShardSpecTest.java
@@ -58,6 +58,7 @@ public class NumberedShardSpecTest
     );
     Assert.assertEquals(1, spec.getPartitionNum());
     Assert.assertEquals(2, spec.getNumCorePartitions());
+    Assert.assertEquals(ShardSpec.Type.NUMBERED, spec.getType());
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionRangeBucketShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionRangeBucketShardSpecTest.java
@@ -99,7 +99,7 @@ public class SingleDimensionRangeBucketShardSpecTest
   public void testSerde() throws JsonProcessingException
   {
     final ObjectMapper mapper = ShardSpecTestUtils.initObjectMapper();
-    mapper.registerSubtypes(new NamedType(SingleDimensionRangeBucketShardSpec.class, SingleDimensionRangeBucketShardSpec.TYPE));
+    mapper.registerSubtypes(new NamedType(SingleDimensionRangeBucketShardSpec.class, ShardSpec.Type.BUCKET_SINGLE_DIM));
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
     final SingleDimensionRangeBucketShardSpec original = new SingleDimensionRangeBucketShardSpec(1, "dim", "start", "end");
     final String json = mapper.writeValueAsString(original);

--- a/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionRangeBucketShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionRangeBucketShardSpecTest.java
@@ -103,7 +103,10 @@ public class SingleDimensionRangeBucketShardSpecTest
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
     final SingleDimensionRangeBucketShardSpec original = new SingleDimensionRangeBucketShardSpec(1, "dim", "start", "end");
     final String json = mapper.writeValueAsString(original);
-    final SingleDimensionRangeBucketShardSpec fromJson = (SingleDimensionRangeBucketShardSpec) mapper.readValue(json, ShardSpec.class);
+    ShardSpec shardSpec = mapper.readValue(json, ShardSpec.class);
+    Assert.assertEquals(ShardSpec.Type.BUCKET_SINGLE_DIM, shardSpec.getType());
+
+    final SingleDimensionRangeBucketShardSpec fromJson = (SingleDimensionRangeBucketShardSpec) shardSpec;
     Assert.assertEquals(original, fromJson);
   }
 

--- a/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/SingleDimensionShardSpecTest.java
@@ -175,6 +175,7 @@ public class SingleDimensionShardSpecTest
                         + "\"numCorePartitions\": 10}";
     ShardSpec shardSpec = OBJECT_MAPPER.readValue(json, ShardSpec.class);
     Assert.assertTrue(shardSpec instanceof SingleDimensionShardSpec);
+    Assert.assertEquals(ShardSpec.Type.SINGLE, shardSpec.getType());
 
     SingleDimensionShardSpec singleDimShardSpec = (SingleDimensionShardSpec) shardSpec;
     Assert.assertEquals(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -252,6 +252,10 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
     // getSegments() should return an empty set if announceHistoricalSegments() failed
     for (DataSegment segment : retVal.getSegments()) {
       metricBuilder.setDimension(DruidMetrics.INTERVAL, segment.getInterval().toString());
+      metricBuilder.setDimension(
+          DruidMetrics.PARTITIONING_TYPE,
+          segment.getShardSpec() == null ? null : segment.getShardSpec().getType()
+      );
       toolbox.getEmitter().emit(metricBuilder.build("segment/added/bytes", segment.getSize()));
     }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
@@ -176,11 +176,5 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
     {
       throw new UnsupportedOperationException();
     }
-
-    @Override
-    public String getType()
-    {
-      return null;
-    }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
@@ -176,5 +176,11 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
     {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String getType()
+    {
+      return null;
+    }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
@@ -279,11 +279,5 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
     {
       throw new UnsupportedOperationException();
     }
-
-    @Override
-    public String getType()
-    {
-      return null;
-    }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
@@ -279,5 +279,11 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
     {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String getType()
+    {
+      return null;
+    }
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -35,6 +35,8 @@ public class DruidMetrics
   public static final String TASK_ID = "taskId";
   public static final String STATUS = "status";
 
+  public static final String PARTITIONING_TYPE = "partitioningType";
+
   // task metrics
   public static final String TASK_TYPE = "taskType";
   public static final String TASK_STATUS = "taskStatus";


### PR DESCRIPTION
### Changes
- Add method `ShardSpec.getType()` to get name of shard spec type
- List all names of shard spec types in the interface `ShardSpec` itself
   for easy reference and maintenance
- Add dimension `partitioningType` to metric `segment/added/bytes`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
