### PR TITLE
Avoid materializing list of segment files when finding a partition file during shuffle

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManager.java
@@ -373,6 +373,7 @@ public class LocalIntermediaryDataManager implements IntermediaryDataManager
   public Optional<ByteSource> findPartitionFile(String supervisorTaskId, String subTaskId, Interval interval, int bucketId)
   {
     IdUtils.validateId("supervisorTaskId", supervisorTaskId);
+    IdUtils.validateId("subTaskId", subTaskId);
     for (StorageLocation location : shuffleDataLocations) {
       final File partitionDir = new File(location.getPath(), getPartitionDirPath(supervisorTaskId, interval, bucketId));
       if (partitionDir.exists()) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManager.java
@@ -377,20 +377,14 @@ public class LocalIntermediaryDataManager implements IntermediaryDataManager
       final File partitionDir = new File(location.getPath(), getPartitionDirPath(supervisorTaskId, interval, bucketId));
       if (partitionDir.exists()) {
         supervisorTaskCheckTimes.put(supervisorTaskId, getExpiryTimeFromNow());
-        final File[] segmentFiles = partitionDir.listFiles();
-        if (segmentFiles == null) {
-          return Optional.empty();
+        final File segmentFile = new File(partitionDir, subTaskId);
+        if (segmentFile.exists()) {
+          return Optional.of(Files.asByteSource(segmentFile));
         } else {
-          for (File segmentFile : segmentFiles) {
-            if (segmentFile.getName().equals(subTaskId)) {
-              return Optional.of(Files.asByteSource(segmentFile));
-            }
-          }
           return Optional.empty();
         }
       }
     }
-
     return Optional.empty();
   }
 


### PR DESCRIPTION
Avoid materializing list of segment files (it can cause OOM/memory pressure) as well as looping over the files.

### Description
This fixes a memory pressure/OOM bug seen in the field when the middlemanager may get an "out of memory" error because the list of segments is too large. Besides, looping through the segments files is inefficient and this commit avoids that. It does not need new unit tests, the existing unit tests cover this code already.


This PR has:
- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
