### PR TITLE
Fix incorrect comparison in RowSignature.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
@@ -277,7 +277,7 @@ public class RowSignature implements ColumnInspector
           default:
             assert finalization == Finalization.UNKNOWN;
 
-            if (aggregator.getType() == aggregator.getFinalizedType()) {
+            if (aggregator.getType().equals(aggregator.getFinalizedType())) {
               type = aggregator.getType();
             } else {
               // Use null if the type depends on whether the aggregator is finalized, since we don't know if


### PR DESCRIPTION
PR #11882 introduced a type comparison using ==, but while it was in flight,
another PR #11713 changed the type enum to a class. So the comparison should
properly be done with "equals".