### PR TITLE
restore and deprecate AggregatorFactory methods

### DIFF
--- a/core/src/main/java/org/apache/druid/segment/column/ColumnType.java
+++ b/core/src/main/java/org/apache/druid/segment/column/ColumnType.java
@@ -61,7 +61,7 @@ public class ColumnType extends BaseTypeSignature<ValueType>
   {
     return ColumnTypeFactory.getInstance().ofArray(elementType);
   }
-  public static ColumnType ofComplex(String complexTypeName)
+  public static ColumnType ofComplex(@Nullable String complexTypeName)
   {
     return ColumnTypeFactory.getInstance().ofComplex(complexTypeName);
   }

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
@@ -200,13 +200,13 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
    * and {@link DistinctCountAggregator#get} returns an integer for the number of set bits in the bitmap.
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.LONG;
   }

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
@@ -200,13 +200,13 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
    * and {@link DistinctCountAggregator#get} returns an integer for the number of set bits in the bitmap.
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.LONG;
   }

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
@@ -244,13 +244,13 @@ public class MomentSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link MomentSketchWrapper}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return TYPE;
   }

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
@@ -244,13 +244,13 @@ public class MomentSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link MomentSketchWrapper}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return TYPE;
   }

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
@@ -162,15 +162,15 @@ public class AveragerFactoryWrapper<T, R> extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.UNKNOWN_COMPLEX;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
-    return getType();
+    return getColumnType();
   }
 
   /**

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
@@ -162,15 +162,15 @@ public class AveragerFactoryWrapper<T, R> extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.UNKNOWN_COMPLEX;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
-    return getColumnType();
+    return getIntermediateType();
   }
 
   /**

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactory.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactory.java
@@ -216,13 +216,13 @@ public class TDigestSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link MergingDigest}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return TYPE;
   }

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactory.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactory.java
@@ -216,13 +216,13 @@ public class TDigestSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link MergingDigest}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return TYPE;
   }

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
@@ -200,7 +200,7 @@ public abstract class TimestampAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.LONG;
   }
@@ -209,7 +209,7 @@ public abstract class TimestampAggregatorFactory extends AggregatorFactory
    * actual type is {@link DateTime}
    */
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return FINALIZED_TYPE;
   }

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
@@ -200,7 +200,7 @@ public abstract class TimestampAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.LONG;
   }
@@ -209,7 +209,7 @@ public abstract class TimestampAggregatorFactory extends AggregatorFactory
    * actual type is {@link DateTime}
    */
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return FINALIZED_TYPE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
@@ -170,7 +170,7 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return round ? ColumnType.LONG : ColumnType.DOUBLE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
@@ -170,7 +170,7 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return round ? ColumnType.LONG : ColumnType.DOUBLE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
@@ -56,7 +56,7 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
@@ -56,7 +56,7 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -77,7 +77,7 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -77,7 +77,7 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
@@ -354,13 +354,13 @@ public class DoublesSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link DoublesSketch}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return DoublesSketchModule.TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.LONG;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
@@ -354,13 +354,13 @@ public class DoublesSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link DoublesSketch}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return DoublesSketchModule.TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.LONG;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -144,7 +144,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
    * actual type is {@link SketchHolder}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return isInputThetaSketch ? SketchModule.MERGE_TYPE : SketchModule.BUILD_TYPE;
   }
@@ -156,12 +156,12 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
    * if {@link #shouldFinalize} is NOT set, type is {@link SketchHolder}
    */
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     if (shouldFinalize && errorBoundsStdDev == null) {
       return ColumnType.DOUBLE;
     }
-    return getColumnType();
+    return getIntermediateType();
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -144,7 +144,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
    * actual type is {@link SketchHolder}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return isInputThetaSketch ? SketchModule.MERGE_TYPE : SketchModule.BUILD_TYPE;
   }
@@ -156,12 +156,12 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
    * if {@link #shouldFinalize} is NOT set, type is {@link SketchHolder}
    */
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     if (shouldFinalize && errorBoundsStdDev == null) {
       return ColumnType.DOUBLE;
     }
-    return getType();
+    return getColumnType();
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
@@ -297,13 +297,13 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link ArrayOfDoublesSketch}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return metricColumns == null ? ArrayOfDoublesSketchModule.MERGE_TYPE : ArrayOfDoublesSketchModule.BUILD_TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.DOUBLE;
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
@@ -297,13 +297,13 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
    * actual type is {@link ArrayOfDoublesSketch}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return metricColumns == null ? ArrayOfDoublesSketchModule.MERGE_TYPE : ArrayOfDoublesSketchModule.BUILD_TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.DOUBLE;
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -352,7 +352,7 @@ public class HllSketchAggregatorFactoryTest
     }
 
     @Override
-    public ColumnType getType()
+    public ColumnType getColumnType()
     {
       return new ColumnType(ValueType.COMPLEX, DUMMY_TYPE_NAME, null);
     }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -352,7 +352,7 @@ public class HllSketchAggregatorFactoryTest
     }
 
     @Override
-    public ColumnType getColumnType()
+    public ColumnType getIntermediateType()
     {
       return new ColumnType(ValueType.COMPLEX, DUMMY_TYPE_NAME, null);
     }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
@@ -190,13 +190,13 @@ public class BloomFilterAggregatorFactory extends AggregatorFactory
    * actual type is {@link ByteBuffer} containing {@link BloomKFilter}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return TYPE;
   }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
@@ -190,13 +190,13 @@ public class BloomFilterAggregatorFactory extends AggregatorFactory
    * actual type is {@link ByteBuffer} containing {@link BloomKFilter}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return TYPE;
   }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -327,7 +327,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link ApproximateHistogram}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
@@ -336,7 +336,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link ApproximateHistogram} if {@link #finalizeAsBase64Binary} is set, else {@link Histogram}
    */
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return finalizeAsBase64Binary ? TYPE : HistogramAggregatorFactory.TYPE;
   }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -327,7 +327,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link ApproximateHistogram}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
@@ -336,7 +336,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link ApproximateHistogram} if {@link #finalizeAsBase64Binary} is set, else {@link Histogram}
    */
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return finalizeAsBase64Binary ? TYPE : HistogramAggregatorFactory.TYPE;
   }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
@@ -282,7 +282,7 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link FixedBucketsHistogram}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return FixedBucketsHistogramAggregator.TYPE;
   }
@@ -291,7 +291,7 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link FixedBucketsHistogram} if {@link #finalizeAsBase64Binary} is set
    */
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return finalizeAsBase64Binary ? FixedBucketsHistogramAggregator.TYPE : ColumnType.STRING;
   }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
@@ -282,7 +282,7 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link FixedBucketsHistogram}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return FixedBucketsHistogramAggregator.TYPE;
   }
@@ -291,7 +291,7 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link FixedBucketsHistogram} if {@link #finalizeAsBase64Binary} is set
    */
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return finalizeAsBase64Binary ? FixedBucketsHistogramAggregator.TYPE : ColumnType.STRING;
   }

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -100,13 +100,13 @@ public class VarianceAggregatorFactory extends AggregatorFactory
    * actual type is {@link VarianceAggregatorCollector}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.DOUBLE;
   }

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -100,13 +100,13 @@ public class VarianceAggregatorFactory extends AggregatorFactory
    * actual type is {@link VarianceAggregatorCollector}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.DOUBLE;
   }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
@@ -342,7 +342,7 @@ public class InputRowSerde
             parseExceptionMessages.add(e.getMessage());
           }
 
-          final ColumnType type = aggFactory.getColumnType();
+          final ColumnType type = aggFactory.getIntermediateType();
 
           if (agg.isNull()) {
             out.writeByte(NullHandling.IS_NULL_BYTE);
@@ -473,7 +473,7 @@ public class InputRowSerde
       for (int i = 0; i < metricSize; i++) {
         final String metric = readString(in);
         final AggregatorFactory agg = getAggregator(metric, aggs, i);
-        final ColumnType type = agg.getColumnType();
+        final ColumnType type = agg.getIntermediateType();
         final byte metricNullability = in.readByte();
 
         if (metricNullability == NullHandling.IS_NULL_BYTE) {
@@ -487,7 +487,7 @@ public class InputRowSerde
         } else if (type.is(ValueType.DOUBLE)) {
           event.put(metric, in.readDouble());
         } else {
-          ComplexMetricSerde serde = getComplexMetricSerde(agg.getColumnType().getComplexTypeName());
+          ComplexMetricSerde serde = getComplexMetricSerde(agg.getIntermediateType().getComplexTypeName());
           byte[] value = readBytes(in);
           event.put(metric, serde.fromBytes(value, 0, value.length));
         }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
@@ -342,7 +342,7 @@ public class InputRowSerde
             parseExceptionMessages.add(e.getMessage());
           }
 
-          final ColumnType type = aggFactory.getType();
+          final ColumnType type = aggFactory.getColumnType();
 
           if (agg.isNull()) {
             out.writeByte(NullHandling.IS_NULL_BYTE);
@@ -473,7 +473,7 @@ public class InputRowSerde
       for (int i = 0; i < metricSize; i++) {
         final String metric = readString(in);
         final AggregatorFactory agg = getAggregator(metric, aggs, i);
-        final ColumnType type = agg.getType();
+        final ColumnType type = agg.getColumnType();
         final byte metricNullability = in.readByte();
 
         if (metricNullability == NullHandling.IS_NULL_BYTE) {
@@ -487,7 +487,7 @@ public class InputRowSerde
         } else if (type.is(ValueType.DOUBLE)) {
           event.put(metric, in.readDouble());
         } else {
-          ComplexMetricSerde serde = getComplexMetricSerde(agg.getType().getComplexTypeName());
+          ComplexMetricSerde serde = getComplexMetricSerde(agg.getColumnType().getComplexTypeName());
           byte[] value = readBytes(in);
           event.put(metric, serde.fromBytes(value, 0, value.length));
         }

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/InputRowSerdeTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/InputRowSerdeTest.java
@@ -104,13 +104,13 @@ public class InputRowSerdeTest
 
     final AggregatorFactory mockedAggregatorFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(mockedAggregatorFactory.factorize(EasyMock.anyObject(ColumnSelectorFactory.class))).andReturn(mockedAggregator);
-    EasyMock.expect(mockedAggregatorFactory.getType()).andReturn(ColumnType.DOUBLE).anyTimes();
+    EasyMock.expect(mockedAggregatorFactory.getColumnType()).andReturn(ColumnType.DOUBLE).anyTimes();
     EasyMock.expect(mockedAggregatorFactory.getName()).andReturn("mockedAggregator").anyTimes();
 
     final AggregatorFactory mockedNullAggregatorFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(mockedNullAggregatorFactory.factorize(EasyMock.anyObject(ColumnSelectorFactory.class))).andReturn(mockedNullAggregator);
     EasyMock.expect(mockedNullAggregatorFactory.getName()).andReturn("mockedNullAggregator").anyTimes();
-    EasyMock.expect(mockedNullAggregatorFactory.getType()).andReturn(ColumnType.DOUBLE).anyTimes();
+    EasyMock.expect(mockedNullAggregatorFactory.getColumnType()).andReturn(ColumnType.DOUBLE).anyTimes();
 
     EasyMock.replay(mockedAggregatorFactory, mockedNullAggregatorFactory);
 

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/InputRowSerdeTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/InputRowSerdeTest.java
@@ -104,13 +104,13 @@ public class InputRowSerdeTest
 
     final AggregatorFactory mockedAggregatorFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(mockedAggregatorFactory.factorize(EasyMock.anyObject(ColumnSelectorFactory.class))).andReturn(mockedAggregator);
-    EasyMock.expect(mockedAggregatorFactory.getColumnType()).andReturn(ColumnType.DOUBLE).anyTimes();
+    EasyMock.expect(mockedAggregatorFactory.getIntermediateType()).andReturn(ColumnType.DOUBLE).anyTimes();
     EasyMock.expect(mockedAggregatorFactory.getName()).andReturn("mockedAggregator").anyTimes();
 
     final AggregatorFactory mockedNullAggregatorFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(mockedNullAggregatorFactory.factorize(EasyMock.anyObject(ColumnSelectorFactory.class))).andReturn(mockedNullAggregator);
     EasyMock.expect(mockedNullAggregatorFactory.getName()).andReturn("mockedNullAggregator").anyTimes();
-    EasyMock.expect(mockedNullAggregatorFactory.getColumnType()).andReturn(ColumnType.DOUBLE).anyTimes();
+    EasyMock.expect(mockedNullAggregatorFactory.getIntermediateType()).andReturn(ColumnType.DOUBLE).anyTimes();
 
     EasyMock.replay(mockedAggregatorFactory, mockedNullAggregatorFactory);
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -1984,7 +1984,7 @@ public class CompactionTaskTest
 
   private static ColumnHolder createColumn(AggregatorFactory aggregatorFactory)
   {
-    return new TestColumn(aggregatorFactory.getColumnType());
+    return new TestColumn(aggregatorFactory.getIntermediateType());
   }
 
   private static class TestColumn implements ColumnHolder

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -1984,7 +1984,7 @@ public class CompactionTaskTest
 
   private static ColumnHolder createColumn(AggregatorFactory aggregatorFactory)
   {
-    return new TestColumn(aggregatorFactory.getType());
+    return new TestColumn(aggregatorFactory.getColumnType());
   }
 
   private static class TestColumn implements ColumnHolder

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -51,7 +51,7 @@ public class DruidMetrics
   {
     int retVal = 0;
     for (AggregatorFactory agg : aggs) {
-      if (agg.getType().is(ValueType.COMPLEX)) {
+      if (agg.getColumnType().is(ValueType.COMPLEX)) {
         retVal++;
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -51,7 +51,7 @@ public class DruidMetrics
   {
     int retVal = 0;
     for (AggregatorFactory agg : aggs) {
-      if (agg.getColumnType().is(ValueType.COMPLEX)) {
+      if (agg.getIntermediateType().is(ValueType.COMPLEX)) {
         retVal++;
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -27,6 +27,7 @@ import org.apache.druid.query.PerSegmentQueryOptimizationContext;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.ColumnTypeFactory;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 
@@ -219,7 +220,13 @@ public abstract class AggregatorFactory implements Cacheable
    *
    * Refer to the {@link ColumnType} javadocs for details on the implications of choosing a type.
    */
-  public abstract ColumnType getType();
+  public ColumnType getColumnType()
+  {
+    if (getType() == ValueType.COMPLEX) {
+      return ColumnType.ofComplex(getComplexTypeName());
+    }
+    return ColumnTypeFactory.ofValueType(getType());
+  }
 
   /**
    * Get the type for the final form of this this aggregator, i.e. the type of the value returned by
@@ -228,7 +235,47 @@ public abstract class AggregatorFactory implements Cacheable
    *
    * Refer to the {@link ColumnType} javadocs for details on the implications of choosing a type.
    */
-  public abstract ColumnType getFinalizedType();
+  public ColumnType getFinalizedColumnType()
+  {
+    if (getFinalizedType() == ValueType.COMPLEX) {
+      return ColumnType.UNKNOWN_COMPLEX;
+    }
+    return ColumnTypeFactory.ofValueType(getFinalizedType());
+  }
+
+
+  /**
+   * This method is deprecated and will be removed soon. Use {@link #getColumnType()} instead.
+   */
+  @Deprecated
+  public ValueType getType()
+  {
+    throw new UnsupportedOperationException(
+        "Do not call or implement this method, it is deprecated, use 'getColumnType'"
+    );
+  }
+
+  /**
+   * This method is deprecated and will be removed soon. Use {@link #getFinalizedColumnType()} instead.
+   */
+  @Deprecated
+  public ValueType getFinalizedType()
+  {
+    throw new UnsupportedOperationException(
+        "Do not call or implement this method, it is deprecated, use 'getFinalizedColumnType'"
+    );
+  }
+
+  /**
+   * This method is deprecated and will be removed soon. Use {@link #getColumnType()} instead.
+   */
+  @Deprecated
+  public String getComplexTypeName()
+  {
+    throw new UnsupportedOperationException(
+        "Do not call or implement this method, it is deprecated, use 'getColumnType'"
+    );
+  }
 
   /**
    * Returns the maximum size that this aggregator will require in bytes for intermediate storage of results.

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -214,13 +214,13 @@ public abstract class AggregatorFactory implements Cacheable
   public abstract List<String> requiredFields();
 
   /**
-   * Get the "intermediate" {@link ValueType} for this aggregator. This is the same as the type returned by
+   * Get the "intermediate" {@link ColumnType} for this aggregator. This is the same as the type returned by
    * {@link #deserialize} and the type accepted by {@link #combine}. However, it is *not* necessarily the same type
    * returned by {@link #finalizeComputation}.
    *
    * Refer to the {@link ColumnType} javadocs for details on the implications of choosing a type.
    */
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     if (getType() == ValueType.COMPLEX) {
       return ColumnType.ofComplex(getComplexTypeName());
@@ -229,14 +229,15 @@ public abstract class AggregatorFactory implements Cacheable
   }
 
   /**
-   * Get the type for the final form of this this aggregator, i.e. the type of the value returned by
+   * Get the {@link ColumnType} for the final form of this aggregator, i.e. the type of the value returned by
    * {@link #finalizeComputation}. This may be the same as or different than the types expected in {@link #deserialize}
    * and {@link #combine}.
    *
    * Refer to the {@link ColumnType} javadocs for details on the implications of choosing a type.
    */
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
+    // this default 'fill' method is incomplete and can at best return 'unknown' complex
     if (getFinalizedType() == ValueType.COMPLEX) {
       return ColumnType.UNKNOWN_COMPLEX;
     }
@@ -245,36 +246,34 @@ public abstract class AggregatorFactory implements Cacheable
 
 
   /**
-   * This method is deprecated and will be removed soon. Use {@link #getColumnType()} instead.
+   * This method is deprecated and will be removed soon. Use {@link #getIntermediateType()} instead.
    */
   @Deprecated
   public ValueType getType()
   {
     throw new UnsupportedOperationException(
-        "Do not call or implement this method, it is deprecated, use 'getColumnType'"
+        "Do not call or implement this method, it is deprecated, use 'getIntermediateType'"
     );
   }
 
   /**
-   * This method is deprecated and will be removed soon. Use {@link #getFinalizedColumnType()} instead.
+   * This method is deprecated and will be removed soon. Use {@link #getResultType()} instead.
    */
   @Deprecated
   public ValueType getFinalizedType()
   {
     throw new UnsupportedOperationException(
-        "Do not call or implement this method, it is deprecated, use 'getFinalizedColumnType'"
+        "Do not call or implement this method, it is deprecated, use 'getResultType'"
     );
   }
 
   /**
-   * This method is deprecated and will be removed soon. Use {@link #getColumnType()} instead.
+   * This method is deprecated and will be removed soon. Use {@link #getIntermediateType()} instead.
    */
   @Deprecated
   public String getComplexTypeName()
   {
-    throw new UnsupportedOperationException(
-        "Do not call or implement this method, it is deprecated, use 'getColumnType'"
-    );
+    return null;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -222,10 +222,11 @@ public abstract class AggregatorFactory implements Cacheable
    */
   public ColumnType getIntermediateType()
   {
-    if (getType() == ValueType.COMPLEX) {
+    final ValueType intermediateType = getType();
+    if (intermediateType == ValueType.COMPLEX) {
       return ColumnType.ofComplex(getComplexTypeName());
     }
-    return ColumnTypeFactory.ofValueType(getType());
+    return ColumnTypeFactory.ofValueType(intermediateType);
   }
 
   /**
@@ -238,15 +239,17 @@ public abstract class AggregatorFactory implements Cacheable
   public ColumnType getResultType()
   {
     // this default 'fill' method is incomplete and can at best return 'unknown' complex
-    if (getFinalizedType() == ValueType.COMPLEX) {
+    final ValueType finalized = getFinalizedType();
+    if (finalized == ValueType.COMPLEX) {
       return ColumnType.UNKNOWN_COMPLEX;
     }
-    return ColumnTypeFactory.ofValueType(getFinalizedType());
+    return ColumnTypeFactory.ofValueType(finalized);
   }
 
 
   /**
-   * This method is deprecated and will be removed soon. Use {@link #getIntermediateType()} instead.
+   * This method is deprecated and will be removed soon. Use {@link #getIntermediateType()} instead. Do not call this
+   * method, it will likely produce incorrect results, it exists for backwards compatibility.
    */
   @Deprecated
   public ValueType getType()
@@ -257,7 +260,8 @@ public abstract class AggregatorFactory implements Cacheable
   }
 
   /**
-   * This method is deprecated and will be removed soon. Use {@link #getResultType()} instead.
+   * This method is deprecated and will be removed soon. Use {@link #getResultType()} instead. Do not call this
+   * method, it will likely produce incorrect results, it exists for backwards compatibility.
    */
   @Deprecated
   public ValueType getFinalizedType()
@@ -268,8 +272,10 @@ public abstract class AggregatorFactory implements Cacheable
   }
 
   /**
-   * This method is deprecated and will be removed soon. Use {@link #getIntermediateType()} instead.
+   * This method is deprecated and will be removed soon. Use {@link #getIntermediateType()} instead. Do not call this
+   * method, it will likely produce incorrect results, it exists for backwards compatibility.
    */
+  @Nullable
   @Deprecated
   public String getComplexTypeName()
   {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/BufferAggregator.java
@@ -104,7 +104,7 @@ public interface BufferAggregator extends HotLoopCallee
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
    * Implementations are only required to support this method if they are aggregations which
-   * have an {@link AggregatorFactory#getColumnType()} ()} of {@link org.apache.druid.segment.column.ValueType#FLOAT}.
+   * have an {@link AggregatorFactory#getIntermediateType()} ()} of {@link org.apache.druid.segment.column.ValueType#FLOAT}.
    * If unimplemented, throwing an {@link UnsupportedOperationException} is common and recommended.
    *
    * @param buf byte buffer storing the byte array representation of the aggregate
@@ -122,7 +122,7 @@ public interface BufferAggregator extends HotLoopCallee
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
    * Implementations are only required to support this method if they are aggregations which
-   * have an {@link AggregatorFactory#getColumnType()} of  of {@link org.apache.druid.segment.column.ValueType#LONG}.
+   * have an {@link AggregatorFactory#getIntermediateType()} of  of {@link org.apache.druid.segment.column.ValueType#LONG}.
    * If unimplemented, throwing an {@link UnsupportedOperationException} is common and recommended.
    *
    * @param buf byte buffer storing the byte array representation of the aggregate
@@ -140,7 +140,7 @@ public interface BufferAggregator extends HotLoopCallee
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
    * Implementations are only required to support this method if they are aggregations which
-   * have an {@link AggregatorFactory#getColumnType()} of  of {@link org.apache.druid.segment.column.ValueType#DOUBLE}.
+   * have an {@link AggregatorFactory#getIntermediateType()} of  of {@link org.apache.druid.segment.column.ValueType#DOUBLE}.
    * If unimplemented, throwing an {@link UnsupportedOperationException} is common and recommended.
    *
    * The default implementation casts {@link BufferAggregator#getFloat(ByteBuffer, int)} to double.

--- a/processing/src/main/java/org/apache/druid/query/aggregation/BufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/BufferAggregator.java
@@ -104,7 +104,7 @@ public interface BufferAggregator extends HotLoopCallee
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
    * Implementations are only required to support this method if they are aggregations which
-   * have an {@link AggregatorFactory#getType()} ()} of {@link org.apache.druid.segment.column.ValueType#FLOAT}.
+   * have an {@link AggregatorFactory#getColumnType()} ()} of {@link org.apache.druid.segment.column.ValueType#FLOAT}.
    * If unimplemented, throwing an {@link UnsupportedOperationException} is common and recommended.
    *
    * @param buf byte buffer storing the byte array representation of the aggregate
@@ -122,7 +122,7 @@ public interface BufferAggregator extends HotLoopCallee
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
    * Implementations are only required to support this method if they are aggregations which
-   * have an {@link AggregatorFactory#getType()} of  of {@link org.apache.druid.segment.column.ValueType#LONG}.
+   * have an {@link AggregatorFactory#getColumnType()} of  of {@link org.apache.druid.segment.column.ValueType#LONG}.
    * If unimplemented, throwing an {@link UnsupportedOperationException} is common and recommended.
    *
    * @param buf byte buffer storing the byte array representation of the aggregate
@@ -140,7 +140,7 @@ public interface BufferAggregator extends HotLoopCallee
    * <b>Implementations must not change the position, limit or mark of the given buffer</b>
    *
    * Implementations are only required to support this method if they are aggregations which
-   * have an {@link AggregatorFactory#getType()} of  of {@link org.apache.druid.segment.column.ValueType#DOUBLE}.
+   * have an {@link AggregatorFactory#getColumnType()} of  of {@link org.apache.druid.segment.column.ValueType#DOUBLE}.
    * If unimplemented, throwing an {@link UnsupportedOperationException} is common and recommended.
    *
    * The default implementation casts {@link BufferAggregator#getFloat(ByteBuffer, int)} to double.

--- a/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
@@ -136,13 +136,13 @@ public class CountAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
@@ -136,13 +136,13 @@ public class CountAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
@@ -395,7 +395,7 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     if (fields == null) {
       return ExpressionType.toColumnType(initialCombineValue.get().type());
@@ -404,7 +404,7 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     Expr finalizeExpr = finalizeExpression.get();
     ExprEval<?> initialVal = initialCombineValue.get();
@@ -423,7 +423,7 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
   {
     // numeric expressions are either longs or doubles, with strings or arrays max size is unknown
     // for numeric arguments, the first 2 bytes are used for expression type byte and is_null byte
-    return getType().isNumeric() ? 2 + Long.BYTES : maxSizeBytes.getBytesInInt();
+    return getColumnType().isNumeric() ? 2 + Long.BYTES : maxSizeBytes.getBytesInInt();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
@@ -395,7 +395,7 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     if (fields == null) {
       return ExpressionType.toColumnType(initialCombineValue.get().type());
@@ -404,7 +404,7 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     Expr finalizeExpr = finalizeExpression.get();
     ExprEval<?> initialVal = initialCombineValue.get();
@@ -423,7 +423,7 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
   {
     // numeric expressions are either longs or doubles, with strings or arrays max size is unknown
     // for numeric arguments, the first 2 bytes are used for expression type byte and is_null byte
-    return getColumnType().isNumeric() ? 2 + Long.BYTES : maxSizeBytes.getBytesInInt();
+    return getIntermediateType().isNumeric() ? 2 + Long.BYTES : maxSizeBytes.getBytesInInt();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -187,15 +187,15 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
-    return delegate.getColumnType();
+    return delegate.getIntermediateType();
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
-    return delegate.getFinalizedColumnType();
+    return delegate.getResultType();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -187,15 +187,15 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
-    return delegate.getType();
+    return delegate.getColumnType();
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
-    return delegate.getFinalizedType();
+    return delegate.getFinalizedColumnType();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/GroupingAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/GroupingAggregatorFactory.java
@@ -207,13 +207,13 @@ public class GroupingAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/GroupingAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/GroupingAggregatorFactory.java
@@ -207,13 +207,13 @@ public class GroupingAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -209,7 +209,7 @@ public class HistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link Histogram}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
@@ -218,7 +218,7 @@ public class HistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link HistogramVisual}
    */
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return TYPE_VISUAL;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -209,7 +209,7 @@ public class HistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link Histogram}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
@@ -218,7 +218,7 @@ public class HistogramAggregatorFactory extends AggregatorFactory
    * actual type is {@link HistogramVisual}
    */
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return TYPE_VISUAL;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -268,13 +268,13 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -268,13 +268,13 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
@@ -148,8 +148,8 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
-    return getType();
+    return getColumnType();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/NullableNumericAggregatorFactory.java
@@ -148,8 +148,8 @@ public abstract class NullableNumericAggregatorFactory<T extends BaseNullableCol
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
-    return getColumnType();
+    return getIntermediateType();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
@@ -150,7 +150,7 @@ public abstract class SimpleDoubleAggregatorFactory extends NullableNumericAggre
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     if (storeDoubleAsFloat) {
       return ColumnType.FLOAT;

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleDoubleAggregatorFactory.java
@@ -150,7 +150,7 @@ public abstract class SimpleDoubleAggregatorFactory extends NullableNumericAggre
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     if (storeDoubleAsFloat) {
       return ColumnType.FLOAT;

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
@@ -131,7 +131,7 @@ public abstract class SimpleFloatAggregatorFactory extends NullableNumericAggreg
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
@@ -131,7 +131,7 @@ public abstract class SimpleFloatAggregatorFactory extends NullableNumericAggreg
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
@@ -134,7 +134,7 @@ public abstract class SimpleLongAggregatorFactory extends NullableNumericAggrega
 
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
@@ -134,7 +134,7 @@ public abstract class SimpleLongAggregatorFactory extends NullableNumericAggrega
 
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
@@ -139,15 +139,15 @@ public class SuppressedAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
-    return delegate.getColumnType();
+    return delegate.getIntermediateType();
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
-    return delegate.getFinalizedColumnType();
+    return delegate.getResultType();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
@@ -139,15 +139,15 @@ public class SuppressedAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
-    return delegate.getType();
+    return delegate.getColumnType();
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
-    return delegate.getFinalizedType();
+    return delegate.getFinalizedColumnType();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
@@ -209,15 +209,15 @@ public class DoubleAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return storeDoubleAsFloat ? ColumnType.FLOAT : ColumnType.DOUBLE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
-    return getType();
+    return getColumnType();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
@@ -209,15 +209,15 @@ public class DoubleAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return storeDoubleAsFloat ? ColumnType.FLOAT : ColumnType.DOUBLE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
-    return getColumnType();
+    return getIntermediateType();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
@@ -207,13 +207,13 @@ public class FloatAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
@@ -207,13 +207,13 @@ public class FloatAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
@@ -205,13 +205,13 @@ public class LongAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
@@ -205,13 +205,13 @@ public class LongAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
@@ -178,13 +178,13 @@ public class StringAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return ColumnType.STRING;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.STRING;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
@@ -178,13 +178,13 @@ public class StringAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return ColumnType.STRING;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.STRING;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -321,13 +321,13 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
    * actual type is {@link HyperLogLogCollector}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return round ? ColumnType.LONG : ColumnType.DOUBLE;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -321,13 +321,13 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
    * actual type is {@link HyperLogLogCollector}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return round ? ColumnType.LONG : ColumnType.DOUBLE;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
@@ -274,14 +274,14 @@ public class DoubleFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return storeDoubleAsFloat ? ColumnType.FLOAT : ColumnType.DOUBLE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     // this is a copy of getComplexTypeName in the hopes that someday groupby v1 is no more and it will report it's actual
     // type of COMPLEX

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
@@ -274,14 +274,14 @@ public class DoubleFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return storeDoubleAsFloat ? ColumnType.FLOAT : ColumnType.DOUBLE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     // this is a copy of getComplexTypeName in the hopes that someday groupby v1 is no more and it will report it's actual
     // type of COMPLEX

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
@@ -271,14 +271,14 @@ public class FloatFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
@@ -271,14 +271,14 @@ public class FloatFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/LongFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/LongFirstAggregatorFactory.java
@@ -269,14 +269,14 @@ public class LongFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/LongFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/LongFirstAggregatorFactory.java
@@ -269,14 +269,14 @@ public class LongFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
@@ -263,13 +263,13 @@ public class StringFirstAggregatorFactory extends AggregatorFactory
    * actual type is {@link SerializablePairLongString}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.STRING;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
@@ -263,13 +263,13 @@ public class StringFirstAggregatorFactory extends AggregatorFactory
    * actual type is {@link SerializablePairLongString}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.STRING;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
@@ -108,7 +108,7 @@ public class HyperUniqueFinalizingPostAggregator implements PostAggregator
   public ColumnType getType(ColumnInspector signature)
   {
     return aggregatorFactory != null
-           ? aggregatorFactory.getFinalizedColumnType()
+           ? aggregatorFactory.getResultType()
            : null;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
@@ -108,7 +108,7 @@ public class HyperUniqueFinalizingPostAggregator implements PostAggregator
   public ColumnType getType(ColumnInspector signature)
   {
     return aggregatorFactory != null
-           ? aggregatorFactory.getFinalizedType()
+           ? aggregatorFactory.getFinalizedColumnType()
            : null;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -267,13 +267,13 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
    * actual type is {@link HyperLogLogCollector}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return isInputHyperUnique ? PRECOMPUTED_TYPE : TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return round ? ColumnType.LONG : ColumnType.DOUBLE;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -267,13 +267,13 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
    * actual type is {@link HyperLogLogCollector}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return isInputHyperUnique ? PRECOMPUTED_TYPE : TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return round ? ColumnType.LONG : ColumnType.DOUBLE;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
@@ -272,14 +272,14 @@ public class DoubleLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return storeDoubleAsFloat ? ColumnType.FLOAT : ColumnType.DOUBLE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     // this is a copy of getComplexTypeName in the hopes that someday groupby v1 is no more and it will report it's actual
     // type

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
@@ -272,14 +272,14 @@ public class DoubleLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return storeDoubleAsFloat ? ColumnType.FLOAT : ColumnType.DOUBLE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     // this is a copy of getComplexTypeName in the hopes that someday groupby v1 is no more and it will report it's actual
     // type

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
@@ -269,14 +269,14 @@ public class FloatLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
@@ -269,14 +269,14 @@ public class FloatLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.FLOAT;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.FLOAT;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
@@ -267,14 +267,14 @@ public class LongLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
@@ -267,14 +267,14 @@ public class LongLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     // if we don't pretend to be a primitive, group by v1 gets sad and doesn't work because no complex type serde
     return ColumnType.LONG;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.LONG;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
@@ -220,13 +220,13 @@ public class StringLastAggregatorFactory extends AggregatorFactory
    * actual type is {@link SerializablePairLongString}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.STRING;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
@@ -220,13 +220,13 @@ public class StringLastAggregatorFactory extends AggregatorFactory
    * actual type is {@link SerializablePairLongString}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.STRING;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
@@ -83,13 +83,13 @@ public class DoubleMeanAggregatorFactory extends AggregatorFactory
    * actual type is {@link DoubleMeanHolder}
    */
   @Override
-  public ColumnType getColumnType()
+  public ColumnType getIntermediateType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedColumnType()
+  public ColumnType getResultType()
   {
     return ColumnType.DOUBLE;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
@@ -83,13 +83,13 @@ public class DoubleMeanAggregatorFactory extends AggregatorFactory
    * actual type is {@link DoubleMeanHolder}
    */
   @Override
-  public ColumnType getType()
+  public ColumnType getColumnType()
   {
     return TYPE;
   }
 
   @Override
-  public ColumnType getFinalizedType()
+  public ColumnType getFinalizedColumnType()
   {
     return ColumnType.DOUBLE;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/FieldAccessPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/FieldAccessPostAggregator.java
@@ -109,7 +109,7 @@ public class FieldAccessPostAggregator implements PostAggregator
     final ColumnType type;
 
     if (aggregators != null && aggregators.containsKey(fieldName)) {
-      type = aggregators.get(fieldName).getType();
+      type = aggregators.get(fieldName).getColumnType();
     } else {
       type = null;
     }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/FieldAccessPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/FieldAccessPostAggregator.java
@@ -109,7 +109,7 @@ public class FieldAccessPostAggregator implements PostAggregator
     final ColumnType type;
 
     if (aggregators != null && aggregators.containsKey(fieldName)) {
-      type = aggregators.get(fieldName).getColumnType();
+      type = aggregators.get(fieldName).getIntermediateType();
     } else {
       type = null;
     }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
@@ -123,7 +123,7 @@ public class FinalizingFieldAccessPostAggregator implements PostAggregator
       //noinspection unchecked
       theComparator = aggregators.get(fieldName).getComparator();
       theFinalizer = aggregators.get(fieldName)::finalizeComputation;
-      finalizedType = aggregators.get(fieldName).getFinalizedColumnType();
+      finalizedType = aggregators.get(fieldName).getResultType();
     } else {
       //noinspection unchecked
       theComparator = (Comparator) Comparators.naturalNullsFirst();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregator.java
@@ -123,7 +123,7 @@ public class FinalizingFieldAccessPostAggregator implements PostAggregator
       //noinspection unchecked
       theComparator = aggregators.get(fieldName).getComparator();
       theFinalizer = aggregators.get(fieldName)::finalizeComputation;
-      finalizedType = aggregators.get(fieldName).getFinalizedType();
+      finalizedType = aggregators.get(fieldName).getFinalizedColumnType();
     } else {
       //noinspection unchecked
       theComparator = (Comparator) Comparators.naturalNullsFirst();

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GrouperBufferComparatorUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GrouperBufferComparatorUtils.java
@@ -148,7 +148,7 @@ public class GrouperBufferComparatorUtils
         int aggIndex = OrderByColumnSpec.getAggIndexForOrderBy(orderSpec, Arrays.asList(aggregatorFactories));
         if (aggIndex >= 0) {
           final StringComparator stringComparator = orderSpec.getDimensionComparator();
-          final ColumnType valueType = aggregatorFactories[aggIndex].getType();
+          final ColumnType valueType = aggregatorFactories[aggIndex].getColumnType();
           // Aggregators start after dimensions
           final int aggOffset = keySize + aggregatorOffsets[aggIndex];
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GrouperBufferComparatorUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GrouperBufferComparatorUtils.java
@@ -148,7 +148,7 @@ public class GrouperBufferComparatorUtils
         int aggIndex = OrderByColumnSpec.getAggIndexForOrderBy(orderSpec, Arrays.asList(aggregatorFactories));
         if (aggIndex >= 0) {
           final StringComparator stringComparator = orderSpec.getDimensionComparator();
-          final ColumnType valueType = aggregatorFactories[aggIndex].getColumnType();
+          final ColumnType valueType = aggregatorFactories[aggIndex].getIntermediateType();
           // Aggregators start after dimensions
           final int aggOffset = keySize + aggregatorOffsets[aggIndex];
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -901,7 +901,7 @@ public class RowBasedGrouperHelper
             fieldIndices.add(aggIndex);
             needsReverses.add(needsReverse);
             aggFlags.add(true);
-            fieldValueTypes.add(aggregatorFactories[aggIndex].getColumnType());
+            fieldValueTypes.add(aggregatorFactories[aggIndex].getIntermediateType());
             comparators.add(orderSpec.getDimensionComparator());
           }
         }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -901,7 +901,7 @@ public class RowBasedGrouperHelper
             fieldIndices.add(aggIndex);
             needsReverses.add(needsReverse);
             aggFlags.add(true);
-            fieldValueTypes.add(aggregatorFactories[aggIndex].getType());
+            fieldValueTypes.add(aggregatorFactories[aggIndex].getColumnType());
             comparators.add(orderSpec.getDimensionComparator());
           }
         }

--- a/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
@@ -267,18 +267,18 @@ public class RowSignature implements ColumnInspector
 
         switch (finalization) {
           case YES:
-            type = aggregator.getFinalizedColumnType();
+            type = aggregator.getResultType();
             break;
 
           case NO:
-            type = aggregator.getColumnType();
+            type = aggregator.getIntermediateType();
             break;
 
           default:
             assert finalization == Finalization.UNKNOWN;
 
-            if (aggregator.getColumnType().equals(aggregator.getFinalizedColumnType())) {
-              type = aggregator.getColumnType();
+            if (aggregator.getIntermediateType().equals(aggregator.getResultType())) {
+              type = aggregator.getIntermediateType();
             } else {
               // Use null if the type depends on whether the aggregator is finalized, since we don't know if
               // it will be finalized or not.

--- a/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
@@ -267,18 +267,18 @@ public class RowSignature implements ColumnInspector
 
         switch (finalization) {
           case YES:
-            type = aggregator.getFinalizedType();
+            type = aggregator.getFinalizedColumnType();
             break;
 
           case NO:
-            type = aggregator.getType();
+            type = aggregator.getColumnType();
             break;
 
           default:
             assert finalization == Finalization.UNKNOWN;
 
-            if (aggregator.getType().equals(aggregator.getFinalizedType())) {
-              type = aggregator.getType();
+            if (aggregator.getColumnType().equals(aggregator.getFinalizedColumnType())) {
+              type = aggregator.getColumnType();
             } else {
               // Use null if the type depends on whether the aggregator is finalized, since we don't know if
               // it will be finalized or not.

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -128,7 +128,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
       @Override
       public ColumnValueSelector<?> makeColumnValueSelector(final String column)
       {
-        final boolean isComplexMetric = agg.getColumnType().is(ValueType.COMPLEX);
+        final boolean isComplexMetric = agg.getIntermediateType().is(ValueType.COMPLEX);
 
         final ColumnValueSelector selector = baseSelectorFactory.makeColumnValueSelector(column);
 
@@ -138,7 +138,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
           // Wrap selector in a special one that uses ComplexMetricSerde to modify incoming objects.
           // For complex aggregators that read from multiple columns, we wrap all of them. This is not ideal but it
           // has worked so far.
-          final String complexTypeName = agg.getColumnType().getComplexTypeName();
+          final String complexTypeName = agg.getIntermediateType().getComplexTypeName();
           final ComplexMetricSerde serde = ComplexMetrics.getSerdeForType(complexTypeName);
           if (serde == null) {
             throw new ISE("Don't know how to handle type[%s]", complexTypeName);
@@ -939,7 +939,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
       this.index = index;
       this.name = factory.getName();
 
-      ColumnType valueType = factory.getColumnType();
+      ColumnType valueType = factory.getIntermediateType();
 
       if (valueType.isNumeric()) {
         capabilities = ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(valueType);

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -128,7 +128,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
       @Override
       public ColumnValueSelector<?> makeColumnValueSelector(final String column)
       {
-        final boolean isComplexMetric = agg.getType().is(ValueType.COMPLEX);
+        final boolean isComplexMetric = agg.getColumnType().is(ValueType.COMPLEX);
 
         final ColumnValueSelector selector = baseSelectorFactory.makeColumnValueSelector(column);
 
@@ -138,7 +138,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
           // Wrap selector in a special one that uses ComplexMetricSerde to modify incoming objects.
           // For complex aggregators that read from multiple columns, we wrap all of them. This is not ideal but it
           // has worked so far.
-          final String complexTypeName = agg.getType().getComplexTypeName();
+          final String complexTypeName = agg.getColumnType().getComplexTypeName();
           final ComplexMetricSerde serde = ComplexMetrics.getSerdeForType(complexTypeName);
           if (serde == null) {
             throw new ISE("Don't know how to handle type[%s]", complexTypeName);
@@ -939,7 +939,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
       this.index = index;
       this.name = factory.getName();
 
-      ColumnType valueType = factory.getType();
+      ColumnType valueType = factory.getColumnType();
 
       if (valueType.isNumeric()) {
         capabilities = ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(valueType);

--- a/processing/src/test/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactoryTest.java
@@ -113,7 +113,7 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    agg.getColumnType();
+    agg.getIntermediateType();
   }
 
   @Test
@@ -137,7 +137,7 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    agg.getFinalizedColumnType();
+    agg.getResultType();
   }
 
   @Test
@@ -222,9 +222,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.STRING, agg.getColumnType());
-    Assert.assertEquals(ColumnType.STRING, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING, agg.getResultType());
   }
 
   @Test
@@ -245,9 +245,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.LONG, agg.getColumnType());
-    Assert.assertEquals(ColumnType.LONG, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.LONG, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.LONG, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.LONG, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.LONG, agg.getResultType());
   }
 
   @Test
@@ -268,9 +268,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getResultType());
   }
 
   @Test
@@ -291,9 +291,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.STRING, agg.getColumnType());
-    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getResultType());
   }
 
   @Test
@@ -314,9 +314,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.STRING, agg.getColumnType());
-    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING, agg.getResultType());
   }
 
   @Test
@@ -337,9 +337,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.LONG, agg.getColumnType());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.LONG, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getResultType());
   }
 
   @Test
@@ -360,9 +360,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.LONG, agg.getColumnType());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.LONG, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING, agg.getResultType());
   }
 
   @Test
@@ -383,9 +383,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getResultType());
   }
 
   @Test
@@ -406,9 +406,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.STRING, agg.getResultType());
   }
 
   @Test
@@ -429,9 +429,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getColumnType());
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getFinalizedColumnType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getIntermediateType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getResultType());
   }
 
   @Test
@@ -452,9 +452,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getColumnType());
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getFinalizedColumnType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getIntermediateType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getIntermediateType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getResultType());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactoryTest.java
@@ -113,7 +113,7 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    agg.getType();
+    agg.getColumnType();
   }
 
   @Test
@@ -137,7 +137,7 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    agg.getFinalizedType();
+    agg.getFinalizedColumnType();
   }
 
   @Test
@@ -222,9 +222,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.STRING, agg.getType());
-    Assert.assertEquals(ColumnType.STRING, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.STRING, agg.getColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -245,9 +245,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.LONG, agg.getType());
-    Assert.assertEquals(ColumnType.LONG, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.LONG, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.LONG, agg.getColumnType());
+    Assert.assertEquals(ColumnType.LONG, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.LONG, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -268,9 +268,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getType());
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -291,9 +291,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.STRING, agg.getType());
-    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.STRING, agg.getColumnType());
+    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -314,9 +314,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.STRING, agg.getType());
-    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.STRING, agg.getColumnType());
+    Assert.assertEquals(ColumnType.STRING_ARRAY, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -337,9 +337,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.LONG, agg.getType());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.LONG, agg.getColumnType());
+    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -360,9 +360,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.LONG, agg.getType());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.LONG, agg.getColumnType());
+    Assert.assertEquals(ColumnType.LONG_ARRAY, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -383,9 +383,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getType());
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -406,9 +406,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getType());
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.STRING, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -429,9 +429,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getType());
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getType());
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getFinalizedType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getColumnType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getFinalizedColumnType());
   }
 
   @Test
@@ -452,9 +452,9 @@ public class ExpressionLambdaAggregatorFactoryTest extends InitializedNullHandli
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getType());
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getType());
-    Assert.assertEquals(ColumnType.DOUBLE, agg.getFinalizedType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getColumnType());
+    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, agg.getCombiningFactory().getColumnType());
+    Assert.assertEquals(ColumnType.DOUBLE, agg.getFinalizedColumnType());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregatorTest.java
@@ -85,7 +85,7 @@ public class FinalizingFieldAccessPostAggregatorTest extends InitializedNullHand
     AggregatorFactory aggFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(aggFactory.getComparator()).andReturn(Comparators.naturalNullsFirst()).once();
     EasyMock.expect(aggFactory.finalizeComputation("test")).andReturn(3L).once();
-    EasyMock.expect(aggFactory.getFinalizedColumnType()).andReturn(ColumnType.LONG).once();
+    EasyMock.expect(aggFactory.getResultType()).andReturn(ColumnType.LONG).once();
     EasyMock.replay(aggFactory);
 
     FinalizingFieldAccessPostAggregator postAgg = buildDecorated(
@@ -109,7 +109,7 @@ public class FinalizingFieldAccessPostAggregatorTest extends InitializedNullHand
     AggregatorFactory aggFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(aggFactory.getComparator()).andReturn(Comparators.naturalNullsFirst()).once();
     EasyMock.expect(aggFactory.finalizeComputation("test")).andReturn(3L).once();
-    EasyMock.expect(aggFactory.getFinalizedColumnType()).andReturn(ColumnType.LONG).once();
+    EasyMock.expect(aggFactory.getResultType()).andReturn(ColumnType.LONG).once();
     EasyMock.replay(aggFactory);
 
     FinalizingFieldAccessPostAggregator postAgg = buildDecorated(
@@ -149,7 +149,7 @@ public class FinalizingFieldAccessPostAggregatorTest extends InitializedNullHand
             .andReturn(Ordering.natural().<Long>nullsLast())
             .times(1);
 
-    EasyMock.expect(aggFactory.getFinalizedColumnType()).andReturn(ColumnType.LONG).once();
+    EasyMock.expect(aggFactory.getResultType()).andReturn(ColumnType.LONG).once();
     EasyMock.replay(aggFactory);
 
     FinalizingFieldAccessPostAggregator postAgg = buildDecorated(

--- a/processing/src/test/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/post/FinalizingFieldAccessPostAggregatorTest.java
@@ -85,7 +85,7 @@ public class FinalizingFieldAccessPostAggregatorTest extends InitializedNullHand
     AggregatorFactory aggFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(aggFactory.getComparator()).andReturn(Comparators.naturalNullsFirst()).once();
     EasyMock.expect(aggFactory.finalizeComputation("test")).andReturn(3L).once();
-    EasyMock.expect(aggFactory.getFinalizedType()).andReturn(ColumnType.LONG).once();
+    EasyMock.expect(aggFactory.getFinalizedColumnType()).andReturn(ColumnType.LONG).once();
     EasyMock.replay(aggFactory);
 
     FinalizingFieldAccessPostAggregator postAgg = buildDecorated(
@@ -109,7 +109,7 @@ public class FinalizingFieldAccessPostAggregatorTest extends InitializedNullHand
     AggregatorFactory aggFactory = EasyMock.createMock(AggregatorFactory.class);
     EasyMock.expect(aggFactory.getComparator()).andReturn(Comparators.naturalNullsFirst()).once();
     EasyMock.expect(aggFactory.finalizeComputation("test")).andReturn(3L).once();
-    EasyMock.expect(aggFactory.getFinalizedType()).andReturn(ColumnType.LONG).once();
+    EasyMock.expect(aggFactory.getFinalizedColumnType()).andReturn(ColumnType.LONG).once();
     EasyMock.replay(aggFactory);
 
     FinalizingFieldAccessPostAggregator postAgg = buildDecorated(
@@ -149,7 +149,7 @@ public class FinalizingFieldAccessPostAggregatorTest extends InitializedNullHand
             .andReturn(Ordering.natural().<Long>nullsLast())
             .times(1);
 
-    EasyMock.expect(aggFactory.getFinalizedType()).andReturn(ColumnType.LONG).once();
+    EasyMock.expect(aggFactory.getFinalizedColumnType()).andReturn(ColumnType.LONG).once();
     EasyMock.replay(aggFactory);
 
     FinalizingFieldAccessPostAggregator postAgg = buildDecorated(

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
@@ -445,7 +445,7 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     }
 
     @Override
-    public ColumnType getType()
+    public ColumnType getColumnType()
     {
       return new ColumnType(ValueType.COMPLEX, TYPE, null);
     }
@@ -463,9 +463,9 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     }
 
     @Override
-    public ColumnType getFinalizedType()
+    public ColumnType getFinalizedColumnType()
     {
-      return getType();
+      return getColumnType();
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
@@ -445,7 +445,7 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     }
 
     @Override
-    public ColumnType getColumnType()
+    public ColumnType getIntermediateType()
     {
       return new ColumnType(ValueType.COMPLEX, TYPE, null);
     }
@@ -463,9 +463,9 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     }
 
     @Override
-    public ColumnType getFinalizedColumnType()
+    public ColumnType getResultType()
     {
-      return getColumnType();
+      return getIntermediateType();
     }
   }
 


### PR DESCRIPTION
### Description
This PR renames `AggregatorFactory.getType` and `AggregatorFactory.getFinalizedType` to `getIntermediateType` and `getResultType`, and restores the previous 3 methods `getType`, `getFinalizedType`, and `getComplexTypeName` to their earlier incarnations before #11713, making default implementations of `getIntermediateType` and `getResultType` out of these previous methods. The previous methods all now have default implementation that explode so that they did not need restored to all existing `AggregatorFactory` implementations.

This is hella ugly, and now NONE of these methods are abstract, but it will be less disruptive to extension writers.

I am going to effectively revert this after the 0.23 release, but this at least gives slightly more warning to extension writers than release notes. I guess?

<hr>

##### Key changed/added classes in this PR
 * `AggregatorFactory`
