### PR TITLE
Upgrade ORC to 1.7.1

### DIFF
--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -31,7 +31,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <orc.version>1.7.0</orc.version>
+        <orc.version>1.7.1</orc.version>
     </properties>
     <dependencies>
         <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4543,7 +4543,7 @@ name: Apache ORC libraries
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 1.7.0
+version: 1.7.1
 libraries:
   - org.apache.orc: orc-mapreduce
   - org.apache.orc: orc-core


### PR DESCRIPTION
### Description
This PR aims to upgrade ORC to 1.7.1. 

Apache ORC 1.7.1 is the maintenance release with the following bug fixes. 

- https://github.com/apache/orc/releases/tag/rel%2Frelease-1.7.1

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
