### PR TITLE
only get bitmap index for string dictionary encoded columns

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelectorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.segment.column.BitmapIndex;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.StringDictionaryEncodedColumn;
+import org.apache.druid.segment.data.Indexed;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ColumnSelectorBitmapIndexSelectorTest
+{
+  private static final String STRING_DICTIONARY_COLUMN_NAME = "string";
+  private static final String NON_STRING_DICTIONARY_COLUMN_NAME = "not-string";
+
+  BitmapFactory bitmapFactory;
+  VirtualColumns virtualColumns;
+  ColumnSelector index;
+
+  ColumnSelectorBitmapIndexSelector bitmapIndexSelector;
+
+  @Before
+  public void setup()
+  {
+    bitmapFactory = EasyMock.createMock(BitmapFactory.class);
+    virtualColumns = EasyMock.createMock(VirtualColumns.class);
+    index = EasyMock.createMock(ColumnSelector.class);
+    bitmapIndexSelector = new ColumnSelectorBitmapIndexSelector(bitmapFactory, virtualColumns, index);
+
+    EasyMock.expect(virtualColumns.getVirtualColumn(STRING_DICTIONARY_COLUMN_NAME)).andReturn(null).anyTimes();
+    EasyMock.expect(virtualColumns.getVirtualColumn(NON_STRING_DICTIONARY_COLUMN_NAME)).andReturn(null).anyTimes();
+
+    ColumnHolder holder = EasyMock.createMock(ColumnHolder.class);
+    EasyMock.expect(index.getColumnHolder(STRING_DICTIONARY_COLUMN_NAME)).andReturn(holder).anyTimes();
+    StringDictionaryEncodedColumn stringColumn = EasyMock.createMock(StringDictionaryEncodedColumn.class);
+    EasyMock.expect(holder.getCapabilities()).andReturn(
+        ColumnCapabilitiesImpl.createDefault()
+                              .setType(ColumnType.STRING)
+                              .setDictionaryEncoded(true)
+                              .setDictionaryValuesUnique(true)
+                              .setDictionaryValuesSorted(true)
+                              .setHasBitmapIndexes(true)
+    ).anyTimes();
+    EasyMock.expect(holder.getColumn()).andReturn(stringColumn).anyTimes();
+    BitmapIndex someIndex = EasyMock.createMock(BitmapIndex.class);
+    EasyMock.expect(holder.getBitmapIndex()).andReturn(someIndex).anyTimes();
+    ImmutableBitmap someBitmap = EasyMock.createMock(ImmutableBitmap.class);
+    EasyMock.expect(someIndex.getIndex("foo")).andReturn(0).anyTimes();
+    EasyMock.expect(someIndex.getBitmap(0)).andReturn(someBitmap).anyTimes();
+
+
+    ColumnHolder nonStringHolder = EasyMock.createMock(ColumnHolder.class);
+    EasyMock.expect(index.getColumnHolder(NON_STRING_DICTIONARY_COLUMN_NAME)).andReturn(nonStringHolder).anyTimes();
+
+    EasyMock.expect(nonStringHolder.getCapabilities()).andReturn(
+        ColumnCapabilitiesImpl.createDefault()
+                              .setType(ColumnType.ofComplex("testBlob"))
+                              .setDictionaryEncoded(true)
+                              .setDictionaryValuesUnique(true)
+                              .setDictionaryValuesSorted(true)
+                              .setHasBitmapIndexes(true)
+                              .setFilterable(true)
+    ).anyTimes();
+
+    EasyMock.replay(bitmapFactory, virtualColumns, index, holder, stringColumn, nonStringHolder, someIndex, someBitmap);
+  }
+
+  @Test
+  public void testStringDictionaryUseIndex()
+  {
+    BitmapIndex bitmapIndex = bitmapIndexSelector.getBitmapIndex(STRING_DICTIONARY_COLUMN_NAME);
+    Assert.assertNotNull(bitmapIndex);
+    Indexed<String> vals = bitmapIndexSelector.getDimensionValues(STRING_DICTIONARY_COLUMN_NAME);
+
+    Assert.assertNotNull(vals);
+
+    ImmutableBitmap valueIndex = bitmapIndexSelector.getBitmapIndex(STRING_DICTIONARY_COLUMN_NAME, "foo");
+    Assert.assertNotNull(valueIndex);
+    EasyMock.verify(bitmapFactory, virtualColumns, index);
+  }
+
+  @Test
+  public void testNonStringDictionaryDoNotUseIndex()
+  {
+    BitmapIndex bitmapIndex = bitmapIndexSelector.getBitmapIndex(NON_STRING_DICTIONARY_COLUMN_NAME);
+    Assert.assertNull(bitmapIndex);
+    Indexed<String> vals = bitmapIndexSelector.getDimensionValues(NON_STRING_DICTIONARY_COLUMN_NAME);
+
+    Assert.assertNull(vals);
+
+    ImmutableBitmap valueIndex = bitmapIndexSelector.getBitmapIndex(NON_STRING_DICTIONARY_COLUMN_NAME, "foo");
+    Assert.assertNull(valueIndex);
+    EasyMock.verify(bitmapFactory, virtualColumns, index);
+  }
+}


### PR DESCRIPTION
### Description
Follow-up to #11829, this PR adds safeguards to prevent using `BitmapIndex` (which still relies on the underlying column using a String typed dictionary) from being used directly for non-virtual columns that are dictionary encoded, but not String typed. Virtual columns may still provide bitmap indexes, but only dictionary encoded string columns will supply them directly from the column after the changes of this patch.

We should be able to remove these in the future if we modify filtering to be more friendly to non-string types, but until then this will prevent funny class cast exceptions when filters notice that a column has a bitmap and so will use it, but then fail when actually trying to use them.

<hr>

##### Key changed/added classes in this PR
 * `ColumnSelectorBitmapIndexSelector`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
