### PR TITLE
Fix TestServerInventoryView behavioral discrepancy.

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/TestServerInventoryView.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/TestServerInventoryView.java
@@ -187,8 +187,11 @@ public class TestServerInventoryView implements TimelineServerView
     timelineCallbackExecs.forEach(
         execAndCallback -> execAndCallback.lhs.execute(() -> {
           execAndCallback.rhs.serverSegmentRemoved(whichServer, segment);
-          // assume that all replicas have been removed and fire this one too
-          execAndCallback.rhs.segmentRemoved(segment);
+
+          // Fire segmentRemoved if all replicas have been removed.
+          if (!segments.contains(segment) && !brokerSegments.contains(segment) && !realtimeSegments.contains(segment)) {
+            execAndCallback.rhs.segmentRemoved(segment);
+          }
         })
     );
   }


### PR DESCRIPTION
Unlike a real one, TestServerInventoryView would call segmentRemoved
any time _any_ segment was removed. It should only be called when _all_
segments have been removed.