### PR TITLE
Fix bug Unrecognized token 'No': was expecting (JSON String,...) when…

### DIFF
--- a/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
@@ -32,6 +32,7 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.timeline.DataSegment;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -53,6 +54,7 @@ import java.util.Set;
 
 public class HttpIndexingServiceClient implements IndexingServiceClient
 {
+  private static final Logger log = new Logger(HttpIndexingServiceClient.class);
   private final DruidLeaderClient druidLeaderClient;
   private final ObjectMapper jsonMapper;
 
@@ -350,7 +352,10 @@ public class HttpIndexingServiceClient implements IndexingServiceClient
           )
       );
 
-      if (responseHolder.getContent().length() == 0) {
+      if (responseHolder.getContent().length() == 0 || responseHolder.getStatus() != HttpResponseStatus.OK) {
+        if (responseHolder.getStatus() == HttpResponseStatus.NOT_FOUND) {
+          log.info("Report not found for taskId [%s] because [%s]", taskId, responseHolder.getContent());
+        }
         return null;
       }
 

--- a/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
@@ -355,6 +355,9 @@ public class HttpIndexingServiceClient implements IndexingServiceClient
       if (responseHolder.getContent().length() == 0 || responseHolder.getStatus() != HttpResponseStatus.OK) {
         if (responseHolder.getStatus() == HttpResponseStatus.NOT_FOUND) {
           log.info("Report not found for taskId [%s] because [%s]", taskId, responseHolder.getContent());
+        } else {
+          // also log other non-ok statuses:
+          log.info("Non OK response for taskId [%s] because [%s]", taskId, responseHolder.getContent());
         }
         return null;
       }


### PR DESCRIPTION
### Description
Fixes bug were a peon task (supervisor?) makes a request to the leader (overlord) for a task report but the leader cannot find the report then the leader responds with something like:

"No task reports were found for this task. The task may not exist, or it may not have completed yet

But the client is expecting JSON to be returned. So client chokes with this response and dies with an exception like this one:

``` 
2021-10-12T21:42:47,310 WARN [qtp1027158270-111] org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSuperv\
     isorTask - Encountered exception when getting live subtask report for task: single_phase_sub_task_test_100gb_125million_2\
     5segment_nmealobf_2021-10-12T21:42:37.944Z
 584 java.lang.RuntimeException: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'No': was expecting (JSON S\
     tring, Number, Array, Object or token 'null', 'true' or 'false')
 585  at [Source: (String)"No task reports were found for this task. The task may not exist, or it may not have completed yet.\
     "; line: 1, column: 3]
 586         at org.apache.druid.client.indexing.HttpIndexingServiceClient.getTaskReport(HttpIndexingServiceClient.java:361) ~\
     [druid-server-2021.10.0-iap.jar:2021.10.0-iap]
```

It has been observed in the field that sometimes this leads to the supervisor task starting to kill all other tasks running under its supervision.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
