### PR TITLE
AWS "Data read has a different length than the expected" error should reset stream and try again

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/InputEntity.java
+++ b/core/src/main/java/org/apache/druid/data/input/InputEntity.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import org.apache.druid.data.input.impl.RetryingInputStream;
 import org.apache.druid.guice.annotations.UnstableApi;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
@@ -128,4 +129,15 @@ public interface InputEntity
   {
     return Predicates.alwaysFalse();
   }
+
+  /**
+   * Returns a reset condition that the caller should retry on.
+   * The returned condition should be used when reading data from this InputEntity such as in {@link #fetch}
+   * or {@link RetryingInputEntity}.
+   */
+  default Predicate<Throwable> getResetCondition()
+  {
+    return RetryingInputStream.DEFAULT_RESET_CONDITION;
+  }
+
 }

--- a/core/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
+++ b/core/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
@@ -41,9 +41,15 @@ public abstract class RetryingInputEntity implements InputEntity
         new RetryingInputEntityOpenFunction(),
         getRetryCondition(),
         getResetCondition(),
-        RetryUtils.DEFAULT_MAX_TRIES
+        getMaxRetries()
     );
     return CompressionUtils.decompress(retryingInputStream, getPath());
+  }
+
+  // override this in sub-classes to customize retries
+  protected int getMaxRetries()
+  {
+    return RetryUtils.DEFAULT_MAX_TRIES;
   }
 
   /**

--- a/core/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
+++ b/core/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
@@ -40,6 +40,7 @@ public abstract class RetryingInputEntity implements InputEntity
         this,
         new RetryingInputEntityOpenFunction(),
         getRetryCondition(),
+        null,
         RetryUtils.DEFAULT_MAX_TRIES
     );
     return CompressionUtils.decompress(retryingInputStream, getPath());

--- a/core/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
+++ b/core/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
@@ -40,7 +40,7 @@ public abstract class RetryingInputEntity implements InputEntity
         this,
         new RetryingInputEntityOpenFunction(),
         getRetryCondition(),
-        null,
+        getResetCondition(),
         RetryUtils.DEFAULT_MAX_TRIES
     );
     return CompressionUtils.decompress(retryingInputStream, getPath());

--- a/core/src/main/java/org/apache/druid/data/input/impl/prefetch/FileFetcher.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/prefetch/FileFetcher.java
@@ -98,7 +98,7 @@ public class FileFetcher<T> extends Fetcher<T>
   {
     return new OpenObject<>(
         object,
-        new RetryingInputStream<>(object, openObjectFunction, retryCondition, getFetchConfig().getMaxFetchRetry()),
+        new RetryingInputStream<>(object, openObjectFunction, retryCondition, null, getFetchConfig().getMaxFetchRetry()),
         getNoopCloser()
     );
   }

--- a/core/src/test/java/org/apache/druid/data/input/impl/prefetch/RetryingInputStreamTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/prefetch/RetryingInputStreamTest.java
@@ -97,7 +97,7 @@ public class RetryingInputStreamTest
 
 
   @Test(expected = IOException.class)
-  public void testDefaultsRead() throws IOException
+  public void testDefaultsReadThrows() throws IOException
   {
     throwIOException = true;
     final InputStream retryingInputStream = new RetryingInputStream<>(
@@ -139,7 +139,7 @@ public class RetryingInputStreamTest
   }
 
   @Test
-  public void testIOExceptionNotRetriableReadThrows() throws IOException
+  public void testIOExceptionNotRetriableRead() throws IOException
   {
     throwCustomException = true;
     throwIOException = true;

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.s3;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
@@ -84,4 +85,13 @@ public class S3Entity extends RetryingInputEntity
   {
     return S3Utils.S3RETRY;
   }
+
+  @Override
+  public Predicate<Throwable> getResetCondition()
+  {
+    return t -> super.getResetCondition().apply(t) ||
+                (t instanceof SdkClientException &&
+                 t.getMessage().contains("Data read has a different length than the expected"));
+  }
+
 }

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
@@ -23,10 +23,12 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import org.apache.druid.data.input.RetryingInputEntity;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.storage.s3.S3StorageDruidModule;
 import org.apache.druid.storage.s3.S3Utils;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
@@ -39,11 +41,29 @@ public class S3Entity extends RetryingInputEntity
 {
   private final ServerSideEncryptingAmazonS3 s3Client;
   private final CloudObjectLocation object;
+  private final int maxRetries;
 
   S3Entity(ServerSideEncryptingAmazonS3 s3Client, CloudObjectLocation coords)
   {
     this.s3Client = s3Client;
     this.object = coords;
+    this.maxRetries = RetryUtils.DEFAULT_MAX_TRIES;
+  }
+
+  // this was added for testing but it might be useful in other cases (you can
+  // configure maxRetries...
+  S3Entity(ServerSideEncryptingAmazonS3 s3Client, CloudObjectLocation coords, int maxRetries)
+  {
+    Preconditions.checkArgument(maxRetries >= 0);
+    this.s3Client = s3Client;
+    this.object = coords;
+    this.maxRetries = maxRetries;
+  }
+
+  @Override
+  protected int getMaxRetries()
+  {
+    return maxRetries;
   }
 
   @Override

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
@@ -89,6 +89,9 @@ public class S3Entity extends RetryingInputEntity
   @Override
   public Predicate<Throwable> getResetCondition()
   {
+    // SdkClientException can be thrown for many reasons and the only way to
+    // distinguish it is to look at the message, this is not ideal since the
+    // message may change so it may need to be adjusted in the future
     return t -> super.getResetCondition().apply(t) ||
                 (t instanceof SdkClientException &&
                  t.getMessage().contains("Data read has a different length than the expected"));

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -554,7 +554,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null,
         ImmutableList.of(PREFIXES.get(0)),
         null,
-        null
+        null,
+        3 // only have three retries since they are slow
     );
 
     InputRowSchema someSchema = new InputRowSchema(

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.s3;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -28,6 +29,7 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -86,6 +88,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.easymock.EasyMock.expectLastCall;
 
 public class S3InputSourceTest extends InitializedNullHandlingTest
 {
@@ -535,6 +539,48 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     EasyMock.verify(S3_CLIENT);
   }
 
+  @Test(expected = SdkClientException.class)
+  public void testReaderRetriesOnSdkClientExceptionButNeverSucceedsThenThrows() throws Exception
+  {
+    EasyMock.reset(S3_CLIENT);
+    expectListObjects(PREFIXES.get(0), ImmutableList.of(EXPECTED_URIS.get(0)), CONTENT);
+    expectSdkClientException(EXPECTED_URIS.get(0));
+    EasyMock.replay(S3_CLIENT);
+
+    S3InputSource inputSource = new S3InputSource(
+        SERVICE,
+        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+        INPUT_DATA_CONFIG,
+        null,
+        ImmutableList.of(PREFIXES.get(0)),
+        null,
+        null
+    );
+
+    InputRowSchema someSchema = new InputRowSchema(
+        new TimestampSpec("time", "auto", null),
+        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dim1", "dim2"))),
+        ColumnsFilter.all()
+    );
+
+    InputSourceReader reader = inputSource.reader(
+        someSchema,
+        new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
+        temporaryFolder.newFolder()
+    );
+
+    CloseableIterator<InputRow> iterator = reader.read();
+
+    while (iterator.hasNext()) {
+      InputRow nextRow = iterator.next();
+      Assert.assertEquals(NOW, nextRow.getTimestamp());
+      Assert.assertEquals("hello", nextRow.getDimension("dim1").get(0));
+      Assert.assertEquals("world", nextRow.getDimension("dim2").get(0));
+    }
+
+    EasyMock.verify(S3_CLIENT);
+  }
+
   @Test
   public void testCompressedReader() throws IOException
   {
@@ -619,6 +665,31 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     someObject.setObjectContent(new ByteArrayInputStream(CONTENT));
     EasyMock.expect(S3_CLIENT.getObject(EasyMock.anyObject(GetObjectRequest.class))).andReturn(someObject).once();
   }
+
+
+  // Setup mocks for invoquing the resettable condition for the S3Entity:
+  private static void expectSdkClientException(URI uri) throws IOException
+  {
+    final String s3Bucket = uri.getAuthority();
+    final String key = S3Utils.extractS3Key(uri);
+
+    S3ObjectInputStream someInputStream = EasyMock.createMock(S3ObjectInputStream.class);
+    EasyMock.expect(someInputStream.read(EasyMock.anyObject(), EasyMock.anyInt(), EasyMock.anyInt()))
+            .andThrow(new SdkClientException("Data read has a different length than the expected")).anyTimes();
+    someInputStream.close();
+    expectLastCall().andVoid().anyTimes();
+
+    S3Object someObject = EasyMock.createMock(S3Object.class);
+    EasyMock.expect(someObject.getBucketName()).andReturn(s3Bucket).anyTimes();
+    EasyMock.expect(someObject.getKey()).andReturn(key).anyTimes();
+    EasyMock.expect(someObject.getObjectContent()).andReturn(someInputStream).anyTimes();
+
+    EasyMock.expect(S3_CLIENT.getObject(EasyMock.anyObject(GetObjectRequest.class))).andReturn(someObject).anyTimes();
+
+    EasyMock.replay(someObject);
+    EasyMock.replay(someInputStream);
+  }
+
 
   private static void expectGetObjectCompressed(URI uri) throws IOException
   {


### PR DESCRIPTION

### Description
The `S3Entity` reads objects (i.e. files)  stored in an AWS bucket using a stream. Often those files are large and S3 may drop the connection. One of the symptoms of a dropped connection is an exception coming from the AWS client sdk like this:

```
2021-10-13T01:04:21,019 ERROR [task-runner-0-priority-0] org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseSubTask - Encountered exception in parallel sub task.
java.lang.IllegalStateException: java.io.IOException: com.amazonaws.SdkClientException: Data read has a different length than the expected: dataLength=589456583; expectedLength=4288561114; includeSkipped=true; in.getClass()=class com.amazonaws.services.s3.AmazonS3Client$2; markedSupported=false; marked=0; resetSinceLastMarked=false; markCount=0; resetCount=0
	at org.apache.commons.io.LineIterator.hasNext(LineIterator.java:108) ~[commons-io-2.11.0.jar:2.11.0]
	at org.apache.druid.data.input.TextReader$1.hasNext(TextReader.java:73) 
``` 

Today this exception in the code is not considered retry-able. In addition, the current code in `org.apache.druid.data.input.impl.RetryinInputStrem` has a private "reset condition". The retry condition simply retries inserting sleeps in between but the reset condition actually first resets the input stream in the offset where it left off, reopens, and retries. 

For the exception above we want to add a custom "reset condition" (similar to the already existing custom "retry condition") that the S3entity can use to signal that the above exception should be resettable.

This PR implements that custom resettable condition and adds the proper condition to the `S3Entty` so that it can recover from such exception.

### Algorithmic choices
Another choice could have been to use the [Amazon's SDK TransferManager](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/transfer/TransferManager.html) or `org.apache.druid.data.input.InputEntity#fetch` to completely download the S3 object to local storage and then fetch from there. But we decided to leave this for future work if needed since reset & retry may be enough.



<hr>

##### Key changed/added classes in this PR
 * `InputEntity`
 * `RetryingInputStream`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [X] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
