### PR TITLE
StorageAdapter: Add getRowSignature method.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentReader.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentReader.java
@@ -52,7 +52,6 @@ import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.QueryableIndexStorageAdapter;
 import org.apache.druid.segment.VirtualColumns;
-import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.filter.Filters;
@@ -127,11 +126,7 @@ public class DruidSegmentReader extends IntermediateRowParsingReader<Map<String,
     // schemaless mode.
     final Set<String> columnsToRead = Sets.newLinkedHashSet(
         Iterables.filter(
-            Iterables.concat(
-                Collections.singleton(ColumnHolder.TIME_COLUMN_NAME),
-                storageAdapter.getAdapter().getAvailableDimensions(),
-                storageAdapter.getAdapter().getAvailableMetrics()
-            ),
+            storageAdapter.getAdapter().getRowSignature().getColumnNames(),
             columnsFilter::apply
         )
     );

--- a/processing/src/main/java/org/apache/druid/segment/RowBasedStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowBasedStorageAdapter.java
@@ -83,6 +83,12 @@ public class RowBasedStorageAdapter<RowType> implements StorageAdapter
   }
 
   @Override
+  public RowSignature getRowSignature()
+  {
+    return rowSignature;
+  }
+
+  @Override
   public int getDimensionCardinality(String column)
   {
     return Integer.MAX_VALUE;

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.segment.join;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.granularity.Granularity;
@@ -34,7 +33,6 @@ import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
-import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.filter.Filters;
@@ -370,10 +368,7 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
       @Nullable List<VirtualColumn> postJoinVirtualColumns
   )
   {
-    final Set<String> baseColumns = new HashSet<>();
-    baseColumns.add(ColumnHolder.TIME_COLUMN_NAME);
-    Iterables.addAll(baseColumns, baseAdapter.getAvailableDimensions());
-    Iterables.addAll(baseColumns, baseAdapter.getAvailableMetrics());
+    final Set<String> baseColumns = new HashSet<>(baseAdapter.getRowSignature().getColumnNames());
 
     for (VirtualColumn virtualColumn : virtualColumns.getVirtualColumns()) {
       // Virtual columns cannot depend on each other, so we don't need to check transitive dependencies.

--- a/processing/src/test/java/org/apache/druid/segment/RowBasedStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/RowBasedStorageAdapterTest.java
@@ -254,6 +254,13 @@ public class RowBasedStorageAdapterTest
   }
 
   @Test
+  public void test_getRowSignature()
+  {
+    final RowBasedStorageAdapter<Integer> adapter = createIntAdapter();
+    Assert.assertEquals(ROW_SIGNATURE, adapter.getRowSignature());
+  }
+
+  @Test
   public void test_getDimensionCardinality_knownColumns()
   {
     final RowBasedStorageAdapter<Integer> adapter = createIntAdapter(0, 1, 2);


### PR DESCRIPTION
Simplifies logic for callers that only want to get a list of all the
column names, or column names and types. Updated callers SegmentAnalyzer,
HashJoinSegmentStorageAdapter, and DruidSegmentReader.