### PR TITLE
TestKafkaExtractionCluster: Shut down Kafka, ZK in @After.

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -91,6 +91,9 @@ public class TestKafkaExtractionCluster
   {
     zkServer = new TestingCluster(1);
     zkServer.start();
+    closer.register(() -> {
+      zkServer.stop();
+    });
 
     kafkaServer = new KafkaServer(
           getBrokerProperties(),
@@ -99,6 +102,10 @@ public class TestKafkaExtractionCluster
           false);
 
     kafkaServer.startup();
+    closer.register(() -> {
+      kafkaServer.shutdown();
+      kafkaServer.awaitShutdown();
+    });
     log.info("---------------------------Started Kafka Broker ---------------------------");
 
     log.info("---------------------------Publish Messages to topic-----------------------");


### PR DESCRIPTION
Fixes flaky test due to cleaning up temporary directories before the things that are using those temporary directories. See also investigation in #11962.