### PR TITLE
Docs - Corrected leaderlatch name

### DIFF
--- a/docs/dependencies/zookeeper.md
+++ b/docs/dependencies/zookeeper.md
@@ -43,7 +43,7 @@ The operations that happen over ZK are
 
 ## Coordinator Leader Election
 
-We use the Curator LeadershipLatch recipe to do leader election at path
+We use the Curator [LeaderLatch](https://curator.apache.org/curator-recipes/leader-latch.html) recipe to perform leader election at path
 
 ```
 ${druid.zk.paths.coordinatorPath}/_COORDINATOR


### PR DESCRIPTION
### Description

The Curator LeaderLatch instance was incorrectly referred to as LeadershipLatch. This PR corrects this issue.

This PR has:
- [ X ] been self-reviewed.