### PR TITLE
Try to fix flaky ITBroadcastJoinQueryTest.

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractS3AssumeRoleIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractS3AssumeRoleIndexTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.utils.CloseableUtils;
 import org.testng.Assert;
 import org.testng.SkipException;
 
@@ -190,7 +191,10 @@ public abstract class AbstractS3AssumeRoleIndexTest extends AbstractITBatchIndex
     }
     finally {
       // If the test pass, then there is no datasource to unload
-      closeQuietly(unloader(indexDatasource + config.getExtraDatasourceNameSuffix()));
+      CloseableUtils.closeAndSuppressExceptions(
+          unloader(indexDatasource + config.getExtraDatasourceNameSuffix()),
+          e -> {}
+      );
     }
   }
 
@@ -258,17 +262,6 @@ public abstract class AbstractS3AssumeRoleIndexTest extends AbstractITBatchIndex
           true,
           new Pair<>(false, false)
       );
-    }
-  }
-
-  private void closeQuietly(Closeable closeable)
-  {
-    try {
-      if (closeable != null) {
-        closeable.close();
-      }
-    }
-    catch (Exception var2) {
     }
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.MediaType;
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class ITAppenderatorDriverRealtimeIndexTaskTest extends AbstractITRealtim
     final ServerDiscoverySelector eventReceiverSelector = factory.createSelector(EVENT_RECEIVER_SERVICE_NAME);
     eventReceiverSelector.start();
     InputStreamReader isr;
-    try {
+    try (final Closeable ignored = eventReceiverSelector::stop) {
       isr = new InputStreamReader(
           ITRealtimeIndexTaskTest.class.getResourceAsStream(EVENT_DATA_FILE),
           StandardCharsets.UTF_8
@@ -127,9 +128,6 @@ public class ITAppenderatorDriverRealtimeIndexTaskTest extends AbstractITRealtim
     }
     catch (Exception e) {
       throw new RuntimeException(e);
-    }
-    finally {
-      eventReceiverSelector.stop();
     }
   }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.MediaType;
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -87,7 +88,7 @@ public class ITRealtimeIndexTaskTest extends AbstractITRealtimeIndexTaskTest
     final ServerDiscoverySelector eventReceiverSelector = factory.createSelector(EVENT_RECEIVER_SERVICE_NAME);
     eventReceiverSelector.start();
     InputStreamReader isr;
-    try {
+    try (final Closeable ignored = eventReceiverSelector::stop) {
       isr = new InputStreamReader(
           ITRealtimeIndexTaskTest.class.getResourceAsStream(EVENT_DATA_FILE),
           StandardCharsets.UTF_8
@@ -144,9 +145,6 @@ public class ITRealtimeIndexTaskTest extends AbstractITRealtimeIndexTaskTest
     }
     catch (Exception e) {
       throw new RuntimeException(e);
-    }
-    finally {
-      eventReceiverSelector.stop();
     }
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITS3OverrideCredentialsIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITS3OverrideCredentialsIndexTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
 import org.apache.druid.tests.TestNGGroup;
+import org.apache.druid.utils.CloseableUtils;
 import org.testng.Assert;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
@@ -191,7 +192,10 @@ public class ITS3OverrideCredentialsIndexTest extends AbstractITBatchIndexTest
     }
     finally {
       // If the test pass, then there is no datasource to unload
-      closeQuietly(unloader(indexDatasource + config.getExtraDatasourceNameSuffix()));
+      CloseableUtils.closeAndSuppressExceptions(
+          unloader(indexDatasource + config.getExtraDatasourceNameSuffix()),
+          e -> {}
+      );
     }
   }
 
@@ -264,18 +268,10 @@ public class ITS3OverrideCredentialsIndexTest extends AbstractITBatchIndexTest
     }
     finally {
       // If the test pass, then there is no datasource to unload
-      closeQuietly(unloader(indexDatasource + config.getExtraDatasourceNameSuffix()));
-    }
-  }
-
-  private void closeQuietly(Closeable closeable)
-  {
-    try {
-      if (closeable != null) {
-        closeable.close();
-      }
-    }
-    catch (Exception var2) {
+      CloseableUtils.closeAndSuppressExceptions(
+          unloader(indexDatasource + config.getExtraDatasourceNameSuffix()),
+          e -> {}
+      );
     }
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITUnionQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITUnionQueryTest.java
@@ -88,14 +88,13 @@ public class ITUnionQueryTest extends AbstractIndexerTest
   }
 
   @Test
-  public void testUnionQuery() throws IOException
+  public void testUnionQuery() throws Exception
   {
     final int numTasks = 3;
-    final Closer closer = Closer.create();
-    for (int i = 0; i < numTasks; i++) {
-      closer.register(unloader(fullDatasourceName + i));
-    }
-    try {
+    try (final Closer closer = Closer.create()) {
+      for (int i = 0; i < numTasks; i++) {
+        closer.register(unloader(fullDatasourceName + i));
+      }
       // Load 3 datasources with same dimensions
       String task = setShutOffTime(
           getResourceAsString(UNION_TASK_RESOURCE),
@@ -178,12 +177,6 @@ public class ITUnionQueryTest extends AbstractIndexerTest
       // run queries on historical nodes
       this.queryHelper.testQueriesFromString(queryResponseTemplate);
 
-    }
-    catch (Throwable e) {
-      throw closer.rethrow(e);
-    }
-    finally {
-      closer.close();
     }
   }
 


### PR DESCRIPTION
I saw it fail in another branch: https://api.travis-ci.com/v3/job/549055156/log.txt

I suspect an underyling exception was getting chomped by the fact that a test is being run in a finally block. I moved the test out of the finally block in the hopes that the underlying exception will pop up again. This won't fix whatever is happening, but may make it easier to debug.

I also adjusted some other finally blocks to be more nice.