### PR TITLE
Docs: Remove reference to deprecated field `targetPartitionSize`

### DIFF
--- a/docs/design/segments.md
+++ b/docs/design/segments.md
@@ -32,7 +32,7 @@ operate well under heavy query load, it is important for the segment
 file size to be within the recommended range of 300MB-700MB. If your
 segment files are larger than this range, then consider either
 changing the granularity of the time interval or partitioning your
-data and tweaking the `targetPartitionSize` in your `partitionsSpec`
+data and tweaking the `targetRowsPerSegment` in your `partitionsSpec`
 (a good starting point for this parameter is 5 million rows).  See the
 sharding section below and the 'Partitioning specification' section of
 the [Batch ingestion](../ingestion/hadoop.md#partitionsspec) documentation

--- a/website/.spelling
+++ b/website/.spelling
@@ -473,7 +473,7 @@ druid-s3-extensions
  - ../docs/dependencies/metadata-storage.md
 BasicDataSource
  - ../docs/dependencies/zookeeper.md
-LeadershipLatch
+LeaderLatch
 3.5.x
 3.4.x
  - ../docs/design/auth.md


### PR DESCRIPTION
### Description

`targetPartitionSize` has been deprecated in favour of `targetRowsPerSegment`
(or `maxRowsPerSegment` in case of dynamic partitioning)

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.