### PR TITLE
Log correct hydrant count

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
@@ -1148,9 +1148,9 @@ public class BatchAppenderator implements Appenderator
       sm.setPersistedFileDir(persistDir);
 
       log.info(
-          "About to persist in-memory data for segment[%s] spill[%s] to disk in [%,d] ms (%,d rows).",
+          "Persisted in-memory data for segment[%s] spill[%s] to disk in [%,d] ms (%,d rows).",
           indexToPersist.getSegmentId(),
-          indexToPersist.getCount(),
+          sm.getNumHydrants(),
           (System.nanoTime() - startTime) / 1000000,
           numRows
       );


### PR DESCRIPTION
### Description
This PR fixes a logging bug in the `BatchAppendrator` class when hydrants are persisted. The bug is that the count of hydrants before this class was added was being kept in the `IncrementalIndex` and obtained using its `getCount()` method. Now the hydrant count is being kept in the new `sinksMetadata` that keeps tracks of `Sink` metadata (such as the hydrant count). The reason to change the place for keeping that count is that Sinks & Hydrants are no longer kept in memory as soon as they are persisted. 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X ] been tested in a test Druid cluster.
