### PR TITLE
HttpResponseHandler: Fill out truncated javadoc.

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/http/client/response/HttpResponseHandler.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/response/HttpResponseHandler.java
@@ -90,7 +90,11 @@ public interface HttpResponseHandler<IntermediateType, FinalType>
     /**
      * Call this to resume reading after you have suspended it.
      *
-     * @param chunkNum chunk number corresponding to the handleChunk() or handleResponse() call from which you
+     * This method will do nothing if reading is not currently suspended.
+     *
+     * @param chunkNum chunk number corresponding to the handleChunk() or handleResponse() call from which you returned
+     *                 a ClientResponse where {@link ClientResponse#isContinueReading()} was true.
+     *
      * @return time that backpressure was applied (channel was closed for reads)
      */
     long resume(long chunkNum);


### PR DESCRIPTION
The existing javadocs ended abruptly without