### PR TITLE
RemoteTaskRunner: Fix NPE in streamTaskReports.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -662,6 +662,12 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     }
 
     final TaskLocation taskLocation = runningWorkItem.getLocation();
+
+    if (TaskLocation.unknown().equals(taskLocation)) {
+      // No location known for this task. It may have not been assigned one yet.
+      return Optional.absent();
+    }
+
     final URL url = TaskRunnerUtils.makeTaskLocationURL(
         taskLocation,
         "/druid/worker/v1/chat/%s/liveReports",

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -1010,6 +1010,12 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     } else {
       // Worker is still running this task
       TaskLocation taskLocation = taskRunnerWorkItem.getLocation();
+
+      if (TaskLocation.unknown().equals(taskLocation)) {
+        // No location known for this task. It may have not been assigned a location yet.
+        return Optional.absent();
+      }
+
       final URL url = TaskRunnerUtils.makeTaskLocationURL(
           taskLocation,
           "/druid/worker/v1/chat/%s/liveReports",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
@@ -19,12 +19,16 @@
 
 package org.apache.druid.indexing.common.tasklogs;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
+import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.config.FileTaskLogsConfig;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.TestHelper;
 import org.apache.druid.tasklogs.TaskLogs;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -67,6 +71,28 @@ public class FileTaskLogsTest
     finally {
       FileUtils.deleteDirectory(tmpDir);
     }
+  }
+
+  @Test
+  public void testSimpleReport() throws Exception
+  {
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
+    final File tmpDir = temporaryFolder.newFolder();
+    final File logDir = new File(tmpDir, "druid/logs");
+    final File reportFile = new File(tmpDir, "report.json");
+
+    final String taskId = "myTask";
+    final TestTaskReport testReport = new TestTaskReport(taskId);
+    final String testReportString = mapper.writeValueAsString(TaskReport.buildTaskReports(testReport));
+    Files.write(testReportString, reportFile, StandardCharsets.UTF_8);
+
+    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+    taskLogs.pushTaskReports("foo", reportFile);
+
+    Assert.assertEquals(
+        testReportString,
+        StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskReports("foo").get().openStream()))
+    );
   }
 
   @Test
@@ -122,5 +148,38 @@ public class FileTaskLogsTest
   private String readLog(TaskLogs taskLogs, String logFile, long offset) throws IOException
   {
     return StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskLog(logFile, offset).get().openStream()));
+  }
+
+  private static class TestTaskReport implements TaskReport
+  {
+    static final String KEY = "testReport";
+    static final Map<String, Object> PAYLOAD = ImmutableMap.of("foo", "bar");
+
+    private final String taskId;
+
+    public TestTaskReport(String taskId)
+    {
+      this.taskId = taskId;
+    }
+
+    @Override
+    @JsonProperty
+    public String getTaskId()
+    {
+      return taskId;
+    }
+
+    @Override
+    public String getReportKey()
+    {
+      return KEY;
+    }
+
+    @Override
+    @JsonProperty
+    public Object getPayload()
+    {
+      return PAYLOAD;
+    }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/OverlordBlinkLeadershipTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/OverlordBlinkLeadershipTest.java
@@ -73,9 +73,17 @@ public class OverlordBlinkLeadershipTest
   public void testOverlordBlinkLeadership()
   {
     try {
-      RemoteTaskRunner remoteTaskRunner1 = rtrUtils.makeRemoteTaskRunner(remoteTaskRunnerConfig, resourceManagement);
+      RemoteTaskRunner remoteTaskRunner1 = rtrUtils.makeRemoteTaskRunner(
+          remoteTaskRunnerConfig,
+          resourceManagement,
+          null
+      );
       remoteTaskRunner1.stop();
-      RemoteTaskRunner remoteTaskRunner2 = rtrUtils.makeRemoteTaskRunner(remoteTaskRunnerConfig, resourceManagement);
+      RemoteTaskRunner remoteTaskRunner2 = rtrUtils.makeRemoteTaskRunner(
+          remoteTaskRunnerConfig,
+          resourceManagement,
+          null
+      );
       remoteTaskRunner2.stop();
     }
     catch (Exception e) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerRunPendingTasksConcurrencyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerRunPendingTasksConcurrencyTest.java
@@ -69,7 +69,8 @@ public class RemoteTaskRunnerRunPendingTasksConcurrencyTest
           {
             return 2;
           }
-        }
+        },
+        null
     );
 
     int numTasks = 6;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.indexing.overlord;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.util.ByteStreams;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -29,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.curator.framework.CuratorFramework;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -20,16 +20,20 @@
 package org.apache.druid.indexing.overlord;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.ByteStreams;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.IndexingServiceCondition;
@@ -45,6 +49,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.testing.DeadlockDetectingTimeout;
 import org.easymock.Capture;
@@ -58,6 +64,9 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -69,10 +78,14 @@ public class RemoteTaskRunnerTest
 {
   private static final Joiner JOINER = RemoteTaskRunnerTestUtils.JOINER;
   private static final String WORKER_HOST = "worker";
-  private static final String ANNOUCEMENTS_PATH = JOINER.join(RemoteTaskRunnerTestUtils.ANNOUNCEMENTS_PATH, WORKER_HOST);
+  private static final String ANNOUCEMENTS_PATH = JOINER.join(
+      RemoteTaskRunnerTestUtils.ANNOUNCEMENTS_PATH,
+      WORKER_HOST
+  );
   private static final String STATUS_PATH = JOINER.join(RemoteTaskRunnerTestUtils.STATUS_PATH, WORKER_HOST);
 
   private RemoteTaskRunner remoteTaskRunner;
+  private HttpClient httpClient;
   private RemoteTaskRunnerTestUtils rtrTestUtils = new RemoteTaskRunnerTestUtils();
   private ObjectMapper jsonMapper;
   private CuratorFramework cf;
@@ -377,7 +390,8 @@ public class RemoteTaskRunnerTest
         new TaskResource("first", 1),
         "foo",
         TaskStatus.running("first"),
-        jsonMapper);
+        jsonMapper
+    );
     remoteTaskRunner.run(task1);
     Assert.assertTrue(taskAnnounced(task1.getId()));
     mockWorkerRunningTask(task1);
@@ -387,15 +401,17 @@ public class RemoteTaskRunnerTest
         new TaskResource("task", 2),
         "foo",
         TaskStatus.running("task"),
-        jsonMapper);
+        jsonMapper
+    );
     remoteTaskRunner.run(task);
-    
+
     TestRealtimeTask task2 = new TestRealtimeTask(
         "second",
         new TaskResource("second", 2),
         "foo",
         TaskStatus.running("second"),
-        jsonMapper);
+        jsonMapper
+    );
     remoteTaskRunner.run(task2);
     Assert.assertTrue(taskAnnounced(task2.getId()));
     mockWorkerRunningTask(task2);
@@ -425,7 +441,8 @@ public class RemoteTaskRunnerTest
         new TaskResource("testTask", 2),
         "foo",
         TaskStatus.success("testTask"),
-        jsonMapper);
+        jsonMapper
+    );
     remoteTaskRunner.run(task1);
     Assert.assertTrue(taskAnnounced(task1.getId()));
     mockWorkerRunningTask(task1);
@@ -566,7 +583,8 @@ public class RemoteTaskRunnerTest
 
   private void makeRemoteTaskRunner(RemoteTaskRunnerConfig config)
   {
-    remoteTaskRunner = rtrTestUtils.makeRemoteTaskRunner(config);
+    httpClient = EasyMock.createMock(HttpClient.class);
+    remoteTaskRunner = rtrTestUtils.makeRemoteTaskRunner(config, httpClient);
   }
 
   private void makeWorker() throws Exception
@@ -1004,7 +1022,10 @@ public class RemoteTaskRunnerTest
     mockWorkerCompleteFailedTask(task3);
     Assert.assertTrue(taskFuture3.get().isFailure());
     Assert.assertEquals(1, remoteTaskRunner.getBlackListedWorkers().size());
-    Assert.assertEquals(3, remoteTaskRunner.getBlacklistedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(
+        3,
+        remoteTaskRunner.getBlacklistedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue()
+    );
 
     mockWorkerCompleteSuccessfulTask(task2);
     Assert.assertTrue(taskFuture2.get().isSuccess());
@@ -1028,7 +1049,8 @@ public class RemoteTaskRunnerTest
 
     PathChildrenCache cache = new PathChildrenCache(cf, "/test", true);
     testStartWithNoWorker();
-    cache.getListenable().addListener(remoteTaskRunner.getStatusListener(worker, new ZkWorker(worker, cache, jsonMapper), null));
+    cache.getListenable()
+         .addListener(remoteTaskRunner.getStatusListener(worker, new ZkWorker(worker, cache, jsonMapper), null));
     cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
 
     // Status listener will recieve event with null data
@@ -1043,5 +1065,57 @@ public class RemoteTaskRunnerTest
     Assert.assertTrue(alertDataMap.containsKey("znode"));
     Assert.assertNull(alertDataMap.get("znode"));
     // Status listener should successfully completes without throwing exception
+  }
+
+  @Test
+  public void testStreamTaskReportsUnknownTask() throws Exception
+  {
+    doSetup();
+    Assert.assertEquals(Optional.absent(), remoteTaskRunner.streamTaskReports("foo"));
+  }
+
+  @Test
+  public void testStreamTaskReportsKnownTask() throws Exception
+  {
+    doSetup();
+    final Capture<Request> capturedRequest = Capture.newInstance();
+    final String reportString = "my report!";
+    final ByteArrayInputStream reportResponse = new ByteArrayInputStream(StringUtils.toUtf8(reportString));
+    EasyMock.expect(httpClient.go(EasyMock.capture(capturedRequest), EasyMock.anyObject()))
+            .andReturn(Futures.immediateFuture(reportResponse));
+    EasyMock.replay(httpClient);
+
+    ListenableFuture<TaskStatus> result = remoteTaskRunner.run(task);
+    Assert.assertTrue(taskAnnounced(task.getId()));
+    mockWorkerRunningTask(task);
+
+    // Wait for the task to have a known location.
+    Assert.assertTrue(
+        TestUtils.conditionValid(
+            () ->
+                !remoteTaskRunner.getRunningTasks().isEmpty()
+                && !Iterables.getOnlyElement(remoteTaskRunner.getRunningTasks())
+                             .getLocation()
+                             .equals(TaskLocation.unknown())
+        )
+    );
+
+    // Stream task reports from a running task.
+    final InputStream in = remoteTaskRunner.streamTaskReports(task.getId()).get().openStream();
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ByteStreams.copy(in, baos);
+    Assert.assertEquals(reportString, StringUtils.fromUtf8(baos.toByteArray()));
+
+    // Stream task reports from a completed task.
+    mockWorkerCompleteSuccessfulTask(task);
+    Assert.assertTrue(workerCompletedTask(result));
+    Assert.assertEquals(Optional.absent(), remoteTaskRunner.streamTaskReports(task.getId()));
+
+    // Verify the HTTP request.
+    EasyMock.verify(httpClient);
+    Assert.assertEquals(
+        "http://dummy:9000/druid/worker/v1/chat/task%20id%20with%20spaces/liveReports",
+        capturedRequest.getValue().getUrl().toString()
+    );
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -105,15 +105,16 @@ public class RemoteTaskRunnerTestUtils
     testingCluster.stop();
   }
 
-  RemoteTaskRunner makeRemoteTaskRunner(RemoteTaskRunnerConfig config)
+  RemoteTaskRunner makeRemoteTaskRunner(RemoteTaskRunnerConfig config, HttpClient httpClient)
   {
     NoopProvisioningStrategy<WorkerTaskRunner> resourceManagement = new NoopProvisioningStrategy<>();
-    return makeRemoteTaskRunner(config, resourceManagement);
+    return makeRemoteTaskRunner(config, resourceManagement, httpClient);
   }
 
   public RemoteTaskRunner makeRemoteTaskRunner(
       RemoteTaskRunnerConfig config,
-      ProvisioningStrategy<WorkerTaskRunner> provisioningStrategy
+      ProvisioningStrategy<WorkerTaskRunner> provisioningStrategy,
+      HttpClient httpClient
   )
   {
     RemoteTaskRunner remoteTaskRunner = new TestableRemoteTaskRunner(
@@ -131,7 +132,7 @@ public class RemoteTaskRunnerTestUtils
         ),
         cf,
         new PathChildrenCacheFactory.Builder(),
-        null,
+        httpClient,
         DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
         provisioningStrategy
     );


### PR DESCRIPTION
It is possible for a work item to drop out of runningTasks after the
ZkWorker is retrieved. In this case, the current code would throw
an NPE. The new code will return an absent Optional, which
enables the caller to try a different place to find the task report.