### PR TITLE
allow `DruidSchema` to fallback to segment metadata 'type' if 'typeSignature' is null

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -875,7 +875,8 @@ public class DruidSchema extends AbstractSchema
         .runSimple(segmentMetadataQuery, escalator.createEscalatedAuthenticationResult(), Access.OK);
   }
 
-  private static RowSignature analysisToRowSignature(final SegmentAnalysis analysis)
+  @VisibleForTesting
+  static RowSignature analysisToRowSignature(final SegmentAnalysis analysis)
   {
     final RowSignature.Builder rowSignatureBuilder = RowSignature.builder();
     for (Map.Entry<String, ColumnAnalysis> entry : analysis.getColumns().entrySet()) {
@@ -886,9 +887,18 @@ public class DruidSchema extends AbstractSchema
 
       ColumnType valueType = entry.getValue().getTypeSignature();
 
-      // this shouldn't happen, but if it does assume types are some flavor of COMPLEX.
+      // this shouldn't happen, but if it does, first try to fall back to legacy type information field in case
+      // standard upgrade order was not followed for 0.22 to 0.23+, and if that also fails, then assume types are some
+      // flavor of COMPLEX.
       if (valueType == null) {
-        valueType = ColumnType.UNKNOWN_COMPLEX;
+        // at some point in the future this can be simplified to the contents of the catch clause here, once the
+        // likelyhood of upgrading from some version lower than 0.23 is low
+        try {
+          valueType = ColumnType.fromString(entry.getValue().getType());
+        }
+        catch (IllegalArgumentException ignored) {
+          valueType = ColumnType.UNKNOWN_COMPLEX;
+        }
       }
 
       rowSignatureBuilder.add(entry.getKey(), valueType);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -69,7 +69,6 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.easymock.EasyMock;
-import org.joda.time.Interval;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1098,7 +1097,7 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
     RowSignature signature = DruidSchema.analysisToRowSignature(
         new SegmentAnalysis(
             "id",
-            ImmutableList.of(new Interval(1L, 2L)),
+            ImmutableList.of(Intervals.utc(1L, 2L)),
             ImmutableMap.of(
                 "a",
                 new ColumnAnalysis(
@@ -1147,7 +1146,7 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
     RowSignature signature = DruidSchema.analysisToRowSignature(
         new SegmentAnalysis(
             "id",
-            ImmutableList.of(new Interval(1L, 2L)),
+            ImmutableList.of(Intervals.utc(1L, 2L)),
             ImmutableMap.of(
                 "a",
                 new ColumnAnalysis(


### PR DESCRIPTION
### Description
This PR adds a fallback mechanism to `DruidSchema` to use the legacy 'type' string field of segment metadata results, after #11895 changed `DruidSchema` to use a new, richer, `typeSignature` field instead. This fixes an issue where the SQL schema for a datasource can be marked entirely as `COMPLEX` typed columns if a broker is updated to 0.23 before historical servers are, and will remain in this state until restarted or all segments have been moved to new servers after all historicals are upgraded. See https://github.com/apache/druid/pull/11713#issuecomment-983269047 for details.

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
