### PR TITLE
Fix the error case when there are multi top level unions

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -445,6 +445,7 @@ public class DruidPlanner implements Closeable
       throw new ISE("DruidUnionRel is only supported at the outermost RelNode.");
     }
     catch (Exception e) {
+      log.error(e, "Unknown exception encountered while converting to native queries for explanation.");
       throw new ISE("Unable to convert the RelNode structure to DruidQuery for explaining");
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -434,21 +434,11 @@ public class DruidPlanner implements Closeable
   {
     ObjectMapper jsonMapper = plannerContext.getJsonMapper();
     List<DruidQuery> druidQueryList;
-    try {
-      druidQueryList = flattenOutermostRel(rel)
-          .stream()
-          .map(druidRel -> druidRel.toDruidQuery(false))
-          .collect(Collectors.toList());
+    druidQueryList = flattenOutermostRel(rel)
+        .stream()
+        .map(druidRel -> druidRel.toDruidQuery(false))
+        .collect(Collectors.toList());
 
-    }
-    catch (UnsupportedOperationException unsupportedOperationException) {
-      log.error("DruidUnionRel can only be the outermost RelNode. This error shouldn't be encountered");
-      throw new ISE("DruidUnionRel is only supported at the outermost RelNode.");
-    }
-    catch (Exception e) {
-      log.error(e, "Unknown exception encountered while converting to native queries for explanation.");
-      throw new ISE("Unable to convert the RelNode structure to DruidQuery for explaining");
-    }
 
     // Putting the queries as object node in an ArrayNode, since directly returning a list causes issues when
     // serializing the "queryType". Another method would be to create a POJO containing query and signature, and then

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -66,7 +66,6 @@ import org.apache.calcite.tools.Planner;
 import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.calcite.util.Pair;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.BaseSequence;
 import org.apache.druid.java.util.common.guava.Sequence;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -431,25 +431,26 @@ public class DruidPlanner implements Closeable
    */
   private String explainSqlPlanAsNativeQueries(DruidRel<?> rel) throws JsonProcessingException
   {
-    // Only if rel is an instance of DruidUnionRel, do we run multiple native queries corresponding to single SQL query
-    // Also, DruidUnionRel can only be a top level node, so we don't need to check for this condition in the subsequent
-    // child nodes
     ObjectMapper jsonMapper = plannerContext.getJsonMapper();
     List<DruidQuery> druidQueryList;
-    if (rel instanceof DruidUnionRel) {
-      druidQueryList = rel.getInputs().stream().map(childRel -> (DruidRel<?>) childRel).map(childRel -> {
-        if (childRel instanceof DruidUnionRel) {
-          log.error("DruidUnionRel can only be the outermost RelNode. This error shouldn't be encountered");
-          throw new ISE("DruidUnionRel is only supported at the outermost RelNode.");
-        }
-        return childRel.toDruidQuery(false);
-      }).collect(Collectors.toList());
-    } else {
-      druidQueryList = ImmutableList.of(rel.toDruidQuery(false));
+    try {
+      druidQueryList = flattenOutermostRel(rel)
+          .stream()
+          .map(druidRel -> druidRel.toDruidQuery(false))
+          .collect(Collectors.toList());
+
+    }
+    catch (UnsupportedOperationException unsupportedOperationException) {
+      log.error("DruidUnionRel can only be the outermost RelNode. This error shouldn't be encountered");
+      throw new ISE("DruidUnionRel is only supported at the outermost RelNode.");
+    }
+    catch (Exception e) {
+      throw new ISE("Unable to convert the RelNode structure to DruidQuery for explaining");
     }
 
     // Putting the queries as object node in an ArrayNode, since directly returning a list causes issues when
-    // serializing the "queryType"
+    // serializing the "queryType". Another method would be to create a POJO containing query and signature, and then
+    // serializing it using normal list method.
     ArrayNode nativeQueriesArrayNode = jsonMapper.createArrayNode();
 
     for (DruidQuery druidQuery : druidQueryList) {
@@ -461,6 +462,47 @@ public class DruidPlanner implements Closeable
     }
 
     return jsonMapper.writeValueAsString(nativeQueriesArrayNode);
+  }
+
+  /**
+   * Given a {@link DruidRel}, this method recursively flattens the Rels if they are of the type {@link DruidUnionRel}
+   * It is implicitly assumed that the {@link DruidUnionRel} can never be the child of a non {@link DruidUnionRel}
+   * node
+   * For eg, a DruidRel structure of kind:
+   * DruidUnionRel
+   *  DruidUnionRel
+   *    DruidRel (A)
+   *    DruidRel (B)
+   *  DruidRel(C)
+   * will return [DruidRel(A), DruidRel(B), DruidRel(C)]
+   * @param outermostDruidRel The outermost rel which is to be flattened
+   * @return a list of DruidRel's which donot have a DruidUnionRel nested in between them
+   */
+  private List<DruidRel<?>> flattenOutermostRel(DruidRel<?> outermostDruidRel)
+  {
+    List<DruidRel<?>> druidRels = new ArrayList<>();
+    flattenOutermostRel(outermostDruidRel, druidRels);
+    return druidRels;
+  }
+
+  /**
+   * Recursive function (DFS) which traverses the nodes and collects the corresponding {@link DruidRel} into a list if
+   * they are not of the type {@link DruidUnionRel} or else calls the method with the child nodes. The DFS order of the
+   * nodes are retained, since that is the order in which they will actually be called in {@link DruidUnionRel#runQuery()}
+   * @param druidRel The current relNode
+   * @param flattendListAccumulator Accumulator list which needs to be appended by this method
+   */
+  private void flattenOutermostRel(DruidRel<?> druidRel, List<DruidRel<?>> flattendListAccumulator)
+  {
+    if (druidRel instanceof DruidUnionRel) {
+      DruidUnionRel druidUnionRel = (DruidUnionRel) druidRel;
+      druidUnionRel.getInputs().forEach(innerRelNode -> {
+        DruidRel<?> innerDruidRelNode = (DruidRel<?>) innerRelNode; // This type conversion should always be possible
+        flattenOutermostRel(innerDruidRelNode, flattendListAccumulator);
+      });
+    } else {
+      flattendListAccumulator.add(druidRel);
+    }
   }
 
   /**

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6878,7 +6878,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testtest() throws Exception
+  public void testExplainMultipleTopLevelUnionAllQueries() throws Exception
   {
     // Skip vectorization since otherwise the "context" will change for each subtest.
     skipVectorize();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -133,6 +133,7 @@ import java.util.stream.Collectors;
 public class CalciteQueryTest extends BaseCalciteQueryTest
 {
 
+
   @Test
   public void testGroupByWithPostAggregatorReferencingTimeFloorColumnOnTimeseries() throws Exception
   {
@@ -6873,6 +6874,53 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of(new Object[]{legacyExplanationWithContext, resources})
+    );
+  }
+
+  @Test
+  public void testtest() throws Exception
+  {
+    // Skip vectorization since otherwise the "context" will change for each subtest.
+    skipVectorize();
+
+    final String query = "EXPLAIN PLAN FOR SELECT dim1 FROM druid.foo\n"
+                         + "UNION ALL (SELECT dim1 FROM druid.foo WHERE dim1 = '42'\n"
+                         + "UNION ALL SELECT dim1 FROM druid.foo WHERE dim1 = '44')";
+    final String legacyExplanation = "DruidUnionRel(limit=[-1])\n"
+                                     + "  DruidQueryRel(query=[{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"virtualColumns\":[],\"resultFormat\":\"compactedList\",\"batchSize\":20480,\"filter\":null,\"columns\":[\"dim1\"],\"legacy\":false,\"context\":{\"defaultTimeout\":300000,\"maxScatterGatherBytes\":9223372036854775807,\"sqlCurrentTimestamp\":\"2000-01-01T00:00:00Z\",\"sqlQueryId\":\"dummy\",\"vectorize\":\"false\",\"vectorizeVirtualColumns\":\"false\"},\"descending\":false,\"granularity\":{\"type\":\"all\"}}], signature=[{dim1:STRING}])\n"
+                                     + "  DruidUnionRel(limit=[-1])\n"
+                                     + "    DruidQueryRel(query=[{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"virtualColumns\":[],\"resultFormat\":\"compactedList\",\"batchSize\":20480,\"filter\":{\"type\":\"selector\",\"dimension\":\"dim1\",\"value\":\"42\",\"extractionFn\":null},\"columns\":[\"dim1\"],\"legacy\":false,\"context\":{\"defaultTimeout\":300000,\"maxScatterGatherBytes\":9223372036854775807,\"sqlCurrentTimestamp\":\"2000-01-01T00:00:00Z\",\"sqlQueryId\":\"dummy\",\"vectorize\":\"false\",\"vectorizeVirtualColumns\":\"false\"},\"descending\":false,\"granularity\":{\"type\":\"all\"}}], signature=[{dim1:STRING}])\n"
+                                     + "    DruidQueryRel(query=[{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"virtualColumns\":[],\"resultFormat\":\"compactedList\",\"batchSize\":20480,\"filter\":{\"type\":\"selector\",\"dimension\":\"dim1\",\"value\":\"44\",\"extractionFn\":null},\"columns\":[\"dim1\"],\"legacy\":false,\"context\":{\"defaultTimeout\":300000,\"maxScatterGatherBytes\":9223372036854775807,\"sqlCurrentTimestamp\":\"2000-01-01T00:00:00Z\",\"sqlQueryId\":\"dummy\",\"vectorize\":\"false\",\"vectorizeVirtualColumns\":\"false\"},\"descending\":false,\"granularity\":{\"type\":\"all\"}}], signature=[{dim1:STRING}])\n";
+    final String explanation = "["
+                               + "{"
+                               + "\"query\":{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"virtualColumns\":[],\"resultFormat\":\"compactedList\",\"batchSize\":20480,\"filter\":null,\"columns\":[\"dim1\"],\"legacy\":false,\"context\":{\"defaultTimeout\":300000,\"maxScatterGatherBytes\":9223372036854775807,\"sqlCurrentTimestamp\":\"2000-01-01T00:00:00Z\",\"sqlQueryId\":\"dummy\",\"vectorize\":\"false\",\"vectorizeVirtualColumns\":\"false\"},\"descending\":false,\"granularity\":{\"type\":\"all\"}},"
+                               + "\"signature\":[{\"name\":\"dim1\",\"type\":\"STRING\"}]"
+                               + "},"
+                               + "{"
+                               + "\"query\":{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"virtualColumns\":[],\"resultFormat\":\"compactedList\",\"batchSize\":20480,\"filter\":{\"type\":\"selector\",\"dimension\":\"dim1\",\"value\":\"42\",\"extractionFn\":null},\"columns\":[\"dim1\"],\"legacy\":false,\"context\":{\"defaultTimeout\":300000,\"maxScatterGatherBytes\":9223372036854775807,\"sqlCurrentTimestamp\":\"2000-01-01T00:00:00Z\",\"sqlQueryId\":\"dummy\",\"vectorize\":\"false\",\"vectorizeVirtualColumns\":\"false\"},\"descending\":false,\"granularity\":{\"type\":\"all\"}},"
+                               + "\"signature\":[{\"name\":\"dim1\",\"type\":\"STRING\"}]"
+                               + "},"
+                               + "{"
+                               + "\"query\":{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"virtualColumns\":[],\"resultFormat\":\"compactedList\",\"batchSize\":20480,\"filter\":{\"type\":\"selector\",\"dimension\":\"dim1\",\"value\":\"44\",\"extractionFn\":null},\"columns\":[\"dim1\"],\"legacy\":false,\"context\":{\"defaultTimeout\":300000,\"maxScatterGatherBytes\":9223372036854775807,\"sqlCurrentTimestamp\":\"2000-01-01T00:00:00Z\",\"sqlQueryId\":\"dummy\",\"vectorize\":\"false\",\"vectorizeVirtualColumns\":\"false\"},\"descending\":false,\"granularity\":{\"type\":\"all\"}},"
+                               + "\"signature\":[{\"name\":\"dim1\",\"type\":\"STRING\"}]"
+                               + "}]";
+    final String resources = "[{\"name\":\"foo\",\"type\":\"DATASOURCE\"}]";
+
+    testQuery(
+        query,
+        ImmutableList.of(),
+        ImmutableList.of(
+            new Object[]{legacyExplanation, resources}
+        )
+    );
+    testQuery(
+        PLANNER_CONFIG_NATIVE_QUERY_EXPLAIN,
+        query,
+        CalciteTests.REGULAR_USER_AUTH_RESULT,
+        ImmutableList.of(),
+        ImmutableList.of(
+            new Object[]{explanation, resources}
+        )
     );
   }
 


### PR DESCRIPTION
### Description
This is a follow up to the PR #11908. This fixes the bug in top level union all queries when there are more than 2 SQL subqueries are present. For example, if the following query was passed:

```
SELECT channel FROM wikipedia
UNION ALL SELECT channel FROM wikipedia WHERE channel = '#en.wikipedia'
UNION ALL SELECT channel FROM wikipedia WHERE channel = '#de.wikipedia'
```
it would fail to be explained in the newer format, and would revert to the original plan. 
Reason for the bug: In the original PR, I assumed that `DruidUnionRel` can only be the top level DruidRel node after parsing, according to the comment [here](https://github.com/apache/druid/blob/1f95a42bb8b32c314934e8e2ecdeb6569c7e8db3/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionRel.java#L48), and all the three queries would be children to that top level parent node.

When there are more than 2 queries connected by a top level UNION ALL, then the DruidRel structure looks like this:
```
DruidUnionRel
  DruidRel (query 1)
  DruidUnionRel
    DruidRel (query 2)
    DruidRel (query 3)
```

This PR introduces a recursive method which flattens this structure, and produces the native queries as expected.
<hr>

##### Key changed/added classes in this PR
 * `DruidPlanner`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
