### PR TITLE
SeekableStreamSupervisor: Coalesce adjacent RunNotices.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -107,7 +107,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -282,6 +282,15 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     String getType();
 
     void handle() throws ExecutionException, InterruptedException, TimeoutException;
+
+    /**
+     * Whether this notice can also handle the work of another notice. Used to coalesce notices and avoid
+     * redundant work.
+     */
+    default boolean canAlsoHandle(Notice otherNotice)
+    {
+      return false;
+    }
   }
 
   private static class StatsFromTaskResult
@@ -337,6 +346,12 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     public String getType()
     {
       return TYPE;
+    }
+
+    @Override
+    public boolean canAlsoHandle(Notice otherNotice)
+    {
+      return otherNotice.getType().equals(TYPE);
     }
   }
 
@@ -653,7 +668,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   private final ScheduledExecutorService scheduledExec;
   private final ScheduledExecutorService reportingExec;
   private final ListeningExecutorService workerExec;
-  private final BlockingQueue<Notice> notices = new LinkedBlockingDeque<>();
+  private final BlockingDeque<Notice> notices = new LinkedBlockingDeque<>();
   private final Object stopLock = new Object();
   private final Object stateChangeLock = new Object();
   private final ReentrantLock recordSupplierLock = new ReentrantLock();
@@ -945,6 +960,12 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                   final Notice notice = notices.poll(pollTimeout, TimeUnit.MILLISECONDS);
                   if (notice == null) {
                     continue;
+                  }
+
+                  // Coalesce notices.
+                  Notice nextNotice;
+                  while ((nextNotice = notices.peek()) != null && notice.canAlsoHandle(nextNotice)) {
+                    notices.removeFirst();
                   }
 
                   try {


### PR DESCRIPTION
The idea is that if multiple notices come in around the same time due to lots of task status changes, we don't need to execute all of them. One is enough, since it will serve as a trigger to make sure we pick up the collective changes.

Inspired by a discussion in https://lists.apache.org/thread/9jgdwrodwsfcg98so6kzfhdmn95gzyrj.