### PR TITLE
Handle compatible PartitionChunk in PartitionHolder

### DIFF
--- a/core/src/main/java/org/apache/druid/timeline/partition/IntegerPartitionChunk.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/IntegerPartitionChunk.java
@@ -70,6 +70,12 @@ public class IntegerPartitionChunk<T extends Overshadowable> implements Partitio
   }
 
   @Override
+  public boolean abutsCompatible(PartitionChunk<T> chunk)
+  {
+    return false;
+  }
+
+  @Override
   public boolean isStart()
   {
     return start == null;

--- a/core/src/main/java/org/apache/druid/timeline/partition/LinearPartitionChunk.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/LinearPartitionChunk.java
@@ -46,6 +46,12 @@ public class LinearPartitionChunk<T> implements PartitionChunk<T>
   }
 
   @Override
+  public boolean abutsCompatible(PartitionChunk<T> chunk)
+  {
+    return false;
+  }
+
+  @Override
   public boolean isStart()
   {
     return true; // always complete

--- a/core/src/main/java/org/apache/druid/timeline/partition/NumberedOverwritingPartitionChunk.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/NumberedOverwritingPartitionChunk.java
@@ -60,6 +60,12 @@ public class NumberedOverwritingPartitionChunk<T> implements PartitionChunk<T>
   }
 
   @Override
+  public boolean abutsCompatible(PartitionChunk<T> chunk)
+  {
+    return false;
+  }
+
+  @Override
   public boolean isStart()
   {
     return true;

--- a/core/src/main/java/org/apache/druid/timeline/partition/NumberedPartitionChunk.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/NumberedPartitionChunk.java
@@ -73,6 +73,17 @@ public class NumberedPartitionChunk<T> implements PartitionChunk<T>
   }
 
   @Override
+  public boolean abutsCompatible(PartitionChunk<T> chunk)
+  {
+    if (chunk instanceof NumberedOverwritingPartitionChunk) {
+      NumberedOverwritingPartitionChunk<T> castedOverwriteOther = (NumberedOverwritingPartitionChunk<T>) chunk;
+      return castedOverwriteOther.getChunkNumber() == PartitionIds.NON_ROOT_GEN_START_PARTITION_ID;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
   public boolean isStart()
   {
     return chunks > 0 ? chunkNumber == 0 : true;

--- a/core/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
@@ -220,7 +220,7 @@ class OvershadowableManager<T extends Overshadowable<T>>
    * minorVersion with {@link PartitionChunk}.
    */
   @Nullable
-  private AtomicUpdateGroup<T> findAtomicUpdateGroupWith(PartitionChunk<T> chunk, State state)
+  AtomicUpdateGroup<T> findAtomicUpdateGroupWith(PartitionChunk<T> chunk, State state)
   {
     final Short2ObjectSortedMap<AtomicUpdateGroup<T>> versionToGroup = getStateMap(state).get(
         RootPartitionRange.of(chunk)

--- a/core/src/main/java/org/apache/druid/timeline/partition/PartitionChunk.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/PartitionChunk.java
@@ -47,6 +47,15 @@ public interface PartitionChunk<T> extends Comparable<PartitionChunk<T>>
   boolean abuts(PartitionChunk<T> chunk);
 
   /**
+   * Determines if this PartitionChunk abuts another PartitionChunk of a different but compatible type.  A sequence of abutting PartitionChunks should
+   * start with an object where isStart() == true and eventually end with an object where isEnd() == true.
+   *
+   * @param chunk input chunk
+   * @return true if this chunk abuts the input chunk
+   */
+  boolean abutsCompatible(PartitionChunk<T> chunk);
+
+  /**
    * Returns true if this chunk is the beginning of the partition. Most commonly, that means it represents the range
    * [-infinity, X) for some concrete X.
    *

--- a/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/PartitionHolder.java
@@ -102,7 +102,10 @@ public class PartitionHolder<T extends Overshadowable<T>> implements Iterable<Pa
     while (iter.hasNext()) {
       PartitionChunk<T> next = iter.next();
       if (!curr.abuts(next)) {
-        return false;
+        if (!(curr.abutsCompatible(next)
+            && overshadowableManager.findAtomicUpdateGroupWith(next, OvershadowableManager.State.STANDBY) == null)) {
+          return false;
+        }
       }
 
       if (next.isEnd()) {

--- a/core/src/main/java/org/apache/druid/timeline/partition/SingleElementPartitionChunk.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/SingleElementPartitionChunk.java
@@ -44,6 +44,12 @@ public class SingleElementPartitionChunk<T> implements PartitionChunk<T>
   }
 
   @Override
+  public boolean abutsCompatible(PartitionChunk<T> chunk)
+  {
+    return false;
+  }
+
+  @Override
   public boolean isStart()
   {
     return true;

--- a/core/src/main/java/org/apache/druid/timeline/partition/StringPartitionChunk.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/StringPartitionChunk.java
@@ -79,6 +79,12 @@ public class StringPartitionChunk<T> implements PartitionChunk<T>
   }
 
   @Override
+  public boolean abutsCompatible(PartitionChunk<T> chunk)
+  {
+    return false;
+  }
+
+  @Override
   public boolean isStart()
   {
     return start == null;

--- a/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineTest.java
@@ -1572,4 +1572,22 @@ public class VersionedIntervalTimelineTest extends VersionedIntervalTimelineTest
         timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2019-01-01/2019-01-04"), Partitions.INCOMPLETE_OK)
     );
   }
+
+  @Test
+  public void testWhenHigherPartOfCorePartitionSetIsPartiallyOvershadowed()
+  {
+    final String intervalString = "2019-01-01/2019-01-02";
+    // The core partition set is [0, 3).
+    // Add the first segment in the core partition set.
+    add(intervalString, "0", makeNumbered("0", 0, 3, 0));
+    // Add a segment partially overshadowing the core partition set of [1, 3).
+    add("2019-01-01/2019-01-02", "0", makeNumberedOverwriting("0", 0, 1, 1, 3, 1, 1));
+    Assert.assertEquals(
+        ImmutableSet.of(
+            makeNumbered("0", 0, 3, 0).getObject(),
+            makeNumberedOverwriting("0", 0, 1, 1, 3, 1, 1).getObject()
+        ),
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.of(intervalString), Partitions.ONLY_COMPLETE)
+    );
+  }
 }


### PR DESCRIPTION
Fixes #10155.

### Description

Enabling comparison of compatible PartitionChunks.

Added abutsCompatible method to check if PartitionChunk abuts a PartitionChunk that is compatible with  previous. The original abuts() method is not changed. Added check on atomic update group if compatible Partition Chunks are used.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
