### PR TITLE
fix build warnings for forbidden-apis

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -29,7 +29,7 @@ java.lang.String#replace(java.lang.CharSequence,java.lang.CharSequence) @ Use on
 java.lang.String#replaceAll(java.lang.String,java.lang.String) @ Use one of the appropriate methods in StringUtils instead, or compile and cache a Pattern explicitly
 java.lang.String#replaceFirst(java.lang.String,java.lang.String) @ Use String.indexOf() and substring methods, or compile and cache a Pattern explicitly
 java.nio.file.Files#createTempDirectory(java.lang.String,java.nio.file.attribute.FileAttribute[]) @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
-java.nio.file.Files#createTempDirectory(java.lang.String,java.nio.file.Path,java.nio.file.attribute.FileAttribute[]) @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
+java.nio.file.Files#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute[]) @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
 java.util.HashMap#<init>(int) @ Use com.google.common.collect.Maps#newHashMapWithExpectedSize(int) instead
 java.util.HashMap#<init>(int, float) @ Use com.google.common.collect.Maps#newHashMapWithExpectedSize(int) instead
 java.util.LinkedHashMap#<init>(int) @ Use org.apache.druid.utils.CollectionUtils#newLinkedHashMapWithExpectedSize(int) instead

--- a/core/src/test/java/org/apache/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactoryTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactoryTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.impl.prefetch;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.io.CountingOutputStream;
+import io.netty.util.SuppressForbidden;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.druid.common.config.NullHandling;
@@ -152,6 +153,7 @@ public class PrefetchableTextFilesFirehoseFactoryTest
     Assert.assertEquals(expectedNumFiles, files.length);
   }
 
+  @SuppressForbidden(reason = "Files#createTempDirectory")
   private static File createFirehoseTmpDir(String dirPrefix) throws IOException
   {
     return Files.createTempDirectory(tempDir.getRoot().toPath(), dirPrefix).toFile();

--- a/pom.xml
+++ b/pom.xml
@@ -1290,7 +1290,7 @@
                 <artifactId>forbiddenapis</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
+                    <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
                     <bundledSignatures>
                         <!--
                           This will automatically choose the right


### PR DESCRIPTION
* replace deprecated forbidden-apis config failOnUnresolvableSignatures
with ignoreSignaturesOfMissingClasses which avoids warnings for
classes not present in a particular sub-module

* fix incorrect signature for Files.createTempDirectory
