### PR TITLE
Docs: Fix column name in ingestion rollup doc

### DIFF
--- a/docs/ingestion/rollup.md
+++ b/docs/ingestion/rollup.md
@@ -40,7 +40,7 @@ If you have conflicting needs for different use cases, you can create multiple t
 
 ## Maximizing rollup ratio
 
-To measure the rollup ratio of a datasource compare the number of rows in Druid (`COUNT`) with the number of ingested events. For example, run a [Druid SQL](../querying/sql.md) query where "count" refers to a `count`-type metric generated at ingestion time as follows:
+To measure the rollup ratio of a datasource compare the number of rows in Druid (`COUNT`) with the number of ingested events. For example, run a [Druid SQL](../querying/sql.md) query where "cnt" refers to a `count`-type metric generated at ingestion time as follows:
 
 ```sql
 SELECT SUM("cnt") / (COUNT(*) * 1.0) FROM datasource

--- a/docs/ingestion/rollup.md
+++ b/docs/ingestion/rollup.md
@@ -40,10 +40,10 @@ If you have conflicting needs for different use cases, you can create multiple t
 
 ## Maximizing rollup ratio
 
-To measure the rollup ratio of a datasource compare the number of rows in Druid (`COUNT`) with the number of ingested events. For example, run a [Druid SQL](../querying/sql.md) query where "cnt" refers to a `count`-type metric generated at ingestion time as follows:
+To measure the rollup ratio of a datasource compare the number of rows in Druid (`COUNT`) with the number of ingested events. For example, run a [Druid SQL](../querying/sql.md) query where "num_rows" refers to a `count`-type metric generated at ingestion time as follows:
 
 ```sql
-SELECT SUM("cnt") / (COUNT(*) * 1.0) FROM datasource
+SELECT SUM("num_rows") / (COUNT(*) * 1.0) FROM datasource
 ```
 The higher the result, the greater the benefit you gain from rollup. See [Counting the number of ingested events](schema-design.md#counting) for more details about how counting works with rollup is enabled.
 

--- a/docs/ingestion/rollup.md
+++ b/docs/ingestion/rollup.md
@@ -40,7 +40,7 @@ If you have conflicting needs for different use cases, you can create multiple t
 
 ## Maximizing rollup ratio
 
-To measure the rollup ratio of a datasource compare the number of rows in Druid (`COUNT`) with the number of ingested events. For example, run a [Druid SQL](../querying/sql.md) query where "num_rows" refers to a `count`-type metric generated at ingestion time as follows:
+To measure the rollup ratio of a datasource, compare the number of rows in Druid (`COUNT`) with the number of ingested events. For example, run a [Druid SQL](../querying/sql.md) query where "num_rows" refers to a `count`-type metric generated at ingestion time as follows:
 
 ```sql
 SELECT SUM("num_rows") / (COUNT(*) * 1.0) FROM datasource


### PR DESCRIPTION
### Description

Fix the referred column name from "count" to "num_rows" as "count" vs. "COUNT(*)" might be a little confusing in this example.

---

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)