### PR TITLE
Web console: use query actions in query view

### DIFF
--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -104,6 +104,7 @@ function start() {
      _error "${DRUID_PID_FILE} exists with pid '$(<${DRUID_PID_FILE})'. Either shutdown druid or delete this file."
   fi
 
+  export DRUID_SKIP_JAVA_CHECK=1
   "$(_get_code_root)/distribution/target/apache-druid-$(_get_druid_version)/bin/start-micro-quickstart" > /dev/null &
   local pid="$!"
   echo "$pid" > "$DRUID_PID_FILE"

--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -104,7 +104,7 @@ function start() {
      _error "${DRUID_PID_FILE} exists with pid '$(<${DRUID_PID_FILE})'. Either shutdown druid or delete this file."
   fi
 
-  export DRUID_SKIP_JAVA_CHECK=1
+  export DRUID_SKIP_JAVA_CHECK=1 # Make it simpler to develop the web console when localhost is on JDK11
   "$(_get_code_root)/distribution/target/apache-druid-$(_get_druid_version)/bin/start-micro-quickstart" > /dev/null &
   local pid="$!"
   echo "$pid" > "$DRUID_PID_FILE"

--- a/web-console/src/druid-models/time.ts
+++ b/web-console/src/druid-models/time.ts
@@ -83,10 +83,8 @@ export function timeFormatMatches(format: string, value: string | number | bigin
   }
 }
 
-export function possibleDruidFormatForValues(values: any[]): string | null {
-  return (
-    ALL_FORMAT_VALUES.filter(format => {
-      return values.every(value => timeFormatMatches(format, value));
-    })[0] || null
-  );
+export function possibleDruidFormatForValues(values: any[]): string | undefined {
+  return ALL_FORMAT_VALUES.find(format => {
+    return values.every(value => timeFormatMatches(format, value));
+  });
 }

--- a/web-console/src/hooks/index.ts
+++ b/web-console/src/hooks/index.ts
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+export * from './use-constant';
 export * from './use-global-event-listener';
 export * from './use-interval';
+export * from './use-last-defined';
+export * from './use-local-storage-state';
+export * from './use-permanent-callback';
 export * from './use-query-manager';

--- a/web-console/src/hooks/use-constant.ts
+++ b/web-console/src/hooks/use-constant.ts
@@ -16,20 +16,18 @@
  * limitations under the License.
  */
 
-export * from './capabilities';
-export * from './column-metadata';
-export * from './date';
-export * from './druid-lookup';
-export * from './druid-query';
-export * from './formatter';
-export * from './general';
-export * from './intermediate-query-state';
-export * from './local-storage-backed-visibility';
-export * from './local-storage-keys';
-export * from './object-change';
-export * from './query-action';
-export * from './query-cursor';
-export * from './query-manager';
-export * from './query-state';
-export * from './sanitizers';
-export * from './table-helpers';
+import { useRef } from 'react';
+
+interface ValueBox<T> {
+  value: T;
+}
+
+export function useConstant<T>(fn: () => T): T {
+  const box = useRef<ValueBox<T>>();
+
+  if (!box.current) {
+    box.current = { value: fn() };
+  }
+
+  return box.current.value;
+}

--- a/web-console/src/hooks/use-last-defined.tsx
+++ b/web-console/src/hooks/use-last-defined.tsx
@@ -16,20 +16,15 @@
  * limitations under the License.
  */
 
-export * from './capabilities';
-export * from './column-metadata';
-export * from './date';
-export * from './druid-lookup';
-export * from './druid-query';
-export * from './formatter';
-export * from './general';
-export * from './intermediate-query-state';
-export * from './local-storage-backed-visibility';
-export * from './local-storage-keys';
-export * from './object-change';
-export * from './query-action';
-export * from './query-cursor';
-export * from './query-manager';
-export * from './query-state';
-export * from './sanitizers';
-export * from './table-helpers';
+import { useEffect, useRef } from 'react';
+
+export function useLastDefined<T>(cur: T | undefined): T | undefined {
+  const last = useRef<T>();
+
+  useEffect(() => {
+    if (typeof cur === 'undefined') return;
+    last.current = cur;
+  }, [cur]);
+
+  return typeof cur === 'undefined' ? last.current : cur;
+}

--- a/web-console/src/hooks/use-local-storage-state.ts
+++ b/web-console/src/hooks/use-local-storage-state.ts
@@ -16,20 +16,28 @@
  * limitations under the License.
  */
 
-export * from './capabilities';
-export * from './column-metadata';
-export * from './date';
-export * from './druid-lookup';
-export * from './druid-query';
-export * from './formatter';
-export * from './general';
-export * from './intermediate-query-state';
-export * from './local-storage-backed-visibility';
-export * from './local-storage-keys';
-export * from './object-change';
-export * from './query-action';
-export * from './query-cursor';
-export * from './query-manager';
-export * from './query-state';
-export * from './sanitizers';
-export * from './table-helpers';
+import * as JSONBig from 'json-bigint-native';
+import { Dispatch, SetStateAction, useState } from 'react';
+
+export function useLocalStorageState<T>(
+  key: string,
+  initialValue?: T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSONBig.parse(item) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setValue: Dispatch<SetStateAction<T>> = (value: T | ((prevState: T) => T)) => {
+    const valueToStore = value instanceof Function ? value(state) : value;
+    setState(valueToStore);
+    try {
+      window.localStorage.setItem(key, JSONBig.stringify(valueToStore));
+    } catch {}
+  };
+  return [state, setValue];
+}

--- a/web-console/src/hooks/use-permanent-callback.ts
+++ b/web-console/src/hooks/use-permanent-callback.ts
@@ -16,20 +16,16 @@
  * limitations under the License.
  */
 
-export * from './capabilities';
-export * from './column-metadata';
-export * from './date';
-export * from './druid-lookup';
-export * from './druid-query';
-export * from './formatter';
-export * from './general';
-export * from './intermediate-query-state';
-export * from './local-storage-backed-visibility';
-export * from './local-storage-keys';
-export * from './object-change';
-export * from './query-action';
-export * from './query-cursor';
-export * from './query-manager';
-export * from './query-state';
-export * from './sanitizers';
-export * from './table-helpers';
+import { useEffect, useRef } from 'react';
+
+import { useConstant } from './use-constant';
+
+export function usePermanentCallback<T extends (...args: never[]) => unknown>(callback: T): T {
+  const lastCallback = useRef<T>(callback);
+
+  useEffect(() => {
+    lastCallback.current = callback;
+  }, [callback]);
+
+  return useConstant<T>(() => ((...args) => lastCallback.current(...args)) as T);
+}

--- a/web-console/src/utils/druid-query.ts
+++ b/web-console/src/utils/druid-query.ts
@@ -236,7 +236,7 @@ export class DruidError extends Error {
   public host?: string;
   public suggestion?: QuerySuggestion;
 
-  constructor(e: any) {
+  constructor(e: any, removeLines?: number) {
     super(axios.isCancel(e) ? CANCELED_MESSAGE : getDruidErrorMessage(e));
     if (axios.isCancel(e)) {
       this.canceled = true;
@@ -262,6 +262,13 @@ export class DruidError extends Error {
       Object.assign(this, druidErrorResponse);
 
       if (this.errorMessage) {
+        if (removeLines) {
+          this.errorMessage = this.errorMessage.replace(
+            /line (\d+),/g,
+            (_, c) => `line ${Number(c) - removeLines},`,
+          );
+        }
+
         this.position = DruidError.parsePosition(this.errorMessage);
         this.suggestion = DruidError.getSuggestion(this.errorMessage);
 

--- a/web-console/src/utils/intermediate-query-state.ts
+++ b/web-console/src/utils/intermediate-query-state.ts
@@ -16,20 +16,12 @@
  * limitations under the License.
  */
 
-export * from './capabilities';
-export * from './column-metadata';
-export * from './date';
-export * from './druid-lookup';
-export * from './druid-query';
-export * from './formatter';
-export * from './general';
-export * from './intermediate-query-state';
-export * from './local-storage-backed-visibility';
-export * from './local-storage-keys';
-export * from './object-change';
-export * from './query-action';
-export * from './query-cursor';
-export * from './query-manager';
-export * from './query-state';
-export * from './sanitizers';
-export * from './table-helpers';
+export class IntermediateQueryState<S> {
+  public readonly state: S;
+  public readonly delay: number | undefined;
+
+  constructor(state: S, delay?: number) {
+    this.state = state;
+    this.delay = delay;
+  }
+}

--- a/web-console/src/utils/query-action.ts
+++ b/web-console/src/utils/query-action.ts
@@ -16,20 +16,6 @@
  * limitations under the License.
  */
 
-export * from './capabilities';
-export * from './column-metadata';
-export * from './date';
-export * from './druid-lookup';
-export * from './druid-query';
-export * from './formatter';
-export * from './general';
-export * from './intermediate-query-state';
-export * from './local-storage-backed-visibility';
-export * from './local-storage-keys';
-export * from './object-change';
-export * from './query-action';
-export * from './query-cursor';
-export * from './query-manager';
-export * from './query-state';
-export * from './sanitizers';
-export * from './table-helpers';
+import { SqlQuery } from 'druid-query-toolkit';
+
+export type QueryAction = (query: SqlQuery) => SqlQuery;

--- a/web-console/src/utils/query-manager.tsx
+++ b/web-console/src/utils/query-manager.tsx
@@ -16,45 +16,68 @@
  * limitations under the License.
  */
 
-import axios, { CancelToken } from 'axios';
+import axios, { Canceler, CancelToken } from 'axios';
 import debounce from 'lodash.debounce';
 
+import { wait } from './general';
+import { IntermediateQueryState } from './intermediate-query-state';
 import { QueryState } from './query-state';
 
-export interface QueryManagerOptions<Q, R> {
+export interface QueryManagerOptions<Q, R, I = never, E extends Error = Error> {
+  initState?: QueryState<R, E, I>;
   processQuery: (
     query: Q,
     cancelToken: CancelToken,
     setIntermediateQuery: (intermediateQuery: any) => void,
-  ) => Promise<R>;
-  onStateChange?: (queryResolve: QueryState<R>) => void;
+  ) => Promise<R | IntermediateQueryState<I>>;
+  backgroundStatusCheck?: (
+    state: I,
+    query: Q,
+    cancelToken: CancelToken,
+  ) => Promise<R | IntermediateQueryState<I>>;
+  onStateChange?: (queryResolve: QueryState<R, E, I>) => void;
   debounceIdle?: number;
   debounceLoading?: number;
+  backgroundStatusCheckInitDelay?: number;
+  backgroundStatusCheckDelay?: number;
 }
 
-export class QueryManager<Q, R> {
+export class QueryManager<Q, R, I = never, E extends Error = Error> {
+  static TERMINATION_MESSAGE = 'QUERY_MANAGER_TERMINATED';
+
   private readonly processQuery: (
     query: Q,
     cancelToken: CancelToken,
     setIntermediateQuery: (intermediateQuery: any) => void,
-  ) => Promise<R>;
+  ) => Promise<R | IntermediateQueryState<I>>;
 
-  private readonly onStateChange?: (queryResolve: QueryState<R>) => void;
+  private readonly backgroundStatusCheck?: (
+    state: I,
+    query: Q,
+    cancelToken: CancelToken,
+  ) => Promise<R | IntermediateQueryState<I>>;
+
+  private readonly onStateChange?: (queryResolve: QueryState<R, E, I>) => void;
+  private readonly backgroundStatusCheckInitDelay: number;
+  private readonly backgroundStatusCheckDelay: number;
 
   private terminated = false;
   private nextQuery: Q | undefined;
   private lastQuery: Q | undefined;
   private lastIntermediateQuery: any;
-  private currentRunCancelFn: (() => void) | undefined;
-  private state: QueryState<R> = QueryState.INIT;
+  private currentRunCancelFn?: Canceler;
+  private state: QueryState<R, E, I>;
   private currentQueryId = 0;
 
   private readonly runWhenIdle: () => void;
   private readonly runWhenLoading: () => void;
 
-  constructor(options: QueryManagerOptions<Q, R>) {
+  constructor(options: QueryManagerOptions<Q, R, I, E>) {
     this.processQuery = options.processQuery;
+    this.backgroundStatusCheck = options.backgroundStatusCheck;
     this.onStateChange = options.onStateChange;
+    this.backgroundStatusCheckInitDelay = options.backgroundStatusCheckInitDelay || 500;
+    this.backgroundStatusCheckDelay = options.backgroundStatusCheckDelay || 1000;
     if (options.debounceIdle !== 0) {
       this.runWhenIdle = debounce(this.run, options.debounceIdle || 100);
     } else {
@@ -65,16 +88,17 @@ export class QueryManager<Q, R> {
     } else {
       this.runWhenLoading = this.run;
     }
+    this.state = options.initState || QueryState.INIT;
   }
 
-  private setState(queryState: QueryState<R>) {
+  private setState(queryState: QueryState<R, E, I>) {
     this.state = queryState;
     if (this.onStateChange && !this.terminated) {
       this.onStateChange(queryState);
     }
   }
 
-  private run() {
+  private async run(): Promise<void> {
     this.lastQuery = this.nextQuery;
     if (typeof this.lastQuery === 'undefined') return;
     this.currentQueryId++;
@@ -86,32 +110,77 @@ export class QueryManager<Q, R> {
     const cancelToken = new axios.CancelToken(cancelFn => {
       this.currentRunCancelFn = cancelFn;
     });
-    this.processQuery(this.lastQuery, cancelToken, (intermediateQuery: any) => {
-      this.lastIntermediateQuery = intermediateQuery;
-    }).then(
-      data => {
-        if (this.currentQueryId !== myQueryId) return;
-        this.currentRunCancelFn = undefined;
-        this.setState(
-          new QueryState<R>({
-            data,
-            lastData: this.state.getSomeData(),
-          }),
-        );
-      },
-      (e: any) => {
-        if (this.currentQueryId !== myQueryId) return;
-        this.currentRunCancelFn = undefined;
-        if (axios.isCancel(e)) {
-          e = new Error(`canceled.`); // ToDo: fix!
+
+    const query = this.lastQuery;
+    let data: R | IntermediateQueryState<I>;
+    try {
+      data = await this.processQuery(query, cancelToken, (intermediateQuery: any) => {
+        this.lastIntermediateQuery = intermediateQuery;
+      });
+    } catch (e) {
+      if (this.currentQueryId !== myQueryId) return;
+      this.currentRunCancelFn = undefined;
+      this.setState(
+        new QueryState<R, E>({
+          error: axios.isCancel(e) ? new Error(`canceled.`) : e, // ToDo: why does the cancel error get remapped?
+          lastData: this.state.getSomeData(),
+        }),
+      );
+      return;
+    }
+
+    let bacgroundChecks = 0;
+    while (data instanceof IntermediateQueryState) {
+      try {
+        if (!this.backgroundStatusCheck) {
+          throw new Error(
+            'backgroundStatusCheck must be set in intermediate query state is returned',
+          );
         }
+        cancelToken.throwIfRequested();
+
         this.setState(
-          new QueryState<R>({
-            error: e,
+          new QueryState<R, E, I>({
+            loading: true,
+            intermediate: data.state,
             lastData: this.state.getSomeData(),
           }),
         );
-      },
+
+        const delay =
+          data.delay ??
+          (bacgroundChecks > 0
+            ? this.backgroundStatusCheckDelay
+            : this.backgroundStatusCheckInitDelay);
+
+        if (delay) {
+          await wait(delay);
+          cancelToken.throwIfRequested();
+        }
+
+        data = await this.backgroundStatusCheck(data.state, query, cancelToken);
+      } catch (e) {
+        if (this.currentQueryId !== myQueryId) return;
+        this.currentRunCancelFn = undefined;
+        this.setState(
+          new QueryState<R, E>({
+            error: axios.isCancel(e) ? new Error(`canceled.`) : e, // ToDo: why does the cancel error get remapped?
+            lastData: this.state.getSomeData(),
+          }),
+        );
+        return;
+      }
+
+      bacgroundChecks++;
+    }
+
+    if (this.currentQueryId !== myQueryId) return;
+    this.currentRunCancelFn = undefined;
+    this.setState(
+      new QueryState<R, E>({
+        data,
+        lastData: this.state.getSomeData(),
+      }),
     );
   }
 
@@ -119,7 +188,7 @@ export class QueryManager<Q, R> {
     const currentlyLoading = Boolean(this.currentRunCancelFn);
 
     this.setState(
-      new QueryState<R>({
+      new QueryState<R, E>({
         loading: true,
         lastData: this.state.getSomeData(),
       }),
@@ -162,14 +231,19 @@ export class QueryManager<Q, R> {
     return this.lastIntermediateQuery;
   }
 
-  public getState(): QueryState<R> {
+  public getState(): QueryState<R, Error, I> {
     return this.state;
+  }
+
+  public reset(): void {
+    this.cancelCurrent();
+    this.setState(QueryState.INIT);
   }
 
   public terminate(): void {
     this.terminated = true;
     if (this.currentRunCancelFn) {
-      this.currentRunCancelFn();
+      this.currentRunCancelFn(QueryManager.TERMINATION_MESSAGE);
     }
   }
 }

--- a/web-console/src/utils/query-manager.tsx
+++ b/web-console/src/utils/query-manager.tsx
@@ -122,19 +122,19 @@ export class QueryManager<Q, R, I = never, E extends Error = Error> {
       this.currentRunCancelFn = undefined;
       this.setState(
         new QueryState<R, E>({
-          error: axios.isCancel(e) ? new Error(`canceled.`) : e, // ToDo: why does the cancel error get remapped?
+          error: axios.isCancel(e) ? new Error(`canceled.`) : e, // remap cancellation into a simple error to hide away the axios implementation specifics
           lastData: this.state.getSomeData(),
         }),
       );
       return;
     }
 
-    let bacgroundChecks = 0;
+    let backgroundChecks = 0;
     while (data instanceof IntermediateQueryState) {
       try {
         if (!this.backgroundStatusCheck) {
           throw new Error(
-            'backgroundStatusCheck must be set in intermediate query state is returned',
+            'backgroundStatusCheck must be set if intermediate query state is returned',
           );
         }
         cancelToken.throwIfRequested();
@@ -149,7 +149,7 @@ export class QueryManager<Q, R, I = never, E extends Error = Error> {
 
         const delay =
           data.delay ??
-          (bacgroundChecks > 0
+          (backgroundChecks > 0
             ? this.backgroundStatusCheckDelay
             : this.backgroundStatusCheckInitDelay);
 
@@ -164,14 +164,14 @@ export class QueryManager<Q, R, I = never, E extends Error = Error> {
         this.currentRunCancelFn = undefined;
         this.setState(
           new QueryState<R, E>({
-            error: axios.isCancel(e) ? new Error(`canceled.`) : e, // ToDo: why does the cancel error get remapped?
+            error: axios.isCancel(e) ? new Error(`canceled.`) : e, // remap cancellation into a simple error to hide away the axios implementation specifics
             lastData: this.state.getSomeData(),
           }),
         );
         return;
       }
 
-      bacgroundChecks++;
+      backgroundChecks++;
     }
 
     if (this.currentQueryId !== myQueryId) return;

--- a/web-console/src/utils/query-state.ts
+++ b/web-console/src/utils/query-state.ts
@@ -18,23 +18,25 @@
 
 export type QueryStateState = 'init' | 'loading' | 'data' | 'error';
 
-export interface QueryStateOptions<T, E extends Error = Error> {
+export interface QueryStateOptions<T, E extends Error = Error, I = never> {
   loading?: boolean;
+  intermediate?: I;
   error?: E;
   data?: T;
   lastData?: T;
 }
 
-export class QueryState<T, E extends Error = Error> {
-  static INIT: QueryState<any> = new QueryState({});
+export class QueryState<T, E extends Error = Error, I = never> {
+  static INIT: QueryState<any, any> = new QueryState({});
   static LOADING: QueryState<any> = new QueryState({ loading: true });
 
   public state: QueryStateState = 'init';
+  public intermediate?: I;
   public error?: E;
   public data?: T;
   public lastData?: T;
 
-  constructor(opts: QueryStateOptions<T, E>) {
+  constructor(opts: QueryStateOptions<T, E, I>) {
     const hasData = typeof opts.data !== 'undefined';
     if (typeof opts.error !== 'undefined') {
       if (hasData) {
@@ -47,8 +49,11 @@ export class QueryState<T, E extends Error = Error> {
       if (hasData) {
         this.state = 'data';
         this.data = opts.data;
+      } else if (opts.loading) {
+        this.state = 'loading';
+        this.intermediate = opts.intermediate;
       } else {
-        this.state = opts.loading ? 'loading' : 'init';
+        this.state = 'init';
       }
     }
     this.lastData = opts.lastData;

--- a/web-console/src/views/query-view/query-output/query-output.spec.tsx
+++ b/web-console/src/views/query-view/query-output/query-output.spec.tsx
@@ -17,21 +17,23 @@
  */
 
 import { render } from '@testing-library/react';
-import { QueryResult, SqlQuery } from 'druid-query-toolkit';
+import { QueryResult, sane, SqlQuery } from 'druid-query-toolkit';
 import React from 'react';
 
 import { QueryOutput } from './query-output';
 
 describe('query output', () => {
   it('matches snapshot', () => {
-    const parsedQuery = SqlQuery.parse(`SELECT
-  "language",
-  COUNT(*) AS "Count", COUNT(DISTINCT "language") AS "dist_language", COUNT(*) FILTER (WHERE "language"= 'xxx') AS "language_filtered_count"
-FROM "github"
-WHERE "__time" >= CURRENT_TIMESTAMP - INTERVAL '1' DAY AND "language" != 'TypeScript'
-GROUP BY 1
-HAVING "Count" != 37392
-ORDER BY "Count" DESC`);
+    const parsedQuery = SqlQuery.parse(sane`
+      SELECT
+        "language",
+        COUNT(*) AS "Count", COUNT(DISTINCT "language") AS "dist_language", COUNT(*) FILTER (WHERE "language"= 'xxx') AS "language_filtered_count"
+      FROM "github"
+      WHERE "__time" >= CURRENT_TIMESTAMP - INTERVAL '1' DAY AND "language" != 'TypeScript'
+      GROUP BY 1
+      HAVING "Count" != 37392
+      ORDER BY "Count" DESC
+    `);
 
     const queryOutput = (
       <QueryOutput
@@ -48,7 +50,7 @@ ORDER BY "Count" DESC`);
           false,
           true,
         ).attachQuery({}, parsedQuery)}
-        onQueryChange={() => {}}
+        onQueryAction={() => {}}
         onLoadMore={() => {}}
       />
     );

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -41,6 +41,7 @@ import {
   LocalStorageKeys,
   localStorageSet,
   localStorageSetJson,
+  QueryAction,
   queryDruidSql,
   QueryManager,
   QueryState,
@@ -470,7 +471,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
             <QueryOutput
               runeMode={runeMode}
               queryResult={someQueryResult}
-              onQueryChange={this.handleQueryChange}
+              onQueryAction={this.handleQueryAction}
               onLoadMore={this.handleLoadMore}
             />
           )}
@@ -529,13 +530,18 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
     }
   };
 
+  private readonly handleQueryAction = (queryAction: QueryAction): void => {
+    const { parsedQuery } = this.state;
+    if (!parsedQuery) return;
+    this.handleQueryChange(parsedQuery.apply(queryAction), true);
+  };
+
   private readonly handleQueryStringChange = (
     queryString: string,
     preferablyRun?: boolean,
   ): void => {
     const parsedQuery = parser(queryString);
-    const newSate = { queryString, parsedQuery };
-    this.setState(newSate, preferablyRun ? this.handleRunIfLive : undefined);
+    this.setState({ queryString, parsedQuery }, preferablyRun ? this.handleRunIfLive : undefined);
   };
 
   private readonly handleQueryContextChange = (queryContext: QueryContext) => {

--- a/web-console/src/views/query-view/run-button/run-button.tsx
+++ b/web-console/src/views/query-view/run-button/run-button.tsx
@@ -28,7 +28,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { MenuCheckbox } from '../../../components';
 import { getLink } from '../../../links';
@@ -129,12 +129,12 @@ const RunButtonExtraMenu = (props: RunButtonProps) => {
 export const RunButton = React.memo(function RunButton(props: RunButtonProps) {
   const { runeMode, onRun, loading, onExplain } = props;
 
-  const handleRun = React.useCallback(() => {
+  const handleRun = useCallback(() => {
     if (!onRun) return;
     onRun();
   }, [onRun]);
 
-  const hotkeys = React.useMemo(() => {
+  const hotkeys = useMemo(() => {
     return [
       {
         allowInInput: true,


### PR DESCRIPTION
Right now there is a bug that can lead to parts of queries typed into the query view being lost:

To repro:

1. Run some query e.g:

```sql
SELECT
  channel,
  COUNT(*) AS "Count"
FROM wikipedia
GROUP BY 1
ORDER BY 2 DESC
```

2. Edit the query somehow, say change "Count" to "CountBlah"

3. Use the table actions to modify the query:

![image](https://user-images.githubusercontent.com/177816/145162336-0fe6fd8b-579e-49aa-978a-be1534e1c8c6.png)

Notice the query edit of "Blah" is lost as the table action overwrites the query completely.

Instead it should now provide an action (a function that takes a query and manipulates it) instead so the action is simply applied to the edited query.

This PR also:
- Skips the java check in the helper script to make JDK11 dev easier
- Simplifies the format guesser
- Adds and improves react hooks

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
