### PR TITLE
Introduce query/long/count metric and add long query identifier to request log

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -58,6 +58,7 @@ Available Metrics
 |`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/segments/count`|This metric is not enabled by default. See the `QueryMetrics` Interface for reference regarding enabling this metric. Number of segments that will be touched by the query. In the broker, it makes a plan to distribute the query to realtime tasks and historicals based on a snapshot of segment distribution state. If there are some segments moved after this snapshot is created, certain historicals and realtime tasks can report those segments as missing to the broker. The broker will re-send the query to the new servers that serve those segments after move. In this case, those segments can be counted more than once in this metric.|Varies.|
+|`query/long/count`|number of long queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`sqlQuery/time`|Milliseconds taken to complete a SQL query.|id, nativeQueryIds, dataSource, remoteAddress, success.|< 1s|
 |`sqlQuery/bytes`|number of bytes returned in SQL query response.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
 
@@ -76,6 +77,8 @@ Available Metrics
 |`query/failed/count`|number of failed queries|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/long/count`|number of long queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
+
 
 ### Real-time
 
@@ -89,6 +92,8 @@ Available Metrics
 |`query/failed/count`|number of failed queries|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/interrupted/count`|number of queries interrupted due to cancellation.|This metric is only available if the QueryCountStatsMonitor module is included.||
 |`query/timeout/count`|number of timed out queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
+|`query/long/count`|number of long queries.|This metric is only available if the QueryCountStatsMonitor module is included.||
+
 
 ### Jetty
 

--- a/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
@@ -20,6 +20,7 @@
   "query/failed/count": [],
   "query/interrupted/count": [],
   "query/timeout/count": [],
+  "query/long/count": [],
   "query/wait/time": [
     "segment"
   ],

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -17,6 +17,7 @@
   "query/failed/count" : { "dimensions" : [], "type" : "count" },
   "query/interrupted/count" : { "dimensions" : [], "type" : "count" },
   "query/timeout/count" : { "dimensions" : [], "type" : "count" },
+  "query/long/count" : { "dimensions" : [], "type" : "count" },
 
   "query/cache/delta/numEntries" : { "dimensions" : [], "type" : "count" },
   "query/cache/delta/sizeBytes" : { "dimensions" : [], "type" : "count" },

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -40,9 +40,11 @@ public class QueryContexts
   public static final String PRIORITY_KEY = "priority";
   public static final String LANE_KEY = "lane";
   public static final String TIMEOUT_KEY = "timeout";
+  public static final String LONG_QUERY_KEY = "longQuery";
   public static final String MAX_SCATTER_GATHER_BYTES_KEY = "maxScatterGatherBytes";
   public static final String MAX_QUEUED_BYTES_KEY = "maxQueuedBytes";
   public static final String DEFAULT_TIMEOUT_KEY = "defaultTimeout";
+  public static final String DEFAULT_LONG_QUERY_KEY = "defaultlongQuery";
   public static final String BROKER_PARALLEL_MERGE_KEY = "enableParallelMerge";
   public static final String BROKER_PARALLEL_MERGE_INITIAL_YIELD_ROWS_KEY = "parallelMergeInitialYieldRows";
   public static final String BROKER_PARALLEL_MERGE_SMALL_BATCH_ROWS_KEY = "parallelMergeSmallBatchRows";
@@ -79,7 +81,9 @@ public class QueryContexts
   public static final int DEFAULT_PRIORITY = 0;
   public static final int DEFAULT_UNCOVERED_INTERVALS_LIMIT = 0;
   public static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
+  public static final long DEFAULT_LONG_QUERY_MILLIS = TimeUnit.SECONDS.toMillis(10);
   public static final long NO_TIMEOUT = 0;
+  public static final long NO_LONG_QUERY = 0;
   public static final boolean DEFAULT_ENABLE_PARALLEL_MERGE = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_REWRITE = true;
@@ -412,6 +416,31 @@ public class QueryContexts
     Preconditions.checkState(defaultTimeout >= 0, "Timeout must be a non negative value, but was [%s]", defaultTimeout);
     return defaultTimeout;
   }
+
+  public static <T> boolean hasLongQueryTime(Query<T> query)
+  {
+    return getLongQueryTime(query) != NO_LONG_QUERY;
+  }
+
+  public static <T> long getLongQueryTime(Query<T> query)
+  {
+    return getLongQueryTime(query, getDefaultLongQueryTime(query));
+  }
+
+  public static <T> long getLongQueryTime(Query<T> query, long defaultLongQueryTime)
+  {
+    final long longQueryTime = parseLong(query, LONG_QUERY_KEY, defaultLongQueryTime);
+    Preconditions.checkState(longQueryTime >= 0, "longQueryTime must be a non negative value, but was [%s]", longQueryTime);
+    return longQueryTime;
+  }
+
+  static <T> long getDefaultLongQueryTime(Query<T> query)
+  {
+    final long defaultLongQueryTime = parseLong(query, DEFAULT_LONG_QUERY_KEY, DEFAULT_LONG_QUERY_MILLIS);
+    Preconditions.checkState(defaultLongQueryTime >= 0, "longQueryTime must be a non negative value, but was [%s]", defaultLongQueryTime);
+    return defaultLongQueryTime;
+  }
+
 
   public static <T> int getNumRetriesOnMissingSegments(Query<T> query, int defaultValue)
   {

--- a/processing/src/test/java/org/apache/druid/query/QueryContextsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryContextsTest.java
@@ -192,4 +192,42 @@ public class QueryContextsTest
     Assert.assertTrue(QueryContexts.isDebug(query));
     Assert.assertTrue(QueryContexts.isDebug(query.getContext()));
   }
+
+  @Test
+  public void testDefaultLongQueryTime()
+  {
+    final Query<?> query = new TestQuery(
+        new TableDataSource("test"),
+        new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("0/100"))),
+        false,
+        new HashMap()
+    );
+    Assert.assertEquals(10_000, QueryContexts.getDefaultLongQueryTime(query));
+  }
+
+  @Test
+  public void testLongQueryTime()
+  {
+    Query<?> query = new TestQuery(
+        new TableDataSource("test"),
+        new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("0/100"))),
+        false,
+        ImmutableMap.of(QueryContexts.LONG_QUERY_KEY, 5000)
+    );
+    Assert.assertEquals(5000, QueryContexts.getLongQueryTime(query));
+  }
+
+  @Test
+  public void testHasLongQueryTime()
+  {
+    Query<?> query = new TestQuery(
+        new TableDataSource("test"),
+        new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("0/100"))),
+        false,
+        ImmutableMap.of(QueryContexts.LONG_QUERY_KEY, 0)
+    );
+    Assert.assertEquals(false, QueryContexts.hasLongQueryTime(query));
+  }
+
 }
+

--- a/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsMonitor.java
@@ -49,16 +49,18 @@ public class QueryCountStatsMonitor extends AbstractMonitor
     final long failedQueryCount = statsProvider.getFailedQueryCount();
     final long interruptedQueryCount = statsProvider.getInterruptedQueryCount();
     final long timedOutQueryCount = statsProvider.getTimedOutQueryCount();
+    final long longQueryCount = statsProvider.getLongQueryCount();
 
     Map<String, Long> diff = keyedDiff.to(
         "queryCountStats",
-        ImmutableMap.of(
-            "query/count", successfulQueryCount + failedQueryCount + interruptedQueryCount + timedOutQueryCount,
-            "query/success/count", successfulQueryCount,
-            "query/failed/count", failedQueryCount,
-            "query/interrupted/count", interruptedQueryCount,
-            "query/timeout/count", timedOutQueryCount
-        )
+        ImmutableMap.<String, Long>builder()
+            .put("query/count", successfulQueryCount + failedQueryCount + interruptedQueryCount + timedOutQueryCount + longQueryCount)
+            .put("query/success/count", successfulQueryCount)
+            .put("query/failed/count", failedQueryCount)
+            .put("query/interrupted/count", interruptedQueryCount)
+            .put("query/timeout/count", timedOutQueryCount)
+            .put("query/long/count", longQueryCount)
+            .build()
     );
     if (diff != null) {
       for (Map.Entry<String, Long> diffEntry : diff.entrySet()) {

--- a/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsProvider.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsProvider.java
@@ -40,4 +40,9 @@ public interface QueryCountStatsProvider
    * Returns the number of timed out queries during the emission period.
    */
   long getTimedOutQueryCount();
+
+  /**
+   * Returns the number of long queries during the emission period.
+   */
+  long getLongQueryCount();
 }

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -26,6 +26,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.UnmodifiableIterator;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Injector;
@@ -86,12 +87,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -167,6 +170,23 @@ public class QueryResourceTest
       + "      }\n"
       + "    ],\n"
       + "    \"context\": { \"priority\": -1 }"
+      + "}";
+
+  private static final String SIMPLE_TIMESERIES_QUERY_LONGQUERY =
+      "{\n"
+      + "    \"queryType\": \"timeseries\",\n"
+      + "    \"dataSource\": \"mmx_metrics\",\n"
+      + "    \"granularity\": \"hour\",\n"
+      + "    \"intervals\": [\n"
+      + "      \"2014-12-17/2015-12-30\"\n"
+      + "    ],\n"
+      + "    \"aggregations\": [\n"
+      + "      {\n"
+      + "        \"type\": \"count\",\n"
+      + "        \"name\": \"rows\"\n"
+      + "      }\n"
+      + "    ],\n"
+      + "    \"context\": { \"longQuery\": 250 }"
       + "}";
 
 
@@ -355,6 +375,91 @@ public class QueryResourceTest
     Assert.assertTrue(testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext().containsKey(overrideConfigKey));
     Assert.assertEquals(-1, testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext().get(overrideConfigKey));
   }
+
+
+  @Test
+  public void testGoodQueryWithLongQueryConfig() throws IOException
+  {
+    ImmutableList<Integer> delayList = ImmutableList.of(10, 100, 150, 200, 300, 500, 600, 700, 800, 1000);
+    UnmodifiableIterator<Integer> delayIt = delayList.iterator();
+    QuerySegmentWalker randomQuerytimeWalker = new QuerySegmentWalker()
+    {
+      @Override
+      public <T> QueryRunner<T> getQueryRunnerForIntervals(Query<T> query, Iterable<Interval> intervals)
+      {
+        return (queryPlus, responseContext) -> Sequences.simple(() -> new Iterator<T>()
+        {
+          @Override
+          public boolean hasNext()
+          {
+            try {
+              if (delayIt.hasNext()) {
+                Thread.sleep(delayIt.next());
+              }
+            }
+            catch (InterruptedException e) {
+              e.printStackTrace();
+            }
+            return false;
+          }
+
+          @Override
+          public T next()
+          {
+            return null;
+          }
+        });
+      }
+
+      @Override
+      public <T> QueryRunner<T> getQueryRunnerForSegments(Query<T> query, Iterable<SegmentDescriptor> specs)
+      {
+        return getQueryRunnerForIntervals(null, null);
+      }
+    };
+    queryResource = new QueryResource(
+        new QueryLifecycleFactory(
+            WAREHOUSE,
+            randomQuerytimeWalker,
+            new DefaultGenericQueryMetricsFactory(),
+            new NoopServiceEmitter(),
+            testRequestLogger,
+            new AuthConfig(),
+            AuthTestUtils.TEST_AUTHORIZER_MAPPER,
+            Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
+        ),
+        jsonMapper,
+        smileMapper,
+        queryScheduler,
+        new AuthConfig(),
+        null,
+        ResponseContextConfig.newConfig(true),
+        DRUID_NODE
+    );
+    expectPermissiveHappyPathAuth();
+    int longQueryCount = 0;
+    for (int i = 0; i < delayList.size(); i++) {
+      Response response = queryResource.doPost(
+          new ByteArrayInputStream(SIMPLE_TIMESERIES_QUERY_LONGQUERY.getBytes(StandardCharsets.UTF_8)),
+          null /*pretty*/,
+          testServletRequest
+      );
+
+      Assert.assertNotNull(response);
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      ((StreamingOutput) response.getEntity()).write(baos);
+      List<RequestLogLine> nativeQuerylogs = testRequestLogger.getNativeQuerylogs();
+      int size = nativeQuerylogs.size();
+      QueryStats queryStats = testRequestLogger.getNativeQuerylogs().get(size - 1).getQueryStats();
+      boolean longQuery = (boolean) queryStats.getStats().get("longQuery");
+      if (longQuery) {
+        longQueryCount++;
+      }
+    }
+
+    Assert.assertEquals(queryResource.getLongQueryCount(), longQueryCount);
+  }
+
 
   @Test
   public void testTruncatedResponseContextShouldFail() throws IOException

--- a/server/src/test/java/org/apache/druid/server/metrics/QueryCountStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/QueryCountStatsMonitorTest.java
@@ -40,6 +40,7 @@ public class QueryCountStatsMonitorTest
       private long failedEmitCount = 0;
       private long interruptedEmitCount = 0;
       private long timedOutEmitCount = 0;
+      private long longQueryEmitCount = 0;
 
       @Override
       public long getSuccessfulQueryCount()
@@ -68,6 +69,14 @@ public class QueryCountStatsMonitorTest
         timedOutEmitCount += 4;
         return timedOutEmitCount;
       }
+
+      @Override
+      public long getLongQueryCount()
+      {
+        longQueryEmitCount += 5;
+        return longQueryEmitCount;
+      }
+
     };
   }
 
@@ -85,12 +94,13 @@ public class QueryCountStatsMonitorTest
                                              event -> (String) event.toMap().get("metric"),
                                              event -> (Long) event.toMap().get("value")
                                          ));
-    Assert.assertEquals(5, resultMap.size());
+    Assert.assertEquals(6, resultMap.size());
     Assert.assertEquals(1L, (long) resultMap.get("query/success/count"));
     Assert.assertEquals(2L, (long) resultMap.get("query/failed/count"));
     Assert.assertEquals(3L, (long) resultMap.get("query/interrupted/count"));
     Assert.assertEquals(4L, (long) resultMap.get("query/timeout/count"));
-    Assert.assertEquals(10L, (long) resultMap.get("query/count"));
+    Assert.assertEquals(5L, (long) resultMap.get("query/long/count"));
+    Assert.assertEquals(15L, (long) resultMap.get("query/count"));
 
   }
 }

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -532,6 +532,14 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
     return 0L;
   }
 
+  @Override
+  public long getLongQueryCount()
+  {
+    // Query long metric is not relevant here and this metric is already being tracked in the Broker and the
+    // data nodes using QueryResource
+    return 0;
+  }
+
   @VisibleForTesting
   static String getAvaticaConnectionId(Map<String, Object> requestMap)
   {
@@ -703,6 +711,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       super.onComplete(result);
     }
 
+    @SuppressWarnings("checkstyle:Indentation")
     @Override
     public void onFailure(Response response, Throwable failure)
     {

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -800,6 +800,26 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     }
   }
 
+  @Test
+  public void testGetLongQueryCount()
+  {
+    final AsyncQueryForwardingServlet testGetLongQueryCountServlet = new AsyncQueryForwardingServlet(
+        new MapQueryToolChestWarehouse(ImmutableMap.of()),
+        null,
+        TestHelper.makeSmileMapper(),
+        null,
+        null,
+        null,
+        new NoopServiceEmitter(),
+        new NoopRequestLogger(),
+        new DefaultGenericQueryMetricsFactory(),
+        new AuthenticatorMapper(ImmutableMap.of()),
+        new Properties(),
+        new ServerConfig()
+    );
+    Assert.assertEquals(0, testGetLongQueryCountServlet.getLongQueryCount());
+  }
+
   private static Map<String, Object> asMap(String json, ObjectMapper mapper) throws JsonProcessingException
   {
     return mapper.readValue(json, JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT);


### PR DESCRIPTION
### Description

When we use druid for various query operations, there may be some query requests that take a long time. These query requests may be some bad query requests. If there are many such requests, it will cause a lot of pressure on druid, so we hope A metric can be added to count the number of occurrences of these query requests, and to mark these requests in the request log. So that we can analyze these queries and can make it a little easier for cluster operators to diagnose query issues better.

This PR adds a new query metric query/long/count  that represents the number of long queries during the emission period and request logging will mark if this request is a long query request

This PR has:

- [x]  been self-reviewed.
- [x]  added documentation for new or modified features or behaviors.
- [x]  added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x]  added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage is met.