### PR TITLE
Add interface for external schema provider to Druid SQL

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/DruidSchemaInternRowSignatureBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/DruidSchemaInternRowSignatureBenchmark.java
@@ -90,7 +90,8 @@ public class DruidSchemaInternRowSignatureBenchmark
           joinableFactory,
           config,
           escalator,
-          brokerInternalQueryConfig
+          brokerInternalQueryConfig,
+          null
       );
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.schema;
+
+import org.apache.druid.sql.calcite.table.DruidTable;
+
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * This interface provides a map of datasource names to {@link DruidTable} objects, used by the {@link DruidSchema}
+ * class as the SQL planner's view of Druid datasource schemas. If a non-default implementation is provided,
+ * the segment metadata polling-based view of the Druid tables will not be built in DruidSchema.
+ */
+public interface DruidSchemaManager
+{
+  ConcurrentMap<String, DruidTable> getTables();
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.sql.calcite.schema;
 
+import org.apache.druid.guice.annotations.ExtensionPoint;
+import org.apache.druid.guice.annotations.UnstableApi;
 import org.apache.druid.sql.calcite.table.DruidTable;
 
 import java.util.concurrent.ConcurrentMap;
@@ -28,6 +30,8 @@ import java.util.concurrent.ConcurrentMap;
  * class as the SQL planner's view of Druid datasource schemas. If a non-default implementation is provided,
  * the segment metadata polling-based view of the Druid tables will not be built in DruidSchema.
  */
+@ExtensionPoint
+@UnstableApi
 public interface DruidSchemaManager
 {
   ConcurrentMap<String, DruidTable> getTables();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/NoopDruidSchemaManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/NoopDruidSchemaManager.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.schema;
+
+import org.apache.druid.sql.calcite.table.DruidTable;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class NoopDruidSchemaManager implements DruidSchemaManager
+{
+  public static final String TYPE = "noop";
+
+  private static ConcurrentMap<String, DruidTable> MAP = new ConcurrentHashMap<>();
+
+  @Override
+  public ConcurrentMap<String, DruidTable> getTables()
+  {
+    return MAP;
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/guice/SqlModule.java
+++ b/sql/src/main/java/org/apache/druid/sql/guice/SqlModule.java
@@ -33,6 +33,8 @@ import org.apache.druid.sql.calcite.expression.builtin.QueryLookupOperatorConver
 import org.apache.druid.sql.calcite.planner.CalcitePlannerModule;
 import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.schema.DruidCalciteSchemaModule;
+import org.apache.druid.sql.calcite.schema.DruidSchemaManager;
+import org.apache.druid.sql.calcite.schema.NoopDruidSchemaManager;
 import org.apache.druid.sql.calcite.view.DruidViewModule;
 import org.apache.druid.sql.calcite.view.NoopViewManager;
 import org.apache.druid.sql.calcite.view.ViewManager;
@@ -46,6 +48,7 @@ public class SqlModule implements Module
   public static final String PROPERTY_SQL_ENABLE_JSON_OVER_HTTP = "druid.sql.http.enable";
   public static final String PROPERTY_SQL_ENABLE_AVATICA = "druid.sql.avatica.enable";
   public static final String PROPERTY_SQL_VIEW_MANAGER_TYPE = "druid.sql.viewmanager.type";
+  public static final String PROPERTY_SQL_SCHEMA_MANAGER_TYPE = "druid.sql.schemamanager.type";
   public static final String PROPERTY_SQL_APPROX_COUNT_DISTINCT_CHOICE = "druid.sql.approxCountDistinct.function";
 
   @Inject
@@ -80,6 +83,18 @@ public class SqlModule implements Module
           PROPERTY_SQL_VIEW_MANAGER_TYPE,
           Key.get(ViewManager.class),
           NoopViewManager.TYPE
+      );
+
+      PolyBind.optionBinder(binder, Key.get(DruidSchemaManager.class))
+              .addBinding(NoopDruidSchemaManager.TYPE)
+              .to(NoopDruidSchemaManager.class)
+              .in(LazySingleton.class);
+
+      PolyBind.createChoiceWithDefault(
+          binder,
+          PROPERTY_SQL_SCHEMA_MANAGER_TYPE,
+          Key.get(DruidSchemaManager.class),
+          NoopDruidSchemaManager.TYPE
       );
 
       binder.install(new DruidCalciteSchemaModule());

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -88,6 +88,7 @@ import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.planner.PlannerFactory;
 import org.apache.druid.sql.calcite.schema.DruidSchemaCatalog;
+import org.apache.druid.sql.calcite.schema.NoopDruidSchemaManager;
 import org.apache.druid.sql.calcite.util.CalciteTestBase;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.sql.calcite.util.QueryLogHook;
@@ -995,6 +996,7 @@ public class BaseCalciteQueryTest extends CalciteTestBase
         walker,
         plannerConfig,
         viewManager,
+        new NoopDruidSchemaManager(),
         authorizerMapper
     );
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidCalciteSchemaModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidCalciteSchemaModuleTest.java
@@ -119,6 +119,7 @@ public class DruidCalciteSchemaModuleTest extends CalciteTestBase
                 .annotatedWith(IndexingService.class)
                 .toInstance(overlordDruidLeaderClient);
           binder.bind(DruidNodeDiscoveryProvider.class).toInstance(druidNodeDiscoveryProvider);
+          binder.bind(DruidSchemaManager.class).toInstance(new NoopDruidSchemaManager());
           binder.bind(ObjectMapper.class).annotatedWith(Json.class).toInstance(objectMapper);
           binder.bindScope(LazySingleton.class, Scopes.SINGLETON);
           binder.bind(LookupExtractorFactoryContainerProvider.class).toInstance(lookupReferencesManager);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaConcurrencyTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaConcurrencyTest.java
@@ -137,7 +137,8 @@ public class DruidSchemaConcurrencyTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -241,7 +242,8 @@ public class DruidSchemaConcurrencyTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaNoDataInitTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaNoDataInitTest.java
@@ -59,7 +59,8 @@ public class DruidSchemaNoDataInitTest extends CalciteTestBase
           new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
           PLANNER_CONFIG_DEFAULT,
           new NoopEscalator(),
-          new BrokerInternalQueryConfig()
+          new BrokerInternalQueryConfig(),
+          null
       );
 
       druidSchema.start();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -181,7 +181,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         ),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -207,7 +208,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(globalTableJoinable), ImmutableMap.of(globalTableJoinable.getClass(), GlobalTableDataSource.class)),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
 
@@ -485,7 +487,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -527,7 +530,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -573,7 +577,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -616,7 +621,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -656,7 +662,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -713,7 +720,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -773,7 +781,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -807,7 +816,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -854,7 +864,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     )
     {
       @Override
@@ -1076,7 +1087,8 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         ),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        brokerInternalQueryConfig
+        brokerInternalQueryConfig,
+        null
     );
 
     EasyMock.expect(factoryMock.factorize()).andReturn(lifecycleMock).once();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -253,7 +253,8 @@ public class SystemSchemaTest extends CalciteTestBase
         new MapJoinableFactory(ImmutableSet.of(), ImmutableMap.of()),
         PLANNER_CONFIG_DEFAULT,
         new NoopEscalator(),
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        null
     );
     druidSchema.start();
     druidSchema.awaitInitialization();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -123,6 +123,7 @@ import org.apache.druid.sql.calcite.run.NativeQueryMakerFactory;
 import org.apache.druid.sql.calcite.run.QueryMakerFactory;
 import org.apache.druid.sql.calcite.schema.DruidSchema;
 import org.apache.druid.sql.calcite.schema.DruidSchemaCatalog;
+import org.apache.druid.sql.calcite.schema.DruidSchemaManager;
 import org.apache.druid.sql.calcite.schema.InformationSchema;
 import org.apache.druid.sql.calcite.schema.LookupSchema;
 import org.apache.druid.sql.calcite.schema.MetadataSegmentView;
@@ -131,6 +132,7 @@ import org.apache.druid.sql.calcite.schema.NamedLookupSchema;
 import org.apache.druid.sql.calcite.schema.NamedSchema;
 import org.apache.druid.sql.calcite.schema.NamedSystemSchema;
 import org.apache.druid.sql.calcite.schema.NamedViewSchema;
+import org.apache.druid.sql.calcite.schema.NoopDruidSchemaManager;
 import org.apache.druid.sql.calcite.schema.SystemSchema;
 import org.apache.druid.sql.calcite.schema.ViewSchema;
 import org.apache.druid.sql.calcite.view.DruidViewMacroFactory;
@@ -1164,7 +1166,7 @@ public class CalciteTests
       final AuthorizerMapper authorizerMapper
   )
   {
-    return createMockRootSchema(conglomerate, walker, plannerConfig, null, authorizerMapper);
+    return createMockRootSchema(conglomerate, walker, plannerConfig, null, new NoopDruidSchemaManager(), authorizerMapper);
   }
 
   public static DruidSchemaCatalog createMockRootSchema(
@@ -1172,10 +1174,11 @@ public class CalciteTests
       final SpecificSegmentsQuerySegmentWalker walker,
       final PlannerConfig plannerConfig,
       @Nullable final ViewManager viewManager,
+      final DruidSchemaManager druidSchemaManager,
       final AuthorizerMapper authorizerMapper
   )
   {
-    DruidSchema druidSchema = createMockSchema(conglomerate, walker, plannerConfig);
+    DruidSchema druidSchema = createMockSchema(conglomerate, walker, plannerConfig, druidSchemaManager);
     SystemSchema systemSchema =
         CalciteTests.createMockSystemSchema(druidSchema, walker, plannerConfig, authorizerMapper);
 
@@ -1216,7 +1219,8 @@ public class CalciteTests
   private static DruidSchema createMockSchema(
       final QueryRunnerFactoryConglomerate conglomerate,
       final SpecificSegmentsQuerySegmentWalker walker,
-      final PlannerConfig plannerConfig
+      final PlannerConfig plannerConfig,
+      final DruidSchemaManager druidSchemaManager
   )
   {
     final DruidSchema schema = new DruidSchema(
@@ -1233,7 +1237,8 @@ public class CalciteTests
         createDefaultJoinableFactory(),
         plannerConfig,
         TEST_AUTHENTICATOR_ESCALATOR,
-        new BrokerInternalQueryConfig()
+        new BrokerInternalQueryConfig(),
+        druidSchemaManager
     );
 
     try {


### PR DESCRIPTION
This PR adds a `DruidSchemaManager` that can be implemented by extensions, specified with `druid.sql.schemamanager.type` allowing the extension to provide the Druid table schemas to the Druid SQL planner.

If an extension implementation is used, the default segment metadata polling mechanism will not be active.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
