### PR TITLE
Segment pruning for multi-dim partitioning given query domain

### DIFF
--- a/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeShardSpec.java
@@ -186,7 +186,7 @@ public class DimensionRangeShardSpec implements ShardSpec
    * start = (3, 25, 10)
    * end = (5, 15, 30)
    * query domain = {4} * [0, 10] * {10, 20, 30, 40}
-   * EffectiveDomain[:1] == {4} (!= start[:1] && != {end[:1]}) -> ACCEPT
+   * EffectiveDomain[:1] == {4} (!= {} && != start[:1] && != {end[:1]}) -> ACCEPT
    *
    * III)
    * start = (3, 25, 10)
@@ -194,7 +194,7 @@ public class DimensionRangeShardSpec implements ShardSpec
    * query domain = {5} * [0, 10] * {10, 20, 30, 40}
    * EffectiveDomain[:1] == {5} == end[:1]
    * EffectiveDomain[:2] == {5} * ([0, 10] INTERSECTION (-INF, 15])
-   *                     == {5} * [0, 10] (!= {end[:2]}) -> ACCEPT
+   *                     == {5} * [0, 10] (! ={} && != {end[:2]}) -> ACCEPT
    *
    * IV)
    * start = (3, 25, 10)

--- a/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeShardSpec.java
+++ b/core/src/main/java/org/apache/druid/timeline/partition/DimensionRangeShardSpec.java
@@ -161,16 +161,16 @@ public class DimensionRangeShardSpec implements ShardSpec
    * Set[:i] is the cartesian product of Set[0],...,Set[i - 1]
    * EffectiveDomain[:i] is defined as QueryDomain[:i] INTERSECTION SegmentRange[:i]
    *
-   *        i = 1
-   * 1)     If EffectiveDomain[:i] == {start[:i]} || EffectiveDomain == {end[:i]}:
-   * 1.a)     if i == index.dimensions.size:
-   *            ACCEPT segment
-   * 1.b)     else:
-   *            Repeat (1) with i = i + 1
-   * 2)     else if EffectiveDomain[:i] == {}:
-   *          PRUNE segment
-   * 3)     else:
-   *          ACCEPT segment
+   * i = 1
+   * If EffectiveDomain[:i] == {start[:i]} || EffectiveDomain == {end[:i]}:
+   *  if i == index.dimensions.size:
+   *    ACCEPT segment
+   *  else:
+   *    REPEAT with i = i + 1
+   *else if EffectiveDomain[:i] == {}:
+   *  PRUNE segment
+   *else:
+   *  ACCEPT segment
    *
    *
    * Example: Index on (Hour, Minute, Second). Index.size is 3

--- a/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeShardSpecTest.java
@@ -19,10 +19,16 @@
 
 package org.apache.druid.timeline.partition;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.StringTuple;
 import org.apache.druid.java.util.common.DateTimes;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -295,6 +301,25 @@ public class DimensionRangeShardSpecTest
         shardSpec,
         createRow("United Kingdom", "London")
     ));
+  }
+
+  @Test
+  public void testPossibleInDomain()
+  {
+    // multi-dim index on <d1, d2, d3>
+    setDimensions("d1", "d2", "d3");
+
+    // start: <s1, s2, s3>, end: <e1, e2, e3>
+    StringTuple start = StringTuple.create("Earth", "France", "Paris");
+    StringTuple end = StringTuple.create("Earth", "USA", "New York");
+    ShardSpec shard = new DimensionRangeShardSpec(dimensions, start, end, 0, null);
+
+    // domain -> empty
+    Map<String, RangeSet<String>> domain = new HashMap<>();
+    domain.put("d1", TreeRangeSet.create());
+    domain.put("d2", TreeRangeSet.create());
+    domain.put("d3", TreeRangeSet.create());
+    assertFalse(shard.possibleInDomain(domain));
   }
 
   /**

--- a/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeShardSpecTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/DimensionRangeShardSpecTest.java
@@ -315,42 +315,50 @@ public class DimensionRangeShardSpecTest
     Map<String, RangeSet<String>> domain = new HashMap<>();
 
     // {Mars} * {Zoo, Zuu} * {Blah, Random}
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Mars")),
-                   // EffectiveDomain[:1].size > 1 -> ACCEPT
-                   getUnion(getRangeSet(Range.singleton("Zoo")),
-                            getRangeSet(Range.singleton("Zuu"))),
-                   getUnion(getRangeSet(Range.singleton("Blah")),
-                            getRangeSet(Range.singleton("Random")))
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Mars")),
+        // EffectiveDomain[:1].size > 1 -> ACCEPT
+        getUnion(
+            getRangeSet(Range.singleton("Zoo")),
+            getRangeSet(Range.singleton("Zuu"))
+        ),
+        getUnion(
+            getRangeSet(Range.singleton("Blah")),
+            getRangeSet(Range.singleton("Random"))
+        )
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // {Saturn} * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Saturn")),
-                   // EffectiveDomain[:1] == {end[:1]}
-                   universalSet,
-                   // EffectiveDomain[:2].size > 1 -> ACCEPT
-                   universalSet
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Saturn")),
+        // EffectiveDomain[:1] == {end[:1]}
+        universalSet,
+        // EffectiveDomain[:2].size > 1 -> ACCEPT
+        universalSet
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // {Saturn} * {Zoo} * (-INF, INF)
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Saturn")),
-                   // EffectiveDomain[:1] == {end[:1]}
-                   getRangeSet(Range.singleton("Zoo")),
-                   // EffectiveDomain[:2] == {} -> PRUNE
-                   universalSet
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Saturn")),
+        // EffectiveDomain[:1] == {end[:1]}
+        getRangeSet(Range.singleton("Zoo")),
+        // EffectiveDomain[:2] == {} -> PRUNE
+        universalSet
     );
     assertFalse(shard.possibleInDomain(domain));
 
     // (Xeon) * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Xeon")),
-                   // EffectiveDomain[:1] == {} -> PRUNE
-                   universalSet,
-                   universalSet
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Xeon")),
+        // EffectiveDomain[:1] == {} -> PRUNE
+        universalSet,
+        universalSet
     );
     assertFalse(shard.possibleInDomain(domain));
   }
@@ -370,59 +378,67 @@ public class DimensionRangeShardSpecTest
     Map<String, RangeSet<String>> domain = new HashMap<>();
 
     // (-INF, INF) * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   universalSet,
-                   // EffectiveDomain[:1].size > 1 -> ACCEPT
-                   universalSet,
-                   universalSet
+    populateDomain(
+        domain,
+        universalSet,
+        // EffectiveDomain[:1].size > 1 -> ACCEPT
+        universalSet,
+        universalSet
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // {Earth} * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Earth")),
-                   // EffectiveDomain[:1] == {start[:1]}
-                   universalSet,
-                   // EffectiveDomain[:2].size > 1 -> ACCEPT
-                   universalSet
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Earth")),
+        // EffectiveDomain[:1] == {start[:1]}
+        universalSet,
+        // EffectiveDomain[:2].size > 1 -> ACCEPT
+        universalSet
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // (-INF, Earth) U (Krypton, INF) * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   getUnion(getRangeSet(Range.lessThan("Earth")),
-                            getRangeSet(Range.greaterThan("Krypton"))),
-                   // EffectiveDomain[:1] = {} -> PRUNE
-                   universalSet,
-                   universalSet
+    populateDomain(
+        domain,
+        getUnion(
+            getRangeSet(Range.lessThan("Earth")),
+            getRangeSet(Range.greaterThan("Krypton"))
+        ),
+        // EffectiveDomain[:1] = {} -> PRUNE
+        universalSet,
+        universalSet
     );
     assertFalse(shard.possibleInDomain(domain));
 
     // (-INF, INF) * (-INF, France) * (-INF, INF)
-    populateDomain(domain,
-                   universalSet,
-                   // EffectiveDomain[:1].size > 2 -> ACCEPT
-                   getRangeSet(Range.lessThan("France")),
-                   universalSet
+    populateDomain(
+        domain,
+        universalSet,
+        // EffectiveDomain[:1].size > 2 -> ACCEPT
+        getRangeSet(Range.lessThan("France")),
+        universalSet
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // {Jupiter} * (Foo) * {Bar}
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Jupiter")),
-                   // EffectiveDomain[:1] != {} OR {start[:1]} OR {end[:1]} -> ACCEPT
-                   getRangeSet(Range.singleton("Foo")),
-                   getRangeSet(Range.singleton("Bar"))
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Jupiter")),
+        // EffectiveDomain[:1] != {} OR {start[:1]} OR {end[:1]} -> ACCEPT
+        getRangeSet(Range.singleton("Foo")),
+        getRangeSet(Range.singleton("Bar"))
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // {Krypton} * (-INF, France] * {Paris}
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Krypton")),
-                   // EffectiveDomain[:1] == {end[:1]}
-                   getRangeSet(Range.atMost("France")),
-                   // EffectiveDomain[:2].size > 1 -> ACCEPT
-                   universalSet
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Krypton")),
+        // EffectiveDomain[:1] == {end[:1]}
+        getRangeSet(Range.atMost("France")),
+        // EffectiveDomain[:2].size > 1 -> ACCEPT
+        universalSet
     );
     assertTrue(shard.possibleInDomain(domain));
   }
@@ -442,56 +458,61 @@ public class DimensionRangeShardSpecTest
     Map<String, RangeSet<String>> domain = new HashMap<>();
 
     // (-INF, INF) * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   universalSet,
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   universalSet,
-                   // EffectiveDomain[:2].size > 1 -> ACCEPT
-                   universalSet
+    populateDomain(
+        domain,
+        universalSet,
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        universalSet,
+        // EffectiveDomain[:2].size > 1 -> ACCEPT
+        universalSet
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // {Earth} * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Earth")),
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   universalSet,
-                   // EffectiveDomain[:2].size > 1 -> ACCEPT
-                   universalSet
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Earth")),
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        universalSet,
+        // EffectiveDomain[:2].size > 1 -> ACCEPT
+        universalSet
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // (-INF, INF) * [USA, INF) * {New York}
-    populateDomain(domain,
-                   universalSet,
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   getRangeSet(Range.atLeast("USA")),
-                   // EffectiveDomain[:2] == {end[:2]}
-                   getRangeSet(Range.singleton("New York"))
-                   // EffectiveDomain[:3] == {end[:3]}
+    populateDomain(
+        domain,
+        universalSet,
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        getRangeSet(Range.atLeast("USA")),
+        // EffectiveDomain[:2] == {end[:2]}
+        getRangeSet(Range.singleton("New York"))
+        // EffectiveDomain[:3] == {end[:3]}
     );
     //EffectiveDomain[:].size > 0 -> ACCEPT
     assertTrue(shard.possibleInDomain(domain));
 
     // (-INF, INF) * (-INF, "France"] * (Paris, INF)
-    populateDomain(domain,
-                   universalSet,
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   getRangeSet(Range.atMost("France")),
-                   // EffectiveDomain[:2] == {<Earth, France>} == {start[:2]}
-                   getRangeSet(Range.greaterThan("Paris"))
-                   // EffectiveDomain[:3].size > 1 -> ACCEPT
+    populateDomain(
+        domain,
+        universalSet,
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        getRangeSet(Range.atMost("France")),
+        // EffectiveDomain[:2] == {<Earth, France>} == {start[:2]}
+        getRangeSet(Range.greaterThan("Paris"))
+        // EffectiveDomain[:3].size > 1 -> ACCEPT
     );
     assertTrue(shard.possibleInDomain(domain));
 
     // {Earth} * {India} * Any Non-empty set
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Earth")),
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   getRangeSet(Range.singleton("India")),
-                   // EffectiveDomain[:2] == {<Earth, India>} != {start[:2]} OR {end[:2]}
-                   getRangeSet(Range.greaterThan("New York"))
-                   // EffectiveDomain[:3].size > 1 -> ACCEPT
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Earth")),
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        getRangeSet(Range.singleton("India")),
+        // EffectiveDomain[:2] == {<Earth, India>} != {start[:2]} OR {end[:2]}
+        getRangeSet(Range.greaterThan("New York"))
+        // EffectiveDomain[:3].size > 1 -> ACCEPT
     );
     assertTrue(shard.possibleInDomain(domain));
   }
@@ -511,49 +532,56 @@ public class DimensionRangeShardSpecTest
     Map<String, RangeSet<String>> domain = new HashMap<>();
 
     // (-INF, Earth) U (Earth, INF) * (-INF, INF) * (-INF, INF)
-    populateDomain(domain,
-                   getUnion(getRangeSet(Range.lessThan("Earth")),
-                            getRangeSet(Range.greaterThan("Earth"))),
-                   // EffectiveDomain[:1] == {} -> PRUNE
-                   universalSet,
-                   universalSet
+    populateDomain(
+        domain,
+        getUnion(
+            getRangeSet(Range.lessThan("Earth")),
+            getRangeSet(Range.greaterThan("Earth"))
+        ),
+        // EffectiveDomain[:1] == {} -> PRUNE
+        universalSet,
+        universalSet
     );
     assertFalse(shard.possibleInDomain(domain));
 
     // (-INF, INF) * (-INF, "France") * (-INF, INF)
-    populateDomain(domain,
-                   universalSet,
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   getRangeSet(Range.lessThan("France")),
-                   // EffectiveDomain[:2] == {} -> PRUNE
-                   universalSet
+    populateDomain(
+        domain,
+        universalSet,
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        getRangeSet(Range.lessThan("France")),
+        // EffectiveDomain[:2] == {} -> PRUNE
+        universalSet
     );
     assertFalse(shard.possibleInDomain(domain));
 
     // (-INF, INF) * (-INF, "France] * (-INF, Paris)
-    populateDomain(domain,
-                   universalSet,
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   getRangeSet(Range.atMost("France")),
-                   // EffectiveDomain[:2] == {<Earth, France>} == {start[:2]}
-                   getRangeSet(Range.lessThan("Paris"))
-                   // EffectiveDomain[:3] == {} -> PRUNE
+    populateDomain(
+        domain,
+        universalSet,
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        getRangeSet(Range.atMost("France")),
+        // EffectiveDomain[:2] == {<Earth, France>} == {start[:2]}
+        getRangeSet(Range.lessThan("Paris"))
+        // EffectiveDomain[:3] == {} -> PRUNE
     );
     assertFalse(shard.possibleInDomain(domain));
 
     // {Earth} * {USA} * (New York, INF)
-    populateDomain(domain,
-                   getRangeSet(Range.singleton("Earth")),
-                   // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
-                   getRangeSet(Range.singleton("USA")),
-                   // EffectiveDomain[:2] == {<Earth, USA>} == {end[:2]}
-                   getRangeSet(Range.greaterThan("New York"))
-                   // EffectiveDomain[:3] == {} -> PRUNE
+    populateDomain(
+        domain,
+        getRangeSet(Range.singleton("Earth")),
+        // EffectiveDomain[:1] == {Earth} == {start[:1]} == {end[:1]}
+        getRangeSet(Range.singleton("USA")),
+        // EffectiveDomain[:2] == {<Earth, USA>} == {end[:2]}
+        getRangeSet(Range.greaterThan("New York"))
+        // EffectiveDomain[:3] == {} -> PRUNE
     );
     assertFalse(shard.possibleInDomain(domain));
   }
 
-  private RangeSet<String> getRangeSet(Range range) {
+  private RangeSet<String> getRangeSet(Range range)
+  {
     RangeSet<String> rangeSet = TreeRangeSet.create();
     rangeSet.add(range);
     return rangeSet;


### PR DESCRIPTION
### Description
Segment pruning for multi-dim partitioning for a given query

`DimensionRangeShardSpec#possibleInDomain` has been modified to enhance pruning when multi-dim partitioning is used.

#### Idea
While iterating through each dimension,
1) If query domain doesn't overlap with the set of permissible values in the segment, the segment is pruned.
2) If the overlap happens on a boundary, consider the next dimensions.
3) If there is an overlap within the segment boundaries, the segment cannot be pruned.

 #### Example
Index on (Hour, Minute, Second). Index.size is 3
 I)
 start = (3, 25, 10)
 end = (5, 10, 30)
 query domain = {3} * [0, 10] * {10, 20, 30, 40}
 EffectiveDomain[:1] == {3} == start[:1]
 EffectiveDomain[:2] == {3} * ([0, 10] INTERSECTION [25, INF))
                     == {} -> PRUNE
                                                                             
 II)
 start = (3, 25, 10)
 end = (5, 15, 30)
 query domain = {4} * [0, 10] * {10, 20, 30, 40}
 EffectiveDomain[:1] == {4} (!= {} && != start[:1] && != {end[:1]}) -> ACCEPT
                                                                             
 III)
 start = (3, 25, 10)
 end = (5, 15, 30)
 query domain = {5} * [0, 10] * {10, 20, 30, 40}
 EffectiveDomain[:1] == {5} == end[:1]
 EffectiveDomain[:2] == {5} * ([0, 10] INTERSECTION (-INF, 15])
                     == {5} * [0, 10] (! ={} && != {end[:2]}) -> ACCEPT
                                                                             
 IV)
 start = (3, 25, 10)
 end = (5, 15, 30)
 query domain = {5} * [15, 40] * {10, 20, 30, 40}
 EffectiveDomain[:1] == {5} == end[:1]
 EffectiveDomain[:2] == {5} * ([15, 40] INTERSECTION (-INF, 15])
                     == {5} * {15} == {end[:2]}
 EffectiveDomain[:3] == {5} * {15} * ({10, 20, 30, 40} * (-INF, 30])
                     == {5} * {15} * {10, 20, 30} != {}  -> ACCEPT
                                                                             
 V)
 start = (3, 25, 10)
 end = (5, 15, 30)
 query domain = {5} * [15, 40] * {50}
 EffectiveDomain[:1] == {5} == end[:1]
 EffectiveDomain[:2] == {5} * ([15, 40] INTERSECTION (-INF, 15])
                     == {5} * {15} == {end[:2]}
 EffectiveDomain[:3] == {5} * {15} * ({40} * (-INF, 30])
                     == {5} * {15} * {}
                     == {} -> PRUNE

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.