### PR TITLE
Grouping keys incorrectly reduce where they shouldn't

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
@@ -192,7 +192,7 @@ public class Grouping
     // actually want to include a dimension 'dummy'.
     Set<DruidExpression> literalsInInput = new HashSet<>();
     RexUtil.apply(
-        new RexVisitorImpl<Void>(false) // Only mess with top level literals
+        new RexVisitorImpl<Void>(true)
         {
           @Override
           public Void visitLiteral(RexLiteral literal)


### PR DESCRIPTION
### Description

In [Grouping#applyProject](https://github.com/apache/druid/blob/6ac4e2dbb8d2e390f0f4a9c0130ce2fb223c297b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java#L188), their is an attempt made to reduce the dimensions on which group by is done, if they are not appearing in the final result/`Project`.
However, this ends up removing all of the literal dimensions which are present in the group by. 
Consider the following query
```
SELECT dim1, 'dummy' FROM druid.foo GROUP BY dim1, 'dummy'
```
According to our intentions, the 'dummy' shouldn't be removed in the GROUP BY, since it is present in the projection, but it gets removed (Due to the implementation of the `RelOptUtil.InputFinder.bits(project.getChildExps(), null);` not setting bit corresponding to `dummy` to true. It is a `RexLiteral` as opposed to `RexInputRef`.

In a more obscure case like:
```
SELECT 'A', dim1 FROM druid.foo WHERE m1 = 10310313 AND dim1 = 'dummy' GROUP BY dim1
```
The dim1 gets reduced to 'dummy' by Calcite (and is treated as a literal), which gets subsequently removed by the current implementation of the Groupings#applyProject, and it results a row of ('A', 'dummy') when it shouldn't have returned anything. 

This fix changes the visitor which is used to find  the literals in the input expression, and directly compares the DruidExpression of the literal in the input expression, with the dimensions in the group by. 


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `Grouping#applyProject`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
