### PR TITLE
fix IncrementalIndex performance regression

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
@@ -331,7 +331,7 @@ public class InputRowSerde
         writeString(k, out);
 
         try (Aggregator agg = aggFactory.factorize(
-            IncrementalIndex.makeColumnSelectorFactory(RowSignature::empty, VirtualColumns.EMPTY, aggFactory, supplier, true)
+            IncrementalIndex.makeColumnSelectorFactory(RowSignature.empty(), VirtualColumns.EMPTY, aggFactory, supplier, true)
         )) {
           try {
             agg.aggregate();

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -403,7 +403,7 @@ public class RowBasedGrouperHelper
     return RowBasedColumnSelectorFactory.create(
         adapter,
         supplier::get,
-        () -> decoratedSignature,
+        decoratedSignature,
         false
     );
   }

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -232,7 +232,7 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
                              RowBasedColumnSelectorFactory.create(
                                  RowAdapters.standardRow(),
                                  () -> new MapBasedRow(null, null),
-                                 () -> aggregatorsSignature,
+                                 aggregatorsSignature,
                                  false
                              )
                          );

--- a/processing/src/main/java/org/apache/druid/segment/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowBasedColumnSelectorFactory.java
@@ -56,7 +56,7 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
   @Nullable
   private final LongSupplier rowIdSupplier;
   private final RowAdapter<T> adapter;
-  private final Supplier<ColumnInspector> columnInspectorSupplier;
+  private final ColumnInspector columnInspector;
   private final boolean throwParseExceptions;
 
   /**
@@ -67,15 +67,15 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
       final Supplier<T> rowSupplier,
       @Nullable final LongSupplier rowIdSupplier,
       final RowAdapter<T> adapter,
-      final Supplier<ColumnInspector> columnInspectorSupplier,
+      final ColumnInspector columnInspector,
       final boolean throwParseExceptions
   )
   {
     this.rowSupplier = rowSupplier;
     this.rowIdSupplier = rowIdSupplier;
     this.adapter = adapter;
-    this.columnInspectorSupplier =
-        Preconditions.checkNotNull(columnInspectorSupplier, "columnInspectorSupplier must be nonnull");
+    this.columnInspector =
+        Preconditions.checkNotNull(columnInspector, "columnInspector must be nonnull");
     this.throwParseExceptions = throwParseExceptions;
   }
 
@@ -84,7 +84,7 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
    *
    * @param adapter                 adapter for these row objects
    * @param supplier                supplier of row objects
-   * @param columnInspectorSupplier will be used for reporting available columns and their capabilities. Note that this
+   * @param columnInspector         will be used for reporting available columns and their capabilities. Note that this
    *                                factory will still allow creation of selectors on any named field in the rows, even if
    *                                it doesn't appear in "columnInspector". (It only needs to be accessible via
    *                                {@link RowAdapter#columnFunction}.) As a result, you can achieve an untyped mode by
@@ -95,11 +95,11 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
   public static <RowType> RowBasedColumnSelectorFactory<RowType> create(
       final RowAdapter<RowType> adapter,
       final Supplier<RowType> supplier,
-      final Supplier<ColumnInspector> columnInspectorSupplier,
+      final ColumnInspector columnInspector,
       final boolean throwParseExceptions
   )
   {
-    return new RowBasedColumnSelectorFactory<>(supplier, null, adapter, columnInspectorSupplier, throwParseExceptions);
+    return new RowBasedColumnSelectorFactory<>(supplier, null, adapter, columnInspector, throwParseExceptions);
   }
 
   @Nullable
@@ -495,6 +495,6 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
   @Override
   public ColumnCapabilities getColumnCapabilities(String columnName)
   {
-    return getColumnCapabilities(columnInspectorSupplier.get(), columnName);
+    return getColumnCapabilities(columnInspector, columnName);
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/RowBasedCursor.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowBasedCursor.java
@@ -69,7 +69,7 @@ public class RowBasedCursor<RowType> implements Cursor
             rowWalker::currentRow,
             () -> rowId,
             rowAdapter,
-            () -> rowSignature,
+            rowSignature,
             false
         )
     );

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -221,7 +221,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   @Override
   public ColumnCapabilities getCapabilities(String column)
   {
-    return index.getCapabilities(column);
+    return index.getColumnCapabilities(column);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -209,7 +209,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
   @Override
   public ColumnCapabilities getColumnCapabilities(String column)
   {
-    // Different from index.getCapabilities because, in a way, IncrementalIndex's string-typed dimensions
+    // Different from index.getColumnCapabilities because, in a way, IncrementalIndex's string-typed dimensions
     // are always potentially multi-valued at query time. (Missing / null values for a row can potentially be
     // represented by an empty array; see StringDimensionIndexer.IndexerDimensionSelector's getRow method.)
     //
@@ -222,7 +222,10 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
     // to the StringDimensionIndexer so the selector built on top of it can produce values from the snapshot state of
     // multi-valuedness at cursor creation time, instead of the latest state, and getSnapshotColumnCapabilities could
     // be removed.
-    return ColumnCapabilitiesImpl.snapshot(index.getCapabilities(column), STORAGE_ADAPTER_CAPABILITIES_COERCE_LOGIC);
+    return ColumnCapabilitiesImpl.snapshot(
+        index.getColumnCapabilities(column),
+        STORAGE_ADAPTER_CAPABILITIES_COERCE_LOGIC
+    );
   }
 
   /**
@@ -234,7 +237,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
   public ColumnCapabilities getSnapshotColumnCapabilities(String column)
   {
     return ColumnCapabilitiesImpl.snapshot(
-        index.getCapabilities(column),
+        index.getColumnCapabilities(column),
         SNAPSHOT_STORAGE_ADAPTER_CAPABILITIES_COERCE_LOGIC
     );
   }

--- a/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
@@ -59,7 +59,7 @@ public class Transformer
                                       RowBasedColumnSelectorFactory.create(
                                           RowAdapters.standardRow(),
                                           rowSupplierForValueMatcher::get,
-                                          RowSignature::empty, // sad
+                                          RowSignature.empty(), // sad
                                           false
                                       )
                                   );

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -217,7 +217,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final RowBasedColumnSelectorFactory<MapBasedRow> columnSelectorFactory = RowBasedColumnSelectorFactory.create(
         RowAdapters.standardRow(),
         () -> new MapBasedRow(0, row),
-        () -> RowSignature.builder().add("dim", ColumnType.STRING).build(),
+        RowSignature.builder().add("dim", ColumnType.STRING).build(),
         true
     );
 

--- a/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
@@ -159,13 +159,13 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   public void testNumericColumns()
   {
     // incremental index
-    assertNonStringColumnCapabilities(INC_INDEX.getCapabilities(ColumnHolder.TIME_COLUMN_NAME), ColumnType.LONG);
-    assertNonStringColumnCapabilities(INC_INDEX.getCapabilities("d3"), ColumnType.DOUBLE);
-    assertNonStringColumnCapabilities(INC_INDEX.getCapabilities("d4"), ColumnType.FLOAT);
-    assertNonStringColumnCapabilities(INC_INDEX.getCapabilities("d5"), ColumnType.LONG);
-    assertNonStringColumnCapabilities(INC_INDEX.getCapabilities("m1"), ColumnType.DOUBLE);
-    assertNonStringColumnCapabilities(INC_INDEX.getCapabilities("m2"), ColumnType.FLOAT);
-    assertNonStringColumnCapabilities(INC_INDEX.getCapabilities("m3"), ColumnType.LONG);
+    assertNonStringColumnCapabilities(INC_INDEX.getColumnCapabilities(ColumnHolder.TIME_COLUMN_NAME), ColumnType.LONG);
+    assertNonStringColumnCapabilities(INC_INDEX.getColumnCapabilities("d3"), ColumnType.DOUBLE);
+    assertNonStringColumnCapabilities(INC_INDEX.getColumnCapabilities("d4"), ColumnType.FLOAT);
+    assertNonStringColumnCapabilities(INC_INDEX.getColumnCapabilities("d5"), ColumnType.LONG);
+    assertNonStringColumnCapabilities(INC_INDEX.getColumnCapabilities("m1"), ColumnType.DOUBLE);
+    assertNonStringColumnCapabilities(INC_INDEX.getColumnCapabilities("m2"), ColumnType.FLOAT);
+    assertNonStringColumnCapabilities(INC_INDEX.getColumnCapabilities("m3"), ColumnType.LONG);
 
     // segment index
     assertNonStringColumnCapabilities(
@@ -186,15 +186,15 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
     // incremental index
     // time does not have nulls
     assertNonStringColumnCapabilities(
-        INC_INDEX_WITH_NULLS.getCapabilities(ColumnHolder.TIME_COLUMN_NAME),
+        INC_INDEX_WITH_NULLS.getColumnCapabilities(ColumnHolder.TIME_COLUMN_NAME),
         ColumnType.LONG
     );
-    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getCapabilities("d3"), ColumnType.DOUBLE);
-    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getCapabilities("d4"), ColumnType.FLOAT);
-    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getCapabilities("d5"), ColumnType.LONG);
-    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getCapabilities("m1"), ColumnType.DOUBLE);
-    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getCapabilities("m2"), ColumnType.FLOAT);
-    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getCapabilities("m3"), ColumnType.LONG);
+    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getColumnCapabilities("d3"), ColumnType.DOUBLE);
+    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getColumnCapabilities("d4"), ColumnType.FLOAT);
+    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getColumnCapabilities("d5"), ColumnType.LONG);
+    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getColumnCapabilities("m1"), ColumnType.DOUBLE);
+    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getColumnCapabilities("m2"), ColumnType.FLOAT);
+    assertNonStringColumnCapabilitiesWithNulls(INC_INDEX_WITH_NULLS.getColumnCapabilities("m3"), ColumnType.LONG);
 
     // segment index
     assertNonStringColumnCapabilities(
@@ -230,7 +230,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   @Test
   public void testStringColumn()
   {
-    ColumnCapabilities caps = INC_INDEX.getCapabilities("d1");
+    ColumnCapabilities caps = INC_INDEX.getColumnCapabilities("d1");
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
     Assert.assertTrue(caps.isDictionaryEncoded().isMaybeTrue());
@@ -265,7 +265,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   @Test
   public void testStringColumnWithNulls()
   {
-    ColumnCapabilities caps = INC_INDEX_WITH_NULLS.getCapabilities("d1");
+    ColumnCapabilities caps = INC_INDEX_WITH_NULLS.getColumnCapabilities("d1");
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
     Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
@@ -298,7 +298,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   @Test
   public void testMultiStringColumn()
   {
-    ColumnCapabilities caps = INC_INDEX.getCapabilities("d2");
+    ColumnCapabilities caps = INC_INDEX.getColumnCapabilities("d2");
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
     Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
@@ -323,7 +323,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   @Test
   public void testMultiStringColumnWithNulls()
   {
-    ColumnCapabilities caps = INC_INDEX_WITH_NULLS.getCapabilities("d2");
+    ColumnCapabilities caps = INC_INDEX_WITH_NULLS.getColumnCapabilities("d2");
     Assert.assertEquals(ValueType.STRING, caps.getType());
     Assert.assertTrue(caps.hasBitmapIndexes());
     Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
@@ -347,10 +347,10 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   @Test
   public void testComplexColumn()
   {
-    assertComplexColumnCapabilites(INC_INDEX.getCapabilities("m4"));
+    assertComplexColumnCapabilites(INC_INDEX.getColumnCapabilities("m4"));
     assertComplexColumnCapabilites(MMAP_INDEX.getColumnHolder("m4").getCapabilities());
     // results for this complex aren't different, we only know that nullability is unknown
-    assertComplexColumnCapabilites(INC_INDEX_WITH_NULLS.getCapabilities("m4"));
+    assertComplexColumnCapabilites(INC_INDEX_WITH_NULLS.getColumnCapabilities("m4"));
     assertComplexColumnCapabilites(MMAP_INDEX_WITH_NULLS.getColumnHolder("m4").getCapabilities());
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -754,7 +754,7 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
             RowBasedColumnSelectorFactory.create(
                 RowAdapters.standardRow(),
                 rowSupplier::get,
-                rowSignatureBuilder::build,
+                rowSignatureBuilder.build(),
                 false
             )
         )

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -205,7 +205,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
   private static final ColumnSelectorFactory COLUMN_SELECTOR_FACTORY = RowBasedColumnSelectorFactory.create(
       RowAdapters.standardRow(),
       CURRENT_ROW::get,
-      RowSignature::empty,
+      RowSignature.empty(),
       false
   );
 
@@ -745,7 +745,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         RowBasedColumnSelectorFactory.create(
             RowAdapters.standardRow(),
             CURRENT_ROW::get,
-            RowSignature.builder().add("x", ColumnType.LONG)::build,
+            RowSignature.builder().add("x", ColumnType.LONG).build(),
             false
         ),
         Parser.parse(SCALE_LONG.getExpression(), TestExprMacroTable.INSTANCE)
@@ -768,7 +768,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         RowBasedColumnSelectorFactory.create(
             RowAdapters.standardRow(),
             CURRENT_ROW::get,
-            RowSignature.builder().add("x", ColumnType.DOUBLE)::build,
+            RowSignature.builder().add("x", ColumnType.DOUBLE).build(),
             false
         ),
         Parser.parse(SCALE_FLOAT.getExpression(), TestExprMacroTable.INSTANCE)
@@ -791,7 +791,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         RowBasedColumnSelectorFactory.create(
             RowAdapters.standardRow(),
             CURRENT_ROW::get,
-            RowSignature.builder().add("x", ColumnType.FLOAT)::build,
+            RowSignature.builder().add("x", ColumnType.FLOAT).build(),
             false
         ),
         Parser.parse(SCALE_FLOAT.getExpression(), TestExprMacroTable.INSTANCE)

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnSelectorTest.java
@@ -276,7 +276,7 @@ public class ListFilteredVirtualColumnSelectorTest extends InitializedNullHandli
         RowBasedColumnSelectorFactory.create(
             RowAdapters.standardRow(),
             () -> new MapBasedRow(0L, ImmutableMap.of(COLUMN_NAME, ImmutableList.of("a", "b", "c", "d"))),
-            () -> rowSignature,
+            rowSignature,
             false
         ),
         VirtualColumns.create(ImmutableList.of(virtualColumn))

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
@@ -303,7 +303,7 @@ class ExpressionTestHelper
             RowBasedColumnSelectorFactory.create(
                 RowAdapters.standardRow(),
                 () -> new MapBasedRow(0L, bindings),
-                () -> rowSignature,
+                rowSignature,
                 false
             ),
             VirtualColumns.create(virtualColumns)


### PR DESCRIPTION
### Description
This PR fixes a performance regression caused by #11853, where adding type information to the `RowBasedColumnSelectorFactory` of `IncrementalIndex` was done by using the `getColumnCapabilities` method the latter had, which built a hashmap of all the capabilities and then translated that into a `RowSignature`. This turned out to be very dramatically expensive.

To fix this, `IncrementalIndex` now just implements `ColumnInspector` so that it can cut out the middle-man and serve as the `ColumnInspector` for the `RowBasedColumnSelectorFactory`.

Before:
![Screen Shot 2021-12-09 at 2 27 38 PM](https://user-images.githubusercontent.com/1577461/145486999-7fe3e064-3779-424d-9c88-9a111617e2ec.png)

After:
![Screen Shot 2021-12-09 at 2 27 28 PM](https://user-images.githubusercontent.com/1577461/145487077-b868e1b5-98f6-42f8-bd2f-86d002f0921e.png)


Zoomed into sink.add:
before:
![Screen Shot 2021-12-09 at 2 28 40 PM](https://user-images.githubusercontent.com/1577461/145487072-33547634-06bc-4f04-9550-469e4cf3b9b2.png)

after:
![Screen Shot 2021-12-09 at 2 28 31 PM](https://user-images.githubusercontent.com/1577461/145487010-83f873a3-5856-4c5c-968d-823ee3cb84c9.png)


Task run times are shorter too:
before:
<img width="1640" alt="Screen Shot 2021-12-09 at 2 24 21 PM" src="https://user-images.githubusercontent.com/1577461/145487240-9633c828-d300-44e4-bfa6-dd84eed30405.png">
after:
<img width="1639" alt="Screen Shot 2021-12-09 at 2 27 00 PM" src="https://user-images.githubusercontent.com/1577461/145487244-6642a2aa-ccfb-456d-9078-9179fcd0be8e.png">

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
