### PR TITLE
Lock count guardrail for parallel single phase/sequential task

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -195,7 +195,7 @@ public class CompactionTask extends AbstractBatchIndexTask
       @JacksonInject RetryPolicyFactory retryPolicyFactory
   )
   {
-    super(getOrMakeId(id, TYPE, dataSource), null, taskResource, dataSource, context);
+    super(getOrMakeId(id, TYPE, dataSource), null, taskResource, dataSource, context, -1);
     Checks.checkOneNotNullOrEmpty(
         ImmutableList.of(
             new Property<>("ioConfig", ioConfig),
@@ -1271,7 +1271,8 @@ public class CompactionTask extends AbstractBatchIndexTask
           maxParseExceptions,
           maxSavedParseExceptions,
           maxColumnsToMerge,
-          awaitSegmentAvailabilityTimeoutMillis
+          awaitSegmentAvailabilityTimeoutMillis,
+          null
       );
 
       Preconditions.checkArgument(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -194,7 +194,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
         ingestionSchema.dataSchema.getDataSource(),
         null,
         ingestionSchema,
-        context
+        context,
+        -1
     );
   }
 
@@ -205,7 +206,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       String dataSource,
       @Nullable String baseSequenceName,
       IndexIngestionSpec ingestionSchema,
-      Map<String, Object> context
+      Map<String, Object> context,
+      int maxAllowedLockCount
   )
   {
     super(
@@ -213,7 +215,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
         groupId,
         resource,
         dataSource,
-        context
+        context,
+        maxAllowedLockCount
     );
     this.baseSequenceName = baseSequenceName == null ? getId() : baseSequenceName;
     this.ingestionSchema = ingestionSchema;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/MaxAllowedLocksExceededException.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/MaxAllowedLocksExceededException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch;
+
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+
+public class MaxAllowedLocksExceededException extends ISE
+{
+  public MaxAllowedLocksExceededException(int maxAllowedLockCount)
+  {
+    super(createMessage(maxAllowedLockCount));
+  }
+
+  private static String createMessage(
+      int maxAllowedLockCount
+  )
+  {
+    return StringUtils.format(
+        "Number of locks exceeded maxAllowedLockCount [%s].",
+        maxAllowedLockCount
+    );
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractBatchSubtask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractBatchSubtask.java
@@ -40,7 +40,7 @@ public abstract class AbstractBatchSubtask extends AbstractBatchIndexTask
       @Nullable Map<String, Object> context
   )
   {
-    super(id, groupId, taskResource, dataSource, context);
+    super(id, groupId, taskResource, dataSource, context, -1);
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexPhaseRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexPhaseRunner.java
@@ -71,6 +71,7 @@ public abstract class ParallelIndexPhaseRunner<SubTaskType extends Task, SubTask
 
   private volatile boolean subTaskScheduleAndMonitorStopped;
   private volatile TaskMonitor<SubTaskType, SubTaskReportType> taskMonitor;
+  private volatile String stopReason;
 
   private int nextSpecId = 0;
 
@@ -266,9 +267,10 @@ public abstract class ParallelIndexPhaseRunner<SubTaskType extends Task, SubTask
   }
 
   @Override
-  public void stopGracefully()
+  public void stopGracefully(String stopReason)
   {
     subTaskScheduleAndMonitorStopped = true;
+    this.stopReason = stopReason;
     stopInternal();
   }
 
@@ -420,6 +422,12 @@ public abstract class ParallelIndexPhaseRunner<SubTaskType extends Task, SubTask
     }
   }
 
+  @Override
+  public String getStopReason()
+  {
+    return stopReason;
+  }
+
   String getTaskId()
   {
     return taskId;
@@ -444,6 +452,7 @@ public abstract class ParallelIndexPhaseRunner<SubTaskType extends Task, SubTask
   {
     return tuningConfig;
   }
+
 
   @VisibleForTesting
   TaskToolbox getToolbox()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -57,6 +57,7 @@ import org.apache.druid.indexing.common.task.IndexTaskUtils;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.common.task.Tasks;
+import org.apache.druid.indexing.common.task.batch.MaxAllowedLocksExceededException;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTaskRunner.SubTaskSpecStatus;
 import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringDistribution;
 import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringDistributionMerger;
@@ -202,7 +203,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         groupId,
         taskResource,
         ingestionSchema.getDataSchema().getDataSource(),
-        context
+        context,
+        ingestionSchema.getTuningConfig().getMaxAllowedLockCount()
     );
 
     this.ingestionSchema = ingestionSchema;
@@ -502,7 +504,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     if (isParallelMode()) {
       currentSubTaskHolder = new CurrentSubTaskHolder((currentRunnerObject, taskConfig) -> {
         final ParallelIndexTaskRunner runner = (ParallelIndexTaskRunner) currentRunnerObject;
-        runner.stopGracefully();
+        runner.stopGracefully(null);
       });
     } else {
       currentSubTaskHolder = new CurrentSubTaskHolder((taskObject, taskConfig) -> {
@@ -580,10 +582,15 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     } else {
       // there is only success or failure after running....
       Preconditions.checkState(state.isFailure(), "Unrecognized state after task is complete[%s]", state);
-      final String errorMessage = StringUtils.format(
-          TASK_PHASE_FAILURE_MSG,
-          parallelSinglePhaseRunner.getName()
-      );
+      final String errorMessage;
+      if (parallelSinglePhaseRunner.getStopReason() != null) {
+        errorMessage = parallelSinglePhaseRunner.getStopReason();
+      } else {
+        errorMessage = StringUtils.format(
+            TASK_PHASE_FAILURE_MSG,
+            parallelSinglePhaseRunner.getName()
+        );
+      }
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
     toolbox.getTaskReportFileWriter().write(
@@ -1088,7 +1095,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
             getIngestionSchema().getIOConfig(),
             convertToIndexTuningConfig(getIngestionSchema().getTuningConfig())
         ),
-        getContext()
+        getContext(),
+        getIngestionSchema().getTuningConfig().getMaxAllowedLockCount()
     );
 
     if (currentSubTaskHolder.setTask(sequentialIndexTask)
@@ -1218,6 +1226,10 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       }
 
       return Response.ok(toolbox.getJsonMapper().writeValueAsBytes(segmentIdentifier)).build();
+    }
+    catch (MaxAllowedLocksExceededException malee) {
+      getCurrentRunner().stopGracefully(malee.getMessage());
+      return Response.status(Response.Status.BAD_REQUEST).entity(malee.getMessage()).build();
     }
     catch (IOException | IllegalStateException e) {
       return Response.serverError().entity(Throwables.getStackTraceAsString(e)).build();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTaskRunner.java
@@ -58,7 +58,9 @@ public interface ParallelIndexTaskRunner<SubTaskType extends Task, SubTaskReport
    * Stop this runner gracefully. This method is called when the task is killed.
    * See {@link org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner#stop}.
    */
-  void stopGracefully();
+  void stopGracefully(String stopReason);
+
+  String getStopReason();
 
   /**
    * {@link SubTaskReport} is the report sent by {@link SubTaskType}s. The subTasks call this method to

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
@@ -47,6 +47,7 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
   private static final int DEFAULT_CHAT_HANDLER_NUM_RETRIES = 5;
   private static final int DEFAULT_MAX_NUM_SEGMENTS_TO_MERGE = 100;
   private static final int DEFAULT_TOTAL_NUM_MERGE_TASKS = 10;
+  private static final int DEFAULT_MAX_ALLOWED_LOCK_COUNT = -1;
 
   private final SplitHintSpec splitHintSpec;
 
@@ -71,9 +72,12 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
    */
   private final int totalNumMergeTasks;
 
+  private final int maxAllowedLockCount;
+
   public static ParallelIndexTuningConfig defaultConfig()
   {
     return new ParallelIndexTuningConfig(
+        null,
         null,
         null,
         null,
@@ -138,7 +142,8 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
       @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
       @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
       @JsonProperty("maxColumnsToMerge") @Nullable Integer maxColumnsToMerge,
-      @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis
+      @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis,
+      @JsonProperty("maxAllowedLockCount") @Nullable Integer maxAllowedLockCount
   )
   {
     super(
@@ -196,6 +201,10 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
     this.totalNumMergeTasks = totalNumMergeTasks == null
                             ? DEFAULT_TOTAL_NUM_MERGE_TASKS
                             : totalNumMergeTasks;
+
+    this.maxAllowedLockCount = maxAllowedLockCount == null
+                               ? DEFAULT_MAX_ALLOWED_LOCK_COUNT
+                               : maxAllowedLockCount;
 
     Preconditions.checkArgument(this.maxNumConcurrentSubTasks > 0, "maxNumConcurrentSubTasks must be positive");
     Preconditions.checkArgument(this.maxNumSegmentsToMerge > 0, "maxNumSegmentsToMerge must be positive");
@@ -257,6 +266,12 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
     return totalNumMergeTasks;
   }
 
+  @JsonProperty
+  public int getMaxAllowedLockCount()
+  {
+    return maxAllowedLockCount;
+  }
+
   @Override
   public ParallelIndexTuningConfig withPartitionsSpec(PartitionsSpec partitionsSpec)
   {
@@ -290,7 +305,8 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
         getMaxParseExceptions(),
         getMaxSavedParseExceptions(),
         getMaxColumnsToMerge(),
-        getAwaitSegmentAvailabilityTimeoutMillis()
+        getAwaitSegmentAvailabilityTimeoutMillis(),
+        getMaxAllowedLockCount()
     );
   }
 
@@ -313,6 +329,7 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
            chatHandlerNumRetries == that.chatHandlerNumRetries &&
            maxNumSegmentsToMerge == that.maxNumSegmentsToMerge &&
            totalNumMergeTasks == that.totalNumMergeTasks &&
+           maxAllowedLockCount == that.maxAllowedLockCount &&
            Objects.equals(splitHintSpec, that.splitHintSpec) &&
            Objects.equals(chatHandlerTimeout, that.chatHandlerTimeout);
   }
@@ -329,7 +346,8 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
         chatHandlerTimeout,
         chatHandlerNumRetries,
         maxNumSegmentsToMerge,
-        totalNumMergeTasks
+        totalNumMergeTasks,
+        maxAllowedLockCount
     );
   }
 
@@ -345,6 +363,7 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
            ", chatHandlerNumRetries=" + chatHandlerNumRetries +
            ", maxNumSegmentsToMerge=" + maxNumSegmentsToMerge +
            ", totalNumMergeTasks=" + totalNumMergeTasks +
+           ", maxAllowedLockCount=" + maxAllowedLockCount +
            "} " + super.toString();
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
@@ -35,6 +35,7 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.LockListAction;
 import org.apache.druid.indexing.common.actions.TimeChunkLockTryAcquireAction;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.common.task.batch.MaxAllowedLocksExceededException;
 import org.apache.druid.indexing.common.task.batch.parallel.TaskMonitor.SubTaskCompleteEvent;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
@@ -343,6 +344,11 @@ public class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner
       interval = granularitySpec.getSegmentGranularity().bucket(timestamp);
       version = ParallelIndexSupervisorTask.findVersion(versions, interval);
       if (version == null) {
+        final int maxAllowedLockCount = getIngestionSchema().getTuningConfig().getMaxAllowedLockCount();
+        if (maxAllowedLockCount >= 0 && locks.size() == maxAllowedLockCount) {
+          throw new MaxAllowedLocksExceededException(maxAllowedLockCount);
+        }
+
         // We don't have a lock for this interval, so we should lock it now.
         final TaskLock lock = Preconditions.checkNotNull(
             getToolbox().getTaskActionClient().submit(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
@@ -345,7 +345,7 @@ public class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner
       version = ParallelIndexSupervisorTask.findVersion(versions, interval);
       if (version == null) {
         final int maxAllowedLockCount = getIngestionSchema().getTuningConfig().getMaxAllowedLockCount();
-        if (maxAllowedLockCount >= 0 && locks.size() == maxAllowedLockCount) {
+        if (maxAllowedLockCount >= 0 && locks.size() >= maxAllowedLockCount) {
           throw new MaxAllowedLocksExceededException(maxAllowedLockCount);
         }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitor.java
@@ -97,7 +97,7 @@ public class TaskMonitor<T extends Task, SubTaskReportType extends SubTaskReport
    * This metric is used only for unit tests because the current task status system doesn't track the canceled task
    * status. Currently, this metric only represents the number of canceled tasks by {@link ParallelIndexTaskRunner}.
    * See {@link #stop()}, {@link ParallelIndexPhaseRunner#run()}, and
-   * {@link ParallelIndexPhaseRunner#stopGracefully()}.
+   * {@link ParallelIndexPhaseRunner#stopGracefully(String)} ()}.
    */
   private int numCanceledTasks;
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -35,6 +35,7 @@ import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.task.IndexTaskUtils;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.Tasks;
+import org.apache.druid.indexing.common.task.batch.MaxAllowedLocksExceededException;
 import org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseParallelIndexTaskRunner;
 import org.apache.druid.indexing.overlord.config.DefaultTaskConfig;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
@@ -288,8 +289,13 @@ public class TaskQueue
           }
           catch (Exception e) {
             log.warn(e, "Exception thrown during isReady for task: %s", task.getId());
-            final String errorMessage = "Failed while waiting for the task to be ready to run. "
-                                        + "See overlord logs for more details.";
+            final String errorMessage;
+            if (e instanceof MaxAllowedLocksExceededException) {
+              errorMessage = e.getMessage();
+            } else {
+              errorMessage = "Failed while waiting for the task to be ready to run. "
+                                          + "See overlord logs for more details.";
+            }
             notifyStatus(task, TaskStatus.failure(task.getId(), errorMessage), errorMessage);
             continue;
           }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -279,6 +279,7 @@ public class ClientCompactionTaskQuerySerdeTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -320,6 +320,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -748,6 +748,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -179,6 +179,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
           null,
           5,
           null,
+          null,
           null
       );
 
@@ -288,6 +289,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         null,
         null,
         maxNumConcurrentSubTasks,
+        null,
         null,
         null,
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -387,9 +387,15 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     }
 
     @Override
-    public void stopGracefully()
+    public void stopGracefully(String stopReason)
     {
 
+    }
+
+    @Override
+    public String getStopReason()
+    {
+      return null;
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -201,6 +201,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
             null,
             null,
             null,
+            null,
             null
         )
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -448,6 +448,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
             null,
             null,
             null,
+            null,
             null
         )
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
@@ -275,6 +275,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
           null,
           null,
           null,
+          null,
           null
       );
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -251,6 +251,7 @@ public class ParallelIndexSupervisorTaskTest
           null,
           null,
           null,
+          null,
           null
       );
       final ParallelIndexIngestionSpec indexIngestionSpec = new ParallelIndexIngestionSpec(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
@@ -187,6 +187,7 @@ class ParallelIndexTestingFactory
           maxParseExceptions,
           25,
           null,
+          null,
           null
       );
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
@@ -102,6 +102,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
     final byte[] json = mapper.writeValueAsBytes(tuningConfig);
@@ -148,6 +149,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
     final byte[] json = mapper.writeValueAsBytes(tuningConfig);
@@ -191,6 +193,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         false,
+        null,
         null,
         null,
         null,
@@ -242,6 +245,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -284,6 +288,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         false,
+        null,
         null,
         null,
         null,
@@ -332,6 +337,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
   }
@@ -374,6 +380,7 @@ public class ParallelIndexTuningConfigTest
         null,
         null,
         false,
+        null,
         null,
         null,
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
@@ -324,9 +324,15 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
     }
 
     @Override
-    public void stopGracefully()
+    public void stopGracefully(String stopReason)
     {
 
+    }
+
+    @Override
+    public String getStopReason()
+    {
+      return null;
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -591,6 +591,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
             null,
             null,
             null,
+            null,
             null
         ),
         VALID_INPUT_SOURCE_FILTER

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -53,7 +53,9 @@ import org.joda.time.Interval;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -76,6 +78,9 @@ import java.util.stream.Collectors;
 @RunWith(Parameterized.class)
 public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSupervisorTaskTest
 {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
   @Parameterized.Parameters(name = "{0}, useInputFormatApi={1}")
   public static Iterable<Object[]> constructorFeeder()
   {
@@ -658,6 +663,127 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         .forSegments(afterAppendSegments);
     final Set<DataSegment> visibles = timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE);
     Assert.assertEquals(new HashSet<>(afterAppendSegments), visibles);
+  }
+
+  @Test
+  public void testMaxLocksWith1MaxNumConcurrentSubTasks()
+  {
+    final Interval interval = Intervals.of("2017-12/P1M");
+    final boolean appendToExisting = false;
+    final ParallelIndexSupervisorTask task = newTask(
+        interval,
+        Granularities.DAY,
+        appendToExisting,
+        true,
+        new ParallelIndexTuningConfig(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            1,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0
+        ),
+        VALID_INPUT_SOURCE_FILTER
+    );
+    task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
+
+    if (lockGranularity.equals(LockGranularity.TIME_CHUNK)) {
+      expectedException.expect(RuntimeException.class);
+      expectedException.expectMessage(
+          "Number of locks exceeded maxAllowedLockCount [0]"
+      );
+      getIndexingServiceClient().runAndWait(task);
+    } else {
+      Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+      Assert.assertNull("Runner must be null if the task was in the sequential mode", task.getCurrentRunner());
+      assertShardSpec(task, lockGranularity, appendToExisting, Collections.emptyList());
+    }
+  }
+
+
+  @Test
+  public void testMaxLocksWith2MaxNumConcurrentSubTasks()
+  {
+    final Interval interval = Intervals.of("2017-12/P1M");
+    final boolean appendToExisting = false;
+    final ParallelIndexSupervisorTask task = newTask(
+        interval,
+        Granularities.DAY,
+        appendToExisting,
+        true,
+        new ParallelIndexTuningConfig(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            2,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0
+        ),
+        VALID_INPUT_SOURCE_FILTER
+    );
+    task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
+
+    if (lockGranularity.equals(LockGranularity.TIME_CHUNK)) {
+      expectedException.expect(RuntimeException.class);
+      expectedException.expectMessage(
+          "Number of locks exceeded maxAllowedLockCount [0]"
+      );
+      getIndexingServiceClient().runAndWait(task);
+    } else {
+      Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+      Assert.assertNull("Runner must be null if the task was in the sequential mode", task.getCurrentRunner());
+      assertShardSpec(task, lockGranularity, appendToExisting, Collections.emptyList());
+    }
   }
 
   private ParallelIndexSupervisorTask newTask(


### PR DESCRIPTION
This PR adds a `maxAllowedLockCount` tuning config parameter for the parallel single phase and sequential modes that serves as a guardrail on the number of locks that the task set is allowed to acquired. An excessive number of locks can result in a very slow task and excessive load on the overlord.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
