### PR TITLE
Response "trailer" support

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBenchmark.java
@@ -468,7 +468,7 @@ public class SqlBenchmark
     final String sql = QUERIES.get(Integer.parseInt(query));
     try (final DruidPlanner planner = plannerFactory.createPlannerForTesting(context, sql)) {
       final PlannerResult plannerResult = planner.plan();
-      final Sequence<Object[]> resultSequence = plannerResult.run();
+      final Sequence<Object[]> resultSequence = plannerResult.run().getResults();
       final Object[] lastRow = resultSequence.accumulate(null, (accumulated, in) -> in);
       blackhole.consume(lastRow);
     }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlExpressionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlExpressionBenchmark.java
@@ -314,7 +314,7 @@ public class SqlExpressionBenchmark
     final String sql = QUERIES.get(Integer.parseInt(query));
     try (final DruidPlanner planner = plannerFactory.createPlannerForTesting(context, sql)) {
       final PlannerResult plannerResult = planner.plan();
-      final Sequence<Object[]> resultSequence = plannerResult.run();
+      final Sequence<Object[]> resultSequence = plannerResult.run().getResults();
       final Object[] lastRow = resultSequence.accumulate(null, (accumulated, in) -> in);
       blackhole.consume(lastRow);
     }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlVsNativeBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlVsNativeBenchmark.java
@@ -163,7 +163,7 @@ public class SqlVsNativeBenchmark
   {
     try (final DruidPlanner planner = plannerFactory.createPlannerForTesting(null, sqlQuery)) {
       final PlannerResult plannerResult = planner.plan();
-      final Sequence<Object[]> resultSequence = plannerResult.run();
+      final Sequence<Object[]> resultSequence = plannerResult.run().getResults();
       final Object[] lastRow = resultSequence.accumulate(null, (accumulated, in) -> in);
       blackhole.consume(lastRow);
     }

--- a/core/src/main/java/org/apache/druid/query/QueryException.java
+++ b/core/src/main/java/org/apache/druid/query/QueryException.java
@@ -57,7 +57,9 @@ public class QueryException extends RuntimeException implements SanitizableExcep
       @JsonProperty("host") @Nullable String host
   )
   {
-    super(errorMessage);
+    // The JsonParserIterator accepts a minimum of just the error field.
+    // If that's all that's provided, use the error as the message.
+    super(errorMessage == null ? errorCode : errorMessage);
     this.errorCode = errorCode;
     this.errorClass = errorClass;
     this.host = host;

--- a/core/src/main/java/org/apache/druid/query/QueryTimeoutException.java
+++ b/core/src/main/java/org/apache/druid/query/QueryTimeoutException.java
@@ -33,12 +33,13 @@ import javax.annotation.Nullable;
  * {@link #STATUS_CODE} instead of the default HTTP 500 status.
  */
 
+@SuppressWarnings("serial")
 public class QueryTimeoutException extends QueryException
 {
   private static final String ERROR_CLASS = QueryTimeoutException.class.getName();
   public static final String ERROR_CODE = "Query timeout";
   public static final String ERROR_MESSAGE = "Query Timed Out!";
-  public static final int STATUS_CODE = 504;
+  public static final int STATUS_CODE = 504; // Gateway Timeout
 
   @JsonCreator
   public QueryTimeoutException(

--- a/core/src/test/java/org/apache/druid/java/util/common/JsonUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/JsonUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.input.ReaderInputStream;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonUtilsTest
+{
+  @Test
+  public void testSkipValue() throws IOException
+  {
+    String input = "{"
+        + "\"scalar\": 10,"
+        + "\"map\": {\"foo\": 10, \"bar\": null},"
+        + "\"array\": [10, 20]"
+        + "}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonParser jp = objectMapper.getFactory().createParser(
+        new ReaderInputStream(new StringReader(input), StandardCharsets.UTF_8));
+    jp.nextToken();
+    jp.nextToken();
+    assertEquals(JsonToken.FIELD_NAME, jp.currentToken());
+    jp.nextToken();
+    JsonUtils.skipValue(jp, "scalar");
+    assertEquals(JsonToken.FIELD_NAME, jp.currentToken());
+    jp.nextToken();
+    JsonUtils.skipValue(jp, "map");
+    assertEquals(JsonToken.FIELD_NAME, jp.currentToken());
+    jp.nextToken();
+    JsonUtils.skipValue(jp, "array");
+    assertEquals(JsonToken.END_OBJECT, jp.currentToken());
+  }
+}

--- a/core/src/test/java/org/apache/druid/query/QueryExceptionTest.java
+++ b/core/src/test/java/org/apache/druid/query/QueryExceptionTest.java
@@ -49,7 +49,7 @@ public class QueryExceptionTest
     QueryException actual = queryException.sanitize(trasformFunction);
     Assert.assertNotNull(actual);
     Assert.assertEquals(actual.getErrorCode(), ERROR_CODE);
-    Assert.assertNull(actual.getMessage());
+    Assert.assertEquals(ERROR_CODE, actual.getMessage());
     Assert.assertNull(actual.getHost());
     Assert.assertNull(actual.getErrorClass());
     Mockito.verify(trasformFunction).apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL));

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -57,8 +57,8 @@ public class KafkaEmitterTest
     };
   }
 
-  // there is 10 seconds wait in kafka emitter before it starts sending events to broker, so set a timeout for 15 seconds
-  @Test(timeout = 15_000)
+  // there is 10 seconds wait in kafka emitter before it starts sending events to broker, so set a timeout for 20 seconds
+  @Test(timeout = 20_000)
   public void testKafkaEmitter() throws InterruptedException
   {
     final List<ServiceMetricEvent> serviceMetricEvents = ImmutableList.of(

--- a/processing/src/main/java/org/apache/druid/query/BadQueryException.java
+++ b/processing/src/main/java/org/apache/druid/query/BadQueryException.java
@@ -24,9 +24,10 @@ package org.apache.druid.query;
  *
  * See {@code BadRequestException} for non-query requests.
  */
+@SuppressWarnings("serial")
 public abstract class BadQueryException extends QueryException
 {
-  public static final int STATUS_CODE = 400;
+  public static final int STATUS_CODE = 400; // Bad Request
 
   protected BadQueryException(String errorCode, String errorMessage, String errorClass)
   {

--- a/processing/src/main/java/org/apache/druid/query/MultiQueryMetricsCollector.java
+++ b/processing/src/main/java/org/apache/druid/query/MultiQueryMetricsCollector.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.common.guava.GuavaUtils;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MultiQueryMetricsCollector
+{
+  // subQueryId -> metrics collector
+  private final Map<String, SingleQueryMetricsCollector> collectorMap;
+
+  private MultiQueryMetricsCollector(Map<String, SingleQueryMetricsCollector> collectorMap)
+  {
+    this.collectorMap = collectorMap;
+  }
+
+  public static MultiQueryMetricsCollector newCollector()
+  {
+    return new MultiQueryMetricsCollector(new HashMap<>());
+  }
+
+  @JsonCreator
+  public static MultiQueryMetricsCollector fromList(final List<SingleQueryMetricsCollector> collectors)
+  {
+    return new MultiQueryMetricsCollector(
+        collectors.stream()
+                  .collect(
+                      Collectors.toMap(
+                          SingleQueryMetricsCollector::getSubQueryId,
+                          collector -> collector
+                      )
+                  )
+    );
+  }
+
+  public MultiQueryMetricsCollector add(final SingleQueryMetricsCollector otherCollector)
+  {
+    final String key = otherCollector.getSubQueryId() == null ? "" : otherCollector.getSubQueryId();
+    collectorMap.merge(key, otherCollector, SingleQueryMetricsCollector::add);
+    return this;
+  }
+
+  public MultiQueryMetricsCollector addAll(final MultiQueryMetricsCollector other)
+  {
+    for (SingleQueryMetricsCollector otherCollector : other.collectorMap.values()) {
+      add(otherCollector);
+    }
+
+    return this;
+  }
+
+  @JsonValue
+  public List<SingleQueryMetricsCollector> getCollectors()
+  {
+    return ImmutableList.copyOf(
+        collectorMap
+            .values()
+            .stream()
+            .sorted(
+                Comparator.comparing(
+                    collector -> {
+                      final String subQueryId = collector.getSubQueryId();
+
+                      if (subQueryId == null) {
+                        return -2L;
+                      } else {
+                        // Parsing the subQueryIds that were generated in ClientQuerySegmentWalker.
+                        final int lastUnderscore = subQueryId.lastIndexOf('_');
+
+                        if (lastUnderscore >= 0 && lastUnderscore < subQueryId.length() - 1) {
+                          final Long n = GuavaUtils.tryParseLong(subQueryId.substring(lastUnderscore + 1));
+
+                          if (n != null) {
+                            return n;
+                          }
+                        }
+                      }
+
+                      return -1L;
+                    }
+                )
+            )
+            .collect(Collectors.toList()));
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/Query.java
+++ b/processing/src/main/java/org/apache/druid/query/Query.java
@@ -210,4 +210,21 @@ public interface Query<T>
   {
     return null;
   }
+
+  /**
+   * Get the row count of a result object of type {@code T}.
+   */
+  default int getRowCountOf(T result)
+  {
+    return result == null ? 0 : 1;
+  }
+
+  /**
+   * Get the row count of a result object, provided as a generic object.
+   */
+  @SuppressWarnings("unchecked")
+  default int getRowCount(Object result)
+  {
+    return getRowCountOf((T) result);
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryCapacityExceededException.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryCapacityExceededException.java
@@ -44,7 +44,7 @@ public class QueryCapacityExceededException extends QueryException
       "Too many concurrent queries for lane '%s', query capacity of %s exceeded. Please try your query again later.";
   private static final String ERROR_CLASS = QueryCapacityExceededException.class.getName();
   public static final String ERROR_CODE = "Query capacity exceeded";
-  public static final int STATUS_CODE = 429;
+  public static final int STATUS_CODE = 429; // Non-standard code
 
   public QueryCapacityExceededException(int capacity)
   {

--- a/processing/src/main/java/org/apache/druid/query/QueryInterruptedException.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryInterruptedException.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CancellationException;
  * The QueryResource is expected to emit the JSON form of this object when errors happen, and the DirectDruidClient
  * deserializes and wraps them.
  */
+@SuppressWarnings("serial")
 public class QueryInterruptedException extends QueryException
 {
   public static final String QUERY_INTERRUPTED = "Query interrupted";
@@ -49,6 +50,7 @@ public class QueryInterruptedException extends QueryException
   public static final String UNSUPPORTED_OPERATION = "Unsupported operation";
   public static final String TRUNCATED_RESPONSE_CONTEXT = "Truncated response context";
   public static final String UNKNOWN_EXCEPTION = "Unknown exception";
+  public static final int STATUS_CODE = 409; // CONFLICT
 
   @JsonCreator
   public QueryInterruptedException(

--- a/processing/src/main/java/org/apache/druid/query/QueryUnsupportedException.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryUnsupportedException.java
@@ -33,11 +33,12 @@ import javax.annotation.Nullable;
  * As a {@link QueryException} it is expected to be serialized to a json response with a proper HTTP error code
  * ({@link #STATUS_CODE}).
  */
+@SuppressWarnings("serial")
 public class QueryUnsupportedException extends QueryException
 {
   private static final String ERROR_CLASS = QueryUnsupportedException.class.getName();
   public static final String ERROR_CODE = "Unsupported query";
-  public static final int STATUS_CODE = 501;
+  public static final int STATUS_CODE = 501; // Not Implemented
 
   @JsonCreator
   public QueryUnsupportedException(

--- a/processing/src/main/java/org/apache/druid/query/SingleQueryMetricsCollector.java
+++ b/processing/src/main/java/org/apache/druid/query/SingleQueryMetricsCollector.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import org.apache.druid.java.util.common.IAE;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.Objects;
+
+@NotThreadSafe
+public class SingleQueryMetricsCollector
+{
+  private String subQueryId;
+  private int segments;
+  private int segmentsProcessed;
+  private int segmentsVectorProcessed;
+  private long segmentRows;
+  private long preFilteredRows;
+  private long nodeRows;
+  private long resultRows;
+  private long cpuNanos;
+  private int threads;
+  private long queryStart;
+  private long queryMs;
+
+  private final LongSet threadAccumulator;
+
+  public static SingleQueryMetricsCollector newCollector()
+  {
+    return new SingleQueryMetricsCollector(null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  }
+
+  @JsonCreator
+  public SingleQueryMetricsCollector(
+      @JsonProperty("subQueryId") @Nullable String subQueryId,
+      @JsonProperty("segments") int segments,
+      @JsonProperty("segmentsProcessed") int segmentsProcessed,
+      @JsonProperty("segmentsVectorProcessed") int segmentsVectorProcessed,
+      @JsonProperty("segmentRows") long segmentRows,
+      @JsonProperty("preFilteredRows") long preFilteredRows,
+      @JsonProperty("nodeRows") long nodeRows,
+      @JsonProperty("resultRows") long resultRows,
+      @JsonProperty("cpuNanos") long cpuNanos,
+      @JsonProperty("threads") int threads,
+      @JsonProperty("queryStart") long queryStart,
+      @JsonProperty("queryMs") long queryMs
+  )
+  {
+    this.subQueryId = subQueryId;
+    this.threadAccumulator = new LongOpenHashSet();
+    this.segments = segments;
+    this.segmentsProcessed = segmentsProcessed;
+    this.segmentsVectorProcessed = segmentsVectorProcessed;
+    this.segmentRows = segmentRows;
+    this.preFilteredRows = preFilteredRows;
+    this.nodeRows = nodeRows;
+    this.resultRows = resultRows;
+    this.cpuNanos = cpuNanos;
+    this.threads = threads;
+    this.queryStart = queryStart;
+    this.queryMs = queryMs;
+  }
+
+  @Nullable
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public String getSubQueryId()
+  {
+    return subQueryId;
+  }
+
+  @JsonProperty
+  public int getSegments()
+  {
+    return segments;
+  }
+
+  @JsonProperty
+  public int getSegmentsProcessed()
+  {
+    return segmentsProcessed;
+  }
+
+  @JsonProperty
+  public int getSegmentsVectorProcessed()
+  {
+    return segmentsVectorProcessed;
+  }
+
+  @JsonProperty
+  public long getSegmentRows()
+  {
+    return segmentRows;
+  }
+
+  @JsonProperty
+  public long getNodeRows()
+  {
+    return nodeRows;
+  }
+
+  @JsonProperty
+  public long getPreFilteredRows()
+  {
+    return preFilteredRows;
+  }
+
+  @JsonProperty
+  public long getResultRows()
+  {
+    return resultRows;
+  }
+
+  @JsonProperty
+  public long getCpuNanos()
+  {
+    return cpuNanos;
+  }
+
+  // Comment about how this works with snapshots and serde etc. it's a little tricky/weird
+  @JsonProperty("threads")
+  public int getThreadsSnapshot()
+  {
+    return threads + threadAccumulator.size();
+  }
+
+  public int getThreads()
+  {
+    return threads;
+  }
+
+  @JsonProperty
+  public long getQueryStart()
+  {
+    return queryStart;
+  }
+
+  @JsonProperty
+  public long getQueryMs()
+  {
+    return queryMs;
+  }
+
+  public SingleQueryMetricsCollector setSubQueryId(@Nullable final String subQueryId)
+  {
+    this.subQueryId = subQueryId;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addCurrentThread()
+  {
+    threadAccumulator.add(Thread.currentThread().getId());
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addSegment()
+  {
+    this.segments++;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addSegmentProcessed()
+  {
+    this.segmentsProcessed++;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addSegmentVectorProcessed()
+  {
+    this.segmentsVectorProcessed++;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addSegmentRows(final long numRows)
+  {
+    this.segmentRows += numRows;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addPreFilteredRows(final long numRows)
+  {
+    this.preFilteredRows += numRows;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addNodeRows(final long numRows)
+  {
+    this.nodeRows += numRows;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector setResultRows(final long resultRows)
+  {
+    this.resultRows = resultRows;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector addCpuNanos(final long timeNs)
+  {
+    this.cpuNanos += timeNs;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector setQueryStart(final long queryStart)
+  {
+    this.queryStart = queryStart;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector setQueryMs(final long queryMs)
+  {
+    this.queryMs = queryMs;
+    return this;
+  }
+
+  public SingleQueryMetricsCollector add(final SingleQueryMetricsCollector other)
+  {
+    if (!Objects.equals(subQueryId, other.subQueryId)) {
+      // Sanity check
+      throw new IAE("Cannot merge collectors for different queries");
+    }
+
+    this.segments += other.segments;
+    this.segmentsProcessed += other.segmentsProcessed;
+    this.segmentsVectorProcessed += other.segmentsVectorProcessed;
+    this.segmentRows += other.segmentRows;
+    this.preFilteredRows += other.preFilteredRows;
+    this.nodeRows += other.nodeRows;
+    this.resultRows = other.resultRows > 0 ? other.resultRows : resultRows;
+    this.cpuNanos += other.cpuNanos;
+    this.threads += other.threads;
+    this.threadAccumulator.addAll(other.threadAccumulator);
+    this.queryStart = other.queryStart > 0 ? other.queryStart : queryStart;
+    this.queryMs = other.queryMs > 0 ? other.queryMs : queryMs;
+    return this;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/TruncatedResponseContextException.java
+++ b/processing/src/main/java/org/apache/druid/query/TruncatedResponseContextException.java
@@ -26,9 +26,10 @@ import org.apache.druid.java.util.common.StringUtils;
  * in historicals or realtime tasks. The serialized response context can be truncated if its size is larger than
  * {@code QueryResource#RESPONSE_CTX_HEADER_LEN_LIMIT}.
  *
- * See {@link org.apache.druid.query.context.ResponseContext#serializeWith} and
+ * See {@link org.apache.druid.query.context.ResponseContext#toHeader} and
  * {@code ResponseContextConfig#shouldFailOnTruncatedResponseContext}.
  */
+@SuppressWarnings("serial")
 public class TruncatedResponseContextException extends RuntimeException
 {
   public TruncatedResponseContextException(String message, Object... arguments)

--- a/processing/src/main/java/org/apache/druid/query/context/DefaultResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/DefaultResponseContext.java
@@ -35,7 +35,17 @@ public class DefaultResponseContext extends ResponseContext
     return new DefaultResponseContext();
   }
 
-  private final HashMap<Key, Object> delegate = new HashMap<>();
+  private final Map<Key, Object> delegate;
+
+  public DefaultResponseContext()
+  {
+    this(new HashMap<>());
+  }
+
+  public DefaultResponseContext(final Map<Key, Object> map)
+  {
+    this.delegate = map;
+  }
 
   @Override
   protected Map<Key, Object> getDelegate()

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -457,6 +457,7 @@ public class GroupByQuery extends BaseQuery<ResultRow>
     return getContextBoolean(GroupByQueryConfig.CTX_KEY_APPLY_LIMIT_PUSH_DOWN, true);
   }
 
+  @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
   public Ordering getResultOrdering()
   {
@@ -988,7 +989,7 @@ public class GroupByQuery extends BaseQuery<ResultRow>
       return this;
     }
 
-    public Builder setDataSource(Query query)
+    public Builder setDataSource(Query<?> query)
     {
       this.dataSource = new QueryDataSource(query);
       return this;

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQuery.java
@@ -455,6 +455,25 @@ public class ScanQuery extends BaseQuery<ScanResultValue>
     }
   }
 
+  @Override
+  public int getRowCountOf(ScanResultValue result)
+  {
+    if (result == null) {
+      return 0;
+    }
+    if (result.getEvents() == null) {
+      return 0;
+    }
+    switch (resultFormat) {
+      case RESULT_FORMAT_LIST:
+      case RESULT_FORMAT_COMPACTED_LIST:
+        return ((List<?>) result.getEvents()).size();
+
+      default:
+        return 1;
+    }
+  }
+
   public ScanQuery withOffset(final long newOffset)
   {
     return Druids.ScanQueryBuilder.copy(this).offset(newOffset).build();

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
@@ -172,6 +172,20 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     );
   }
 
+  @Override
+  public int getRowCountOf(Result<TopNResultValue> result)
+  {
+    if (result == null) {
+      return 0;
+    }
+    TopNResultValue value = result.getValue();
+    if (value == null) {
+      return 0;
+    }
+    // Constructor ensures there is always a list.
+    return value.getValue().size();
+  }
+
   public void initTopNAlgorithmSelector(TopNAlgorithmSelector selector)
   {
     if (dimensionSpec.getExtractionFn() != null) {

--- a/processing/src/test/java/org/apache/druid/query/QueryInterruptedExceptionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryInterruptedExceptionTest.java
@@ -129,7 +129,7 @@ public class QueryInterruptedExceptionTest
         roundTrip(new QueryInterruptedException(new QueryInterruptedException(new CancellationException()))).getErrorClass()
     );
     Assert.assertEquals(
-        null,
+        "Query cancelled",
         roundTrip(new QueryInterruptedException(new QueryInterruptedException(new CancellationException()))).getMessage()
     );
     Assert.assertEquals(

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryTest.java
@@ -57,7 +57,7 @@ public class GroupByQueryTest
   @Test
   public void testQuerySerialization() throws IOException
   {
-    Query query = GroupByQuery
+    Query<?> query = GroupByQuery
         .builder()
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
@@ -78,7 +78,7 @@ public class GroupByQueryTest
         .build();
 
     String json = JSON_MAPPER.writeValueAsString(query);
-    Query serdeQuery = JSON_MAPPER.readValue(json, Query.class);
+    Query<?> serdeQuery = JSON_MAPPER.readValue(json, Query.class);
 
     Assert.assertEquals(query, serdeQuery);
   }
@@ -171,5 +171,19 @@ public class GroupByQueryTest
                       "universalTimestamp"
                   )
                   .verify();
+  }
+
+  @Test
+  public void testRowCount()
+  {
+    final GroupByQuery query = GroupByQuery.builder()
+        .setDataSource("dummy")
+        .setGranularity(Granularities.ALL)
+        .setInterval("2000/2001")
+        .addDimension(new DefaultDimensionSpec("foo", "foo", ColumnType.LONG))
+        .build();
+    Assert.assertEquals(0, query.getRowCount(null));
+    ResultRow row = ResultRow.of(10);
+    Assert.assertEquals(1, query.getRowCount(row));
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/metrics/QueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metrics/QueryMetricsTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.metrics;
+
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.query.MultiQueryMetricsCollector;
+import org.apache.druid.query.SingleQueryMetricsCollector;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryMetricsTest
+{
+  @Test
+  public void testSingleMetrics()
+  {
+    SingleQueryMetricsCollector coll = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id")
+        .addCurrentThread()
+        .addSegment()
+        .addSegmentProcessed()
+        .addSegmentProcessed()
+        .addSegmentVectorProcessed()
+        .addSegmentVectorProcessed()
+        .addSegmentVectorProcessed()
+        .addPreFilteredRows(10)
+        .addNodeRows(20)
+        .setResultRows(30)
+        .addCpuNanos(40)
+        .setQueryStart(50)
+        .setQueryMs(60)
+        .addSegmentRows(70);
+
+    assertEquals("query-id", coll.getSubQueryId());
+    assertEquals(1, coll.getSegments());
+    assertEquals(2, coll.getSegmentsProcessed());
+    assertEquals(3, coll.getSegmentsVectorProcessed());
+    assertEquals(10, coll.getPreFilteredRows());
+    assertEquals(20, coll.getNodeRows());
+    assertEquals(30, coll.getResultRows());
+    assertEquals(40, coll.getCpuNanos());
+    assertEquals(50, coll.getQueryStart());
+    assertEquals(60, coll.getQueryMs());
+    assertEquals(70, coll.getSegmentRows());
+    // Kinda weird, but the count is zero for a "live" collector.
+    assertEquals(0, coll.getThreads());
+    assertEquals(1, coll.getThreadsSnapshot());
+  }
+
+  @Test
+  public void testSingleMetricsAdd()
+  {
+    SingleQueryMetricsCollector coll = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id")
+        .addCurrentThread()
+        .addSegment()
+        .addSegmentProcessed()
+        .addSegmentProcessed()
+        .addSegmentVectorProcessed()
+        .addSegmentVectorProcessed()
+        .addSegmentVectorProcessed()
+        .addPreFilteredRows(10)
+        .addNodeRows(20)
+        .setResultRows(30)
+        .addCpuNanos(40)
+        .setQueryStart(50)
+        .setQueryMs(60)
+        .addSegmentRows(70);
+    SingleQueryMetricsCollector second = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id")
+        .addCurrentThread()
+        .addSegment()
+        .addSegmentProcessed()
+        .addSegmentVectorProcessed()
+        .addPreFilteredRows(110)
+        .addNodeRows(120)
+        .setResultRows(130)
+        .addCpuNanos(140)
+        .setQueryStart(150)
+        .setQueryMs(160)
+        .addSegmentRows(170);
+    coll.add(second);
+
+    assertEquals("query-id", coll.getSubQueryId());
+    assertEquals(2, coll.getSegments());
+    assertEquals(3, coll.getSegmentsProcessed());
+    assertEquals(4, coll.getSegmentsVectorProcessed());
+    assertEquals(120, coll.getPreFilteredRows());
+    assertEquals(140, coll.getNodeRows());
+    // Second set wins
+    assertEquals(130, coll.getResultRows());
+    assertEquals(180, coll.getCpuNanos());
+    // Second set wins
+    assertEquals(150, coll.getQueryStart());
+    // Second set wins
+    assertEquals(160, coll.getQueryMs());
+    assertEquals(240, coll.getSegmentRows());
+    // Not set yet
+    assertEquals(0, coll.getThreads());
+    // Both in same thread
+    assertEquals(1, coll.getThreadsSnapshot());
+  }
+
+  @Test(expected = IAE.class)
+  public void testMismatchedIds()
+  {
+    SingleQueryMetricsCollector coll = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id");
+    SingleQueryMetricsCollector second = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("different-id");
+    coll.add(second);
+  }
+
+  @Test
+  public void testMultiMetricsSameId()
+  {
+    SingleQueryMetricsCollector single = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id")
+        .addCurrentThread()
+        .addNodeRows(20);
+
+    MultiQueryMetricsCollector multi = MultiQueryMetricsCollector
+        .newCollector()
+        .add(single);
+    assertEquals(1, multi.getCollectors().size());
+
+    SingleQueryMetricsCollector second = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id")
+        .addNodeRows(120);
+
+    multi.add(second);
+    assertEquals(1, multi.getCollectors().size());
+    SingleQueryMetricsCollector coll = multi.getCollectors().get(0);
+
+    assertEquals("query-id", coll.getSubQueryId());
+    assertEquals(140, coll.getNodeRows());
+
+    MultiQueryMetricsCollector secondMulti = MultiQueryMetricsCollector
+        .newCollector()
+        .addAll(multi);
+    assertEquals(1, secondMulti.getCollectors().size());
+    coll = secondMulti.getCollectors().get(0);
+
+    assertEquals("query-id", coll.getSubQueryId());
+    assertEquals(140, coll.getNodeRows());
+  }
+
+  @Test
+  public void testMultiMetricsSubQuery()
+  {
+    SingleQueryMetricsCollector root = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id")
+        .addNodeRows(20);
+    SingleQueryMetricsCollector subquery = SingleQueryMetricsCollector
+        .newCollector()
+        .setSubQueryId("query-id_1")
+        .addNodeRows(20);
+
+    MultiQueryMetricsCollector multi = MultiQueryMetricsCollector
+        .fromList(Arrays.asList(root, subquery));
+    assertEquals(2, multi.getCollectors().size());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
@@ -380,4 +380,43 @@ public class ScanQueryTest
 
     Assert.assertEquals(ImmutableSet.of("__time", "foo", "bar"), query.getRequiredColumns());
   }
+
+  @Test
+  public void testListFormatRowCount()
+  {
+    final ScanQuery query =
+        Druids.newScanQueryBuilder()
+              .order(ScanQuery.Order.DESCENDING)
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+              .dataSource("some src")
+              .intervals(intervalSpec)
+              .columns(Collections.emptyList())
+              .build();
+    doRowCountTest(query);
+  }
+
+  @Test
+  public void testCompactListFormatRowCount()
+  {
+    final ScanQuery query =
+        Druids.newScanQueryBuilder()
+              .order(ScanQuery.Order.DESCENDING)
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+              .dataSource("some src")
+              .intervals(intervalSpec)
+              .columns(Collections.emptyList())
+              .build();
+    doRowCountTest(query);
+  }
+
+  private void doRowCountTest(ScanQuery query)
+  {
+    Assert.assertEquals(0, query.getRowCount(null));
+    ScanResultValue result = new ScanResultValue(null, null, null);
+    Assert.assertEquals(0, query.getRowCount(result));
+    result = new ScanResultValue(null, null, Collections.emptyList());
+    Assert.assertEquals(0, query.getRowCount(result));
+    result = new ScanResultValue(null, null, Arrays.asList("foo", "bar"));
+    Assert.assertEquals(2, query.getRowCount(result));
+  }
 }

--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.JsonUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.Query;
@@ -34,7 +35,7 @@ import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.query.QueryUnsupportedException;
 import org.apache.druid.query.ResourceLimitExceededException;
-import org.apache.druid.utils.CloseableUtils;
+import org.apache.druid.query.context.ResponseContext;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -47,12 +48,54 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * Parses results from a remote server. The results can be in either
+ * array format (an array of rows that comprise the result set) or
+ * in object format. If in object format, the object can represent
+ * either an error or the newer object format with trailer.
+ * <p>
+ * Thus, the three valid result formats are:
+ * <code<pre> [ <rows> ]
+ * { "error": msg ... }
+ * { "results": [ <rows> ], "context": { ... } }
+ * </pre></code>
+ * <p>
+ * The caller specified the expected format. Since the object format
+ * is new, during upgrades, older servers may ignore the request and still
+ * return the array format. Thus, valid combinations are:
+ * <ul>
+ * <li>As for object, receive array or object</li>
+ * <li>As for array, receive array or error object</li>
+ * </ul>
+ */
 public class JsonParserIterator<T> implements Iterator<T>, Closeable
 {
+  /**
+   * When returning results as an Object, the key of the result set within the object.
+   */
+  public static final String FIELD_RESULTS = "results";
+  /**
+   * When returning results as an Object, the key of the trailer within the object.
+   */
+  public static final String FIELD_CONTEXT = "context";
+  public static final String FIELD_ERROR = "error";
+
+
   private static final Logger LOG = new Logger(JsonParserIterator.class);
+
+  public enum ResultStructure
+  {
+    ARRAY,
+    OBJECT
+  }
 
   private JsonParser jp;
   private ObjectCodec objectCodec;
+  private ResponseContext responseTrailer;
+  private long resultRows;
+  private boolean success;
+  private final ResultStructure expectedStructure;
+  private ResultStructure actualStructure;
   private final JavaType typeRef;
   private final Future<InputStream> future;
   private final String url;
@@ -60,9 +103,13 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
   private final ObjectMapper objectMapper;
   private final boolean hasTimeout;
   private final long timeoutAt;
+  @Nullable
+  private final Query<T> query;
+  @Nullable
   private final String queryId;
 
   public JsonParserIterator(
+      ResultStructure resultStructure,
       JavaType typeRef,
       Future<InputStream> future,
       String url,
@@ -71,9 +118,11 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
       ObjectMapper objectMapper
   )
   {
+    this.expectedStructure = resultStructure;
     this.typeRef = typeRef;
     this.future = future;
     this.url = url;
+    this.query = query;
     if (query != null) {
       this.timeoutAt = query.<Long>getContextValue(DirectDruidClient.QUERY_FAIL_TIME, -1L);
       this.queryId = query.getId();
@@ -90,27 +139,154 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
   @Override
   public boolean hasNext()
   {
-    init();
-
+    if (jp == null) {
+      init();
+    }
     if (jp.isClosed()) {
       return false;
     }
-    if (jp.getCurrentToken() == JsonToken.END_ARRAY) {
-      CloseableUtils.closeAndWrapExceptions(jp);
+    try {
+      if (jp.getCurrentToken() != JsonToken.END_ARRAY) {
+        return true;
+      }
+      if (actualStructure == ResultStructure.OBJECT) {
+        // Read response context, if present (it occurs after the main results).
+        jp.nextToken();
+        // { "results": [ ... ] ^ ...
+
+        // Skip all fields except the known one. Handles the case of a newer server
+        // which returns something unexpected.
+        while (jp.currentToken() == JsonToken.FIELD_NAME) {
+          final String fieldName = jp.getText();
+          jp.nextToken();
+          if (FIELD_CONTEXT.equals(fieldName)) {
+            // Leaves the parser with no token, positioned on the last value token.
+            responseTrailer = jp.getCodec().readValue(jp, ResponseContext.class);
+            jp.nextToken();
+          } else {
+            // Consumes the value token
+            JsonUtils.skipValue(jp, fieldName);
+          }
+        }
+
+        if (jp.currentToken() != JsonToken.END_OBJECT) {
+          throw wrongTokenException(JsonToken.END_OBJECT);
+        }
+      }
+
+      // Should be at the end of the response.
+      if (jp.nextToken() != null) {
+        throw wrongTokenException(null);
+      }
+
+      jp.close();
+      jp = null;
+      success = true;
       return false;
     }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-    return true;
+  private void init()
+  {
+    try {
+      long timeLeftMillis = timeoutAt - System.currentTimeMillis();
+      if (checkTimeout(timeLeftMillis)) {
+        throw timeoutQuery();
+      }
+      InputStream is = hasTimeout ? future.get(timeLeftMillis, TimeUnit.MILLISECONDS) : future.get();
+
+      if (is != null) {
+        jp = objectMapper.getFactory().createParser(is);
+      } else if (checkTimeout()) {
+        throw timeoutQuery();
+      } else {
+        // TODO: NettyHttpClient should check the actual cause of the failure and set it in the future properly.
+        throw ResourceLimitExceededException.withMessage(
+            "Possibly max scatter-gather bytes limit reached while reading from url[%s].",
+            url
+        );
+      }
+
+      final JsonToken nextToken = jp.nextToken();
+      if (nextToken == null) {
+        throw unexpectedEOF();
+      }
+
+      // We may expect an object (with trailer), but the server could be a prior version that does
+      // not support that feature, and so has returned an array anyway. So, here we check
+      // what the server has given us, not what we wanted.
+      if (nextToken == JsonToken.START_ARRAY) {
+        actualStructure = ResultStructure.ARRAY;
+
+        jp.nextToken();
+        // Positioned at [ ^ ...
+        objectCodec = jp.getCodec();
+      } else if (nextToken != JsonToken.START_OBJECT) {
+        throw wrongTokenException(
+            expectedStructure == ResultStructure.OBJECT ? JsonToken.START_OBJECT : JsonToken.START_ARRAY);
+      } else {
+        // Expect a top-level object to contain key "results" or "error".
+        // { ^ "error" | "results" ...
+
+        jp.nextToken();
+
+        //
+        if (jp.currentToken() != JsonToken.FIELD_NAME) {
+          throw wrongTokenException(JsonToken.FIELD_NAME);
+        }
+
+        if (FIELD_ERROR.equals(jp.getText())) {
+          // Some versions of Druid incorrectly create the error structure
+          // as doubly nested: {"error: {"error": ... "errorMessage": ... }
+          throw convertException(jp.getCodec().readValue(jp, QueryInterruptedException.class));
+        } else if (!FIELD_RESULTS.equals(jp.getText())) {
+          throw convertException(new IAE("Unexpected starting field[%s] from url[%s]", jp.getText(), url));
+        } else if (expectedStructure == ResultStructure.ARRAY) {
+          // Wanted an array structure (old format), but got the new format.
+          // This is more of a code error than a compatibility error.
+          throw convertException(new IAE("Got object format, expected array from url[%s]", url));
+        }
+
+        // Should be: "results": ^ [ ...
+        jp.nextToken();
+        if (jp.currentToken() != JsonToken.START_ARRAY) {
+          throw wrongTokenException(JsonToken.START_ARRAY);
+        }
+
+        // We are safely in the object structure, positioned to read the array of results.
+        // Positioned at: { "results": [ ^ ...
+        actualStructure = ResultStructure.OBJECT;
+        jp.nextToken();
+        objectCodec = jp.getCodec();
+      }
+    }
+    catch (ExecutionException | CancellationException e) {
+      throw convertException(e.getCause() == null ? e : e.getCause());
+    }
+    catch (IOException | InterruptedException e) {
+      throw convertException(e);
+    }
+    catch (TimeoutException e) {
+      throw new QueryTimeoutException(StringUtils.nonStrictFormat("Query [%s] timed out!", queryId), host);
+    }
   }
 
   @Override
   public T next()
   {
-    init();
-
     try {
       final T retVal = objectCodec.readValue(jp, typeRef);
       jp.nextToken();
+
+      if (query != null) {
+        resultRows += query.getRowCountOf(retVal);
+      } else {
+        resultRows++;
+      }
+
       return retVal;
     }
     catch (IOException e) {
@@ -126,82 +302,44 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
   }
 
   @Override
-  public void remove()
-  {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public void close() throws IOException
   {
     if (jp != null) {
       jp.close();
+      jp = null;
     }
+  }
+
+  public boolean isSuccess()
+  {
+    return jp == null && success;
+  }
+
+  public long getResultRows()
+  {
+    return resultRows;
   }
 
   private boolean checkTimeout()
   {
-    long timeLeftMillis = timeoutAt - System.currentTimeMillis();
+    final long timeLeftMillis = timeoutAt - System.currentTimeMillis();
     return checkTimeout(timeLeftMillis);
   }
 
   private boolean checkTimeout(long timeLeftMillis)
   {
-    if (hasTimeout && timeLeftMillis < 1) {
-      return true;
-    }
-    return false;
-  }
-
-  private void init()
-  {
-    if (jp == null) {
-      try {
-        long timeLeftMillis = timeoutAt - System.currentTimeMillis();
-        if (checkTimeout(timeLeftMillis)) {
-          throw timeoutQuery();
-        }
-        InputStream is = hasTimeout ? future.get(timeLeftMillis, TimeUnit.MILLISECONDS) : future.get();
-
-        if (is != null) {
-          jp = objectMapper.getFactory().createParser(is);
-        } else if (checkTimeout()) {
-          throw timeoutQuery();
-        } else {
-          // TODO: NettyHttpClient should check the actual cause of the failure and set it in the future properly.
-          throw ResourceLimitExceededException.withMessage(
-              "Possibly max scatter-gather bytes limit reached while reading from url[%s].",
-              url
-          );
-        }
-
-        final JsonToken nextToken = jp.nextToken();
-        if (nextToken == JsonToken.START_ARRAY) {
-          jp.nextToken();
-          objectCodec = jp.getCodec();
-        } else if (nextToken == JsonToken.START_OBJECT) {
-          throw convertException(jp.getCodec().readValue(jp, QueryException.class));
-        } else {
-          throw convertException(
-              new IAE("Next token wasn't a START_ARRAY, was[%s] from url[%s]", jp.getCurrentToken(), url)
-          );
-        }
-      }
-      catch (ExecutionException | CancellationException e) {
-        throw convertException(e.getCause() == null ? e : e.getCause());
-      }
-      catch (IOException | InterruptedException e) {
-        throw convertException(e);
-      }
-      catch (TimeoutException e) {
-        throw new QueryTimeoutException(StringUtils.nonStrictFormat("Query [%s] timed out!", queryId), host);
-      }
-    }
+    return hasTimeout && timeLeftMillis < 1;
   }
 
   private QueryTimeoutException timeoutQuery()
   {
     return new QueryTimeoutException(StringUtils.nonStrictFormat("url[%s] timed out", url), host);
+  }
+
+  @Nullable
+  public ResponseContext responseTrailer()
+  {
+    return responseTrailer;
   }
 
   /**
@@ -210,8 +348,8 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
    *
    * - All non-QueryExceptions are wrapped with {@link QueryInterruptedException}.
    * - The QueryException from {@link DirectDruidClient} is converted to a more specific type of QueryException
-   *   based on {@link QueryException#getErrorCode()}. During conversion, {@link QueryException#host} is overridden
-   *   by {@link #host}.
+   * based on {@link QueryException#getErrorCode()}. During conversion, {@link QueryException#host} is overridden
+   * by {@link #host}.
    */
   private QueryException convertException(Throwable cause)
   {
@@ -219,7 +357,7 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
     if (cause instanceof QueryException) {
       final QueryException queryException = (QueryException) cause;
       if (queryException.getErrorCode() == null) {
-        // errorCode should not be null now, but maybe could be null in the past..
+        // errorCode should not be null now, but maybe could be null in the past.
         return new QueryInterruptedException(
             queryException.getErrorCode(),
             queryException.getMessage(),
@@ -272,5 +410,35 @@ public class JsonParserIterator<T> implements Iterator<T>, Closeable
     } else {
       return new QueryInterruptedException(cause, host);
     }
+  }
+
+  /**
+   * Returns a parse error exception stating that the provided token was expected, but not received, at the current
+   * position of our parser "jp".
+   */
+  private QueryException wrongTokenException(@Nullable final JsonToken expectedToken)
+  {
+    return convertException(
+        new IAE(
+            "Expected %s at line %s, column %s, but got %s from url[%s]",
+            expectedToken == null ? "end of stream" : expectedToken,
+            jp.getTokenLocation().getLineNr(),
+            jp.getTokenLocation().getColumnNr(),
+            jp.currentToken(),
+            url
+        )
+    );
+  }
+
+  private QueryException unexpectedEOF()
+  {
+    return convertException(
+        new IAE(
+            "Unexpected EOF at line %s, column %s from url[%s]",
+            jp.getTokenLocation().getLineNr(),
+            jp.getTokenLocation().getColumnNr(),
+            url
+        )
+    );
   }
 }

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -35,6 +35,7 @@ import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.GenericQueryMetricsFactory;
+import org.apache.druid.query.MultiQueryMetricsCollector;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryInterruptedException;
@@ -44,6 +45,8 @@ import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.QueryToolChestWarehouse;
+import org.apache.druid.query.SingleQueryMetricsCollector;
+import org.apache.druid.query.context.ConcurrentResponseContext;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.security.Access;
@@ -53,8 +56,11 @@ import org.apache.druid.server.security.AuthorizerMapper;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
+
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -66,18 +72,226 @@ import java.util.concurrent.TimeUnit;
  * <li>Initialization ({@link #initialize(Query)})</li>
  * <li>Authorization ({@link #authorize(HttpServletRequest)}</li>
  * <li>Execution ({@link #execute()}</li>
- * <li>Logging ({@link #emitLogsAndMetrics(Throwable, String, long)}</li>
+ * <li>Logging ({@link #emitLogsAndMetrics(Throwable)}</li>
  * </ol>
  *
  * This object is not thread-safe.
+ * <p>
+ * Druid accumulates a number of types of metrics and statistics for each query.
+ * The lifecycle object also gathers the query-level information into a single
+ * place, the <code>LifecycleStats</code>, the distributes it out to the multiple
+ * users.
  */
 public class QueryLifecycle
 {
   private static final Logger log = new Logger(QueryLifecycle.class);
 
+  /**
+   * Gathers query-level statistics then distributes them to the metrics system,
+   * logs, response trailer and query profile.
+   */
+  public class LifecycleStats
+  {
+    private DruidNode node;
+    private String remoteAddress;
+    private Query<?> receivedQuery;
+    private Set<String> trailerOptions;
+    private long endTimeNs;
+    private long bytesWritten = -1;
+    private long rowCount;
+    private ResponseContext responseContext;
+    private Throwable e;
+
+    /**
+     * Called by the query resource to provide the host on which this query is
+     * running, and the remote address that sent the request.
+     */
+    public void onStart(DruidNode node, String remoteAddress, Query<?> receivedQuery)
+    {
+      this.node = node;
+      this.remoteAddress = remoteAddress;
+      this.receivedQuery = receivedQuery;
+      this.trailerOptions = QueryContexts.getTrailerContents(receivedQuery);
+
+      // The "trailer" field controls the format of the response. Even
+      // if the value is invalid, if the key exists, use the trailer
+      // format.
+      if (trailerOptions == null && receivedQuery.getContextValue(QueryContexts.TRAILER_KEY) != null) {
+        trailerOptions = new HashSet<>();
+        trailerOptions.add(QueryContexts.TRAILER_METRICS);
+      }
+    }
+
+    /**
+     * Provides the response context when it becomes available. The actual values
+     * will continue to change as the query runs until a call to
+     * {#link onResultsSent()}.
+     */
+    public void setResponseContext(ResponseContext responseContext)
+    {
+      this.responseContext = responseContext;
+    }
+
+    /**
+     * Partial completion: results written, about to emit the trailer.
+     * Accumulate run time and bytes written up to now. Final result will
+     * differ a bit.
+     */
+    public void onResultsSent(long rowCount, long bytesWritten)
+    {
+      this.rowCount = rowCount;
+      this.bytesWritten = bytesWritten;
+      this.endTimeNs = System.nanoTime();
+    }
+
+    /**
+     * Final completion: all results sent, including the possible
+     * trailer.
+     */
+    public void onCompletion(Throwable e)
+    {
+      this.e = e;
+      this.endTimeNs = System.nanoTime();
+    }
+
+    public String queryId()
+    {
+      return baseQuery.getId();
+    }
+
+    public long runTimeNs()
+    {
+      return endTimeNs - startNs;
+    }
+
+    public long runTimeMs()
+    {
+      return TimeUnit.NANOSECONDS.toMillis(runTimeNs());
+    }
+
+    public boolean succeeded()
+    {
+      return e == null;
+    }
+
+    public String identity()
+    {
+      return authenticationResult == null ? null : authenticationResult.getIdentity();
+    }
+
+    public boolean wasInterrupted()
+    {
+      if (e == null) {
+        return false;
+      }
+      return (e instanceof QueryInterruptedException || e instanceof QueryTimeoutException);
+    }
+
+    /**
+     * Emit final metrics for the query.
+     */
+    public void emitMetrics()
+    {
+      @SuppressWarnings("unchecked")
+      QueryMetrics<?> queryMetrics = DruidMetrics.makeRequestMetrics(
+          queryMetricsFactory,
+          toolChest,
+          baseQuery,
+          StringUtils.nullToEmptyNonDruidDataString(stats.remoteAddress)
+      );
+      queryMetrics.success(succeeded());
+      queryMetrics.reportQueryTime(runTimeNs());
+
+      if (bytesWritten >= 0) {
+        queryMetrics.reportQueryBytes(bytesWritten);
+      }
+
+      String identify = identity();
+      if (identify != null) {
+        queryMetrics.identity(identify);
+      }
+    }
+
+    /**
+     * Gather the query statistics for metrics.
+     */
+    public QueryStats queryStats()
+    {
+      final Map<String, Object> statsMap = new LinkedHashMap<>();
+      statsMap.put("query/time", TimeUnit.NANOSECONDS.toMillis(runTimeNs()));
+      statsMap.put("query/bytes", bytesWritten);
+      statsMap.put("success", succeeded());
+
+      String identity = identity();
+      if (identity != null) {
+        statsMap.put("identity", identity);
+      }
+
+      if (e != null) {
+        statsMap.put("exception", e.toString());
+        if (QueryContexts.isDebug(baseQuery)) {
+          log.error(e, "Exception while processing queryId [%s]", baseQuery.getId());
+        } else {
+          log.noStackTrace().error(e, "Exception while processing queryId [%s]", baseQuery.getId());
+        }
+        if (wasInterrupted()) {
+          // Mimic behavior from QueryResource, where this code was originally taken from.
+          statsMap.put("interrupted", true);
+          statsMap.put("reason", e.toString());
+        }
+      }
+      return new QueryStats(statsMap);
+    }
+
+    public boolean includeTrailer()
+    {
+      return trailerOptions != null;
+    }
+
+    /**
+     * Create the response trailer, if requested. Includes the query profile as well
+     * as various other trailer fields.
+     * @return
+     */
+    public ResponseContext trailer()
+    {
+      // Should not get here if no trailer options were selected
+      assert trailerOptions != null;
+
+      // Note: from here on down the code here is basically the same as
+      // for SqlLifecycle. TODO: Factor out common code. Leaving for now
+      // because this are is under development.
+
+      // Include details?
+      final ResponseContext trailerContext;
+      if (trailerOptions.contains(QueryContexts.TRAILER_CONTEXT)) {
+        trailerContext = responseContext.trailerCopy();
+      } else {
+        trailerContext = ResponseContext.createEmpty();
+      }
+
+      // Include metrics?
+      if (trailerOptions.contains(QueryContexts.TRAILER_METRICS)) {
+        trailerContext.add(
+            ResponseContext.Keys.METRICS,
+            MultiQueryMetricsCollector.newCollector().add(
+                SingleQueryMetricsCollector
+                    .newCollector()
+                    .setQueryStart(getStartMs())
+                    // This is not the same as query/time, its a bit shorter
+                    .setQueryMs(runTimeMs())
+                    .setResultRows(rowCount)
+            )
+        );
+      }
+      return trailerContext;
+    }
+  }
+
   private final QueryToolChestWarehouse warehouse;
   private final QuerySegmentWalker texasRanger;
   private final GenericQueryMetricsFactory queryMetricsFactory;
+  @SuppressWarnings("unused")
   private final ServiceEmitter emitter;
   private final RequestLogger requestLogger;
   private final AuthorizerMapper authorizerMapper;
@@ -87,8 +301,10 @@ public class QueryLifecycle
 
   private State state = State.NEW;
   private AuthenticationResult authenticationResult;
+  @SuppressWarnings("rawtypes")
   private QueryToolChest toolChest;
-  private Query baseQuery;
+  private Query<?> baseQuery;
+  private final LifecycleStats stats;
 
   public QueryLifecycle(
       final QueryToolChestWarehouse warehouse,
@@ -111,8 +327,13 @@ public class QueryLifecycle
     this.defaultQueryConfig = defaultQueryConfig;
     this.startMs = startMs;
     this.startNs = startNs;
+    this.stats = new LifecycleStats();
   }
 
+  public LifecycleStats stats()
+  {
+    return stats;
+  }
 
   /**
    * For callers who have already authorized their query, and where simplicity is desired over flexibility. This method
@@ -126,7 +347,7 @@ public class QueryLifecycle
    * @return results
    */
   @SuppressWarnings("unchecked")
-  public <T> Sequence<T> runSimple(
+  public <T> QueryResponse<T> runSimple(
       final Query<T> query,
       final AuthenticationResult authenticationResult,
       final Access authorizationResult
@@ -134,7 +355,7 @@ public class QueryLifecycle
   {
     initialize(query);
 
-    final Sequence<T> results;
+    final QueryResponse<T> queryResponse;
 
     try {
       preAuthorized(authenticationResult, authorizationResult);
@@ -142,22 +363,20 @@ public class QueryLifecycle
         throw new ISE("Unauthorized");
       }
 
-      final QueryLifecycle.QueryResponse queryResponse = execute();
-      results = queryResponse.getResults();
+      queryResponse = (QueryResponse<T>) execute();
     }
     catch (Throwable e) {
-      emitLogsAndMetrics(e, null, -1);
+      emitLogsAndMetrics(e);
       throw e;
     }
 
-    return Sequences.wrap(
-        results,
+    return queryResponse.wrap(
         new SequenceWrapper()
         {
           @Override
           public void after(final boolean isDone, final Throwable thrown)
           {
-            emitLogsAndMetrics(thrown, null, -1);
+            emitLogsAndMetrics(thrown);
           }
         }
     );
@@ -168,8 +387,7 @@ public class QueryLifecycle
    *
    * @param baseQuery the query
    */
-  @SuppressWarnings("unchecked")
-  public void initialize(final Query baseQuery)
+  public void initialize(final Query<?> baseQuery)
   {
     transition(State.NEW, State.INITIALIZED);
 
@@ -180,7 +398,10 @@ public class QueryLifecycle
 
     Map<String, Object> mergedUserAndConfigContext;
     if (baseQuery.getContext() != null) {
-      mergedUserAndConfigContext = BaseQuery.computeOverriddenContext(defaultQueryConfig.getContext(), baseQuery.getContext());
+      mergedUserAndConfigContext = BaseQuery.computeOverriddenContext(
+          defaultQueryConfig.getContext(),
+          baseQuery.getContext()
+      );
     } else {
       mergedUserAndConfigContext = defaultQueryConfig.getContext();
     }
@@ -240,35 +461,32 @@ public class QueryLifecycle
   /**
    * Execute the query. Can only be called if the query has been authorized. Note that query logs and metrics will
    * not be emitted automatically when the Sequence is fully iterated. It is the caller's responsibility to call
-   * {@link #emitLogsAndMetrics(Throwable, String, long)} to emit logs and metrics.
+   * {@link #emitLogsAndMetrics(Throwable)} to emit logs and metrics.
    *
    * @return result sequence and response context
    */
-  public QueryResponse execute()
+  public QueryResponse<?> execute()
   {
     transition(State.AUTHORIZED, State.EXECUTING);
 
-    final ResponseContext responseContext = DirectDruidClient.makeResponseContextForQuery();
+    final ConcurrentResponseContext responseContext = DirectDruidClient.makeResponseContextForQuery();
 
-    final Sequence res = QueryPlus.wrap(baseQuery)
-                                  .withIdentity(authenticationResult.getIdentity())
-                                  .run(texasRanger, responseContext);
+    //noinspection unchecked
+    final Sequence<?> res =
+        QueryPlus.wrap(baseQuery)
+                 .withIdentity(authenticationResult.getIdentity())
+                 .run(texasRanger, responseContext);
 
-    return new QueryResponse(res == null ? Sequences.empty() : res, responseContext);
+    return QueryResponse.create(res == null ? Sequences.empty() : res, responseContext);
   }
 
   /**
    * Emit logs and metrics for this query.
    *
-   * @param e             exception that occurred while processing this query
-   * @param remoteAddress remote address, for logging; or null if unknown
-   * @param bytesWritten  number of bytes written; will become a query/bytes metric if >= 0
+   * @param e exception that occurred while processing this query
    */
-  @SuppressWarnings("unchecked")
   public void emitLogsAndMetrics(
-      @Nullable final Throwable e,
-      @Nullable final String remoteAddress,
-      final long bytesWritten
+      @Nullable final Throwable e
   )
   {
     if (baseQuery == null) {
@@ -282,59 +500,16 @@ public class QueryLifecycle
 
     state = State.DONE;
 
-    final boolean success = e == null;
-
+    stats.onCompletion(e);
     try {
-      final long queryTimeNs = System.nanoTime() - startNs;
-
-      QueryMetrics queryMetrics = DruidMetrics.makeRequestMetrics(
-          queryMetricsFactory,
-          toolChest,
-          baseQuery,
-          StringUtils.nullToEmptyNonDruidDataString(remoteAddress)
-      );
-      queryMetrics.success(success);
-      queryMetrics.reportQueryTime(queryTimeNs);
-
-      if (bytesWritten >= 0) {
-        queryMetrics.reportQueryBytes(bytesWritten);
-      }
-
-      if (authenticationResult != null) {
-        queryMetrics.identity(authenticationResult.getIdentity());
-      }
-
-      queryMetrics.emit(emitter);
-
-      final Map<String, Object> statsMap = new LinkedHashMap<>();
-      statsMap.put("query/time", TimeUnit.NANOSECONDS.toMillis(queryTimeNs));
-      statsMap.put("query/bytes", bytesWritten);
-      statsMap.put("success", success);
-
-      if (authenticationResult != null) {
-        statsMap.put("identity", authenticationResult.getIdentity());
-      }
-
-      if (e != null) {
-        statsMap.put("exception", e.toString());
-        if (QueryContexts.isDebug(baseQuery)) {
-          log.warn(e, "Exception while processing queryId [%s]", baseQuery.getId());
-        } else {
-          log.noStackTrace().warn(e, "Exception while processing queryId [%s]", baseQuery.getId());
-        }
-        if (e instanceof QueryInterruptedException || e instanceof QueryTimeoutException) {
-          // Mimic behavior from QueryResource, where this code was originally taken from.
-          statsMap.put("interrupted", true);
-          statsMap.put("reason", e.toString());
-        }
-      }
+      stats.emitMetrics();
 
       requestLogger.logNativeQuery(
           RequestLogLine.forNative(
               baseQuery,
               DateTimes.utc(startMs),
-              StringUtils.nullToEmptyNonDruidDataString(remoteAddress),
-              new QueryStats(statsMap)
+              StringUtils.nullToEmptyNonDruidDataString(stats.remoteAddress),
+              stats.queryStats()
           )
       );
     }
@@ -343,11 +518,12 @@ public class QueryLifecycle
     }
   }
 
-  public Query getQuery()
+  public Query<?> getQuery()
   {
     return baseQuery;
   }
 
+  @SuppressWarnings("rawtypes")
   public QueryToolChest getToolChest()
   {
     if (state.compareTo(State.INITIALIZED) < 0) {
@@ -356,6 +532,11 @@ public class QueryLifecycle
 
     //noinspection unchecked
     return toolChest;
+  }
+
+  public long getStartMs()
+  {
+    return startMs;
   }
 
   private void transition(final State from, final State to)
@@ -376,27 +557,5 @@ public class QueryLifecycle
     EXECUTING,
     UNAUTHORIZED,
     DONE
-  }
-
-  public static class QueryResponse
-  {
-    private final Sequence results;
-    private final ResponseContext responseContext;
-
-    private QueryResponse(final Sequence results, final ResponseContext responseContext)
-    {
-      this.results = results;
-      this.responseContext = responseContext;
-    }
-
-    public Sequence getResults()
-    {
-      return results;
-    }
-
-    public ResponseContext getResponseContext()
-    {
-      return responseContext;
-    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/QueryResponse.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResponse.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server;
+
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.guava.SequenceWrapper;
+import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.query.context.ConcurrentResponseContext;
+import org.apache.druid.query.context.ResponseContext;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+/**
+ * Wraps the two results from a query: the results and the response context.
+ */
+public class QueryResponse<T>
+{
+  private final Sequence<T> results;
+  private final ResponseContext responseContext;
+  private final AtomicBoolean resultsComplete;
+
+  private QueryResponse(
+      final Sequence<T> results,
+      final ResponseContext responseContext,
+      final AtomicBoolean resultsComplete
+  )
+  {
+    this.results = results;
+    this.responseContext = responseContext;
+    this.resultsComplete = resultsComplete;
+  }
+
+  public static <T> QueryResponse<T> create(final Sequence<T> results, final ResponseContext responseContext)
+  {
+    final AtomicBoolean resultsComplete = new AtomicBoolean();
+
+    return new QueryResponse<>(
+        Sequences.wrap(
+            results,
+            new SequenceWrapper()
+            {
+              @Override
+              public void after(boolean isDone, Throwable thrown)
+              {
+                resultsComplete.compareAndSet(false, isDone);
+              }
+            }
+        ),
+        responseContext,
+        resultsComplete
+    );
+  }
+
+
+  public static <T> QueryResponse<T> createWithEmptyContext(final Sequence<T> results)
+  {
+    return create(results, ConcurrentResponseContext.createEmpty());
+  }
+
+  /**
+   * Returns the results.
+   */
+  public Sequence<T> getResults()
+  {
+    return results;
+  }
+
+  /**
+   * Returns the response context. Will only be present after the results have been successfully and fully walked.
+   */
+  public Optional<ResponseContext> getResponseContext()
+  {
+    if (resultsComplete.get()) {
+      return Optional.of(responseContext);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Returns the response context. Will be present even before results have been successfully and fully walked.
+   * It may still be undergoing mutation, so it is up to you, the caller, to only access fields with thread-safe values.
+   *
+   * In most cases it is safer to use {@link #getResponseContext()}.
+   */
+  public ResponseContext getResponseContextEarly()
+  {
+    return responseContext;
+  }
+
+  public <U> QueryResponse<U> map(final Function<Sequence<T>, Sequence<U>> mapper)
+  {
+    return new QueryResponse<>(mapper.apply(results), responseContext, resultsComplete);
+  }
+
+  public QueryResponse<T> wrap(final SequenceWrapper wrapper)
+  {
+    return new QueryResponse<>(Sequences.wrap(results, wrapper), responseContext, resultsComplete);
+  }
+
+  /**
+   * Create a new response with new (presumably rewritten) results.
+   */
+  public QueryResponse<T> rewrite(Sequence<T> newResults)
+  {
+    return new QueryResponse<>(newResults, responseContext, resultsComplete);
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -89,12 +89,23 @@ public class ServerConfig
 
   public ServerConfig()
   {
-
   }
 
   @JsonProperty
   @Min(1)
   private int numThreads = getDefaultNumThreads();
+
+  /**
+   * Minimum number of threads in the thread pool. Also the number of threads that
+   * the pool creates at startup. A negative value (the default) means
+   * to use the {@code numThreads} value for backward compatibility. The thread
+   * pool will create additional threads on demand up to {@code numThreads}.
+   * <p>
+   * This property is primarily for debugging: to reduce the number of threads to
+   * a small number (2 or 3) to make debugging a bit easier.
+   */
+  @JsonProperty
+  private int minThreads = -1;
 
   @JsonProperty
   @Min(1)
@@ -161,6 +172,11 @@ public class ServerConfig
   public int getNumThreads()
   {
     return numThreads;
+  }
+
+  public int getMinThreads()
+  {
+    return minThreads;
   }
 
   public int getQueueSize()
@@ -255,6 +271,7 @@ public class ServerConfig
     }
     ServerConfig that = (ServerConfig) o;
     return numThreads == that.numThreads &&
+           minThreads == that.minThreads &&
            queueSize == that.queueSize &&
            enableRequestLimit == that.enableRequestLimit &&
            defaultQueryTimeout == that.defaultQueryTimeout &&
@@ -278,6 +295,7 @@ public class ServerConfig
   {
     return Objects.hash(
         numThreads,
+        minThreads,
         queueSize,
         enableRequestLimit,
         maxIdleTime,
@@ -302,6 +320,7 @@ public class ServerConfig
   {
     return "ServerConfig{" +
            "numThreads=" + numThreads +
+           ", minThreads=" + minThreads +
            ", queueSize=" + queueSize +
            ", enableRequestLimit=" + enableRequestLimit +
            ", maxIdleTime=" + maxIdleTime +

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -121,7 +121,6 @@ public class DirectDruidClientTest
     serverSelector.addServerAndUpdateSegment(queryableDruidServer, serverSelector.getSegment());
   }
 
-
   @Test
   public void testRun() throws Exception
   {

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorSyntaxTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorSyntaxTest.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.druid.client.JsonParserIterator.ResultStructure;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.query.QueryInterruptedException;
+import org.apache.druid.query.ResourceLimitExceededException;
+import org.apache.druid.query.context.ResponseContext;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test the syntax rules for the JSON parser iterator:
+ * handling of array and object values, bogus values, etc.
+ */
+public class JsonParserIteratorSyntaxTest
+{
+  private static final String URL = "http:/host/resource";
+  private static final String HOST = "host";
+  private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapper();
+  private static final JavaType JAVA_TYPE = OBJECT_MAPPER.getTypeFactory().constructType(String.class);
+
+  private static class InputFuture implements Future<InputStream>
+  {
+    private final String json;
+
+    private InputFuture(String json)
+    {
+      this.json = json;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning)
+    {
+      return false;
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+      return false;
+    }
+
+    @Override
+    public boolean isDone()
+    {
+      return false;
+    }
+
+    @Override
+    public InputStream get()
+    {
+      if (json == null) {
+        return null;
+      }
+      return new ReaderInputStream(new StringReader(json), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public InputStream get(long timeout, TimeUnit unit)
+    {
+      return get();
+    }
+  }
+
+  private JsonParserIterator<String> createIterator(
+      ResultStructure kind,
+      String json)
+  {
+    return new JsonParserIterator<>(
+        kind,
+        JAVA_TYPE,
+        new InputFuture(json),
+        URL,
+        null,
+        HOST,
+        OBJECT_MAPPER
+        );
+  }
+
+  @Test
+  public void testNullInput()
+  {
+    for (ResultStructure kind : ResultStructure.values()) {
+      try {
+        createIterator(kind, null).hasNext();
+        fail();
+      }
+      catch (ResourceLimitExceededException e) {
+        // Expected
+      }
+    }
+  }
+
+  @Test
+  public void testEmptyArrayInput()
+  {
+    for (ResultStructure kind : ResultStructure.values()) {
+      try {
+        createIterator(kind, "").hasNext();
+        fail();
+      }
+      catch (QueryInterruptedException e) {
+        assertTrue(e.getMessage().startsWith("Unexpected EOF"));
+      }
+    }
+  }
+
+  @Test
+  public void testScalarInput()
+  {
+    try {
+      createIterator(ResultStructure.ARRAY, "10").hasNext();
+      fail();
+    }
+    catch (QueryInterruptedException e) {
+      assertTrue(e.getMessage().startsWith("Expected START_ARRAY"));
+    }
+    catch (Exception e) {
+      fail();
+    }
+    try {
+      createIterator(ResultStructure.OBJECT, "10").hasNext();
+      fail();
+    }
+    catch (QueryInterruptedException e) {
+      assertTrue(e.getMessage().startsWith("Expected START_OBJECT"));
+    }
+    catch (Exception e) {
+      fail();
+    }
+  }
+
+  @Test
+  public void testMalformedObject()
+  {
+    // The JSON parser catches malformed JSON
+    try {
+      createIterator(ResultStructure.ARRAY, "{").hasNext();
+      fail();
+    }
+    catch (QueryInterruptedException e) {
+      assertTrue(e.getMessage().startsWith("Unexpected end-of-input"));
+    }
+  }
+
+  /**
+   * The JSON iterator expects at least one field.
+   */
+  @Test
+  public void testEmptyObject()
+  {
+    final String input = "{}";
+    for (ResultStructure kind : ResultStructure.values()) {
+      try {
+        createIterator(kind, input).hasNext();
+        fail();
+      }
+      catch (QueryInterruptedException e) {
+        assertTrue(e.getMessage().startsWith("Expected FIELD_NAME"));
+      }
+    }
+  }
+
+  @Test
+  public void testUnkownObject()
+  {
+    final String input = "{\"foo\": 10}";
+    for (ResultStructure kind : ResultStructure.values()) {
+      try {
+        createIterator(kind, input).hasNext();
+        fail();
+      }
+      catch (QueryInterruptedException e) {
+        assertTrue(e.getMessage().startsWith("Unexpected starting field[foo]"));
+      }
+    }
+  }
+
+  /**
+   * The minimal acceptable error result is to include the "error" field
+   * as that's how the parser knows its an error.
+   */
+  @Test
+  public void testMinimalErrorResult()
+  {
+    final String input = "{\"error\": \"bad\"}";
+    for (ResultStructure kind : ResultStructure.values()) {
+      try {
+        createIterator(kind, input).hasNext();
+        fail();
+      }
+      catch (QueryInterruptedException e) {
+        assertEquals("bad", e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Other error fields can occur, but must occur after "error".
+   * This is a harmless deviation from standard JSON which says
+   * fields can occur in any order.
+   */
+  @Test
+  public void testFullErrorResult()
+  {
+    final String input = "{\"error\": \"bad\", \"errorMessage\": \"msg\"}";
+    for (ResultStructure kind : ResultStructure.values()) {
+      try {
+        createIterator(kind, input).hasNext();
+        fail();
+      }
+      catch (QueryInterruptedException e) {
+        assertEquals("msg", e.getMessage());
+      }
+    }
+  }
+
+  @Test
+  public void testArrayResult()
+  {
+    final String input = "[\"first\", \"second\"]";
+    for (ResultStructure kind : ResultStructure.values()) {
+      JsonParserIterator<String> iter = createIterator(kind, input);
+      assertTrue(iter.hasNext());
+      assertEquals("first", iter.next());
+      assertTrue(iter.hasNext());
+      assertEquals("second", iter.next());
+      assertFalse(iter.hasNext());
+      assertEquals(2, iter.getResultRows());
+      assertTrue(iter.isSuccess());
+    }
+  }
+
+  @Test
+  public void testEmptyArrayResult()
+  {
+    final String input = "[]";
+    for (ResultStructure kind : ResultStructure.values()) {
+      JsonParserIterator<String> iter = createIterator(kind, input);
+      assertFalse(iter.hasNext());
+      assertEquals(0, iter.getResultRows());
+      assertTrue(iter.isSuccess());
+    }
+  }
+
+  /**
+   * Nulls should not occur in the result list. But, if they
+   * do, ensure the parser handles them.
+   */
+  @Test
+  public void testNullArrayResult()
+  {
+    final String input = "[\"first\", null]";
+    for (ResultStructure kind : ResultStructure.values()) {
+      Iterator<String> iter = createIterator(kind, input);
+      assertTrue(iter.hasNext());
+      assertEquals("first", iter.next());
+      assertTrue(iter.hasNext());
+      assertNull(iter.next());
+      assertFalse(iter.hasNext());
+    }
+  }
+
+  /**
+   * Fail if the server returns an object format when we asked for
+   * an array.
+   */
+  @Test
+  public void testObjectForArray()
+  {
+    final String input = "{\"results\": []}";
+    try {
+      createIterator(ResultStructure.ARRAY, input).hasNext();
+      fail();
+    }
+    catch (QueryInterruptedException e) {
+      assertTrue(e.getMessage().startsWith("Got object format, expected array"));
+    }
+  }
+
+  /**
+   * The minimal object format is just an empty results array.
+   */
+  @Test
+  public void testEmptyObjectResults()
+  {
+    final String input = "{\"results\": []}";
+    Iterator<String> iter = createIterator(ResultStructure.OBJECT, input);
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testObjectResults()
+  {
+    final String input = "{\"results\": [\"first\", \"second\"]}";
+    JsonParserIterator<String> iter = createIterator(ResultStructure.OBJECT, input);
+    assertTrue(iter.hasNext());
+    assertEquals("first", iter.next());
+    assertTrue(iter.hasNext());
+    assertEquals("second", iter.next());
+    assertFalse(iter.hasNext());
+    assertEquals(2, iter.getResultRows());
+    assertTrue(iter.isSuccess());
+  }
+
+  /**
+   * For forward-compatibility, the parser ignores unexpected
+   * fields in the object result. Verify that the parser "free wheels"
+   * over any unexpected values, even if structured.
+   */
+  @Test
+  public void testUnexpectedObjectField()
+  {
+    {
+      final String input = "{\"results\": [], \"bogus\": 10}";
+      JsonParserIterator<String> iter = createIterator(ResultStructure.OBJECT, input);
+      assertFalse(iter.hasNext());
+      assertEquals(0, iter.getResultRows());
+      assertTrue(iter.isSuccess());
+      assertNull(iter.responseTrailer());
+    }
+    {
+      final String input = "{\"results\": [], " +
+          "\"bogus\": {\"foo\": 10}}";
+      JsonParserIterator<String> iter = createIterator(ResultStructure.OBJECT, input);
+      assertFalse(iter.hasNext());
+      assertEquals(0, iter.getResultRows());
+      assertTrue(iter.isSuccess());
+      assertNull(iter.responseTrailer());
+    }
+    {
+      final String input = "{\"results\": [], " +
+          "\"bogus\": [10]}";
+      JsonParserIterator<String> iter = createIterator(ResultStructure.OBJECT, input);
+      assertFalse(iter.hasNext());
+      assertEquals(0, iter.getResultRows());
+      assertTrue(iter.isSuccess());
+      assertNull(iter.responseTrailer());
+    }
+  }
+
+  /**
+   * We finally get to the point of all the above: the response
+   * trailer, which itself may have unknown fields.
+   */
+  @Test
+  public void testTrailer()
+  {
+    final String input = "{\"results\": [\"first\", \"second\"]," +
+          "\"context\": {\"ETag\": \"the tag\"," +
+          "\"bogus\": 10}}";
+    JsonParserIterator<String> iter = createIterator(ResultStructure.OBJECT, input);
+    assertTrue(iter.hasNext());
+    assertEquals("first", iter.next());
+    assertTrue(iter.hasNext());
+    assertEquals("second", iter.next());
+    assertFalse(iter.hasNext());
+    assertEquals(2, iter.getResultRows());
+    assertTrue(iter.isSuccess());
+    ResponseContext context = iter.responseTrailer();
+    assertNotNull(context);
+    assertEquals("the tag", context.getEntityTag());
+    assertEquals(1, context.toMap().size());
+  }
+}

--- a/server/src/test/java/org/apache/druid/client/TestHttpClient.java
+++ b/server/src/test/java/org/apache/druid/client/TestHttpClient.java
@@ -127,7 +127,7 @@ public class TestHttpClient implements HttpClient
         objectMapper.writeValue(baos, sequence);
         serializedContent = baos.toByteArray();
       }
-      final ResponseContext.SerializationResult serializationResult = responseContext.serializeWith(
+      final ResponseContext.SerializationResult serializationResult = responseContext.toHeader(
           objectMapper,
           RESPONSE_CTX_HEADER_LEN_LIMIT
       );

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -79,6 +79,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * This class does async query processing and should be merged with QueryResource at some point
  */
+@SuppressWarnings("serial")
 public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements QueryCountStatsProvider
 {
   private static final EmittingLogger LOG = new EmittingLogger(AsyncQueryForwardingServlet.class);

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -305,7 +305,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     Mockito.verify(mockMapper).writeValue(ArgumentMatchers.eq(outputStream), captor.capture());
     Assert.assertTrue(captor.getValue() instanceof QueryException);
     Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertNull(captor.getValue().getMessage());
+    Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, captor.getValue().getMessage());
     Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
     Assert.assertNull(((QueryException) captor.getValue()).getHost());
   }
@@ -429,7 +429,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     Mockito.verify(mockMapper).writeValue(ArgumentMatchers.eq(outputStream), captor.capture());
     Assert.assertTrue(captor.getValue() instanceof QueryException);
     Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertNull(captor.getValue().getMessage());
+    Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, captor.getValue().getMessage());
     Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
     Assert.assertNull(((QueryException) captor.getValue()).getHost());
   }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidStatement.java
@@ -217,7 +217,8 @@ public class DruidStatement implements Closeable
         sqlLifecycle.setParameters(parameters);
         sqlLifecycle.validateAndAuthorize(authenticationResult);
         sqlLifecycle.plan();
-        final Sequence<Object[]> baseSequence = yielderOpenCloseExecutor.submit(sqlLifecycle::execute).get();
+        final Sequence<Object[]> baseSequence =
+            yielderOpenCloseExecutor.submit(sqlLifecycle::execute).get().getResults();
 
         // We can't apply limits greater than Integer.MAX_VALUE, ignore them.
         final Sequence<Object[]> retSequence =
@@ -342,7 +343,7 @@ public class DruidStatement implements Closeable
         try {
           onClose.run();
           synchronized (lock) {
-            sqlLifecycle.finalizeStateAndEmitLogsAndMetrics(t, null, -1);
+            sqlLifecycle.finalizeStateAndEmitLogsAndMetrics(t);
           }
         }
         catch (Throwable t1) {
@@ -358,7 +359,7 @@ public class DruidStatement implements Closeable
       try {
         if (!(this.throwable instanceof ForbiddenException)) {
           synchronized (lock) {
-            sqlLifecycle.finalizeStateAndEmitLogsAndMetrics(this.throwable, null, -1);
+            sqlLifecycle.finalizeStateAndEmitLogsAndMetrics(this.throwable);
           }
         } else {
           DruidMeta.logFailure(this.throwable);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerResult.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerResult.java
@@ -21,7 +21,7 @@ package org.apache.druid.sql.calcite.planner;
 
 import com.google.common.base.Supplier;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.server.QueryResponse;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -31,12 +31,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class PlannerResult
 {
-  private final Supplier<Sequence<Object[]>> resultsSupplier;
+  private final Supplier<QueryResponse<Object[]>> resultsSupplier;
   private final RelDataType rowType;
   private final AtomicBoolean didRun = new AtomicBoolean();
 
   public PlannerResult(
-      final Supplier<Sequence<Object[]>> resultsSupplier,
+      final Supplier<QueryResponse<Object[]>> resultsSupplier,
       final RelDataType rowType
   )
   {
@@ -47,7 +47,7 @@ public class PlannerResult
   /**
    * Run the query
    */
-  public Sequence<Object[]> run()
+  public QueryResponse<Object[]> run()
   {
     if (!didRun.compareAndSet(false, true)) {
       // Safety check.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidRel.java
@@ -22,12 +22,13 @@ package org.apache.druid.sql.calcite.rel;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
-import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.server.QueryResponse;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
 import java.util.Set;
 
+@SuppressWarnings("rawtypes")
 public abstract class DruidRel<T extends DruidRel> extends AbstractRelNode
 {
   private final PlannerContext plannerContext;
@@ -45,7 +46,7 @@ public abstract class DruidRel<T extends DruidRel> extends AbstractRelNode
   @Nullable
   public abstract PartialDruidQuery getPartialDruidQuery();
 
-  public Sequence<Object[]> runQuery()
+  public QueryResponse<Object[]> runQuery()
   {
     // runQuery doesn't need to finalize aggregations, because the fact that runQuery is happening suggests this
     // is the outermost query, and it will actually get run as a native query. Druid's native query layer will

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/QueryMaker.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/QueryMaker.java
@@ -20,7 +20,7 @@
 package org.apache.druid.sql.calcite.run;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.server.QueryResponse;
 import org.apache.druid.sql.calcite.rel.DruidQuery;
 
 /**
@@ -38,5 +38,5 @@ public interface QueryMaker extends QueryFeatureInspector
    * Executes a given Druid query, which is expected to correspond to the SQL query that this QueryMaker was originally
    * created for. The returned arrays match the row type given by {@link #getResultType()}.
    */
-  Sequence<Object[]> runQuery(DruidQuery druidQuery);
+  QueryResponse<Object[]> runQuery(DruidQuery druidQuery);
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -899,7 +899,10 @@ public class DruidSchema extends AbstractSchema
 
     return queryLifecycleFactory
         .factorize()
-        .runSimple(segmentMetadataQuery, escalator.createEscalatedAuthenticationResult(), Access.OK);
+        .runSimple(
+            segmentMetadataQuery,
+            escalator.createEscalatedAuthenticationResult(),
+            Access.OK).getResults();
   }
 
   @VisibleForTesting

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -1079,6 +1079,7 @@ public class SystemSchema extends AbstractSchema
 
     final JavaType javaType = jsonMapper.getTypeFactory().constructType(typeRef);
     return new JsonParserIterator<>(
+        JsonParserIterator.ResultStructure.ARRAY,
         javaType,
         Futures.immediateFuture(responseHolder.getContent()),
         request.getUrl().toString(),

--- a/sql/src/main/java/org/apache/druid/sql/http/ArrayWithTrailerWriter.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/ArrayWithTrailerWriter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.client.JsonParserIterator;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.query.context.ResponseContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ArrayWithTrailerWriter extends ArrayWriter
+{
+  private boolean wroteTrailer;
+
+  public ArrayWithTrailerWriter(final OutputStream outputStream, final ObjectMapper jsonMapper) throws IOException
+  {
+    super(outputStream, jsonMapper);
+  }
+
+  @Override
+  public void writeResponseStart() throws IOException
+  {
+    jsonGenerator.writeStartObject();
+    jsonGenerator.writeFieldName(JsonParserIterator.FIELD_RESULTS);
+    jsonGenerator.writeStartArray();
+  }
+
+  @Override
+  public void writeTrailer(final ResponseContext context) throws IOException
+  {
+    if (wroteTrailer) {
+      throw new ISE("Cannot write trailer more than once");
+    }
+
+    // Assumes the caller has included only the desired fields in the context
+    jsonGenerator.writeEndArray();
+    jsonGenerator.writeObjectField(JsonParserIterator.FIELD_CONTEXT, context.toMap());
+    jsonGenerator.writeEndObject();
+    wroteTrailer = true;
+  }
+
+  @Override
+  public void writeResponseEnd() throws IOException
+  {
+    if (!wroteTrailer) {
+      throw new ISE("Expected trailer before response end");
+    }
+
+    // End with LF.
+    jsonGenerator.flush();
+    outputStream.write('\n');
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/http/ArrayWriter.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/ArrayWriter.java
@@ -31,8 +31,8 @@ import java.io.OutputStream;
 
 public class ArrayWriter implements ResultFormat.Writer
 {
-  private final JsonGenerator jsonGenerator;
-  private final OutputStream outputStream;
+  protected final JsonGenerator jsonGenerator;
+  protected final OutputStream outputStream;
 
   public ArrayWriter(final OutputStream outputStream, final ObjectMapper jsonMapper) throws IOException
   {

--- a/sql/src/test/java/org/apache/druid/sql/SqlLifecycleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlLifecycleTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
 import org.apache.druid.query.QueryContexts;
+import org.apache.druid.server.QueryResponse;
 import org.apache.druid.server.QueryStackTests;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.security.Access;
@@ -156,7 +157,9 @@ public class SqlLifecycleTest
     EasyMock.reset(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
 
     // test execute
-    EasyMock.expect(mockPlanResult.run()).andReturn(Sequences.simple(ImmutableList.of(new Object[]{2L}))).once();
+    EasyMock.expect(mockPlanResult.run())
+            .andReturn(QueryResponse.createWithEmptyContext(Sequences.simple(ImmutableList.of(new Object[]{2L}))))
+            .once();
     EasyMock.replay(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
     lifecycle.execute();
     Assert.assertEquals(SqlLifecycle.State.EXECUTING, lifecycle.getState());
@@ -177,7 +180,8 @@ public class SqlLifecycleTest
     EasyMock.expectLastCall();
     EasyMock.replay(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
 
-    lifecycle.finalizeStateAndEmitLogsAndMetrics(null, null, 10);
+    lifecycle.stats().onResultsSent(10, 10);
+    lifecycle.finalizeStateAndEmitLogsAndMetrics(null);
     Assert.assertEquals(SqlLifecycle.State.DONE, lifecycle.getState());
     EasyMock.verify(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
     EasyMock.reset(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
@@ -259,7 +263,7 @@ public class SqlLifecycleTest
     EasyMock.reset(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
 
     // test execute
-    EasyMock.expect(mockPlanResult.run()).andReturn(Sequences.simple(ImmutableList.of(new Object[]{2L}))).once();
+    EasyMock.expect(mockPlanResult.run()).andReturn(QueryResponse.createWithEmptyContext(Sequences.simple(ImmutableList.of(new Object[]{2L})))).once();
     EasyMock.replay(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
     lifecycle.execute();
     Assert.assertEquals(SqlLifecycle.State.EXECUTING, lifecycle.getState());
@@ -280,7 +284,8 @@ public class SqlLifecycleTest
     EasyMock.expectLastCall();
     EasyMock.replay(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
 
-    lifecycle.finalizeStateAndEmitLogsAndMetrics(null, null, 10);
+    lifecycle.stats().onResultsSent(10, 10);
+    lifecycle.finalizeStateAndEmitLogsAndMetrics(null);
     Assert.assertEquals(SqlLifecycle.State.DONE, lifecycle.getState());
     EasyMock.verify(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);
     EasyMock.reset(plannerFactory, serviceEmitter, requestLogger, mockPlanner, mockPlannerContext, mockPrepareResult, mockPlanResult);

--- a/sql/src/test/java/org/apache/druid/sql/avatica/ErrorHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/ErrorHandlerTest.java
@@ -44,7 +44,7 @@ public class ErrorHandlerTest
     QueryException input = new QueryException("error", "error message", "error class", "host");
 
     RuntimeException output = errorHandler.sanitize(input);
-    Assert.assertNull(output.getMessage());
+    Assert.assertEquals("error", output.getMessage());
   }
 
   @Test
@@ -92,6 +92,6 @@ public class ErrorHandlerTest
 
     Exception input = new Exception("message");
     RuntimeException output = errorHandler.sanitize(input);
-    Assert.assertEquals(null, output.getMessage());
+    Assert.assertEquals("Unknown exception", output.getMessage());
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -827,7 +827,10 @@ public class BaseCalciteQueryTest extends CalciteTestBase
         objectMapper
     );
 
-    return sqlLifecycleFactory.factorize().runSimple(sql, queryContext, parameters, authenticationResult).toList();
+    return sqlLifecycleFactory.factorize()
+                              .runSimple(sql, queryContext, parameters, authenticationResult)
+                              .getResults()
+                              .toList();
   }
 
   public void verifyResults(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -4486,7 +4486,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
 
     QueryLifecycleFactory qlf = CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate);
     QueryLifecycle ql = qlf.factorize();
-    Sequence seq = ql.runSimple(query, CalciteTests.SUPER_USER_AUTH_RESULT, Access.OK);
+    Sequence seq = ql.runSimple(query, CalciteTests.SUPER_USER_AUTH_RESULT, Access.OK).getResults();
     List<Object> results = seq.toList();
     Assert.assertEquals(
         ImmutableList.of(ResultRow.of("def")),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlVectorizedExpressionSanityTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlVectorizedExpressionSanityTest.java
@@ -190,8 +190,8 @@ public class SqlVectorizedExpressionSanityTest extends InitializedNullHandlingTe
     ) {
       final PlannerResult vectorPlan = vectorPlanner.plan();
       final PlannerResult nonVectorPlan = nonVectorPlanner.plan();
-      final Sequence<Object[]> vectorSequence = vectorPlan.run();
-      final Sequence<Object[]> nonVectorSequence = nonVectorPlan.run();
+      final Sequence<Object[]> vectorSequence = vectorPlan.run().getResults();
+      final Sequence<Object[]> nonVectorSequence = nonVectorPlan.run().getResults();
       Yielder<Object[]> vectorizedYielder = Yielders.each(vectorSequence);
       Yielder<Object[]> nonVectorizedYielder = Yielders.each(nonVectorSequence);
       int row = 0;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/TestInsertQueryMaker.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/TestInsertQueryMaker.java
@@ -25,9 +25,9 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.server.QueryResponse;
 import org.apache.druid.sql.calcite.rel.DruidQuery;
 import org.apache.druid.sql.calcite.run.QueryFeature;
 import org.apache.druid.sql.calcite.run.QueryMaker;
@@ -87,7 +87,7 @@ public class TestInsertQueryMaker implements QueryMaker
   }
 
   @Override
-  public Sequence<Object[]> runQuery(final DruidQuery druidQuery)
+  public QueryResponse<Object[]> runQuery(final DruidQuery druidQuery)
   {
     // Don't actually execute anything, but do record information that tests will check for.
 
@@ -95,6 +95,7 @@ public class TestInsertQueryMaker implements QueryMaker
     Hook.QUERY_PLAN.run(druidQuery.getQuery());
 
     // 2) Return the dataSource and signature of the insert operation, so tests can confirm they are correct.
-    return Sequences.simple(ImmutableList.of(new Object[]{targetDataSource, signature}));
+    return QueryResponse.createWithEmptyContext(
+        Sequences.simple(ImmutableList.of(new Object[]{targetDataSource, signature})));
   }
 }


### PR DESCRIPTION
Provides a *response trailer* mechanism to include a map of values in the query response after the usual data results.

### Motivation

Druid runs queries using a REST request/response protocol in which the response contains the query result set. There are several use cases where it would be useful to return additional performance data along with the result set. A concrete example is the [query profile](https://github.com/apache/drill/issues/2350) which can optionally return the profile when a query runs. Further, the query profile mechanism uses the response trailer to return a partial profile from each data node during execution.

When not returning a full profile, it is still useful to return a small set of overall metrics. This PR includes only those summary metrics.

Since query metrics are available, by definition, only at the completion of a query, it is necessary to return metrics and profile information *after* the data. Thus, the existing before-the-data header mechanism is not a good fit for this use case and we instead introduce a *response trailer* mechanism.

### Credit

This PR and description are derived from a prototype which @gianm created.

### Design

When running a query with a JSON response format, the response is just the response set as an array of rows, where the rows can be in various formats. When the response trailer is enabled, the JSON response format changes to an object which includes the result set as one of the fields.

This change is clearly highly visible to clients which may expect the JSON array format. To avoid breaking such clients, the client must specifically request the revised format.

#### `ResponseContext` changes

The `ResponseContext` gains a new field, `metrics` to gather the summary metrics. The field contains the object that generates the metrics shown in the API below. On the Broker, the `ResponseContext` may contain metrics for multiple subqueries.

A previous PR clearly identified those `ResponseContext` fields which are to appear in the response header. Those fields not in the header are considered internal fields. This PR extends the idea to tag keys that appear in the trailer. The result is that fields can appear in the header, trailer, both or neither. ("Neither" is useful for keys that are only used internally by query engines within one server, like `timeoutAt` and `count`.)  

The new `metrics` key is tagged as trailer-only.

#### "Starter" metrics

Until the full query profile is available, this PR motivates the response trailer by providing some basic metrics within the `metrics` key:

* `resultRows`: the number of rows returned
* `queryStart`: Query start time
* `queryMs`: Query duration (up until the trailer is written)

In addition, the trailer contains fields which may have been truncated in the header:

* `uncoveredIntervals`
* `missingSegments`

#### `QueryLifecycle` and `SqlLifecycle` changes

The `QueryResource` and `SqlResource` classes process each query, return the results, log data, return the response trailer (in this PR) and, later, will assemble and return the profile.

To better organize this work, the lifecycle classes each gain a `LifecycleStats` that gathers and distributes the above statistics.

#### `QueryResponse`

The SQL-related code to run a query consists of many layers of functions which take the query as input and returns a sequence. The response context is created several layers down in the stack. To return the trailer, we must return the response context up through those top layers that today return only a sequence. The existing `QueryResponse` is pressed into service to solve this issue by wrapping the output sequence and the query profile.

The profile is made available in the `QueryResponse`, but it is not fully populated until the root `Sequence` returns all its results.

#### `Query` changes

Druid queries return a variety of results. The objects returned by a `Sequence` may not represent rows, but rather query-specific batches of rows. To obtain a row count, we must know how to interpret those results. The new `Query.getRowCountOf()` method does this work.

#### `DirectDruidClient` changes

The internal Druid client uses the new results-with-trailer format. It copies the trailer fields into the client-side response context. The Broker-side merge merges results from may clients into the final response context.

### Rationale

The design does not use HTTP trailers. In theory the response context could have been sent using HTTP trailers. However, client and proxy support for HTTP trailers is spotty, and it isn't clear how much data is safe to send in a trailer. For these reasons, we chose to include the trailer in the regular response.

### API

#### Request

In native, include `trailer` context field. The two supported values are:

`metrics`: include the metrics as described below.
`context`: include all fields from the `ResponseContext` marked as included in the trailer.

The `trailer` value can be a single string or an array of strings. To include both metrics and the full context:

```text
POST /druid/v2/
{ ... // other query fields
  "context": { "trailer": [ "metrics", "context" ] }
}
```

The array form allows us to add additional trailer information in the future, such as the query profile mentioned above.

Unsupported values are ignored. Since the presence of the `trailer` field changes the result format of the query, to be extra cautious, the trailer format is used any time the field is present, even if the value is null or invalid.

In SQL, use the result format arrayWithTrailer:

```text
POST /druid/v2/sql/

{
  "query": "SELECT COUNT(*) FROM wikipedia",
  "resultFormat": "arrayWithTrailer"
}
```

SQL also recognizes the `trailer` context field to select what appears in the context. However the `trailer` field has effect only if `arrayWithTrailer` is set as shown above. The default, if `trailer` is unset, or has only invalid values, is `metrics`.

#### Response

In both native and SQL:

```json
{
  "results": [ ... ], // normal results
  "context": { // trailer
    "metrics": [
      {
        "segments": 37,
        "segmentsProcessed": 37,
        "segmentsVectorProcessed": 37,
        "segmentRows": 266472,
        "preFilteredRows": 159739,
        "nodeRows": 1,
        "resultRows": 1,
        "cpuNanos": 5027000,
        "threads": 5,
        "queryStart": 1627010838439,
        "queryMs": 40
      },
      {
        "subQueryId": "ef46510d-668b-45e8-a9ef-9de55949342a_0",
        "segments": 37,
        "segmentsProcessed": 37,
        "segmentsVectorProcessed": 37,
        "segmentRows": 266472,
        "preFilteredRows": 194618,
        "nodeRows": 52,
        "resultRows": 5,
        "cpuNanos": 9541000,
        "threads": 5,
        "queryStart": 1627010838461,
        "queryMs": 11
      }
    ]
  }
}
```

##### Results

The results key contains the actual query results. In native, it is an array that is identical to what you would have received if you did not request the trailer. In SQL it is identical to what you would have received if you set the result format to array.

##### Context

The context key contains the response trailer. Inside the context is a metrics key that contains an array of query metric objects. There is one for the main query (which will be listed first) and one for each subquery (which will be listed in the order that they began execution).

The specific metrics should be considered an Alpha release: they are subject to change and will be re-evaluated once the full query profile is available.

Keys that can be present in a the current "starter" query metric object are:

`subQueryId`: Present for subqueries, absent for the main query. Useful for differentiating subqueries from each other, and for differentiating subqueries from the main query.

`segments`: The number of segments that were considered by data servers. Includes segments that were not processed because the data server ultimately decided to use the per-segment query cache. Does not include segments that were pruned by the Broker. Equivalent to the count of the query/segmentAndCache/time metric.

`segmentsProcessed`: The number of segments that were actually processed by data servers. Does not include segments whose results were served out of the per-segment query cache, or segments that were pruned by the Broker. Equivalent to the count of the query/segment/time metric.

`segmentsVectorProcessed`: The number of segments that was actually processed by data servers, and were processed using a vectorized engine. This is a subset of segmentsProcessed.

`segmentRows`: The total number of rows across all segments processed by data servers. May include rows that were not actually processed because they were filtered out using the index. May include rows that were not actually processed due to pushed-down limits.

`preFilteredRows`: The total number of rows across all segments processed by data servers, after applying index-based filters, but before applying cursor-based filters. Will not be larger than segmentRows. This is the generally the number of rows processed by the query engine, except in cases where the query engine does not process all rows (such as SELECT * FROM tbl LIMIT 5, where limit pushdown means that data servers only read the first few rows).

`nodeRows`: The total number of rows received by the Broker from data servers. May be larger than segmentRows and preFilteredRows due to caching: nodeRows includes rows served from the per-segment query cache, but segmentRows and preFilteredRows do not. May also be larger than preFilteredRows due to queries that generate more than one output row per input row.

`resultRows`: The total number of rows returned by this query after processing has completed on the Broker. This is how many rows a user would receive after issuing the query.

`cpuNanos`: The total number of nanoseconds of CPU time used by this query, summed up across all servers. Equivalent to the sum of the query/cpu/time metric.

`threads`: The total number of threads that participated in this query. Note that not all threads are necessarily active at the same time.

`queryStart`: The time this query started, in milliseconds since the epoch.

`queryMs`: The duration of this query, in milliseconds. This is similar to the query/time metric, but not quite equivalent, because it only measures the time until the response trailer starts being written. The query/time metric includes the time it takes to write the response trailer and fully flush the connection to the client.

### Backward Compatibility

The trailer appears for client queries only if the client explicitly requests it via the `X-Druid-Include-Trailer` header. Since existing clients do not include this header, existing clients will see no functional difference.

The response trailer is always enabled for internal queries between the broker and data nodes, etc. This change is transparent to clients. If a client directly queries a data node, then the above rule applies: the `X-Druid-Include-Trailer` header must be set.

The addition of the trailer changes the format of internal query responses. The following ensures services can be upgraded in any order:

* An old Broker won't request the trailer, so new data nodes will not return one.
* A new Broker will request the trailer, but will accept the old array format.

When running test cases, it appears that some tests may mock or otherwise simulate the data node response to the broker. In this case, the new Broker requests a header, but the mocking code returns an array format. The "will accept the old array format" ensures that these tests continue to run.

### Minor Revisions

The PR includes a number of minor refactoring moves:

#### `QueryResource`

Pull the `StreamingOutput` subclass out as a named class in `QueryResource` so it is easier to see which parts occur within the message handler, and which occur asynchronously to produce the output.

#### Optional `druid.server.http.minThreads` config parameter

Add a `minThreads` to the Jetty server configuration to optionally reduce the initial number of Jetty worker threads to make the IDE experience a bit easier. The default is to retain the current behavior. To change the minimum (and startup) number of threads, add the following to the common config file:

```text
druid.server.http.minThreads=2
```

The thread pool will expand the thread count on demand up to `maxThreads`, so this change affects only the *initial* thread count.

### `SqlResource` error handling

Added a distinct error code, 409 CONFLICT, for the query cancellation case to differentiate cancellation from internal error.

### Tests

Deflaked several tests. Modified others to avoid timeout while debugging. Reduced copy/paste revisions for handling the new header field.

<hr>

This PR has:
- [X] been self-reviewed.
   - [X] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) 
- [ ] added documentation for new or modified features or behaviors.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
- [X] has been tested using a Python client to verify API behavior.
