### PR TITLE
IN filters for numeric go through selector filters and in filters now

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/filtration/ConvertBoundsToSelectors.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/filtration/ConvertBoundsToSelectors.java
@@ -23,6 +23,7 @@ import org.apache.druid.query.filter.BoundDimFilter;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.ordering.StringComparator;
+import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.SimpleExtraction;
 import org.apache.druid.sql.calcite.table.RowSignatures;
@@ -50,13 +51,14 @@ public class ConvertBoundsToSelectors extends BottomUpTransform
           rowSignature,
           SimpleExtraction.of(bound.getDimension(), bound.getExtractionFn())
       );
-
+      boolean numOrString = (bound.getOrdering() == StringComparators.NUMERIC)
+                            || (bound.getOrdering() == StringComparators.LEXICOGRAPHIC);
       if (bound.hasUpperBound()
           && bound.hasLowerBound()
           && bound.getUpper().equals(bound.getLower())
           && !bound.isUpperStrict()
           && !bound.isLowerStrict()
-          && bound.getOrdering().equals(comparator)) {
+          && numOrString) {
         return new SelectorDimFilter(
             bound.getDimension(),
             bound.getUpper(),


### PR DESCRIPTION
Instead of using BoundFilters for numeric IN clauses, they now get converted to SelectorDimFilter which later gets converted to an IN filter. Querying over wikipedia dataset with 10K in clauses with a query `SELECT regionName, user, count(*) as cnt
FROM wikipedia
WHERE metroCode IN (all 10K values here separated by commas)
GROUP BY 1,2`

finished in 10sec

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
