### PR TITLE
Update to log4j 2.16.0.

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1822,7 +1822,7 @@ name: Apache Log4j
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.15.0
+version: 2.16.0
 libraries:
   - org.apache.logging.log4j: log4j-1.2-api
   - org.apache.logging.log4j: log4j-api

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <jersey.version>1.19.3</jersey.version>
         <jackson.version>2.10.5.20201202</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <mysql.version>5.1.48</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>


### PR DESCRIPTION
Log4j 2.16.0 is further hardened and makes it impossible for users to stumble into a configuration that is vulnerable to the CVE-2021-44228 issue. I don't think this is a fire-drill update, because Druid 0.22.1+ with Log4j 2.15.0 is not vulnerable in its default configuration. (We don't ship with any JNDI features enabled.) But the additional hardening would be beneficial to our users.

See announcement at: https://lists.apache.org/thread/t72msv9cpxw9q5zw8rfkhx52v24z57f1