### PR TITLE
Return empty result when a group by gets optimized to a timeseries query

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -856,7 +856,9 @@ public class DruidQuery
     // An aggregation query should return one row per group, with no grouping (e.g. ALL granularity), the entire table
     // is the group, so we should not skip empty buckets. When there are no results, this means we return the
     // initialized state for given aggregators instead of nothing.
-    if (!Granularities.ALL.equals(queryGranularity)) {
+    // Alternatively, the timeseries query should return empty buckets, even with ALL granularity when timeseries query
+    // was originally a groupBy query, but with the grouping dimensions removed away in Grouping#applyProject
+    if (!Granularities.ALL.equals(queryGranularity) || grouping.isDroppedDimensionsWhileApplyingProject()) {
       theContext.put(TimeseriesQuery.SKIP_EMPTY_BUCKETS, true);
     }
     theContext.putAll(plannerContext.getQueryContext());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -858,7 +858,7 @@ public class DruidQuery
     // initialized state for given aggregators instead of nothing.
     // Alternatively, the timeseries query should return empty buckets, even with ALL granularity when timeseries query
     // was originally a groupBy query, but with the grouping dimensions removed away in Grouping#applyProject
-    if (!Granularities.ALL.equals(queryGranularity) || grouping.isOptimizedWhileGrouping()) {
+    if (!Granularities.ALL.equals(queryGranularity) || grouping.hasGroupingDimensionsDropped()) {
       theContext.put(TimeseriesQuery.SKIP_EMPTY_BUCKETS, true);
     }
     theContext.putAll(plannerContext.getQueryContext());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -858,7 +858,7 @@ public class DruidQuery
     // initialized state for given aggregators instead of nothing.
     // Alternatively, the timeseries query should return empty buckets, even with ALL granularity when timeseries query
     // was originally a groupBy query, but with the grouping dimensions removed away in Grouping#applyProject
-    if (!Granularities.ALL.equals(queryGranularity) || grouping.isDroppedDimensionsWhileApplyingProject()) {
+    if (!Granularities.ALL.equals(queryGranularity) || grouping.isOptimizedWhileGrouping()) {
       theContext.put(TimeseriesQuery.SKIP_EMPTY_BUCKETS, true);
     }
     theContext.putAll(plannerContext.getQueryContext());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Grouping.java
@@ -66,7 +66,7 @@ public class Grouping
   // Denotes whether the original Grouping had more dimensions which were dropped while applying projection to optimize
   // the grouping. Used for returning result which is consistent with most SQL implementations, by correspondingly
   // setting/unsetting the SKIP_EMPTY_BUCKETS flag, if the GroupBy query can be reduced to a timeseries query.
-  private final boolean optimizedWhileGrouping;
+  private final boolean groupingDimensionsDropped;
 
   private Grouping(
       final List<DimensionExpression> dimensions,
@@ -85,7 +85,7 @@ public class Grouping
       final List<Aggregation> aggregations,
       @Nullable final DimFilter havingFilter,
       final RowSignature outputRowSignature,
-      final boolean optimizedWhileGrouping
+      final boolean groupingDimensionsDropped
   )
   {
     this.dimensions = ImmutableList.copyOf(dimensions);
@@ -93,7 +93,7 @@ public class Grouping
     this.aggregations = ImmutableList.copyOf(aggregations);
     this.havingFilter = havingFilter;
     this.outputRowSignature = Preconditions.checkNotNull(outputRowSignature, "outputRowSignature");
-    this.optimizedWhileGrouping = optimizedWhileGrouping;
+    this.groupingDimensionsDropped = groupingDimensionsDropped;
 
     // Verify no collisions between dimensions, aggregations, post-aggregations.
     final Set<String> seen = new HashSet<>();
@@ -121,7 +121,7 @@ public class Grouping
     }
   }
 
-  // This method is private since optimizedWhileGrouping should only be deviated from default in
+  // This method is private since groupingDimensionsDropped should only be deviated from default in
   // applyProject
   private static Grouping create(
       final List<DimensionExpression> dimensions,
@@ -129,7 +129,7 @@ public class Grouping
       final List<Aggregation> aggregations,
       @Nullable final DimFilter havingFilter,
       final RowSignature outputRowSignature,
-      final boolean optimizedWhileGrouping
+      final boolean groupingDimensionsDropped
   )
   {
     return new Grouping(
@@ -138,7 +138,7 @@ public class Grouping
         aggregations,
         havingFilter,
         outputRowSignature,
-        optimizedWhileGrouping
+        groupingDimensionsDropped
     );
   }
 
@@ -199,9 +199,9 @@ public class Grouping
     return outputRowSignature;
   }
 
-  public boolean isOptimizedWhileGrouping()
+  public boolean hasGroupingDimensionsDropped()
   {
-    return optimizedWhileGrouping;
+    return groupingDimensionsDropped;
   }
 
   /**
@@ -291,7 +291,7 @@ public class Grouping
            aggregations.equals(grouping.aggregations) &&
            Objects.equals(havingFilter, grouping.havingFilter) &&
            outputRowSignature.equals(grouping.outputRowSignature) &&
-           optimizedWhileGrouping == grouping.optimizedWhileGrouping;
+           groupingDimensionsDropped == grouping.groupingDimensionsDropped;
   }
 
   @Override
@@ -303,7 +303,7 @@ public class Grouping
         aggregations,
         havingFilter,
         outputRowSignature,
-        optimizedWhileGrouping
+        groupingDimensionsDropped
     );
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -13344,7 +13344,59 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   // When optimization in Grouping#applyProject is applied, and it reduces a Group By query to a timeseries, we
   // want it to return empty bucket if no row matches
   @Test
-  public void testReturnEmptyRowWhenGroupByIsConvertedToTimeseries() throws Exception
+  public void testReturnEmptyRowWhenGroupByIsConvertedToTimeseriesWithSingleConstantDimension() throws Exception
+  {
+    skipVectorize();
+    testQuery(
+        "SELECT 'A' from foo WHERE m1 = 50 AND dim1 = 'wat' GROUP BY 'foobar'",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .filters(
+                      and(
+                          selector("m1", "50", null),
+                          selector("dim1", "wat", null)
+                      )
+                  )
+                  .granularity(Granularities.ALL)
+                  .postAggregators(
+                      new ExpressionPostAggregator("p0", "'A'", null, ExprMacroTable.nil())
+                  )
+                  .context(QUERY_CONTEXT_DO_SKIP_EMPTY_BUCKETS)
+                  .build()
+        ),
+        ImmutableList.of()
+    );
+
+
+    // dim1 is not getting reduced to 'wat' in this case in Calcite (ProjectMergeRule is not getting applied),
+    // therefore the query is not optimized to a timeseries query
+    testQuery(
+        "SELECT 'A' from foo WHERE dim1 = 'wat' GROUP BY dim1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            "foo"
+                        )
+                        .setInterval(querySegmentSpec(Intervals.ETERNITY))
+                        .setGranularity(Granularities.ALL)
+                        .addDimension(new DefaultDimensionSpec("dim1", "d0", ColumnType.STRING))
+                        .setDimFilter(selector("dim1", "wat", null))
+                        .setPostAggregatorSpecs(
+                            ImmutableList.of(
+                                new ExpressionPostAggregator("p0", "'A'", null, ExprMacroTable.nil())
+                            )
+                        )
+
+                        .build()
+        ),
+        ImmutableList.of()
+    );
+  }
+
+  @Test
+  public void testReturnEmptyRowWhenGroupByIsConvertedToTimeseriesWithMutlipleConstantDimensions() throws Exception
   {
     skipVectorize();
     testQuery(
@@ -13368,6 +13420,31 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .build()
         ),
         ImmutableList.of()
+    );
+
+    // Sanity test, that even when dimensions are reduced, but should produce a valid result (i.e. when filters are
+    // correct, then they should
+    testQuery(
+        "SELECT 'A', dim1 from foo WHERE m1 = 2.0 AND dim1 = '10.1' GROUP BY dim1",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .filters(
+                      and(
+                          selector("m1", "2.0", null),
+                          selector("dim1", "10.1", null)
+                      )
+                  )
+                  .granularity(Granularities.ALL)
+                  .postAggregators(
+                      new ExpressionPostAggregator("p0", "'A'", null, ExprMacroTable.nil()),
+                      new ExpressionPostAggregator("p1", "'10.1'", null, ExprMacroTable.nil())
+                  )
+                  .context(QUERY_CONTEXT_DO_SKIP_EMPTY_BUCKETS)
+                  .build()
+        ),
+        ImmutableList.of(new Object[]{"A", "10.1"})
     );
   }
 }


### PR DESCRIPTION
### Description
Related to #11188 

The above mentioned PR allowed timeseries queries to return a default result, when queries of type: `select count(*) from table where dim1="_not_present_dim_"` were executed. Before the PR, it returned no row, after the PR, it would return a row with value of `count(*)` as 0 (as expected by SQL standards of different dbs).

In `Grouping#applyProject`, we can sometimes perform optimization of a groupBy query to a timeseries query if possible (when the keys of the groupBy are constants, as generated by automated tools). For example, in `select count(*) from table where dim1="_present_dim_" group by "dummy_key"`, the groupBy clause can be removed. However, in the case when the filter doesn't return anything, i.e. `select count(*) from table where dim1="_not_present_dim_" group by "dummy_key"`, the behavior of general databases would be to return nothing, while druid (due to above change) returns an empty row. This PR aims to fix this divergence of behavior.

Example cases:
1. `select count(*) from table where dim1="_not_present_dim_" group by "dummy_key"`.
_CURRENT_: Returns a row with count(*) = 0
_EXPECTED_: Return no row

2. `select 'A', dim1 from foo where m1 = 123123 and dim1 = '_not_present_again_' group by dim1`
_CURRENT_: Returns a row with ('A', 'wat')
_EXPECTED_: Return no row

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

To do this, a boolean `droppedDimensionsWhileApplyingProject` has been added to `Grouping` which is true whenever we make changes to the original shape with optimization. Hence if a timeseries query has a grouping with this set to true, we set `skipEmptyBuckets=true` in the query context (i.e. donot return any row).
<hr>

##### Key changed/added classes in this PR
 * `Grouping.java`
 * `DruidQuery#toTimeseriesQuery`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
