### PR TITLE
Fix test in ResponseContextTest

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
@@ -320,9 +320,10 @@ public class ResponseContextTest
         Strings.repeat("x", INTERVAL_LEN * 7)
     );
     final DefaultObjectMapper objectMapper = new DefaultObjectMapper();
-    final String fullString = objectMapper.writeValueAsString(ctx.getDelegate());
     final ResponseContext.SerializationResult res1 = ctx.serializeWith(objectMapper, Integer.MAX_VALUE);
-    Assert.assertEquals(fullString, res1.getResult());
+    Assert.assertEquals(ctx.getDelegate(),
+        deserializeContext(res1.getResult(), objectMapper)
+    );
     final int maxLen = INTERVAL_LEN * 4 + Keys.UNCOVERED_INTERVALS.getName().length() + 4 +
                        Keys.TRUNCATED.getName().length() + 6;
     final ResponseContext.SerializationResult res2 = ctx.serializeWith(objectMapper, maxLen);


### PR DESCRIPTION
A minor change that fixes the flakiness in serializeWithTruncateArrayTest. Flakiness arises because we are comparing two maps for equality by serializing them to string and then comparing those two string objects. However, the strings can be different based on the order in which keys are read by the object mapper. 