### PR TITLE
Throw parse exceptions on schema get errors for SchemaRegistryBasedAvroBytesDecoder

### DIFF
--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -442,6 +442,7 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | urls | Array<String> | Specifies the URL endpoints of the multiple Schema Registry instances. | yes (if `url` is not provided) |
 | config | Json | To send additional configurations, configured for Schema Registry.  This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md) | no |
 | headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md) | no |
+| failOnGetSchemaErrors | Boolean | If true, errors when getting the schema from the registry for a message are treated as fatal errors that will fail a task. If false, a parse exception that can be logged will be thrown instead. Defaults to true. | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -442,7 +442,6 @@ For details, see the Schema Registry [documentation](http://docs.confluent.io/cu
 | urls | Array<String> | Specifies the URL endpoints of the multiple Schema Registry instances. | yes (if `url` is not provided) |
 | config | Json | To send additional configurations, configured for Schema Registry.  This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md) | no |
 | headers | Json | To send headers to the Schema Registry.  This can be supplied via a [DynamicConfigProvider](../operations/dynamic-config-provider.md) | no |
-| failOnGetSchemaErrors | Boolean | If true, errors when getting the schema from the registry for a message are treated as fatal errors that will fail a task. If false, a parse exception that can be logged will be thrown instead. Defaults to true. | no |
 
 For a single schema registry instance, use Field `url` or `urls` for multi instances.
 
@@ -488,6 +487,12 @@ Multiple Instances:
 }
 ...
 ```
+
+###### Parse exceptions
+
+The following errors when reading records will be considered parse exceptions, which can be limited and logged with ingestion task configurations such as `maxParseExceptions` and `maxSavedParseExceptions`:
+- Failure to retrieve a schema due to misconfiguration or corrupt records (invalid schema IDs)
+- Failure to decode an Avro message
 
 ### Avro OCF
 

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -155,7 +155,7 @@ public class AvroStreamInputFormatTest
   {
     AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
         flattenSpec,
-        new SchemaRegistryBasedAvroBytesDecoder("http://test:8081", 100, null, null, null, null, null),
+        new SchemaRegistryBasedAvroBytesDecoder("http://test:8081", 100, null, null, null, null),
         false,
         false
     );

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -155,7 +155,7 @@ public class AvroStreamInputFormatTest
   {
     AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
         flattenSpec,
-        new SchemaRegistryBasedAvroBytesDecoder("http://test:8081", 100, null, null, null, null),
+        new SchemaRegistryBasedAvroBytesDecoder("http://test:8081", 100, null, null, null, null, null),
         false,
         false
     );

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -33,7 +33,6 @@ import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.druid.data.input.AvroStreamInputRowParserTest;
 import org.apache.druid.data.input.SomeAvroDatum;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.junit.Assert;
@@ -120,7 +119,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 5).put((byte) 0).putInt(1234).put(bytes);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
   }
 
   @Test(expected = ParseException.class)
@@ -130,7 +129,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(2).put((byte) 0).put(1, (byte) 1);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
   }
 
   @Test(expected = ParseException.class)
@@ -145,10 +144,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(4 + 5).put((byte) 0).putInt(1234).put(bytes, 5, 4);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
   }
 
-  @Test(expected = RE.class)
+  @Test(expected = ParseException.class)
   public void testParseWrongSchemaType() throws Exception
   {
     // Given
@@ -156,21 +155,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
   }
 
   @Test(expected = ParseException.class)
-  public void testParseWrongSchemaTypeThrowParseException() throws Exception
-  {
-    // Given
-    Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234))).thenReturn(Mockito.mock(ParsedSchema.class));
-    ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
-    bb.rewind();
-    // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry, false).parse(bb);
-  }
-
-  @Test(expected = RE.class)
   public void testParseWrongId() throws Exception
   {
     // Given
@@ -178,18 +166,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
-  }
-
-  @Test(expected = ParseException.class)
-  public void testParseWrongIdThrowParseException() throws Exception
-  {
-    // Given
-    Mockito.when(registry.getSchemaById(ArgumentMatchers.anyInt())).thenThrow(new IOException("no pasaran"));
-    ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
-    bb.rewind();
-    // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry, false).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
   }
 
   private byte[] getAvroDatum(Schema schema, GenericRecord someAvroDatum) throws IOException

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -120,7 +120,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 5).put((byte) 0).putInt(1234).put(bytes);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
   }
 
   @Test(expected = ParseException.class)
@@ -130,7 +130,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(2).put((byte) 0).put(1, (byte) 1);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
   }
 
   @Test(expected = ParseException.class)
@@ -145,7 +145,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(4 + 5).put((byte) 0).putInt(1234).put(bytes, 5, 4);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
   }
 
   @Test(expected = RE.class)
@@ -156,7 +156,18 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
+  }
+
+  @Test(expected = ParseException.class)
+  public void testParseWrongSchemaTypeThrowParseException() throws Exception
+  {
+    // Given
+    Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234))).thenReturn(Mockito.mock(ParsedSchema.class));
+    ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
+    bb.rewind();
+    // When
+    new SchemaRegistryBasedAvroBytesDecoder(registry, false).parse(bb);
   }
 
   @Test(expected = RE.class)
@@ -167,7 +178,18 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+    new SchemaRegistryBasedAvroBytesDecoder(registry, true).parse(bb);
+  }
+
+  @Test(expected = ParseException.class)
+  public void testParseWrongIdThrowParseException() throws Exception
+  {
+    // Given
+    Mockito.when(registry.getSchemaById(ArgumentMatchers.anyInt())).thenThrow(new IOException("no pasaran"));
+    ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
+    bb.rewind();
+    // When
+    new SchemaRegistryBasedAvroBytesDecoder(registry, false).parse(bb);
   }
 
   private byte[] getAvroDatum(Schema schema, GenericRecord someAvroDatum) throws IOException


### PR DESCRIPTION
This PR adjusts `SchemaRegistryBasedAvroBytesDecoder` to throw `ParseException` instead of `RE` when failure to retrieve a schema occurs. 

Throwing an `RE` can be problematic when this decoder is used in streaming ingestion: if a corrupt record enters the stream with an invalid schema ID, the user cannot easily recover from this as the streaming ingestion tasks will continue to fail and attempt to read the corrupt record.

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
