### PR TITLE
Update to log4j2 to 2.17.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1822,7 +1822,7 @@ name: Apache Log4j
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.16.0
+version: 2.17.0
 libraries:
   - org.apache.logging.log4j: log4j-1.2-api
   - org.apache.logging.log4j: log4j-api

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <jersey.version>1.19.3</jersey.version>
         <jackson.version>2.10.5.20201202</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <mysql.version>5.1.48</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>


### PR DESCRIPTION
Update to 2.17.0 to address another vulnerability [45015](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105) which also affects the previous 2.16.0 release.

Following is from [log4j site](https://logging.apache.org/log4j/2.x/security.html)
![image](https://user-images.githubusercontent.com/6525742/146665698-9a16f2ca-efc2-4c21-9ca2-2f687ddece8e.png)

Since this CVE score is 7.5 which is lower than the value of previous CVE 45046 fixed in 2.16.0, I don't think we need to release another Druid path release such as 0.22.2.


This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
