### PR TITLE
Update ORC to 1.7.2

### DIFF
--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -31,7 +31,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <orc.version>1.7.1</orc.version>
+        <orc.version>1.7.2</orc.version>
     </properties>
     <dependencies>
         <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4543,7 +4543,7 @@ name: Apache ORC libraries
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 1.7.1
+version: 1.7.2
 libraries:
   - org.apache.orc: orc-mapreduce
   - org.apache.orc: orc-core


### PR DESCRIPTION
### Description
This PR aims to update ORC to 1.7.2. 
Apache ORC 1.7.2 is the maintenance release with the following bug fixes.
- https://orc.apache.org/news/2021/12/20/ORC-1.7.2/
- https://github.com/apache/orc/releases/tag/v1.7.2

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
