### PR TITLE
Docs: add FILTER to sql query syntax

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -79,7 +79,7 @@ documentation.
 
 ### FILTER
 
-The FILTER clause limits an aggregation query to execute only on the rows for which a condition evaluates to true.
+The FILTER clause limits an aggregation query to only the rows for which a condition evaluates to true.
 Druid translates the FILTER clause to a native [filtered aggregator](aggregations.md#filtered-aggregator).
 
 ### WHERE

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -47,7 +47,7 @@ Druid SQL supports SELECT queries with the following structure:
 ```
 [ EXPLAIN PLAN FOR ]
 [ WITH tableName [ ( column1, column2, ... ) ] AS ( query ) ]
-SELECT [ ALL | DISTINCT ] { * | exprs }
+SELECT [ ALL | DISTINCT ] { * | exprs } [ FILTER ( WHERE expr ) ]
 FROM { <table> | (<subquery>) | <o1> [ INNER | LEFT ] JOIN <o2> ON condition }
 [ FILTER ( WHERE condition ) ]
 [ WHERE expr ]

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -49,6 +49,7 @@ Druid SQL supports SELECT queries with the following structure:
 [ WITH tableName [ ( column1, column2, ... ) ] AS ( query ) ]
 SELECT [ ALL | DISTINCT ] { * | exprs }
 FROM { <table> | (<subquery>) | <o1> [ INNER | LEFT ] JOIN <o2> ON condition }
+[ FILTER ( WHERE condition ) ]
 [ WHERE expr ]
 [ GROUP BY [ exprs | GROUPING SETS ( (exprs), ... ) | ROLLUP (exprs) | CUBE (exprs) ] ]
 [ HAVING expr ]
@@ -75,6 +76,11 @@ FROM clause, metadata tables are not considered datasources. They exist only in 
 
 For more information about table, lookup, query, and join datasources, refer to the [Datasources](datasource.md)
 documentation.
+
+### FILTER
+
+The FILTER clause limits an aggregation query to execute only on the rows for which a condition evaluates to true.
+Druid translates the FILTER clause to a native [filtered aggregator](aggregations.md#filtered-aggregator).
 
 ### WHERE
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -47,11 +47,11 @@ Druid SQL supports SELECT queries with the following structure:
 ```
 [ EXPLAIN PLAN FOR ]
 [ WITH tableName [ ( column1, column2, ... ) ] AS ( query ) ]
-SELECT [ ALL | DISTINCT ] { * | exprs } [ FILTER ( WHERE expr ) ]
+SELECT [ ALL | DISTINCT ] { * | exprs }
 FROM { <table> | (<subquery>) | <o1> [ INNER | LEFT ] JOIN <o2> ON condition }
 [ WHERE expr ]
 [ GROUP BY [ exprs | GROUPING SETS ( (exprs), ... ) | ROLLUP (exprs) | CUBE (exprs) ] ]
-[ HAVING expr [ FILTER ( WHERE expr ) ] ]
+[ HAVING expr ]
 [ ORDER BY expr [ ASC | DESC ], expr [ ASC | DESC ], ... ]
 [ LIMIT limit ]
 [ OFFSET offset ]
@@ -75,11 +75,6 @@ FROM clause, metadata tables are not considered datasources. They exist only in 
 
 For more information about table, lookup, query, and join datasources, refer to the [Datasources](datasource.md)
 documentation.
-
-### FILTER
-
-The FILTER clause limits an aggregation query to only the rows for which a condition evaluates to true.
-Druid translates the FILTER clause to a native [filtered aggregator](aggregations.md#filtered-aggregator).
 
 ### WHERE
 
@@ -312,16 +307,28 @@ the [segment internals](../design/segments.md#sql-compatible-null-handling) docu
 
 ## Aggregation functions
 
-Aggregation functions can appear in the SELECT clause of any query. Any aggregator can be filtered using syntax
-like `AGG(expr) FILTER(WHERE whereExpr)`. Filtered aggregators will only aggregate rows that match their filter. It's
-possible for two aggregators in the same SQL query to have different filters.
 
-When no rows are selected, aggregate functions will return their initial value. This can occur when filtering results in
-no matches while aggregating values across an entire table without a grouping, or, when using filtered aggregations
-within a grouping. What this value is exactly varies per aggregator, but COUNT, and the various approximate count
-distinct sketch functions, will always return 0.
+You can use aggregation functions in the SELECT clause of any query.
+Filter any aggregator using the FILTER clause, for example:
 
-Only the COUNT, ARRAY_AGG, and STRING_AGG aggregations can accept the DISTINCT keyword.
+```
+SELECT 
+  SUM(added) FILTER(WHERE channel = '#en.wikipedia')
+FROM wikipedia
+```
+
+The FILTER clause limits an aggregation query to only the rows that match the filter.
+Druid translates the FILTER clause to a native [filtered aggregator](aggregations.md#filtered-aggregator).
+Two aggregators in the same SQL query may have different filters.
+
+When no rows are selected, aggregation functions return their initial value. This can occur from the following:
+* When no rows match the filter while aggregating values across an entire table without a grouping, or
+* When using filtered aggregations within a grouping.
+
+The initial value varies by aggregator. `COUNT` and the approximate count distinct sketch functions
+always return 0 as the initial value.
+
+In the aggregation functions supported by Druid, only `COUNT`, `ARRAY_AGG`, and `STRING_AGG` accept the DISTINCT keyword.
 
 > The order of aggregation operations across segments is not deterministic. This means that non-commutative aggregation
 > functions can produce inconsistent results across the same query. 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -52,7 +52,7 @@ FROM { <table> | (<subquery>) | <o1> [ INNER | LEFT ] JOIN <o2> ON condition }
 [ FILTER ( WHERE condition ) ]
 [ WHERE expr ]
 [ GROUP BY [ exprs | GROUPING SETS ( (exprs), ... ) | ROLLUP (exprs) | CUBE (exprs) ] ]
-[ HAVING expr ]
+[ HAVING expr [ FILTER ( WHERE expr ) ] ]
 [ ORDER BY expr [ ASC | DESC ], expr [ ASC | DESC ], ... ]
 [ LIMIT limit ]
 [ OFFSET offset ]

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -49,7 +49,6 @@ Druid SQL supports SELECT queries with the following structure:
 [ WITH tableName [ ( column1, column2, ... ) ] AS ( query ) ]
 SELECT [ ALL | DISTINCT ] { * | exprs } [ FILTER ( WHERE expr ) ]
 FROM { <table> | (<subquery>) | <o1> [ INNER | LEFT ] JOIN <o2> ON condition }
-[ FILTER ( WHERE condition ) ]
 [ WHERE expr ]
 [ GROUP BY [ exprs | GROUPING SETS ( (exprs), ... ) | ROLLUP (exprs) | CUBE (exprs) ] ]
 [ HAVING expr [ FILTER ( WHERE expr ) ] ]


### PR DESCRIPTION
Adds the FILTER clause to the SQL docs, and links to https://druid.apache.org/docs/latest/querying/aggregations.html#filtered-aggregator


This PR has:
- [x] been self-reviewed.

