### PR TITLE
perf: improve RemoteTaskRunner task assignment loop performance

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/TaskAnnouncement.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/TaskAnnouncement.java
@@ -35,6 +35,8 @@ import javax.annotation.Nullable;
  */
 public class TaskAnnouncement
 {
+  public static final String TASK_ID_KEY = "id";
+
   private final String taskType;
   private final TaskStatus taskStatus;
   private final TaskResource taskResource;
@@ -63,7 +65,7 @@ public class TaskAnnouncement
 
   @JsonCreator
   private TaskAnnouncement(
-      @JsonProperty("id") String taskId,
+      @JsonProperty(TASK_ID_KEY) String taskId,
       @JsonProperty("type") String taskType,
       @JsonProperty("status") TaskState status,
       @JsonProperty("taskStatus") TaskStatus taskStatus,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ZkWorkerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ZkWorkerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.druid.indexing.worker.TaskAnnouncement;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.zookeeper.data.Stat;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+public class ZkWorkerTest
+{
+  Function<ChildData, String> extract;
+
+  @Before
+  public void setup()
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+    extract = ZkWorker.createTaskIdExtractor(mapper);
+  }
+
+  ChildData prepare(String input)
+  {
+    String replaced = StringUtils.format(StringUtils.replaceChar(input, '\'', "\""), TaskAnnouncement.TASK_ID_KEY);
+    byte[] data = StringUtils.toUtf8(replaced);
+    return new ChildData("/a/b/c", new Stat(), data);
+  }
+
+  @Test
+  public void testShallowObjectWithIdFirst()
+  {
+    ChildData input = prepare("{'%s': 'abcd', 'status': 'RUNNING'}");
+    String actual = extract.apply(input);
+    Assert.assertEquals("abcd", actual);
+  }
+
+  @Test
+  public void testShallowObjectWithIdMiddle()
+  {
+    ChildData input = prepare("{'before': 'something', '%s': 'abcd', 'status': 'RUNNING'}");
+    String actual = extract.apply(input);
+    Assert.assertEquals("abcd", actual);
+  }
+
+  @Test
+  public void testShallowObjectWithIdLast()
+  {
+    ChildData input = prepare("{'before': 'something', 'status': 'RUNNING', '%s': 'abcd'}");
+    String actual = extract.apply(input);
+    Assert.assertEquals("abcd", actual);
+  }
+
+  @Test
+  public void testShallowObjectWithNoId()
+  {
+    ChildData input = prepare("{'before': 'something', 'status': 'RUNNING'}");
+    String actual = extract.apply(input);
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void testDeepObjectWithIdFirst()
+  {
+    ChildData input = prepare("{'%s': 'abcd', 'subobject': { 'subkey': 'subvalue' }, 'subarray': [{'key': 'val'}, 2, 3], 'status': 'RUNNING'}");
+    String actual = extract.apply(input);
+    Assert.assertEquals("abcd", actual);
+  }
+
+  @Test
+  public void testDeepObjectWithIdLast()
+  {
+    ChildData input = prepare("{'subobject': { 'subkey': 'subvalue' }, 'subarray': [{'key': 'val'}, 2, 3], 'status': 'RUNNING', '%s': 'abcd'}");
+    String actual = extract.apply(input);
+    Assert.assertEquals("abcd", actual);
+  }
+
+  @Test
+  public void testDeepObjectWithIdInNestedOnly()
+  {
+    ChildData input = prepare("{'subobject': { '%s': 'defg' }, 'subarray': [{'key': 'val'}, 2, 3], 'status': 'RUNNING'}");
+    String actual = extract.apply(input);
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void testDeepObjectWithIdInNestedAndOuter()
+  {
+    ChildData input = prepare("{'subobject': { '%s': 'defg' }, 'subarray': [{'key': 'val'}, 2, 3], 'status': 'RUNNING', '%1$s': 'abcd'}");
+    String actual = extract.apply(input);
+    Assert.assertEquals("abcd", actual);
+  }
+
+  @Test
+  public void testIdWithWrongTypeReturnsNull()
+  {
+    ChildData input = prepare("{'%s': {'nested': 'obj'}'");
+    String actual = extract.apply(input);
+    Assert.assertNull(actual);
+  }
+}


### PR DESCRIPTION
### Description

Improve the performance of `RemoteTaskRunner::tryAssignTask` which consumes long periods of CPU on the Overlord during a task restart operation.

Screenshot of profiler showing long period of `rtr-pending-..` task thread.
![image](https://user-images.githubusercontent.com/3196528/147289897-61da95d8-3a0a-4d4c-9b94-b4679316936e.png)

Screenshot of profile flamegraph for this thread, showing 100pc of CPU in `tryAssignTask` loop:
![image](https://user-images.githubusercontent.com/3196528/147289985-1ee07872-9acb-4a07-81e7-fdf419dac0b2.png)

### Key changed/added classes in this PR

This change:
1. eliminates triple nested call of `getRunningTasks()` in `ZkWorker::toImmutable`, and,
2. reduces the work performed in `ZkWorker::isRunningTask` by parsing only the `id` field instead of the entire ZkWorker json.

By eliminating this extra work, the loop is much tighter.

This is a change coupled to this mailing thread discussion:
https://lists.apache.org/thread/9jgdwrodwsfcg98so6kzfhdmn95gzyrj


### Tests

Tests in `RemoteTaskRunner*Test.java` capture this functionality.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster (as a part of a larger block of changes).
