### PR TITLE
HttpPostEmitter back off send() busy-loop

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpEmitterConfig.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpEmitterConfig.java
@@ -129,6 +129,12 @@ public class HttpEmitterConfig extends BaseHttpEmittingConfig
       return this;
     }
 
+    public Builder setMinHttpTimeoutMillis(int minHttpTimeoutMillis)
+    {
+      this.minHttpTimeoutMillis = minHttpTimeoutMillis;
+      return this;
+    }
+
     public HttpEmitterConfig build()
     {
       return new HttpEmitterConfig(this, recipientBaseUrl);

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
@@ -729,7 +729,7 @@ public class HttpPostEmitter implements Flushable, Closeable, Emitter
       try {
         Thread.sleep(backoffCheckDelayMillis);
       }
-      catch (InterruptedException e) {
+      catch (InterruptedException ignored) {
         return;
       }
     }

--- a/core/src/test/java/org/apache/druid/java/util/emitter/core/HttpPostEmitterLoggerStressTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/core/HttpPostEmitterLoggerStressTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.emitter.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.testing.junit.LoggerCaptureRule;
+import org.apache.logging.log4j.Level;
+import org.asynchttpclient.ListenableFuture;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.Response;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.TimeoutException;
+
+public class HttpPostEmitterLoggerStressTest
+{
+  @Rule
+  public LoggerCaptureRule logCapture = new LoggerCaptureRule(HttpPostEmitter.class);
+
+  private final MockHttpClient httpClient = new MockHttpClient();
+
+  @Test(timeout = 20_000L)
+  public void testBurstFollowedByQuietPeriod() throws InterruptedException, IOException
+  {
+    HttpEmitterConfig config = new HttpEmitterConfig.Builder("http://foo.bar")
+        .setFlushMillis(5000)
+        .setFlushCount(3)
+        .setBatchingStrategy(BatchingStrategy.ONLY_EVENTS)
+        .setMaxBatchSize(1024 * 1024)
+        .setBatchQueueSizeLimit(10)
+        .setMinHttpTimeoutMillis(100)
+        .build();
+    final HttpPostEmitter emitter = new HttpPostEmitter(config, httpClient, new ObjectMapper());
+
+    emitter.start();
+
+    httpClient.setGoHandler(new GoHandler() {
+      @Override
+      protected <X extends Exception> ListenableFuture<Response> go(Request request) throws X
+      {
+        return GoHandlers.immediateFuture(EmitterTest.okResponse());
+      }
+    });
+
+    Event smallEvent = ServiceMetricEvent.builder()
+                                       .setFeed("smallEvents")
+                                       .setDimension("test", "hi")
+                                       .build("metric", 10)
+                                       .build("qwerty", "asdfgh");
+
+    for (int i = 0; i < 1000; i++) {
+      emitter.emit(smallEvent);
+
+      Assert.assertTrue(emitter.getTotalFailedBuffers() <= 10);
+      Assert.assertTrue(emitter.getBuffersToEmit() <= 12);
+    }
+
+    // by the end of this test, there should be no outstanding failed buffers
+
+    // with a flush time of 5s, min timeout of 100ms, 20s should be
+    // easily enough to get through all of the events
+
+    while (emitter.getTotalFailedBuffers() > 0) {
+      Thread.sleep(500);
+    }
+
+    // there is also no reason to have too many log events
+    // refer to: https://github.com/apache/druid/issues/11279;
+
+    long countOfTimeouts = logCapture.getLogEvents().stream()
+        .filter(ev -> ev.getLevel() == Level.DEBUG)
+        .filter(ev -> ev.getThrown() instanceof TimeoutException)
+        .count();
+
+    // 1000 events limit, implies we should have no more than
+    // 1000 rejected send events within the expected 20sec
+    // duration of the test
+    long limitTimeoutEvents = 1000;
+
+    Assert.assertTrue(
+        String.format(
+          Locale.getDefault(),
+          "too many timeouts (%d), expect less than (%d)",
+          countOfTimeouts,
+          limitTimeoutEvents),
+        countOfTimeouts < limitTimeoutEvents);
+
+    emitter.close();
+  }
+}


### PR DESCRIPTION
### Description

Introduce a back-off to the `HttpPostEmitter` `send()` thread loop to minimise the amount of log spamming and CPU.

Fixes #11279.

#### Introduce HttpPostEmitterLoggerStressTest

Introduce a test to count how many logged events are triggered during a loop scenario. It confirms that no more than some maximum send timeout log events are written in duration of the test. Test runs typically for 6 seconds, and expects limit of 1000 send attempts in that 6 second period.

Currently, the HttpPostEmitter thread submits 150K events in the test window.
```
[ERROR] Failures: 
[ERROR] org.apache.druid.java.util.emitter.core.HttpPostEmitterLoggerStressTest.testBurstFollowedByQuietPeriod(org.apache.druid.java.util.emitter.core.HttpPostEmitterLoggerStressTest)
[ERROR]   Run 1: HttpPostEmitterLoggerStressTest.testBurstFollowedByQuietPeriod:98 too many timeouts (159620), expect less than (1000)
[ERROR]   Run 2: HttpPostEmitterLoggerStressTest.testBurstFollowedByQuietPeriod:98 too many timeouts (166201), expect less than (1000)
[ERROR]   Run 3: HttpPostEmitterLoggerStressTest.testBurstFollowedByQuietPeriod:98 too many timeouts (173177), expect less than (1000)
[ERROR]   Run 4: HttpPostEmitterLoggerStressTest.testBurstFollowedByQuietPeriod:98 too many timeouts (175135), expect less than (1000)
```

#### Introduce a backoff to the send() loop when the specific timeout is experienced.

A simple backoff is chosen at 1/5th the minimum time.

An alternative solution which might be better involves a larger rewrite of this class, as the class currently splits responsibilities for managing the batching and sending across multiple classes and threads. A simpler codebase might run a simpler submission loop with a more explicit throttle and batching mechanism instead of the current batching handoffs.

This PR has:
- [x] been self-reviewed.
   - [ ] N/A using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] N/A added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] N/A added integration tests.
- [ ] been tested in a test Druid cluster.
