### PR TITLE
perf: indexing: Introduce a bulk getValuesInto function to read values

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
@@ -32,6 +32,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -53,7 +54,7 @@ public class StringDimensionIndexerBenchmark
   @Param({"10000"})
   public int cardinality;
 
-  @Param({"8"})
+  @Param({"8", "40"})
   public int rowSize;
 
   @Setup
@@ -75,7 +76,18 @@ public class StringDimensionIndexerBenchmark
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(1)
   public void estimateEncodedKeyComponentSize(Blackhole blackhole)
+  {
+    long sz = indexer.estimateEncodedKeyComponentSize(exampleArray);
+    blackhole.consume(sz);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(2)
+  public void estimateEncodedKeyComponentSizeTwoThreads(Blackhole blackhole)
   {
     long sz = indexer.estimateEncodedKeyComponentSize(exampleArray);
     blackhole.consume(sz);

--- a/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnIndexer.java
@@ -46,17 +46,6 @@ public abstract class DictionaryEncodedColumnIndexer<KeyType, ActualType extends
   protected SortedDimensionDictionary<ActualType> sortedLookup;
 
   /**
-   * Creates a new DictionaryEncodedColumnIndexer with the default implementation
-   * of {@link DimensionDictionary}.
-   * <p>
-   * Using this constructor disables memory estimations of the dictionary size.
-   */
-  public DictionaryEncodedColumnIndexer()
-  {
-    this(new DimensionDictionary<>());
-  }
-
-  /**
    * Creates a new DictionaryEncodedColumnIndexer.
    *
    * @param dimLookup Dimension Dictionary to lookup dimension values.

--- a/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
@@ -19,10 +19,12 @@
 
 package org.apache.druid.segment;
 
+import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -88,6 +90,8 @@ public class DimensionDictionary<T extends Comparable<T>>
 
   public void getValuesInto(int[] ids, T[] values)
   {
+    Preconditions.checkArgument(ids.length == values.length, "ids.length == values.length");
+
     lock.readLock().lock();
     try {
       for (int i = 0; i < ids.length; i++) {

--- a/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
@@ -86,6 +86,19 @@ public class DimensionDictionary<T extends Comparable<T>>
     }
   }
 
+  public void getValuesInto(int[] ids, T[] values)
+  {
+    lock.readLock().lock();
+    try {
+      for (int i = 0; i < ids.length; i++) {
+        values[i] = (ids[i] == idForNull) ? null : idToValue.get(ids[i]);
+      }
+    }
+    finally {
+      lock.readLock().unlock();
+    }
+  }
+
   public int size()
   {
     lock.readLock().lock();

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionDictionary.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionDictionary.java
@@ -34,6 +34,7 @@ public class StringDimensionDictionary extends DimensionDictionary<String>
    */
   public StringDimensionDictionary(boolean computeOnHeapSize)
   {
+    super(String.class);
     this.computeOnHeapSize = computeOnHeapSize;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -148,15 +148,15 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
    * Deprecated method. Use {@link #processRowValsToUnsortedEncodedKeyComponent(Object, boolean)}
    * and {@link EncodedKeyComponent#getEffectiveSizeBytes()}.
    */
-  public long estimateEncodedKeyComponentSize(int[] key)
+  public long estimateEncodedKeyComponentSize(int[] keys)
   {
     // string length is being accounted for each time they are referenced, based on dimension handler interface,
     // even though they are stored just once. It may overestimate the size by a bit, but we wanted to leave
     // more buffer to be safe
-    long estimatedSize = key.length * Integer.BYTES;
+    long estimatedSize = keys.length * Integer.BYTES;
 
-    String[] vals = new String[key.length];
-    dimLookup.getValuesInto(key, vals);
+    String[] vals = new String[keys.length];
+    dimLookup.getValuesInto(keys, vals);
     for (String val : vals) {
       if (val != null) {
         // According to https://www.ibm.com/developerworks/java/library/j-codetoheap/index.html

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -154,8 +154,10 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
     // even though they are stored just once. It may overestimate the size by a bit, but we wanted to leave
     // more buffer to be safe
     long estimatedSize = key.length * Integer.BYTES;
-    for (int element : key) {
-      String val = dimLookup.getValue(element);
+
+    String[] vals = new String[key.length];
+    dimLookup.getValuesInto(key, vals);
+    for (String val : vals) {
       if (val != null) {
         // According to https://www.ibm.com/developerworks/java/library/j-codetoheap/index.html
         // String has the following memory usuage...

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -155,8 +155,7 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
     // more buffer to be safe
     long estimatedSize = keys.length * Integer.BYTES;
 
-    String[] vals = new String[keys.length];
-    dimLookup.getValuesInto(keys, vals);
+    String[] vals = dimLookup.getValues(keys);
     for (String val : vals) {
       if (val != null) {
         // According to https://www.ibm.com/developerworks/java/library/j-codetoheap/index.html


### PR DESCRIPTION
### Description

If large number of values are required from `DimensionDictionary` during indexing, fetch them all in a single lock/unlock call instead of lock/unlock each individual item.

During indexing there are repeated lock/unlock boundary crossing. In a sample application (57 fields to index), this consumes ~9% of the taskrunner CPU.

Depending on indexing row configuration specifics, the indexer usage of `DimensionDictionary` can consume anywhere from 1-20% of the CPU time during processing. This PR addresses one aspect of the processing, specifically the getValues. (I'll introduce another PR on the add/size change).

#### Introduce a `getValuesInto()` call to the `DimensionDictionary`, and use it

This introduces a `getValuesInto` call, which accepts an array of IDs to fetch, and performs the equivalent of many `getValue()` calls.

#### Expand benchmarks to cover wider rows and some concurrency

### Design option

There is one other design option, that is in fact much faster again, but is a bit less intuitive.

Here are the benchmark results across all three:

```
single getValue()
Benchmark                                                                  (cardinality)  (rowSize)  Mode  Cnt  Score    Error  Units
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize                    10000          8  avgt   10  0.046 ±  0.001  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize                    10000         40  avgt   10  0.215 ±  0.007  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSizeTwoThreads          10000          8  avgt   10  3.484 ±  0.032  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSizeTwoThreads          10000         40  avgt   10  8.638 ±  0.514  us/op

bulk getValuesInto() <----- THIS SOLUTION
Benchmark                                                                  (cardinality)  (rowSize)  Mode  Cnt  Score    Error  Units
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize                    10000          8  avgt   10  0.039 ±  0.001  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize                    10000         40  avgt   10  0.120 ±  0.002  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSizeTwoThreads          10000          8  avgt   10  0.383 ±  0.052  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSizeTwoThreads          10000         40  avgt   10  0.386 ±  0.018  us/op

using doInsideReadLock() <----- ALTERNATIVE, FASTER BUT LESS CLEAN
Benchmark                                                                  (cardinality)  (rowSize)  Mode  Cnt  Score    Error  Units
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize                    10000          8  avgt   10  0.018 ±  0.001  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize                    10000         40  avgt   10  0.077 ±  0.002  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSizeTwoThreads          10000          8  avgt   10  0.241 ±  0.004  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSizeTwoThreads          10000         40  avgt   10  0.486 ±  0.002  us/op
```

### Alternatives (faster!)

The alternative, `doInsideReadLoop()` is to pass a lambda / closure into the `DimensionDictionary` boundary and have it perform locking and execute on the other side. This is likely to be faster for most cases, however, it's a bit less clear in the API (I'll leave an extra comment).

The solution involves similar changes, and passing a closure across the boundary. However, it does leak implementation concerns...

```
/************ DimensionDictionary.java **************/
public void doInsideReadLock(BiConsumer<List<T>, Integer> fn)
{
  lock.readLock().lock();
  try {
    fn.accept(idToValue, idForNull);
  }
  finally {
    lock.readLock().unlock();
  }
}


/************ StringDimensionIndexer.java **************/
@Override
public long estimateEncodedKeyComponentSize(int[] key)
{
  int[] estimatedSize = new int[]{key.length * Integer.BYTES};
  dimLookup.doInsideReadLock((List<String> idToValue, Integer idForNull) -> {
    for (int id : key) {
      if (id != idForNull) {
          String val = idToValue.get(id);
          int sizeOfString = 28 + 16 + (2 * val.length());
          estimatedSize[0] += sizeOfString;
      }
    }
  });
  return estimatedSize[0];
}
```


Otherwise, I think the changes are straightforward!

<hr>


This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster. (as part of other changes)
