### PR TITLE
perf: indexing: improve DimensionDictionary index locking on add path

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerProcessBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerProcessBenchmark.java
@@ -69,8 +69,8 @@ public class StringDimensionIndexerProcessBenchmark
   @Threads(1)
   public void singleThread(Blackhole blackhole)
   {
-    for (int i = 0; i < inputData.length; i++) {
-      freshIndexer.processRowValsToUnsortedEncodedKeyComponent(inputData[i], true);
+    for (String data : inputData) {
+      freshIndexer.processRowValsToUnsortedEncodedKeyComponent(data, true);
     }
   }
 
@@ -80,8 +80,8 @@ public class StringDimensionIndexerProcessBenchmark
   @Threads(2)
   public void twoThreads(Blackhole blackhole)
   {
-    for (int i = 0; i < inputData.length; i++) {
-      freshIndexer.processRowValsToUnsortedEncodedKeyComponent(inputData[i], true);
+    for (String data : inputData) {
+      freshIndexer.processRowValsToUnsortedEncodedKeyComponent(data, true);
     }
   }
 }

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerProcessBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerProcessBenchmark.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.indexing;
+
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.data.input.impl.DimensionSchema;
+import org.apache.druid.segment.StringDimensionIndexer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class StringDimensionIndexerProcessBenchmark
+{
+  static {
+    NullHandling.initializeForTests();
+  }
+
+  String[] inputData;
+  StringDimensionIndexer freshIndexer;
+
+  @Setup()
+  public void setup()
+  {
+    inputData = new String[5000];
+    for (int i = 0; i < inputData.length; i++) {
+      int next = ThreadLocalRandom.current().nextInt(100);
+      inputData[i] = (next < 10) ? null : ("abcd-" + next);
+    }
+
+    freshIndexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(1)
+  public void singleThread(Blackhole blackhole)
+  {
+    for (int i = 0; i < inputData.length; i++) {
+      freshIndexer.processRowValsToUnsortedEncodedKeyComponent(inputData[i], true);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Threads(2)
+  public void twoThreads(Blackhole blackhole)
+  {
+    for (int i = 0; i < inputData.length; i++) {
+      freshIndexer.processRowValsToUnsortedEncodedKeyComponent(inputData[i], true);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
@@ -143,8 +143,8 @@ public class DimensionDictionary<T extends Comparable<T>>
    */
   protected AddResult addNull()
   {
-    long stamp = 0;
-    AddResult result = null;
+    long stamp;
+    AddResult result;
 
     // try until we can complete an optimistic read
     do {
@@ -175,7 +175,7 @@ public class DimensionDictionary<T extends Comparable<T>>
 
   public T getMinValue()
   {
-    long stamp = 0;
+    long stamp;
     T result;
     do {
       stamp = lock.tryOptimisticRead();
@@ -187,7 +187,7 @@ public class DimensionDictionary<T extends Comparable<T>>
 
   public T getMaxValue()
   {
-    long stamp = 0;
+    long stamp;
     T result;
     do {
       stamp = lock.tryOptimisticRead();

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -76,26 +76,18 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
     final int[] encodedDimensionValues;
     boolean didAddNew = false;
 
-    if (dimValues == null) {
-      final int nullId = dimLookup.getId(null);
-      if (nullId == DimensionDictionary.ABSENT_VALUE_ID) {
-        AddResult result = dimLookup.add(null);
-        encodedDimensionValues = new int[]{result.getIndex()};
-        didAddNew = true;
-      } else {
-        encodedDimensionValues = new int[]{nullId};
-        didAddNew = false;
-      }
-    } else if (dimValues instanceof List) {
+    if (dimValues instanceof List) {
       List<Object> dimValuesList = (List<Object>) dimValues;
       if (dimValuesList.isEmpty()) {
         AddResult result = dimLookup.add(null);
         didAddNew = result.wasAdded();
         encodedDimensionValues = IntArrays.EMPTY_ARRAY;
+
       } else if (dimValuesList.size() == 1) {
         AddResult result = dimLookup.add(emptyToNullIfNeeded(dimValuesList.get(0)));
         didAddNew = result.wasAdded();
         encodedDimensionValues = new int[]{result.getIndex()};
+
       } else {
         hasMultipleValues = true;
         final String[] dimensionValues = new String[dimValuesList.size()];
@@ -112,14 +104,12 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
         int prevId = -1;
         int pos = 0;
         for (String dimensionValue : dimensionValues) {
+          AddResult result = dimLookup.add(dimensionValue);
+          didAddNew |= result.wasAdded();
           if (multiValueHandling != MultiValueHandling.SORTED_SET) {
-            AddResult result = dimLookup.add(dimensionValue);
-            didAddNew |= result.wasAdded();
             retVal[pos++] = result.getIndex();
             continue;
           }
-          AddResult result = dimLookup.add(dimensionValue);
-          didAddNew |= result.wasAdded();
           if (result.getIndex() != prevId) {
             prevId = retVal[pos++] = result.getIndex();
           }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -33,6 +33,7 @@ import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.query.filter.ValueMatcher;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.DimensionDictionary.AddResult;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
@@ -73,18 +74,28 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
   public int[] processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
   {
     final int[] encodedDimensionValues;
-    final int oldDictSize = dimLookup.size();
+    boolean didAddNew = false;
 
     if (dimValues == null) {
       final int nullId = dimLookup.getId(null);
-      encodedDimensionValues = nullId == DimensionDictionary.ABSENT_VALUE_ID ? new int[]{dimLookup.add(null)} : new int[]{nullId};
+      if (nullId == DimensionDictionary.ABSENT_VALUE_ID) {
+        AddResult result = dimLookup.add(null);
+        encodedDimensionValues = new int[]{result.getIndex()};
+        didAddNew = true;
+      } else {
+        encodedDimensionValues = new int[]{nullId};
+        didAddNew = false;
+      }
     } else if (dimValues instanceof List) {
       List<Object> dimValuesList = (List<Object>) dimValues;
       if (dimValuesList.isEmpty()) {
-        dimLookup.add(null);
+        AddResult result = dimLookup.add(null);
+        didAddNew = result.wasAdded();
         encodedDimensionValues = IntArrays.EMPTY_ARRAY;
       } else if (dimValuesList.size() == 1) {
-        encodedDimensionValues = new int[]{dimLookup.add(emptyToNullIfNeeded(dimValuesList.get(0)))};
+        AddResult result = dimLookup.add(emptyToNullIfNeeded(dimValuesList.get(0)));
+        didAddNew = result.wasAdded();
+        encodedDimensionValues = new int[]{result.getIndex()};
       } else {
         hasMultipleValues = true;
         final String[] dimensionValues = new String[dimValuesList.size()];
@@ -102,23 +113,28 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
         int pos = 0;
         for (String dimensionValue : dimensionValues) {
           if (multiValueHandling != MultiValueHandling.SORTED_SET) {
-            retVal[pos++] = dimLookup.add(dimensionValue);
+            AddResult result = dimLookup.add(dimensionValue);
+            didAddNew |= result.wasAdded();
+            retVal[pos++] = result.getIndex();
             continue;
           }
-          int index = dimLookup.add(dimensionValue);
-          if (index != prevId) {
-            prevId = retVal[pos++] = index;
+          AddResult result = dimLookup.add(dimensionValue);
+          didAddNew |= result.wasAdded();
+          if (result.getIndex() != prevId) {
+            prevId = retVal[pos++] = result.getIndex();
           }
         }
 
         encodedDimensionValues = pos == retVal.length ? retVal : Arrays.copyOf(retVal, pos);
       }
     } else {
-      encodedDimensionValues = new int[]{dimLookup.add(emptyToNullIfNeeded(dimValues))};
+      AddResult result = dimLookup.add(emptyToNullIfNeeded(dimValues));
+      didAddNew = result.wasAdded();
+      encodedDimensionValues = new int[]{result.getIndex()};
     }
 
     // If dictionary size has changed, the sorted lookup is no longer valid.
-    if (oldDictSize != dimLookup.size()) {
+    if (didAddNew) {
       sortedLookup = null;
     }
 


### PR DESCRIPTION
### Description

Following from #12105 with 1-20% CPU in `DimensionDictionary`, there are some improvements to be made to the `add()` path on the `StringDimensionIndexer`.

There are three sub-changes:

#### Introduce a new benchmark

`StringDimensionIndexerProcessBenchmark` in cff7a6caaab2d28218ab01655c44d24e99c40e0c covers the `StringDimensionIndexer` `processRowValsToUnsortedEncodedKeyComponent` for throughput.

#### Optimise `StringDimensionIndexer` -> `DimensionDictionary` boundary

in 400f0a5137264d9c4f0a88dc346b6730458b1b09 introduce an `AddResult` class to combine the result of both (a) what is the index of the result, and (b) was the result a new addition or refers to a previous element.

This results in a ~30% improvement on this codepath single threaded, and ~70%  by bypassing multiple `size()` calls to determine whether the dictionary has changed.

#### Switch lock implementation in `DimensionDictionary` to `StampedLock`

In aea89f5c502317b69957fbf592d84e4e9ee3f9a5 introduce improved concurrency under multiple-reader scenarios, and scenarios where `add()` of existing elements. Results in 3x improvement in contended situation.

#### Refactor

Slight refactor in 3e5c410047a74b3cae8044070260384803a2e1e5 to simplify flow in `StringDimensionIndexer`.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster. -> nb: partly, have not tested `StampedLock` in prod
