### PR TITLE
perf: cache row if it is a transformed row

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
@@ -146,10 +146,15 @@ public class Transformer
     private final InputRow row;
     private final Map<String, RowFunction> transforms;
 
+    // cached column, because it will be read frequently
+    private final long timestamp;
+
     public TransformedInputRow(final InputRow row, final Map<String, RowFunction> transforms)
     {
       this.row = row;
       this.transforms = transforms;
+
+      this.timestamp = readTimestampFromRow(row, transforms);
     }
 
     @Override
@@ -158,8 +163,7 @@ public class Transformer
       return row.getDimensions();
     }
 
-    @Override
-    public long getTimestampFromEpoch()
+    static long readTimestampFromRow(final InputRow row, final Map<String, RowFunction> transforms)
     {
       final RowFunction transform = transforms.get(ColumnHolder.TIME_COLUMN_NAME);
       if (transform != null) {
@@ -171,14 +175,15 @@ public class Transformer
     }
 
     @Override
+    public long getTimestampFromEpoch()
+    {
+      return timestamp;
+    }
+
+    @Override
     public DateTime getTimestamp()
     {
-      final RowFunction transform = transforms.get(ColumnHolder.TIME_COLUMN_NAME);
-      if (transform != null) {
-        return DateTimes.utc(getTimestampFromEpoch());
-      } else {
-        return row.getTimestamp();
-      }
+      return DateTimes.utc(getTimestampFromEpoch());
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
@@ -147,7 +147,7 @@ public class Transformer
     private final Map<String, RowFunction> transforms;
 
     // cached column, because it will be read frequently
-    private final long timestamp;
+    private final DateTime timestamp;
 
     public TransformedInputRow(final InputRow row, final Map<String, RowFunction> transforms)
     {
@@ -163,27 +163,29 @@ public class Transformer
       return row.getDimensions();
     }
 
-    static long readTimestampFromRow(final InputRow row, final Map<String, RowFunction> transforms)
+    static DateTime readTimestampFromRow(final InputRow row, final Map<String, RowFunction> transforms)
     {
       final RowFunction transform = transforms.get(ColumnHolder.TIME_COLUMN_NAME);
+      final long ts;
       if (transform != null) {
         //noinspection ConstantConditions time column is never null
-        return Rows.objectToNumber(ColumnHolder.TIME_COLUMN_NAME, transform.eval(row), true).longValue();
+        ts = Rows.objectToNumber(ColumnHolder.TIME_COLUMN_NAME, transform.eval(row), true).longValue();
       } else {
-        return row.getTimestampFromEpoch();
+        ts = row.getTimestampFromEpoch();
       }
+      return DateTimes.utc(ts);
     }
 
     @Override
     public long getTimestampFromEpoch()
     {
-      return timestamp;
+      return timestamp.getMillis();
     }
 
     @Override
     public DateTime getTimestamp()
     {
-      return DateTimes.utc(getTimestampFromEpoch());
+      return timestamp;
     }
 
     @Override


### PR DESCRIPTION
Reduce the number of times a timestamp is parsed and read if the row is a transformed row.

During ingestion the parsing and appending functionality requires repeated access to the timestamp information from the row. In the case of a TransformedInputRow, this could be an expensive step:

```
{
  "type": "expression",
  "name": "__time",
  "expression": "(point_seconds * 1000.0) + (point_nanos / 1000000.0)"
},
```

By caching this row, a significant reduction in CPU time can be achieved, in this example from 14% to 4% of CPU involved in reading Timestamps, a 10% reduction. This change converts the processing from lazy load of timestamp during Transform to an eager transform, and then keeps the result.

Before:
![image](https://user-images.githubusercontent.com/3196528/147988949-ed26c604-2c8a-478e-be13-9a476eff70b7.png)

After:
![image](https://user-images.githubusercontent.com/3196528/147988927-922f14f5-2e97-4f0e-a105-8b0fe79e8912.png)

This PR has:
- [x] been self-reviewed.
   - [ ] N/A using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] N/A added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] N/A added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] N/A added integration tests.
- [x] been tested in a test Druid cluster.
