### PR TITLE
Use ubuntu focal for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 
 language: java
 
-dist: focal
+dist: bionic
 
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 
 language: java
 
-dist: xenial
+dist: focal
 
 jdk:
   - openjdk8

--- a/check_test_suite.py
+++ b/check_test_suite.py
@@ -169,4 +169,4 @@ if __name__ == '__main__':
         sys.exit(1)
 
     print("No applicable changes detected, can skip test suite '{}'".format(suite_name))
-    sys.exit(0)
+    sys.exit(1)


### PR DESCRIPTION
### Description

```
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Processing triggers for libc-bin (2.28-10) ...

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
```

I have seen many Travis jobs timed out with the error above. This PR is to test whether using a more recent ubuntu image does anything good with this issue.

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
