### PR TITLE
Support extension services

### DIFF
--- a/core/src/main/java/org/apache/druid/common/exception/ErrorResponseTransformStrategy.java
+++ b/core/src/main/java/org/apache/druid/common/exception/ErrorResponseTransformStrategy.java
@@ -34,7 +34,7 @@ public interface ErrorResponseTransformStrategy
 {
   /**
    * For a given {@link SanitizableException} apply the transformation strategy and return the sanitized Exception
-   * if the transformation stategy was applied.
+   * if the transformation strategy was applied.
    */
   default Exception transformIfNeeded(SanitizableException exception)
   {

--- a/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
+++ b/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
@@ -61,7 +61,7 @@ public class LifecycleModule implements Module
    * is materialized and injected, meaning that objects are not actually instantiated in dependency order.
    * Registering with the LifecyceModule, on the other hand, will instantiate the objects after the normal object
    * graph has already been instantiated, meaning that objects will be created in dependency order and this will
-   * only actually instantiate something that wasn't actually dependend upon.
+   * only actually instantiate something that wasn't actually depended upon.
    *
    * @param clazz the class to instantiate
    * @return this, for chaining.
@@ -85,7 +85,7 @@ public class LifecycleModule implements Module
    * is materialized and injected, meaning that objects are not actually instantiated in dependency order.
    * Registering with the LifecyceModule, on the other hand, will instantiate the objects after the normal object
    * graph has already been instantiated, meaning that objects will be created in dependency order and this will
-   * only actually instantiate something that wasn't actually dependend upon.
+   * only actually instantiate something that wasn't actually depended upon.
    *
    * @param clazz the class to instantiate
    * @param annotation The annotation class to register with Guice
@@ -110,7 +110,7 @@ public class LifecycleModule implements Module
    * is materialized and injected, meaning that objects are not actually instantiated in dependency order.
    * Registering with the LifecyceModule, on the other hand, will instantiate the objects after the normal object
    * graph has already been instantiated, meaning that objects will be created in dependency order and this will
-   * only actually instantiate something that wasn't actually dependend upon.
+   * only actually instantiate something that wasn't actually depended upon.
    *
    * @param key The key to use in finding the DruidNode instance
    */

--- a/core/src/main/java/org/apache/druid/guice/annotations/PrivateApi.java
+++ b/core/src/main/java/org/apache/druid/guice/annotations/PrivateApi.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.guice.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that the annotated entity private API. Primarily used for internal REST
+ * endpoints to indicate that they are not part of the documented public API.
+ */
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Retention(RetentionPolicy.SOURCE)
+public @interface PrivateApi
+{
+}

--- a/core/src/main/java/org/apache/druid/indexer/TaskStatus.java
+++ b/core/src/main/java/org/apache/druid/indexer/TaskStatus.java
@@ -95,7 +95,7 @@ public class TaskStatus
   private final TaskLocation location;
 
   @JsonCreator
-  protected TaskStatus(
+  public TaskStatus(
       @JsonProperty("id") String id,
       @JsonProperty("status") TaskState status,
       @JsonProperty("duration") long duration,

--- a/core/src/main/java/org/apache/druid/query/QueryException.java
+++ b/core/src/main/java/org/apache/druid/query/QueryException.java
@@ -20,7 +20,10 @@
 package org.apache.druid.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.druid.common.exception.SanitizableException;
 
@@ -34,6 +37,9 @@ import java.util.function.Function;
  *
  * QueryResource and SqlResource are expected to emit the JSON form of this object when errors happen.
  */
+@SuppressWarnings("serial")
+// Streaming parser depend on the error field being first.
+@JsonPropertyOrder({"error", "errorMessage"})
 public class QueryException extends RuntimeException implements SanitizableException
 {
   private final String errorCode;
@@ -71,6 +77,7 @@ public class QueryException extends RuntimeException implements SanitizableExcep
   }
 
   @JsonProperty("errorMessage")
+  @JsonInclude(Include.NON_NULL)
   @Override
   public String getMessage()
   {
@@ -78,12 +85,14 @@ public class QueryException extends RuntimeException implements SanitizableExcep
   }
 
   @JsonProperty
+  @JsonInclude(Include.NON_NULL)
   public String getErrorClass()
   {
     return errorClass;
   }
 
   @JsonProperty
+  @JsonInclude(Include.NON_NULL)
   public String getHost()
   {
     return host;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClientTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClientTest.java
@@ -28,7 +28,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.IndexTaskClient;
+import org.apache.druid.indexing.common.TaskClient;
 import org.apache.druid.indexing.common.TaskInfoProvider;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.Status;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -163,7 +163,7 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
   @Test
   public void testTaskNotRunnableException()
   {
-    expectedException.expect(IndexTaskClient.TaskNotRunnableException.class);
+    expectedException.expect(TaskClient.TaskNotRunnableException.class);
     expectedException.expectMessage("Aborting request because task [test-id] is not runnable");
 
     EasyMock.reset(taskInfoProvider);

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
@@ -28,7 +28,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.IndexTaskClient;
+import org.apache.druid.indexing.common.TaskClient;
 import org.apache.druid.indexing.common.TaskInfoProvider;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.Status;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -164,7 +164,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   @Test
   public void testTaskNotRunnableException()
   {
-    expectedException.expect(IndexTaskClient.TaskNotRunnableException.class);
+    expectedException.expect(TaskClient.TaskNotRunnableException.class);
     expectedException.expectMessage("Aborting request because task [test-id] is not runnable");
 
     EasyMock.reset(taskInfoProvider);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/IndexTaskClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/IndexTaskClient.java
@@ -19,87 +19,26 @@
 
 package org.apache.druid.indexing.common;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.java.util.common.Either;
-import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.concurrent.Execs;
-import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.http.client.HttpClient;
-import org.apache.druid.java.util.http.client.Request;
-import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
-import org.apache.druid.java.util.http.client.response.ObjectOrErrorResponseHandler;
-import org.apache.druid.java.util.http.client.response.StringFullResponseHandler;
-import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
-import org.apache.druid.segment.realtime.firehose.ChatHandlerResource;
-import org.jboss.netty.channel.ChannelException;
-import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Duration;
-import org.joda.time.Period;
-
-import javax.annotation.Nullable;
-import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.Socket;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 
 /**
- * Abstract class to communicate with index tasks via HTTP. This class provides interfaces to serialize/deserialize
- * data and send an HTTP request.
+ * Abstract class to communicate with index tasks via HTTP. This class
+ * provides interfaces to serialize/deserialize data and send an HTTP request.
+ *
+ * This subclass assumes that tasks run within the Druid Indexer task
+ * system.
  */
-public abstract class IndexTaskClient implements AutoCloseable
+public abstract class IndexTaskClient extends TaskClient
 {
-  public static class NoTaskLocationException extends RuntimeException
-  {
-    public NoTaskLocationException(String message)
-    {
-      super(message);
-    }
-  }
-
-  public static class TaskNotRunnableException extends RuntimeException
-  {
-    public TaskNotRunnableException(String message)
-    {
-      super(message);
-    }
-  }
-
-  public static final int MAX_RETRY_WAIT_SECONDS = 10;
-
-  private static final EmittingLogger log = new EmittingLogger(IndexTaskClient.class);
   private static final String BASE_PATH = "/druid/worker/v1/chat";
-  private static final int MIN_RETRY_WAIT_SECONDS = 2;
-  private static final int TASK_MISMATCH_RETRY_DELAY_SECONDS = 5;
 
-  private final HttpClient httpClient;
-  private final ObjectMapper objectMapper;
   private final TaskInfoProvider taskInfoProvider;
-  private final Duration httpTimeout;
-  private final RetryPolicyFactory retryPolicyFactory;
-  private final ListeningExecutorService executorService;
 
   public IndexTaskClient(
       HttpClient httpClient,
@@ -111,413 +50,29 @@ public abstract class IndexTaskClient implements AutoCloseable
       long numRetries
   )
   {
-    this.httpClient = httpClient;
-    this.objectMapper = objectMapper;
+    super(httpClient, objectMapper, httpTimeout, callerId, numThreads, numRetries);
     this.taskInfoProvider = taskInfoProvider;
-    this.httpTimeout = httpTimeout;
-    this.retryPolicyFactory = initializeRetryPolicyFactory(numRetries);
-    this.executorService = MoreExecutors.listeningDecorator(
-        Execs.multiThreaded(
-            numThreads,
-            StringUtils.format(
-                "IndexTaskClient-%s-%%d",
-                StringUtils.encodeForFormat(callerId)
-            )
-        )
-    );
-  }
-
-  private static RetryPolicyFactory initializeRetryPolicyFactory(long numRetries)
-  {
-    // Retries [numRetries] times before giving up; this should be set long enough to handle any temporary
-    // unresponsiveness such as network issues, if a task is still in the process of starting up, or if the task is in
-    // the middle of persisting to disk and doesn't respond immediately.
-    return new RetryPolicyFactory(
-        new RetryPolicyConfig()
-            .setMinWait(Period.seconds(MIN_RETRY_WAIT_SECONDS))
-            .setMaxWait(Period.seconds(MAX_RETRY_WAIT_SECONDS))
-            .setMaxRetryCount(numRetries)
-    );
-  }
-
-  protected HttpClient getHttpClient()
-  {
-    return httpClient;
-  }
-
-  protected RetryPolicy newRetryPolicy()
-  {
-    return retryPolicyFactory.makeRetryPolicy();
-  }
-
-  protected <T> T deserialize(String content, JavaType type) throws IOException
-  {
-    return objectMapper.readValue(content, type);
-  }
-
-  protected <T> T deserialize(String content, TypeReference<T> typeReference) throws IOException
-  {
-    return objectMapper.readValue(content, typeReference);
-  }
-
-  protected <T> T deserialize(String content, Class<T> typeReference) throws IOException
-  {
-    return objectMapper.readValue(content, typeReference);
-  }
-
-  protected <T> T deserializeMap(String content, Class<? extends Map> mapClass, Class<?> keyClass, Class<?> valueClass)
-      throws IOException
-  {
-    return deserialize(content, objectMapper.getTypeFactory().constructMapType(mapClass, keyClass, valueClass));
-  }
-
-  protected <T> T deserializeNestedValueMap(
-      String content,
-      Class<? extends Map> mapClass,
-      Class<?> keyClass,
-      Class<? extends Map> valueMapClass,
-      Class<?> valueMapClassKey,
-      Class<?> valueMapClassValue
-  )
-      throws IOException
-  {
-    TypeFactory factory = objectMapper.getTypeFactory();
-    return deserialize(
-        content,
-        factory.constructMapType(
-            mapClass,
-            factory.constructType(keyClass),
-            factory.constructMapType(valueMapClass, valueMapClassKey, valueMapClassValue)
-        )
-    );
-  }
-
-  protected byte[] serialize(Object value) throws JsonProcessingException
-  {
-    return objectMapper.writeValueAsBytes(value);
-  }
-
-  protected <T> ListenableFuture<T> doAsync(Callable<T> callable)
-  {
-    return executorService.submit(callable);
-  }
-
-  protected boolean isSuccess(StringFullResponseHolder responseHolder)
-  {
-    return responseHolder.getStatus().getCode() / 100 == 2;
-  }
-
-  @VisibleForTesting
-  protected void checkConnection(String host, int port) throws IOException
-  {
-    new Socket(host, port).close();
-  }
-
-  protected StringFullResponseHolder submitRequestWithEmptyContent(
-      String taskId,
-      HttpMethod method,
-      String encodedPathSuffix,
-      @Nullable String encodedQueryString,
-      boolean retry
-  ) throws IOException, ChannelException, NoTaskLocationException
-  {
-    return submitRequest(
-        taskId,
-        null,
-        method,
-        encodedPathSuffix,
-        encodedQueryString,
-        new byte[0],
-        new StringFullResponseHandler(StandardCharsets.UTF_8),
-        retry
-    );
-  }
-
-  /**
-   * To use this method, {@link #objectMapper} should be a jsonMapper.
-   */
-  protected StringFullResponseHolder submitJsonRequest(
-      String taskId,
-      HttpMethod method,
-      String encodedPathSuffix,
-      @Nullable String encodedQueryString,
-      byte[] content,
-      boolean retry
-  ) throws IOException, ChannelException, NoTaskLocationException
-  {
-    return submitRequest(
-        taskId,
-        MediaType.APPLICATION_JSON,
-        method,
-        encodedPathSuffix,
-        encodedQueryString,
-        content,
-        new StringFullResponseHandler(StandardCharsets.UTF_8),
-        retry
-    );
-  }
-
-  /**
-   * To use this method, {@link #objectMapper} should be a smileMapper.
-   */
-  protected StringFullResponseHolder submitSmileRequest(
-      String taskId,
-      HttpMethod method,
-      String encodedPathSuffix,
-      @Nullable String encodedQueryString,
-      byte[] content,
-      boolean retry
-  ) throws IOException, ChannelException, NoTaskLocationException
-  {
-    return submitRequest(
-        taskId,
-        SmileMediaTypes.APPLICATION_JACKSON_SMILE,
-        method,
-        encodedPathSuffix,
-        encodedQueryString,
-        content,
-        new StringFullResponseHandler(StandardCharsets.UTF_8),
-        retry
-    );
-  }
-
-  private Request createRequest(
-      String taskId,
-      TaskLocation location,
-      String path,
-      @Nullable String encodedQueryString,
-      HttpMethod method,
-      @Nullable String mediaType,
-      byte[] content
-  ) throws MalformedURLException
-  {
-    // The below line can throw a MalformedURLException, and this method should return immediately without rety.
-    final URL serviceUrl = location.makeURL(
-        encodedQueryString == null ? path : StringUtils.format("%s?%s", path, encodedQueryString)
-    );
-
-    final Request request = new Request(method, serviceUrl);
-    // used to validate that we are talking to the correct worker
-    request.addHeader(ChatHandlerResource.TASK_ID_HEADER, StringUtils.urlEncode(taskId));
-    if (content.length > 0) {
-      request.setContent(Preconditions.checkNotNull(mediaType, "mediaType"), content);
-    }
-    return request;
-  }
-
-  /**
-   * Sends an HTTP request to the task of the specified {@code taskId} and returns a response if it succeeded.
-   */
-  protected <IntermediateType, FinalType> FinalType submitRequest(
-      String taskId,
-      @Nullable String mediaType, // nullable if content is empty
-      HttpMethod method,
-      String encodedPathSuffix,
-      @Nullable String encodedQueryString,
-      byte[] content,
-      HttpResponseHandler<IntermediateType, FinalType> responseHandler,
-      boolean retry
-  ) throws IOException, ChannelException, NoTaskLocationException
-  {
-    final RetryPolicy retryPolicy = retryPolicyFactory.makeRetryPolicy();
-
-    while (true) {
-      String path = StringUtils.format("%s/%s/%s", BASE_PATH, StringUtils.urlEncode(taskId), encodedPathSuffix);
-
-      Optional<TaskStatus> status = taskInfoProvider.getTaskStatus(taskId);
-      if (!status.isPresent() || !status.get().isRunnable()) {
-        throw new TaskNotRunnableException(
-            StringUtils.format(
-                "Aborting request because task [%s] is not runnable",
-                taskId
-            )
-        );
-      }
-
-      final TaskLocation location = taskInfoProvider.getTaskLocation(taskId);
-      if (location.equals(TaskLocation.unknown())) {
-        throw new NoTaskLocationException(StringUtils.format("No TaskLocation available for task [%s]", taskId));
-      }
-
-      final Request request = createRequest(
-          taskId,
-          location,
-          path,
-          encodedQueryString,
-          method,
-          mediaType,
-          content
-      );
-
-      Either<StringFullResponseHolder, FinalType> response = null;
-      try {
-        // Netty throws some annoying exceptions if a connection can't be opened, which happens relatively frequently
-        // for tasks that happen to still be starting up, so test the connection first to keep the logs clean.
-        checkConnection(request.getUrl().getHost(), request.getUrl().getPort());
-
-        response = submitRequest(request, responseHandler);
-
-        if (response.isValue()) {
-          return response.valueOrThrow();
-        } else {
-          final StringBuilder exceptionMessage = new StringBuilder();
-          final HttpResponseStatus httpResponseStatus = response.error().getStatus();
-          final String httpResponseContent = response.error().getContent();
-          exceptionMessage.append("Received server error with status [").append(httpResponseStatus).append("]");
-
-          if (!Strings.isNullOrEmpty(httpResponseContent)) {
-            final String choppedMessage =
-                StringUtils.chop(
-                    StringUtils.nullToEmptyNonDruidDataString(httpResponseContent),
-                    1000
-                );
-
-            exceptionMessage.append("; first 1KB of body: ").append(choppedMessage);
-          }
-
-          if (httpResponseStatus.getCode() == 400) {
-            // don't bother retrying if it's a bad request
-            throw new IAE(exceptionMessage.toString());
-          } else {
-            throw new IOE(exceptionMessage.toString());
-          }
-        }
-      }
-      catch (IOException | ChannelException e) {
-
-        // Since workers are free to move tasks around to different ports, there is a chance that a task may have been
-        // moved but our view of its location has not been updated yet from ZK. To detect this case, we send a header
-        // identifying our expected recipient in the request; if this doesn't correspond to the worker we messaged, the
-        // worker will return an HTTP 404 with its ID in the response header. If we get a mismatching task ID, then
-        // we will wait for a short period then retry the request indefinitely, expecting the task's location to
-        // eventually be updated.
-
-        final Duration delay;
-        if (response != null && !response.isValue()
-            && response.error().getStatus().equals(HttpResponseStatus.NOT_FOUND)) {
-          String headerId = StringUtils.urlDecode(
-              response.error().getResponse().headers().get(ChatHandlerResource.TASK_ID_HEADER)
-          );
-          if (headerId != null && !headerId.equals(taskId)) {
-            log.warn(
-                "Expected worker to have taskId [%s] but has taskId [%s], will retry in [%d]s",
-                taskId,
-                headerId,
-                TASK_MISMATCH_RETRY_DELAY_SECONDS
-            );
-            delay = Duration.standardSeconds(TASK_MISMATCH_RETRY_DELAY_SECONDS);
-          } else {
-            delay = retryPolicy.getAndIncrementRetryDelay();
-          }
-        } else {
-          delay = retryPolicy.getAndIncrementRetryDelay();
-        }
-        final String urlForLog = request.getUrl().toString();
-        if (!retry) {
-          // if retry=false, we probably aren't too concerned if the operation doesn't succeed (i.e. the request was
-          // for informational purposes only); log at INFO instead of WARN.
-          log.noStackTrace().info(e, "submitRequest failed for [%s]", urlForLog);
-          throw e;
-        } else if (delay == null) {
-          // When retrying, log the final failure at WARN level, since it is likely to be bad news.
-          log.warn(e, "submitRequest failed for [%s]", urlForLog);
-          throw e;
-        } else {
-          try {
-            final long sleepTime = delay.getMillis();
-            // When retrying, log non-final failures at INFO level.
-            log.noStackTrace().info(
-                e,
-                "submitRequest failed for [%s]; will try again in [%s]",
-                urlForLog,
-                new Duration(sleepTime).toString()
-            );
-
-            Thread.sleep(sleepTime);
-          }
-          catch (InterruptedException e2) {
-            Thread.currentThread().interrupt();
-            e.addSuppressed(e2);
-            throw new RuntimeException(e);
-          }
-        }
-      }
-      catch (NoTaskLocationException e) {
-        log.info(
-            "No TaskLocation available for task [%s], this task may not have been assigned to a worker yet "
-            + "or may have already completed",
-            taskId
-        );
-        throw e;
-      }
-      catch (Exception e) {
-        log.warn(e, "Exception while sending request");
-        throw e;
-      }
-    }
-  }
-
-  private <IntermediateType, FinalType> Either<StringFullResponseHolder, FinalType> submitRequest(
-      Request request,
-      HttpResponseHandler<IntermediateType, FinalType> responseHandler
-  ) throws IOException, ChannelException
-  {
-    final ObjectOrErrorResponseHandler<IntermediateType, FinalType> wrappedHandler =
-        new ObjectOrErrorResponseHandler<>(responseHandler);
-
-    try {
-      log.debug("HTTP %s: %s", request.getMethod().getName(), request.getUrl().toString());
-      return httpClient.go(request, wrappedHandler, httpTimeout).get();
-    }
-    catch (Exception e) {
-      throw throwIfPossible(e);
-    }
-  }
-
-  /**
-   * Throws if it's possible to throw the given Throwable.
-   * <p>
-   * - The input throwable shouldn't be null.
-   * - If Throwable is an {@link ExecutionException}, this calls itself recursively with the cause of ExecutionException.
-   * - If Throwable is an {@link IOException} or a {@link ChannelException}, this simply throws it.
-   * - If Throwable is an {@link InterruptedException}, this interrupts the current thread and throws a RuntimeException
-   * wrapping the InterruptedException
-   * - Otherwise, this simply returns the given Throwable.
-   * <p>
-   * Note that if the given Throable is an ExecutionException, this can return the cause of ExecutionException.
-   */
-  private RuntimeException throwIfPossible(Throwable t) throws IOException, ChannelException
-  {
-    Preconditions.checkNotNull(t, "Throwable shoulnd't null");
-
-    if (t instanceof ExecutionException) {
-      if (t.getCause() != null) {
-        return throwIfPossible(t.getCause());
-      } else {
-        return new RuntimeException(t);
-      }
-    }
-
-    if (t instanceof IOException) {
-      throw (IOException) t;
-    }
-
-    if (t instanceof ChannelException) {
-      throw (ChannelException) t;
-    }
-
-    if (t instanceof InterruptedException) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(t);
-    }
-
-    Throwables.propagateIfPossible(t);
-    return new RuntimeException(t);
   }
 
   @Override
-  public void close()
+  protected String buildPath(String taskId, String encodedPathSuffix)
   {
-    executorService.shutdownNow();
+    return StringUtils.format("%s/%s/%s", BASE_PATH, StringUtils.urlEncode(taskId), encodedPathSuffix);
+  }
+
+  @Override
+  protected TaskLocation resolveLocation(String taskId)
+  {
+    Optional<TaskStatus> status = taskInfoProvider.getTaskStatus(taskId);
+    if (!status.isPresent() || !status.get().isRunnable()) {
+      throw new TaskNotRunnableException(
+          StringUtils.format(
+              "Aborting request because task [%s] is not runnable",
+              taskId
+          )
+      );
+    }
+
+    return taskInfoProvider.getTaskLocation(taskId);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
@@ -53,7 +53,6 @@ public class SingleFileTaskReportFileWriter implements TaskReportFileWriter
     }
   }
 
-
   @Override
   public void setObjectMapper(ObjectMapper objectMapper)
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskClient.java
@@ -1,0 +1,516 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.druid.indexer.TaskLocation;
+import org.apache.druid.java.util.common.Either;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.IOE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
+import org.apache.druid.java.util.http.client.response.ObjectOrErrorResponseHandler;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
+import org.apache.druid.segment.realtime.firehose.ChatHandlerResource;
+import org.jboss.netty.channel.ChannelException;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MediaType;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Abstract class to communicate with index tasks via HTTP. This class provides
+ * interfaces to serialize/deserialize data and send an HTTP request.
+ *
+ * The class assumes it communicates with tasks, but delegates to subclasses
+ * exactly how tasks relate to endpoints.
+ */
+public abstract class TaskClient implements AutoCloseable
+{
+  @SuppressWarnings("serial")
+  public static class NoTaskLocationException extends RuntimeException
+  {
+    public NoTaskLocationException(String message)
+    {
+      super(message);
+    }
+  }
+
+  @SuppressWarnings("serial")
+  public static class TaskNotRunnableException extends RuntimeException
+  {
+    public TaskNotRunnableException(String message)
+    {
+      super(message);
+    }
+  }
+
+  public static final int MAX_RETRY_WAIT_SECONDS = 10;
+
+  private static final EmittingLogger log = new EmittingLogger(TaskClient.class);
+  private static final int MIN_RETRY_WAIT_SECONDS = 2;
+  private static final int TASK_MISMATCH_RETRY_DELAY_SECONDS = 5;
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final Duration httpTimeout;
+  private final RetryPolicyFactory retryPolicyFactory;
+  private final ListeningExecutorService executorService;
+
+  public TaskClient(
+      HttpClient httpClient,
+      ObjectMapper objectMapper,
+      Duration httpTimeout,
+      String threadName,
+      int numThreads,
+      long numRetries
+  )
+  {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.httpTimeout = httpTimeout;
+    this.retryPolicyFactory = initializeRetryPolicyFactory(numRetries);
+    this.executorService = MoreExecutors.listeningDecorator(
+        Execs.multiThreaded(
+            numThreads,
+            StringUtils.format(
+                "IndexTaskClient-%s-%%d",
+                StringUtils.encodeForFormat(threadName)
+            )
+        )
+    );
+  }
+
+  private static RetryPolicyFactory initializeRetryPolicyFactory(long numRetries)
+  {
+    // Retries [numRetries] times before giving up; this should be set long enough to handle any temporary
+    // unresponsiveness such as network issues, if a task is still in the process of starting up, or if the task is in
+    // the middle of persisting to disk and doesn't respond immediately.
+    return new RetryPolicyFactory(
+        new RetryPolicyConfig()
+            .setMinWait(Period.seconds(MIN_RETRY_WAIT_SECONDS))
+            .setMaxWait(Period.seconds(MAX_RETRY_WAIT_SECONDS))
+            .setMaxRetryCount(numRetries)
+    );
+  }
+  protected HttpClient getHttpClient()
+  {
+    return httpClient;
+  }
+
+  protected RetryPolicy newRetryPolicy()
+  {
+    return retryPolicyFactory.makeRetryPolicy();
+  }
+
+  protected <T> T deserialize(String content, JavaType type) throws IOException
+  {
+    return objectMapper.readValue(content, type);
+  }
+
+  protected <T> T deserialize(String content, TypeReference<T> typeReference) throws IOException
+  {
+    return objectMapper.readValue(content, typeReference);
+  }
+
+  protected <T> T deserialize(String content, Class<T> typeReference) throws IOException
+  {
+    return objectMapper.readValue(content, typeReference);
+  }
+
+  @SuppressWarnings("rawtypes")
+  protected <T> T deserializeMap(String content, Class<? extends Map> mapClass, Class<?> keyClass, Class<?> valueClass)
+      throws IOException
+  {
+    return deserialize(content, objectMapper.getTypeFactory().constructMapType(mapClass, keyClass, valueClass));
+  }
+
+  @SuppressWarnings("rawtypes")
+  protected <T> T deserializeNestedValueMap(
+      String content,
+      Class<? extends Map> mapClass,
+      Class<?> keyClass,
+      Class<? extends Map> valueMapClass,
+      Class<?> valueMapClassKey,
+      Class<?> valueMapClassValue
+  )
+      throws IOException
+  {
+    TypeFactory factory = objectMapper.getTypeFactory();
+    return deserialize(
+        content,
+        factory.constructMapType(
+            mapClass,
+            factory.constructType(keyClass),
+            factory.constructMapType(valueMapClass, valueMapClassKey, valueMapClassValue)
+        )
+    );
+  }
+
+  protected byte[] serialize(Object value) throws JsonProcessingException
+  {
+    return objectMapper.writeValueAsBytes(value);
+  }
+
+  protected <T> ListenableFuture<T> doAsync(Callable<T> callable)
+  {
+    return executorService.submit(callable);
+  }
+
+  protected boolean isSuccess(StringFullResponseHolder responseHolder)
+  {
+    return responseHolder.getStatus().getCode() / 100 == 2;
+  }
+
+  @VisibleForTesting
+  protected void checkConnection(String host, int port) throws IOException
+  {
+    new Socket(host, port).close();
+  }
+
+  protected StringFullResponseHolder submitRequestWithEmptyContent(
+      String taskId,
+      HttpMethod method,
+      String encodedPathSuffix,
+      @Nullable String encodedQueryString,
+      boolean retry
+  ) throws IOException, ChannelException, NoTaskLocationException
+  {
+    return submitRequest(
+        taskId,
+        null,
+        method,
+        encodedPathSuffix,
+        encodedQueryString,
+        new byte[0],
+        new StringFullResponseHandler(StandardCharsets.UTF_8),
+        retry
+    );
+  }
+
+  /**
+   * To use this method, {@link #objectMapper} should be a jsonMapper.
+   */
+  protected StringFullResponseHolder submitJsonRequest(
+      String taskId,
+      HttpMethod method,
+      String encodedPathSuffix,
+      @Nullable String encodedQueryString,
+      byte[] content,
+      boolean retry
+  ) throws IOException, ChannelException, NoTaskLocationException
+  {
+    return submitRequest(
+        taskId,
+        MediaType.APPLICATION_JSON,
+        method,
+        encodedPathSuffix,
+        encodedQueryString,
+        content,
+        new StringFullResponseHandler(StandardCharsets.UTF_8),
+        retry
+    );
+  }
+
+  /**
+   * To use this method, {@link #objectMapper} should be a smileMapper.
+   */
+  protected StringFullResponseHolder submitSmileRequest(
+      String taskId,
+      HttpMethod method,
+      String encodedPathSuffix,
+      @Nullable String encodedQueryString,
+      byte[] content,
+      boolean retry
+  ) throws IOException, ChannelException, NoTaskLocationException
+  {
+    return submitRequest(
+        taskId,
+        SmileMediaTypes.APPLICATION_JACKSON_SMILE,
+        method,
+        encodedPathSuffix,
+        encodedQueryString,
+        content,
+        new StringFullResponseHandler(StandardCharsets.UTF_8),
+        retry
+    );
+  }
+
+  private Request createRequest(
+      String taskId,
+      TaskLocation location,
+      String path,
+      @Nullable String encodedQueryString,
+      HttpMethod method,
+      @Nullable String mediaType,
+      byte[] content
+  ) throws MalformedURLException
+  {
+    // The below line can throw a MalformedURLException, and this method should return immediately without rety.
+    final URL serviceUrl = location.makeURL(
+        encodedQueryString == null ? path : StringUtils.format("%s?%s", path, encodedQueryString)
+    );
+
+    final Request request = new Request(method, serviceUrl);
+    // used to validate that we are talking to the correct worker
+    request.addHeader(ChatHandlerResource.TASK_ID_HEADER, StringUtils.urlEncode(taskId));
+    if (content.length > 0) {
+      request.setContent(Preconditions.checkNotNull(mediaType, "mediaType"), content);
+    }
+    return request;
+  }
+
+  protected abstract String buildPath(String taskId, String encodedPathSuffix);
+  protected abstract TaskLocation resolveLocation(String taskId);
+
+  /**
+   * Sends an HTTP request to the task of the specified {@code taskId} and returns a response if it succeeded.
+   */
+  protected <IntermediateType, FinalType> FinalType submitRequest(
+      String taskId,
+      @Nullable String mediaType, // nullable if content is empty
+      HttpMethod method,
+      String encodedPathSuffix,
+      @Nullable String encodedQueryString,
+      byte[] content,
+      HttpResponseHandler<IntermediateType, FinalType> responseHandler,
+      boolean retry
+  ) throws IOException, ChannelException, NoTaskLocationException
+  {
+    final RetryPolicy retryPolicy = retryPolicyFactory.makeRetryPolicy();
+
+    while (true) {
+      String path = buildPath(taskId, encodedPathSuffix);
+      final TaskLocation location = resolveLocation(taskId);
+      if (location.equals(TaskLocation.unknown())) {
+        throw new NoTaskLocationException(StringUtils.format("No TaskLocation available for task [%s]", taskId));
+      }
+
+      final Request request = createRequest(
+          taskId,
+          location,
+          path,
+          encodedQueryString,
+          method,
+          mediaType,
+          content
+      );
+
+      Either<StringFullResponseHolder, FinalType> response = null;
+      try {
+        // Netty throws some annoying exceptions if a connection can't be opened, which happens relatively frequently
+        // for tasks that happen to still be starting up, so test the connection first to keep the logs clean.
+        checkConnection(request.getUrl().getHost(), request.getUrl().getPort());
+
+        response = submitRequest(request, responseHandler);
+
+        if (response.isValue()) {
+          return response.valueOrThrow();
+        } else {
+          final StringBuilder exceptionMessage = new StringBuilder();
+          final HttpResponseStatus httpResponseStatus = response.error().getStatus();
+          final String httpResponseContent = response.error().getContent();
+          exceptionMessage.append("Received server error with status [").append(httpResponseStatus).append("]");
+
+          if (!Strings.isNullOrEmpty(httpResponseContent)) {
+            final String choppedMessage =
+                StringUtils.chop(
+                    StringUtils.nullToEmptyNonDruidDataString(httpResponseContent),
+                    1000
+                );
+
+            exceptionMessage.append("; first 1KB of body: ").append(choppedMessage);
+          }
+
+          if (httpResponseStatus.getCode() == 400) {
+            // don't bother retrying if it's a bad request
+            throw new IAE(exceptionMessage.toString());
+          } else {
+            throw new IOE(exceptionMessage.toString());
+          }
+        }
+      }
+      catch (IOException | ChannelException e) {
+
+        // Since workers are free to move tasks around to different ports, there is a chance that a task may have been
+        // moved but our view of its location has not been updated yet from ZK. To detect this case, we send a header
+        // identifying our expected recipient in the request; if this doesn't correspond to the worker we messaged, the
+        // worker will return an HTTP 404 with its ID in the response header. If we get a mismatching task ID, then
+        // we will wait for a short period then retry the request indefinitely, expecting the task's location to
+        // eventually be updated.
+
+        final Duration delay;
+        if (response != null && !response.isValue()
+            && response.error().getStatus().equals(HttpResponseStatus.NOT_FOUND)) {
+          String headerId = StringUtils.urlDecode(
+              response.error().getResponse().headers().get(ChatHandlerResource.TASK_ID_HEADER)
+          );
+          if (headerId != null && !headerId.equals(taskId)) {
+            log.warn(
+                "Expected worker to have taskId [%s] but has taskId [%s], will retry in [%d]s",
+                taskId,
+                headerId,
+                TASK_MISMATCH_RETRY_DELAY_SECONDS
+            );
+            delay = Duration.standardSeconds(TASK_MISMATCH_RETRY_DELAY_SECONDS);
+          } else {
+            delay = retryPolicy.getAndIncrementRetryDelay();
+          }
+        } else {
+          delay = retryPolicy.getAndIncrementRetryDelay();
+        }
+        final String urlForLog = request.getUrl().toString();
+        if (!retry) {
+          // if retry=false, we probably aren't too concerned if the operation doesn't succeed (i.e. the request was
+          // for informational purposes only); log at INFO instead of WARN.
+          log.noStackTrace().info(e, "submitRequest failed for [%s]", urlForLog);
+          throw e;
+        } else if (delay == null) {
+          // When retrying, log the final failure at WARN level, since it is likely to be bad news.
+          log.warn(e, "submitRequest failed for [%s]", urlForLog);
+          throw e;
+        } else {
+          try {
+            final long sleepTime = delay.getMillis();
+            // When retrying, log non-final failures at INFO level.
+            log.noStackTrace().info(
+                e,
+                "submitRequest failed for [%s]; will try again in [%s]",
+                urlForLog,
+                new Duration(sleepTime).toString()
+            );
+
+            Thread.sleep(sleepTime);
+          }
+          catch (InterruptedException e2) {
+            Thread.currentThread().interrupt();
+            e.addSuppressed(e2);
+            throw new RuntimeException(e);
+          }
+        }
+      }
+      catch (NoTaskLocationException e) {
+        log.info(
+            "No TaskLocation available for task [%s], this task may not have been assigned to a worker yet "
+            + "or may have already completed",
+            taskId
+        );
+        throw e;
+      }
+      catch (Exception e) {
+        log.warn(e, "Exception while sending request");
+        throw e;
+      }
+    }
+  }
+
+  private <IntermediateType, FinalType> Either<StringFullResponseHolder, FinalType> submitRequest(
+      Request request,
+      HttpResponseHandler<IntermediateType, FinalType> responseHandler
+  ) throws IOException, ChannelException
+  {
+    final ObjectOrErrorResponseHandler<IntermediateType, FinalType> wrappedHandler =
+        new ObjectOrErrorResponseHandler<>(responseHandler);
+
+    try {
+      log.debug("HTTP %s: %s", request.getMethod().getName(), request.getUrl().toString());
+      return httpClient.go(request, wrappedHandler, httpTimeout).get();
+    }
+    catch (Exception e) {
+      throw throwIfPossible(e);
+    }
+  }
+
+  /**
+   * Throws if it's possible to throw the given Throwable.
+   * <p>
+   * - The input throwable shouldn't be null.
+   * - If Throwable is an {@link ExecutionException}, this calls itself recursively with the cause of ExecutionException.
+   * - If Throwable is an {@link IOException} or a {@link ChannelException}, this simply throws it.
+   * - If Throwable is an {@link InterruptedException}, this interrupts the current thread and throws a RuntimeException
+   * wrapping the InterruptedException
+   * - Otherwise, this simply returns the given Throwable.
+   * <p>
+   * Note that if the given Throwable is an ExecutionException, this can return the cause of ExecutionException.
+   */
+  private RuntimeException throwIfPossible(Throwable t) throws IOException, ChannelException
+  {
+    Preconditions.checkNotNull(t, "Throwable shoulnd't null");
+
+    if (t instanceof ExecutionException) {
+      if (t.getCause() != null) {
+        return throwIfPossible(t.getCause());
+      } else {
+        return new RuntimeException(t);
+      }
+    }
+
+    if (t instanceof IOException) {
+      throw (IOException) t;
+    }
+
+    if (t instanceof ChannelException) {
+      throw (ChannelException) t;
+    }
+
+    if (t instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(t);
+    }
+
+    Throwables.propagateIfPossible(t);
+    return new RuntimeException(t);
+  }
+
+  @Override
+  public void close()
+  {
+    executorService.shutdownNow();
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClient.java
@@ -39,12 +39,12 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class RemoteTaskActionClient implements TaskActionClient
 {
+  private static final Logger log = new Logger(RemoteTaskActionClient.class);
+
   private final Task task;
   private final RetryPolicyFactory retryPolicyFactory;
   private final ObjectMapper jsonMapper;
   private final DruidLeaderClient druidLeaderClient;
-
-  private static final Logger log = new Logger(RemoteTaskActionClient.class);
 
   public RemoteTaskActionClient(
       Task task,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
@@ -38,10 +38,10 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Configurations for ingestion tasks. These configurations can be applied per middleManager, indexer, or overlord.
+ * Configurations for ingestion tasks. These configurations can be applied per MiddleManager, Indexer, or Overlord.
  *
  * See {@link org.apache.druid.indexing.overlord.config.DefaultTaskConfig} if you want to apply the same configuration
- * to all tasks submitted to the overlord.
+ * to all tasks submitted to the Overlord.
  */
 public class TaskConfig
 {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -1160,12 +1160,12 @@ public class CompactionTask extends AbstractBatchIndexTask
   }
 
   /**
-   * Compcation Task Tuning Config.
+   * Compaction Task Tuning Config.
    *
    * An extension of ParallelIndexTuningConfig. As of now, all this TuningConfig
    * does is fail if the TuningConfig contains
    * `awaitSegmentAvailabilityTimeoutMillis` that is != 0 since it is not
-   * supported for Compcation Tasks.
+   * supported for Compaction Tasks.
    */
   public static class CompactionTuningConfig extends ParallelIndexTuningConfig
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * TaskRunner implemention for the CliIndexer task execution service, which runs all tasks in a single process.
+ * TaskRunner implementation for the CliIndexer task execution service, which runs all tasks in a single process.
  *
  * Two thread pools are used:
  * - A task execution pool, sized to number of worker slots. This is used to setup and execute the Task run() methods.
@@ -98,7 +98,7 @@ public class ThreadingTaskRunner
   private final ListeningExecutorService controlThreadExecutor;
   private final WorkerConfig workerConfig;
 
-  private volatile boolean stopping = false;
+  private volatile boolean stopping;
 
   @Inject
   public ThreadingTaskRunner(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -114,6 +114,8 @@ public class OverlordResource
 {
   private static final Logger log = new Logger(OverlordResource.class);
 
+  public static final String ERROR_KEY = "error";
+
   private final TaskMaster taskMaster;
   private final TaskStorageQueryAdapter taskStorageQueryAdapter;
   private final IndexerMetadataStorageAdapter indexerMetadataStorageAdapter;
@@ -190,7 +192,7 @@ public class OverlordResource
               return Response.status(Response.Status.BAD_REQUEST)
                              .entity(
                                  ImmutableMap.of(
-                                     "error",
+                                     ERROR_KEY,
                                      StringUtils.format("Task[%s] already exists!", task.getId())
                                  )
                              )
@@ -234,7 +236,13 @@ public class OverlordResource
   public Response getDatasourceLockedIntervals(Map<String, Integer> minTaskPriority)
   {
     if (minTaskPriority == null || minTaskPriority.isEmpty()) {
-      return Response.status(Status.BAD_REQUEST).entity("No Datasource provided").build();
+      return Response
+          .status(Status.BAD_REQUEST)
+          .entity(
+              ImmutableMap.of(
+                  ERROR_KEY,
+                  "No Datasource provided"))
+          .build();
     }
 
     // Build the response

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -124,7 +124,7 @@ public class OverlordResource
   private final WorkerTaskRunnerQueryAdapter workerTaskRunnerQueryAdapter;
 
   private AtomicReference<WorkerBehaviorConfig> workerConfigRef = null;
-  private static final List API_TASK_STATES = ImmutableList.of("pending", "waiting", "running", "complete");
+  private static final List<String> API_TASK_STATES = ImmutableList.of("pending", "waiting", "running", "complete");
 
   @Inject
   public OverlordResource(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/TaskResourceFilter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/TaskResourceFilter.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.overlord.http.security;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ContainerRequest;
@@ -38,6 +39,7 @@ import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
@@ -77,10 +79,16 @@ public class TaskResourceFilter extends AbstractResourceFilter
 
     Optional<Task> taskOptional = taskStorageQueryAdapter.getTask(taskId);
     if (!taskOptional.isPresent()) {
+      // This response is returned from APIs that promise to return JSON.
       throw new WebApplicationException(
-          Response.status(Response.Status.NOT_FOUND)
-                  .entity(StringUtils.format("Cannot find any task with id: [%s]", taskId))
-                  .build()
+          Response
+              .status(Response.Status.NOT_FOUND)
+              .type(MediaType.APPLICATION_JSON_TYPE)
+              .entity(
+                  ImmutableMap.of(
+                      "error",
+                      StringUtils.format("Cannot find any task with id: [%s]", taskId)))
+              .build()
       );
     }
     final String dataSourceName = Preconditions.checkNotNull(taskOptional.get().getDataSource());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -44,7 +44,7 @@ import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.IndexTaskClient;
+import org.apache.druid.indexing.common.TaskClient;
 import org.apache.druid.indexing.common.TaskInfoProvider;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
@@ -841,7 +841,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     this.futureTimeoutInSeconds = Math.max(
         MINIMUM_FUTURE_TIMEOUT_IN_SECONDS,
         tuningConfig.getChatRetries() * (tuningConfig.getHttpTimeout().getStandardSeconds()
-                                         + IndexTaskClient.MAX_RETRY_WAIT_SECONDS)
+                                         + TaskClient.MAX_RETRY_WAIT_SECONDS)
     );
 
     this.taskClient = taskClientFactory.build(

--- a/processing/src/main/java/org/apache/druid/query/Druids.java
+++ b/processing/src/main/java/org/apache/druid/query/Druids.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -45,6 +46,7 @@ import org.apache.druid.query.search.SearchQuery;
 import org.apache.druid.query.search.SearchQuerySpec;
 import org.apache.druid.query.search.SearchSortSpec;
 import org.apache.druid.query.spec.LegacySegmentSpec;
+import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.spec.QuerySegmentSpec;
 import org.apache.druid.query.timeboundary.TimeBoundaryQuery;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
@@ -775,9 +777,11 @@ public class Druids
    * Usage example:
    * <pre><code>
    *   ScanQuery query = new ScanQueryBuilder()
-   *                                  .dataSource("Example")
-   *                                  .interval("2010/2013")
-   *                                  .build();
+   *           .dataSource("Example")
+   *           .intervals(
+   *               new MultipleIntervalSegmentSpec(
+   *                   ImmutableList.of(Intervals.ETERNITY)))
+   *           .build();
    * </code></pre>
    *
    * @see ScanQuery
@@ -793,26 +797,13 @@ public class Druids
     private long offset;
     private long limit;
     private DimFilter dimFilter;
-    private List<String> columns;
+    private List<String> columns = new ArrayList<>();
     private Boolean legacy;
     private ScanQuery.Order order;
     private List<ScanQuery.OrderBy> orderBy;
 
     public ScanQueryBuilder()
     {
-      dataSource = null;
-      querySegmentSpec = null;
-      virtualColumns = null;
-      context = null;
-      resultFormat = null;
-      batchSize = 0;
-      offset = 0;
-      limit = 0;
-      dimFilter = null;
-      columns = new ArrayList<>();
-      legacy = null;
-      order = null;
-      orderBy = null;
     }
 
     public ScanQuery build()
@@ -867,6 +858,16 @@ public class Druids
     {
       querySegmentSpec = q;
       return this;
+    }
+
+    /**
+     * Convenience method for an interval over all time.
+     */
+    public ScanQueryBuilder eternity()
+    {
+      return intervals(
+            new MultipleIntervalSegmentSpec(
+                  ImmutableList.of(Intervals.ETERNITY)));
     }
 
     public ScanQueryBuilder virtualColumns(VirtualColumns virtualColumns)

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryRunnerTest.java
@@ -197,7 +197,7 @@ public class ScanQueryRunnerTest extends InitializedNullHandlingTest
     return Druids.newScanQueryBuilder()
                  .dataSource(new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE))
                  .columns(Collections.emptyList())
-                 .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+                 .eternity()
                  .limit(3)
                  .legacy(legacy);
   }

--- a/server/src/main/java/org/apache/druid/client/FilteredHttpServerInventoryViewProvider.java
+++ b/server/src/main/java/org/apache/druid/client/FilteredHttpServerInventoryViewProvider.java
@@ -36,20 +36,20 @@ public class FilteredHttpServerInventoryViewProvider implements FilteredServerIn
   @JacksonInject
   @NotNull
   @EscalatedClient
-  HttpClient httpClient = null;
+  HttpClient httpClient;
 
   @JacksonInject
   @NotNull
   @Smile
-  ObjectMapper smileMapper = null;
+  ObjectMapper smileMapper;
 
   @JacksonInject
   @NotNull
-  HttpServerInventoryViewConfig config = null;
+  HttpServerInventoryViewConfig config;
 
   @JacksonInject
   @NotNull
-  private DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = null;
+  private DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
 
   @Override
   public HttpServerInventoryView get()

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -126,7 +126,6 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
     this.execNamePrefix = execNamePrefix;
   }
 
-
   @LifecycleStart
   public void start()
   {

--- a/server/src/main/java/org/apache/druid/discovery/NodeRoles.java
+++ b/server/src/main/java/org/apache/druid/discovery/NodeRoles.java
@@ -24,6 +24,7 @@ import com.google.inject.multibindings.Multibinder;
 import org.apache.druid.guice.annotations.Global;
 import org.apache.druid.java.util.common.logger.Logger;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,9 +39,7 @@ public class NodeRoles
   public static Set<NodeRole> knownRoles()
   {
     Set<NodeRole> nodeRoles = new HashSet<>();
-    for (NodeRole role : NodeRole.values()) {
-      nodeRoles.add(role);
-    }
+    nodeRoles.addAll(Arrays.asList(NodeRole.values()));
     return nodeRoles;
   }
 

--- a/server/src/main/java/org/apache/druid/discovery/NodeRoles.java
+++ b/server/src/main/java/org/apache/druid/discovery/NodeRoles.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.discovery;
+
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+import org.apache.druid.guice.annotations.Global;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class NodeRoles
+{
+  private static final Logger LOG = new Logger(NodeRoles.class);
+
+  /**
+   * Simulate the Guice binding of all node roles, but using just
+   * the known roles. Primarily for testing.
+   */
+  public static Set<NodeRole> knownRoles()
+  {
+    Set<NodeRole> nodeRoles = new HashSet<>();
+    for (NodeRole role : NodeRole.values()) {
+      nodeRoles.add(role);
+    }
+    return nodeRoles;
+  }
+
+  public static void addKnownRoles(Binder binder)
+  {
+    Multibinder<NodeRole> roleBinder = binder(binder);
+    for (NodeRole role : NodeRole.values()) {
+      roleBinder.addBinding().toInstance(role);
+    }
+  }
+
+  /**
+   * Add a node role for an extension service.
+   */
+  public static void addRole(Binder binder, NodeRole role)
+  {
+    LOG.debug("Adding node role: " + role.getJsonName());
+    binder(binder)
+               .addBinding()
+               .toInstance(role);
+  }
+
+  public static Multibinder<NodeRole> binder(Binder binder)
+  {
+    return Multibinder.newSetBinder(binder, NodeRole.class, Global.class);
+  }
+}

--- a/server/src/main/java/org/apache/druid/discovery/NodeRoles.java
+++ b/server/src/main/java/org/apache/druid/discovery/NodeRoles.java
@@ -38,9 +38,7 @@ public class NodeRoles
    */
   public static Set<NodeRole> knownRoles()
   {
-    Set<NodeRole> nodeRoles = new HashSet<>();
-    nodeRoles.addAll(Arrays.asList(NodeRole.values()));
-    return nodeRoles;
+    return new HashSet<>(Arrays.asList(NodeRole.values()));
   }
 
   public static void addKnownRoles(Binder binder)

--- a/server/src/main/java/org/apache/druid/initialization/Initialization.java
+++ b/server/src/main/java/org/apache/druid/initialization/Initialization.java
@@ -517,7 +517,13 @@ public class Initialization
       Set<NodeRole> rolesPredicate = Arrays.stream(loadScope.roles())
                                            .map(NodeRole::fromJsonName)
                                            .collect(Collectors.toSet());
-      return rolesPredicate.stream().anyMatch(nodeRoles::contains);
+      boolean shouldLoad = rolesPredicate.stream().anyMatch(nodeRoles::contains);
+      if (!shouldLoad) {
+        log.debug(
+            "Module [%s] excluded by LoadScope rules",
+            object.getClass().getName());
+      }
+      return shouldLoad;
     }
 
     private boolean checkModuleClass(Class<?> moduleClass)

--- a/server/src/main/java/org/apache/druid/server/initialization/AuthenticatorMapperModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/AuthenticatorMapperModule.java
@@ -34,7 +34,6 @@ import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.security.AllowAllAuthenticator;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.Authenticator;
@@ -50,7 +49,6 @@ import java.util.Set;
 public class AuthenticatorMapperModule implements DruidModule
 {
   private static final String AUTHENTICATOR_PROPERTIES_FORMAT_STRING = "druid.auth.authenticator.%s";
-  private static Logger log = new Logger(AuthenticatorMapperModule.class);
 
   @Override
   public void configure(Binder binder)

--- a/server/src/main/java/org/apache/druid/server/security/AllowAllAuthenticator.java
+++ b/server/src/main/java/org/apache/druid/server/security/AllowAllAuthenticator.java
@@ -73,7 +73,6 @@ public class AllowAllAuthenticator implements Authenticator
       @Override
       public void init(FilterConfig filterConfig)
       {
-
       }
 
       @Override

--- a/server/src/main/java/org/apache/druid/server/security/UnsecuredResourceFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/UnsecuredResourceFilter.java
@@ -36,7 +36,6 @@ public class UnsecuredResourceFilter implements Filter
   @Override
   public void init(FilterConfig filterConfig)
   {
-
   }
 
   @Override
@@ -63,6 +62,5 @@ public class UnsecuredResourceFilter implements Filter
   @Override
   public void destroy()
   {
-
   }
 }

--- a/server/src/test/java/org/apache/druid/curator/discovery/NodeRolesTest.java
+++ b/server/src/test/java/org/apache/druid/curator/discovery/NodeRolesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.curator.discovery;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.discovery.NodeRoles;
+import org.apache.druid.guice.annotations.Global;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the NodeRoles class allows injecting a set of roles
+ * which includes custom roles defined by an extension.
+ */
+public class NodeRolesTest
+{
+  @Test
+  public void testNodeRoles()
+  {
+    Set<NodeRole> knownRules = NodeRoles.knownRoles();
+    assertEquals(NodeRole.values().length, knownRules.size());
+
+    NodeRole customRole = new NodeRole("custom");
+    Injector injector = Guice.createInjector(
+        binder -> {
+          NodeRoles.addKnownRoles(binder);
+          NodeRoles.addRole(binder, customRole);
+        });
+    Set<NodeRole> roles = injector.getInstance(
+        Key.get(new TypeLiteral<Set<NodeRole>>(){}, Global.class));
+    assertEquals(NodeRole.values().length + 1, roles.size());
+    assertTrue(roles.contains(customRole));
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
+++ b/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
@@ -59,7 +59,6 @@ import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.GroupByQueryHelper;
 import org.apache.druid.query.groupby.strategy.GroupByStrategyV2;
 import org.apache.druid.query.scan.ScanQuery;
-import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.topn.TopNQuery;
 import org.apache.druid.query.topn.TopNQueryBuilder;
@@ -636,11 +635,7 @@ public class ClientQuerySegmentWalkerTest
   {
     ScanQuery subquery = new Druids.ScanQueryBuilder().dataSource(MULTI)
                                                       .columns("s", "n")
-                                                      .intervals(
-                                                          new MultipleIntervalSegmentSpec(
-                                                              ImmutableList.of(Intervals.ETERNITY)
-                                                          )
-                                                      )
+                                                      .eternity()
                                                       .legacy(false)
                                                       .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                                                       .build();
@@ -691,11 +686,7 @@ public class ClientQuerySegmentWalkerTest
   {
     ScanQuery subquery = new Druids.ScanQueryBuilder().dataSource(MULTI)
                                                       .columns("s", "n")
-                                                      .intervals(
-                                                          new MultipleIntervalSegmentSpec(
-                                                              ImmutableList.of(Intervals.ETERNITY)
-                                                          )
-                                                      )
+                                                      .eternity()
                                                       .legacy(false)
                                                       .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                                                       .build();
@@ -1382,12 +1373,12 @@ public class ClientQuerySegmentWalkerTest
       this.how = how;
     }
 
-    static ExpectedQuery local(final Query query)
+    static ExpectedQuery local(final Query<?> query)
     {
       return new ExpectedQuery(query, ClusterOrLocal.LOCAL);
     }
 
-    static ExpectedQuery cluster(final Query query)
+    static ExpectedQuery cluster(final Query<?> query)
     {
       return new ExpectedQuery(query, ClusterOrLocal.CLUSTER);
     }

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -340,7 +340,7 @@ public class CliPeon extends GuiceRunnable
     }
   }
 
-  static void bindRowIngestionMeters(Binder binder)
+  public static void bindRowIngestionMeters(Binder binder)
   {
     PolyBind.createChoice(
         binder,

--- a/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
@@ -32,6 +32,7 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import org.apache.druid.discovery.DruidService;
 import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.discovery.NodeRoles;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.StringUtils;
@@ -119,6 +120,8 @@ public abstract class GuiceRunnable implements Runnable
             new TypeLiteral<NodeRole>(){},
             new TypeLiteral<Set<Class<? extends DruidService>>>(){}
         );
+
+        NodeRoles.addKnownRoles(binder);
       };
     }
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -2919,7 +2919,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                 new QueryDataSource(
                     newScanQueryBuilder()
                         .dataSource(CalciteTests.DATASOURCE1)
-                        .intervals(querySegmentSpec(Filtration.eternity()))
+                        .eternity()
                         .filters(new SelectorDimFilter("dim1", "10.1", null))
                         .virtualColumns(expressionVirtualColumn("v0", "\'10.1\'", ColumnType.STRING))
                         .columns(ImmutableList.of("__time", "v0"))
@@ -2930,7 +2930,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                 new QueryDataSource(
                     newScanQueryBuilder()
                         .dataSource(CalciteTests.DATASOURCE1)
-                        .intervals(querySegmentSpec(Filtration.eternity()))
+                        .eternity()
                         .filters(new SelectorDimFilter("dim1", "10.1", null))
                         .columns(ImmutableList.of("dim1"))
                         .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -153,7 +153,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Druids.ScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .virtualColumns(expressionVirtualColumn("v0", "concat(\"dim3\",'foo')", ColumnType.STRING))
                 .columns(ImmutableList.of("v0"))
                 .context(QUERY_CONTEXT_DEFAULT)
@@ -181,7 +181,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Druids.ScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .virtualColumns(expressionVirtualColumn("v0", "concat(\"dim3\",'-lol-',\"dim3\")", ColumnType.STRING))
                 .columns(ImmutableList.of("v0"))
                 .context(QUERY_CONTEXT_DEFAULT)
@@ -208,7 +208,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Druids.ScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .virtualColumns(expressionVirtualColumn("v0", "concat(\"dim3\",'foo')", ColumnType.STRING))
                 .filters(selector("v0", "bfoo", null))
                 .columns(ImmutableList.of("v0"))
@@ -233,7 +233,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .filters(new InDimFilter("dim3", ImmutableList.of("a", "b"), null))
                 .columns("dim3")
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
@@ -256,7 +256,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .filters(expressionFilter("array_overlap(\"dim3\",array(\"dim2\"))"))
                 .columns("dim3")
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
@@ -279,7 +279,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .filters(
                     new AndDimFilter(
                         new SelectorDimFilter("dim3", "a", null),
@@ -306,7 +306,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .filters(new SelectorDimFilter("dim3", "a", null))
                 .columns("dim3")
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
@@ -328,7 +328,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             newScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .filters(expressionFilter("array_contains(\"dim3\",array(\"dim2\"))"))
                 .columns("dim3")
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
@@ -351,7 +351,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Druids.ScanQueryBuilder()
                 .dataSource(CalciteTests.DATASOURCE3)
-                .intervals(querySegmentSpec(Filtration.eternity()))
+                .eternity()
                 .virtualColumns(expressionVirtualColumn("v0", "array_slice(\"dim3\",1)", ColumnType.STRING))
                 .columns(ImmutableList.of("v0"))
                 .context(QUERY_CONTEXT_DEFAULT)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidCalciteSchemaModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidCalciteSchemaModuleTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
+import org.apache.druid.discovery.NodeRoles;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.guice.annotations.Json;
@@ -123,6 +124,7 @@ public class DruidCalciteSchemaModuleTest extends CalciteTestBase
           binder.bind(ObjectMapper.class).annotatedWith(Json.class).toInstance(objectMapper);
           binder.bindScope(LazySingleton.class, Scopes.SINGLETON);
           binder.bind(LookupExtractorFactoryContainerProvider.class).toInstance(lookupReferencesManager);
+          NodeRoles.addKnownRoles(binder);
         },
         new LifecycleModule(),
         target);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -49,6 +49,7 @@ import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscovery;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.discovery.NodeRoles;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
@@ -270,6 +271,7 @@ public class SystemSchemaTest extends CalciteTestBase
         client,
         client,
         druidNodeDiscoveryProvider,
+        NodeRoles.knownRoles(),
         mapper
     );
   }
@@ -729,7 +731,8 @@ public class SystemSchemaTest extends CalciteTestBase
                                                          serverInventoryView,
                                                          authMapper,
                                                          overlordClient,
-                                                         coordinatorClient
+                                                         coordinatorClient,
+                                                         NodeRoles.knownRoles()
                                                      )
                                                      .createMock();
     EasyMock.replay(serversTable);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -53,6 +53,7 @@ import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscovery;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.discovery.NodeRoles;
 import org.apache.druid.guice.ExpressionModule;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.DateTimes;
@@ -1155,6 +1156,7 @@ public class CalciteTests
         druidLeaderClient,
         overlordLeaderClient,
         provider,
+        NodeRoles.knownRoles(),
         getJsonMapper()
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
+import org.apache.druid.discovery.NodeRoles;
 import org.apache.druid.guice.DruidGuiceExtensions;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.LazySingleton;
@@ -148,7 +149,7 @@ public class SqlModuleTest
     Assert.assertNotNull(viewManager);
     Assert.assertTrue(viewManager instanceof NoopViewManager);
   }
-  
+
   @Test
   public void testNonDefaultViewManagerBind()
   {
@@ -198,6 +199,7 @@ public class SqlModuleTest
               binder.bind(QueryScheduler.class)
                     .toProvider(QuerySchedulerProvider.class)
                     .in(LazySingleton.class);
+              NodeRoles.addKnownRoles(binder);
             },
             new SqlModule(props),
             new TestViewManagerModule()


### PR DESCRIPTION
### Description

Several changes to better support extension services:

* Use Guice to publish the list of known node roles so an extension can add to it.
* Use the Guice list in for SQL servers system table so it will publish instances of the extension service.
* Split out the index task client into a base class to allow the client to be used for an extension service.
* Add a PrivateApi annotation to mark REST services primarily used internally to the server.
* Misc. code cleanup.

<hr>

##### Key changed/added classes in this PR

 * `NodeRoles` - A Guice multi-binder to hold the list of Druid- and extension-defined node roles.
 * `PrivateAPI` - Annotation to use to mark a REST service which is private to a server rather than being public. Such private APIs should not be documented.
 * `TaskClient` - Holds most of what was in `IndexTaskClient`, but without the tight binding to the indexer. `IndexTaskClient` now extends `TaskClient` and adds the Indexer-specific assumptions.

<hr>

This PR has:

- [X] been self-reviewed.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] been tested via the Maven build and the tests run in Github.
