### PR TITLE
Use ListFilteredVirtualColumn for left/fact table expression in join condition

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
@@ -222,6 +222,12 @@ public class JoinDataSource implements DataSource
     return false;
   }
 
+  /**
+   * Computes a set of column names for left table expressions in join condition which may already have been defined as
+   * a virtual column in the virtual column registry. It helps to remove any extraenous virtual columns created and only
+   * use the relevant ones.
+   * @return a set of column names which might be virtual columns on left table in join condition
+   */
   public Set<String> getVirtualColumnCandidates()
   {
     return getConditionAnalysis().getEquiConditions()

--- a/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/JoinDataSource.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Represents a join of two datasources.
@@ -219,6 +220,16 @@ public class JoinDataSource implements DataSource
   public boolean isConcrete()
   {
     return false;
+  }
+
+  public Set<String> getVirtualColumnCandidates()
+  {
+    return getConditionAnalysis().getEquiConditions()
+                                 .stream()
+                                 .filter(equality -> equality.getLeftExpr() != null)
+                                 .map(equality -> equality.getLeftExpr().analyzeInputs().getRequiredBindings())
+                                 .flatMap(Set::stream)
+                                 .collect(Collectors.toSet());
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/JoinDataSourceTest.java
+++ b/processing/src/test/java/org/apache/druid/query/JoinDataSourceTest.java
@@ -204,4 +204,19 @@ public class JoinDataSourceTest
     );
     Assert.assertEquals(TrueDimFilter.instance(), dataSource.getLeftFilter());
   }
+
+  @Test
+  public void testVirtualColumnCandidates()
+  {
+    JoinDataSource dataSource = JoinDataSource.create(
+        new TableDataSource("table1"),
+        new TableDataSource("table2"),
+        "j.",
+        "x == \"j.x\"",
+        JoinType.LEFT,
+        null,
+        ExprMacroTable.nil()
+    );
+    Assert.assertEquals(dataSource.getVirtualColumnCandidates(), ImmutableSet.of("x"));
+  }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
@@ -32,6 +32,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.math.expr.Parser;
+import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.virtual.ListFilteredVirtualColumn;
 import org.apache.druid.sql.calcite.expression.AliasedOperatorConversion;
@@ -352,7 +354,7 @@ public class MultiValueStringOperatorConversions
              .append(")");
 
       if (druidExpressions.get(0).isSimpleExtraction()) {
-        return DruidExpression.forVirtualColumn(
+        DruidExpression druidExpression = DruidExpression.forVirtualColumn(
             builder.toString(),
             (name, outputType, macroTable) -> new ListFilteredVirtualColumn(
                 name,
@@ -361,6 +363,17 @@ public class MultiValueStringOperatorConversions
                 isAllowList()
             )
         );
+
+        if (plannerContext.getVirtualColumnRegistry() != null) {
+          VirtualColumn vc = plannerContext.getVirtualColumnRegistry().getOrCreateVirtualColumnForExpression(
+              plannerContext,
+              druidExpression,
+              ColumnType.STRING
+          );
+          return DruidExpression.fromColumn(vc.getOutputName());
+        }
+
+        return druidExpression;
       }
 
       return DruidExpression.fromExpression(builder.toString());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
@@ -364,8 +364,10 @@ public class MultiValueStringOperatorConversions
             )
         );
 
-        if (plannerContext.getVirtualColumnRegistry() != null) {
-          VirtualColumn vc = plannerContext.getVirtualColumnRegistry().getOrCreateVirtualColumnForExpression(
+        // if the join expression VC registry is present, it means that this expression is part of a join condition
+        // and since that's the case, create virtual column here itself for optimized usage in join matching
+        if (plannerContext.getJoinExpressionVirtualColumnRegistry() != null) {
+          VirtualColumn vc = plannerContext.getJoinExpressionVirtualColumnRegistry().getOrCreateVirtualColumnForExpression(
               plannerContext,
               druidExpression,
               ColumnType.STRING

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -96,7 +96,7 @@ public class PlannerContext
   @Nullable
   private String planningError;
   private QueryMaker queryMaker;
-  private VirtualColumnRegistry virtualColumnRegistry;
+  private VirtualColumnRegistry joinExpressionVirtualColumnRegistry;
 
   private PlannerContext(
       final String sql,
@@ -395,13 +395,13 @@ public class PlannerContext
     return Preconditions.checkNotNull(queryMaker, "QueryMaker not available");
   }
 
-  public VirtualColumnRegistry getVirtualColumnRegistry()
+  public VirtualColumnRegistry getJoinExpressionVirtualColumnRegistry()
   {
-    return virtualColumnRegistry;
+    return joinExpressionVirtualColumnRegistry;
   }
 
-  public void setVirtualColumnRegistry(VirtualColumnRegistry virtualColumnRegistry)
+  public void setJoinExpressionVirtualColumnRegistry(VirtualColumnRegistry joinExpressionVirtualColumnRegistry)
   {
-    this.virtualColumnRegistry = virtualColumnRegistry;
+    this.joinExpressionVirtualColumnRegistry = joinExpressionVirtualColumnRegistry;
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.BaseQuery;
 import org.apache.druid.server.security.Access;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.ResourceAction;
+import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
 import org.apache.druid.sql.calcite.run.QueryMaker;
 import org.apache.druid.sql.calcite.schema.DruidSchemaCatalog;
 import org.joda.time.DateTime;
@@ -95,6 +96,7 @@ public class PlannerContext
   @Nullable
   private String planningError;
   private QueryMaker queryMaker;
+  private VirtualColumnRegistry virtualColumnRegistry;
 
   private PlannerContext(
       final String sql,
@@ -391,5 +393,15 @@ public class PlannerContext
   public QueryMaker getQueryMaker()
   {
     return Preconditions.checkNotNull(queryMaker, "QueryMaker not available");
+  }
+
+  public VirtualColumnRegistry getVirtualColumnRegistry()
+  {
+    return virtualColumnRegistry;
+  }
+
+  public void setVirtualColumnRegistry(VirtualColumnRegistry virtualColumnRegistry)
+  {
+    this.virtualColumnRegistry = virtualColumnRegistry;
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -163,6 +163,9 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
 
     final Pair<String, RowSignature> prefixSignaturePair = computeJoinRowSignature(leftSignature, rightSignature);
 
+    VirtualColumnRegistry virtualColumnRegistry = VirtualColumnRegistry.create(prefixSignaturePair.rhs);
+    getPlannerContext().setVirtualColumnRegistry(virtualColumnRegistry);
+
     // Generate the condition for this join as a Druid expression.
     final DruidExpression condition = Expressions.toDruidExpression(
         getPlannerContext(),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -161,7 +161,9 @@ public class DruidQuery
   )
   {
     final RelDataType outputRowType = partialQuery.leafRel().getRowType();
-    final VirtualColumnRegistry virtualColumnRegistry = VirtualColumnRegistry.create(sourceRowSignature);
+    final VirtualColumnRegistry virtualColumnRegistry = plannerContext.getVirtualColumnRegistry() == null
+                                                        ? VirtualColumnRegistry.create(sourceRowSignature)
+                                                        : plannerContext.getVirtualColumnRegistry();
 
     // Now the fun begins.
     final DimFilter filter;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -660,6 +660,14 @@ public class DruidQuery
       virtualColumns.addAll(sorting.getProjection().getVirtualColumns());
     }
 
+    if (dataSource instanceof JoinDataSource) {
+      for (String expression : ((JoinDataSource) dataSource).getVirtualColumnCandidates()) {
+        if (virtualColumnRegistry.isVirtualColumnDefined(expression)) {
+          virtualColumns.add(virtualColumnRegistry.getVirtualColumn(expression));
+        }
+      }
+    }
+
     // sort for predictable output
     List<VirtualColumn> columns = new ArrayList<>(virtualColumns);
     columns.sort(Comparator.comparing(VirtualColumn::getOutputName));

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -157,13 +157,14 @@ public class DruidQuery
       final RowSignature sourceRowSignature,
       final PlannerContext plannerContext,
       final RexBuilder rexBuilder,
-      final boolean finalizeAggregations
+      final boolean finalizeAggregations,
+      @Nullable VirtualColumnRegistry virtualColumnRegistry
   )
   {
     final RelDataType outputRowType = partialQuery.leafRel().getRowType();
-    final VirtualColumnRegistry virtualColumnRegistry = plannerContext.getVirtualColumnRegistry() == null
-                                                        ? VirtualColumnRegistry.create(sourceRowSignature)
-                                                        : plannerContext.getVirtualColumnRegistry();
+    if (virtualColumnRegistry == null) {
+      virtualColumnRegistry = VirtualColumnRegistry.create(sourceRowSignature);
+    }
 
     // Now the fun begins.
     final DimFilter filter;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/PartialDruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/PartialDruidQuery.java
@@ -39,6 +39,7 @@ import org.apache.druid.query.DataSource;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -310,7 +311,28 @@ public class PartialDruidQuery
         sourceRowSignature,
         plannerContext,
         rexBuilder,
-        finalizeAggregations
+        finalizeAggregations,
+        null
+    );
+  }
+
+  public DruidQuery build(
+      final DataSource dataSource,
+      final RowSignature sourceRowSignature,
+      final PlannerContext plannerContext,
+      final RexBuilder rexBuilder,
+      final boolean finalizeAggregations,
+      @Nullable VirtualColumnRegistry virtualColumnRegistry
+  )
+  {
+    return DruidQuery.fromPartialQuery(
+        this,
+        dataSource,
+        sourceRowSignature,
+        plannerContext,
+        rexBuilder,
+        finalizeAggregations,
+        virtualColumnRegistry
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.druid.common.config.NullHandling;
@@ -75,6 +76,7 @@ import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.join.JoinType;
+import org.apache.druid.segment.virtual.ListFilteredVirtualColumn;
 import org.apache.druid.server.QueryLifecycle;
 import org.apache.druid.server.QueryLifecycleFactory;
 import org.apache.druid.server.security.Access;
@@ -4615,4 +4617,52 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @Test
+  @Parameters(source = QueryContextForJoinProvider.class)
+  public void testVirtualColumnOnMVFilterJoinExpression(Map<String, Object> queryContext) throws Exception
+  {
+    testQuery(
+        "SELECT foo1.dim3, foo2.dim3 FROM druid.numfoo as foo1 INNER JOIN druid.numfoo as foo2 "
+        + "ON MV_FILTER_ONLY(foo1.dim3, ARRAY['a']) = MV_FILTER_ONLY(foo2.dim3, ARRAY['a'])\n",
+        queryContext,
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(
+                    join(
+                        new TableDataSource(CalciteTests.DATASOURCE3),
+                        new QueryDataSource(
+                            newScanQueryBuilder()
+                                .dataSource(CalciteTests.DATASOURCE3)
+                                .intervals(querySegmentSpec(Intervals.of(
+                                    "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z")))
+                                .virtualColumns(new ListFilteredVirtualColumn(
+                                    "v0",
+                                    new DefaultDimensionSpec("dim3", "dim3", ColumnType.STRING),
+                                    ImmutableSet.of("a"),
+                                    true
+                                ))
+                                .columns("dim3", "v0")
+                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                .context(queryContext)
+                                .build()
+                        ),
+                        "j0.",
+                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.v0")),
+                        JoinType.INNER
+                    )
+                )
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .virtualColumns(new ListFilteredVirtualColumn(
+                    "v0",
+                    new DefaultDimensionSpec("dim3", "dim3", ColumnType.STRING),
+                    ImmutableSet.of("a"),
+                    true
+                ))
+                .columns("dim3", "j0.dim3")
+                .context(queryContext)
+                .build()
+        ),
+        ImmutableList.of(new Object[]{"[\"a\",\"b\"]", "[\"a\",\"b\"]"})
+    );
+  }
 }


### PR DESCRIPTION
This change allows for usage of `ListFilteredVirtualColumn` if `MV_FILTER` functions are used in a join condition on the left/fact table expression.
<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
