### PR TITLE
fix delegated smoosh writer and some new facilities for segment writeout medium

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/io/smoosh/FileSmoosher.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/io/smoosh/FileSmoosher.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A class that concatenates files together into configurable sized chunks,
@@ -86,7 +87,7 @@ public class FileSmoosher implements Closeable
   private List<File> filesInProcess = new ArrayList<>();
   // delegated smooshedWriter creates a new temporary file per file added. we use a counter to name these temporary
   // files, and map the file number to the file name so we don't have to escape the file names (e.g. names with '/')
-  private int delegateFileCounter = 0;
+  private AtomicLong delegateFileCounter = new AtomicLong(0);
   private Map<String, String> delegateFileNameMap;
 
   private Outer currOut = null;
@@ -356,7 +357,7 @@ public class FileSmoosher implements Closeable
 
   private String getDelegateFileName(String name)
   {
-    final String delegateName = String.valueOf(delegateFileCounter++);
+    final String delegateName = String.valueOf(delegateFileCounter.getAndIncrement());
     delegateFileNameMap.put(delegateName, name);
     return delegateName;
   }

--- a/core/src/main/java/org/apache/druid/java/util/common/io/smoosh/FileSmoosher.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/io/smoosh/FileSmoosher.java
@@ -21,6 +21,7 @@ package org.apache.druid.java.util.common.io.smoosh;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
@@ -46,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -82,6 +84,10 @@ public class FileSmoosher implements Closeable
   private List<File> completedFiles = new ArrayList<>();
   // list of files in process writing content using delegated smooshedWriter.
   private List<File> filesInProcess = new ArrayList<>();
+  // delegated smooshedWriter creates a new temporary file per file added. we use a counter to name these temporary
+  // files, and map the file number to the file name so we don't have to escape the file names (e.g. names with '/')
+  private int delegateFileCounter = 0;
+  private Map<String, String> delegateFileNameMap;
 
   private Outer currOut = null;
   private boolean writerCurrentlyInUse = false;
@@ -100,6 +106,7 @@ public class FileSmoosher implements Closeable
   {
     this.baseDir = baseDir;
     this.maxChunkSize = maxChunkSize;
+    this.delegateFileNameMap = new HashMap<>();
 
     Preconditions.checkArgument(maxChunkSize > 0, "maxChunkSize must be a positive value.");
   }
@@ -223,18 +230,20 @@ public class FileSmoosher implements Closeable
       @Override
       public void close() throws IOException
       {
-        open = false;
-        internalFiles.put(name, new Metadata(currOut.getFileNum(), startOffset, currOut.getCurrOffset()));
-        writerCurrentlyInUse = false;
+        if (open) {
+          open = false;
+          internalFiles.put(name, new Metadata(currOut.getFileNum(), startOffset, currOut.getCurrOffset()));
+          writerCurrentlyInUse = false;
 
-        if (bytesWritten != currOut.getCurrOffset() - startOffset) {
-          throw new ISE("Perhaps there is some concurrent modification going on?");
+          if (bytesWritten != currOut.getCurrOffset() - startOffset) {
+            throw new ISE("Perhaps there is some concurrent modification going on?");
+          }
+          if (bytesWritten != size) {
+            throw new IOE("Expected [%,d] bytes, only saw [%,d], potential corruption?", size, bytesWritten);
+          }
+          // Merge temporary files on to the main smoosh file.
+          mergeWithSmoosher();
         }
-        if (bytesWritten != size) {
-          throw new IOE("Expected [%,d] bytes, only saw [%,d], potential corruption?", size, bytesWritten);
-        }
-        // Merge temporary files on to the main smoosh file.
-        mergeWithSmoosher();
       }
     };
   }
@@ -249,9 +258,11 @@ public class FileSmoosher implements Closeable
   {
     // Get processed elements from the stack and write.
     List<File> fileToProcess = new ArrayList<>(completedFiles);
+    Map<String, String> fileNameMap = ImmutableMap.copyOf(delegateFileNameMap);
     completedFiles = new ArrayList<>();
+    delegateFileNameMap = new HashMap<>();
     for (File file : fileToProcess) {
-      add(file);
+      add(fileNameMap.get(file.getName()), file);
       if (!file.delete()) {
         LOG.warn("Unable to delete file [%s]", file);
       }
@@ -272,7 +283,8 @@ public class FileSmoosher implements Closeable
    */
   private SmooshedWriter delegateSmooshedWriter(final String name, final long size) throws IOException
   {
-    final File tmpFile = new File(baseDir, name);
+    final String delegateName = getDelegateFileName(name);
+    final File tmpFile = new File(baseDir, delegateName);
     filesInProcess.add(tmpFile);
 
     return new SmooshedWriter()
@@ -340,6 +352,13 @@ public class FileSmoosher implements Closeable
 
     };
 
+  }
+
+  private String getDelegateFileName(String name)
+  {
+    final String delegateName = String.valueOf(delegateFileCounter++);
+    delegateFileNameMap.put(delegateName, name);
+    return delegateName;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/writeout/ByteBufferWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/ByteBufferWriteOutBytes.java
@@ -47,6 +47,7 @@ public abstract class ByteBufferWriteOutBytes extends WriteOutBytes
   ByteBuffer headBuffer;
   long size;
   long capacity;
+  boolean open = true;
 
   ByteBufferWriteOutBytes()
   {
@@ -253,7 +254,17 @@ public abstract class ByteBufferWriteOutBytes extends WriteOutBytes
   @Override
   public boolean isOpen()
   {
-    return true;
+    return open;
+  }
+
+  public void free()
+  {
+    open = false;
+    buffers.clear();
+    headBufferIndex = -1;
+    headBuffer = null;
+    size = 0;
+    capacity = 0;
   }
 
   private void checkOpen()

--- a/processing/src/main/java/org/apache/druid/segment/writeout/DirectByteBufferWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/DirectByteBufferWriteOutBytes.java
@@ -25,8 +25,6 @@ import java.nio.ByteBuffer;
 
 final class DirectByteBufferWriteOutBytes extends ByteBufferWriteOutBytes
 {
-  private boolean open = true;
-
   @Override
   protected ByteBuffer allocateBuffer()
   {
@@ -34,12 +32,7 @@ final class DirectByteBufferWriteOutBytes extends ByteBufferWriteOutBytes
   }
 
   @Override
-  public boolean isOpen()
-  {
-    return open;
-  }
-
-  void free()
+  public void free()
   {
     open = false;
     buffers.forEach(ByteBufferUtils::free);

--- a/processing/src/main/java/org/apache/druid/segment/writeout/OffHeapMemorySegmentWriteOutMedium.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/OffHeapMemorySegmentWriteOutMedium.java
@@ -36,6 +36,14 @@ public final class OffHeapMemorySegmentWriteOutMedium implements SegmentWriteOut
   }
 
   @Override
+  public SegmentWriteOutMedium makeChildWriteOutMedium()
+  {
+    OffHeapMemorySegmentWriteOutMedium medium = new OffHeapMemorySegmentWriteOutMedium();
+    closer.register(medium);
+    return medium;
+  }
+
+  @Override
   public Closer getCloser()
   {
     return closer;

--- a/processing/src/main/java/org/apache/druid/segment/writeout/OnHeapMemorySegmentWriteOutMedium.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/OnHeapMemorySegmentWriteOutMedium.java
@@ -32,7 +32,17 @@ public final class OnHeapMemorySegmentWriteOutMedium implements SegmentWriteOutM
   @Override
   public WriteOutBytes makeWriteOutBytes()
   {
-    return new HeapByteBufferWriteOutBytes();
+    HeapByteBufferWriteOutBytes writeOutBytes = new HeapByteBufferWriteOutBytes();
+    closer.register(writeOutBytes::free);
+    return writeOutBytes;
+  }
+
+  @Override
+  public SegmentWriteOutMedium makeChildWriteOutMedium()
+  {
+    OnHeapMemorySegmentWriteOutMedium medium = new OnHeapMemorySegmentWriteOutMedium();
+    closer.register(medium);
+    return medium;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/writeout/SegmentWriteOutMedium.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/SegmentWriteOutMedium.java
@@ -40,6 +40,18 @@ public interface SegmentWriteOutMedium extends Closeable
   WriteOutBytes makeWriteOutBytes() throws IOException;
 
   /**
+   * Creates a 'child' version of the {@link SegmentWriteOutMedium}, which can be optionally closed,
+   * independent of this {@link SegmentWriteOutMedium} but otherwise shares the same configuration. This allows callers
+   * using a shared {@link SegmentWriteOutMedium} but which control the complete lifecycle of the {@link WriteOutBytes}
+   * which they require to free the backing resources when they are finished, rather than waiting until
+   * {@link #close()} is called for this medium.
+   *
+   * The 'child' medium will be closed when {@link #close()} is called, if not called explicitly prior to closing this
+   * medium.
+   */
+  SegmentWriteOutMedium makeChildWriteOutMedium() throws IOException;
+
+  /**
    * Returns a closer of this SegmentWriteOutMedium, which is closed in this SegmentWriteOutMedium's close() method.
    * Could be used to "attach" some random resources to this SegmentWriteOutMedium, to be closed at the same time.
    */

--- a/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMedium.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMedium.java
@@ -55,6 +55,14 @@ public final class TmpFileSegmentWriteOutMedium implements SegmentWriteOutMedium
   }
 
   @Override
+  public SegmentWriteOutMedium makeChildWriteOutMedium() throws IOException
+  {
+    TmpFileSegmentWriteOutMedium tmpFileSegmentWriteOutMedium = new TmpFileSegmentWriteOutMedium(dir);
+    closer.register(tmpFileSegmentWriteOutMedium);
+    return tmpFileSegmentWriteOutMedium;
+  }
+
+  @Override
   public Closer getCloser()
   {
     return closer;

--- a/processing/src/test/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.writeout;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.io.Closer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+
+@RunWith(Parameterized.class)
+public class SegmentWriteOutMediumTest
+{
+
+  @Parameterized.Parameters(name = "medium = {0}")
+  public static Iterable<?> constructorFeeder()
+  {
+    return ImmutableList.of(
+        TmpFileSegmentWriteOutMediumFactory.instance(),
+        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
+        OnHeapMemorySegmentWriteOutMediumFactory.instance()
+    );
+  }
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private SegmentWriteOutMediumFactory factory;
+  private SegmentWriteOutMedium medium;
+
+  public SegmentWriteOutMediumTest(SegmentWriteOutMediumFactory factory)
+  {
+    this.factory = factory;
+  }
+
+  @Before
+  public void setup() throws IOException
+  {
+    this.medium = factory.makeSegmentWriteOutMedium(temporaryFolder.newFolder());
+  }
+
+  @Test
+  public void testSanity() throws IOException
+  {
+    WriteOutBytes bytes1 = medium.makeWriteOutBytes();
+    WriteOutBytes bytes2 = medium.makeWriteOutBytes();
+
+    Assert.assertTrue(bytes1.isOpen());
+    Assert.assertTrue(bytes2.isOpen());
+
+    Closer closer = medium.getCloser();
+    closer.close();
+
+    Assert.assertFalse(bytes1.isOpen());
+    Assert.assertFalse(bytes2.isOpen());
+  }
+
+  @Test
+  public void testChildCloseFreesResourcesButNotParents() throws IOException
+  {
+    WriteOutBytes bytes1 = medium.makeWriteOutBytes();
+    WriteOutBytes bytes2 = medium.makeWriteOutBytes();
+
+    Assert.assertTrue(bytes1.isOpen());
+    Assert.assertTrue(bytes2.isOpen());
+
+    SegmentWriteOutMedium childMedium = medium.makeChildWriteOutMedium();
+    Assert.assertTrue(childMedium.getClass().equals(medium.getClass()));
+
+    WriteOutBytes bytes3 = childMedium.makeWriteOutBytes();
+    WriteOutBytes bytes4 = childMedium.makeWriteOutBytes();
+
+    Assert.assertTrue(bytes3.isOpen());
+    Assert.assertTrue(bytes4.isOpen());
+
+    Closer childCloser = childMedium.getCloser();
+    childCloser.close();
+
+    Assert.assertFalse(bytes3.isOpen());
+    Assert.assertFalse(bytes4.isOpen());
+
+    Assert.assertTrue(bytes1.isOpen());
+    Assert.assertTrue(bytes2.isOpen());
+
+    Closer closer = medium.getCloser();
+    closer.close();
+
+    Assert.assertFalse(bytes1.isOpen());
+    Assert.assertFalse(bytes2.isOpen());
+  }
+
+  @Test
+  public void testChildNotClosedExplicitlyIsClosedByParent() throws IOException
+  {
+    WriteOutBytes bytes1 = medium.makeWriteOutBytes();
+    WriteOutBytes bytes2 = medium.makeWriteOutBytes();
+
+    Assert.assertTrue(bytes1.isOpen());
+    Assert.assertTrue(bytes2.isOpen());
+
+    SegmentWriteOutMedium childMedium = medium.makeChildWriteOutMedium();
+    Assert.assertTrue(childMedium.getClass().equals(medium.getClass()));
+
+    WriteOutBytes bytes3 = childMedium.makeWriteOutBytes();
+    WriteOutBytes bytes4 = childMedium.makeWriteOutBytes();
+
+    Assert.assertTrue(bytes3.isOpen());
+    Assert.assertTrue(bytes4.isOpen());
+
+    Closer closer = medium.getCloser();
+    closer.close();
+
+    Assert.assertFalse(bytes1.isOpen());
+    Assert.assertFalse(bytes2.isOpen());
+
+    Assert.assertFalse(bytes3.isOpen());
+    Assert.assertFalse(bytes4.isOpen());
+  }
+}


### PR DESCRIPTION
### Description

This PR fixes a bug in `FileSmoosher` when using `addWithSmooshedWriter` in "delegated" mode , which writes to temporary files until the "parent" `SmooshedWriter` is closed, in cases file names which look like valid paths, e.g. 'foo/bar'.

The added test case will explode with an error like:
```
java.nio.file.NoSuchFileException: /var/folders/v0/zc_jt5n12d39kx7dn6xmg73w0000gn/T/junit296384917261983992/base/foo/bar/0
```
prior to the changes in this PR, which is now using a counter to make a temp file name, and a map of the counter value to the actual file name when merging the delegated files back into the parent file.

There are also a couple of other improvements for some future changes that I would like to make. The first is `FileSmoosher.addWithSmooshedWriter`, when _not_ delegating, now checks that it is still open when doing stuff inside of `close`, making it now be a no-op if already closed (allowing column serializers to add additional files and avoid delegated mode if they are finished writing out their own content and ned to add additional files)

Additionally, `SegmentWriteOutMedium` has a new method that allows callers to free-up `WriteOutBytes` when using a shared medium and are fully in control of the lifecycle of the `WriteOutBytes`.

```
  SegmentWriteOutMedium makeChildWriteOutMedium() throws IOException;
```

The contract of this method is that the child medium is registered to the closer of the parent, so need not be explicitly closed, but it also _may be_ explicitly closed, to allow freeing the backing resources of `WriteOutBytes` created by the medium. When using a shared medium, such as is done when serializing columns during segment creation, these resources are typically not able to be released until the medium itself is closed.

The type of use case this method is targeting is actually present in `IntermediateColumnarLongsSerializer`, which does not actually use the `SegmentWriteOutMedium` until `getSerializedSize`/`writeTo` is called where they are immediately written to the channel. However, there is little benefit to changing to this method, because it is a very small number of additional files that will be created when writing out each column, and so not much to gain by releasing them early. Something like #10628 however, which creates a lot of files and immediately dumps them in the channel, could greatly reduce the number of open files on the system if there were for example a very large number of columns.

Finally, `OnHeapMemorySegmentWriteOutMedium` previously would never mark its `WriteOutBytes` as 'closed', meaning that callers could indefinitely write to one of these buffers even after the medium was closed. This seemed like it allows breaking the contract of `SegmentWriteOutMedium` to use `WriteOutBytes` after closed, and the underlying `ByteBufferWriteOutBytes` has methods to check that the medium is open, but the heap implementation has no way to set it as not opened. I have changed this so that all implementations of `SegmentWriteOutMedium` behave identically by pushing the `free` method down to `ByteBufferWriteOutBytes` (and overriding it in the direct implementation).

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
