### PR TITLE
Set plannerContext error when cannot query external datasources and when insert is not supported. 

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalTableScanRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalTableScanRule.java
@@ -46,7 +46,7 @@ public class ExternalTableScanRule extends RelOptRule
     if (plannerContext.getQueryMaker().feature(QueryFeature.CAN_READ_EXTERNAL_DATA)) {
       return super.matches(call);
     } else {
-      plannerContext.setPlanningError("Scanning external datasources is not suported.");
+      plannerContext.setPlanningError("SQL query requires scanning external datasources that is not suported.");
       return false;
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalTableScanRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalTableScanRule.java
@@ -46,6 +46,7 @@ public class ExternalTableScanRule extends RelOptRule
     if (plannerContext.getQueryMaker().feature(QueryFeature.CAN_READ_EXTERNAL_DATA)) {
       return super.matches(call);
     } else {
+      plannerContext.setPlanningError("Scanning external datasources is not suported.");
       return false;
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -215,9 +215,7 @@ public class DruidPlanner implements Closeable
       }
       if (parsed.getInsertNode() != null) {
         // Cannot INSERT with BINDABLE.
-        plannerContext.setPlanningError("Cannot use insert keyword with bindable convention.");
-        String errorMessage = buildSQLPlanningErrorMessage(cannotPlanException);
-        throw new UnsupportedSQLQueryException(errorMessage);
+        throw e;
       }
       // Try again with BINDABLE convention. Used for querying Values and metadata tables.
       try {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -215,7 +215,9 @@ public class DruidPlanner implements Closeable
       }
       if (parsed.getInsertNode() != null) {
         // Cannot INSERT with BINDABLE.
-        throw e;
+        plannerContext.setPlanningError("Cannot use insert keyword with bindable convention.");
+        String errorMessage = buildSQLPlanningErrorMessage(cannotPlanException);
+        throw new UnsupportedSQLQueryException(errorMessage);
       }
       // Try again with BINDABLE convention. Used for querying Values and metadata tables.
       try {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -13480,4 +13480,13 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(new Object[]{"A", "10.1"})
     );
   }
+
+  @Test
+  public void testSurfaceErrorsWhenInsertingThroughIncorrectSelectStatment()
+  {
+    assertQueryIsUnplannable(
+        "INSERT INTO druid.dst SELECT dim2, dim1, m1 FROM foo2 UNION SELECT dim1, dim2, m1 FROM foo",
+        "Possible error: SQL requires 'UNION' but only 'UNION ALL' is supported."
+    );
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/external/ExternalTableScanRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/external/ExternalTableScanRuleTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.external;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.tools.ValidationException;
+import org.apache.druid.query.QueryRunnerFactoryConglomerate;
+import org.apache.druid.query.QuerySegmentWalker;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.schema.DruidSchema;
+import org.apache.druid.sql.calcite.schema.DruidSchemaCatalog;
+import org.apache.druid.sql.calcite.schema.NamedDruidSchema;
+import org.apache.druid.sql.calcite.schema.NamedViewSchema;
+import org.apache.druid.sql.calcite.schema.ViewSchema;
+import org.apache.druid.sql.calcite.util.CalciteTests;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExternalTableScanRuleTest
+{
+  @Test
+  public void testMatchesWhenExternalScanUnsupported() throws ValidationException
+  {
+
+    final PlannerContext plannerContext = PlannerContext.create(
+        "DUMMY", // The actual query isn't important for this test
+        CalciteTests.createOperatorTable(),
+        CalciteTests.createExprMacroTable(),
+        CalciteTests.getJsonMapper(),
+        new PlannerConfig(),
+        new DruidSchemaCatalog(
+            EasyMock.createMock(SchemaPlus.class),
+            ImmutableMap.of(
+                "druid", new NamedDruidSchema(EasyMock.createMock(DruidSchema.class), "druid"),
+                NamedViewSchema.NAME, new NamedViewSchema(EasyMock.createMock(ViewSchema.class))
+            )
+        ),
+        ImmutableMap.of()
+    );
+    plannerContext.setQueryMaker(
+        CalciteTests.createMockQueryMakerFactory(
+                        EasyMock.createMock(QuerySegmentWalker.class),
+                        EasyMock.createMock(QueryRunnerFactoryConglomerate.class)
+                    )
+                    .buildForSelect(EasyMock.createMock(RelRoot.class), plannerContext)
+    );
+
+    ExternalTableScanRule rule = new ExternalTableScanRule(plannerContext);
+    rule.matches(EasyMock.createMock(RelOptRuleCall.class));
+    Assert.assertEquals(
+        "SQL query requires scanning external datasources that is not suported.",
+        plannerContext.getPlanningError()
+    );
+  }
+}


### PR DESCRIPTION
### Description

This PR aims to add `plannerContext.setPlanningError` whenever external table scan rule is invoked, without the queryMaker having the ability to do so. 

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
