### PR TITLE
Update PostAggregator to be backwards compat

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/PostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/PostAggregator.java
@@ -23,6 +23,8 @@ import org.apache.druid.guice.annotations.ExtensionPoint;
 import org.apache.druid.java.util.common.Cacheable;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.ColumnTypeFactory;
+import org.apache.druid.segment.column.ValueType;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
@@ -48,10 +50,27 @@ public interface PostAggregator extends Cacheable
   /**
    * Return the output type of a row processed with this post aggregator. Refer to the {@link ColumnType} javadocs
    * for details on the implications of choosing a type.
+   *
    * @param signature
    */
   @Nullable
-  ColumnType getType(ColumnInspector signature);
+  default ColumnType getType(ColumnInspector signature)
+  {
+    return ColumnTypeFactory.ofValueType(getType());
+  }
+
+  /**
+   * This method is deprecated and will be removed soon. Use {@link #getType(ColumnInspector)} instead. Do not call this
+   * method, it will likely produce incorrect results, it exists for backwards compatibility.
+   */
+  @Deprecated
+  default ValueType getType()
+  {
+    throw new UnsupportedOperationException(
+        "Do not call or implement this method, it is deprecated, use 'getType(ColumnInspector)' instead"
+    );
+  }
+
 
   /**
    * Allows returning an enriched post aggregator, built from contextual information available from the given map of


### PR DESCRIPTION
This change mimics what was done in PR #11917 to
fix the incompatibilities produced by #11713. #11917
fixed it with AggregatorFactory by creating default
methods to allow for extensions built against old
jars to still work.  This does the same for PostAggregator

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
