### PR TITLE
Web console: make range partitioning a first class citizen of the console

### DIFF
--- a/web-console/e2e-tests/reindexing.spec.ts
+++ b/web-console/e2e-tests/reindexing.spec.ts
@@ -24,8 +24,8 @@ import { IngestionOverview } from './component/ingestion/overview';
 import { ConfigureSchemaConfig } from './component/load-data/config/configure-schema';
 import {
   PartitionConfig,
+  RangePartitionsSpec,
   SegmentGranularity,
-  SingleDimPartitionsSpec,
 } from './component/load-data/config/partition';
 import { PublishConfig } from './component/load-data/config/publish';
 import { ReindexDataConnector } from './component/load-data/data-connector/reindex';
@@ -59,8 +59,8 @@ describe('Reindexing from Druid', () => {
     await browser.close();
   });
 
-  it('Reindex datasource from dynamic to single dim partitions', async () => {
-    const testName = 'reindex-dynamic-to-single-dim-';
+  it('Reindex datasource from dynamic to range partitions', async () => {
+    const testName = 'reindex-dynamic-to-range-';
     const datasourceName = testName + new Date().toISOString();
     const interval = '2015-09-12/2015-09-13';
     const dataConnector = new ReindexDataConnector(page, {
@@ -71,8 +71,8 @@ describe('Reindexing from Druid', () => {
     const partitionConfig = new PartitionConfig({
       segmentGranularity: SegmentGranularity.DAY,
       timeIntervals: null,
-      partitionsSpec: new SingleDimPartitionsSpec({
-        partitionDimension: 'channel',
+      partitionsSpec: new RangePartitionsSpec({
+        partitionDimensions: ['channel'],
         targetRowsPerSegment: 10_000,
         maxRowsPerSegment: null,
       }),

--- a/web-console/e2e-tests/util/playwright.ts
+++ b/web-console/e2e-tests/util/playwright.ts
@@ -50,6 +50,13 @@ export async function getLabeledInput(page: playwright.Page, label: string): Pro
   );
 }
 
+export async function getLabeledTextarea(page: playwright.Page, label: string): Promise<string> {
+  return await page.$eval(
+    `//*[text()="${label}"]/following-sibling::div//textarea`,
+    el => (el as HTMLInputElement).value,
+  );
+}
+
 export async function setLabeledInput(
   page: playwright.Page,
   label: string,

--- a/web-console/src/components/array-input/__snapshots__/array-input.spec.tsx.snap
+++ b/web-console/src/components/array-input/__snapshots__/array-input.spec.tsx.snap
@@ -1,10 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArrayInput matches snapshot 1`] = `
-<textarea
-  class="bp3-input bp3-fill test"
-  placeholder="test"
+<div
+  class="array-input test"
 >
-  apple, banana, pear
-</textarea>
+  <textarea
+    class="bp3-input bp3-fill test"
+    placeholder="test"
+  >
+    apple, banana, pear
+  </textarea>
+  <span
+    class="suggestion-button bp3-popover2-target"
+  >
+    <button
+      class="bp3-button bp3-minimal"
+      type="button"
+    >
+      <span
+        class="bp3-icon bp3-icon-plus"
+        icon="plus"
+      >
+        <svg
+          data-icon="plus"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            plus
+          </desc>
+          <path
+            d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </button>
+  </span>
+</div>
 `;

--- a/web-console/src/components/array-input/array-input.scss
+++ b/web-console/src/components/array-input/array-input.scss
@@ -16,24 +16,12 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
-import React from 'react';
+.array-input {
+  position: relative;
 
-import { ArrayInput } from './array-input';
-
-describe('ArrayInput', () => {
-  it('matches snapshot', () => {
-    const arrayInput = (
-      <ArrayInput
-        values={['apple', 'banana', 'pear']}
-        className="test"
-        placeholder="test"
-        onChange={() => {}}
-        suggestions={['dog', 'cat', 'skunk']}
-      />
-    );
-
-    const { container } = render(arrayInput);
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
+  .suggestion-button {
+    position: absolute;
+    top: 1px;
+    right: 1px;
+  }
+}

--- a/web-console/src/components/array-input/array-input.tsx
+++ b/web-console/src/components/array-input/array-input.tsx
@@ -16,10 +16,16 @@
  * limitations under the License.
  */
 
-import { Intent, TextArea } from '@blueprintjs/core';
+import { Button, Intent, Position, TextArea } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import { Popover2 } from '@blueprintjs/popover2';
+import classNames from 'classnames';
 import React, { useState } from 'react';
 
 import { compact } from '../../utils';
+import { Suggestion, SuggestionMenu } from '../suggestion-menu/suggestion-menu';
+
+import './array-input.scss';
 
 export interface ArrayInputProps {
   className?: string;
@@ -29,10 +35,11 @@ export interface ArrayInputProps {
   large?: boolean;
   disabled?: boolean;
   intent?: Intent;
+  suggestions?: Suggestion[];
 }
 
 export const ArrayInput = React.memo(function ArrayInput(props: ArrayInputProps) {
-  const { className, placeholder, large, disabled, intent, onChange } = props;
+  const { className, values, placeholder, large, disabled, intent, onChange, suggestions } = props;
   const [intermediateValue, setIntermediateValue] = useState<string | undefined>();
 
   const handleChange = (e: any) => {
@@ -46,21 +53,36 @@ export const ArrayInput = React.memo(function ArrayInput(props: ArrayInputProps)
     );
   };
 
+  function handleSuggestionSelect(suggestion: undefined | string) {
+    if (!suggestion) return;
+    onChange((values || []).concat([suggestion]));
+  }
+
   return (
-    <TextArea
-      className={className}
-      value={
-        typeof intermediateValue !== 'undefined'
-          ? intermediateValue
-          : props.values?.join(', ') || ''
-      }
-      onChange={handleChange}
-      onBlur={() => setIntermediateValue(undefined)}
-      placeholder={placeholder}
-      large={large}
-      disabled={disabled}
-      intent={intent}
-      fill
-    />
+    <div className={classNames('array-input', className)}>
+      <TextArea
+        className={className}
+        value={
+          typeof intermediateValue !== 'undefined' ? intermediateValue : values?.join(', ') || ''
+        }
+        onChange={handleChange}
+        onBlur={() => setIntermediateValue(undefined)}
+        placeholder={placeholder}
+        large={large}
+        disabled={disabled}
+        intent={intent}
+        fill
+      />
+      {suggestions && (
+        <Popover2
+          className="suggestion-button"
+          content={<SuggestionMenu suggestions={suggestions} onSuggest={handleSuggestionSelect} />}
+          position={Position.BOTTOM_RIGHT}
+          autoFocus={false}
+        >
+          <Button icon={IconNames.PLUS} minimal />
+        </Popover2>
+      )}
+    </div>
   );
 });

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -27,7 +27,8 @@ import { IntervalInput } from '../interval-input/interval-input';
 import { JsonInput } from '../json-input/json-input';
 import { NumericInputWithDefault } from '../numeric-input-with-default/numeric-input-with-default';
 import { PopoverText } from '../popover-text/popover-text';
-import { SuggestibleInput, Suggestion } from '../suggestible-input/suggestible-input';
+import { SuggestibleInput } from '../suggestible-input/suggestible-input';
+import { Suggestion } from '../suggestion-menu/suggestion-menu';
 
 import './auto-form.scss';
 
@@ -369,6 +370,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         large={large}
         disabled={AutoForm.evaluateFunctor(field.disabled, model, false)}
         intent={required && modelValue == null ? AutoForm.REQUIRED_INTENT : undefined}
+        suggestions={AutoForm.evaluateFunctor(field.suggestions, model, undefined)}
       />
     );
   }

--- a/web-console/src/components/index.ts
+++ b/web-console/src/components/index.ts
@@ -40,6 +40,7 @@ export * from './rule-editor/rule-editor';
 export * from './segment-timeline/segment-timeline';
 export * from './show-json/show-json';
 export * from './show-log/show-log';
+export * from './suggestion-menu/suggestion-menu';
 export * from './table-cell/table-cell';
 export * from './table-column-selector/table-column-selector';
 export * from './timed-button/timed-button';

--- a/web-console/src/components/suggestible-input/suggestible-input.tsx
+++ b/web-console/src/components/suggestible-input/suggestible-input.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Menu, MenuItem, Position } from '@blueprintjs/core';
+import { Button, Position } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
 import classNames from 'classnames';
@@ -24,13 +24,7 @@ import React, { useRef } from 'react';
 
 import { JSON_STRING_FORMATTER } from '../../utils';
 import { FormattedInput, FormattedInputProps } from '../formatted-input/formatted-input';
-
-export interface SuggestionGroup {
-  group: string;
-  suggestions: string[];
-}
-
-export type Suggestion = undefined | string | SuggestionGroup;
+import { Suggestion, SuggestionMenu } from '../suggestion-menu/suggestion-menu';
 
 export interface SuggestibleInputProps extends Omit<FormattedInputProps, 'formatter'> {
   onFinalize?: () => void;
@@ -75,39 +69,7 @@ export const SuggestibleInput = React.memo(function SuggestibleInput(props: Sugg
         suggestions && (
           <Popover2
             content={
-              <Menu>
-                {suggestions.map(suggestion => {
-                  if (typeof suggestion === 'undefined') {
-                    return (
-                      <MenuItem
-                        key="__undefined__"
-                        text="(none)"
-                        onClick={() => handleSuggestionSelect(suggestion)}
-                      />
-                    );
-                  } else if (typeof suggestion === 'string') {
-                    return (
-                      <MenuItem
-                        key={suggestion}
-                        text={JSON_STRING_FORMATTER.stringify(suggestion)}
-                        onClick={() => handleSuggestionSelect(suggestion)}
-                      />
-                    );
-                  } else {
-                    return (
-                      <MenuItem key={suggestion.group} text={suggestion.group}>
-                        {suggestion.suggestions.map(suggestion => (
-                          <MenuItem
-                            key={suggestion}
-                            text={suggestion}
-                            onClick={() => handleSuggestionSelect(suggestion)}
-                          />
-                        ))}
-                      </MenuItem>
-                    );
-                  }
-                })}
-              </Menu>
+              <SuggestionMenu suggestions={suggestions} onSuggest={handleSuggestionSelect} />
             }
             position={Position.BOTTOM_RIGHT}
             autoFocus={false}

--- a/web-console/src/components/suggestion-menu/__snapshots__/suggestion-menu.spec.tsx.snap
+++ b/web-console/src/components/suggestion-menu/__snapshots__/suggestion-menu.spec.tsx.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SuggestionMenu matches snapshot 1`] = `
+<ul
+  class="bp3-menu suggestion-menu"
+>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        dog
+      </div>
+    </a>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        cat
+      </div>
+    </a>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        skunk
+      </div>
+    </a>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Fruit
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+</ul>
+`;

--- a/web-console/src/components/suggestion-menu/suggestion-menu.spec.tsx
+++ b/web-console/src/components/suggestion-menu/suggestion-menu.spec.tsx
@@ -19,17 +19,22 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { ArrayInput } from './array-input';
+import { SuggestionMenu } from './suggestion-menu';
 
-describe('ArrayInput', () => {
+describe('SuggestionMenu', () => {
   it('matches snapshot', () => {
     const arrayInput = (
-      <ArrayInput
-        values={['apple', 'banana', 'pear']}
-        className="test"
-        placeholder="test"
-        onChange={() => {}}
-        suggestions={['dog', 'cat', 'skunk']}
+      <SuggestionMenu
+        suggestions={[
+          'dog',
+          'cat',
+          'skunk',
+          {
+            group: 'Fruit',
+            suggestions: ['lemon', 'apple'],
+          },
+        ]}
+        onSuggest={() => {}}
       />
     );
 

--- a/web-console/src/components/suggestion-menu/suggestion-menu.tsx
+++ b/web-console/src/components/suggestion-menu/suggestion-menu.tsx
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Menu, MenuItem } from '@blueprintjs/core';
+import React from 'react';
+
+import { JSON_STRING_FORMATTER } from '../../utils';
+
+export interface SuggestionGroup {
+  group: string;
+  suggestions: string[];
+}
+
+export type Suggestion = undefined | string | SuggestionGroup;
+
+export interface SuggestionMenuProps {
+  suggestions: Suggestion[];
+  onSuggest(suggestion: string | undefined): void;
+}
+
+export const SuggestionMenu = React.memo(function SuggestionMenu(props: SuggestionMenuProps) {
+  const { suggestions, onSuggest } = props;
+  return (
+    <Menu className="suggestion-menu">
+      {suggestions.map(suggestion => {
+        if (typeof suggestion === 'undefined') {
+          return (
+            <MenuItem key="__undefined__" text="(none)" onClick={() => onSuggest(suggestion)} />
+          );
+        } else if (typeof suggestion === 'string') {
+          return (
+            <MenuItem
+              key={suggestion}
+              text={JSON_STRING_FORMATTER.stringify(suggestion)}
+              onClick={() => onSuggest(suggestion)}
+            />
+          );
+        } else {
+          return (
+            <MenuItem key={suggestion.group} text={suggestion.group}>
+              {suggestion.suggestions.map(suggestion => (
+                <MenuItem
+                  key={suggestion}
+                  text={suggestion}
+                  onClick={() => onSuggest(suggestion)}
+                />
+              ))}
+            </MenuItem>
+          );
+        }
+      })}
+    </Menu>
+  );
+});

--- a/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
@@ -40,9 +40,9 @@ exports[`CompactionDialog matches snapshot with compactionConfig (dynamic partit
               </Unknown>
                (partitioning based on the hash of dimensions in each row) or 
               <Unknown>
-                single_dim
+                range
               </Unknown>
-               (based on ranges of a single dimension). For best-effort rollup, you should use 
+               (based on several dimensions). For best-effort rollup, you should use 
               <Unknown>
                 dynamic
               </Unknown>
@@ -53,7 +53,7 @@ exports[`CompactionDialog matches snapshot with compactionConfig (dynamic partit
             "suggestions": Array [
               "dynamic",
               "hashed",
-              "single_dim",
+              "range",
             ],
             "type": "string",
           },
@@ -410,9 +410,9 @@ exports[`CompactionDialog matches snapshot with compactionConfig (hashed partiti
               </Unknown>
                (partitioning based on the hash of dimensions in each row) or 
               <Unknown>
-                single_dim
+                range
               </Unknown>
-               (based on ranges of a single dimension). For best-effort rollup, you should use 
+               (based on several dimensions). For best-effort rollup, you should use 
               <Unknown>
                 dynamic
               </Unknown>
@@ -423,7 +423,7 @@ exports[`CompactionDialog matches snapshot with compactionConfig (hashed partiti
             "suggestions": Array [
               "dynamic",
               "hashed",
-              "single_dim",
+              "range",
             ],
             "type": "string",
           },
@@ -740,7 +740,7 @@ exports[`CompactionDialog matches snapshot with compactionConfig (hashed partiti
 </Blueprint3.Dialog>
 `;
 
-exports[`CompactionDialog matches snapshot with compactionConfig (single_dim partitionsSpec) 1`] = `
+exports[`CompactionDialog matches snapshot with compactionConfig (range partitionsSpec) 1`] = `
 <Blueprint3.Dialog
   canOutsideClickClose={false}
   className="compaction-dialog"
@@ -780,9 +780,9 @@ exports[`CompactionDialog matches snapshot with compactionConfig (single_dim par
               </Unknown>
                (partitioning based on the hash of dimensions in each row) or 
               <Unknown>
-                single_dim
+                range
               </Unknown>
-               (based on ranges of a single dimension). For best-effort rollup, you should use 
+               (based on several dimensions). For best-effort rollup, you should use 
               <Unknown>
                 dynamic
               </Unknown>
@@ -793,7 +793,7 @@ exports[`CompactionDialog matches snapshot with compactionConfig (single_dim par
             "suggestions": Array [
               "dynamic",
               "hashed",
-              "single_dim",
+              "range",
             ],
             "type": "string",
           },
@@ -1076,7 +1076,7 @@ exports[`CompactionDialog matches snapshot with compactionConfig (single_dim par
           "dataSource": "test1",
           "tuningConfig": Object {
             "partitionsSpec": Object {
-              "type": "single_dim",
+              "type": "range",
             },
           },
         }
@@ -1150,9 +1150,9 @@ exports[`CompactionDialog matches snapshot without compactionConfig 1`] = `
               </Unknown>
                (partitioning based on the hash of dimensions in each row) or 
               <Unknown>
-                single_dim
+                range
               </Unknown>
-               (based on ranges of a single dimension). For best-effort rollup, you should use 
+               (based on several dimensions). For best-effort rollup, you should use 
               <Unknown>
                 dynamic
               </Unknown>
@@ -1163,7 +1163,7 @@ exports[`CompactionDialog matches snapshot without compactionConfig 1`] = `
             "suggestions": Array [
               "dynamic",
               "hashed",
-              "single_dim",
+              "range",
             ],
             "type": "string",
           },

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.spec.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.spec.tsx
@@ -67,7 +67,7 @@ describe('CompactionDialog', () => {
     expect(compactionDialog).toMatchSnapshot();
   });
 
-  it('matches snapshot with compactionConfig (single_dim partitionsSpec)', () => {
+  it('matches snapshot with compactionConfig (range partitionsSpec)', () => {
     const compactionDialog = shallow(
       <CompactionDialog
         onClose={() => {}}
@@ -76,7 +76,7 @@ describe('CompactionDialog', () => {
         datasource="test1"
         compactionConfig={{
           dataSource: 'test1',
-          tuningConfig: { partitionsSpec: { type: 'single_dim' } },
+          tuningConfig: { partitionsSpec: { type: 'range' } },
         }}
       />,
     );

--- a/web-console/src/druid-models/compaction-config.tsx
+++ b/web-console/src/druid-models/compaction-config.tsx
@@ -41,12 +41,12 @@ export const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
     name: 'tuningConfig.partitionsSpec.type',
     label: 'Partitioning type',
     type: 'string',
-    suggestions: ['dynamic', 'hashed', 'single_dim'],
+    suggestions: ['dynamic', 'hashed', 'range'],
     info: (
       <p>
         For perfect rollup, you should use either <Code>hashed</Code> (partitioning based on the
-        hash of dimensions in each row) or <Code>single_dim</Code> (based on ranges of a single
-        dimension). For best-effort rollup, you should use <Code>dynamic</Code>.
+        hash of dimensions in each row) or <Code>range</Code> (based on several dimensions). For
+        best-effort rollup, you should use <Code>dynamic</Code>.
       </p>
     ),
   },

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -25,6 +25,7 @@ import {
   formatMillions,
   formatPercent,
   moveElement,
+  moveToIndex,
   sqlQueryCustomTableFilter,
   swapElements,
 } from './general';
@@ -100,6 +101,18 @@ describe('general', () => {
       expect(moveElement(['a', 'b', 'c'], 1, 1)).toEqual(['a', 'b', 'c']);
       expect(moveElement(['F', 'B', 'W', 'B'], 2, 1)).toEqual(['F', 'W', 'B', 'B']);
       expect(moveElement([1, 2, 3], 2, 1)).toEqual([1, 3, 2]);
+    });
+  });
+
+  describe('moveToIndex', () => {
+    it('works', () => {
+      expect(moveToIndex(['a', 'b', 'c', 'd', 'e'], x => ['e', 'c'].indexOf(x))).toEqual([
+        'e',
+        'c',
+        'a',
+        'b',
+        'd',
+      ]);
     });
   });
 

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -429,6 +429,28 @@ export function moveElement<T>(items: readonly T[], fromIndex: number, toIndex: 
   }
 }
 
+export function moveToIndex<T>(
+  items: readonly T[],
+  itemToIndex: (item: T, i: number) => number,
+): T[] {
+  const frontItems: { item: T; index: number }[] = [];
+  const otherItems: T[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const index = itemToIndex(item, i);
+    if (index >= 0) {
+      frontItems.push({ item, index });
+    } else {
+      otherItems.push(item);
+    }
+  }
+
+  return frontItems
+    .sort((a, b) => a.index - b.index)
+    .map(d => d.item)
+    .concat(otherItems);
+}
+
 export function stringifyValue(value: unknown): string {
   switch (typeof value) {
     case 'object':


### PR DESCRIPTION
This PR gives range partitioning first class treatment.

![image](https://user-images.githubusercontent.com/177816/149068550-f1a54cb4-c09d-47b9-94b4-d797034573dd.png)

Now you can select `range` from the dropdown (instead of `single_dim`) and the warning about the dimension order and the partition dimensions not matching up is there also.

Also added suggestions to the `string-array` input:

![image](https://user-images.githubusercontent.com/177816/149068773-e58dee7b-b463-49d0-bd8e-6d5d3ac129b5.png)

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
