### PR TITLE
avoid unnecessary String.format calls in IdUtils.validateId

### DIFF
--- a/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
+++ b/core/src/main/java/org/apache/druid/common/utils/IdUtils.java
@@ -46,20 +46,20 @@ public class IdUtils
   {
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(stringToValidate),
-        StringUtils.format("%s cannot be null or empty. Please provide a %s.", thingToValidate, thingToValidate)
+        "%s cannot be null or empty. Please provide a %s.", thingToValidate, thingToValidate
     );
     Preconditions.checkArgument(
         !stringToValidate.startsWith("."),
-        StringUtils.format("%s cannot start with the '.' character.", thingToValidate)
+        "%s cannot start with the '.' character.", thingToValidate
     );
     Preconditions.checkArgument(
         !stringToValidate.contains("/"),
-        StringUtils.format("%s cannot contain the '/' character.", thingToValidate)
+        "%s cannot contain the '/' character.", thingToValidate
     );
     Matcher m = INVALIDCHARS.matcher(stringToValidate);
     Preconditions.checkArgument(
         !m.matches(),
-        StringUtils.format("%s cannot contain whitespace character except space.", thingToValidate)
+        "%s cannot contain whitespace character except space.", thingToValidate
     );
 
     for (int i = 0; i < stringToValidate.length(); i++) {


### PR DESCRIPTION
Based on profiling data, about 25% of the time de-serializing DataSchema
is spent on formatting strings in validateId.

This can add up quickly, especially when de-serializing task information
in the overlord, where in can consume almost 2% of CPU if there are many
tasks.

Since the formatting is unnecessary unless the checks fail, we can
leverage the built-in formatting of Preconditions.checkArgument instead
to avoid the cost.
