### PR TITLE
Fix node discovery to ignore unknown DruidServices

### DIFF
--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -177,7 +177,7 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
                     node.getDruidNode().getHostAndPort(),
                     node.getDruidNode().getHostAndTlsPort(),
                     ((DataNodeService) node.getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getMaxSize(),
-                    ((DataNodeService) node.getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getType(),
+                    ((DataNodeService) node.getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getServerType(),
                     ((DataNodeService) node.getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getTier(),
                     ((DataNodeService) node.getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getPriority()
                 );

--- a/server/src/main/java/org/apache/druid/discovery/DataNodeService.java
+++ b/server/src/main/java/org/apache/druid/discovery/DataNodeService.java
@@ -22,8 +22,11 @@ package org.apache.druid.discovery;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.server.coordination.ServerType;
 
+import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -32,35 +35,58 @@ import java.util.Objects;
 public class DataNodeService extends DruidService
 {
   public static final String DISCOVERY_SERVICE_KEY = "dataNodeService";
+  public static final String SERVER_TYPE_PROP_KEY = "serverType";
 
   private final String tier;
   private final long maxSize;
-  private final ServerType type;
+  private final ServerType serverType;
   private final int priority;
   private final boolean isDiscoverable;
 
+  /**
+   * This JSON creator requires the subtype key of {@link DruidService} to appear first
+   * in the serialized JSON. Deserialization can fail otherwise. As a result,
+   * {@link DiscoveryDruidNode} does not deserialize this class directly.
+   * Instead, it deserializes the JSON to {@link org.apache.druid.jackson.StringObjectPairList} first,
+   * and then DataNodeService. See {@link DiscoveryDruidNode#toMap(List)} for more details.
+   */
   @JsonCreator
-  public DataNodeService(
+  public static DataNodeService fromJson(
       @JsonProperty("tier") String tier,
       @JsonProperty("maxSize") long maxSize,
-      @JsonProperty("type") ServerType type,
+      @JsonProperty("type") @Deprecated @Nullable ServerType type, // see getType() for deprecation.
+      @JsonProperty(SERVER_TYPE_PROP_KEY) @Nullable ServerType serverType,
       @JsonProperty("priority") int priority
   )
   {
-    this(tier, maxSize, type, priority, true);
+    if (type == null && serverType == null) {
+      throw new IAE("ServerType is missing");
+    }
+    final ServerType theServerType = serverType == null ? type : serverType;
+    return new DataNodeService(tier, maxSize, theServerType, priority);
   }
 
   public DataNodeService(
       String tier,
       long maxSize,
-      ServerType type,
+      ServerType serverType,
+      int priority
+  )
+  {
+    this(tier, maxSize, serverType, priority, true);
+  }
+
+  public DataNodeService(
+      String tier,
+      long maxSize,
+      ServerType serverType,
       int priority,
       boolean isDiscoverable
   )
   {
     this.tier = tier;
     this.maxSize = maxSize;
-    this.type = type;
+    this.serverType = serverType;
     this.priority = priority;
     this.isDiscoverable = isDiscoverable;
   }
@@ -84,15 +110,33 @@ public class DataNodeService extends DruidService
   }
 
   @JsonProperty
-  public ServerType getType()
+  public ServerType getServerType()
   {
-    return type;
+    return serverType;
   }
 
   @JsonProperty
   public int getPriority()
   {
     return priority;
+  }
+
+  /**
+   * Use {@link #getServerType()} instead.
+   *
+   * This method is deprecated as its JSON property key is duplicated with the subtype key of {@link DruidService}.
+   * This seems to happen to work because the subtype key "type" always appears first in the serialized JSON,
+   * which Jackson always picks up as the subtype key. This is not safe though since it will stop working
+   * if Jackson behavior changes in the future. See also {@link DiscoveryDruidNode#toMap(List)}.
+   *
+   * Since entirely removing this property can break compatibility, we just deprecate it for now.
+   * However, we should remove it as soon as possible in a future release.
+   */
+  @Deprecated
+  @JsonProperty
+  public ServerType getType()
+  {
+    return serverType;
   }
 
   @Override
@@ -115,13 +159,13 @@ public class DataNodeService extends DruidService
     return maxSize == that.maxSize &&
            priority == that.priority &&
            Objects.equals(tier, that.tier) &&
-           type == that.type;
+           serverType == that.serverType;
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(tier, maxSize, type, priority);
+    return Objects.hash(tier, maxSize, serverType, priority);
   }
 
   @Override
@@ -130,7 +174,7 @@ public class DataNodeService extends DruidService
     return "DataNodeService{" +
            "tier='" + tier + '\'' +
            ", maxSize=" + maxSize +
-           ", type=" + type +
+           ", serverType=" + serverType +
            ", priority=" + priority +
            '}';
   }

--- a/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
+++ b/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
@@ -89,7 +89,7 @@ public class DiscoveryDruidNode
           services.put(entry.getKey(), jsonMapper.convertValue(toMap(val), DruidService.class));
         }
         catch (RuntimeException e) {
-          LOG.warn("Ingore unparseable DruidService: %s", entry.getValue());
+          LOG.warn("Ignore unparseable DruidService for [%s]: %s", druidNode.getHostAndPortToUse(), val);
         }
       }
     }

--- a/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
+++ b/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
@@ -21,11 +21,9 @@ package org.apache.druid.discovery;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.DruidNode;
 
@@ -89,12 +87,8 @@ public class DiscoveryDruidNode
         try {
           services.put(entry.getKey(), jsonMapper.convertValue(entry.getValue(), DruidService.class));
         }
-        catch (IllegalArgumentException e) {
-          if (e.getCause().getClass() == InvalidTypeIdException.class) {
-            LOG.info("Ingore unparseable DruidService: %s", entry.getValue());
-          } else {
-            throw e;
-          }
+        catch (RuntimeException e) {
+          LOG.warn("Ingore unparseable DruidService: %s", entry.getValue());
         }
       }
     }

--- a/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
+++ b/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
@@ -97,18 +97,18 @@ public class DiscoveryDruidNode
   }
 
   /**
-   * A serialized {@link DataNodeService} can have duplicate "type" keys
-   * as {@link DruidService} uses the same name of property as the subtype key
-   * while DataNodeService has a property of the same name for {@link org.apache.druid.server.coordination.ServerType}.
-   * As a result, if we directly deserialize a JSON to a map, we will lose one of the "type" property.
-   * This is definitely a bug of DataNodeService, but things seems to happen to be working
-   * because the subtype key seems to always appear first in the serialized JSON
-   * and Jackson always picks up the first appeared "type" key as the subtype key.
-   * To fix this, we should renmae one of those duplicate keys, but, since the rename will break compatibility,
-   * DataNodeService still has the deprecated "type" property.
+   * A JSON of a {@link DruidService} is deserialized to a Map and then converted to aDruidService
+   * to ignore any "unknown" DruidServices to the current node. However, directly deserializing a JSON to a Map
+   * is problematic for {@link DataNodeService} as it has duplicate "type" keys in its serialized form.
+   * Because of the duplicate key, if we directly deserialize a JSON to a Map, we will lose one of the "type" property.
+   * This is definitely a bug of DataNodeService, but, since renaming one of those duplicate keys will
+   * break compatibility, DataNodeService still has the deprecated "type" property.
+   * See the Javadoc of DataNodeService for more details.
    *
-   * This function catches such duplicate keys and rename one of them properly, so that we don't lose any properties.
-   * This method can be removed together when we entirely remove the "type" property from DataNodeService.
+   * This function catches such duplicate keys and rewrites the deprecated "type" to "serverType",
+   * so that we don't lose any properties.
+   *
+   * This method can be removed together when we entirely remove the deprecated "type" property from DataNodeService.
    */
   @Deprecated
   private static Map<String, Object> toMap(List<NonnullPair<String, Object>> pairs)

--- a/server/src/main/java/org/apache/druid/guice/ServerModule.java
+++ b/server/src/main/java/org/apache/druid/guice/ServerModule.java
@@ -26,6 +26,7 @@ import com.google.inject.Binder;
 import com.google.inject.Provides;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.jackson.DruidServiceSerializerModifier;
 import org.apache.druid.jackson.StringObjectPairList;
 import org.apache.druid.jackson.ToStringObjectPairListDeserializer;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutorFactory;
@@ -59,7 +60,9 @@ public class ServerModule implements DruidModule
   public List<? extends Module> getJacksonModules()
   {
     return ImmutableList.of(
-        new SimpleModule().addDeserializer(StringObjectPairList.class, new ToStringObjectPairListDeserializer())
+        new SimpleModule()
+            .addDeserializer(StringObjectPairList.class, new ToStringObjectPairListDeserializer())
+            .setSerializerModifier(new DruidServiceSerializerModifier())
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/guice/ServerModule.java
+++ b/server/src/main/java/org/apache/druid/guice/ServerModule.java
@@ -19,19 +19,26 @@
 
 package org.apache.druid.guice;
 
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Provides;
 import org.apache.druid.guice.annotations.Self;
+import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.jackson.StringObjectPairList;
+import org.apache.druid.jackson.ToStringObjectPairListDeserializer;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.initialization.ZkPathsConfig;
 
+import java.util.List;
+
 /**
  */
-public class ServerModule implements Module
+public class ServerModule implements DruidModule
 {
   public static final String ZK_PATHS_PROPERTY_BASE = "druid.zk.paths";
 
@@ -46,5 +53,13 @@ public class ServerModule implements Module
   public ScheduledExecutorFactory getScheduledExecutorFactory(Lifecycle lifecycle)
   {
     return ScheduledExecutors.createFactory(lifecycle);
+  }
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of(
+        new SimpleModule().addDeserializer(StringObjectPairList.class, new ToStringObjectPairListDeserializer())
+    );
   }
 }

--- a/server/src/main/java/org/apache/druid/jackson/DruidServiceSerializer.java
+++ b/server/src/main/java/org/apache/druid/jackson/DruidServiceSerializer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.apache.druid.discovery.DataNodeService;
+import org.apache.druid.discovery.DruidService;
+
+import java.io.IOException;
+
+/**
+ * A custom serializer to handle the bug of duplicate "type" keys in {@link DataNodeService}.
+ * This class can be removed together when we entirely remove the deprecated "type" property from DataNodeService.
+ * See the Javadoc of DataNodeService for more details.
+ */
+public class DruidServiceSerializer extends StdSerializer<DruidService>
+{
+  private final JsonSerializer<Object> defaultSerializer;
+
+  public DruidServiceSerializer(JsonSerializer<Object> defaultSerializer)
+  {
+    super(DruidService.class);
+    this.defaultSerializer = defaultSerializer;
+  }
+
+  @Override
+  public void serialize(DruidService druidService, JsonGenerator gen, SerializerProvider serializers) throws IOException
+  {
+    defaultSerializer.serialize(druidService, gen, serializers);
+  }
+
+  @Override
+  public void serializeWithType(
+      DruidService druidService,
+      JsonGenerator gen,
+      SerializerProvider serializers,
+      TypeSerializer typeSer
+  ) throws IOException
+  {
+    if (druidService instanceof DataNodeService) {
+      DataNodeService dataNodeService = (DataNodeService) druidService;
+      gen.writeStartObject();
+
+      // Write subtype key first. This is important because Jackson picks up the first "type" field as the subtype key
+      // for deserialization.
+      gen.writeStringField("type", DataNodeService.DISCOVERY_SERVICE_KEY);
+
+      // Write properties of DataNodeService
+      gen.writeStringField("tier", dataNodeService.getTier());
+      gen.writeNumberField("maxSize", dataNodeService.getMaxSize());
+      // NOTE: the below line writes a duplicate key of "type".
+      // This is a bug that DataNodeService has a key of the same name as the subtype key.
+      // To address the bug, a new "serverType" field has been added.
+      // However, we cannot remove the deprecated "type" entirely yet because it will break rolling upgrade.
+      // It seems OK to have duplicate keys though because Jackson seems to always pick up the first "type" property
+      // as the subtype key for deserialization.
+      // This duplicate key should be removed in a future release.
+      // See DiscoveryDruidNode.toMap() for deserialization of DruidServices.
+      gen.writeObjectField("type", dataNodeService.getServerType());
+      gen.writeObjectField("serverType", dataNodeService.getServerType());
+      gen.writeNumberField("priority", dataNodeService.getPriority());
+
+      gen.writeEndObject();
+    } else {
+      defaultSerializer.serializeWithType(druidService, gen, serializers, typeSer);
+    }
+  }
+}

--- a/server/src/main/java/org/apache/druid/jackson/DruidServiceSerializerModifier.java
+++ b/server/src/main/java/org/apache/druid/jackson/DruidServiceSerializerModifier.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.jackson;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import org.apache.druid.discovery.DruidService;
+
+/**
+ * A modifier to use a custom serializer for {@link DruidService}.
+ * See {@link DruidServiceSerializer} for details.
+ */
+public class DruidServiceSerializerModifier extends BeanSerializerModifier
+{
+  @Override
+  public JsonSerializer<?> modifySerializer(
+      SerializationConfig config,
+      BeanDescription beanDesc,
+      JsonSerializer<?> serializer
+  )
+  {
+    if (DruidService.class.isAssignableFrom(beanDesc.getBeanClass())) {
+      return new DruidServiceSerializer((JsonSerializer<Object>) serializer);
+    }
+
+    return serializer;
+  }
+}

--- a/server/src/main/java/org/apache/druid/jackson/StringObjectPairList.java
+++ b/server/src/main/java/org/apache/druid/jackson/StringObjectPairList.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.jackson;
+
+import org.apache.druid.discovery.DiscoveryDruidNode;
+import org.apache.druid.java.util.common.NonnullPair;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * When {@link DiscoveryDruidNode} is deserialized from a JSON, the JSON is first converted to this class,
+ * and then to a Map. See {@link DiscoveryDruidNode#toMap} for details.
+ *
+ * @see ToStringObjectPairListDeserializer
+ */
+public class StringObjectPairList
+{
+  private final List<NonnullPair<String, Object>> pairs;
+
+  public StringObjectPairList(List<NonnullPair<String, Object>> pairs)
+  {
+    this.pairs = pairs;
+  }
+
+  public List<NonnullPair<String, Object>> getPairs()
+  {
+    return pairs;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StringObjectPairList that = (StringObjectPairList) o;
+    return Objects.equals(pairs, that.pairs);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(pairs);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "StringObjectPairList{" +
+           "pairs=" + pairs +
+           '}';
+  }
+}

--- a/server/src/main/java/org/apache/druid/jackson/ToStringObjectPairListDeserializer.java
+++ b/server/src/main/java/org/apache/druid/jackson/ToStringObjectPairListDeserializer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.druid.discovery.DiscoveryDruidNode;
+import org.apache.druid.discovery.DruidService;
+import org.apache.druid.java.util.common.NonnullPair;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * When {@link DiscoveryDruidNode} is deserialized from a JSON,
+ * the JSON is first converted to {@link StringObjectPairList}, and then to a Map.
+ * See {@link DiscoveryDruidNode#toMap} for details.
+ */
+public class ToStringObjectPairListDeserializer extends StdDeserializer<StringObjectPairList>
+{
+  public ToStringObjectPairListDeserializer()
+  {
+    super(StringObjectPairList.class);
+  }
+
+  @Override
+  public StringObjectPairList deserialize(JsonParser parser, DeserializationContext ctx) throws IOException
+  {
+    if (parser.currentToken() != JsonToken.START_OBJECT) {
+      throw ctx.wrongTokenException(parser, DruidService.class, JsonToken.START_OBJECT, null);
+    }
+
+    final List<NonnullPair<String, Object>> pairs = new ArrayList<>();
+
+    parser.nextToken();
+
+    while (parser.currentToken() == JsonToken.FIELD_NAME) {
+      final String key = parser.getText();
+      parser.nextToken();
+      final Object val = ctx.readValue(parser, Object.class);
+      pairs.add(new NonnullPair<>(key, val));
+
+      parser.nextToken();
+    }
+
+    if (parser.currentToken() != JsonToken.END_OBJECT) {
+      throw ctx.wrongTokenException(parser, DruidService.class, JsonToken.END_OBJECT, null);
+    }
+
+    return new StringObjectPairList(pairs);
+  }
+}

--- a/server/src/test/java/org/apache/druid/curator/discovery/CuratorDruidNodeAnnouncerAndDiscoveryTest.java
+++ b/server/src/test/java/org/apache/druid/curator/discovery/CuratorDruidNodeAnnouncerAndDiscoveryTest.java
@@ -64,6 +64,7 @@ public class CuratorDruidNodeAnnouncerAndDiscoveryTest extends CuratorTestBase
             .addValue(ServerConfig.class, new ServerConfig())
             .addValue("java.lang.String", "dummy")
             .addValue("java.lang.Integer", 1234)
+            .addValue(ObjectMapper.class, objectMapper)
     );
 
     curator.start();

--- a/server/src/test/java/org/apache/druid/discovery/DataNodeServiceTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DataNodeServiceTest.java
@@ -19,8 +19,9 @@
 
 package org.apache.druid.discovery;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.druid.segment.TestHelper;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.coordination.ServerType;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,6 +30,8 @@ import org.junit.Test;
  */
 public class DataNodeServiceTest
 {
+  private final ObjectMapper mapper = DruidServiceTestUtils.newJsonMapper();
+
   @Test
   public void testSerde() throws Exception
   {
@@ -39,7 +42,6 @@ public class DataNodeServiceTest
         1
     );
 
-    ObjectMapper mapper = TestHelper.makeJsonMapper();
     DruidService actual = mapper.readValue(
         mapper.writeValueAsString(expected),
         DruidService.class
@@ -59,7 +61,6 @@ public class DataNodeServiceTest
                   + "  \"priority\" : 1\n"
                   + "}";
 
-    ObjectMapper mapper = TestHelper.makeJsonMapper();
     DruidService actual = mapper.readValue(
         json,
         DruidService.class
@@ -87,7 +88,6 @@ public class DataNodeServiceTest
                   + "  \"priority\" : 1\n"
                   + "}";
 
-    ObjectMapper mapper = TestHelper.makeJsonMapper();
     DruidService actual = mapper.readValue(
         json,
         DruidService.class
@@ -116,7 +116,6 @@ public class DataNodeServiceTest
                   + "  \"priority\" : 1\n"
                   + "}";
 
-    ObjectMapper mapper = TestHelper.makeJsonMapper();
     DruidService actual = mapper.readValue(
         json,
         DruidService.class
@@ -131,5 +130,18 @@ public class DataNodeServiceTest
         ),
         actual
     );
+  }
+
+  @Test
+  public void testSerializeSubtypeKeyShouldAppearFirstInJson() throws JsonProcessingException
+  {
+    final DataNodeService dataNodeService = new DataNodeService(
+        "tier",
+        100,
+        ServerType.HISTORICAL,
+        1
+    );
+    final String json = mapper.writeValueAsString(dataNodeService);
+    Assert.assertTrue(json.startsWith(StringUtils.format("{\"type\":\"%s\"", DataNodeService.DISCOVERY_SERVICE_KEY)));
   }
 }

--- a/server/src/test/java/org/apache/druid/discovery/DataNodeServiceTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DataNodeServiceTest.java
@@ -47,4 +47,89 @@ public class DataNodeServiceTest
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void testDeserializeWithDeprecatedServerTypeProperty() throws Exception
+  {
+    String json = "{\n"
+                  + "  \"type\" : \"dataNodeService\",\n"
+                  + "  \"tier\" : \"tier\",\n"
+                  + "  \"maxSize\" : 100,\n"
+                  + "  \"type\" : \"historical\",\n"
+                  + "  \"priority\" : 1\n"
+                  + "}";
+
+    ObjectMapper mapper = TestHelper.makeJsonMapper();
+    DruidService actual = mapper.readValue(
+        json,
+        DruidService.class
+    );
+
+    Assert.assertEquals(
+        new DataNodeService(
+            "tier",
+            100,
+            ServerType.HISTORICAL,
+            1
+        ),
+        actual
+    );
+  }
+
+  @Test
+  public void testDeserializeWithServerTypeProperty() throws Exception
+  {
+    String json = "{\n"
+                  + "  \"type\" : \"dataNodeService\",\n"
+                  + "  \"tier\" : \"tier\",\n"
+                  + "  \"maxSize\" : 100,\n"
+                  + "  \"serverType\" : \"historical\",\n"
+                  + "  \"priority\" : 1\n"
+                  + "}";
+
+    ObjectMapper mapper = TestHelper.makeJsonMapper();
+    DruidService actual = mapper.readValue(
+        json,
+        DruidService.class
+    );
+
+    Assert.assertEquals(
+        new DataNodeService(
+            "tier",
+            100,
+            ServerType.HISTORICAL,
+            1
+        ),
+        actual
+    );
+  }
+
+  @Test
+  public void testSerdeDeserializeWithBothDeprecatedAndNewServerTypes() throws Exception
+  {
+    String json = "{\n"
+                  + "  \"type\" : \"dataNodeService\",\n"
+                  + "  \"tier\" : \"tier\",\n"
+                  + "  \"maxSize\" : 100,\n"
+                  + "  \"type\" : \"historical\",\n"
+                  + "  \"serverType\" : \"historical\",\n"
+                  + "  \"priority\" : 1\n"
+                  + "}";
+
+    ObjectMapper mapper = TestHelper.makeJsonMapper();
+    DruidService actual = mapper.readValue(
+        json,
+        DruidService.class
+    );
+
+    Assert.assertEquals(
+        new DataNodeService(
+            "tier",
+            100,
+            ServerType.HISTORICAL,
+            1
+        ),
+        actual
+    );
+  }
 }

--- a/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
@@ -22,10 +22,15 @@ package org.apache.druid.discovery;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues.Std;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.jackson.StringObjectPairList;
+import org.apache.druid.jackson.ToStringObjectPairListDeserializer;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.coordination.ServerType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,6 +54,15 @@ public class DiscoveryDruidNodeTest
         false
     );
     nodeRole = NodeRole.BROKER;
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(DiscoveryDruidNode.class)
+                  .withNonnullFields("druidNode", "nodeRole", "services")
+                  .usingGetClass()
+                  .verify();
   }
 
   @Test
@@ -83,6 +97,180 @@ public class DiscoveryDruidNodeTest
             ImmutableMap.of("service1", new Service1())
         ),
         fromJson
+    );
+  }
+
+  @Test
+  public void testSerdeWithDataNodeService() throws JsonProcessingException
+  {
+    final ObjectMapper mapper = createObjectMapper(ImmutableList.of());
+    final DiscoveryDruidNode node = new DiscoveryDruidNode(
+        new DruidNode(
+            "druid/broker",
+            "druid-broker",
+            false,
+            8082,
+            -1,
+            8282,
+            true,
+            true
+        ),
+        NodeRole.BROKER,
+        ImmutableMap.of(
+            "dataNodeService",
+            new DataNodeService("_default_tier", 1000000000, ServerType.BROKER, 0)
+        )
+    );
+    final String json = mapper.writeValueAsString(node);
+    Assert.assertEquals(
+        node,
+        mapper.readValue(json, DiscoveryDruidNode.class)
+    );
+  }
+
+  @Test
+  public void testDeserializeWithDataNodeServiceWithAWrongPropertyOrder() throws JsonProcessingException
+  {
+    final ObjectMapper mapper = createObjectMapper(ImmutableList.of());
+    final String json = "{\n"
+                        + "  \"druidNode\" : {\n"
+                        + "    \"service\" : \"druid/broker\",\n"
+                        + "    \"host\" : \"druid-broker\",\n"
+                        + "    \"bindOnHost\" : false,\n"
+                        + "    \"plaintextPort\" : 8082,\n"
+                        + "    \"port\" : -1,\n"
+                        + "    \"tlsPort\" : 8282,\n"
+                        + "    \"enablePlaintextPort\" : true,\n"
+                        + "    \"enableTlsPort\" : true\n"
+                        + "  },\n"
+                        + "  \"nodeType\" : \"broker\",\n"
+                        + "  \"services\" : {\n"
+                        + "    \"dataNodeService\" : {\n"
+                        // In normal case, this proprty must appear after another "type" below.
+                        + "      \"type\" : \"broker\",\n"
+                        + "      \"type\" : \"dataNodeService\",\n"
+                        + "      \"tier\" : \"_default_tier\",\n"
+                        + "      \"maxSize\" : 1000000000,\n"
+                        + "      \"serverType\" : \"broker\",\n"
+                        + "      \"priority\" : 0\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}";
+    Assert.assertEquals(
+        new DiscoveryDruidNode(
+            new DruidNode(
+                "druid/broker",
+                "druid-broker",
+                false,
+                8082,
+                -1,
+                8282,
+                true,
+                true
+            ),
+            NodeRole.BROKER,
+            ImmutableMap.of(
+                "dataNodeService",
+                new DataNodeService("_default_tier", 1000000000, ServerType.BROKER, 0)
+            )
+        ),
+        mapper.readValue(json, DiscoveryDruidNode.class)
+    );
+  }
+
+  @Test
+  public void testDeserialize_duplicateProperties_shouldSucceedToDeserialize() throws JsonProcessingException
+  {
+    final ObjectMapper mapper = createObjectMapper(ImmutableList.of());
+    final String json = "{\n"
+                        + "  \"druidNode\" : {\n"
+                        + "    \"service\" : \"druid/broker\",\n"
+                        + "    \"host\" : \"druid-broker\",\n"
+                        + "    \"bindOnHost\" : false,\n"
+                        + "    \"plaintextPort\" : 8082,\n"
+                        + "    \"port\" : -1,\n"
+                        + "    \"tlsPort\" : 8282,\n"
+                        + "    \"enablePlaintextPort\" : true,\n"
+                        + "    \"enableTlsPort\" : true\n"
+                        + "  },\n"
+                        + "  \"nodeType\" : \"broker\",\n"
+                        + "  \"services\" : {\n"
+                        + "    \"dataNodeService\" : {\n"
+                        + "      \"type\" : \"dataNodeService\",\n"
+                        + "      \"tier\" : \"_default_tier\",\n"
+                        + "      \"maxSize\" : 1000000000,\n"
+                        + "      \"maxSize\" : 1000000000,\n"
+                        + "      \"serverType\" : \"broker\",\n"
+                        + "      \"priority\" : 0\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}";
+    Assert.assertEquals(
+        new DiscoveryDruidNode(
+            new DruidNode(
+                "druid/broker",
+                "druid-broker",
+                false,
+                8082,
+                -1,
+                8282,
+                true,
+                true
+            ),
+            NodeRole.BROKER,
+            ImmutableMap.of(
+                "dataNodeService",
+                new DataNodeService("_default_tier", 1000000000, ServerType.BROKER, 0)
+            )
+        ),
+        mapper.readValue(json, DiscoveryDruidNode.class)
+    );
+  }
+
+  @Test
+  public void testDeserialize_duplicateKeysWithDifferentValus_shouldIgnoreDataNodeService()
+      throws JsonProcessingException
+  {
+    final ObjectMapper mapper = createObjectMapper(ImmutableList.of());
+    final String json = "{\n"
+                        + "  \"druidNode\" : {\n"
+                        + "    \"service\" : \"druid/broker\",\n"
+                        + "    \"host\" : \"druid-broker\",\n"
+                        + "    \"bindOnHost\" : false,\n"
+                        + "    \"plaintextPort\" : 8082,\n"
+                        + "    \"port\" : -1,\n"
+                        + "    \"tlsPort\" : 8282,\n"
+                        + "    \"enablePlaintextPort\" : true,\n"
+                        + "    \"enableTlsPort\" : true\n"
+                        + "  },\n"
+                        + "  \"nodeType\" : \"broker\",\n"
+                        + "  \"services\" : {\n"
+                        + "    \"dataNodeService\" : {\n"
+                        + "      \"type\" : \"dataNodeService\",\n"
+                        + "      \"tier\" : \"_default_tier\",\n"
+                        + "      \"maxSize\" : 1000000000,\n"
+                        + "      \"maxSize\" : 10,\n"
+                        + "      \"serverType\" : \"broker\",\n"
+                        + "      \"priority\" : 0\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}";
+    Assert.assertEquals(
+        new DiscoveryDruidNode(
+            new DruidNode(
+                "druid/broker",
+                "druid-broker",
+                false,
+                8082,
+                -1,
+                8282,
+                true,
+                true
+            ),
+            NodeRole.BROKER,
+            ImmutableMap.of()
+        ),
+        mapper.readValue(json, DiscoveryDruidNode.class)
     );
   }
 
@@ -131,6 +319,7 @@ public class DiscoveryDruidNodeTest
   private static ObjectMapper createObjectMapper(Collection<Class<? extends DruidService>> druidServicesToRegister)
   {
     final ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.registerModule(new SimpleModule().addDeserializer(StringObjectPairList.class, new ToStringObjectPairListDeserializer()));
     //noinspection unchecked,rawtypes
     mapper.registerSubtypes((Collection) druidServicesToRegister);
     mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));

--- a/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.discovery;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.InjectableValues.Std;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.server.DruidNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+
+public class DiscoveryDruidNodeTest
+{
+  private final DruidNode druidNode;
+
+  private final NodeRole nodeRole;
+
+  public DiscoveryDruidNodeTest()
+  {
+    this.druidNode = new DruidNode(
+        "testNode",
+        "host",
+        true,
+        8082,
+        null,
+        true,
+        false
+    );
+    nodeRole = NodeRole.BROKER;
+  }
+
+  @Test
+  public void testDeserialize() throws JsonProcessingException
+  {
+    final ObjectMapper mapper = createObjectMapper(ImmutableList.of(Service1.class, Service2.class));
+    final DiscoveryDruidNode node = new DiscoveryDruidNode(
+        druidNode,
+        nodeRole,
+        ImmutableMap.of("service1", new Service1(), "service2", new Service2())
+    );
+    final String json = mapper.writeValueAsString(node);
+    final DiscoveryDruidNode fromJson = mapper.readValue(json, DiscoveryDruidNode.class);
+    Assert.assertEquals(node, fromJson);
+  }
+
+  @Test
+  public void testDeserializeIgnorUnknownDruidService() throws JsonProcessingException
+  {
+    final ObjectMapper mapper = createObjectMapper(ImmutableList.of(Service1.class));
+    final DiscoveryDruidNode node = new DiscoveryDruidNode(
+        druidNode,
+        nodeRole,
+        ImmutableMap.of("service1", new Service1(), "service2", new Service2())
+    );
+    final String json = mapper.writeValueAsString(node);
+    final DiscoveryDruidNode fromJson = mapper.readValue(json, DiscoveryDruidNode.class);
+    Assert.assertEquals(
+        new DiscoveryDruidNode(
+            druidNode,
+            nodeRole,
+            ImmutableMap.of("service1", new Service1())
+        ),
+        fromJson
+    );
+  }
+
+  private static class Service1 extends DruidService
+  {
+    @Override
+    public String getName()
+    {
+      return "service1";
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+      return obj instanceof Service1;
+    }
+  }
+
+  private static class Service2 extends DruidService
+  {
+    @Override
+    public String getName()
+    {
+      return "service2";
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+      return obj instanceof Service2;
+    }
+  }
+
+  private static ObjectMapper createObjectMapper(Collection<Class<? extends DruidService>> druidServicesToRegister)
+  {
+    final ObjectMapper mapper = new DefaultObjectMapper();
+    //noinspection unchecked,rawtypes
+    mapper.registerSubtypes((Collection) druidServicesToRegister);
+    mapper.setInjectableValues(new Std().addValue(ObjectMapper.class, mapper));
+    return mapper;
+  }
+}

--- a/server/src/test/java/org/apache/druid/discovery/DruidServiceTestUtils.java
+++ b/server/src/test/java/org/apache/druid/discovery/DruidServiceTestUtils.java
@@ -20,29 +20,19 @@
 package org.apache.druid.discovery;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.druid.guice.ServerModule;
+import org.apache.druid.jackson.DefaultObjectMapper;
 
-/**
- */
-public class WorkerNodeServiceTest
+public final class DruidServiceTestUtils
 {
-  @Test
-  public void testSerde() throws Exception
+  public static ObjectMapper newJsonMapper()
   {
-    DruidService expected = new WorkerNodeService(
-        "1.1.1.1",
-        100,
-        "v1",
-        "c1"
-    );
+    final ObjectMapper mapper = new DefaultObjectMapper();
+    mapper.registerModules(new ServerModule().getJacksonModules());
+    return mapper;
+  }
 
-    ObjectMapper mapper = DruidServiceTestUtils.newJsonMapper();
-    DruidService actual = mapper.readValue(
-        mapper.writeValueAsString(expected),
-        DruidService.class
-    );
-
-    Assert.assertEquals(expected, actual);
+  private DruidServiceTestUtils()
+  {
   }
 }

--- a/server/src/test/java/org/apache/druid/discovery/LookupNodeServiceTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/LookupNodeServiceTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.discovery;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,7 +34,7 @@ public class LookupNodeServiceTest
         "tier"
     );
 
-    ObjectMapper mapper = TestHelper.makeJsonMapper();
+    ObjectMapper mapper = DruidServiceTestUtils.newJsonMapper();
     DruidService actual = mapper.readValue(
         mapper.writeValueAsString(expected),
         DruidService.class

--- a/server/src/test/java/org/apache/druid/jackson/StringObjectPairListTest.java
+++ b/server/src/test/java/org/apache/druid/jackson/StringObjectPairListTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.jackson;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class StringObjectPairListTest
+{
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(StringObjectPairList.class).usingGetClass().withNonnullFields("pairs").verify();
+  }
+}

--- a/server/src/test/java/org/apache/druid/jackson/ToStringObjectPairListDeserializerTest.java
+++ b/server/src/test/java/org/apache/druid/jackson/ToStringObjectPairListDeserializerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.NonnullPair;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class ToStringObjectPairListDeserializerTest
+{
+  private final ObjectMapper objectMapper;
+
+  public ToStringObjectPairListDeserializerTest()
+  {
+    objectMapper = new DefaultObjectMapper();
+    objectMapper.registerModule(
+        new SimpleModule().addDeserializer(
+            StringObjectPairList.class,
+            new ToStringObjectPairListDeserializer()
+        )
+    );
+  }
+
+  @Test
+  public void testDeserializeNestedMap() throws JsonProcessingException
+  {
+    final Map<String, Object> map = ImmutableMap.of(
+        "rootKey",
+        "rootVal",
+        "innerMap",
+        ImmutableMap.of(
+            "innerKey",
+            "innerVal"
+        )
+    );
+    final String json = objectMapper.writeValueAsString(map);
+    final StringObjectPairList pairList = objectMapper.readValue(json, StringObjectPairList.class);
+    Assert.assertEquals(
+        new StringObjectPairList(
+            ImmutableList.of(
+                new NonnullPair<>("rootKey", "rootVal"),
+                new NonnullPair<>("innerMap", ImmutableMap.of("innerKey", "innerVal"))
+            )
+        ),
+        pairList
+    );
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -665,7 +665,7 @@ public class SystemSchema extends AbstractSchema
             druidNode.getHostAndPort(),
             druidNode.getHostAndTlsPort(),
             dataNodeService.getMaxSize(),
-            dataNodeService.getType(),
+            dataNodeService.getServerType(),
             dataNodeService.getTier(),
             dataNodeService.getPriority()
         );


### PR DESCRIPTION
### Description

This PR fixes a bug that `DiscoveryDruidNode` cannot be created while deserializing it from a JSON when there is an unknown `DruidService`. This bug can be seen when you do rolling update. Suppose you have a custom `MyDruidService` that is added in a new version, `v2`. While you are upgrading your cluster from `v1` to `v2`, other nodes who watch the node that is upgraded first and announces `MyDruidService` will not understand what `MyDruidService` is until they are upgraded to `v2`. In this case, this bug currently can fail node discovery. This PR fixes the bug by ignoring unknown `DruidServices` during deserialization of `DiscoveryDruidNode`.

<hr>

##### Key changed/added classes in this PR
 * `DiscoveryDruidNode`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
