### PR TITLE
Mitigate Kinesis stream LimitExceededException by using listShards API

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -35,6 +35,7 @@ import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.util.AwsHostNameUtils;
@@ -67,11 +68,11 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -673,13 +674,13 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   public Set<String> getPartitionIds(String stream)
   {
     return wrapExceptions(() -> {
-      final Set<String> retVal = new HashSet<>();
+      final Set<String> retVal = new TreeSet<>();
       ListShardsRequest request = new ListShardsRequest().withStreamName(stream);
       while (true) {
         ListShardsResult result = kinesis.listShards(request);
         retVal.addAll(result.getShards()
                             .stream()
-                            .map(x -> x.getShardId())
+                            .map(Shard::getShardId)
                             .collect(Collectors.toList())
         );
         String nextToken = result.getNextToken();

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -35,7 +35,6 @@ import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
-import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.util.AwsHostNameUtils;
@@ -153,10 +152,9 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
         return;
       }
       if (fetchStarted.compareAndSet(false, true)) {
-        log.debug(
-            "Starting scheduled fetch for stream[%s] partition[%s]",
-            streamPartition.getStream(),
-            streamPartition.getPartitionId()
+        log.debug("Starting scheduled fetch for stream[%s] partition[%s]",
+                  streamPartition.getStream(),
+                  streamPartition.getPartitionId()
         );
 
         scheduleBackgroundFetch(fetchDelayMillis);
@@ -166,10 +164,9 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
     private void stopBackgroundFetch()
     {
       if (fetchStarted.compareAndSet(true, false)) {
-        log.debug(
-            "Stopping scheduled fetch for stream[%s] partition[%s]",
-            streamPartition.getStream(),
-            streamPartition.getPartitionId()
+        log.debug("Stopping scheduled fetch for stream[%s] partition[%s]",
+                  streamPartition.getStream(),
+                  streamPartition.getPartitionId()
         );
         if (currentFetch != null && !currentFetch.isDone()) {
           currentFetch.cancel(true);
@@ -215,11 +212,10 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
             log.info("shardIterator[%s] has been closed and has no more records", streamPartition.getPartitionId());
 
             // add an end-of-shard marker so caller knows this shard is closed
-            currRecord = new OrderedPartitionableRecord<>(
-                streamPartition.getStream(),
-                streamPartition.getPartitionId(),
-                KinesisSequenceNumber.END_OF_SHARD_MARKER,
-                null
+            currRecord = new OrderedPartitionableRecord<>(streamPartition.getStream(),
+                                                          streamPartition.getPartitionId(),
+                                                          KinesisSequenceNumber.END_OF_SHARD_MARKER,
+                                                          null
             );
 
             recordsResult = null;
@@ -232,8 +228,8 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
             return;
           }
 
-          recordsResult = kinesis.getRecords(new GetRecordsRequest().withShardIterator(
-              shardIterator).withLimit(recordsPerFetch));
+          recordsResult = kinesis.getRecords(new GetRecordsRequest().withShardIterator(shardIterator)
+                                                                    .withLimit(recordsPerFetch));
 
           currentLagMillis = recordsResult.getMillisBehindLatest();
 
@@ -250,9 +246,7 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
 
               data = new ArrayList<>();
 
-              final List userRecords = (List) deaggregateHandle.invokeExact(
-                  Collections.singletonList(kinesisRecord)
-              );
+              final List userRecords = (List) deaggregateHandle.invokeExact(Collections.singletonList(kinesisRecord));
 
               for (Object userRecord : userRecords) {
                 data.add(new ByteEntity((ByteBuffer) getDataHandle.invoke(userRecord)));
@@ -261,28 +255,22 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
               data = Collections.singletonList(new ByteEntity(kinesisRecord.getData()));
             }
 
-            currRecord = new OrderedPartitionableRecord<>(
-                streamPartition.getStream(),
-                streamPartition.getPartitionId(),
-                kinesisRecord.getSequenceNumber(),
-                data
+            currRecord = new OrderedPartitionableRecord<>(streamPartition.getStream(),
+                                                          streamPartition.getPartitionId(),
+                                                          kinesisRecord.getSequenceNumber(),
+                                                          data
             );
 
 
             if (log.isTraceEnabled()) {
-              log.trace(
-                  "Stream[%s] / partition[%s] / sequenceNum[%s] / bufferRemainingCapacity[%d]: %s",
-                  currRecord.getStream(),
-                  currRecord.getPartitionId(),
-                  currRecord.getSequenceNumber(),
-                  records.remainingCapacity(),
-                  currRecord.getData()
-                            .stream()
-                            .map(b -> StringUtils.fromUtf8(
-                                // duplicate buffer to avoid changing its position when logging
-                                b.getBuffer().duplicate())
-                            )
-                            .collect(Collectors.toList())
+              log.trace("Stream[%s] / partition[%s] / sequenceNum[%s] / bufferRemainingCapacity[%d]: %s",
+                        currRecord.getStream(),
+                        currRecord.getPartitionId(),
+                        currRecord.getSequenceNumber(),
+                        records.remainingCapacity(),
+                        currRecord.getData().stream().map(b -> StringUtils.fromUtf8(
+                            // duplicate buffer to avoid changing its position when logging
+                            b.getBuffer().duplicate())).collect(Collectors.toList())
               );
             }
 
@@ -294,11 +282,10 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
                   recordBufferFullWait
               );
 
-              shardIterator = kinesis.getShardIterator(
-                  currRecord.getStream(),
-                  currRecord.getPartitionId(),
-                  ShardIteratorType.AT_SEQUENCE_NUMBER.toString(),
-                  currRecord.getSequenceNumber()
+              shardIterator = kinesis.getShardIterator(currRecord.getStream(),
+                                                       currRecord.getPartitionId(),
+                                                       ShardIteratorType.AT_SEQUENCE_NUMBER.toString(),
+                                                       currRecord.getSequenceNumber()
               ).getShardIterator();
 
               scheduleBackgroundFetch(recordBufferFullWait);
@@ -311,30 +298,24 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
           scheduleBackgroundFetch(fetchDelayMillis);
         }
         catch (ProvisionedThroughputExceededException e) {
-          log.warn(
-              e,
-              "encounted ProvisionedThroughputExceededException while fetching records, this means "
-              + "that the request rate for the stream is too high, or the requested data is too large for "
-              + "the available throughput. Reduce the frequency or size of your requests."
+          log.warn(e,
+                   "encounted ProvisionedThroughputExceededException while fetching records, this means "
+                   + "that the request rate for the stream is too high, or the requested data is too large for "
+                   + "the available throughput. Reduce the frequency or size of your requests."
           );
           long retryMs = Math.max(PROVISIONED_THROUGHPUT_EXCEEDED_BACKOFF_MS, fetchDelayMillis);
           scheduleBackgroundFetch(retryMs);
         }
         catch (InterruptedException e) {
           // may happen if interrupted while BlockingQueue.offer() is waiting
-          log.warn(
-              e,
-              "Interrupted while waiting to add record to buffer, retrying in [%,dms]",
-              EXCEPTION_RETRY_DELAY_MS
+          log.warn(e,
+                   "Interrupted while waiting to add record to buffer, retrying in [%,dms]",
+                   EXCEPTION_RETRY_DELAY_MS
           );
           scheduleBackgroundFetch(EXCEPTION_RETRY_DELAY_MS);
         }
         catch (ExpiredIteratorException e) {
-          log.warn(
-              e,
-              "ShardIterator expired while trying to fetch records, retrying in [%,dms]",
-              fetchDelayMillis
-          );
+          log.warn(e, "ShardIterator expired while trying to fetch records, retrying in [%,dms]", fetchDelayMillis);
           if (recordsResult != null) {
             shardIterator = recordsResult.getNextShardIterator(); // will be null if the shard has been closed
             scheduleBackgroundFetch(fetchDelayMillis);
@@ -367,18 +348,17 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
 
     private void seek(ShardIteratorType iteratorEnum, String sequenceNumber)
     {
-      log.debug(
-          "Seeking partition [%s] to [%s]",
-          streamPartition.getPartitionId(),
-          sequenceNumber != null ? sequenceNumber : iteratorEnum.toString()
+      log.debug("Seeking partition [%s] to [%s]",
+                streamPartition.getPartitionId(),
+                sequenceNumber != null ? sequenceNumber : iteratorEnum.toString()
       );
 
-      shardIterator = wrapExceptions(() -> kinesis.getShardIterator(
-          streamPartition.getStream(),
-          streamPartition.getPartitionId(),
-          iteratorEnum.toString(),
-          sequenceNumber
-      ).getShardIterator());
+      shardIterator = wrapExceptions(() -> kinesis.getShardIterator(streamPartition.getStream(),
+                                                                    streamPartition.getPartitionId(),
+                                                                    iteratorEnum.toString(),
+                                                                    sequenceNumber
+                                                  )
+                                                  .getShardIterator());
     }
 
     private long getPartitionTimeLag()
@@ -406,13 +386,13 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
 
   private ScheduledExecutorService scheduledExec;
 
-  private final ConcurrentMap<StreamPartition<String>, PartitionResource> partitionResources =
-      new ConcurrentHashMap<>();
+  private final ConcurrentMap<StreamPartition<String>, PartitionResource> partitionResources
+      = new ConcurrentHashMap<>();
   private BlockingQueue<OrderedPartitionableRecord<String, String, ByteEntity>> records;
 
   private final boolean backgroundFetchEnabled;
   private volatile boolean closed = false;
-  private AtomicBoolean partitionsFetchStarted = new AtomicBoolean();
+  private final AtomicBoolean partitionsFetchStarted = new AtomicBoolean();
 
   public KinesisRecordSupplier(
       AmazonKinesis amazonKinesis,
@@ -457,8 +437,11 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
         getDataHandle = lookup.unreflect(getDataMethod);
       }
       catch (ClassNotFoundException e) {
-        throw new ISE(e, "cannot find class[com.amazonaws.services.kinesis.clientlibrary.types.UserRecord], "
-                         + "note that when using deaggregate=true, you must provide the Kinesis Client Library jar in the classpath");
+        throw new ISE(
+            e,
+            "cannot find class[com.amazonaws.services.kinesis.clientlibrary.types.UserRecord], "
+            + "note that when using deaggregate=true, you must provide the Kinesis Client Library jar in the classpath"
+        );
       }
       catch (Exception e) {
         throw new RuntimeException(e);
@@ -469,15 +452,13 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
     }
 
     if (backgroundFetchEnabled) {
-      log.info(
-          "Creating fetch thread pool of size [%d] (Runtime.availableProcessors=%d)",
-          fetchThreads,
-          Runtime.getRuntime().availableProcessors()
+      log.info("Creating fetch thread pool of size [%d] (Runtime.availableProcessors=%d)",
+               fetchThreads,
+               Runtime.getRuntime().availableProcessors()
       );
 
-      scheduledExec = Executors.newScheduledThreadPool(
-          fetchThreads,
-          Execs.makeThreadFactory("KinesisRecordSupplier-Worker-%d")
+      scheduledExec = Executors.newScheduledThreadPool(fetchThreads,
+                                                       Execs.makeThreadFactory("KinesisRecordSupplier-Worker-%d")
       );
     }
 
@@ -485,24 +466,19 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   }
 
   public static AmazonKinesis getAmazonKinesisClient(
-      String endpoint,
-      AWSCredentialsConfig awsCredentialsConfig,
-      String awsAssumedRoleArn,
-      String awsExternalId
+      String endpoint, AWSCredentialsConfig awsCredentialsConfig, String awsAssumedRoleArn, String awsExternalId
   )
   {
     AWSCredentialsProvider awsCredentialsProvider = AWSCredentialsUtils.defaultAWSCredentialsProviderChain(
-        awsCredentialsConfig
-    );
+        awsCredentialsConfig);
 
     if (awsAssumedRoleArn != null) {
       log.info("Assuming role [%s] with externalId [%s]", awsAssumedRoleArn, awsExternalId);
 
-      STSAssumeRoleSessionCredentialsProvider.Builder builder = new STSAssumeRoleSessionCredentialsProvider
-          .Builder(awsAssumedRoleArn, StringUtils.format("druid-kinesis-%s", UUID.randomUUID().toString()))
-          .withStsClient(AWSSecurityTokenServiceClientBuilder.standard()
-                                                             .withCredentials(awsCredentialsProvider)
-                                                             .build());
+      STSAssumeRoleSessionCredentialsProvider.Builder builder = new STSAssumeRoleSessionCredentialsProvider.Builder(
+          awsAssumedRoleArn,
+          StringUtils.format("druid-kinesis-%s", UUID.randomUUID().toString())
+      ).withStsClient(AWSSecurityTokenServiceClientBuilder.standard().withCredentials(awsCredentialsProvider).build());
 
       if (awsExternalId != null) {
         builder.withExternalId(awsExternalId);
@@ -514,13 +490,13 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
     return AmazonKinesisClientBuilder.standard()
                                      .withCredentials(awsCredentialsProvider)
                                      .withClientConfiguration(new ClientConfiguration())
-                                     .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
-                                         endpoint,
-                                         AwsHostNameUtils.parseRegion(
-                                             endpoint,
-                                             null
-                                         )
-                                     )).build();
+                                     .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint,
+                                                                                                           AwsHostNameUtils.parseRegion(
+                                                                                                               endpoint,
+                                                                                                               null
+                                                                                                           )
+                                     ))
+                                     .build();
   }
 
 
@@ -564,12 +540,9 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   {
     checkIfClosed();
 
-    collection.forEach(
-        streamPartition -> partitionResources.putIfAbsent(
-            streamPartition,
-            new PartitionResource(streamPartition)
-        )
-    );
+    collection.forEach(streamPartition -> partitionResources.putIfAbsent(streamPartition,
+                                                                         new PartitionResource(streamPartition)
+    ));
 
     Iterator<Map.Entry<StreamPartition<String>, PartitionResource>> i = partitionResources.entrySet().iterator();
     while (i.hasNext()) {
@@ -626,13 +599,7 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
 
       List<OrderedPartitionableRecord<String, String, ByteEntity>> polledRecords = new ArrayList<>(expectedSize);
 
-      Queues.drain(
-          records,
-          polledRecords,
-          expectedSize,
-          timeout,
-          TimeUnit.MILLISECONDS
-      );
+      Queues.drain(records, polledRecords, expectedSize, timeout, TimeUnit.MILLISECONDS);
 
       polledRecords = polledRecords.stream()
                                    .filter(x -> partitionResources.containsKey(x.getStreamPartition()))
@@ -667,29 +634,28 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
    * This makes the method resilient to LimitExceeded exceptions (compared to 100 shards, 10 TPS of describeStream)
    *
    * @param stream name of stream
-   *
    * @return Set of Shard ids
    */
   @Override
   public Set<String> getPartitionIds(String stream)
   {
-    return wrapExceptions(
-        () -> {
-          final Set<String> retVal = new HashSet<>();
-          ListShardsRequest request = new ListShardsRequest().withStreamName(stream);
-          while (true) {
-            ListShardsResult result = kinesis.listShards(request);
-            List<Shard> shards = kinesis.listShards(request).getShards();
-            for (Shard shard : shards) {
-              retVal.add(shard.getShardId());
-            }
-            if (shards.isEmpty()) {
-              return retVal;
-            }
-            request = new ListShardsRequest().withNextToken(result.getNextToken());
-          }
+    return wrapExceptions(() -> {
+      final Set<String> retVal = new HashSet<>();
+      ListShardsRequest request = new ListShardsRequest().withStreamName(stream);
+      while (true) {
+        ListShardsResult result = kinesis.listShards(request);
+        retVal.addAll(result.getShards()
+                            .stream()
+                            .map(x -> x.getShardId())
+                            .collect(Collectors.toList())
+        );
+        String nextToken = result.getNextToken();
+        if (nextToken == null) {
+          return retVal;
         }
-    );
+        request = new ListShardsRequest().withNextToken(result.getNextToken());
+      }
+    });
   }
 
   /**
@@ -721,12 +687,9 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   {
     return partitionResources.entrySet()
                              .stream()
-                             .collect(
-                                 Collectors.toMap(
-                                     k -> k.getKey().getPartitionId(),
-                                     k -> k.getValue().getPartitionTimeLag()
-                                 )
-                             );
+                             .collect(Collectors.toMap(k -> k.getKey().getPartitionId(),
+                                                       k -> k.getValue().getPartitionTimeLag()
+                             ));
   }
 
   @VisibleForTesting
@@ -775,9 +738,11 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   private String getSequenceNumber(StreamPartition<String> partition, ShardIteratorType iteratorEnum)
   {
     return wrapExceptions(() -> {
-      String shardIterator =
-          kinesis.getShardIterator(partition.getStream(), partition.getPartitionId(), iteratorEnum.toString())
-                 .getShardIterator();
+      String shardIterator = kinesis.getShardIterator(
+          partition.getStream(),
+          partition.getPartitionId(),
+          iteratorEnum.toString()
+      ).getShardIterator();
       long timeoutMillis = System.currentTimeMillis() + fetchSequenceNumberTimeout;
       GetRecordsResult recordsResult = null;
 
@@ -790,27 +755,22 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
         final String currentShardIterator = shardIterator;
         final GetRecordsRequest request = new GetRecordsRequest().withShardIterator(currentShardIterator)
                                                                  .withLimit(GET_SEQUENCE_NUMBER_RECORD_COUNT);
-        recordsResult = RetryUtils.retry(
-            () -> kinesis.getRecords(request),
-            (throwable) -> {
-              if (throwable instanceof ProvisionedThroughputExceededException) {
-                log.warn(
-                    throwable,
-                    "encountered ProvisionedThroughputExceededException while fetching records, this means "
-                    + "that the request rate for the stream is too high, or the requested data is too large for "
-                    + "the available throughput. Reduce the frequency or size of your requests. Consider increasing "
-                    + "the number of shards to increase throughput."
-                );
-                return true;
-              }
-              if (throwable instanceof AmazonClientException) {
-                AmazonClientException ase = (AmazonClientException) throwable;
-                return AWSClientUtil.isClientExceptionRecoverable(ase);
-              }
-              return false;
-            },
-            GET_SEQUENCE_NUMBER_RETRY_COUNT
-        );
+        recordsResult = RetryUtils.retry(() -> kinesis.getRecords(request), (throwable) -> {
+          if (throwable instanceof ProvisionedThroughputExceededException) {
+            log.warn(throwable,
+                     "encountered ProvisionedThroughputExceededException while fetching records, this means "
+                     + "that the request rate for the stream is too high, or the requested data is too large for "
+                     + "the available throughput. Reduce the frequency or size of your requests. Consider increasing "
+                     + "the number of shards to increase throughput."
+            );
+            return true;
+          }
+          if (throwable instanceof AmazonClientException) {
+            AmazonClientException ase = (AmazonClientException) throwable;
+            return AWSClientUtil.isClientExceptionRecoverable(ase);
+          }
+          return false;
+        }, GET_SEQUENCE_NUMBER_RETRY_COUNT);
 
         List<Record> records = recordsResult.getRecords();
 
@@ -863,7 +823,10 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
         offsetToUse = offset;
       }
 
-      GetRecordsResult recordsResult = getRecordsForLag(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString(), offsetToUse, partition);
+      GetRecordsResult recordsResult = getRecordsForLag(ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString(),
+                                                        offsetToUse,
+                                                        partition
+      );
 
       // If no more new data after offsetToUse, it means there is no lag for now.
       // So report lag points as 0L.
@@ -879,16 +842,14 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
 
   private GetRecordsResult getRecordsForLag(String iteratorType, String offsetToUse, StreamPartition<String> partition)
   {
-    String shardIterator = kinesis.getShardIterator(
-            partition.getStream(),
-            partition.getPartitionId(),
-            iteratorType,
-            offsetToUse
+    String shardIterator = kinesis.getShardIterator(partition.getStream(),
+                                                    partition.getPartitionId(),
+                                                    iteratorType,
+                                                    offsetToUse
     ).getShardIterator();
 
-    GetRecordsResult recordsResult = kinesis.getRecords(
-            new GetRecordsRequest().withShardIterator(shardIterator).withLimit(1)
-    );
+    GetRecordsResult recordsResult = kinesis.getRecords(new GetRecordsRequest().withShardIterator(shardIterator)
+                                                                               .withLimit(1));
     return recordsResult;
   }
 
@@ -905,7 +866,7 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   /**
    * This method must be called before a seek operation ({@link #seek}, {@link #seekToLatest}, or
    * {@link #seekToEarliest}).
-   *
+   * <p>
    * When called, it will nuke the {@link #scheduledExec} that is shared by all {@link PartitionResource}, filters
    * records from the buffer for partitions which will have a seek operation performed, and stops background fetch for
    * each {@link PartitionResource} to prepare for the seek. If background fetch is not currently running, the
@@ -927,18 +888,16 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
         throw e;
       }
 
-      scheduledExec = Executors.newScheduledThreadPool(
-          fetchThreads,
-          Execs.makeThreadFactory("KinesisRecordSupplier-Worker-%d")
+      scheduledExec = Executors.newScheduledThreadPool(fetchThreads,
+                                                       Execs.makeThreadFactory("KinesisRecordSupplier-Worker-%d")
       );
     }
 
     // filter records in buffer and only retain ones whose partition was not seeked
-    BlockingQueue<OrderedPartitionableRecord<String, String, ByteEntity>> newQ = new LinkedBlockingQueue<>(recordBufferSize);
+    BlockingQueue<OrderedPartitionableRecord<String, String, ByteEntity>> newQ = new LinkedBlockingQueue<>(
+        recordBufferSize);
 
-    records.stream()
-           .filter(x -> !partitions.contains(x.getStreamPartition()))
-           .forEachOrdered(newQ::offer);
+    records.stream().filter(x -> !partitions.contains(x.getStreamPartition())).forEachOrdered(newQ::offer);
 
     records = newQ;
 

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KinesisAdminClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KinesisAdminClient.java
@@ -57,16 +57,22 @@ public class KinesisAdminClient implements StreamAdminClient
     Properties prop = new Properties();
     prop.load(new FileInputStream(pathToConfigFile));
 
-    AWSStaticCredentialsProvider credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(prop.getProperty(
-        "druid_kinesis_accessKey"), prop.getProperty("druid_kinesis_secretKey")));
+    AWSStaticCredentialsProvider credentials = new AWSStaticCredentialsProvider(
+        new BasicAWSCredentials(
+            prop.getProperty("druid_kinesis_accessKey"),
+            prop.getProperty("druid_kinesis_secretKey")
+        )
+    );
     amazonKinesis = AmazonKinesisClientBuilder.standard()
-                                              .withCredentials(credentials)
-                                              .withClientConfiguration(new ClientConfiguration())
-                                              .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
-                                                  endpoint,
-                                                  AwsHostNameUtils.parseRegion(endpoint, null)
-                                              ))
-                                              .build();
+                              .withCredentials(credentials)
+                              .withClientConfiguration(new ClientConfiguration())
+                              .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
+                                  endpoint,
+                                  AwsHostNameUtils.parseRegion(
+                                      endpoint,
+                                      null
+                                  )
+                              )).build();
   }
 
   @Override
@@ -119,14 +125,15 @@ public class KinesisAdminClient implements StreamAdminClient
     }
     if (blocksUntilStarted) {
       // Wait until the resharding started (or finished)
-      ITRetryUtil.retryUntil(() -> {
-                               int updatedShardCount = getStreamPartitionCount(streamName);
-                               // Stream should be in active or updating state AND
-                               // the number of shards must have increased irrespective
-                               return verifyStreamStatus(streamName, StreamStatus.ACTIVE, StreamStatus.UPDATING)
-                                      && updatedShardCount > originalShardCount;
-                             }, true, 300, // higher value to avoid exceeding kinesis TPS limit
-                             30, "Kinesis stream resharding to start (or finished)"
+      ITRetryUtil.retryUntil(
+          () -> {
+            int updatedShardCount = getStreamPartitionCount(streamName);
+            // Stream should be in active or updating state AND
+            // the number of shards must have increased irrespective
+            return verifyStreamStatus(streamName, StreamStatus.ACTIVE, StreamStatus.UPDATING)
+                   && updatedShardCount > originalShardCount;
+          }, true, 300, // higher value to avoid exceeding kinesis TPS limit
+          30, "Kinesis stream resharding to start (or finished)"
       );
     }
   }
@@ -171,7 +178,7 @@ public class KinesisAdminClient implements StreamAdminClient
   private boolean verifyStreamStatus(String streamName, StreamStatus... streamStatuses)
   {
     String status = getStreamStatus(streamName);
-    for (StreamStatus streamStatus: streamStatuses) {
+    for (StreamStatus streamStatus : streamStatuses) {
       if (status.equals(streamStatus.toString())) {
         return true;
       }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Makes kinesis ingestion resilient to LimitExceededException caused by resharding

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

Replace describeStream with listShards (recommended) to get shard related info.

`describeStream` has a limit (100) to the number of shards returned per call and a low default TPS limit of 10.
`listShards` returns the info for at most 1000 shards and has a higher TPS limit of 100 as well.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `KinesisRecordSupplier`
 * `KinesisAdminClient`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [] added documentation for new or modified features or behaviors.
- [] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
