### PR TITLE
Suppress Avro CVEs

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -462,4 +462,12 @@
     <cve>CVE-2015-7430</cve>
     <cve>CVE-2017-3162</cve>
   </suppress>
+  
+  <suppress>
+    <!-- Suppress avro cves that are only applicable to .NET SDK-->
+    <notes><![CDATA[
+    file name: avro-1.9.2.jar or avro-ipc-jetty-1.9.2.jar
+    ]]></notes>
+    <cve>CVE-2021-43045</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppress CVE-2021-43045 since it only affects .NET applications. As of 18 Jan 6:48 PM IST, druid is still not a .NET application. So we should be safe. 