### PR TITLE
Fix infinite retrying during task pausing

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
@@ -543,6 +543,35 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   }
 
   @Test
+  public void testPauseRetriesExhausted() throws Exception
+  {
+    client = new TestableKinesisIndexTaskClient(httpClient, OBJECT_MAPPER, taskInfoProvider, 2);
+    // ACCEPTED for first pause call and then OK for 3 status call
+    EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.ACCEPTED);
+    EasyMock.expect(responseHolder.getContent()).andReturn(null);
+    EasyMock.expect(responseHolder.getContent()).andReturn(OBJECT_MAPPER.writeValueAsString(Status.READING)).times(3);
+    EasyMock.expect(httpClient.go(
+        EasyMock.anyObject(),
+        EasyMock.anyObject(ObjectOrErrorResponseHandler.class),
+        EasyMock.eq(TEST_HTTP_TIMEOUT)
+    )).andReturn(
+        okResponseHolder()
+    ).times(4);
+    replayAll();
+
+    try {
+      client.pause(TEST_ID);
+    }
+    catch (Exception ex) {
+      Assert.assertEquals("Task [test-id] failed to change its status from [READING] to [PAUSED], aborting", ex.getMessage());
+      verifyAll();
+      return;
+    }
+    Assert.fail("Expected an exception");
+  }
+
+
+  @Test
   public void testResume() throws Exception
   {
     Capture<Request> captured = Capture.newInstance();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClient.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.indexing.common.IndexTaskClient;
+import org.apache.druid.indexing.common.RetryPolicy;
 import org.apache.druid.indexing.common.TaskInfoProvider;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
@@ -129,13 +130,14 @@ public abstract class SeekableStreamIndexTaskClient<PartitionIdType, SequenceOff
         return deserializeMap(responseContent, Map.class, getPartitionType(), getSequenceType());
       } else if (responseStatus.equals(HttpResponseStatus.ACCEPTED)) {
         // The task received the pause request, but its status hasn't been changed yet.
+        RetryPolicy retryPolicy = newRetryPolicy();
         while (true) {
           final SeekableStreamIndexTaskRunner.Status status = getStatus(id);
           if (status == SeekableStreamIndexTaskRunner.Status.PAUSED) {
             return getCurrentOffsets(id, true);
           }
 
-          final Duration delay = newRetryPolicy().getAndIncrementRetryDelay();
+          final Duration delay = retryPolicy.getAndIncrementRetryDelay();
           if (delay == null) {
             throw new ISE(
                 "Task [%s] failed to change its status from [%s] to [%s], aborting",

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClient.java
@@ -130,7 +130,7 @@ public abstract class SeekableStreamIndexTaskClient<PartitionIdType, SequenceOff
         return deserializeMap(responseContent, Map.class, getPartitionType(), getSequenceType());
       } else if (responseStatus.equals(HttpResponseStatus.ACCEPTED)) {
         // The task received the pause request, but its status hasn't been changed yet.
-        RetryPolicy retryPolicy = newRetryPolicy();
+        final RetryPolicy retryPolicy = newRetryPolicy();
         while (true) {
           final SeekableStreamIndexTaskRunner.Status status = getStatus(id);
           if (status == SeekableStreamIndexTaskRunner.Status.PAUSED) {


### PR DESCRIPTION
This fixes a bug that causes TaskClient in overlord to continuously retry to pause tasks. This can happen when a task is not responding to the pause command. Ideally, in such a case when the task is unresponsive, the overlord would have given up after a few retries and would have killed the task. However, due to this bug, retries go on forever. 

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
