### PR TITLE
Forbiddenapis: Split the guava16-only signatures file from main signatures file

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -21,7 +21,6 @@ com.google.common.collect.Sets#newLinkedHashSet() @ Create java.util.LinkedHashS
 com.google.common.collect.Sets#newTreeSet() @ Create java.util.TreeSet directly
 com.google.common.collect.Sets#newTreeSet(java.util.Comparator) @ Create java.util.TreeSet directly
 com.google.common.io.Files#createTempDir() @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
-com.google.common.util.concurrent.MoreExecutors#sameThreadExecutor() @ Use org.apache.druid.java.util.common.concurrent.Execs#directExecutor()
 java.io.File#mkdirs() @ Use org.apache.druid.java.util.common.FileUtils.mkdirp instead
 java.io.File#toURL() @ Use java.io.File#toURI() and java.net.URI#toURL() instead
 java.lang.String#matches(java.lang.String) @ Use startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
@@ -46,7 +45,6 @@ org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.Tempora
 org.apache.commons.io.FileUtils#deleteDirectory(java.io.File) @ Use org.apache.druid.java.util.common.FileUtils#deleteDirectory()
 org.apache.commons.io.FileUtils#forceMkdir(java.io.File) @ Use org.apache.druid.java.util.common.FileUtils.mkdirp instead
 java.lang.Class#getCanonicalName() @ Class.getCanonicalName can return null for anonymous types, use Class.getName instead.
-com.google.common.base.Objects#firstNonNull(java.lang.Object, java.lang.Object) @ Use org.apache.druid.common.guava.GuavaUtils#firstNonNull(java.lang.Object, java.lang.Object) instead (probably... the GuavaUtils method return object is nullable)
 
 @defaultMessage Use Locale.ENGLISH
 com.ibm.icu.text.DateFormatSymbols#<init>()

--- a/codestyle/guava16-forbidden-apis.txt
+++ b/codestyle/guava16-forbidden-apis.txt
@@ -1,0 +1,3 @@
+# Those signatures are only available in Guava 16:
+com.google.common.util.concurrent.MoreExecutors#sameThreadExecutor() @ Use org.apache.druid.java.util.common.concurrent.Execs#directExecutor()
+com.google.common.base.Objects#firstNonNull(java.lang.Object, java.lang.Object) @ Use org.apache.druid.common.guava.GuavaUtils#firstNonNull(java.lang.Object, java.lang.Object) instead (probably... the GuavaUtils method return object is nullable)

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -212,6 +212,16 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>de.thetaphi</groupId>
+        <artifactId>forbiddenapis</artifactId>
+        <configuration>
+          <signaturesFiles>
+            <signaturesFile>${project.parent.basedir}/codestyle/joda-time-forbidden-apis.txt</signaturesFile>
+            <signaturesFile>${project.parent.basedir}/codestyle/druid-forbidden-apis.txt</signaturesFile>
+          </signaturesFiles>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1297,9 +1297,8 @@
             <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
-                <version>3.1</version>
+                <version>3.2</version>
                 <configuration>
-                    <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
                     <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
                     <bundledSignatures>
                         <!--
@@ -1310,6 +1309,7 @@
                     </bundledSignatures>
                     <signaturesFiles>
                         <signaturesFile>${project.parent.basedir}/codestyle/joda-time-forbidden-apis.txt</signaturesFile>
+                        <signaturesFile>${project.parent.basedir}/codestyle/guava16-forbidden-apis.txt</signaturesFile>
                         <signaturesFile>${project.parent.basedir}/codestyle/druid-forbidden-apis.txt</signaturesFile>
                     </signaturesFiles>
                     <excludes>


### PR DESCRIPTION
Improves workaround introduced in  #12158.

### Description

In #12158 the fix to workaround an issue with forbiddenapis parsing a missing signature in later Guava versions (actualy it is two of them) was to enable a now-deprecated maven plugin setting: `<failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>`

This flag is very risky as it ignores signatures with typos in it. This was made as a workaround for subprojects where some dependencies are missing, but birngs the risk of not cathcing bugs because of typos.

In forbiddenapis 3.1 / 3.2 a new setting was added `ignoreSignaturesOfMissingClasses=true`, as this still prevents typos in signatures and just ignores those where the class is not existent. It then also prints no warnings anymore!

The problem with that is that in case of Guava, which uses a newer version of Guava in telemetry-emitter, a deprecated method was removed, so it triggers "class found, but method missing".

The "correct" fix for those issues is to use separate signatures files per dependency and only load them in sub-projects when the dependency is used. For guava there should be 2 separate files. Unfortunately Maven is a bit limited, as you cannot make the signatures file names dynamic based on dependency versions. Lucene has gone this approach (we have a set of files per dependency) and based on the Maven coordinates our Gradle build script enables them.

In this PR I used a hack, which requires a bit copypaste, because you can't modify configurations of plugin, just replace (default) or add new list items, but not remove them:
- a new signatures file was added: `guava16-forbidden-apis.txt`
- it is enabled by default in parent POM
- for telemetry-emitters the signatures files property is duplicated, with the above file removed.

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
