### PR TITLE
introduce a "tree" type to the flattenSpec

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FlattenJSONBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FlattenJSONBenchmark.java
@@ -56,6 +56,8 @@ public class FlattenJSONBenchmark
   Parser flatParser;
   Parser nestedParser;
   Parser jqParser;
+  Parser treeJqParser;
+  Parser treeTreeParser;
   Parser fieldDiscoveryParser;
   Parser forcedPathParser;
   int flatCounter = 0;
@@ -82,6 +84,8 @@ public class FlattenJSONBenchmark
     flatParser = gen.getFlatParser();
     nestedParser = gen.getNestedParser();
     jqParser = gen.getJqParser();
+    treeJqParser = gen.getTreeJqParser();
+    treeTreeParser = gen.getTreeTreeParser();
     fieldDiscoveryParser = gen.getFieldDiscoveryParser();
     forcedPathParser = gen.getForcedPathParser();
   }
@@ -109,6 +113,32 @@ public class FlattenJSONBenchmark
       blackhole.consume(parsed.get(s));
     }
     nestedCounter = (nestedCounter + 1) % NUM_EVENTS;
+    return parsed;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public Map<String, Object> treejqflatten(final Blackhole blackhole)
+  {
+    Map<String, Object> parsed = treeJqParser.parseToMap(nestedInputs.get(jqCounter));
+    for (String s : parsed.keySet()) {
+      blackhole.consume(parsed.get(s));
+    }
+    jqCounter = (jqCounter + 1) % NUM_EVENTS;
+    return parsed;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public Map<String, Object> treetreeflatten(final Blackhole blackhole)
+  {
+    Map<String, Object> parsed = treeTreeParser.parseToMap(nestedInputs.get(jqCounter));
+    for (String s : parsed.keySet()) {
+      blackhole.consume(parsed.get(s));
+    }
+    jqCounter = (jqCounter + 1) % NUM_EVENTS;
     return parsed;
   }
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FlattenJSONBenchmarkUtil.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FlattenJSONBenchmarkUtil.java
@@ -232,7 +232,7 @@ public class FlattenJSONBenchmarkUtil
     JSONPathSpec flattenSpec = new JSONPathSpec(false, fields);
     JSONParseSpec spec = new JSONParseSpec(
         new TimestampSpec("ts", "iso", null),
-        new DimensionsSpec(null, null, null),
+        DimensionsSpec.EMPTY,
         flattenSpec,
         null,
         null
@@ -264,7 +264,7 @@ public class FlattenJSONBenchmarkUtil
     JSONPathSpec flattenSpec = new JSONPathSpec(false, fields);
     JSONParseSpec spec = new JSONParseSpec(
         new TimestampSpec("ts", "iso", null),
-        new DimensionsSpec(null, null, null),
+        DimensionsSpec.EMPTY,
         flattenSpec,
         null,
         null

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FlattenJSONBenchmarkUtil.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FlattenJSONBenchmarkUtil.java
@@ -35,6 +35,7 @@ import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.java.util.common.parsers.Parser;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -201,6 +202,69 @@ public class FlattenJSONBenchmarkUtil
     JSONParseSpec spec = new JSONParseSpec(
         new TimestampSpec("ts", "iso", null),
         DimensionsSpec.EMPTY,
+        flattenSpec,
+        null,
+        null
+    );
+
+    return spec.makeParser();
+  }
+
+  public Parser getTreeJqParser()
+  {
+    List<JSONPathFieldSpec> fields = new ArrayList<>();
+    fields.add(JSONPathFieldSpec.createRootField("ts"));
+
+    fields.add(JSONPathFieldSpec.createRootField("d1"));
+    fields.add(JSONPathFieldSpec.createJqField("e1.d1", ".e1.d1"));
+    fields.add(JSONPathFieldSpec.createJqField("e1.d2", ".e1.d2"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d3", ".e2.d3"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d4", ".e2.d4"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d5", ".e2.d5"));
+    fields.add(JSONPathFieldSpec.createJqField("e2.d6", ".e2.d6"));
+
+    fields.add(JSONPathFieldSpec.createRootField("m3"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m1", ".e3.m1"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m2", ".e3.m2"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m3", ".e3.m3"));
+    fields.add(JSONPathFieldSpec.createJqField("e3.m4", ".e3.m4"));
+
+    JSONPathSpec flattenSpec = new JSONPathSpec(false, fields);
+    JSONParseSpec spec = new JSONParseSpec(
+        new TimestampSpec("ts", "iso", null),
+        new DimensionsSpec(null, null, null),
+        flattenSpec,
+        null,
+        null
+    );
+
+    return spec.makeParser();
+  }
+
+
+  public Parser getTreeTreeParser()
+  {
+    List<JSONPathFieldSpec> fields = new ArrayList<>();
+    fields.add(JSONPathFieldSpec.createRootField("ts"));
+
+    fields.add(JSONPathFieldSpec.createRootField("d1"));
+    fields.add(JSONPathFieldSpec.createTreeField("e1.d1", Arrays.asList("e1", "d1")));
+    fields.add(JSONPathFieldSpec.createTreeField("e1.d2", Arrays.asList("e1", "d2")));
+    fields.add(JSONPathFieldSpec.createTreeField("e2.d3", Arrays.asList("e2", "d3")));
+    fields.add(JSONPathFieldSpec.createTreeField("e2.d4", Arrays.asList("e2", "d4")));
+    fields.add(JSONPathFieldSpec.createTreeField("e2.d5", Arrays.asList("e2", "d5")));
+    fields.add(JSONPathFieldSpec.createTreeField("e2.d6", Arrays.asList("e2", "d6")));
+
+    fields.add(JSONPathFieldSpec.createRootField("m3"));
+    fields.add(JSONPathFieldSpec.createTreeField("e3.m1", Arrays.asList("e3", "m1")));
+    fields.add(JSONPathFieldSpec.createTreeField("e3.m2", Arrays.asList("e3", "m2")));
+    fields.add(JSONPathFieldSpec.createTreeField("e3.m3", Arrays.asList("e3", "m3")));
+    fields.add(JSONPathFieldSpec.createTreeField("e3.m4", Arrays.asList("e3", "m4")));
+
+    JSONPathSpec flattenSpec = new JSONPathSpec(false, fields);
+    JSONParseSpec spec = new JSONParseSpec(
+        new TimestampSpec("ts", "iso", null),
+        new DimensionsSpec(null, null, null),
         flattenSpec,
         null,
         null

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
@@ -110,6 +110,22 @@ public class JSONFlattenerMaker implements ObjectFlatteners.FlattenerMaker<JsonN
   }
 
   @Override
+  public Function<JsonNode, Object> makeJsonTreeExtractor(final List<String> exprs)
+  {
+    String[] exprsArray = exprs.toArray(new String[0]);
+    return node -> {
+      JsonNode target = node;
+      for (String expr : exprsArray) {
+        target = target.get(expr);
+        if (target == null) {
+          break;
+        }
+      }
+      return valueConversionFunction(target);
+    };
+  }
+
+  @Override
   public JsonProvider getJsonProvider()
   {
     return JSON_PROVIDER;

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
@@ -123,7 +123,7 @@ public class JSONFlattenerMaker implements ObjectFlatteners.FlattenerMaker<JsonN
         }
         targetNode = targetNode.get(keyName);
       }
-      return valueConversionFunction(targetNode);
+      return finalizeConversionForMap(targetNode);
     };
   }
 

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
@@ -110,18 +110,18 @@ public class JSONFlattenerMaker implements ObjectFlatteners.FlattenerMaker<JsonN
   }
 
   @Override
-  public Function<JsonNode, Object> makeJsonTreeExtractor(final List<String> exprs)
+  public Function<JsonNode, Object> makeJsonTreeExtractor(final List<String> nodes)
   {
-    String[] exprsArray = exprs.toArray(new String[0]);
-    return node -> {
-      JsonNode target = node;
-      for (String expr : exprsArray) {
-        target = target.get(expr);
-        if (target == null) {
+    String[] keyNames = nodes.toArray(new String[0]);
+    return jsonNode -> {
+      JsonNode targetNode = jsonNode;
+      for (String keyName : keyNames) {
+        targetNode = targetNode.get(keyName);
+        if (targetNode == null) {
           break;
         }
       }
-      return valueConversionFunction(target);
+      return valueConversionFunction(targetNode);
     };
   }
 

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONFlattenerMaker.java
@@ -112,14 +112,16 @@ public class JSONFlattenerMaker implements ObjectFlatteners.FlattenerMaker<JsonN
   @Override
   public Function<JsonNode, Object> makeJsonTreeExtractor(final List<String> nodes)
   {
-    String[] keyNames = nodes.toArray(new String[0]);
+    // create a defensive copy
+    final String[] keyNames = nodes.toArray(new String[0]);
+
     return jsonNode -> {
       JsonNode targetNode = jsonNode;
       for (String keyName : keyNames) {
-        targetNode = targetNode.get(keyName);
         if (targetNode == null) {
-          break;
+          return null;
         }
+        targetNode = targetNode.get(keyName);
       }
       return valueConversionFunction(targetNode);
     };

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONPathFieldSpec.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONPathFieldSpec.java
@@ -22,6 +22,7 @@ package org.apache.druid.java.util.common.parsers;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import org.apache.druid.utils.CollectionUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -31,14 +32,14 @@ public class JSONPathFieldSpec
   private final JSONPathFieldType type;
   private final String name;
   private final String expr;
-  private final List<String> exprs;
+  private final List<String> nodes;
 
   @JsonCreator
   public JSONPathFieldSpec(
       @JsonProperty("type") JSONPathFieldType type,
       @JsonProperty("name") String name,
       @JsonProperty("expr") String expr,
-      @JsonProperty("exprs") List<String> exprs
+      @JsonProperty("nodes") List<String> nodes
   )
   {
     this.type = type;
@@ -48,18 +49,20 @@ public class JSONPathFieldSpec
     switch (type) {
       case ROOT:
         this.expr = (expr == null) ? name : expr;
-        this.exprs = null;
+        this.nodes = null;
         break;
 
       case TREE:
         this.expr = null;
-        this.exprs = Preconditions.checkNotNull(exprs, "Missing 'exprs' for field[%s]", name);
-        Preconditions.checkArgument(this.exprs.size() >= 1, "Need at least one 'exprs' value for field[%s]", name);
+        Preconditions.checkArgument(
+                !CollectionUtils.isNullOrEmpty(nodes),
+                "Missing 'nodes' for field[%s], was [%s]", name, nodes);
+        this.nodes = nodes;
         break;
 
       default:
         this.expr = Preconditions.checkNotNull(expr, "Missing 'expr' for field[%s]", name);
-        this.exprs = null;
+        this.nodes = null;
     }
   }
 
@@ -91,9 +94,9 @@ public class JSONPathFieldSpec
   }
 
   @JsonProperty
-  public List<String> getExprs()
+  public List<String> getNodes()
   {
-    return exprs;
+    return nodes;
   }
 
   @JsonCreator
@@ -117,9 +120,9 @@ public class JSONPathFieldSpec
     return new JSONPathFieldSpec(JSONPathFieldType.ROOT, name, null);
   }
 
-  public static JSONPathFieldSpec createTreeField(String name, List<String> exprs)
+  public static JSONPathFieldSpec createTreeField(String name, List<String> nodes)
   {
-    return new JSONPathFieldSpec(JSONPathFieldType.TREE, name, null, exprs);
+    return new JSONPathFieldSpec(JSONPathFieldType.TREE, name, null, nodes);
   }
 
   @Override
@@ -135,13 +138,13 @@ public class JSONPathFieldSpec
     return type == that.type &&
            Objects.equals(name, that.name) &&
            Objects.equals(expr, that.expr) &&
-           Objects.equals(exprs, that.exprs);
+           Objects.equals(nodes, that.nodes);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(type, name, expr, exprs);
+    return Objects.hash(type, name, expr, nodes);
   }
 
   @Override
@@ -151,7 +154,7 @@ public class JSONPathFieldSpec
            "type=" + type +
            ", name='" + name + '\'' +
            ", expr='" + expr + '\'' +
-           ", exprs='" + exprs + '\'' +
+           ", nodes='" + nodes + '\'' +
            '}';
   }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONPathFieldType.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/JSONPathFieldType.java
@@ -27,7 +27,8 @@ public enum JSONPathFieldType
 {
   ROOT,
   PATH,
-  JQ;
+  JQ,
+  TREE;
 
   @JsonValue
   @Override

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -66,7 +66,7 @@ public class ObjectFlatteners
           extractor = flattenerMaker.makeJsonQueryExtractor(fieldSpec.getExpr());
           break;
         case TREE:
-          extractor = flattenerMaker.makeJsonTreeExtractor(fieldSpec.getExprs());
+          extractor = flattenerMaker.makeJsonTreeExtractor(fieldSpec.getNodes());
           break;
         default:
           throw new UOE("Unsupported field type[%s]", fieldSpec.getType());
@@ -238,7 +238,7 @@ public class ObjectFlatteners
     /**
      * Create a "field" extractor for nested json expressions
      */
-    Function<T, Object> makeJsonTreeExtractor(List<String> exprs);
+    Function<T, Object> makeJsonTreeExtractor(List<String> nodes);
 
     /**
      * Convert object to Java {@link Map} using {@link #getJsonProvider()} and {@link #finalizeConversionForMap} to

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -58,7 +58,7 @@ public class ObjectFlatteners
 
       switch (fieldSpec.getType()) {
         case ROOT:
-          extractor = flattenerMaker.makeJsonTreeExtractor(Collections.singletonList(fieldSpec.getExpr()));
+          extractor = obj -> flattenerMaker.getRootField(obj, fieldSpec.getExpr());
           break;
         case PATH:
           extractor = flattenerMaker.makeJsonPathExtractor(fieldSpec.getExpr());

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -21,6 +21,7 @@ package org.apache.druid.java.util.common.parsers;
 
 import com.google.common.collect.Iterables;
 import com.jayway.jsonpath.spi.json.JsonProvider;
+import org.apache.druid.guice.annotations.ExtensionPoint;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.UOE;
 
@@ -212,6 +213,7 @@ public class ObjectFlatteners
     };
   }
 
+  @ExtensionPoint
   public interface FlattenerMaker<T>
   {
     JsonProvider getJsonProvider();
@@ -238,7 +240,10 @@ public class ObjectFlatteners
     /**
      * Create a "field" extractor for nested json expressions
      */
-    Function<T, Object> makeJsonTreeExtractor(List<String> nodes);
+    default Function<T, Object> makeJsonTreeExtractor(List<String> nodes)
+    {
+      throw new UOE("makeJsonTreeExtractor has not been implemented.");
+    }
 
     /**
      * Convert object to Java {@link Map} using {@link #getJsonProvider()} and {@link #finalizeConversionForMap} to

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -56,13 +57,16 @@ public class ObjectFlatteners
 
       switch (fieldSpec.getType()) {
         case ROOT:
-          extractor = obj -> flattenerMaker.getRootField(obj, fieldSpec.getExpr());
+          extractor = flattenerMaker.makeJsonTreeExtractor(Collections.singletonList(fieldSpec.getExpr()));
           break;
         case PATH:
           extractor = flattenerMaker.makeJsonPathExtractor(fieldSpec.getExpr());
           break;
         case JQ:
           extractor = flattenerMaker.makeJsonQueryExtractor(fieldSpec.getExpr());
+          break;
+        case TREE:
+          extractor = flattenerMaker.makeJsonTreeExtractor(fieldSpec.getExprs());
           break;
         default:
           throw new UOE("Unsupported field type[%s]", fieldSpec.getType());
@@ -230,6 +234,11 @@ public class ObjectFlatteners
      * Create a "field" extractor for 'jq' expressions
      */
     Function<T, Object> makeJsonQueryExtractor(String expr);
+
+    /**
+     * Create a "field" extractor for nested json expressions
+     */
+    Function<T, Object> makeJsonTreeExtractor(List<String> exprs);
 
     /**
      * Convert object to Java {@link Map} using {@link #getJsonProvider()} and {@link #finalizeConversionForMap} to

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class JsonInputFormatTest
 {
@@ -48,7 +49,9 @@ public class JsonInputFormatTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         ImmutableMap.of(Feature.ALLOW_COMMENTS.name(), true, Feature.ALLOW_UNQUOTED_FIELD_NAMES.name(), false),

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonLineReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonLineReaderTest.java
@@ -52,7 +52,11 @@ public class JsonLineReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,
@@ -83,12 +87,16 @@ public class JsonLineReaderTest
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("tree_baz")));
         Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
         Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("tree_omg")));
 
         Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("tree_baz2").isEmpty());
         Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
         Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("tree_omg2").isEmpty());
         numActualIterations++;
       }
       Assert.assertEquals(numExpectedIterations, numActualIterations);
@@ -148,7 +156,8 @@ public class JsonLineReaderTest
         new JSONPathSpec(
             true,
             ImmutableList.of(
-                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg")
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg"))
             )
         ),
         null,
@@ -175,10 +184,11 @@ public class JsonLineReaderTest
       int numActualIterations = 0;
       while (iterator.hasNext()) {
         final InputRow row = iterator.next();
-        Assert.assertEquals(Arrays.asList("path_omg", "timestamp", "bar", "foo"), row.getDimensions());
+        Assert.assertEquals(Arrays.asList("path_omg", "tree_omg", "timestamp", "bar", "foo"), row.getDimensions());
         Assert.assertTrue(row.getDimension("bar").isEmpty());
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertTrue(row.getDimension("path_omg").isEmpty());
+        Assert.assertTrue(row.getDimension("tree_omg").isEmpty());
         numActualIterations++;
       }
       Assert.assertEquals(numExpectedIterations, numActualIterations);
@@ -192,7 +202,8 @@ public class JsonLineReaderTest
         new JSONPathSpec(
             true,
             ImmutableList.of(
-                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg")
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg"))
             )
         ),
         null,
@@ -219,10 +230,11 @@ public class JsonLineReaderTest
       int numActualIterations = 0;
       while (iterator.hasNext()) {
         final InputRow row = iterator.next();
-        Assert.assertEquals(Arrays.asList("path_omg", "timestamp", "bar", "foo"), row.getDimensions());
+        Assert.assertEquals(Arrays.asList("path_omg", "tree_omg", "timestamp", "bar", "foo"), row.getDimensions());
         Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("bar")));
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("a", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assert.assertEquals("a", Iterables.getOnlyElement(row.getDimension("tree_omg")));
         numActualIterations++;
       }
       Assert.assertEquals(numExpectedIterations, numActualIterations);
@@ -236,7 +248,8 @@ public class JsonLineReaderTest
         new JSONPathSpec(
             true,
             ImmutableList.of(
-                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg")
+                new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg"))
             )
         ),
         null,
@@ -263,10 +276,11 @@ public class JsonLineReaderTest
       int numActualIterations = 0;
       while (iterator.hasNext()) {
         final InputRow row = iterator.next();
-        Assert.assertEquals(Arrays.asList("path_omg", "timestamp", "foo"), row.getDimensions());
+        Assert.assertEquals(Arrays.asList("path_omg", "tree_omg", "timestamp", "foo"), row.getDimensions());
         Assert.assertTrue(row.getDimension("bar").isEmpty());
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("a", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assert.assertEquals("a", Iterables.getOnlyElement(row.getDimension("tree_omg")));
         numActualIterations++;
       }
       Assert.assertEquals(numExpectedIterations, numActualIterations);

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonReaderTest.java
@@ -39,6 +39,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
 public class JsonReaderTest
 {
@@ -57,7 +59,11 @@ public class JsonReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,
@@ -95,12 +101,16 @@ public class JsonReaderTest
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("tree_baz")));
         Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("path_omg")));
         Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("tree_omg")));
 
         Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("tree_baz2").isEmpty());
         Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
         Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("tree_omg2").isEmpty());
       }
 
       Assert.assertEquals(numExpectedIterations, numActualIterations);
@@ -119,7 +129,11 @@ public class JsonReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,
@@ -162,12 +176,16 @@ public class JsonReaderTest
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("tree_baz")));
         Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
         Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("tree_omg")));
 
         Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("tree_baz2").isEmpty());
         Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
         Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("tree_omg2").isEmpty());
 
         numActualIterations++;
       }
@@ -188,7 +206,11 @@ public class JsonReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,
@@ -244,7 +266,11 @@ public class JsonReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,
@@ -287,12 +313,16 @@ public class JsonReaderTest
           Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
           Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
           Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+          Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("tree_baz")));
           Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("path_omg")));
           Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("jq_omg")));
+          Assert.assertEquals(msgId, Iterables.getOnlyElement(row.getDimension("tree_omg")));
 
           Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+          Assert.assertTrue(row.getDimension("tree_baz2").isEmpty());
           Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
           Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+          Assert.assertTrue(row.getDimension("tree_omg2").isEmpty());
         }
       }
     }
@@ -312,7 +342,11 @@ public class JsonReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,
@@ -370,7 +404,11 @@ public class JsonReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,
@@ -428,7 +466,11 @@ public class JsonReaderTest
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
                 new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
                 new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
-                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2"),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz", null, Collections.singletonList("baz")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_baz2", null, Collections.singletonList("baz2")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg", null, Arrays.asList("o", "mg")),
+                new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree_omg2", null, Arrays.asList("o", "mg2"))
             )
         ),
         null,

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/JSONPathParserTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/JSONPathParserTest.java
@@ -28,6 +28,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -173,6 +174,10 @@ public class JSONPathParserTest
     fields.add(new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq-nested-foo.bar2", ".foo.bar2"));
     fields.add(new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq-heybarx0", ".hey[0].barx"));
     fields.add(new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq-met-array", ".met.a"));
+    fields.add(new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree-simpleVal", null, Collections.singletonList("simpleVal")));
+    fields.add(new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree-timestamp", null, Collections.singletonList("timestamp")));
+    fields.add(new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree-nested-foo.bar2", null, Arrays.asList("foo", "bar2")));
+    fields.add(new JSONPathFieldSpec(JSONPathFieldType.TREE, "tree-met-array", null, Arrays.asList("met", "a")));
 
     final Parser<String, Object> jsonParser = new JSONPathParser(new JSONPathSpec(false, fields), null, false);
     final Map<String, Object> jsonMap = jsonParser.parseToMap(NESTED_JSON);
@@ -180,6 +185,8 @@ public class JSONPathParserTest
     // Root fields
     Assert.assertEquals("text", jsonMap.get("simpleVal"));
     Assert.assertEquals("2999", jsonMap.get("timestamp"));
+    Assert.assertEquals("text", jsonMap.get("tree-simpleVal"));
+    Assert.assertEquals("2999", jsonMap.get("tree-timestamp"));
 
     // Nested fields
     Assert.assertEquals("bbb", jsonMap.get("nested-foo.bar2"));
@@ -188,6 +195,9 @@ public class JSONPathParserTest
     Assert.assertEquals("bbb", jsonMap.get("jq-nested-foo.bar2"));
     Assert.assertEquals("asdf", jsonMap.get("jq-heybarx0"));
     Assert.assertEquals(ImmutableList.of(7L, 8L, 9L), jsonMap.get("jq-met-array"));
+
+    Assert.assertEquals(ImmutableList.of(7L, 8L, 9L), jsonMap.get("tree-met-array"));
+    Assert.assertEquals("bbb", jsonMap.get("tree-nested-foo.bar2"));
 
     // Fields that should not be discovered
     Assert.assertFalse(jsonMap.containsKey("newmet"));

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -231,7 +231,7 @@ Configure the ORC `inputFormat` to load ORC data as follows:
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
 | type | String | Set value to `orc`. | yes |
-| flattenSpec | JSON Object | Specifies flattening configuration for nested ORC data. See [`flattenSpec`](#flattenspec) for more info. | no |
+| flattenSpec | JSON Object | Specifies flattening configuration for nested ORC data. Only 'path' expressions are supported ('jq' and 'tree' are unavailable). See [`flattenSpec`](#flattenspec) for more info. | no |
 | binaryAsString | Boolean | Specifies if the binary orc column which is not logically marked as a string should be treated as a UTF-8 encoded string. | no (default = false) |
 
 For example:

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -609,6 +609,7 @@ For example:
   "fields": [
     { "name": "baz", "type": "root" },
     { "name": "foo_bar", "type": "path", "expr": "$.foo.bar" },
+    { "name": "foo_other_bar", "type": "tree", "nodes": ["foo", "other", "bar"] },
     { "name": "first_food", "type": "jq", "expr": ".thing.food[1]" }
   ]
 }
@@ -626,7 +627,7 @@ Each entry in the `fields` list can have the following components:
 | type | Options are as follows:<br /><br /><ul><li>`root`, referring to a field at the root level of the record. Only really useful if `useFieldDiscovery` is false.</li><li>`path`, referring to a field using [JsonPath](https://github.com/jayway/JsonPath) notation. Supported by most data formats that offer nesting, including `avro`, `json`, `orc`, and `parquet`.</li><li>`jq`, referring to a field using [jackson-jq](https://github.com/eiiches/jackson-jq) notation. Only supported for the `json` format.</li><li>`tree`, referring to a nested field from the root level of the record. Useful and more efficient than `path` or `jq` if a simple hierarchical fetch is required. Only supported for the `json` format.</li></ul> | none (required) |
 | name | Name of the field after flattening. This name can be referred to by the [`timestampSpec`](./ingestion-spec.md#timestampspec), [`transformSpec`](./ingestion-spec.md#transformspec), [`dimensionsSpec`](./ingestion-spec.md#dimensionsspec), and [`metricsSpec`](./ingestion-spec.md#metricsspec).| none (required) |
 | expr | Expression for accessing the field while flattening. For type `path`, this should be [JsonPath](https://github.com/jayway/JsonPath). For type `jq`, this should be [jackson-jq](https://github.com/eiiches/jackson-jq) notation. For other types, this parameter is ignored. | none (required for types `path` and `jq`) |
-| exprs | For `tree` only. Multiple-expression field for accessing the field while flattening, representing the hierarchy of field names to read. For other types, this parameter must not be provided. | none (required for type `tree`) |
+| nodes | For `tree` only. Multiple-expression field for accessing the field while flattening, representing the hierarchy of field names to read. For other types, this parameter must not be provided. | none (required for type `tree`) |
 
 #### Notes on flattening
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -558,11 +558,11 @@ For example:
 
 Configure the Protobuf `inputFormat` to load Protobuf data as follows:
 
-| Field | Type | Description                                                                                                                                                            | Required |
-|-------|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-|type| String| Set value to `protobuf`.                                                                                                                                               | yes |
-|flattenSpec| JSON Object | Define a [`flattenSpec`](#flattenspec) to extract nested values from a Protobuf record. Note that only 'path' expression are supported ('jq' and 'tree'is unavailable). | no (default will auto-discover 'root' level properties) |
-|`protoBytesDecoder`| JSON Object | Specifies how to decode bytes to Protobuf record.                                                                                                                      | yes |
+| Field | Type | Description                                                                                                                                                              | Required |
+|-------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+|type| String| Set value to `protobuf`.                                                                                                                                                 | yes |
+|flattenSpec| JSON Object | Define a [`flattenSpec`](#flattenspec) to extract nested values from a Protobuf record. Note that only 'path' expression are supported ('jq' and 'tree' is unavailable). | no (default will auto-discover 'root' level properties) |
+|`protoBytesDecoder`| JSON Object | Specifies how to decode bytes to Protobuf record.                                                                                                                        | yes |
 
 For example:
 ```json

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -261,11 +261,11 @@ To use the Parquet input format load the Druid Parquet extension ([`druid-parque
 
 Configure the Parquet `inputFormat` to load Parquet data as follows:
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-|type| String| Set value to `parquet`.| yes |
-|flattenSpec| JSON Object | Define a [`flattenSpec`](#flattenspec) to extract nested values from a Parquet file. Only 'path' expressions are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
-| binaryAsString | Boolean | Specifies if the bytes parquet column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
+| Field | Type | Description                                                                                                                                                   | Required |
+|-------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+|type| String| Set value to `parquet`.                                                                                                                                       | yes |
+|flattenSpec| JSON Object | Define a [`flattenSpec`](#flattenspec) to extract nested values from a Parquet file. Only 'path' expressions are supported ('jq' and 'tree' are unavailable). | no (default will auto-discover 'root' level properties) |
+| binaryAsString | Boolean | Specifies if the bytes parquet column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string.                     | no (default = false) |
 
 For example:
 ```json
@@ -509,12 +509,12 @@ See the [Avro Types](../development/extensions-core/avro.md#avro-types) section 
 
 Configure the Avro OCF `inputFormat` to load Avro OCF data as follows:
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-|type| String|  Set value to `avro_ocf`. | yes |
-|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from Avro records. Only 'path' expressions are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
-|schema| JSON Object |Define a reader schema to be used when parsing Avro records. This is useful when parsing multiple versions of Avro OCF file data. | no (default will decode using the writer schema contained in the OCF file) |
-| binaryAsString | Boolean | Specifies if the bytes parquet column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string. | no (default = false) |
+| Field | Type | Description                                                                                                                                                 | Required |
+|-------|------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+|type| String| Set value to `avro_ocf`.                                                                                                                                    | yes |
+|flattenSpec| JSON Object | Define a [`flattenSpec`](#flattenspec) to extract nested values from Avro records. Only 'path' expressions are supported ('jq' and 'tree' are unavailable). | no (default will auto-discover 'root' level properties) |
+|schema| JSON Object | Define a reader schema to be used when parsing Avro records. This is useful when parsing multiple versions of Avro OCF file data.                           | no (default will decode using the writer schema contained in the OCF file) |
+| binaryAsString | Boolean | Specifies if the bytes parquet column which is not logically marked as a string or enum type should be treated as a UTF-8 encoded string.                   | no (default = false) |
 
 For example:
 ```json
@@ -558,11 +558,11 @@ For example:
 
 Configure the Protobuf `inputFormat` to load Protobuf data as follows:
 
-| Field | Type | Description | Required |
-|-------|------|-------------|----------|
-|type| String| Set value to `protobuf`. | yes |
-|flattenSpec| JSON Object |Define a [`flattenSpec`](#flattenspec) to extract nested values from a Protobuf record. Note that only 'path' expression are supported ('jq' is unavailable).| no (default will auto-discover 'root' level properties) |
-|`protoBytesDecoder`| JSON Object |Specifies how to decode bytes to Protobuf record. | yes |
+| Field | Type | Description                                                                                                                                                            | Required |
+|-------|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+|type| String| Set value to `protobuf`.                                                                                                                                               | yes |
+|flattenSpec| JSON Object | Define a [`flattenSpec`](#flattenspec) to extract nested values from a Protobuf record. Note that only 'path' expression are supported ('jq' and 'tree'is unavailable). | no (default will auto-discover 'root' level properties) |
+|`protoBytesDecoder`| JSON Object | Specifies how to decode bytes to Protobuf record.                                                                                                                      | yes |
 
 For example:
 ```json
@@ -692,7 +692,8 @@ See [Avro specification](http://avro.apache.org/docs/1.7.7/spec.html#Schema+Reso
 | fromPigAvroStorage | Boolean | Specifies whether the data file is stored using AvroStorage. | no(default == false) |
 
 An Avro parseSpec can contain a [`flattenSpec`](#flattenspec) using either the "root" or "path"
-field types, which can be used to read nested Avro records. The "jq" field type is not currently supported for Avro.
+field types, which can be used to read nested Avro records. The "jq" and "tree" field type is not currently supported
+for Avro.
 
 For example, using Avro Hadoop parser with custom reader's schema file:
 
@@ -1210,7 +1211,7 @@ This parser is for [stream ingestion](./index.md#streaming) and reads Avro data 
 | parseSpec | JSON Object | Specifies the timestamp and dimensions of the data. Should be an "avro" parseSpec. | yes |
 
 An Avro parseSpec can contain a [`flattenSpec`](#flattenspec) using either the "root" or "path"
-field types, which can be used to read nested Avro records. The "jq" field type is not currently supported for Avro.
+field types, which can be used to read nested Avro records. The "jq" and "tree" field type is not currently supported for Avro.
 
 For example, using Avro stream parser with schema repo Avro bytes decoder:
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -623,9 +623,10 @@ Each entry in the `fields` list can have the following components:
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| type | Options are as follows:<br /><br /><ul><li>`root`, referring to a field at the root level of the record. Only really useful if `useFieldDiscovery` is false.</li><li>`path`, referring to a field using [JsonPath](https://github.com/jayway/JsonPath) notation. Supported by most data formats that offer nesting, including `avro`, `json`, `orc`, and `parquet`.</li><li>`jq`, referring to a field using [jackson-jq](https://github.com/eiiches/jackson-jq) notation. Only supported for the `json` format.</li></ul> | none (required) |
+| type | Options are as follows:<br /><br /><ul><li>`root`, referring to a field at the root level of the record. Only really useful if `useFieldDiscovery` is false.</li><li>`path`, referring to a field using [JsonPath](https://github.com/jayway/JsonPath) notation. Supported by most data formats that offer nesting, including `avro`, `json`, `orc`, and `parquet`.</li><li>`jq`, referring to a field using [jackson-jq](https://github.com/eiiches/jackson-jq) notation. Only supported for the `json` format.</li><li>`tree`, referring to a nested field from the root level of the record. Useful and more efficient than `path` or `jq` if a simple hierarchical fetch is required. Only supported for the `json` format.</li></ul> | none (required) |
 | name | Name of the field after flattening. This name can be referred to by the [`timestampSpec`](./ingestion-spec.md#timestampspec), [`transformSpec`](./ingestion-spec.md#transformspec), [`dimensionsSpec`](./ingestion-spec.md#dimensionsspec), and [`metricsSpec`](./ingestion-spec.md#metricsspec).| none (required) |
 | expr | Expression for accessing the field while flattening. For type `path`, this should be [JsonPath](https://github.com/jayway/JsonPath). For type `jq`, this should be [jackson-jq](https://github.com/eiiches/jackson-jq) notation. For other types, this parameter is ignored. | none (required for types `path` and `jq`) |
+| exprs | For `tree` only. Multiple-expression field for accessing the field while flattening, representing the hierarchy of field names to read. For other types, this parameter must not be provided. | none (required for type `tree`) |
 
 #### Notes on flattening
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -141,10 +141,10 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
   }
 
   @Override
-  public Function<GenericRecord, Object> makeJsonTreeExtractor(List<String> exprs)
+  public Function<GenericRecord, Object> makeJsonTreeExtractor(List<String> nodes)
   {
-    if (exprs.size() == 1) {
-      return (GenericRecord record) -> getRootField(record, exprs.get(0));
+    if (nodes.size() == 1) {
+      return (GenericRecord record) -> getRootField(record, nodes.get(0));
     }
 
     throw new UnsupportedOperationException("Avro + nested tree extraction not supported");

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -141,6 +141,16 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
   }
 
   @Override
+  public Function<GenericRecord, Object> makeJsonTreeExtractor(List<String> exprs)
+  {
+    if (exprs.size() == 1) {
+      return (GenericRecord record) -> getRootField(record, exprs.get(0));
+    }
+
+    throw new UnsupportedOperationException("Avro + nested tree extraction not supported");
+  }
+
+  @Override
   public JsonProvider getJsonProvider()
   {
     return avroJsonProvider;

--- a/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcStructFlattenerMaker.java
+++ b/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcStructFlattenerMaker.java
@@ -92,10 +92,10 @@ public class OrcStructFlattenerMaker implements ObjectFlatteners.FlattenerMaker<
   }
 
   @Override
-  public Function<OrcStruct, Object> makeJsonTreeExtractor(List<String> exprs)
+  public Function<OrcStruct, Object> makeJsonTreeExtractor(List<String> nodes)
   {
-    if (exprs.size() == 1) {
-      return (OrcStruct record) -> getRootField(record, exprs.get(0));
+    if (nodes.size() == 1) {
+      return (OrcStruct record) -> getRootField(record, nodes.get(0));
     }
 
     throw new UnsupportedOperationException("ORC flattener does not support nested root queries");

--- a/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcStructFlattenerMaker.java
+++ b/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcStructFlattenerMaker.java
@@ -92,6 +92,16 @@ public class OrcStructFlattenerMaker implements ObjectFlatteners.FlattenerMaker<
   }
 
   @Override
+  public Function<OrcStruct, Object> makeJsonTreeExtractor(List<String> exprs)
+  {
+    if (exprs.size() == 1) {
+      return (OrcStruct record) -> getRootField(record, exprs.get(0));
+    }
+
+    throw new UnsupportedOperationException("ORC flattener does not support nested root queries");
+  }
+
+  @Override
   public JsonProvider getJsonProvider()
   {
     return orcJsonProvider;

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupFlattenerMaker.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupFlattenerMaker.java
@@ -89,6 +89,16 @@ public class ParquetGroupFlattenerMaker implements ObjectFlatteners.FlattenerMak
   }
 
   @Override
+  public Function<Group, Object> makeJsonTreeExtractor(List<String> exprs)
+  {
+    if (exprs.size() == 1) {
+      return (Group group) -> getRootField(group, exprs.get(0));
+    }
+
+    throw new UnsupportedOperationException("Parque does not support nested tree extraction");
+  }
+
+  @Override
   public JsonProvider getJsonProvider()
   {
     return parquetJsonProvider;

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupFlattenerMaker.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupFlattenerMaker.java
@@ -89,10 +89,10 @@ public class ParquetGroupFlattenerMaker implements ObjectFlatteners.FlattenerMak
   }
 
   @Override
-  public Function<Group, Object> makeJsonTreeExtractor(List<String> exprs)
+  public Function<Group, Object> makeJsonTreeExtractor(List<String> nodes)
   {
-    if (exprs.size() == 1) {
-      return (Group group) -> getRootField(group, exprs.get(0));
+    if (nodes.size() == 1) {
+      return (Group group) -> getRootField(group, nodes.get(0));
     }
 
     throw new UnsupportedOperationException("Parque does not support nested tree extraction");


### PR DESCRIPTION
### Overview and benefits

This introduces a `tree` to the `flattenSpec` which allows faster JSON parsing than `jq` and `path` parsing types in the event that a simple hierarchical lookup is required.

For one of our high-volume ingestion tasks, this reduces middle manager CPU load by 25%. This task presently has 3 `root` fields and 8 additional `path` fields of the form 

```
{
  "type": "path",
  "name": "task_detail",
  "expr": "$.metadata.detail"
},
```

Replacing this with a hierarchical lookup as follows:
```
{
  "type": "tree",
  "name": "task_detail",
  "exprs": ["metadata", "detail"]
},
```

In this sample, a switch to the new `tree` spec is submitted at 15.54, and after a moment or two the CPU shifts down at a notably lower total utilization from 3 cores to 2.3 cores.
![image](https://user-images.githubusercontent.com/3196528/150242320-61fedc3d-3c1f-419d-a6b6-273cc47658a8.png)


### Implementation decision

The goal is to introduce the ability to (1) provide a list of expressions instead of a single expression, and, a new `tree` type. 
```
{
  "type": "tree",                     <-- new type
  "name": "task_detail",
  "exprs": ["metadata", "detail"]     <-- name of json keys to traverse as a List<String>
},
```

The crux of the change is this tree extractor for loop (below) and the requisite parser configuration to ensure it is called.
```
public Function<JsonNode, Object> makeJsonTreeExtractor(final List<String> exprs)
{
  String[] exprsArray = exprs.toArray(new String[0]);
  return node -> {
    JsonNode target = node;
    for (String expr : exprsArray) {
      target = target.get(expr);
      if (target == null) {
        break;
      }
    }
    return valueConversionFunction(target);
  };
}
```

Key consideration was to avoid any backwards compatibility issues with deployments, so I opted for using a separate `exprs` parameter rather than overload the `expr` parameter.

### Changes required

The change adds enum entries, the required field spec to parse `List<String> exprs` to configuration, and validate that `exprs` is only provided for the `tree` type.

Then, tie it all into the `ObjectFlatteners` and `JSONFlattenerMaker` with a new `makeJsonTreeExtractor` that iterates each of the keys as a hierarchy in the dataset.

#### Supporting changes

- Update a lot of tests to explicitly verify the parameters are loaded.
- Update `docs/ingestion-data-formats.md` to include a description of the `tree` type and the `exprs` parameter.
- Update Avro, Orc, and Parquet flatteners to acknowledge `tree` but only work with a depth of 1; (would welcome guidance here).
- Added benchmarks to `FlattenJSONBenchmark` to confirm improvements in flattener layer

### Additional supporting data

On flamegraphs, `Flattener` related code before the change makes up ~49% of the `task-runner-xx` threads utilisation; after the change only ~16% of the `task-runner-xx` thread is used running `Flattener` related code.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] N/A added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] N/A added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
