### PR TITLE
In Filters limit for Bounds

### DIFF
--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -199,7 +199,7 @@ public class QueryResource implements QueryCountStatsProvider
       query = queryLifecycle.getQuery();
       final String queryId = query.getId();
 
-      //Special handling for Walmart case
+      //Special handling for one corner case
       int numFilters;
       if (query.getContextValue(MAX_NUMERIC_IN_FILTERS) != null) {
         numFilters = Math.min(DEFAULT_MAX_NUMFILTERS, Integer.parseInt(query.getContextValue(MAX_NUMERIC_IN_FILTERS)));
@@ -213,13 +213,13 @@ public class QueryResource implements QueryCountStatsProvider
         OrDimFilter orDimFilter = (OrDimFilter) query.getFilter();
         if (orDimFilter.getFields().size() > numFilters) {
           String dimension = ((BoundDimFilter) (orDimFilter.getFields().get(0))).getDimension();
-          throw new UOE(StringUtils.format("Cast values in column [%s] to String", dimension));
+          throw new UOE(StringUtils.format("Filters for column [%s] exceeds configured filter limit of [%s]. Cast [%s] values to String", dimension, numFilters, orDimFilter.getFields().size()));
         }
       } else if (query.getFilter() instanceof AndDimFilter) {
         AndDimFilter andDimFilter = (AndDimFilter) query.getFilter();
         if (andDimFilter.getFields().size() > numFilters) {
           String dimension = ((BoundDimFilter) (andDimFilter.getFields().get(0))).getDimension();
-          throw new UOE(StringUtils.format("Cast values in column [%s] to String", dimension));
+          throw new UOE(StringUtils.format("Filters for column [%s] exceeds configured filter limit of [%s]. Cast [%s] values to String", dimension, numFilters, andDimFilter.getFields().size()));
         }
       }
 

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -169,6 +169,23 @@ public class QueryResourceTest
       + "    \"context\": { \"priority\": -1 }"
       + "}";
 
+  private static final String SIMPLE_SCAN_QUERY =
+      "{\n"
+      + "    \"queryType\": \"scan\",\n"
+      + "    \"dataSource\": \"mmx_metrics\",\n"
+      + "    \"granularity\": \"hour\",\n"
+      + "    \"intervals\": [\n"
+      + "      \"2014-12-17/2015-12-30\"\n"
+      + "    ],\n"
+      + "    \"aggregations\": [\n"
+      + "      {\n"
+      + "        \"type\": \"count\",\n"
+      + "        \"name\": \"rows\"\n"
+      + "      }\n"
+      + "    ],\n"
+      + "    \"context\": { \"Max-Numeric-In-Filters\": -1 }"
+      + "}";
+
 
   private static final ServiceEmitter NOOP_SERVICE_EMITTER = new NoopServiceEmitter();
   private static final DruidNode DRUID_NODE = new DruidNode(
@@ -203,6 +220,7 @@ public class QueryResourceTest
     EasyMock.expect(testServletRequest.getContentType()).andReturn(MediaType.APPLICATION_JSON).anyTimes();
     EasyMock.expect(testServletRequest.getHeader("Accept")).andReturn(MediaType.APPLICATION_JSON).anyTimes();
     EasyMock.expect(testServletRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(testServletRequest.getHeader(QueryResource.MAX_NUMERIC_IN_FILTERS)).andReturn("10").anyTimes();
     EasyMock.expect(testServletRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
     queryScheduler = QueryStackTests.DEFAULT_NOOP_SCHEDULER;
     testRequestLogger = new TestRequestLogger();
@@ -245,6 +263,19 @@ public class QueryResourceTest
 
     Response response = queryResource.doPost(
         new ByteArrayInputStream(SIMPLE_TIMESERIES_QUERY.getBytes(StandardCharsets.UTF_8)),
+        null /*pretty*/,
+        testServletRequest
+    );
+    Assert.assertNotNull(response);
+  }
+
+  @Test
+  public void testBadInFilters() throws IOException
+  {
+    expectPermissiveHappyPathAuth();
+
+    Response response = queryResource.doPost(
+        new ByteArrayInputStream(SIMPLE_SCAN_QUERY.getBytes(StandardCharsets.UTF_8)),
         null /*pretty*/,
         testServletRequest
     );
@@ -416,6 +447,7 @@ public class QueryResourceTest
     EasyMock.expect(testServletRequest.getHeader("Accept")).andReturn(acceptHeader).anyTimes();
     EasyMock.expect(testServletRequest.getContentType()).andReturn(contentTypeHeader).anyTimes();
     EasyMock.expect(testServletRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(testServletRequest.getHeader(QueryResource.MAX_NUMERIC_IN_FILTERS)).andReturn("10").anyTimes();
     EasyMock.expect(testServletRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
 
     EasyMock.replay(testServletRequest);
@@ -451,6 +483,7 @@ public class QueryResourceTest
     EasyMock.expect(testServletRequest.getHeader("Accept")).andReturn(acceptHeader).anyTimes();
     EasyMock.expect(testServletRequest.getContentType()).andReturn(contentTypeHeader).anyTimes();
     EasyMock.expect(testServletRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(testServletRequest.getHeader(QueryResource.MAX_NUMERIC_IN_FILTERS)).andReturn("10").anyTimes();
     EasyMock.expect(testServletRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
 
     EasyMock.replay(testServletRequest);
@@ -493,6 +526,7 @@ public class QueryResourceTest
     // Set Accept to Smile
     EasyMock.expect(smileRequest.getHeader("Accept")).andReturn(SmileMediaTypes.APPLICATION_JACKSON_SMILE).anyTimes();
     EasyMock.expect(smileRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(smileRequest.getHeader(QueryResource.MAX_NUMERIC_IN_FILTERS)).andReturn("10").anyTimes();
     EasyMock.expect(smileRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
 
     EasyMock.replay(smileRequest);
@@ -537,6 +571,7 @@ public class QueryResourceTest
     // Set Accept to Smile
     EasyMock.expect(smileRequest.getHeader("Accept")).andReturn(SmileMediaTypes.APPLICATION_JACKSON_SMILE).anyTimes();
     EasyMock.expect(smileRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(smileRequest.getHeader(QueryResource.MAX_NUMERIC_IN_FILTERS)).andReturn("10").anyTimes();
     EasyMock.expect(smileRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
 
     EasyMock.replay(smileRequest);
@@ -582,6 +617,7 @@ public class QueryResourceTest
     // DO NOT set Accept to Smile, Content-Type in response will be default to Content-Type in request
     EasyMock.expect(smileRequest.getHeader("Accept")).andReturn(null).anyTimes();
     EasyMock.expect(smileRequest.getHeader(QueryResource.HEADER_IF_NONE_MATCH)).andReturn(null).anyTimes();
+    EasyMock.expect(smileRequest.getHeader(QueryResource.MAX_NUMERIC_IN_FILTERS)).andReturn("10").anyTimes();
     EasyMock.expect(smileRequest.getRemoteAddr()).andReturn("localhost").anyTimes();
 
     EasyMock.replay(smileRequest);


### PR DESCRIPTION
Historicals now can have querys with lot of IN filters with numeric casts preempt early
This PR has:
- [ x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ x] been tested in a test Druid cluster.
