### PR TITLE
Fix HttpRemoteTaskRunner LifecycleStart / LifecycleStop race condition

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -1368,7 +1368,7 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
           try {
             w.stop();
           }
-          catch (ISE e) {
+          catch (Exception e) {
             log.error(e, e.getMessage());
           }
         });

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.overlord.hrtr;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -191,6 +192,7 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   @Nullable // Null, if zk is disabled
   private final ScheduledExecutorService zkCleanupExec;
   private final IndexerZkConfig indexerZkConfig;
+  private volatile DruidNodeDiscovery.Listener nodeDiscoveryListener;
 
   public HttpRemoteTaskRunner(
       ObjectMapper smileMapper,
@@ -512,29 +514,28 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     final CountDownLatch workerViewInitialized = new CountDownLatch(1);
     DruidNodeDiscovery druidNodeDiscovery =
         druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY);
-    druidNodeDiscovery.registerListener(
-        new DruidNodeDiscovery.Listener()
-        {
-          @Override
-          public void nodesAdded(Collection<DiscoveryDruidNode> nodes)
-          {
-            nodes.forEach(node -> addWorker(toWorker(node)));
-          }
+    this.nodeDiscoveryListener = new DruidNodeDiscovery.Listener()
+    {
+      @Override
+      public void nodesAdded(Collection<DiscoveryDruidNode> nodes)
+      {
+        nodes.forEach(node -> addWorker(toWorker(node)));
+      }
 
-          @Override
-          public void nodesRemoved(Collection<DiscoveryDruidNode> nodes)
-          {
-            nodes.forEach(node -> removeWorker(toWorker(node)));
-          }
+      @Override
+      public void nodesRemoved(Collection<DiscoveryDruidNode> nodes)
+      {
+        nodes.forEach(node -> removeWorker(toWorker(node)));
+      }
 
-          @Override
-          public void nodeViewInitialized()
-          {
-            //CountDownLatch.countDown() does nothing when count has already reached 0.
-            workerViewInitialized.countDown();
-          }
-        }
-    );
+      @Override
+      public void nodeViewInitialized()
+      {
+        //CountDownLatch.countDown() does nothing when count has already reached 0.
+        workerViewInitialized.countDown();
+      }
+    };
+    druidNodeDiscovery.registerListener(nodeDiscoveryListener);
 
     long workerDiscoveryStartTime = System.currentTimeMillis();
     while (!workerViewInitialized.await(30, TimeUnit.SECONDS)) {
@@ -876,6 +877,12 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   public Collection<ImmutableWorkerInfo> getWorkers()
   {
     return workers.values().stream().map(worker -> worker.toImmutable()).collect(Collectors.toList());
+  }
+
+  @VisibleForTesting
+  ConcurrentMap<String, WorkerHolder> getWorkersForTestingReadOnly()
+  {
+    return workers;
   }
 
   @Override
@@ -1340,14 +1347,36 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
       throw new ISE("can't stop.");
     }
 
-    log.info("Stopping...");
+    try {
+      log.info("Stopping...");
 
-    if (provisioningService != null) {
-      provisioningService.close();
+      if (provisioningService != null) {
+        provisioningService.close();
+      }
+      pendingTasksExec.shutdownNow();
+      workersSyncExec.shutdownNow();
+      cleanupExec.shutdown();
+
+      log.info("Removing listener");
+      DruidNodeDiscovery druidNodeDiscovery =
+          druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY);
+      druidNodeDiscovery.removeListener(nodeDiscoveryListener);
+
+      log.info("Stopping worker holders");
+      synchronized (workers) {
+        workers.values().forEach(w -> {
+          try {
+            w.stop();
+          }
+          catch (ISE e) {
+            log.error(e, e.getMessage());
+          }
+        });
+      }
     }
-    pendingTasksExec.shutdownNow();
-    workersSyncExec.shutdownNow();
-    cleanupExec.shutdown();
+    finally {
+      lifecycleLock.exitStop();
+    }
 
     log.info("Stopped.");
   }

--- a/server/src/main/java/org/apache/druid/discovery/DruidNodeDiscovery.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidNodeDiscovery.java
@@ -29,6 +29,11 @@ public interface DruidNodeDiscovery
   Collection<DiscoveryDruidNode> getAllNodes();
   void registerListener(Listener listener);
 
+  default void removeListener(Listener listener)
+  {
+    // do nothing
+  }
+
   /**
    * Listener for watching nodes in a DruidNodeDiscovery instance obtained via {@link
    * DruidNodeDiscoveryProvider}.getXXX(). DruidNodeDiscovery implementation should assume that Listener is not

--- a/server/src/main/java/org/apache/druid/discovery/DruidNodeDiscoveryProvider.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidNodeDiscoveryProvider.java
@@ -126,6 +126,16 @@ public abstract class DruidNodeDiscoveryProvider
       }
     }
 
+    @Override
+    public void removeListener(Listener listener)
+    {
+      synchronized (lock) {
+        if (listener != null) {
+          listeners.remove(listener);
+        }
+      }
+    }
+
     DruidNodeDiscovery.Listener filteringUpstreamListener()
     {
       return new FilteringUpstreamListener();

--- a/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
@@ -121,14 +121,20 @@ public class ChangeRequestHttpSyncer<T>
 
   public void start()
   {
+
     synchronized (startStopLock) {
+
       if (!startStopLock.canStart()) {
         throw new ISE("Can't start ChangeRequestHttpSyncer[%s].", logIdentity);
       }
+      try {
 
-      log.info("Starting ChangeRequestHttpSyncer[%s].", logIdentity);
-      startStopLock.started();
-      startStopLock.exitStart();
+        log.info("Starting ChangeRequestHttpSyncer[%s].", logIdentity);
+        startStopLock.started();
+      }
+      finally {
+        startStopLock.exitStart();
+      }
 
       addNextSyncToWorkQueue();
     }
@@ -139,6 +145,12 @@ public class ChangeRequestHttpSyncer<T>
     synchronized (startStopLock) {
       if (!startStopLock.canStop()) {
         throw new ISE("Can't stop ChangeRequestHttpSyncer[%s].", logIdentity);
+      }
+      try {
+        log.info("Stopping ChangeRequestHttpSyncer[%s].", logIdentity);
+      }
+      finally {
+        startStopLock.exitStop();
       }
 
       log.info("Stopped ChangeRequestHttpSyncer[%s].", logIdentity);
@@ -416,9 +428,9 @@ public class ChangeRequestHttpSyncer<T>
   }
 
   @VisibleForTesting
-  public boolean isExecutorTerminated()
+  public boolean isExecutorShutdown()
   {
-    return executor.isTerminated();
+    return executor.isShutdown();
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordination;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -412,6 +413,12 @@ public class ChangeRequestHttpSyncer<T>
     }
 
     return false;
+  }
+
+  @VisibleForTesting
+  public boolean isExecutorTerminated()
+  {
+    return executor.isTerminated();
   }
 
   /**

--- a/server/src/test/java/org/apache/druid/discovery/DruidNodeDiscoveryProviderTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DruidNodeDiscoveryProviderTest.java
@@ -180,6 +180,15 @@ public class DruidNodeDiscoveryProviderTest
     Assert.assertEquals(ImmutableSet.of(node1, node3), lookupNodes);
   }
 
+  @Test
+  public void test_removeListener_withNullListener_noException()
+  {
+    TestDruidNodeDiscoveryProvider provider = new TestDruidNodeDiscoveryProvider();
+
+    DruidNodeDiscovery dataNodeDiscovery = provider.getForService(DataNodeService.DISCOVERY_SERVICE_KEY);
+    dataNodeDiscovery.removeListener(null);
+  }
+
   private static class TestDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
   {
     private List<DruidNodeDiscovery.Listener> listeners = new ArrayList<>();


### PR DESCRIPTION
### Description

Fixed a bug, where HttpRemoteTaksRunner.stop could clobber HttpRemoteTaskRunner.start, and cause the overlord leader to have worker execs and other execs shutdown, and unable to assign tasks to workers. This required adding a call to exitStop() in the stop() method of the class, in a finally block. The worker holders  and node listener are now stopped when HttpRemoteTaskRunner is stopped as well.


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
