### PR TITLE
fix StringAnyAggregatorFactory to use single value selector for non-existent columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
@@ -86,7 +86,8 @@ public class StringAnyAggregatorFactory extends AggregatorFactory
   {
 
     ColumnCapabilities capabilities = selectorFactory.getColumnCapabilities(fieldName);
-    if (capabilities == null || capabilities.hasMultipleValues().isMaybeTrue()) {
+    // null capabilities mean the column doesn't exist, so in vector engines the selector will never be multi-value
+    if (capabilities != null && capabilities.hasMultipleValues().isMaybeTrue()) {
       return new StringAnyVectorAggregator(
           null,
           selectorFactory.makeMultiValueDimensionSelector(DefaultDimensionSpec.of(fieldName)),

--- a/processing/src/main/java/org/apache/druid/segment/ColumnProcessors.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnProcessors.java
@@ -342,7 +342,7 @@ public class ColumnProcessors
           );
         }
 
-        if (mayBeMultiValue(capabilities)) {
+        if (capabilities.hasMultipleValues().isMaybeTrue()) {
           return processorFactory.makeMultiValueDimensionProcessor(
               capabilities,
               multiValueDimensionSelectorFn.apply(selectorFactory)
@@ -367,8 +367,13 @@ public class ColumnProcessors
   }
 
   /**
-   * Returns true if a given set of capabilities might indicate an underlying multi-value column. Errs on the side
-   * of returning true if unknown; i.e. if this returns false, there are _definitely not_ mul.
+   * Returns true if a given set of {@link ColumnCapabilities} indicate that a processor should handle the column as a
+   * multi-value column. If capabilities are null, or if {@link ColumnCapabilities#hasMultipleValues()} is unknown,
+   * this method errs on the side of returning true. If this method returns false, the column is _definitely not_
+   * multi-value.
+   *
+   * Note, this method is not suitable for use with vector engines because null capabilities are indicative of a column
+   * that does not exist, rather than unknown capabilities.
    */
   private static boolean mayBeMultiValue(@Nullable final ColumnCapabilities capabilities)
   {

--- a/processing/src/test/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactoryTest.java
@@ -73,8 +73,9 @@ public class StringAnyAggregatorFactoryTest extends InitializedNullHandlingTest
   public void factorizeVectorWithoutCapabilitiesShouldReturnAggregatorWithMultiDimensionSelector()
   {
     Mockito.doReturn(null).when(vectorSelectorFactory).getColumnCapabilities(FIELD_NAME);
-    Mockito.doReturn(multiValueDimensionVectorSelector)
-           .when(vectorSelectorFactory).makeMultiValueDimensionSelector(any());
+    Mockito.doReturn(singleValueDimensionVectorSelector)
+           .when(vectorSelectorFactory)
+           .makeSingleValueDimensionSelector(any());
     StringAnyVectorAggregator aggregator = target.factorizeVector(vectorSelectorFactory);
     Assert.assertNotNull(aggregator);
   }
@@ -83,7 +84,8 @@ public class StringAnyAggregatorFactoryTest extends InitializedNullHandlingTest
   public void factorizeVectorWithUnknownCapabilitiesShouldReturnAggregatorWithMultiDimensionSelector()
   {
     Mockito.doReturn(multiValueDimensionVectorSelector)
-           .when(vectorSelectorFactory).makeMultiValueDimensionSelector(any());
+           .when(vectorSelectorFactory)
+           .makeMultiValueDimensionSelector(any());
     StringAnyVectorAggregator aggregator = target.factorizeVector(vectorSelectorFactory);
     Assert.assertNotNull(aggregator);
   }
@@ -93,7 +95,8 @@ public class StringAnyAggregatorFactoryTest extends InitializedNullHandlingTest
   {
     Mockito.doReturn(ColumnCapabilities.Capable.TRUE).when(capabilities).hasMultipleValues();
     Mockito.doReturn(multiValueDimensionVectorSelector)
-           .when(vectorSelectorFactory).makeMultiValueDimensionSelector(any());
+           .when(vectorSelectorFactory)
+           .makeMultiValueDimensionSelector(any());
     StringAnyVectorAggregator aggregator = target.factorizeVector(vectorSelectorFactory);
     Assert.assertNotNull(aggregator);
   }
@@ -103,7 +106,8 @@ public class StringAnyAggregatorFactoryTest extends InitializedNullHandlingTest
   {
     Mockito.doReturn(ColumnCapabilities.Capable.FALSE).when(capabilities).hasMultipleValues();
     Mockito.doReturn(singleValueDimensionVectorSelector)
-           .when(vectorSelectorFactory).makeSingleValueDimensionSelector(any());
+           .when(vectorSelectorFactory)
+           .makeSingleValueDimensionSelector(any());
     StringAnyVectorAggregator aggregator = target.factorizeVector(vectorSelectorFactory);
     Assert.assertNotNull(aggregator);
   }


### PR DESCRIPTION
### Description
Fixes an issue with `StringAnyAggregatorFactory` which was incorrectly using a multi-value dimension selector when `ColumnCapabilities` were unavailable for a column, treating it as "unknown", which is correct for the non-vectorized engines, but incorrect for vector engines where missing capabilities means that the column doesn't exist and so is definitely nulls, which are always represented with a single value dimension selector.

This PR fixes the issue and adds additional javadoc and comments to try to help avoid making this mistake. Longer term, it might be wise to consider moving aggregator factorize methods to using the `ColumnProcessors` factories, so that we can re-use the same code for deciding what type of aggregators to make for a given input, but I did not do this in this PR.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
