### PR TITLE
Added url support and change the way metrics are written

### DIFF
--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
@@ -21,6 +21,7 @@ package org.apache.druid.emitter.prometheus;
 
 
 import com.google.common.collect.ImmutableMap;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
@@ -32,6 +33,8 @@ import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -77,10 +80,26 @@ public class PrometheusEmitter implements Emitter
       } else {
         log.error("HTTPServer is already started");
       }
-    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway)) {
-      pushGateway = new PushGateway(config.getPushGatewayAddress());
+    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway) && config.getPushGatewayAddress() != null) {
+      String address = config.getPushGatewayAddress();
+      if (address.startsWith("https") || address.startsWith("http")) {
+        URL myURL = createURLSneakily(address);
+        pushGateway = new PushGateway(myURL);
+      } else {
+        pushGateway = new PushGateway(address);
+      }
     }
 
+  }
+
+  private static URL createURLSneakily(final String urlString)
+  {
+    try {
+      return new URL(urlString);
+    }
+    catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -127,15 +146,17 @@ public class PrometheusEmitter implements Emitter
   private void pushMetric()
   {
     Map<String, DimensionsAndCollector> map = metrics.getRegisteredMetrics();
-    try {
-      for (DimensionsAndCollector collector : map.values()) {
-        if (config.getNamespace() != null) {
-          pushGateway.push(collector.getCollector(), config.getNamespace(), ImmutableMap.of(config.getNamespace(), identifier));
+    CollectorRegistry metrics = new CollectorRegistry();
+    if (config.getNamespace() != null) {
+      try {
+        for (DimensionsAndCollector collector : map.values()) {
+          metrics.register(collector.getCollector());
         }
+        pushGateway.push(metrics, config.getNamespace(), ImmutableMap.of(config.getNamespace(), identifier));
       }
-    }
-    catch (IOException e) {
-      log.error(e, "Unable to push prometheus metrics to pushGateway");
+      catch (IOException e) {
+        log.error(e, "Unable to push prometheus metrics to pushGateway");
+      }
     }
   }
 

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
@@ -80,7 +80,7 @@ public class PrometheusEmitter implements Emitter
       } else {
         log.error("HTTPServer is already started");
       }
-    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway) && config.getPushGatewayAddress() != null) {
+    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway)) {
       String address = config.getPushGatewayAddress();
       if (address.startsWith("https") || address.startsWith("http")) {
         URL myURL = createURLSneakily(address);

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
@@ -33,8 +33,6 @@ import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -80,26 +78,10 @@ public class PrometheusEmitter implements Emitter
       } else {
         log.error("HTTPServer is already started");
       }
-    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway) && config.getPushGatewayAddress() != null) {
-      String address = config.getPushGatewayAddress();
-      if (address.startsWith("https") || address.startsWith("http")) {
-        URL myURL = createURLSneakily(address);
-        pushGateway = new PushGateway(myURL);
-      } else {
-        pushGateway = new PushGateway(address);
-      }
+    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway)) {
+      pushGateway = new PushGateway(config.getPushGatewayAddress());
     }
 
-  }
-
-  private static URL createURLSneakily(final String urlString)
-  {
-    try {
-      return new URL(urlString);
-    }
-    catch (MalformedURLException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   @Override

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
@@ -33,6 +33,8 @@ import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -78,10 +80,25 @@ public class PrometheusEmitter implements Emitter
       } else {
         log.error("HTTPServer is already started");
       }
-    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway)) {
-      pushGateway = new PushGateway(config.getPushGatewayAddress());
+    } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway) && config.getPushGatewayAddress() != null) {
+      String address = config.getPushGatewayAddress();
+      if (address.startsWith("https") || address.startsWith("http")) {
+        URL myURL = createURLSneakily(address);
+        pushGateway = new PushGateway(myURL);
+      } else {
+        pushGateway = new PushGateway(address);
+      }
     }
+  }
 
+  private static URL createURLSneakily(final String urlString)
+  {
+    try {
+      return new URL(urlString);
+    }
+    catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -69,7 +69,7 @@ public class PrometheusEmitterConfig
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
     if (this.strategy == Strategy.pushgateway) {
-      Preconditions.checkNotNull(pushGatewayAddress, "Invalid address");
+      Preconditions.checkNotNull(pushGatewayAddress, "Invalid pushGateway address");
     }
     this.pushGatewayAddress = pushGatewayAddress;
   }

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -69,10 +69,11 @@ public class PrometheusEmitterConfig
     Preconditions.checkArgument(PATTERN.matcher(this.namespace).matches(), "Invalid namespace " + this.namespace);
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
-    this.pushGatewayAddress = pushGatewayAddress != null ? getValidAddress(pushGatewayAddress): null;
+    this.pushGatewayAddress = pushGatewayAddress != null ? getValidAddress(pushGatewayAddress) : null;
   }
 
-  private String getValidAddress(String address) {
+  private String getValidAddress(String address)
+  {
     if (address.startsWith("https") || address.startsWith("http")) {
       return createURLSneakily(address);
     } else {

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -68,7 +68,8 @@ public class PrometheusEmitterConfig
     Preconditions.checkArgument(PATTERN.matcher(this.namespace).matches(), "Invalid namespace " + this.namespace);
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
-    if (this.strategy == Strategy.pushgateway) {
+    if (this.strategy == Strategy.pushgateway)
+    {
       Preconditions.checkNotNull(pushGatewayAddress, "Invalid pushGateway address");
     }
     this.pushGatewayAddress = pushGatewayAddress;

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -68,8 +68,7 @@ public class PrometheusEmitterConfig
     Preconditions.checkArgument(PATTERN.matcher(this.namespace).matches(), "Invalid namespace " + this.namespace);
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
-    if (this.strategy == Strategy.pushgateway)
-    {
+    if (this.strategy == Strategy.pushgateway) {
       Preconditions.checkNotNull(pushGatewayAddress, "Invalid pushGateway address");
     }
     this.pushGatewayAddress = pushGatewayAddress;

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -68,6 +68,9 @@ public class PrometheusEmitterConfig
     Preconditions.checkArgument(PATTERN.matcher(this.namespace).matches(), "Invalid namespace " + this.namespace);
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
+    if (this.strategy == Strategy.pushgateway) {
+      Preconditions.checkNotNull(pushGatewayAddress, "Invalid address");
+    }
     this.pushGatewayAddress = pushGatewayAddress;
   }
 

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
 import javax.annotation.Nullable;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.regex.Pattern;
 
 /**
@@ -62,13 +64,30 @@ public class PrometheusEmitterConfig
       @JsonProperty("pushGatewayAddress") @Nullable String pushGatewayAddress
   )
   {
-
     this.strategy = strategy != null ? strategy : Strategy.exporter;
     this.namespace = namespace != null ? namespace : "druid";
     Preconditions.checkArgument(PATTERN.matcher(this.namespace).matches(), "Invalid namespace " + this.namespace);
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
-    this.pushGatewayAddress = pushGatewayAddress;
+    this.pushGatewayAddress = pushGatewayAddress != null ? getValidAddress(pushGatewayAddress): null;
+  }
+
+  private String getValidAddress(String address) {
+    if (address.startsWith("https") || address.startsWith("http")) {
+      return createURLSneakily(address);
+    } else {
+      return address;
+    }
+  }
+
+  private static String createURLSneakily(final String urlString)
+  {
+    try {
+      return String.valueOf(new URL(urlString));
+    }
+    catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public String getNamespace()

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
 import javax.annotation.Nullable;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.regex.Pattern;
 
 /**
@@ -64,31 +62,13 @@ public class PrometheusEmitterConfig
       @JsonProperty("pushGatewayAddress") @Nullable String pushGatewayAddress
   )
   {
+
     this.strategy = strategy != null ? strategy : Strategy.exporter;
     this.namespace = namespace != null ? namespace : "druid";
     Preconditions.checkArgument(PATTERN.matcher(this.namespace).matches(), "Invalid namespace " + this.namespace);
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
-    this.pushGatewayAddress = pushGatewayAddress != null ? getValidAddress(pushGatewayAddress) : null;
-  }
-
-  private String getValidAddress(String address)
-  {
-    if (address.startsWith("https") || address.startsWith("http")) {
-      return createURLSneakily(address);
-    } else {
-      return address;
-    }
-  }
-
-  private static String createURLSneakily(final String urlString)
-  {
-    try {
-      return String.valueOf(new URL(urlString));
-    }
-    catch (MalformedURLException e) {
-      throw new RuntimeException(e);
-    }
+    this.pushGatewayAddress = pushGatewayAddress;
   }
 
   public String getNamespace()

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -109,4 +109,22 @@ public class PrometheusEmitterTest
     emitter.emit(build);
     emitter.flush();
   }
+
+  @Test
+  public void testEmitterStartWithHttpURL()
+  {
+    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, "http://pushgateway");
+    PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
+    pushEmitter.start();
+    Assert.assertNotNull(pushEmitter.getPushGateway());
+  }
+
+  @Test
+  public void testEmitterStartWithHttpsURL()
+  {
+    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace5", null, 0, "https://pushgateway");
+    PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
+    pushEmitter.start();
+    Assert.assertNotNull(pushEmitter.getPushGateway());
+  }
 }

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -111,7 +111,7 @@ public class PrometheusEmitterTest
   }
 
   @Test
-  public void testEmitterStartWithHttpURL()
+  public void testEmitterStartWithHttpUrl()
   {
     PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, "http://pushgateway");
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
@@ -120,7 +120,7 @@ public class PrometheusEmitterTest
   }
 
   @Test
-  public void testEmitterStartWithHttpsURL()
+  public void testEmitterStartWithHttpsUrl()
   {
     PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace5", null, 0, "https://pushgateway");
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -111,6 +111,12 @@ public class PrometheusEmitterTest
   }
 
   @Test
+  public void testEmitterConfigCreationWithNullAsAddress()
+  {
+    Assert.assertThrows(NullPointerException.class, () -> new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, null));
+  }
+
+  @Test
   public void testEmitterStartWithHttpUrl()
   {
     PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, "http://pushgateway");


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description

**In Prometheus-emitter:**
Added support in "https" and "http" pushgateway addresses which means now, users will be able to send URL as pushgateway address.
Also, we faced a problem in which we saw only the last metrics.
Apparently, each metric was sent separately and deleted the previous message.
The solution was to group all metrics and push them together.

### Related Issue - #12199 
<hr>

##### Key changed/added classes in this PR
 * `Prometheus Emitter`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage is met.
