### PR TITLE
upgrade core Apache Kafka dependencies to 3.1.0

### DIFF
--- a/extensions-core/kafka-extraction-namespace/pom.xml
+++ b/extensions-core/kafka-extraction-namespace/pom.xml
@@ -159,21 +159,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>2.13.3</version>

--- a/extensions-core/kafka-extraction-namespace/pom.xml
+++ b/extensions-core/kafka-extraction-namespace/pom.xml
@@ -122,12 +122,6 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/extensions-core/kafka-extraction-namespace/pom.xml
+++ b/extensions-core/kafka-extraction-namespace/pom.xml
@@ -151,12 +151,6 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.objenesis</groupId>
-          <artifactId>objenesis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.Sets;
 import com.google.common.primitives.Bytes;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.server.lookup.namespace.cache.CacheHandler;
+import org.apache.druid.server.lookup.namespace.cache.MockNamespaceExtractionCacheManager;
 import org.apache.druid.server.lookup.namespace.cache.NamespaceExtractionCacheManager;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -37,33 +37,13 @@ import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({
-    NamespaceExtractionCacheManager.class,
-    CacheHandler.class
-})
-@PowerMockIgnore({
-    "javax.management.*",
-    "javax.net.ssl.*",
-    "org.apache.logging.*",
-    "org.slf4j.*",
-    "com.sun.*",
-    "javax.script.*",
-    "jdk.*"
-})
 public class KafkaLookupExtractorFactoryTest
 {
   private static final String TOPIC = "some_topic";
@@ -71,9 +51,7 @@ public class KafkaLookupExtractorFactoryTest
       "some.property", "some.value"
   );
   private final ObjectMapper mapper = new DefaultObjectMapper();
-  private final NamespaceExtractionCacheManager cacheManager = PowerMock.createStrictMock(
-      NamespaceExtractionCacheManager.class);
-  private final CacheHandler cacheHandler = PowerMock.createStrictMock(CacheHandler.class);
+  private final NamespaceExtractionCacheManager cacheManager = MockNamespaceExtractionCacheManager.createMockNamespaceExtractionCacheManager();
 
   @Before
   public void setUp()
@@ -268,14 +246,7 @@ public class KafkaLookupExtractorFactoryTest
   public void testStartStop()
   {
     Consumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-    EasyMock.expect(cacheManager.createCache())
-            .andReturn(cacheHandler)
-            .once();
-    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
-    cacheHandler.close();
-    EasyMock.expectLastCall();
-
-    PowerMock.replay(cacheManager, cacheHandler);
+    EasyMock.replay(cacheManager);
 
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
@@ -295,20 +266,14 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertTrue(factory.getFuture().isDone());
-    PowerMock.verify(cacheManager, cacheHandler);
+    EasyMock.verify(cacheManager);
   }
 
 
   @Test
   public void testStartFailsFromTimeout()
   {
-    EasyMock.expect(cacheManager.createCache())
-            .andReturn(cacheHandler)
-            .once();
-    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
-    cacheHandler.close();
-    EasyMock.expectLastCall();
-    PowerMock.replay(cacheManager, cacheHandler);
+    EasyMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
@@ -333,20 +298,14 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertFalse(factory.start());
     Assert.assertTrue(factory.getFuture().isDone());
     Assert.assertTrue(factory.getFuture().isCancelled());
-    PowerMock.verify(cacheManager, cacheHandler);
+    EasyMock.verify(cacheManager);
   }
 
   @Test
   public void testStartStopStart()
   {
     Consumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-    EasyMock.expect(cacheManager.createCache())
-            .andReturn(cacheHandler)
-            .once();
-    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
-    cacheHandler.close();
-    EasyMock.expectLastCall().once();
-    PowerMock.replay(cacheManager, cacheHandler);
+    EasyMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
@@ -362,20 +321,14 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertFalse(factory.start());
-    PowerMock.verify(cacheManager, cacheHandler);
+    EasyMock.verify(cacheManager);
   }
 
   @Test
   public void testStartStartStopStop()
   {
     Consumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-    EasyMock.expect(cacheManager.createCache())
-            .andReturn(cacheHandler)
-            .once();
-    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
-    cacheHandler.close();
-    EasyMock.expectLastCall().once();
-    PowerMock.replay(cacheManager, cacheHandler);
+    EasyMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
@@ -394,7 +347,7 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertTrue(factory.close());
-    PowerMock.verify(cacheManager, cacheHandler);
+    EasyMock.verify(cacheManager);
   }
 
   @Test
@@ -458,7 +411,7 @@ public class KafkaLookupExtractorFactoryTest
   @Test
   public void testSerDe() throws Exception
   {
-    final NamespaceExtractionCacheManager cacheManager = PowerMock.createStrictMock(NamespaceExtractionCacheManager.class);
+    final NamespaceExtractionCacheManager cacheManager = EasyMock.createStrictMock(NamespaceExtractionCacheManager.class);
     final String kafkaTopic = "some_topic";
     final Map<String, String> kafkaProperties = ImmutableMap.of("some_key", "some_value");
     final long connectTimeout = 999;

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -413,7 +413,7 @@ public class KafkaLookupExtractorFactoryTest
     );
     Assert.assertThrows(
         "bootstrap.servers required property",
-        IAE.class,
+        NullPointerException.class,
         () -> factory.start()
     );
     Assert.assertTrue(factory.close());

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -400,12 +400,6 @@ public class KafkaLookupExtractorFactoryTest
   @Test
   public void testStartFailsOnMissingConnect()
   {
-    EasyMock.expect(cacheManager.createCache())
-            .andReturn(cacheHandler)
-            .once();
-    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
-    cacheHandler.close();
-    PowerMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
@@ -417,18 +411,11 @@ public class KafkaLookupExtractorFactoryTest
         () -> factory.start()
     );
     Assert.assertTrue(factory.close());
-    PowerMock.verify(cacheManager);
   }
 
   @Test
   public void testStartFailsOnGroupID()
   {
-    EasyMock.expect(cacheManager.createCache())
-            .andReturn(cacheHandler)
-            .once();
-    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>());
-    cacheHandler.close();
-    PowerMock.replay(cacheManager, cacheHandler);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
@@ -440,19 +427,11 @@ public class KafkaLookupExtractorFactoryTest
         () -> factory.start()
     );
     Assert.assertTrue(factory.close());
-    PowerMock.verify(cacheManager);
   }
 
   @Test
   public void testStartFailsOnAutoOffset()
   {
-    EasyMock.expect(cacheManager.createCache())
-            .andReturn(cacheHandler)
-            .once();
-    EasyMock.expect(cacheHandler.getCache()).andReturn(new ConcurrentHashMap<>()).once();
-    cacheHandler.close();
-    EasyMock.expectLastCall();
-    PowerMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
@@ -464,7 +443,6 @@ public class KafkaLookupExtractorFactoryTest
         () -> factory.start()
     );
     Assert.assertTrue(factory.close());
-    PowerMock.verify(cacheManager);
   }
 
   @Test

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -157,7 +157,7 @@ public class TestKafkaExtractionCluster
   private Map<String, String> getConsumerProperties()
   {
     final Map<String, String> props = new HashMap<>(KAFKA_PROPERTIES);
-    int port = kafkaServer.socketServer().config().advertisedListeners().apply(0).port();
+    int port = kafkaServer.advertisedListeners().apply(0).port();
     props.put("bootstrap.servers", StringUtils.format("127.0.0.1:%d", port));
     return props;
   }
@@ -201,7 +201,7 @@ public class TestKafkaExtractionCluster
   {
     final Properties kafkaProducerProperties = new Properties();
     kafkaProducerProperties.putAll(KAFKA_PROPERTIES);
-    int port = kafkaServer.socketServer().config().advertisedListeners().apply(0).port();
+    int port = kafkaServer.advertisedListeners().apply(0).port();
     kafkaProducerProperties.put("bootstrap.servers", StringUtils.format("127.0.0.1:%d", port));
     kafkaProducerProperties.put("key.serializer", ByteArraySerializer.class.getName());
     kafkaProducerProperties.put("value.serializer", ByteArraySerializer.class.getName());

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/server/lookup/namespace/cache/MockNamespaceExtractionCacheManager.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/server/lookup/namespace/cache/MockNamespaceExtractionCacheManager.java
@@ -25,7 +25,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class MockNamespaceExtractionCacheManager
 {
-  public static NamespaceExtractionCacheManager createMockNamespaceExtractionCacheManager() {
+  public static NamespaceExtractionCacheManager createMockNamespaceExtractionCacheManager()
+  {
     final NamespaceExtractionCacheManager cacheManager = EasyMock.createStrictMock(NamespaceExtractionCacheManager.class);
     final CacheHandler cacheHandler = new CacheHandler(cacheManager, new ConcurrentHashMap<>(), "cache1");
 

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/server/lookup/namespace/cache/MockNamespaceExtractionCacheManager.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/server/lookup/namespace/cache/MockNamespaceExtractionCacheManager.java
@@ -34,6 +34,8 @@ public class MockNamespaceExtractionCacheManager
             .andReturn(cacheHandler)
             .once();
 
+    // disposeCache is package private, requiring us to have this methoe
+    // in the same package as NamespaceExtractionCacheManager
     cacheManager.disposeCache(cacheHandler);
     EasyMock.expectLastCall().once();
     return cacheManager;

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/server/lookup/namespace/cache/MockNamespaceExtractionCacheManager.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/server/lookup/namespace/cache/MockNamespaceExtractionCacheManager.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.lookup.namespace.cache;
+
+import org.easymock.EasyMock;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockNamespaceExtractionCacheManager
+{
+  public static NamespaceExtractionCacheManager createMockNamespaceExtractionCacheManager() {
+    final NamespaceExtractionCacheManager cacheManager = EasyMock.createStrictMock(NamespaceExtractionCacheManager.class);
+    final CacheHandler cacheHandler = new CacheHandler(cacheManager, new ConcurrentHashMap<>(), "cache1");
+
+    EasyMock.expect(cacheManager.createCache())
+            .andReturn(cacheHandler)
+            .once();
+
+    cacheManager.disposeCache(cacheHandler);
+    EasyMock.expectLastCall().once();
+    return cacheManager;
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/TestBroker.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/test/TestBroker.java
@@ -26,7 +26,6 @@ import org.apache.druid.indexing.kafka.KafkaConsumerConfigs;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.utils.Time;
@@ -95,7 +94,7 @@ public class TestBroker implements Closeable
 
   public int getPort()
   {
-    return server.socketServer().config().advertisedListeners().apply(0).port();
+    return server.advertisedListeners().apply(0).port();
   }
 
   public KafkaProducer<byte[], byte[]> newProducer()
@@ -113,11 +112,6 @@ public class TestBroker implements Closeable
     final Map<String, Object> props = new HashMap<>();
     commonClientProperties(props);
     return props;
-  }
-
-  public KafkaConsumer<byte[], byte[]> newConsumer()
-  {
-    return new KafkaConsumer<>(consumerProperties());
   }
 
   public Map<String, Object> producerProperties()

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3766,7 +3766,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 3.0.0
+version: 3.1.0
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -4676,7 +4676,7 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 3.0.0
+version: 3.1.0
 libraries:
   - org.apache.kafka: kafka-clients
 notices:

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>4.3.0</apache.curator.version>
-        <apache.curator.test.version>2.12.0</apache.curator.test.version>
         <apache.kafka.version>3.1.0</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
@@ -981,7 +980,7 @@
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-test</artifactId>
-                <version>${apache.curator.test.version}</version>
+                <version>${apache.curator.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>4.3.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
-        <apache.kafka.version>3.0.0</apache.kafka.version>
+        <apache.kafka.version>3.1.0</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
         <avatica.version>1.17.0</avatica.version>

--- a/pom.xml
+++ b/pom.xml
@@ -921,7 +921,7 @@
             <dependency>
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
-                <version>4.2</version>
+                <version>4.3</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Announcement: https://blogs.apache.org/kafka/entry/what-s-new-in-apache7
Release notes: https://dist.apache.org/repos/dist/release/kafka/3.1.0/RELEASE_NOTES.html

* upgrade core Apache Kafka dependencies to 3.1.0
* fix use of private Kafka APIs
* remove deprecated test rules
* remove mock calls that weren't verified in the first place
* remove the need for powermock in KafkaLookupExtractorFactoryTest
* align curator-test version with curator itself
* update easymock to 4.3.0