### PR TITLE
use reflection to check for mysql transient exception type

### DIFF
--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -35,6 +35,7 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.util.StringMapper;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.sql.SQLException;
 
@@ -47,6 +48,7 @@ public class MySQLConnector extends SQLMetadataConnector
   private static final String COLLATION = "CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
   private static final String MYSQL_TRANSIENT_EXCEPTION_CLASS_NAME = "com.mysql.jdbc.exceptions.MySQLTransientException";
 
+  private final Class<?> myTransientExceptionClass;
   private final DBI dbi;
 
   @Inject
@@ -58,17 +60,13 @@ public class MySQLConnector extends SQLMetadataConnector
   )
   {
     super(config, dbTables);
-    try {
-      log.info("Loading \"MySQL\" metadata connector driver %s", driverConfig.getDriverClassName());
-      Class.forName(driverConfig.getDriverClassName(), false, getClass().getClassLoader());
-    }
-    catch (ClassNotFoundException e) {
-      throw new ISE(e, "Could not find %s on the classpath. The MySQL Connector library is not included in the Druid "
-                   + "distribution but is required to use MySQL. Please download a compatible library (for example "
-                   + "'mysql-connector-java-5.1.48.jar') and place it under 'extensions/mysql-metadata-storage/'. See "
-                   + "https://druid.apache.org/downloads for more details.",
-                    driverConfig.getDriverClassName()
-      );
+    log.info("Loading \"MySQL\" metadata connector driver %s", driverConfig.getDriverClassName());
+    tryLoadDriverClass(driverConfig.getDriverClassName());
+
+    if (driverConfig.getDriverClassName().contains("mysql")) {
+      myTransientExceptionClass = tryLoadDriverClass(MYSQL_TRANSIENT_EXCEPTION_CLASS_NAME);
+    } else {
+      myTransientExceptionClass = null;
     }
 
     final BasicDataSource datasource = getDatasource();
@@ -206,7 +204,7 @@ public class MySQLConnector extends SQLMetadataConnector
   @Override
   protected boolean connectorIsTransientException(Throwable e)
   {
-    return isTransientException(getClass().getClassLoader(), getDatasource().getDriverClassName(), e);
+    return isTransientException(myTransientExceptionClass, e);
   }
 
   @Override
@@ -242,17 +240,27 @@ public class MySQLConnector extends SQLMetadataConnector
     return dbi;
   }
 
-  @VisibleForTesting
-  static boolean isTransientException(ClassLoader classLoader, String driverName, Throwable e)
+  private Class<?> tryLoadDriverClass(String className)
   {
-    if (driverName.contains("mysql")) {
-      try {
-        Class<?> clazz = Class.forName(MYSQL_TRANSIENT_EXCEPTION_CLASS_NAME, false, classLoader);
-        return e.getClass().equals(clazz)
-               || e instanceof SQLException && ((SQLException) e).getErrorCode() == 1317 /* ER_QUERY_INTERRUPTED */;
-      }
-      catch (ClassNotFoundException ignored) {
-      }
+    try {
+      return Class.forName(className, false, getClass().getClassLoader());
+    }
+    catch (ClassNotFoundException e) {
+      throw new ISE(e, "Could not find %s on the classpath. The MySQL Connector library is not included in the Druid "
+                       + "distribution but is required to use MySQL. Please download a compatible library (for example "
+                       + "'mysql-connector-java-5.1.48.jar') and place it under 'extensions/mysql-metadata-storage/'. See "
+                       + "https://druid.apache.org/downloads for more details.",
+                    className
+      );
+    }
+  }
+
+  @VisibleForTesting
+  static boolean isTransientException(@Nullable Class<?> driverClazz, Throwable e)
+  {
+    if (driverClazz != null) {
+      return driverClazz.isAssignableFrom(e.getClass())
+             || e instanceof SQLException && ((SQLException) e).getErrorCode() == 1317 /* ER_QUERY_INTERRUPTED */;
     }
     return false;
   }

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -48,6 +48,7 @@ public class MySQLConnector extends SQLMetadataConnector
   private static final String COLLATION = "CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
   private static final String MYSQL_TRANSIENT_EXCEPTION_CLASS_NAME = "com.mysql.jdbc.exceptions.MySQLTransientException";
 
+  @Nullable
   private final Class<?> myTransientExceptionClass;
   private final DBI dbi;
 

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.metadata.storage.mysql;
+
+import com.mysql.jdbc.exceptions.MySQLTransientException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.sql.SQLTransientConnectionException;
+
+public class MySQLConnectorTest
+{
+  @Test
+  public void testIsExceptionTransient()
+  {
+    final String driver = "com.mysql.jdbc.Driver";
+    final ClassLoader loader = getClass().getClassLoader();
+    Assert.assertTrue(MySQLConnector.isTransientException(loader, driver, new MySQLTransientException()));
+    Assert.assertTrue(
+        MySQLConnector.isTransientException(loader, driver, new SQLException("some transient failure", "wtf", 1317))
+    );
+    Assert.assertFalse(
+        MySQLConnector.isTransientException(loader, driver, new SQLException("totally realistic test data", "wtf", 1337))
+    );
+    // this method does not specially handle normal transient exceptions either, since it is not vendor specific
+    Assert.assertFalse(
+        MySQLConnector.isTransientException(loader, driver, new SQLTransientConnectionException("transient"))
+    );
+  }
+}

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -171,6 +171,9 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                          || (e instanceof DBIException && isTransientException(e.getCause())));
   }
 
+  /**
+   * Vendor specific errors that are not covered by {@link #isTransientException(Throwable)}
+   */
   protected boolean connectorIsTransientException(Throwable e)
   {
     return false;


### PR DESCRIPTION
Missed this in #11402, this change will make the `MySQLConnector` implementation of `SQLMetadataConnector.connectorIsTransientException` not explode when using MariaDB driver (and added javadocs that only vendor specific errors need handled here). I poked around the MariaDB connector and didn't find any obvious custom transient exceptions to add here for it.