### PR TITLE
Fix compile error in VirtualizedColumnSelectorFactoryTest

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/virtual/VirtualizedColumnSelectorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/VirtualizedColumnSelectorFactoryTest.java
@@ -40,7 +40,7 @@ public class VirtualizedColumnSelectorFactoryTest extends InitializedNullHandlin
       RowBasedColumnSelectorFactory.create(
           RowAdapters.standardRow(),
           () -> new MapBasedRow(0L, ImmutableMap.of("x", 10L, "y", 20.0)),
-          () -> RowSignature.builder().add("x", ColumnType.LONG).add("y", ColumnType.DOUBLE).build(),
+          RowSignature.builder().add("x", ColumnType.LONG).add("y", ColumnType.DOUBLE).build(),
           false
       ),
       VirtualColumns.create(


### PR DESCRIPTION
### Description

Compiling the master branch fails because of a wrong parameter passed in `RowBasedColumnSelectorFactory` in `VirtualizedColumnSelectorFactoryTest`.

<hr>

This PR has:
- [x] been self-reviewed.
