### PR TITLE
add backwards compatibility mode for multi-value string array null value coercion

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/ExpressionProcessing.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExpressionProcessing.java
@@ -48,13 +48,19 @@ public class ExpressionProcessing
   @VisibleForTesting
   public static void initializeForTests(@Nullable Boolean allowNestedArrays)
   {
-    INSTANCE = new ExpressionProcessingConfig(allowNestedArrays, null, null);
+    INSTANCE = new ExpressionProcessingConfig(allowNestedArrays, null, null, null);
   }
 
   @VisibleForTesting
   public static void initializeForStrictBooleansTests(boolean useStrict)
   {
-    INSTANCE = new ExpressionProcessingConfig(null, useStrict, null);
+    INSTANCE = new ExpressionProcessingConfig(null, useStrict, null, null);
+  }
+
+  @VisibleForTesting
+  public static void initializeForHomogenizeNullMultiValueStrings()
+  {
+    INSTANCE = new ExpressionProcessingConfig(null, null, null, true);
   }
 
   /**
@@ -62,35 +68,47 @@ public class ExpressionProcessing
    */
   public static boolean allowNestedArrays()
   {
-    // this should only be null in a unit test context
-    // in production this will be injected by the expression processing module
-    if (INSTANCE == null) {
-      throw new IllegalStateException(
-          "Expressions module not initialized, call ExpressionProcessing.initializeForTests()"
-      );
-    }
+    checkInitialized();
     return INSTANCE.allowNestedArrays();
   }
 
-
+  /**
+   * All boolean expressions are {@link ExpressionType#LONG}
+   */
   public static boolean useStrictBooleans()
   {
-    // this should only be null in a unit test context, in production this will be injected by the null handling module
-    if (INSTANCE == null) {
-      throw new IllegalStateException("ExpressionProcessing module not initialized, call ExpressionProcessing.initializeForTests()");
-    }
+    checkInitialized();
     return INSTANCE.isUseStrictBooleans();
   }
 
-
+  /**
+   * All {@link ExprType#ARRAY} values will be converted to {@link ExpressionType#STRING} by their column selectors
+   * (not within expression processing) to be treated as multi-value strings instead of native arrays.
+   */
   public static boolean processArraysAsMultiValueStrings()
+  {
+    checkInitialized();
+    return INSTANCE.processArraysAsMultiValueStrings();
+  }
+
+  /**
+   * All multi-value string expression input values of 'null', '[]', and '[null]' will be coerced to '[null]'. If false,
+   * (the default) this will only be done when single value expressions are implicitly mapped across multi-value rows,
+   * so that the single valued expression will always be evaluated with an input value of 'null'
+   */
+  public static boolean isHomogenizeNullMultiValueStringArrays()
+  {
+    checkInitialized();
+    return INSTANCE.isHomogenizeNullMultiValueStringArrays();
+  }
+
+  private static void checkInitialized()
   {
     // this should only be null in a unit test context, in production this will be injected by the null handling module
     if (INSTANCE == null) {
       throw new IllegalStateException(
-          "ExpressionProcessing module not initialized, call ExpressionProcessing.initializeForTests()"
+          "ExpressionProcessing module not initialized, call ExpressionProcessing.initializeForTests() or one of its variants"
       );
     }
-    return INSTANCE.processArraysAsMultiValueStrings();
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.sql.calcite;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import junitparams.JUnitParamsRunner;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IAE;
@@ -56,7 +55,6 @@ import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.sql.calcite.filtration.Filtration;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,7 +63,6 @@ import java.util.List;
 /**
  * Tests for array functions and array types
  */
-@RunWith(JUnitParamsRunner.class)
 public class CalciteArraysQueryTest extends BaseCalciteQueryTest
 {
   // test some query stuffs, sort of limited since no native array column types so either need to use constructor or

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteParameterQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteParameterQueryTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.sql.calcite;
 
 import com.google.common.collect.ImmutableList;
-import junitparams.JUnitParamsRunner;
 import org.apache.calcite.avatica.SqlType;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.DateTimes;
@@ -43,7 +42,6 @@ import org.apache.druid.sql.calcite.filtration.Filtration;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.sql.http.SqlParameter;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +52,6 @@ import java.util.List;
  * were merely chosen to produce a selection of parameter types and positions within query expressions and have been
  * renamed to reflect this
  */
-@RunWith(JUnitParamsRunner.class)
 public class CalciteParameterQueryTest extends BaseCalciteQueryTest
 {
   @Test


### PR DESCRIPTION

### Description

Follow up to #12078, adds `druid.expressions.homogenizeNullMultiValueStringArrays` with a default value of 'false'. If set to true, it opens an escape hatch to a backwards compatibility mode for the 'buggy' behavior of some multi-value string array functions such as `MV_APPEND` which was fixed in #12078. Prior to that PR, all `null`, `[]`, and `[null]` values were treated as `[null]`, which was only intended for implicitly mapped single value expression across multi-valued string rows, and could produce unintuitive results. This option has been added in case anyone happened to be depending on that behavior, but it produces odd behavior that impacts all array expressions, so it is not recommended to set this flag to true if possible, and instead add a workaround by coercing the values explicitly with additional expressions if needed.


<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
