### PR TITLE
Reduce RemoteTaskRunnerTest flakiness

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -223,7 +223,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
       return;
     }
     try {
-      log.info("Starting...");
+      log.info("Starting RemoteTaskRunner...");
       final MutableInt waitingFor = new MutableInt(1);
       final Object waitingForMonitor = new Object();
 
@@ -351,7 +351,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
       return;
     }
     try {
-      log.info("Stopping...");
+      log.info("Stopping RemoteTaskRunner...");
       provisioningService.close();
 
       Closer closer = Closer.create();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -223,6 +223,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
       return;
     }
     try {
+      log.info("Starting...");
       final MutableInt waitingFor = new MutableInt(1);
       final Object waitingForMonitor = new Object();
 
@@ -350,6 +351,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
       return;
     }
     try {
+      log.info("Stopping...");
       provisioningService.close();
 
       Closer closer = Closer.create();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -76,6 +76,9 @@ public class RemoteTaskRunnerTest
   private static final String ANNOUCEMENTS_PATH = JOINER.join(RemoteTaskRunnerTestUtils.ANNOUNCEMENTS_PATH, WORKER_HOST);
   private static final String STATUS_PATH = JOINER.join(RemoteTaskRunnerTestUtils.STATUS_PATH, WORKER_HOST);
 
+  // higher timeout to reduce flakiness on CI pipeline
+  private static final Period TIMEOUT_PERIOD = Period.millis(30000);
+
   private RemoteTaskRunner remoteTaskRunner;
   private RemoteTaskRunnerTestUtils rtrTestUtils = new RemoteTaskRunnerTestUtils();
   private ObjectMapper jsonMapper;
@@ -175,7 +178,7 @@ public class RemoteTaskRunnerTest
   @Test
   public void testStartWithNoWorker()
   {
-    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(new Period("PT1S")));
+    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD));
   }
 
   @Test
@@ -386,10 +389,9 @@ public class RemoteTaskRunnerTest
   @Test
   public void testBootstrap() throws Exception
   {
-    Period timeoutPeriod = Period.millis(1000);
     makeWorker();
 
-    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD);
     rtrConfig.setMaxPercentageBlacklistWorkers(100);
 
     makeRemoteTaskRunner(rtrConfig);
@@ -532,7 +534,7 @@ public class RemoteTaskRunnerTest
     Assert.assertTrue(workerRunningTask(task.getId()));
 
     remoteTaskRunner.stop();
-    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(new Period("PT5S")));
+    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD));
     final RemoteTaskRunnerWorkItem newWorkItem = remoteTaskRunner
         .getKnownTasks()
         .stream()
@@ -569,7 +571,7 @@ public class RemoteTaskRunnerTest
   public void testRunPendingTaskTimeoutToAssign() throws Exception
   {
     makeWorker();
-    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(new Period("PT1S")));
+    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD));
     RemoteTaskRunnerWorkItem workItem = remoteTaskRunner.addPendingTask(task);
     remoteTaskRunner.runPendingTask(workItem);
     TaskStatus taskStatus = workItem.getResult().get(0, TimeUnit.MILLISECONDS);
@@ -583,7 +585,7 @@ public class RemoteTaskRunnerTest
   private void doSetup() throws Exception
   {
     makeWorker();
-    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(new Period("PT5S")));
+    makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD));
   }
 
   private void makeRemoteTaskRunner(RemoteTaskRunnerConfig config)
@@ -792,10 +794,9 @@ public class RemoteTaskRunnerTest
   @Test
   public void testBlacklistZKWorkers() throws Exception
   {
-    Period timeoutPeriod = Period.millis(1000);
     makeWorker();
 
-    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD);
     rtrConfig.setMaxPercentageBlacklistWorkers(100);
 
     makeRemoteTaskRunner(rtrConfig);
@@ -843,7 +844,7 @@ public class RemoteTaskRunnerTest
     Assert.assertEquals(1, remoteTaskRunner.getBlackListedWorkers().size());
 
     ((RemoteTaskRunnerTestUtils.TestableRemoteTaskRunner) remoteTaskRunner)
-        .setCurrentTimeMillis(System.currentTimeMillis() + 2 * timeoutPeriod.toStandardDuration().getMillis());
+        .setCurrentTimeMillis(System.currentTimeMillis() + 2 * TIMEOUT_PERIOD.toStandardDuration().getMillis());
     remoteTaskRunner.checkBlackListedNodes();
 
     // After backOffTime the nodes are removed from blacklist
@@ -879,12 +880,10 @@ public class RemoteTaskRunnerTest
   @Test
   public void testBlacklistZKWorkers25Percent() throws Exception
   {
-    Period timeoutPeriod = Period.millis(1000);
-
     rtrTestUtils.makeWorker("worker", 10);
     rtrTestUtils.makeWorker("worker2", 10);
 
-    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD);
     rtrConfig.setMaxPercentageBlacklistWorkers(25);
 
     makeRemoteTaskRunner(rtrConfig);
@@ -936,12 +935,10 @@ public class RemoteTaskRunnerTest
   @Test
   public void testBlacklistZKWorkers50Percent() throws Exception
   {
-    Period timeoutPeriod = Period.millis(1000);
-
     rtrTestUtils.makeWorker("worker", 10);
     rtrTestUtils.makeWorker("worker2", 10);
 
-    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD);
     rtrConfig.setMaxPercentageBlacklistWorkers(50);
 
     makeRemoteTaskRunner(rtrConfig);
@@ -989,10 +986,9 @@ public class RemoteTaskRunnerTest
   @Test
   public void testSuccessfulTaskOnBlacklistedWorker() throws Exception
   {
-    Period timeoutPeriod = Period.millis(1000);
     makeWorker();
 
-    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(timeoutPeriod);
+    RemoteTaskRunnerConfig rtrConfig = new TestRemoteTaskRunnerConfig(TIMEOUT_PERIOD);
     rtrConfig.setMaxPercentageBlacklistWorkers(100);
 
     makeRemoteTaskRunner(rtrConfig);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -43,6 +43,7 @@ import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
@@ -56,6 +57,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -67,6 +70,7 @@ import java.util.concurrent.TimeUnit;
 
 public class RemoteTaskRunnerTest
 {
+  private static final Logger LOG = new Logger(RemoteTaskRunnerTest.class);
   private static final Joiner JOINER = RemoteTaskRunnerTestUtils.JOINER;
   private static final String WORKER_HOST = "worker";
   private static final String ANNOUCEMENTS_PATH = JOINER.join(RemoteTaskRunnerTestUtils.ANNOUNCEMENTS_PATH, WORKER_HOST);
@@ -79,6 +83,24 @@ public class RemoteTaskRunnerTest
 
   private Task task;
   private Worker worker;
+
+  @Rule
+  public TestRule watcher = new TestWatcher() {
+    @Override
+    protected void starting(Description description)
+    {
+      LOG.info("Starting test: " + description.getMethodName());
+    }
+
+    @Override
+    protected void finished(Description description)
+    {
+      LOG.info("Finishing test: " + description.getMethodName());
+    }
+  };
+
+
+
 
   @Rule
   public final TestRule timeout = new DeadlockDetectingTimeout(60, TimeUnit.SECONDS);


### PR DESCRIPTION
It was found that tests in this test class occasionally fail because the certain work expected to be completed isn't done within the timeout period, 1 second. These failures are seen more often when the CI system is under heavy load. The thread that is responsible for doing the work that is best tested may not have  chance to run within this period of time. The timeout period is configured to be 5 minutes by default in production, so changing the timeout to the test to be something more reasonable, 30 seconds.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
