### PR TITLE
Web console: Adding a shard detail column to the segments view

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5813,7 +5813,7 @@ license_category: binary
 module: web-console
 license_name: MIT License
 copyright: Vadim Ogievetsky, Andrey Sidorov
-version: 1.1.0
+version: 1.2.0
 license_file_path: licenses/bin/json-bigint-native.MIT
 
 ---

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -14771,9 +14771,9 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-bigint-native": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/json-bigint-native/-/json-bigint-native-1.1.0.tgz",
-      "integrity": "sha512-PPL9AlDP0ift5v8siEsR7oQsamOAIOLjn14GRaijZRUWDXsJC5rHXNlmtLPkPjK0k2i5yHK30VPqiFTZHolXaA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/json-bigint-native/-/json-bigint-native-1.2.0.tgz",
+      "integrity": "sha512-qC9EtJsyULhbwC2KEYoR8sRsC+PH7VwwPdxU6+CZTZxMtM23zlxCfhIa+6Sn74FQ4VqDqWUaHaBeU0bMUTU9jQ=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -85,7 +85,7 @@
     "fontsource-open-sans": "^3.0.9",
     "has-own-prop": "^2.0.0",
     "hjson": "^3.2.1",
-    "json-bigint-native": "^1.1.0",
+    "json-bigint-native": "^1.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.escape": "^4.0.1",
     "memoize-one": "^5.1.1",

--- a/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
+++ b/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
@@ -45,6 +45,7 @@ exports[`AutoForm matches snapshot 1`] = `
   >
     <Memo(SuggestibleInput)
       disabled={false}
+      multiline={false}
       onBlur={[Function]}
       onValueChange={[Function]}
       placeholder=""
@@ -57,6 +58,20 @@ exports[`AutoForm matches snapshot 1`] = `
   >
     <Memo(SuggestibleInput)
       disabled={false}
+      multiline={false}
+      onBlur={[Function]}
+      onValueChange={[Function]}
+      placeholder=""
+      value="Hello World"
+    />
+  </Memo(FormGroupWithInfo)>
+  <Memo(FormGroupWithInfo)
+    key="testStringWithMultiline"
+    label="Test string with multiline"
+  >
+    <Memo(SuggestibleInput)
+      disabled={false}
+      multiline={true}
       onBlur={[Function]}
       onValueChange={[Function]}
       placeholder=""
@@ -148,6 +163,7 @@ exports[`AutoForm matches snapshot 1`] = `
     <Memo(SuggestibleInput)
       disabled={false}
       intent="primary"
+      multiline={false}
       onBlur={[Function]}
       onValueChange={[Function]}
       placeholder=""

--- a/web-console/src/components/auto-form/auto-form.spec.tsx
+++ b/web-console/src/components/auto-form/auto-form.spec.tsx
@@ -32,6 +32,12 @@ describe('AutoForm', () => {
           { name: 'testSizeBytes', type: 'size-bytes' },
           { name: 'testString', type: 'string' },
           { name: 'testStringWithDefault', type: 'string', defaultValue: 'Hello World' },
+          {
+            name: 'testStringWithMultiline',
+            type: 'string',
+            multiline: true,
+            defaultValue: 'Hello World',
+          },
           { name: 'testBoolean', type: 'boolean' },
           { name: 'testBooleanWithDefault', type: 'boolean', defaultValue: false },
           { name: 'testStringArray', type: 'string-array' },

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -57,6 +57,7 @@ export interface Field<M> {
   disabled?: Functor<M, boolean>;
   defined?: Functor<M, boolean>;
   required?: Functor<M, boolean>;
+  multiline?: Functor<M, boolean>;
   hide?: Functor<M, boolean>;
   hideInMore?: Functor<M, boolean>;
   valueAdjustment?: (value: any) => any;
@@ -303,6 +304,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         large={large}
         disabled={AutoForm.evaluateFunctor(field.disabled, model, false)}
         intent={required && modelValue == null ? AutoForm.REQUIRED_INTENT : undefined}
+        multiline={AutoForm.evaluateFunctor(field.multiline, model, false)}
       />
     );
   }

--- a/web-console/src/components/formatted-input/__snapshots__/formatted-input.spec.tsx.snap
+++ b/web-console/src/components/formatted-input/__snapshots__/formatted-input.spec.tsx.snap
@@ -31,3 +31,15 @@ exports[`FormattedInput matches snapshot with escaped value 1`] = `
   </div>
 </div>
 `;
+
+exports[`FormattedInput matches works with multiline 1`] = `
+<div
+  class="formatted-input"
+>
+  <textarea
+    class="bp3-input"
+  >
+    Here are some chars \\t\\r\\n lol
+  </textarea>
+</div>
+`;

--- a/web-console/src/components/formatted-input/formatted-input.scss
+++ b/web-console/src/components/formatted-input/formatted-input.scss
@@ -26,4 +26,9 @@
     top: 0;
     bottom: 0;
   }
+
+  textarea {
+    width: 100%;
+    resize: vertical;
+  }
 }

--- a/web-console/src/components/formatted-input/formatted-input.spec.tsx
+++ b/web-console/src/components/formatted-input/formatted-input.spec.tsx
@@ -45,4 +45,18 @@ describe('FormattedInput', () => {
     const { container } = render(suggestibleInput);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('matches works with multiline', () => {
+    const suggestibleInput = (
+      <FormattedInput
+        value={`Here are some chars \t\r\n lol`}
+        onValueChange={() => {}}
+        formatter={JSON_STRING_FORMATTER}
+        multiline
+      />
+    );
+
+    const { container } = render(suggestibleInput);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/web-console/src/druid-models/ingestion-spec.spec.ts
+++ b/web-console/src/druid-models/ingestion-spec.spec.ts
@@ -330,6 +330,185 @@ describe('ingestion-spec', () => {
     });
   });
 
+  it('upgrades / downgrades back compat supervisor spec', () => {
+    const backCompatSupervisorSpec = {
+      type: 'kafka',
+      spec: {
+        dataSchema: {
+          dataSource: 'metrics-kafka',
+          parser: {
+            type: 'string',
+            parseSpec: {
+              format: 'json',
+              timestampSpec: {
+                column: 'timestamp',
+                format: 'auto',
+              },
+              dimensionsSpec: {
+                dimensions: [],
+                dimensionExclusions: ['timestamp', 'value'],
+              },
+            },
+          },
+          metricsSpec: [
+            {
+              name: 'count',
+              type: 'count',
+            },
+            {
+              name: 'value_sum',
+              fieldName: 'value',
+              type: 'doubleSum',
+            },
+            {
+              name: 'value_min',
+              fieldName: 'value',
+              type: 'doubleMin',
+            },
+            {
+              name: 'value_max',
+              fieldName: 'value',
+              type: 'doubleMax',
+            },
+          ],
+          granularitySpec: {
+            type: 'uniform',
+            segmentGranularity: 'HOUR',
+            queryGranularity: 'NONE',
+          },
+        },
+        tuningConfig: {
+          type: 'kafka',
+          maxRowsPerSegment: 5000000,
+        },
+        ioConfig: {
+          topic: 'metrics',
+          consumerProperties: {
+            'bootstrap.servers': 'localhost:9092',
+          },
+          taskCount: 1,
+          replicas: 1,
+          taskDuration: 'PT1H',
+        },
+      },
+      dataSchema: {
+        dataSource: 'metrics-kafka',
+        parser: {
+          type: 'string',
+          parseSpec: {
+            format: 'json',
+            timestampSpec: {
+              column: 'timestamp',
+              format: 'auto',
+            },
+            dimensionsSpec: {
+              dimensions: [],
+              dimensionExclusions: ['timestamp', 'value'],
+            },
+          },
+        },
+        metricsSpec: [
+          {
+            name: 'count',
+            type: 'count',
+          },
+          {
+            name: 'value_sum',
+            fieldName: 'value',
+            type: 'doubleSum',
+          },
+          {
+            name: 'value_min',
+            fieldName: 'value',
+            type: 'doubleMin',
+          },
+          {
+            name: 'value_max',
+            fieldName: 'value',
+            type: 'doubleMax',
+          },
+        ],
+        granularitySpec: {
+          type: 'uniform',
+          segmentGranularity: 'HOUR',
+          queryGranularity: 'NONE',
+        },
+      },
+      tuningConfig: {
+        type: 'kafka',
+        maxRowsPerSegment: 5000000,
+      },
+      ioConfig: {
+        topic: 'metrics',
+        consumerProperties: {
+          'bootstrap.servers': 'localhost:9092',
+        },
+        taskCount: 1,
+        replicas: 1,
+        taskDuration: 'PT1H',
+      },
+    };
+
+    expect(cleanSpec(upgradeSpec(backCompatSupervisorSpec))).toEqual({
+      spec: {
+        dataSchema: {
+          dataSource: 'metrics-kafka',
+          dimensionsSpec: {
+            dimensionExclusions: ['timestamp', 'value'],
+            dimensions: [],
+          },
+          granularitySpec: {
+            queryGranularity: 'NONE',
+            segmentGranularity: 'HOUR',
+            type: 'uniform',
+          },
+          metricsSpec: [
+            {
+              name: 'count',
+              type: 'count',
+            },
+            {
+              fieldName: 'value',
+              name: 'value_sum',
+              type: 'doubleSum',
+            },
+            {
+              fieldName: 'value',
+              name: 'value_min',
+              type: 'doubleMin',
+            },
+            {
+              fieldName: 'value',
+              name: 'value_max',
+              type: 'doubleMax',
+            },
+          ],
+          timestampSpec: {
+            column: 'timestamp',
+            format: 'auto',
+          },
+        },
+        ioConfig: {
+          consumerProperties: {
+            'bootstrap.servers': 'localhost:9092',
+          },
+          inputFormat: {
+            type: 'json',
+          },
+          replicas: 1,
+          taskCount: 1,
+          taskDuration: 'PT1H',
+          topic: 'metrics',
+        },
+        tuningConfig: {
+          maxRowsPerSegment: 5000000,
+          type: 'kafka',
+        },
+      },
+      type: 'kafka',
+    });
+  });
+
   it('cleanSpec', () => {
     expect(
       cleanSpec({

--- a/web-console/src/druid-models/ingestion-spec.spec.ts
+++ b/web-console/src/druid-models/ingestion-spec.spec.ts
@@ -630,6 +630,10 @@ describe('spec utils', () => {
       expect(guessColumnTypeFromInput(['a', ['b'], 'c'], false)).toEqual('string');
       expect(guessColumnTypeFromInput([1, [2], 3], false)).toEqual('string');
     });
+
+    it('works for strange input (object with no prototype)', () => {
+      expect(guessColumnTypeFromInput([1, Object.create(null), 3], false)).toEqual('string');
+    });
   });
 
   describe('guessColumnTypeFromHeaderAndRows', () => {

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -250,7 +250,7 @@ export async function sampleForConnect(
   if (!reingestMode) {
     ioConfig = deepSet(ioConfig, 'inputFormat', {
       type: 'regex',
-      pattern: '(.*)',
+      pattern: '([\\s\\S]*)', // Match the entire line, every single character
       listDelimiter: '56616469-6de2-9da4-efb8-8f416e6e6965', // Just a UUID to disable the list delimiter, let's hope we do not see this UUID in the data
       columns: ['raw'],
     });

--- a/web-console/src/views/segments-view/__snapshots__/segments-view.spec.tsx.snap
+++ b/web-console/src/views/segments-view/__snapshots__/segments-view.spec.tsx.snap
@@ -56,6 +56,7 @@ exports[`SegmentsView matches snapshot 1`] = `
             "Version",
             "Time span",
             "Partitioning",
+            "Shard detail",
             "Partition",
             "Size",
             "Num rows",
@@ -74,6 +75,7 @@ exports[`SegmentsView matches snapshot 1`] = `
           Array [
             "Time span",
             "Partitioning",
+            "Shard detail",
           ]
         }
       />
@@ -205,6 +207,15 @@ exports[`SegmentsView matches snapshot 1`] = `
             "show": false,
             "sortable": true,
             "width": 100,
+          },
+          Object {
+            "Cell": [Function],
+            "Header": "Shard detail",
+            "accessor": "shard_spec",
+            "filterable": false,
+            "show": false,
+            "sortable": false,
+            "width": 400,
           },
           Object {
             "Header": "Partition",

--- a/web-console/src/views/segments-view/segments-view.scss
+++ b/web-console/src/views/segments-view/segments-view.scss
@@ -31,6 +31,17 @@
     .-totalPages {
       display: none;
     }
+
+    .range-detail {
+      cursor: default;
+
+      .range-label {
+        display: inline-block;
+        width: 35px;
+        text-align: right;
+        margin-right: 5px;
+      }
+    }
   }
 
   &.show-segment-timeline {


### PR DESCRIPTION
Makes the segments look beautiful with `range` or `single_dim` partitioning by rendering the segment boundaries.

![image](https://user-images.githubusercontent.com/177816/151641976-a5435436-282b-4673-be1c-f045bbfedf49.png)

Also fixes a small bug is spec cleanup and prevents an issue around `JSONBig` returning objects with no prototype by doing `Object.create(null)` internally.
