### PR TITLE
Support extension server commands

### DIFF
--- a/core/src/main/java/org/apache/druid/cli/CliCommandCreator.java
+++ b/core/src/main/java/org/apache/druid/cli/CliCommandCreator.java
@@ -22,6 +22,8 @@ package org.apache.druid.cli;
 import io.airlift.airline.Cli;
 import org.apache.druid.guice.annotations.ExtensionPoint;
 
+import java.util.List;
+
 /**
  * An extension point to create a custom Druid service. Druid can understand and execute custom commands
  * to run services loaded via Druid's extension system (see {@code Initialization#getFromExtensions}). See
@@ -32,5 +34,14 @@ import org.apache.druid.guice.annotations.ExtensionPoint;
 @ExtensionPoint
 public interface CliCommandCreator
 {
-  void addCommands(Cli.CliBuilder builder);
+  void addCommands(Cli.CliBuilder<Runnable> builder);
+
+  /**
+   * Add an extension server. Note that the server should be of type
+   * {@code ServerRunnable}, but that class is not visible here.
+   */
+  default List<Class<? extends Runnable>> servers()
+  {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
+++ b/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
@@ -61,7 +61,7 @@ public class LifecycleModule implements Module
    * is materialized and injected, meaning that objects are not actually instantiated in dependency order.
    * Registering with the LifecyceModule, on the other hand, will instantiate the objects after the normal object
    * graph has already been instantiated, meaning that objects will be created in dependency order and this will
-   * only actually instantiate something that wasn't actually dependend upon.
+   * only actually instantiate something that wasn't actually depended upon.
    *
    * @param clazz the class to instantiate
    * @return this, for chaining.
@@ -85,7 +85,7 @@ public class LifecycleModule implements Module
    * is materialized and injected, meaning that objects are not actually instantiated in dependency order.
    * Registering with the LifecyceModule, on the other hand, will instantiate the objects after the normal object
    * graph has already been instantiated, meaning that objects will be created in dependency order and this will
-   * only actually instantiate something that wasn't actually dependend upon.
+   * only actually instantiate something that wasn't actually depended upon.
    *
    * @param clazz the class to instantiate
    * @param annotation The annotation class to register with Guice
@@ -110,7 +110,7 @@ public class LifecycleModule implements Module
    * is materialized and injected, meaning that objects are not actually instantiated in dependency order.
    * Registering with the LifecyceModule, on the other hand, will instantiate the objects after the normal object
    * graph has already been instantiated, meaning that objects will be created in dependency order and this will
-   * only actually instantiate something that wasn't actually dependend upon.
+   * only actually instantiate something that wasn't actually depended upon.
    *
    * @param key The key to use in finding the DruidNode instance
    */

--- a/core/src/main/java/org/apache/druid/guice/annotations/PrivateApi.java
+++ b/core/src/main/java/org/apache/druid/guice/annotations/PrivateApi.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.guice.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that the annotated entity private API. Primarily used for internal REST
+ * endpoints to indicate that they are not part of the documented public API.
+ */
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Retention(RetentionPolicy.SOURCE)
+public @interface PrivateApi
+{
+}


### PR DESCRIPTION
### Description

See [Support Services in Extensions](https://github.com/apache/druid/issues/12218). Adds the support for an extension service in the `Main` routine, and provides the `PrivateApi` annotation to mark extension service REST endpoints as private.

This PR allows launching an extension service as:

`<druid> server <extn>`

As it turns out, an extension service can be added more simply: just by introducing a new command. However the resulting command is:

`<druid> <extn>`

Which introduces an odd asymmetry between built-in and extension servers. The proposed solution allows extension services to work identically to built-in services.

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] been tested in a test Druid cluster (as part of the extension in question: hard to test by itself).
