### PR TITLE
Fix a few small errors in exception handling

### DIFF
--- a/core/src/test/java/org/apache/druid/query/QueryExceptionTest.java
+++ b/core/src/test/java/org/apache/druid/query/QueryExceptionTest.java
@@ -39,35 +39,35 @@ public class QueryExceptionTest
   private static final String ERROR_MESSAGE_TRANSFORMED = "bbbb";
 
   @Mock
-  private Function<String, String> trasformFunction;
+  private Function<String, String> transformFunction;
 
   @Test
   public void testSanitizeWithTransformFunctionReturningNull()
   {
-    Mockito.when(trasformFunction.apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL))).thenReturn(null);
+    Mockito.when(transformFunction.apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL))).thenReturn(null);
     QueryException queryException = new QueryException(ERROR_CODE, ERROR_MESSAGE_ORIGINAL, ERROR_CLASS, HOST);
-    QueryException actual = queryException.sanitize(trasformFunction);
+    QueryException actual = queryException.sanitize(transformFunction);
     Assert.assertNotNull(actual);
     Assert.assertEquals(actual.getErrorCode(), ERROR_CODE);
-    Assert.assertNull(actual.getMessage());
+    Assert.assertEquals(ERROR_CODE, actual.getMessage());
     Assert.assertNull(actual.getHost());
     Assert.assertNull(actual.getErrorClass());
-    Mockito.verify(trasformFunction).apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL));
-    Mockito.verifyNoMoreInteractions(trasformFunction);
+    Mockito.verify(transformFunction).apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL));
+    Mockito.verifyNoMoreInteractions(transformFunction);
   }
 
   @Test
   public void testSanitizeWithTransformFunctionReturningNewString()
   {
-    Mockito.when(trasformFunction.apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL))).thenReturn(ERROR_MESSAGE_TRANSFORMED);
+    Mockito.when(transformFunction.apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL))).thenReturn(ERROR_MESSAGE_TRANSFORMED);
     QueryException queryException = new QueryException(ERROR_CODE, ERROR_MESSAGE_ORIGINAL, ERROR_CLASS, HOST);
-    QueryException actual = queryException.sanitize(trasformFunction);
+    QueryException actual = queryException.sanitize(transformFunction);
     Assert.assertNotNull(actual);
     Assert.assertEquals(actual.getErrorCode(), ERROR_CODE);
     Assert.assertEquals(actual.getMessage(), ERROR_MESSAGE_TRANSFORMED);
     Assert.assertNull(actual.getHost());
     Assert.assertNull(actual.getErrorClass());
-    Mockito.verify(trasformFunction).apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL));
-    Mockito.verifyNoMoreInteractions(trasformFunction);
+    Mockito.verify(transformFunction).apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL));
+    Mockito.verifyNoMoreInteractions(transformFunction);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -1156,12 +1156,12 @@ public class CompactionTask extends AbstractBatchIndexTask
   }
 
   /**
-   * Compcation Task Tuning Config.
+   * Compaction Task Tuning Config.
    *
    * An extension of ParallelIndexTuningConfig. As of now, all this TuningConfig
    * does is fail if the TuningConfig contains
    * `awaitSegmentAvailabilityTimeoutMillis` that is != 0 since it is not
-   * supported for Compcation Tasks.
+   * supported for Compaction Tasks.
    */
   public static class CompactionTuningConfig extends ParallelIndexTuningConfig
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * TaskRunner implemention for the CliIndexer task execution service, which runs all tasks in a single process.
+ * TaskRunner implementation for the CliIndexer task execution service, which runs all tasks in a single process.
  *
  * Two thread pools are used:
  * - A task execution pool, sized to number of worker slots. This is used to setup and execute the Task run() methods.
@@ -98,7 +98,7 @@ public class ThreadingTaskRunner
   private final ListeningExecutorService controlThreadExecutor;
   private final WorkerConfig workerConfig;
 
-  private volatile boolean stopping = false;
+  private volatile boolean stopping;
 
   @Inject
   public ThreadingTaskRunner(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/TaskResourceFilter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/security/TaskResourceFilter.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.overlord.http.security;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ContainerRequest;
@@ -78,11 +79,18 @@ public class TaskResourceFilter extends AbstractResourceFilter
 
     Optional<Task> taskOptional = taskStorageQueryAdapter.getTask(taskId);
     if (!taskOptional.isPresent()) {
+      // This response is returned from APIs that promise to return JSON.
       throw new WebApplicationException(
-          Response.status(Response.Status.NOT_FOUND)
-                  .type(MediaType.TEXT_PLAIN)
-                  .entity(StringUtils.format("Cannot find any task with id: [%s]", taskId))
-                  .build()
+          Response
+              .status(Response.Status.NOT_FOUND)
+              .type(MediaType.APPLICATION_JSON_TYPE)
+              .entity(
+                  ImmutableMap.of(
+                      "error",
+                      "Not found",
+                      "errorMessage",
+                      StringUtils.format("Cannot find any task with id: [%s]", taskId)))
+              .build()
       );
     }
     final String dataSourceName = Preconditions.checkNotNull(taskOptional.get().getDataSource());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -1094,7 +1094,7 @@ public class OverlordResourceTest
         .getTasks("blah", "ds_test", null, null, null, req)
         .getEntity();
     Assert.assertEquals(
-        "Invalid state : blah, valid values are: [pending, waiting, running, complete]",
+        "{error=Invalid, errorMessage=Invalid state : blah, valid values are: [pending, waiting, running, complete]}",
         responseObject.toString()
     );
   }
@@ -1501,7 +1501,9 @@ public class OverlordResourceTest
     final Response response = overlordResource.enableWorker(host);
 
     Assert.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(), response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "Worker API returns error!"), response.getEntity());
+    Assert.assertEquals(
+        ImmutableMap.of("error", "Failed", "errorMessage", "Worker API returns error!"),
+        response.getEntity());
   }
 
   @Test
@@ -1524,7 +1526,9 @@ public class OverlordResourceTest
     final Response response = overlordResource.disableWorker(host);
 
     Assert.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(), response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "Worker API returns error!"), response.getEntity());
+    Assert.assertEquals(
+        ImmutableMap.of("error", "Failed", "errorMessage", "Worker API returns error!"),
+        response.getEntity());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/QueryInterruptedExceptionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryInterruptedExceptionTest.java
@@ -129,7 +129,7 @@ public class QueryInterruptedExceptionTest
         roundTrip(new QueryInterruptedException(new QueryInterruptedException(new CancellationException()))).getErrorClass()
     );
     Assert.assertEquals(
-        null,
+        "Query cancelled",
         roundTrip(new QueryInterruptedException(new QueryInterruptedException(new CancellationException()))).getMessage()
     );
     Assert.assertEquals(

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -305,7 +305,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     Mockito.verify(mockMapper).writeValue(ArgumentMatchers.eq(outputStream), captor.capture());
     Assert.assertTrue(captor.getValue() instanceof QueryException);
     Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertNull(captor.getValue().getMessage());
+    Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, captor.getValue().getMessage());
     Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
     Assert.assertNull(((QueryException) captor.getValue()).getHost());
   }
@@ -429,7 +429,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     Mockito.verify(mockMapper).writeValue(ArgumentMatchers.eq(outputStream), captor.capture());
     Assert.assertTrue(captor.getValue() instanceof QueryException);
     Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertNull(captor.getValue().getMessage());
+    Assert.assertEquals(QueryInterruptedException.UNKNOWN_EXCEPTION, captor.getValue().getMessage());
     Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
     Assert.assertNull(((QueryException) captor.getValue()).getHost());
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserImplFactory.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserImplFactory.java
@@ -26,7 +26,6 @@ import java.io.Reader;
 
 public class DruidSqlParserImplFactory implements SqlParserImplFactory
 {
-
   @Override
   public SqlAbstractParserImpl getParser(Reader stream)
   {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
@@ -39,7 +39,6 @@ import java.util.List;
 
 public class DruidSqlParserUtils
 {
-
   private static final Logger log = new Logger(DruidSqlParserUtils.class);
 
   /**

--- a/sql/src/test/java/org/apache/druid/sql/avatica/ErrorHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/ErrorHandlerTest.java
@@ -30,7 +30,6 @@ import org.mockito.Mockito;
 
 public class ErrorHandlerTest
 {
-
   @Test
   public void testErrorHandlerSanitizesErrorAsExpected()
   {
@@ -44,7 +43,7 @@ public class ErrorHandlerTest
     QueryException input = new QueryException("error", "error message", "error class", "host");
 
     RuntimeException output = errorHandler.sanitize(input);
-    Assert.assertNull(output.getMessage());
+    Assert.assertEquals("error", output.getMessage());
   }
 
   @Test
@@ -92,6 +91,6 @@ public class ErrorHandlerTest
 
     Exception input = new Exception("message");
     RuntimeException output = errorHandler.sanitize(input);
-    Assert.assertEquals(null, output.getMessage());
+    Assert.assertEquals("Unknown exception", output.getMessage());
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -1357,7 +1357,7 @@ public class SqlResourceTest extends CalciteTestBase
     final QueryException exception = doPost(badQuery).lhs;
 
     Assert.assertNotNull(exception);
-    Assert.assertNull(exception.getMessage());
+    Assert.assertEquals("Unsupported query", exception.getMessage());
     Assert.assertNull(exception.getHost());
     Assert.assertEquals(exception.getErrorCode(), QueryUnsupportedException.ERROR_CODE);
     Assert.assertNull(exception.getErrorClass());
@@ -1397,7 +1397,7 @@ public class SqlResourceTest extends CalciteTestBase
     final QueryException exception = doPost(badQuery).lhs;
 
     Assert.assertNotNull(exception);
-    Assert.assertNull(exception.getMessage());
+    Assert.assertEquals("Unknown exception", exception.getMessage());
     Assert.assertNull(exception.getHost());
     Assert.assertEquals(exception.getErrorCode(), QueryInterruptedException.UNKNOWN_EXCEPTION);
     Assert.assertNull(exception.getErrorClass());


### PR DESCRIPTION
### Description

The Overlord REST APIs return JSON for the successful cases, and use a filter to handle errors. Unfortunately, the error handler returns plain text, which breaks a client that expects to receive the JSON error format added in recent PRs. This PR converts the errors to JSON following the emerging standard.

In addition. the recently-added standard error handling has a couple of holes. If the code provides just an error message, then the error code (which is what is primarily shown) is blank. If just an error code, then the error message is blank. This PR says that if only one is provided, use it for both places.

Jackson provides ways to omit fields which are at a null value. This PR uses that feature to not include fields which are null, simplifying the returned error JSON.

This error handling was encountered in the process of creating an Overlord service. In doing that, it turned out that it was necessary to create a `TaskStatus`, but the constructor was private. This PR makes the constructor public at no loss of functionality.

The PR also contains a number of typo cleanups encountered during the work.

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] been tested in a test Druid cluster as part of an overall project.
