### PR TITLE
make EncodedKeyComponent constructor public, remove nullable from DimensionIndexer.processRowValsToUnsortedEncodedKeyComponent 

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/DimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionIndexer.java
@@ -130,7 +130,6 @@ public interface DimensionIndexer<
    * Contains an object of the {@link EncodedKeyComponentType} and the effective
    * size of the key component in bytes.
    */
-  @Nullable
   EncodedKeyComponent<EncodedKeyComponentType> processRowValsToUnsortedEncodedKeyComponent(
       @Nullable Object dimValues,
       boolean reportParseExceptions

--- a/processing/src/main/java/org/apache/druid/segment/DoubleDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/DoubleDimensionIndexer.java
@@ -43,7 +43,6 @@ public class DoubleDimensionIndexer implements DimensionIndexer<Double, Double, 
 
   private volatile boolean hasNulls = false;
 
-  @Nullable
   @Override
   public EncodedKeyComponent<Double> processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
   {

--- a/processing/src/main/java/org/apache/druid/segment/EncodedKeyComponent.java
+++ b/processing/src/main/java/org/apache/druid/segment/EncodedKeyComponent.java
@@ -42,7 +42,7 @@ public class EncodedKeyComponent<K>
    *                           must account for the footprint of both the original
    *                           and encoded dimension values, as applicable.
    */
-  EncodedKeyComponent(@Nullable K component, long effectiveSizeBytes)
+  public EncodedKeyComponent(@Nullable K component, long effectiveSizeBytes)
   {
     this.component = component;
     this.effectiveSizeBytes = effectiveSizeBytes;

--- a/processing/src/main/java/org/apache/druid/segment/FloatDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/FloatDimensionIndexer.java
@@ -43,7 +43,6 @@ public class FloatDimensionIndexer implements DimensionIndexer<Float, Float, Flo
 
   private volatile boolean hasNulls = false;
 
-  @Nullable
   @Override
   public EncodedKeyComponent<Float> processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
   {

--- a/processing/src/main/java/org/apache/druid/segment/LongDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/LongDimensionIndexer.java
@@ -43,8 +43,6 @@ public class LongDimensionIndexer implements DimensionIndexer<Long, Long, Long>
 
   private volatile boolean hasNulls = false;
 
-
-  @Nullable
   @Override
   public EncodedKeyComponent<Long> processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
   {


### PR DESCRIPTION
Follow up to #12073, allow DimensionIndexers not in core druid to make `EncodedKeyComponent` so they can adhere to the new contract