### PR TITLE
Officially support Java 11.

### DIFF
--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -25,7 +25,7 @@ From the root of the repo, run `docker build -t apache/druid:tag -f distribution
 
 Edit `environment` to suite. Run `docker-compose -f distribution/docker/docker-compose.yml up`
 
-## Java 11 (experimental)
+## Java 11
 
 From the root of the repo, run `docker build -t apache/druid:tag -f distribution/docker/Dockerfile.java11 .` which will build Druid to run in a Java 11 environment.
 

--- a/docs/tutorials/cluster.md
+++ b/docs/tutorials/cluster.md
@@ -130,13 +130,10 @@ The [basic cluster tuning guide](../operations/basic-cluster-tuning.md) has info
 
 ## Select OS
 
-We recommend running your favorite Linux distribution. You will also need:
+We recommend running your favorite Linux distribution. You will also need Java 8 or 11.
 
-  * **Java 8 or later**
-
-> **Warning:** Druid only officially supports Java 8. Any Java version later than 8 is still experimental.
->
-> If needed, you can specify where to find Java using the environment variables `DRUID_JAVA_HOME` or `JAVA_HOME`. For more details run the verify-java script.
+> If needed, you can specify where to find Java using the environment variables
+> `DRUID_JAVA_HOME` or `JAVA_HOME`. For more details run the `bin/verify-java` script.
 
 Your OS package manager should be able to help for both Java. If your Ubuntu-based OS
 does not have a recent enough version of Java, WebUpd8 offers [packages for those

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -46,11 +46,9 @@ information on deploying Druid services across clustered machines.
 The software requirements for the installation machine are:
 
 * Linux, Mac OS X, or other Unix-like OS (Windows is not supported)
-* Java 8, Update 92 or later (8u92+)
+* Java 8, Update 92 or later (8u92+) or Java 11
 
-> Druid officially supports Java 8 only. Support for later major versions of Java is currently in experimental status.
-
-> Druid relies on the environment variables `JAVA_HOME` or `DRUID_JAVA_HOME` to find Java on the machine. You can set 
+> Druid relies on the environment variables `JAVA_HOME` or `DRUID_JAVA_HOME` to find Java on the machine. You can set
 `DRUID_JAVA_HOME` if there is more than one instance of Java. To verify Java requirements for your environment, run the 
 `bin/verify-java` script.
 

--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -25,23 +25,23 @@ sub fail_check {
   my ($current_version) = @_;
   my $current_version_text = $current_version
     ? "Your current version is: $current_version."
-    : "Make sure that \"java\" is installed and on your PATH.";
+    : "No Java runtime was detected on your system.";
 
   print STDERR <<"EOT";
-Druid only officially supports Java 8. Any Java version later than 8 is still experimental. $current_version_text
+Druid requires Java 8 or 11. $current_version_text
 
-If you believe this check is in error or you still want to proceed with Java version other than 8,
-you can skip this check using an environment variable:
+If you believe this check is in error, or you want to proceed with a potentially
+unsupported Java runtime, you can skip this check using an environment variable:
 
   export DRUID_SKIP_JAVA_CHECK=1
 
-Otherwise, install Java 8 and try again.
+Otherwise, install Java 8 or 11 in one of the following locations.
 
-This script searches for Java 8 in 3 locations in the following
-order
   * DRUID_JAVA_HOME
   * JAVA_HOME
   * java (installed on PATH)
+
+Other versions of Java versions may work, but are not officially supported.
 EOT
   exit 1;
 }
@@ -65,6 +65,6 @@ if ($?) {
 }
 
 # If we know it won't work, die. Otherwise hope for the best.
-if ($java_version =~ /version \"((\d+)\.(\d+).*?)\"/ && ($2 != 1 || $3 != 8)) {
+if ($java_version =~ /version \"((\d+)\.(\d+).*?)\"/ && !($2 == 1 && $3 == 8) && $2 != 11 ) {
   fail_check($1);
 }

--- a/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
@@ -71,10 +71,7 @@ public abstract class DruidProcessingConfig extends ExecutorServiceConfig implem
     catch (UnsupportedOperationException e) {
       // max direct memory defaults to max heap size on recent JDK version, unless set explicitly
       directSizeBytes = computeMaxMemoryFromMaxHeapSize();
-      log.info(
-          "Defaulting to at most [%,d] bytes (25%% of max heap size) of direct memory for computation buffers",
-          directSizeBytes
-      );
+      log.info("Using up to [%,d] bytes of direct memory for computation buffers.", directSizeBytes);
     }
 
     int numProcessingThreads = getNumThreads();
@@ -85,7 +82,9 @@ public abstract class DruidProcessingConfig extends ExecutorServiceConfig implem
     final int computedSizePerBuffer = Math.min(sizePerBuffer, MAX_DEFAULT_PROCESSING_BUFFER_SIZE_BYTES);
     if (computedBufferSizeBytes.compareAndSet(null, computedSizePerBuffer)) {
       log.info(
-          "Auto sizing buffers to [%,d] bytes each for [%,d] processing and [%,d] merge buffers",
+          "Auto sizing buffers to [%,d] bytes each for [%,d] processing and [%,d] merge buffers. "
+          + "If you run out of direct memory, you may need to set these parameters explicitly using the guidelines at "
+          + "https://druid.apache.org/docs/latest/operations/basic-cluster-tuning.html#processing-threads-buffers.",
           computedSizePerBuffer,
           numProcessingThreads,
           numMergeBuffers

--- a/web-console/src/dialogs/doctor-dialog/doctor-checks.tsx
+++ b/web-console/src/dialogs/doctor-dialog/doctor-checks.tsx
@@ -90,13 +90,14 @@ export const DOCTOR_CHECKS: DoctorCheck[] = [
         );
       }
 
-      // Check that the underlying Java is Java 8 the only officially supported Java version at the moment.
+      // Check for Java 8 or 11
       if (
         properties['java.specification.version'] &&
-        properties['java.specification.version'] !== '1.8'
+        properties['java.specification.version'] !== '1.8' &&
+        properties['java.specification.version'] !== '11'
       ) {
         controls.addSuggestion(
-          `It looks like are running Java ${properties['java.runtime.version']}. Druid only officially supports Java 1.8.x`,
+          `It looks like are running Java ${properties['java.runtime.version']}. Druid officially supports Java 8 or 11`,
         );
       }
 
@@ -372,7 +373,7 @@ FROM (
   WHERE is_published = 1 AND "start" < '${dayAgo}'
   GROUP BY 1, 2, 3
   HAVING "num_segments" > 1 AND "total_size" > 1 AND "avg_segment_size_in_time_chunk" < 100000000
-) 
+)
 GROUP BY 1
 ORDER BY "num_bad_time_chunks"`,
         });


### PR DESCRIPTION
There aren't any changes in this patch that improve Java 11
compatibility; these changes have already been done separately. This
patch merely updates documentation and explicit Java version checks.

The log message adjustments in DruidProcessingConfig are there to make
things a little nicer when running in Java 11, where we can't measure
direct memory _directly_, and so we may auto-size processing buffers
incorrectly.