### PR TITLE
Optimize kinesis ingestion task assignment after resharding

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -687,10 +687,11 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   public Set<String> getPartitionIds(String stream)
   {
     return wrapExceptions(() -> {
-      return ImmutableSet.copyOf(getShards(stream).stream()
-                                                  .map(shard -> shard.getShardId())
-                                                  .collect(Collectors.toList())
-      );
+      ImmutableSet.Builder<String> partitionIds = ImmutableSet.builder();
+      for (Shard shard : getShards(stream)) {
+        partitionIds.add(shard.getShardId());
+      }
+      return partitionIds.build();
     });
   }
 
@@ -753,10 +754,10 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   }
 
   /**
-   * Is costly and requires polling the shard to determine if it's empty
+   * Fetches records from the specified shard to determine if it is empty.
    * @param stream to which shard belongs
    * @param shardId of the closed shard
-   * @return if the closed shard is empty
+   * @return true if the closed shard is empty, false otherwise.
    */
   public boolean isClosedShardEmpty(String stream, String shardId)
   {

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -755,10 +755,10 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
   /**
    * Is costly and requires polling the shard to determine if it's empty
    * @param stream to which shard belongs
-   * @param shardId of the shard
-   * @return if the shard is empty
+   * @param shardId of the closed shard
+   * @return if the closed shard is empty
    */
-  public boolean isShardEmpty(String stream, String shardId)
+  public boolean isClosedShardEmpty(String stream, String shardId)
   {
     String shardIterator = kinesis.getShardIterator(stream,
                                                     shardId,

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -23,7 +23,6 @@ import com.amazonaws.services.kinesis.model.Shard;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.aws.AWSCredentialsConfig;
@@ -439,7 +438,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
   protected Set<String> getIgnorablePartitionIds()
   {
     updateClosedShardCache();
-    return getEmptyClosedShardIds();
+    return ImmutableSet.copyOf(emptyClosedShardIds);
   }
 
   private void updateClosedShardCache()
@@ -548,7 +547,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
   }
 
   /**
-   * Checking if a shard is empty requires polling for records which is quite expensive
+   * Checking if a shard is empty requires fetching records which is quite expensive
    * Fortunately, the results can be cached for closed shards as no more records can be written to them
    * Please use this method only if the info is absent from the cache
    *
@@ -559,23 +558,5 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
   private boolean isClosedShardEmpty(String stream, String shardId)
   {
     return ((KinesisRecordSupplier) recordSupplier).isClosedShardEmpty(stream, shardId);
-  }
-
-  /**
-   * @return immutable copy of cache for empty, closed shards
-   */
-  @VisibleForTesting
-  Set<String> getEmptyClosedShardIds()
-  {
-    return ImmutableSet.copyOf(emptyClosedShardIds);
-  }
-
-  /**
-   * @return immutable copy of cache for non-empty, closed shards
-   */
-  @VisibleForTesting
-  Set<String> getNonEmptyClosedShardIds()
-  {
-    return ImmutableSet.copyOf(nonEmptyClosedShardIds);
   }
 }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -442,7 +442,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
   protected Set<String> getIgnorablePartitionIds()
   {
     updateClosedShardCache();
-    return ImmutableSet.copyOf(emptyClosedShardIds);
+    return getEmptyClosedShardIds();
   }
 
   private void updateClosedShardCache()
@@ -564,5 +564,21 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
 
     // Make an expensive call to kinesis
     return ((KinesisRecordSupplier) recordSupplier).isClosedShardEmpty(stream, shardId);
+  }
+
+  /**
+   * @return immutable copy of cache for empty, closed shards
+   */
+  Set<String> getEmptyClosedShardIds()
+  {
+    return ImmutableSet.copyOf(emptyClosedShardIds);
+  }
+
+  /**
+   * @return immutable copy of cache for non-empty, closed shards
+   */
+  Set<String> getNonEmptyClosedShardIds()
+  {
+    return ImmutableSet.copyOf(nonEmptyClosedShardIds);
   }
 }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -434,7 +434,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
    * Closed and empty shards can be ignored for ingestion,
    * Use this method if skipIgnorablePartitions is true in the spec
    *
-   * These partitions can be safely ignored for both ingesetion task assignment and autoscaler limits
+   * These partitions can be safely ignored for both ingestion task assignment and autoscaler limits
    *
    * @return the set of ignorable shards' ids
    */
@@ -450,7 +450,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
     String stream = spec.getSource();
     Set<Shard> allActiveShards = ((KinesisRecordSupplier) recordSupplier).getShards(stream);
     Set<String> activeClosedShards = allActiveShards.stream()
-                                                    .filter(shard -> isShardOpen(shard))
+                                                    .filter(shard -> isShardClosed(shard))
                                                     .map(Shard::getShardId).collect(Collectors.toSet());
 
     // clear stale shards
@@ -534,14 +534,14 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
   }
 
   /**
-   * Open shards iff they don't have an ending sequence number
+   * Closed shards iff they have an ending sequence number
    *
    * @param shard to be checked
-   * @return if shard is open
+   * @return if shard is closed
    */
-  private boolean isShardOpen(Shard shard)
+  private boolean isShardClosed(Shard shard)
   {
-    return shard.getSequenceNumberRange().getEndingSequenceNumber() == null;
+    return shard.getSequenceNumberRange().getEndingSequenceNumber() != null;
   }
 
   /**
@@ -563,6 +563,6 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
     }
 
     // Make an expensive call to kinesis
-    return ((KinesisRecordSupplier) recordSupplier).isShardEmpty(stream, shardId);
+    return ((KinesisRecordSupplier) recordSupplier).isClosedShardEmpty(stream, shardId);
   }
 }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -435,7 +435,7 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
    * @return set of shards ignorable by kinesis ingestion
    */
   @Override
-  protected Set<String> getIgnorablePartitionIds()
+  protected Set<String> computeIgnorablePartitionIds()
   {
     updateClosedShardCache();
     return ImmutableSet.copyOf(emptyClosedShardIds);

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
@@ -217,7 +217,7 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
   }
 
   @JsonProperty
-  public boolean shouldSkipIgnorableShards()
+  public boolean isSkipIgnorableShards()
   {
     return skipIgnorableShards;
   }
@@ -256,7 +256,7 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
            ", maxRecordsPerPoll=" + getMaxRecordsPerPoll() +
            ", intermediateHandoffPeriod=" + getIntermediateHandoffPeriod() +
            ", repartitionTransitionDuration=" + getRepartitionTransitionDuration() +
-           ", skipIgnorableShards=" + shouldSkipIgnorableShards() +
+           ", skipIgnorableShards=" + isSkipIgnorableShards() +
            '}';
   }
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfig.java
@@ -41,10 +41,12 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
   private final Duration shutdownTimeout;
   private final Duration repartitionTransitionDuration;
   private final Duration offsetFetchPeriod;
+  private final boolean skipIgnorableShards;
 
   public static KinesisSupervisorTuningConfig defaultConfig()
   {
     return new KinesisSupervisorTuningConfig(
+        null,
         null,
         null,
         null,
@@ -114,7 +116,8 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
       @JsonProperty("maxRecordsPerPoll") @Nullable Integer maxRecordsPerPoll,
       @JsonProperty("intermediateHandoffPeriod") Period intermediateHandoffPeriod,
       @JsonProperty("repartitionTransitionDuration") Period repartitionTransitionDuration,
-      @JsonProperty("offsetFetchPeriod") Period offsetFetchPeriod
+      @JsonProperty("offsetFetchPeriod") Period offsetFetchPeriod,
+      @JsonProperty("skipIgnorableShards") Boolean skipIgnorableShards
   )
   {
     super(
@@ -162,6 +165,7 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
         offsetFetchPeriod,
         DEFAULT_OFFSET_FETCH_PERIOD
     );
+    this.skipIgnorableShards = (skipIgnorableShards != null ? skipIgnorableShards : false);
   }
 
   @Override
@@ -212,6 +216,12 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
     return offsetFetchPeriod;
   }
 
+  @JsonProperty
+  public boolean shouldSkipIgnorableShards()
+  {
+    return skipIgnorableShards;
+  }
+
   @Override
   public String toString()
   {
@@ -246,6 +256,7 @@ public class KinesisSupervisorTuningConfig extends KinesisIndexTaskTuningConfig
            ", maxRecordsPerPoll=" + getMaxRecordsPerPoll() +
            ", intermediateHandoffPeriod=" + getIntermediateHandoffPeriod() +
            ", repartitionTransitionDuration=" + getRepartitionTransitionDuration() +
+           ", skipIgnorableShards=" + shouldSkipIgnorableShards() +
            '}';
   }
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
@@ -317,6 +317,7 @@ public class KinesisIndexTaskTuningConfigTest
         null,
         null,
         null,
+        null,
         null
     );
     KinesisIndexTaskTuningConfig copy = (KinesisIndexTaskTuningConfig) original.convertToTaskTuningConfig();

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
@@ -1043,25 +1043,25 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     );
     Record record = new Record();
 
-    //Empty if and only if returned records are empty and the iterator is null
-    final String recordsAbsentAndNullNext = "0";
-    setupMockKinesisForShardId(mockKinesis, recordsAbsentAndNullNext, new ArrayList<>(), null);
+    final String shardWithoutRecordsAndNullNextIterator = "0";
+    setupMockKinesisForShardId(mockKinesis, shardWithoutRecordsAndNullNextIterator, new ArrayList<>(), null);
 
-    final String recordsPresentAndNullNext = "1";
-    setupMockKinesisForShardId(mockKinesis, recordsPresentAndNullNext, Collections.singletonList(record), null);
+    final String shardWithRecordsAndNullNextIterator = "1";
+    setupMockKinesisForShardId(mockKinesis, shardWithRecordsAndNullNextIterator, Collections.singletonList(record), null);
 
-    final String recordsAbsentAndNonNullNext = "2";
-    setupMockKinesisForShardId(mockKinesis, recordsAbsentAndNonNullNext, new ArrayList<>(), "nextIterator");
+    final String shardWithoutRecordsAndNonNullNextIterator = "2";
+    setupMockKinesisForShardId(mockKinesis, shardWithoutRecordsAndNonNullNextIterator, new ArrayList<>(), "nextIterator");
 
-    final String recordsPresentAndNonNullNext = "3";
-    setupMockKinesisForShardId(mockKinesis, recordsPresentAndNonNullNext, Collections.singletonList(record), "nextIterator");
+    final String shardWithRecordsAndNonNullNextIterator = "3";
+    setupMockKinesisForShardId(mockKinesis, shardWithRecordsAndNonNullNextIterator, Collections.singletonList(record), "nextIterator");
 
     EasyMock.replay(mockKinesis);
 
-    Assert.assertTrue(target.isClosedShardEmpty(STREAM, recordsAbsentAndNullNext));
-    Assert.assertFalse(target.isClosedShardEmpty(STREAM, recordsPresentAndNullNext));
-    Assert.assertFalse(target.isClosedShardEmpty(STREAM, recordsAbsentAndNonNullNext));
-    Assert.assertFalse(target.isClosedShardEmpty(STREAM, recordsPresentAndNonNullNext));
+    // A closed shard is empty only when the records are empty and the next iterator is null
+    Assert.assertTrue(target.isClosedShardEmpty(STREAM, shardWithoutRecordsAndNullNextIterator));
+    Assert.assertFalse(target.isClosedShardEmpty(STREAM, shardWithRecordsAndNullNextIterator));
+    Assert.assertFalse(target.isClosedShardEmpty(STREAM, shardWithoutRecordsAndNonNullNextIterator));
+    Assert.assertFalse(target.isClosedShardEmpty(STREAM, shardWithRecordsAndNonNullNextIterator));
   }
 
   private void setupMockKinesisForShardId(AmazonKinesis kinesis, String shardId,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
@@ -1026,7 +1026,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   }
 
   @Test
-  public void isClosedShardEmpty()
+  public void testIsClosedShardEmpty()
   {
     AmazonKinesis mockKinesis = EasyMock.mock(AmazonKinesis.class);
     KinesisRecordSupplier target = new KinesisRecordSupplier(mockKinesis,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -4925,18 +4925,18 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     // ActiveShards = {open, empty-closed, nonEmpty-closed}, IgnorableShards = {empty-closed}
     // {empty-closed, nonEmpty-closed} added to cache
-    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
+    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.computeIgnorablePartitionIds());
     // ActiveShards = {open, empty-closed, nonEmpty-closed}, IgnorableShards = {empty-closed}
-    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
+    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.computeIgnorablePartitionIds());
     // ActiveShards = {open, empty-closed}, IgnorableShards = {empty-closed}
     // {nonEmpty-closed} removed from cache
-    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
+    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.computeIgnorablePartitionIds());
     // ActiveShards = {open}, IgnorableShards = {}
     // {empty-closed} removed from cache
-    Assert.assertEquals(new HashSet<>(), supervisor.getIgnorablePartitionIds());
+    Assert.assertEquals(new HashSet<>(), supervisor.computeIgnorablePartitionIds());
     // ActiveShards = {open, empty-closed, nonEmpty-closed}, IgnorableShards = {empty-closed}
     // {empty-closed, nonEmpty-closed} re-added to cache
-    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
+    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.computeIgnorablePartitionIds());
   }
 
   private TestableKinesisSupervisor getTestableSupervisor(

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -309,17 +309,17 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     AutoScalerConfig autoScalerConfig = OBJECT_MAPPER.convertValue(autoScalerConfigMap, AutoScalerConfig.class);
     supervisor = getTestableSupervisor(
-        1,
-        1,
-        true,
-        "PT1H",
-        null,
-        null,
-        false,
-        null,
-        null,
-        autoScalerConfig
-    );
+            1,
+            1,
+            true,
+            "PT1H",
+            null,
+            null,
+            false,
+            null,
+            null,
+            autoScalerConfig
+            );
     KinesisSupervisorSpec kinesisSupervisorSpec = supervisor.getKinesisSupervisorSpec();
     SupervisorTaskAutoScaler autoscaler = kinesisSupervisorSpec.createAutoscaler(supervisor);
 
@@ -383,16 +383,16 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     AutoScalerConfig autoScalerConfig = OBJECT_MAPPER.convertValue(autoScalerConfigMap, AutoScalerConfig.class);
     supervisor = getTestableSupervisor(
-        1,
-        2,
-        true,
-        "PT1H",
-        null,
-        null,
-        false,
-        null,
-        null,
-        autoScalerConfig
+            1,
+            2,
+            true,
+            "PT1H",
+            null,
+            null,
+            false,
+            null,
+            null,
+            autoScalerConfig
     );
 
     KinesisSupervisorSpec kinesisSupervisorSpec = supervisor.getKinesisSupervisorSpec();
@@ -417,9 +417,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.absent()).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).anyTimes();
     EasyMock
-        .expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
-        .andReturn(new KinesisDataSourceMetadata(null))
-        .anyTimes();
+            .expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
+            .andReturn(new KinesisDataSourceMetadata(null))
+            .anyTimes();
     EasyMock.expect(taskQueue.add(EasyMock.capture(captured))).andReturn(true).times(2);
     replayAll();
 
@@ -508,26 +508,26 @@ public class KinesisSupervisorTest extends EasyMockSupport
   {
     // create KinesisSupervisorIOConfig with autoScalerConfig null
     KinesisSupervisorIOConfig kinesisSupervisorIOConfigWithNullAutoScalerConfig = new KinesisSupervisorIOConfig(
-        STREAM,
-        INPUT_FORMAT,
-        "awsEndpoint",
-        null,
-        1,
-        1,
-        new Period("PT30M"),
-        new Period("P1D"),
-        new Period("PT30S"),
-        false,
-        new Period("PT30M"),
-        null,
-        null,
-        null,
-        100,
-        1000,
-        null,
-        null,
-        null,
-        false
+            STREAM,
+            INPUT_FORMAT,
+            "awsEndpoint",
+            null,
+            1,
+            1,
+            new Period("PT30M"),
+            new Period("P1D"),
+            new Period("PT30S"),
+            false,
+            new Period("PT30M"),
+            null,
+            null,
+            null,
+            100,
+            1000,
+            null,
+            null,
+            null,
+            false
     );
 
     AutoScalerConfig autoscalerConfigNull = kinesisSupervisorIOConfigWithNullAutoScalerConfig.getAutoscalerConfig();
@@ -535,26 +535,26 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     // create KinesisSupervisorIOConfig with autoScalerConfig Empty
     KinesisSupervisorIOConfig kinesisSupervisorIOConfigWithEmptyAutoScalerConfig = new KinesisSupervisorIOConfig(
-        STREAM,
-        INPUT_FORMAT,
-        "awsEndpoint",
-        null,
-        1,
-        1,
-        new Period("PT30M"),
-        new Period("P1D"),
-        new Period("PT30S"),
-        false,
-        new Period("PT30M"),
-        null,
-        null,
-        null,
-        100,
-        1000,
-        null,
-        null,
-        OBJECT_MAPPER.convertValue(new HashMap<>(), AutoScalerConfig.class),
-        false
+            STREAM,
+            INPUT_FORMAT,
+            "awsEndpoint",
+            null,
+            1,
+            1,
+            new Period("PT30M"),
+            new Period("P1D"),
+            new Period("PT30S"),
+            false,
+            new Period("PT30M"),
+            null,
+            null,
+            null,
+            100,
+            1000,
+            null,
+            null,
+             OBJECT_MAPPER.convertValue(new HashMap<>(), AutoScalerConfig.class),
+            false
     );
 
     AutoScalerConfig autoscalerConfig = kinesisSupervisorIOConfigWithEmptyAutoScalerConfig.getAutoscalerConfig();
@@ -2582,11 +2582,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
                 "1"
             )));
     EasyMock.expect(taskClient.setEndOffsetsAsync("id2", ImmutableMap.of(
-                SHARD_ID1,
-                "12",
-                SHARD_ID0,
-                "1"
-            ), true))
+        SHARD_ID1,
+        "12",
+        SHARD_ID0,
+        "1"
+    ), true))
             .andReturn(Futures.immediateFuture(true));
     taskQueue.shutdown("id3", "Killing task for graceful shutdown");
     EasyMock.expectLastCall().times(1);
@@ -3253,11 +3253,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskStorage.getTask("id2")).andReturn(Optional.of(id2)).anyTimes();
     EasyMock.expect(taskStorage.getTask("id3")).andReturn(Optional.of(id3)).anyTimes();
     EasyMock.expect(
-                indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
-            .andReturn(new KinesisDataSourceMetadata(
-                null)
-            )
-            .anyTimes();
+        indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(new KinesisDataSourceMetadata(
+        null)
+    ).anyTimes();
     EasyMock.expect(taskClient.getStatusAsync("id1"))
             .andReturn(Futures.immediateFuture(SeekableStreamIndexTaskRunner.Status.READING));
     EasyMock.expect(taskClient.getStatusAsync("id2"))
@@ -3409,11 +3407,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskStorage.getTask("id2")).andReturn(Optional.of(id2)).anyTimes();
     EasyMock.expect(taskStorage.getTask("id3")).andReturn(Optional.of(id3)).anyTimes();
     EasyMock.expect(
-                indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
-            .andReturn(new KinesisDataSourceMetadata(
-                null)
-            )
-            .anyTimes();
+        indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(new KinesisDataSourceMetadata(
+        null)
+    ).anyTimes();
 
     replayAll();
 
@@ -3628,11 +3624,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
                 "1"
             )));
     EasyMock.expect(taskClient.setEndOffsetsAsync("id2", ImmutableMap.of(
-                SHARD_ID1,
-                "12",
-                SHARD_ID0,
-                "1"
-            ), true))
+        SHARD_ID1,
+        "12",
+        SHARD_ID0,
+        "1"
+    ), true))
             .andReturn(Futures.immediateFuture(true));
     taskQueue.shutdown("id3", "Killing task for graceful shutdown");
     EasyMock.expectLastCall().times(1);

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -108,7 +108,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -204,6 +204,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
+        null,
         null
     );
     rowIngestionMetersFactory = new TestUtils().getRowIngestionMetersFactory();
@@ -3941,6 +3942,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         42, // This property is different from tuningConfig
         null,
         null,
+        null,
         null
     );
 
@@ -4988,6 +4990,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         5000,
+        null,
         null,
         null,
         null,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -115,8 +115,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class KinesisSupervisorTest extends EasyMockSupport
 {

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.indexing.kinesis.supervisor;
 
+import com.amazonaws.services.kinesis.model.SequenceNumberRange;
+import com.amazonaws.services.kinesis.model.Shard;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -106,6 +108,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -307,17 +310,17 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     AutoScalerConfig autoScalerConfig = OBJECT_MAPPER.convertValue(autoScalerConfigMap, AutoScalerConfig.class);
     supervisor = getTestableSupervisor(
-            1,
-            1,
-            true,
-            "PT1H",
-            null,
-            null,
-            false,
-            null,
-            null,
-            autoScalerConfig
-            );
+        1,
+        1,
+        true,
+        "PT1H",
+        null,
+        null,
+        false,
+        null,
+        null,
+        autoScalerConfig
+    );
     KinesisSupervisorSpec kinesisSupervisorSpec = supervisor.getKinesisSupervisorSpec();
     SupervisorTaskAutoScaler autoscaler = kinesisSupervisorSpec.createAutoscaler(supervisor);
 
@@ -340,9 +343,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).anyTimes();
     EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(
-            new KinesisDataSourceMetadata(
-                    null
-            )
+        new KinesisDataSourceMetadata(
+            null
+        )
     ).anyTimes();
     EasyMock.expect(taskQueue.add(EasyMock.capture(captured))).andReturn(true);
     taskRunner.registerListener(EasyMock.anyObject(TaskRunnerListener.class), EasyMock.anyObject(Executor.class));
@@ -381,16 +384,16 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     AutoScalerConfig autoScalerConfig = OBJECT_MAPPER.convertValue(autoScalerConfigMap, AutoScalerConfig.class);
     supervisor = getTestableSupervisor(
-            1,
-            2,
-            true,
-            "PT1H",
-            null,
-            null,
-            false,
-            null,
-            null,
-            autoScalerConfig
+        1,
+        2,
+        true,
+        "PT1H",
+        null,
+        null,
+        false,
+        null,
+        null,
+        autoScalerConfig
     );
 
     KinesisSupervisorSpec kinesisSupervisorSpec = supervisor.getKinesisSupervisorSpec();
@@ -415,9 +418,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.absent()).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).anyTimes();
     EasyMock
-            .expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
-            .andReturn(new KinesisDataSourceMetadata(null))
-            .anyTimes();
+        .expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
+        .andReturn(new KinesisDataSourceMetadata(null))
+        .anyTimes();
     EasyMock.expect(taskQueue.add(EasyMock.capture(captured))).andReturn(true).times(2);
     replayAll();
 
@@ -506,26 +509,26 @@ public class KinesisSupervisorTest extends EasyMockSupport
   {
     // create KinesisSupervisorIOConfig with autoScalerConfig null
     KinesisSupervisorIOConfig kinesisSupervisorIOConfigWithNullAutoScalerConfig = new KinesisSupervisorIOConfig(
-            STREAM,
-            INPUT_FORMAT,
-            "awsEndpoint",
-            null,
-            1,
-            1,
-            new Period("PT30M"),
-            new Period("P1D"),
-            new Period("PT30S"),
-            false,
-            new Period("PT30M"),
-            null,
-            null,
-            null,
-            100,
-            1000,
-            null,
-            null,
-            null,
-            false
+        STREAM,
+        INPUT_FORMAT,
+        "awsEndpoint",
+        null,
+        1,
+        1,
+        new Period("PT30M"),
+        new Period("P1D"),
+        new Period("PT30S"),
+        false,
+        new Period("PT30M"),
+        null,
+        null,
+        null,
+        100,
+        1000,
+        null,
+        null,
+        null,
+        false
     );
 
     AutoScalerConfig autoscalerConfigNull = kinesisSupervisorIOConfigWithNullAutoScalerConfig.getAutoscalerConfig();
@@ -533,26 +536,26 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     // create KinesisSupervisorIOConfig with autoScalerConfig Empty
     KinesisSupervisorIOConfig kinesisSupervisorIOConfigWithEmptyAutoScalerConfig = new KinesisSupervisorIOConfig(
-            STREAM,
-            INPUT_FORMAT,
-            "awsEndpoint",
-            null,
-            1,
-            1,
-            new Period("PT30M"),
-            new Period("P1D"),
-            new Period("PT30S"),
-            false,
-            new Period("PT30M"),
-            null,
-            null,
-            null,
-            100,
-            1000,
-            null,
-            null,
-             OBJECT_MAPPER.convertValue(new HashMap<>(), AutoScalerConfig.class),
-            false
+        STREAM,
+        INPUT_FORMAT,
+        "awsEndpoint",
+        null,
+        1,
+        1,
+        new Period("PT30M"),
+        new Period("P1D"),
+        new Period("PT30S"),
+        false,
+        new Period("PT30M"),
+        null,
+        null,
+        null,
+        100,
+        1000,
+        null,
+        null,
+        OBJECT_MAPPER.convertValue(new HashMap<>(), AutoScalerConfig.class),
+        false
     );
 
     AutoScalerConfig autoscalerConfig = kinesisSupervisorIOConfigWithEmptyAutoScalerConfig.getAutoscalerConfig();
@@ -1295,7 +1298,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
             .times(1);
 
 
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(captured.getValue())).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(captured.getValue()))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus(iHaveFailed.getId()))
             .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId(), "Dummy task status failure err message")));
     EasyMock.expect(taskStorage.getStatus(runningTaskId))
@@ -1973,7 +1978,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(id1, id2))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getTask("id1")).andReturn(Optional.of(id1)).anyTimes();
@@ -2515,7 +2522,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(id1, id2, id3))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -2574,11 +2583,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
                 "1"
             )));
     EasyMock.expect(taskClient.setEndOffsetsAsync("id2", ImmutableMap.of(
-        SHARD_ID1,
-        "12",
-        SHARD_ID0,
-        "1"
-    ), true))
+                SHARD_ID1,
+                "12",
+                SHARD_ID0,
+                "1"
+            ), true))
             .andReturn(Futures.immediateFuture(true));
     taskQueue.shutdown("id3", "Killing task for graceful shutdown");
     EasyMock.expectLastCall().times(1);
@@ -2750,7 +2759,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
             .anyTimes();
     supervisorRecordSupplier.seekToLatest(EasyMock.anyObject());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject())).andReturn("300").anyTimes();
+    EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject()))
+            .andReturn("300")
+            .anyTimes();
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("400").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
@@ -2918,7 +2929,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(id1, id2, id3))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3073,7 +3086,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(id1, id2, id3))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3229,7 +3244,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(id1, id2, id3))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3237,9 +3254,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskStorage.getTask("id2")).andReturn(Optional.of(id2)).anyTimes();
     EasyMock.expect(taskStorage.getTask("id3")).andReturn(Optional.of(id3)).anyTimes();
     EasyMock.expect(
-        indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(new KinesisDataSourceMetadata(
-        null)
-    ).anyTimes();
+                indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
+            .andReturn(new KinesisDataSourceMetadata(
+                null)
+            )
+            .anyTimes();
     EasyMock.expect(taskClient.getStatusAsync("id1"))
             .andReturn(Futures.immediateFuture(SeekableStreamIndexTaskRunner.Status.READING));
     EasyMock.expect(taskClient.getStatusAsync("id2"))
@@ -3381,7 +3400,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(id1, id2, id3))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3389,9 +3410,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskStorage.getTask("id2")).andReturn(Optional.of(id2)).anyTimes();
     EasyMock.expect(taskStorage.getTask("id3")).andReturn(Optional.of(id3)).anyTimes();
     EasyMock.expect(
-        indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(new KinesisDataSourceMetadata(
-        null)
-    ).anyTimes();
+                indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
+            .andReturn(new KinesisDataSourceMetadata(
+                null)
+            )
+            .anyTimes();
 
     replayAll();
 
@@ -3552,7 +3575,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
+            .andReturn(ImmutableList.of(id1, id2, id3))
+            .anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3604,11 +3629,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
                 "1"
             )));
     EasyMock.expect(taskClient.setEndOffsetsAsync("id2", ImmutableMap.of(
-        SHARD_ID1,
-        "12",
-        SHARD_ID0,
-        "1"
-    ), true))
+                SHARD_ID1,
+                "12",
+                SHARD_ID0,
+                "1"
+            ), true))
             .andReturn(Futures.immediateFuture(true));
     taskQueue.shutdown("id3", "Killing task for graceful shutdown");
     EasyMock.expectLastCall().times(1);
@@ -4887,6 +4912,135 @@ public class KinesisSupervisorTest extends EasyMockSupport
     Assert.assertEquals(expectedPartitionOffsets, supervisor.getPartitionOffsets());
   }
 
+  @Test
+  public void testUpdateClosedShardCache()
+  {
+    supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null);
+    supervisor.setupRecordSupplier();
+    supervisor.tryInit();
+    String stream = supervisor.getKinesisSupervisorSpec().getSource();
+    Shard openShard = EasyMock.mock(Shard.class);
+    Shard emptyClosedShard = EasyMock.mock(Shard.class);
+    Shard nonEmptyClosedShard = EasyMock.mock(Shard.class);
+    Set<Shard> activeShards;
+    Set<String> emptyClosedShardIds;
+    Set<String> nonEmptyClosedShardIds;
+
+    // ITERATION 0:
+    // active shards: an open shard, closed-empty shard and closed-nonEmpty shard
+    activeShards = getActiveShards(openShard, true,
+                                   emptyClosedShard, true,
+                                   nonEmptyClosedShard, true);
+
+    EasyMock.reset(supervisorRecordSupplier);
+    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards).once();
+    // The following two calls DO happen since the shards are processed for the first time after being closed
+    EasyMock.expect(supervisorRecordSupplier.isClosedShardEmpty(stream, emptyClosedShard.getShardId())).andReturn(true).once();
+    EasyMock.expect(supervisorRecordSupplier.isClosedShardEmpty(stream, nonEmptyClosedShard.getShardId())).andReturn(false).once();
+    EasyMock.replay(supervisorRecordSupplier);
+
+    supervisor.getIgnorablePartitionIds();
+    emptyClosedShardIds = supervisor.getEmptyClosedShardIds();
+    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), emptyClosedShardIds);
+    nonEmptyClosedShardIds = supervisor.getNonEmptyClosedShardIds();
+    Assert.assertEquals(Collections.singleton(nonEmptyClosedShard.getShardId()), nonEmptyClosedShardIds);
+
+
+    // ITERATION 1:
+    // active shards: an open shard, closed-empty shard and closed-nonEmpty shard
+    activeShards = getActiveShards(openShard, true,
+                                   emptyClosedShard, true,
+                                   nonEmptyClosedShard, true);
+
+    EasyMock.reset(supervisorRecordSupplier);
+    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards).once();
+    // calls to KinesisRecordSupplier#isClosedShardEmpty DO NOT happen
+    EasyMock.replay(supervisorRecordSupplier);
+
+    supervisor.getIgnorablePartitionIds();
+    emptyClosedShardIds = supervisor.getEmptyClosedShardIds();
+    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), emptyClosedShardIds);
+    nonEmptyClosedShardIds = supervisor.getNonEmptyClosedShardIds();
+    Assert.assertEquals(Collections.singleton(nonEmptyClosedShard.getShardId()), nonEmptyClosedShardIds);
+
+
+    // ITERATION 2:
+    // active shards: an open shard, closed-empty shard. closed-nonEmpty shard has expired
+    activeShards = getActiveShards(openShard, true,
+                                   emptyClosedShard, true,
+                                   nonEmptyClosedShard, false);
+
+    EasyMock.reset(supervisorRecordSupplier);
+    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards).once();
+    // calls to KinesisRecordSupplier#isClosedShardEmpty DO NOT happen
+    EasyMock.replay(supervisorRecordSupplier);
+
+    supervisor.getIgnorablePartitionIds();
+    emptyClosedShardIds = supervisor.getEmptyClosedShardIds();
+    Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), emptyClosedShardIds);
+    // Expired shard is cleared from cache
+    nonEmptyClosedShardIds = supervisor.getNonEmptyClosedShardIds();
+    Assert.assertEquals(Collections.emptySet(), nonEmptyClosedShardIds);
+
+    // ITERATION 3:
+    // active shards: an open shard, closed-empty shard. closed-nonEmpty shard has expired
+    activeShards = getActiveShards(openShard, true,
+                                   emptyClosedShard, false,
+                                   nonEmptyClosedShard, false);
+
+    EasyMock.reset(supervisorRecordSupplier);
+    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards).once();
+    // calls to KinesisRecordSupplier#isClosedShardEmpty DO NOT happen
+    EasyMock.replay(supervisorRecordSupplier);
+
+    supervisor.getIgnorablePartitionIds();
+    // Expired shard is cleared from cache
+    emptyClosedShardIds = supervisor.getEmptyClosedShardIds();
+    Assert.assertEquals(Collections.emptySet(), emptyClosedShardIds);
+    // Expired shard is cleared from cache
+    nonEmptyClosedShardIds = supervisor.getNonEmptyClosedShardIds();
+    Assert.assertEquals(Collections.emptySet(), nonEmptyClosedShardIds);
+  }
+
+  private Set<Shard> getActiveShards(Shard openShard, boolean isOpenShardActive,
+                                      Shard emptyClosedShard, boolean isEmptyClosedShardActive,
+                                      Shard nonEmptyClosedShard, boolean isNonEmptyClosedShardActive)
+  {
+    ImmutableSet.Builder<Shard> activeShards = ImmutableSet.builder();
+
+    if (isOpenShardActive) {
+      EasyMock.reset(openShard);
+      EasyMock.expect(openShard.getShardId()).andReturn("openShard");
+      SequenceNumberRange openShardRange = EasyMock.mock(SequenceNumberRange.class);
+      EasyMock.expect(openShardRange.getEndingSequenceNumber()).andReturn(null);
+      EasyMock.expect(openShard.getSequenceNumberRange()).andReturn(openShardRange);
+      EasyMock.replay(openShard, openShardRange);
+      activeShards.add(openShard);
+    }
+
+    if (isEmptyClosedShardActive) {
+      EasyMock.reset(emptyClosedShard);
+      EasyMock.expect(emptyClosedShard.getShardId()).andReturn("emptyClosedShard").times(3);
+      SequenceNumberRange emptyClosedShardRange = EasyMock.mock(SequenceNumberRange.class);
+      EasyMock.expect(emptyClosedShardRange.getEndingSequenceNumber()).andReturn("notNull");
+      EasyMock.expect(emptyClosedShard.getSequenceNumberRange()).andReturn(emptyClosedShardRange);
+      EasyMock.replay(emptyClosedShard, emptyClosedShardRange);
+      activeShards.add(emptyClosedShard);
+    }
+
+    if (isNonEmptyClosedShardActive) {
+      EasyMock.reset(nonEmptyClosedShard);
+      EasyMock.expect(nonEmptyClosedShard.getShardId()).andReturn("nonEmptyClosedShard").times(3);
+      SequenceNumberRange nonEmptyClosedShardRange = EasyMock.mock(SequenceNumberRange.class);
+      EasyMock.expect(nonEmptyClosedShardRange.getEndingSequenceNumber()).andReturn("notNull");
+      EasyMock.expect(nonEmptyClosedShard.getSequenceNumberRange()).andReturn(nonEmptyClosedShardRange);
+      EasyMock.replay(nonEmptyClosedShard, nonEmptyClosedShardRange);
+      activeShards.add(nonEmptyClosedShard);
+    }
+
+    return activeShards.build();
+  }
+
   private TestableKinesisSupervisor getTestableSupervisor(
       int replicas,
       int taskCount,
@@ -5084,7 +5238,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         fetchDelayMillis,
         null,
         null,
-         autoScalerConfig,
+        autoScalerConfig,
         false
     );
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -344,9 +344,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).anyTimes();
-    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE))
-            .andReturn(new KinesisDataSourceMetadata(null))
-            .anyTimes();
+    EasyMock.expect(indexerMetadataStorageCoordinator.retrieveDataSourceMetadata(DATASOURCE)).andReturn(
+            new KinesisDataSourceMetadata(
+                    null
+            )
+    ).anyTimes();
     EasyMock.expect(taskQueue.add(EasyMock.capture(captured))).andReturn(true);
     taskRunner.registerListener(EasyMock.anyObject(TaskRunnerListener.class), EasyMock.anyObject(Executor.class));
     replayAll();
@@ -1298,9 +1300,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
             .times(1);
 
 
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(captured.getValue()))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(captured.getValue())).anyTimes();
     EasyMock.expect(taskStorage.getStatus(iHaveFailed.getId()))
             .andReturn(Optional.of(TaskStatus.failure(iHaveFailed.getId(), "Dummy task status failure err message")));
     EasyMock.expect(taskStorage.getStatus(runningTaskId))
@@ -1978,9 +1978,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(id1, id2))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2)).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getTask("id1")).andReturn(Optional.of(id1)).anyTimes();
@@ -2522,9 +2520,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(id1, id2, id3))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -2759,9 +2755,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
             .anyTimes();
     supervisorRecordSupplier.seekToLatest(EasyMock.anyObject());
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject()))
-            .andReturn("300")
-            .anyTimes();
+    EasyMock.expect(supervisorRecordSupplier.getEarliestSequenceNumber(EasyMock.anyObject())).andReturn("300").anyTimes();
     EasyMock.expect(supervisorRecordSupplier.getLatestSequenceNumber(EasyMock.anyObject())).andReturn("400").anyTimes();
     supervisorRecordSupplier.seek(EasyMock.anyObject(), EasyMock.anyString());
     EasyMock.expectLastCall().anyTimes();
@@ -2929,9 +2923,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(id1, id2, id3))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3086,9 +3078,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(id1, id2, id3))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3244,9 +3234,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(id1, id2, id3))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3398,9 +3386,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(id1, id2, id3))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -3571,9 +3557,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
     EasyMock.expect(taskRunner.getRunningTasks()).andReturn(workItems).anyTimes();
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(ImmutableList.of(id1, id2, id3))
-            .anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of(id1, id2, id3)).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id1")).andReturn(Optional.of(TaskStatus.running("id1"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id2")).andReturn(Optional.of(TaskStatus.running("id2"))).anyTimes();
     EasyMock.expect(taskStorage.getStatus("id3")).andReturn(Optional.of(TaskStatus.running("id3"))).anyTimes();
@@ -4915,77 +4899,54 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisor.setupRecordSupplier();
     supervisor.tryInit();
     String stream = supervisor.getKinesisSupervisorSpec().getSource();
+    SequenceNumberRange openShardRange = new SequenceNumberRange().withEndingSequenceNumber(null);
+    SequenceNumberRange closedShardRange = new SequenceNumberRange().withEndingSequenceNumber("non-null");
 
     // Open shard
     Shard openShard = EasyMock.mock(Shard.class);
     EasyMock.expect(openShard.getShardId()).andReturn("openShard").anyTimes();
-    SequenceNumberRange openShardRange = EasyMock.mock(SequenceNumberRange.class);
     EasyMock.expect(openShard.getSequenceNumberRange()).andReturn(openShardRange).anyTimes();
-    EasyMock.expect(openShardRange.getEndingSequenceNumber()).andReturn(null).anyTimes();
 
     // Empty, closed shard
     Shard emptyClosedShard = EasyMock.mock(Shard.class);
     EasyMock.expect(emptyClosedShard.getShardId()).andReturn("emptyClosedShard").anyTimes();
-    SequenceNumberRange emptyClosedShardRange = EasyMock.mock(SequenceNumberRange.class);
-    EasyMock.expect(emptyClosedShard.getSequenceNumberRange()).andReturn(emptyClosedShardRange).anyTimes();
-    EasyMock.expect(emptyClosedShardRange.getEndingSequenceNumber()).andReturn("notNull").anyTimes();
+    EasyMock.expect(emptyClosedShard.getSequenceNumberRange()).andReturn(closedShardRange).anyTimes();
 
     // Non-empty, closed shard
     Shard nonEmptyClosedShard = EasyMock.mock(Shard.class);
     EasyMock.expect(nonEmptyClosedShard.getShardId()).andReturn("nonEmptyClosedShard").anyTimes();
-    SequenceNumberRange nonEmptyClosedShardRange = EasyMock.mock(SequenceNumberRange.class);
-    EasyMock.expect(nonEmptyClosedShard.getSequenceNumberRange()).andReturn(nonEmptyClosedShardRange).anyTimes();
-    EasyMock.expect(nonEmptyClosedShardRange.getEndingSequenceNumber()).andReturn("notNull").anyTimes();
+    EasyMock.expect(nonEmptyClosedShard.getSequenceNumberRange()).andReturn(closedShardRange).anyTimes();
 
-    EasyMock.replay(openShardRange, emptyClosedShardRange, nonEmptyClosedShardRange);
     EasyMock.replay(openShard, emptyClosedShard, nonEmptyClosedShard);
 
-    // ITERATION 0:
-    // active shards: open shard, closed-empty shard and closed-nonEmpty shard
     Set<Shard> activeShards0 = Stream.of(openShard, emptyClosedShard, nonEmptyClosedShard).collect(Collectors.toSet());
-    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards0).once();
-    // The following two calls DO happen since the shards are processed for the first time after being closed
-    EasyMock.expect(supervisorRecordSupplier.isClosedShardEmpty(stream, emptyClosedShard.getShardId()))
-            .andReturn(true).once();
-    EasyMock.expect(supervisorRecordSupplier.isClosedShardEmpty(stream, nonEmptyClosedShard.getShardId()))
-            .andReturn(false).once();
-
-    // ITERATION 1:
-    // active shards: open shard, closed-empty shard and closed-nonEmpty shard
     Set<Shard> activeShards1 = Stream.of(openShard, emptyClosedShard, nonEmptyClosedShard).collect(Collectors.toSet());
-    // No calls to KinesisRecordSupplier#isClosedShardEmpty happen since the values have been cached
-    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards1).once();
-
-    // ITERATION 2:
-    // active shards: open shard, closed-empty shard
     Set<Shard> activeShards2 = Stream.of(openShard, emptyClosedShard).collect(Collectors.toSet());
-    // No calls to KinesisRecordSupplier#isClosedShardEmpty happen since the values have been cached
-    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards2).once();
-
-    // ITERATION 3:
-    // active shards: open shard
     Set<Shard> activeShards3 = Stream.of(openShard).collect(Collectors.toSet());
-    // No calls to KinesisRecordSupplier#isClosedShardEmpty happen since the values have been cached
-    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards3).once();
+    Set<Shard> activeShards4 = Stream.of(openShard, emptyClosedShard, nonEmptyClosedShard).collect(Collectors.toSet());
+    EasyMock.expect(supervisorRecordSupplier.getShards(stream))
+            .andReturn(activeShards0).once()
+            .andReturn(activeShards1).once()
+            .andReturn(activeShards2).once()
+            .andReturn(activeShards3).once()
+            .andReturn(activeShards4).once();
 
-
-    // ITERATION 4:
-    // active shards: open shard, closed-empty shard and closed-nonEmpty shard
-    Set<Shard> activeShards4 = Stream.of(openShard, emptyClosedShard, nonEmptyClosedShard)
-                                     .collect(Collectors.toSet());
-    EasyMock.expect(supervisorRecordSupplier.getShards(stream)).andReturn(activeShards4).once();
-    // The following two calls DO happen since the shards are processed after the cache has been cleared
+    // The following calls happen twice, once during the first call since there was no cache,
+    // and once during the last since the cache was cleared prior to it
     EasyMock.expect(supervisorRecordSupplier.isClosedShardEmpty(stream, emptyClosedShard.getShardId()))
-            .andReturn(true).once();
+            .andReturn(true).times(2);
     EasyMock.expect(supervisorRecordSupplier.isClosedShardEmpty(stream, nonEmptyClosedShard.getShardId()))
-            .andReturn(false).once();
+            .andReturn(false).times(2);
 
     EasyMock.replay(supervisorRecordSupplier);
 
+    // There is a closed and empty shard, which can be ignored
     Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
     Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
     Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
+    // The closed and empty shard expired and no longer needs to be considered
     Assert.assertEquals(new HashSet<>(), supervisor.getIgnorablePartitionIds());
+    // A closed and empty shard has been added again, which can be ignored
     Assert.assertEquals(Collections.singleton(emptyClosedShard.getShardId()), supervisor.getIgnorablePartitionIds());
   }
 
@@ -5186,7 +5147,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         fetchDelayMillis,
         null,
         null,
-        autoScalerConfig,
+         autoScalerConfig,
         false
     );
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -5002,8 +5002,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
   }
 
   private Set<Shard> getActiveShards(Shard openShard, boolean isOpenShardActive,
-                                      Shard emptyClosedShard, boolean isEmptyClosedShardActive,
-                                      Shard nonEmptyClosedShard, boolean isNonEmptyClosedShardActive)
+                                     Shard emptyClosedShard, boolean isEmptyClosedShardActive,
+                                     Shard nonEmptyClosedShard, boolean isNonEmptyClosedShardActive)
   {
     ImmutableSet.Builder<Shard> activeShards = ImmutableSet.builder();
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/RecordSupplier.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/RecordSupplier.java
@@ -116,9 +116,7 @@ public interface RecordSupplier<PartitionIdType, SequenceOffsetType, RecordType 
   SequenceOffsetType getPosition(StreamPartition<PartitionIdType> partition);
 
   /**
-   * returns the set of relevant partitions under the given stream
-   * For kafka, this returns all the partitions
-   * For kinesis, only shards which are either currently OPEN or have at least one record are relevant
+   * returns the set of all available partitions under the given stream
    *
    * @param stream name of stream
    *

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/RecordSupplier.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/RecordSupplier.java
@@ -116,11 +116,13 @@ public interface RecordSupplier<PartitionIdType, SequenceOffsetType, RecordType 
   SequenceOffsetType getPosition(StreamPartition<PartitionIdType> partition);
 
   /**
-   * returns the set of partitions under the given stream
+   * returns the set of relevant partitions under the given stream
+   * For kafka, this returns all the partitions
+   * For kinesis, only shards which are either currently OPEN or have at least one record are relevant
    *
    * @param stream name of stream
    *
-   * @return set of partitions
+   * @return set of partition ids belonging to the stream
    */
   Set<PartitionIdType> getPartitionIds(String stream);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2296,6 +2296,13 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     return false;
   }
 
+  /**
+   * Use this method if skipIgnorablePartitions is true in the spec
+   *
+   * These partitions can be safely ignored for both ingestion task assignment and autoscaler limits
+   *
+   * @return set of ids of ignorable partitions
+   */
   protected Set<PartitionIdType> getIgnorablePartitionIds()
   {
     return ImmutableSet.of();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2303,7 +2303,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
    *
    * @return set of ids of ignorable partitions
    */
-  protected Set<PartitionIdType> getIgnorablePartitionIds()
+  protected Set<PartitionIdType> computeIgnorablePartitionIds()
   {
     return ImmutableSet.of();
   }
@@ -2312,7 +2312,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   {
     int partitionCount = recordSupplier.getPartitionIds(ioConfig.getStream()).size();
     if (shouldSkipIgnorablePartitions()) {
-      partitionCount -= getIgnorablePartitionIds().size();
+      partitionCount -= computeIgnorablePartitionIds().size();
     }
     return partitionCount;
   }
@@ -2325,7 +2325,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     try {
       partitionIdsFromSupplier = recordSupplier.getPartitionIds(ioConfig.getStream());
       if (shouldSkipIgnorablePartitions()) {
-        partitionIdsFromSupplier.removeAll(getIgnorablePartitionIds());
+        partitionIdsFromSupplier.removeAll(computeIgnorablePartitionIds());
       }
     }
     catch (Exception e) {

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/KinesisAdminClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/KinesisAdminClient.java
@@ -174,7 +174,7 @@ public class KinesisAdminClient implements StreamAdminClient
       if (nextToken == null) {
         return shards.build();
       }
-      listShardsRequest = new ListShardsRequest().withNextToken(listShardsResult.getNextToken());
+      listShardsRequest = new ListShardsRequest().withNextToken(nextToken);
     }
   }
 


### PR DESCRIPTION
### Description

- When a kinesis stream is resharded, the original shards are closed. A large number of intermediate shards may also be created in the process which are eventually closed as well. 
- If a shard is closed before any records are put into it, it would be ideal to ignore this shard for ingestion, to increase efficiency. Skipping such tasks can help avoid waste of task resources due to unnecessary allocation.
- While we read from kinesis for shards frequently, both open and closed shards are returned and it is expensive to determine if a closed shard was ever written to, since it requires polling each shard for its records.
- Skipping "bad" shards when counting the partitions also helps since fewer slots may be allocated by the autoscaler.


KinesisRecordSupplier is used to get a list of all shards during Kinesis ingestion. 
Additional methods have been added to determine which shards are closed and empty.
Repetitive calls to kinesis for shards' records are avoided by maintaining an in-memory cache in the supervisor.


### Proposed Design:

- The in memory cache is implemented in KinesisSupervisor to maintain closed shard (empty and non-empty, separately) to avoid making redundant expensive calls.
- When the flag `skipIgnorableShards` is set to true, the cache is utilized and updated. This also means that "ignorable" shards no longer participate in task allocation for ingestion or for autoscaler estimations.
- When a shard is discovered after being closed for the first time, it is added to the cache to ensure that unnecessary expensive calls are not made.
- Active closed shards are computed to eliminate stale entries corresponding to expired shards


Limitations:
- All closed shards (not just the empty ones) are polled once, which can be an overhead.
- Since metadata is not updated for these shards, each supervisor restart would incur the above overhead again.


### Alternative design:

Update the metdata with end offsets of closed and empty shards. This may be simpler to implement since it doesn't require a cache but would lead to waste of resources since a task would have to update the metadata



##### Key changed/added classes in this PR
 * `KinesisSupervisor`

<hr>


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
