### PR TITLE
Assign partitionIds in the same order as bucketIds

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -932,10 +932,10 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       Map<String, GeneratedPartitionsReport> subTaskIdToReport
   )
   {
-    // Create a set of PartitionStats, sorted by (interval, bucketId, subTaskId)
+    // Create a set of PartitionStats, sorted by (interval, bucketId, subTaskId).
     // This ensures that within an interval, partitionIds are assigned in the
-    // same order as bucketIds. Comparison on subTaskId is needed to retain parts
-    // of the same partition written by different tasks, which will later be merged.
+    // same order as bucketIds. Comparison on subTaskId ensures that different
+    // PartitionStats of the same partition are not ignored as duplicates.
     final Set<Pair<PartitionStat, String>> partitionStatTaskIdPairs = new TreeSet<>(
         Comparator
             .comparingLong((Pair<PartitionStat, String> pair) -> pair.lhs.getInterval().getStartMillis())
@@ -948,10 +948,11 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         )
     );
 
-    // Create locations for each partition (interval + bucketId -> locations)
+    // Map from partition (interval + bucketId) to list of partition locations
     final Map<Pair<Interval, Integer>, List<PartitionLocation>> partitionToLocations = new HashMap<>();
     final Map<Pair<Interval, Integer>, BuildingShardSpec<?>> partitionToShardSpecs = new HashMap<>();
 
+    // Create a location for each PartitionStat
     Interval prevInterval = null;
     final AtomicInteger partitionId = new AtomicInteger(0);
     for (Pair<PartitionStat, String> partitionStatTaskIdPair : partitionStatTaskIdPairs) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -932,8 +932,10 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       Map<String, GeneratedPartitionsReport> subTaskIdToReport
   )
   {
-    // Create a sorted set of PartitionStats so that partitionIds are assigned
-    // in the same order as bucketIds
+    // Create a set of PartitionStats, sorted by (interval, bucketId, subTaskId)
+    // This ensures that within an interval, partitionIds are assigned in the
+    // same order as bucketIds. Comparison on subTaskId is needed to retain parts
+    // of the same partition written by different tasks, which will later be merged.
     final Set<Pair<PartitionStat, String>> partitionStatTaskIdPairs = new TreeSet<>(
         Comparator
             .comparingLong((Pair<PartitionStat, String> pair) -> pair.lhs.getInterval().getStartMillis())

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -963,11 +963,13 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         prevInterval = interval;
       }
 
-      // This list would always be non-empty
+      // Use any PartitionStat of this partition to create a shard spec
       final List<PartitionReport> reportsOfPartition = entry.getValue();
       final BuildingShardSpec<?> shardSpec = reportsOfPartition
           .get(0).getPartitionStat().getSecondaryPartition()
           .convert(partitionId.getAndIncrement());
+
+      // Create a PartitionLocation for each PartitionStat
       List<PartitionLocation> locationsOfPartition = reportsOfPartition
           .stream()
           .map(report -> report.getPartitionStat().toPartitionLocation(report.getSubTaskId(), shardSpec))

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -348,14 +348,15 @@ public class ParallelIndexSupervisorTaskTest
       final String task1 = "task1";
       final String task2 = "task2";
 
-      Map<String, GeneratedPartitionsReport> reports = new HashMap<>();
-      reports.put(task1, new GeneratedPartitionsReport(task1, Arrays.asList(
+      // Create task reports
+      Map<String, GeneratedPartitionsReport> taskIdToReport = new HashMap<>();
+      taskIdToReport.put(task1, new GeneratedPartitionsReport(task1, Arrays.asList(
           createRangePartitionStat(day1, 1),
           createRangePartitionStat(day2, 7),
           createRangePartitionStat(day1, 0),
           createRangePartitionStat(day2, 1)
       )));
-      reports.put(task2, new GeneratedPartitionsReport(task2, Arrays.asList(
+      taskIdToReport.put(task2, new GeneratedPartitionsReport(task2, Arrays.asList(
           createRangePartitionStat(day1, 4),
           createRangePartitionStat(day1, 6),
           createRangePartitionStat(day2, 1),
@@ -363,10 +364,10 @@ public class ParallelIndexSupervisorTaskTest
       )));
 
       Map<ParallelIndexSupervisorTask.Partition, List<PartitionLocation>> partitionToLocations
-          = ParallelIndexSupervisorTask.getPartitionToLocations(reports);
+          = ParallelIndexSupervisorTask.getPartitionToLocations(taskIdToReport);
       Assert.assertEquals(6, partitionToLocations.size());
 
-      // Verify locations and partitionId for all the partitions
+      // Verify that partitionIds are packed and in the same order as bucketIds
       verifyPartitionIdAndLocations(day1, 0, partitionToLocations,
                                     0, task1);
       verifyPartitionIdAndLocations(day1, 1, partitionToLocations,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -31,7 +31,6 @@ import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.data.CompressionFactory.LongEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
@@ -39,6 +38,7 @@ import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.partition.BuildingHashBasedNumberedShardSpec;
+import org.apache.druid.timeline.partition.DimensionRangeBucketShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;
 import org.easymock.EasyMock;
 import org.hamcrest.Matchers;
@@ -54,8 +54,11 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -131,14 +134,14 @@ public class ParallelIndexSupervisorTaskTest
       );
     }
 
-    private static Map<Pair<Interval, Integer>, List<PartitionLocation>> createPartitionToLocations(
+    private static Map<ParallelIndexSupervisorTask.Partition, List<PartitionLocation>> createPartitionToLocations(
         int count,
         String partitionLocationType
     )
     {
       return IntStream.range(0, count).boxed().collect(
           Collectors.toMap(
-              i -> Pair.of(createInterval(i), i),
+              i -> new ParallelIndexSupervisorTask.Partition(createInterval(i), i),
               i -> Collections.singletonList(createPartitionLocation(i, partitionLocationType))
           )
       );
@@ -334,6 +337,87 @@ public class ParallelIndexSupervisorTaskTest
       EasyMock.replay(inputSource, tuningConfig);
 
       Assert.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+    }
+
+    @Test
+    public void test_getPartitionToLocations_ordersPartitionsCorrectly()
+    {
+      final Interval day1 = Intervals.of("2022-01-01/2022-01-02");
+      final Interval day2 = Intervals.of("2022-01-02/2022-01-03");
+
+      final String task1 = "task1";
+      final String task2 = "task2";
+
+      Map<String, GeneratedPartitionsReport> reports = new HashMap<>();
+      reports.put(task1, new GeneratedPartitionsReport(task1, Arrays.asList(
+          createRangePartitionStat(day1, 1),
+          createRangePartitionStat(day2, 7),
+          createRangePartitionStat(day1, 0),
+          createRangePartitionStat(day2, 1)
+      )));
+      reports.put(task2, new GeneratedPartitionsReport(task2, Arrays.asList(
+          createRangePartitionStat(day1, 4),
+          createRangePartitionStat(day1, 6),
+          createRangePartitionStat(day2, 1),
+          createRangePartitionStat(day1, 1)
+      )));
+
+      Map<ParallelIndexSupervisorTask.Partition, List<PartitionLocation>> partitionToLocations
+          = ParallelIndexSupervisorTask.getPartitionToLocations(reports);
+      Assert.assertEquals(6, partitionToLocations.size());
+
+      // Verify locations and partitionId for all the partitions
+      verifyPartitionIdAndLocations(day1, 0, partitionToLocations,
+                                    0, task1);
+      verifyPartitionIdAndLocations(day1, 1, partitionToLocations,
+                                    1, task1, task2);
+      verifyPartitionIdAndLocations(day1, 4, partitionToLocations,
+                                    2, task2);
+      verifyPartitionIdAndLocations(day1, 6, partitionToLocations,
+                                    3, task2);
+
+      verifyPartitionIdAndLocations(day2, 1, partitionToLocations,
+                                    0, task1, task2);
+      verifyPartitionIdAndLocations(day2, 7, partitionToLocations,
+                                    1, task1);
+    }
+
+    private PartitionStat createRangePartitionStat(Interval interval, int bucketId)
+    {
+      return new DeepStoragePartitionStat(
+          interval,
+          new DimensionRangeBucketShardSpec(bucketId, Arrays.asList("dim1", "dim2"), null, null),
+          new HashMap<>()
+      );
+    }
+
+    private void verifyPartitionIdAndLocations(
+        Interval interval,
+        int bucketId,
+        Map<ParallelIndexSupervisorTask.Partition, List<PartitionLocation>> partitionToLocations,
+        int expectedPartitionId,
+        String... expectedTaskIds
+    )
+    {
+      final ParallelIndexSupervisorTask.Partition partition
+          = new ParallelIndexSupervisorTask.Partition(interval, bucketId);
+      List<PartitionLocation> locations = partitionToLocations.get(partition);
+      Assert.assertEquals(expectedTaskIds.length, locations.size());
+
+      final Set<String> observedTaskIds = new HashSet<>();
+      for (PartitionLocation location : locations) {
+        Assert.assertEquals(bucketId, location.getBucketId());
+        Assert.assertEquals(interval, location.getInterval());
+        Assert.assertEquals(expectedPartitionId, location.getShardSpec().getPartitionNum());
+
+        observedTaskIds.add(location.getSubTaskId());
+      }
+
+      // Verify the taskIds of the locations
+      Assert.assertEquals(
+          new HashSet<>(Arrays.asList(expectedTaskIds)),
+          observedTaskIds
+      );
     }
   }
 


### PR DESCRIPTION
### Description

When `ParallelIndexSupervisorTask` converts `BucketShardSpecs` to the corresponding `BuildingShardSpecs`, the order gets lost. This means that the newly assigned partitionIds are not in the same order as the original bucketIds.

Particularly, for range partitioning, this results in the partitionIds not being in the same order as increasing partition boundaries. While not a bug, this can be potentially confusing and aesthetically displeasing.

### Changes
- Refactor `ParallelIndexSupervisorTask.groupGenericPartitionLocationsPerPartition`

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

Order Before:
![order_before](https://user-images.githubusercontent.com/18635897/152737790-25992950-09e4-4107-97c9-39a9168be71e.png)

Order After:
![order_after](https://user-images.githubusercontent.com/18635897/152737824-01f2b2af-e000-49ec-9381-5fde02cef90e.png)