### PR TITLE
allow optimizing sql expressions and virtual columns

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -63,6 +63,11 @@ public interface Expr extends Cacheable
     return false;
   }
 
+  default boolean isIdentifier()
+  {
+    return false;
+  }
+
   /**
    * Returns the value of expr if expr is a literal, or throws an exception otherwise.
    *

--- a/core/src/main/java/org/apache/druid/math/expr/IdentifierExpr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/IdentifierExpr.java
@@ -86,6 +86,12 @@ class IdentifierExpr implements Expr
     return binding;
   }
 
+  @Override
+  public boolean isIdentifier()
+  {
+    return true;
+  }
+
   @Nullable
   @Override
   public String getIdentifierIfIdentifier()

--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -726,6 +726,7 @@ public class ParserTest extends InitializedNullHandlingTest
     Expr parsedFlat = Parser.parse(expr, ExprMacroTable.nil(), true);
     Assert.assertTrue(parsed.isLiteral());
     Assert.assertTrue(parsedFlat.isLiteral());
+    Assert.assertFalse(parsed.isIdentifier());
     Assert.assertEquals(type, parsed.getOutputType(emptyBinding));
     Assert.assertEquals(type, parsedFlat.getOutputType(emptyBinding));
     Assert.assertEquals(expected, parsed.getLiteralValue());
@@ -770,6 +771,11 @@ public class ParserTest extends InitializedNullHandlingTest
   )
   {
     final Expr parsed = Parser.parse(expression, ExprMacroTable.nil());
+    if (parsed instanceof IdentifierExpr) {
+      Assert.assertTrue(parsed.isIdentifier());
+    } else {
+      Assert.assertFalse(parsed.isIdentifier());
+    }
     final Expr.BindingAnalysis deets = parsed.analyzeInputs();
     Assert.assertEquals(expression, expected, parsed.toString());
     Assert.assertEquals(expression, identifiers, deets.getRequiredBindingsList());

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchUtils.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchUtils.java
@@ -22,8 +22,6 @@ package org.apache.druid.query.aggregation.tdigestsketch;
 import com.tdunning.math.stats.MergingDigest;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.segment.VirtualColumn;
-import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
 
@@ -88,7 +86,7 @@ public class TDigestSketchUtils
   {
     // Check input for equivalence.
     final boolean inputMatches;
-    final VirtualColumn virtualInput =
+    final DruidExpression virtualInput =
         virtualColumnRegistry.findVirtualColumns(factory.requiredFields())
                              .stream()
                              .findFirst()
@@ -97,7 +95,7 @@ public class TDigestSketchUtils
     if (virtualInput == null) {
       inputMatches = input.isDirectColumnAccess() && input.getDirectColumn().equals(factory.getFieldName());
     } else {
-      inputMatches = ((ExpressionVirtualColumn) virtualInput).getExpression().equals(input.getExpression());
+      inputMatches = virtualInput.equals(input);
     }
     return inputMatches && compression == factory.getCompression();
   }

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchUtils.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchUtils.java
@@ -87,7 +87,7 @@ public class TDigestSketchUtils
     // Check input for equivalence.
     final boolean inputMatches;
     final DruidExpression virtualInput =
-        virtualColumnRegistry.findVirtualColumns(factory.requiredFields())
+        virtualColumnRegistry.findVirtualColumnExpressions(factory.requiredFields())
                              .stream()
                              .findFirst()
                              .orElse(null);

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestGenerateSketchSqlAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestGenerateSketchSqlAggregator.java
@@ -35,7 +35,6 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.tdigestsketch.TDigestSketchAggregatorFactory;
 import org.apache.druid.query.aggregation.tdigestsketch.TDigestSketchUtils;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -135,16 +134,11 @@ public class TDigestGenerateSketchSqlAggregator implements SqlAggregator
           compression
       );
     } else {
-      VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           input,
           ColumnType.FLOAT
       );
-      aggregatorFactory = new TDigestSketchAggregatorFactory(
-          aggName,
-          virtualColumn.getOutputName(),
-          compression
-      );
+      aggregatorFactory = new TDigestSketchAggregatorFactory(aggName, virtualColumnName, compression);
     }
 
     return Aggregation.create(aggregatorFactory);

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchQuantileSqlAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchQuantileSqlAggregator.java
@@ -38,7 +38,6 @@ import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.apache.druid.query.aggregation.tdigestsketch.TDigestSketchAggregatorFactory;
 import org.apache.druid.query.aggregation.tdigestsketch.TDigestSketchToQuantilePostAggregator;
 import org.apache.druid.query.aggregation.tdigestsketch.TDigestSketchUtils;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -154,16 +153,11 @@ public class TDigestSketchQuantileSqlAggregator implements SqlAggregator
           compression
       );
     } else {
-      VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           input,
           ColumnType.FLOAT
       );
-      aggregatorFactory = new TDigestSketchAggregatorFactory(
-          sketchName,
-          virtualColumn.getOutputName(),
-          compression
-      );
+      aggregatorFactory = new TDigestSketchAggregatorFactory(sketchName, virtualColumnName, compression);
     }
 
     return Aggregation.create(

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -33,7 +33,6 @@ import org.apache.druid.query.aggregation.datasketches.hll.HllSketchBuildAggrega
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchMergeAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
@@ -143,12 +142,11 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
       if (columnArg.isDirectColumnAccess()) {
         dimensionSpec = columnArg.getSimpleExtraction().toDimensionSpec(null, inputType);
       } else {
-        VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-            plannerContext,
+        String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
             columnArg,
             dataType
         );
-        dimensionSpec = new DefaultDimensionSpec(virtualColumn.getOutputName(), null, inputType);
+        dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
       }
 
       aggregatorFactory = new HllSketchBuildAggregatorFactory(

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
@@ -134,7 +134,7 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
           // Check input for equivalence.
           final boolean inputMatches;
           final DruidExpression virtualInput =
-              virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
+              virtualColumnRegistry.findVirtualColumnExpressions(theFactory.requiredFields())
                                    .stream()
                                    .findFirst()
                                    .orElse(null);

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
@@ -38,10 +38,8 @@ import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchAggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchToQuantilePostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.aggregation.Aggregations;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
@@ -135,7 +133,7 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
 
           // Check input for equivalence.
           final boolean inputMatches;
-          final VirtualColumn virtualInput =
+          final DruidExpression virtualInput =
               virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
                                    .stream()
                                    .findFirst()
@@ -144,7 +142,7 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
           if (virtualInput == null) {
             inputMatches = input.isDirectColumnAccess() && input.getDirectColumn().equals(theFactory.getFieldName());
           } else {
-            inputMatches = ((ExpressionVirtualColumn) virtualInput).getExpression().equals(input.getExpression());
+            inputMatches = virtualInput.equals(input);
           }
 
           final boolean matches = inputMatches
@@ -177,14 +175,13 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
           getMaxStreamLengthFromQueryContext(plannerContext.getQueryContext())
       );
     } else {
-      VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           input,
           ColumnType.FLOAT
       );
       aggregatorFactory = new DoublesSketchAggregatorFactory(
           histogramName,
-          virtualColumn.getOutputName(),
+          virtualColumnName,
           k,
           getMaxStreamLengthFromQueryContext(plannerContext.getQueryContext())
       );

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchObjectSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchObjectSqlAggregator.java
@@ -35,7 +35,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchAggregatorFactory;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -117,14 +116,13 @@ public class DoublesSketchObjectSqlAggregator implements SqlAggregator
           DoublesSketchApproxQuantileSqlAggregator.getMaxStreamLengthFromQueryContext(plannerContext.getQueryContext())
       );
     } else {
-      VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           input,
           ColumnType.FLOAT
       );
       aggregatorFactory = new DoublesSketchAggregatorFactory(
           histogramName,
-          virtualColumn.getOutputName(),
+          virtualColumnName,
           k,
           DoublesSketchApproxQuantileSqlAggregator.getMaxStreamLengthFromQueryContext(plannerContext.getQueryContext())
       );

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -32,7 +32,6 @@ import org.apache.druid.query.aggregation.datasketches.theta.SketchAggregatorFac
 import org.apache.druid.query.aggregation.datasketches.theta.SketchMergeAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
@@ -123,12 +122,11 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
       if (columnArg.isDirectColumnAccess()) {
         dimensionSpec = columnArg.getSimpleExtraction().toDimensionSpec(null, inputType);
       } else {
-        VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-            plannerContext,
+        String virtualColumnName  = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
             columnArg,
             dataType
         );
-        dimensionSpec = new DefaultDimensionSpec(virtualColumn.getOutputName(), null, inputType);
+        dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
       }
 
       aggregatorFactory = new SketchMergeAggregatorFactory(

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -122,7 +122,7 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
       if (columnArg.isDirectColumnAccess()) {
         dimensionSpec = columnArg.getSimpleExtraction().toDimensionSpec(null, inputType);
       } else {
-        String virtualColumnName  = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
+        String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
             columnArg,
             dataType
         );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -479,14 +479,14 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
                           new FieldAccessPostAggregator("p1", "a1"),
                           new HllSketchToEstimatePostAggregator("p3", new FieldAccessPostAggregator("p2", "a0"), false),
                           new HllSketchToEstimatePostAggregator("p5", new FieldAccessPostAggregator("p4", "a0"), false),
-                          new ExpressionPostAggregator("p6", "(p5 + 1)", null, TestExprMacroTable.INSTANCE),
+                          new ExpressionPostAggregator("p6", "(\"p5\" + 1)", null, TestExprMacroTable.INSTANCE),
                           new HllSketchToEstimatePostAggregator("p8", new FieldAccessPostAggregator("p7", "a2"), false),
                           new HllSketchToEstimatePostAggregator(
                               "p10",
                               new FieldAccessPostAggregator("p9", "a0"),
                               false
                           ),
-                          new ExpressionPostAggregator("p11", "abs(p10)", null, TestExprMacroTable.INSTANCE),
+                          new ExpressionPostAggregator("p11", "abs(\"p10\")", null, TestExprMacroTable.INSTANCE),
                           new HllSketchToEstimateWithBoundsPostAggregator(
                               "p13",
                               new FieldAccessPostAggregator("p12", "a0"),
@@ -500,7 +500,7 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
                           new FieldAccessPostAggregator("p16", "a3"),
                           new HllSketchToStringPostAggregator("p18", new FieldAccessPostAggregator("p17", "a0")),
                           new HllSketchToStringPostAggregator("p20", new FieldAccessPostAggregator("p19", "a0")),
-                          new ExpressionPostAggregator("p21", "upper(p20)", null, TestExprMacroTable.INSTANCE),
+                          new ExpressionPostAggregator("p21", "upper(\"p20\")", null, TestExprMacroTable.INSTANCE),
                           new HllSketchToEstimatePostAggregator("p23", new FieldAccessPostAggregator("p22", "a0"), true)
                       )
                   )

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
@@ -564,7 +564,7 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
                       ),
                       new ExpressionPostAggregator(
                           "p3",
-                          "(p2 + 1000)",
+                          "(\"p2\" + 1000)",
                           null,
                           TestExprMacroTable.INSTANCE
                       ),
@@ -578,7 +578,7 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
                       ),
                       new ExpressionPostAggregator(
                           "p6",
-                          "(p5 + 1000)",
+                          "(\"p5\" + 1000)",
                           null,
                           TestExprMacroTable.INSTANCE
                       ),
@@ -590,7 +590,7 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
                           ),
                           0.5f
                       ),
-                      new ExpressionPostAggregator("p9", "abs(p8)", null, TestExprMacroTable.INSTANCE),
+                      new ExpressionPostAggregator("p9", "abs(\"p8\")", null, TestExprMacroTable.INSTANCE),
                       new DoublesSketchToQuantilesPostAggregator(
                           "p11",
                           new FieldAccessPostAggregator(
@@ -633,7 +633,7 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
                       ),
                       new ExpressionPostAggregator(
                           "p20",
-                          "replace(replace(p19,'HeapCompactDoublesSketch','HeapUpdateDoublesSketch'),"
+                          "replace(replace(\"p19\",'HeapCompactDoublesSketch','HeapUpdateDoublesSketch'),"
                           + "'Combined Buffer Capacity     : 6',"
                           + "'Combined Buffer Capacity     : 8')",
                           null,

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
@@ -37,10 +37,8 @@ import org.apache.druid.query.aggregation.bloom.BloomFilterAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.dimension.ExtractionDimensionSpec;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
@@ -114,10 +112,10 @@ public class BloomFilterSqlAggregator implements SqlAggregator
 
           // Check input for equivalence.
           final boolean inputMatches;
-          final VirtualColumn virtualInput = virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
-                                                                  .stream()
-                                                                  .findFirst()
-                                                                  .orElse(null);
+          final DruidExpression virtualInput = virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
+                                                                    .stream()
+                                                                    .findFirst()
+                                                                    .orElse(null);
           if (virtualInput == null) {
             if (input.isDirectColumnAccess()) {
               inputMatches =
@@ -128,7 +126,7 @@ public class BloomFilterSqlAggregator implements SqlAggregator
                   input.getSimpleExtraction().getExtractionFn().equals(theFactory.getField().getExtractionFn());
             }
           } else {
-            inputMatches = ((ExpressionVirtualColumn) virtualInput).getExpression().equals(input.getExpression());
+            inputMatches = virtualInput.equals(input);
           }
 
           final boolean matches = inputMatches && theFactory.getMaxNumEntries() == maxNumEntries;
@@ -161,14 +159,13 @@ public class BloomFilterSqlAggregator implements SqlAggregator
           input.getSimpleExtraction().getExtractionFn()
       );
     } else {
-      VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           input,
           inputOperand.getType()
       );
       spec = new DefaultDimensionSpec(
-          virtualColumn.getOutputName(),
-          StringUtils.format("%s:%s", name, virtualColumn.getOutputName())
+          virtualColumnName,
+          StringUtils.format("%s:%s", name, virtualColumnName)
       );
     }
 

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
@@ -112,7 +112,7 @@ public class BloomFilterSqlAggregator implements SqlAggregator
 
           // Check input for equivalence.
           final boolean inputMatches;
-          final DruidExpression virtualInput = virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
+          final DruidExpression virtualInput = virtualColumnRegistry.findVirtualColumnExpressions(theFactory.requiredFields())
                                                                     .stream()
                                                                     .findFirst()
                                                                     .orElse(null);

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/sql/BloomFilterOperatorConversion.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/sql/BloomFilterOperatorConversion.java
@@ -33,7 +33,6 @@ import org.apache.druid.query.filter.BloomDimFilter;
 import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.query.filter.BloomKFilterHolder;
 import org.apache.druid.query.filter.DimFilter;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
@@ -104,16 +103,15 @@ public class BloomFilterOperatorConversion extends DirectOperatorConversion
           null
       );
     } else if (virtualColumnRegistry != null) {
-      VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           druidExpression,
           operands.get(0).getType()
       );
-      if (virtualColumn == null) {
+      if (virtualColumnName == null) {
         return null;
       }
       return new BloomDimFilter(
-          virtualColumn.getOutputName(),
+          virtualColumnName,
           holder,
           null,
           null

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
@@ -186,7 +186,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
           // Check input for equivalence.
           final boolean inputMatches;
           final DruidExpression virtualInput =
-              virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
+              virtualColumnRegistry.findVirtualColumnExpressions(theFactory.requiredFields())
                                    .stream()
                                    .findFirst()
                                    .orElse(null);

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
@@ -37,10 +37,8 @@ import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.histogram.FixedBucketsHistogram;
 import org.apache.druid.query.aggregation.histogram.FixedBucketsHistogramAggregatorFactory;
 import org.apache.druid.query.aggregation.histogram.QuantilePostAggregator;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.aggregation.Aggregations;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
@@ -187,7 +185,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
 
           // Check input for equivalence.
           final boolean inputMatches;
-          final VirtualColumn virtualInput =
+          final DruidExpression virtualInput =
               virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
                                    .stream()
                                    .findFirst()
@@ -197,8 +195,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
             inputMatches = input.isDirectColumnAccess()
                            && input.getDirectColumn().equals(theFactory.getFieldName());
           } else {
-            inputMatches = ((ExpressionVirtualColumn) virtualInput).getExpression()
-                                                                   .equals(input.getExpression());
+            inputMatches = virtualInput.equals(input);
           }
 
           final boolean matches = inputMatches
@@ -230,14 +227,13 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
           false
       );
     } else {
-      VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           input,
           ColumnType.FLOAT
       );
       aggregatorFactory = new FixedBucketsHistogramAggregatorFactory(
           histogramName,
-          virtualColumn.getOutputName(),
+          virtualColumnName,
           numBuckets,
           lowerLimit,
           upperLimit,

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
@@ -38,11 +38,9 @@ import org.apache.druid.query.aggregation.histogram.ApproximateHistogram;
 import org.apache.druid.query.aggregation.histogram.ApproximateHistogramAggregatorFactory;
 import org.apache.druid.query.aggregation.histogram.ApproximateHistogramFoldingAggregatorFactory;
 import org.apache.druid.query.aggregation.histogram.QuantilePostAggregator;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
-import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.aggregation.Aggregations;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
@@ -137,7 +135,7 @@ public class QuantileSqlAggregator implements SqlAggregator
 
           // Check input for equivalence.
           final boolean inputMatches;
-          final VirtualColumn virtualInput =
+          final DruidExpression virtualInput =
               virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
                                    .stream()
                                    .findFirst()
@@ -147,8 +145,7 @@ public class QuantileSqlAggregator implements SqlAggregator
             inputMatches = input.isDirectColumnAccess()
                            && input.getDirectColumn().equals(theFactory.getFieldName());
           } else {
-            inputMatches = ((ExpressionVirtualColumn) virtualInput).getExpression()
-                                                                   .equals(input.getExpression());
+            inputMatches = virtualInput.equals(input);
           }
 
           final boolean matches = inputMatches
@@ -192,11 +189,11 @@ public class QuantileSqlAggregator implements SqlAggregator
         );
       }
     } else {
-      final VirtualColumn virtualColumn =
-          virtualColumnRegistry.getOrCreateVirtualColumnForExpression(plannerContext, input, ColumnType.FLOAT);
+      final String virtualColumnName =
+          virtualColumnRegistry.getOrCreateVirtualColumnForExpression(input, ColumnType.FLOAT);
       aggregatorFactory = new ApproximateHistogramAggregatorFactory(
           histogramName,
-          virtualColumn.getOutputName(),
+          virtualColumnName,
           resolution,
           numBuckets,
           lowerLimit,

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
@@ -136,7 +136,7 @@ public class QuantileSqlAggregator implements SqlAggregator
           // Check input for equivalence.
           final boolean inputMatches;
           final DruidExpression virtualInput =
-              virtualColumnRegistry.findVirtualColumns(theFactory.requiredFields())
+              virtualColumnRegistry.findVirtualColumnExpressions(theFactory.requiredFields())
                                    .stream()
                                    .findFirst()
                                    .orElse(null);

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/sql/BaseVarianceSqlAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/sql/BaseVarianceSqlAggregator.java
@@ -35,7 +35,6 @@ import org.apache.druid.query.aggregation.variance.StandardDeviationPostAggregat
 import org.apache.druid.query.aggregation.variance.VarianceAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -93,9 +92,9 @@ public abstract class BaseVarianceSqlAggregator implements SqlAggregator
     if (input.isSimpleExtraction()) {
       dimensionSpec = input.getSimpleExtraction().toDimensionSpec(null, inputType);
     } else {
-      VirtualColumn virtualColumn =
-          virtualColumnRegistry.getOrCreateVirtualColumnForExpression(plannerContext, input, dataType);
-      dimensionSpec = new DefaultDimensionSpec(virtualColumn.getOutputName(), null, inputType);
+      String virtualColumnName =
+          virtualColumnRegistry.getOrCreateVirtualColumnForExpression(input, dataType);
+      dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
     }
 
     if (inputType == null) {

--- a/extensions-core/testing-tools/src/main/java/org/apache/druid/query/sql/SleepOperatorConversion.java
+++ b/extensions-core/testing-tools/src/main/java/org/apache/druid/query/sql/SleepOperatorConversion.java
@@ -57,6 +57,6 @@ public class SleepOperatorConversion implements SqlOperatorConversion
   @Override
   public DruidExpression toDruidExpression(PlannerContext plannerContext, RowSignature rowSignature, RexNode rexNode)
   {
-    return OperatorConversions.convertCall(plannerContext, rowSignature, rexNode, "sleep");
+    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, "sleep");
   }
 }

--- a/extensions-core/testing-tools/src/main/java/org/apache/druid/query/sql/SleepOperatorConversion.java
+++ b/extensions-core/testing-tools/src/main/java/org/apache/druid/query/sql/SleepOperatorConversion.java
@@ -57,6 +57,6 @@ public class SleepOperatorConversion implements SqlOperatorConversion
   @Override
   public DruidExpression toDruidExpression(PlannerContext plannerContext, RowSignature rowSignature, RexNode rexNode)
   {
-    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, "sleep");
+    return OperatorConversions.convertDirectCall(plannerContext, rowSignature, rexNode, "sleep");
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/generator/GeneratorBasicSchemas.java
+++ b/processing/src/main/java/org/apache/druid/segment/generator/GeneratorBasicSchemas.java
@@ -321,6 +321,13 @@ public class GeneratorBasicSchemas
         GeneratorColumnSchema.makeLazyDiscreteUniform("string4", ValueType.STRING, false, 1, null, 1, 10_000),
         GeneratorColumnSchema.makeLazyDiscreteUniform("string5", ValueType.STRING, false, 1, 0.3, 1, 1_000_000),
 
+        // multi string dims
+        GeneratorColumnSchema.makeSequential("multi-string1", ValueType.STRING, false, 8, null, 0, 10000),
+        GeneratorColumnSchema.makeLazyZipf("multi-string2", ValueType.STRING, false, 8, null, 1, 100, 1.5),
+        GeneratorColumnSchema.makeLazyZipf("multi-string3", ValueType.STRING, false, 16, 0.1, 1, 1_000_000, 2.0),
+        GeneratorColumnSchema.makeLazyDiscreteUniform("multi-string4", ValueType.STRING, false, 4, null, 1, 10_000),
+        GeneratorColumnSchema.makeLazyDiscreteUniform("multi-string5", ValueType.STRING, false, 8, 0.3, 1, 1_000_000),
+
         // numeric dims
         GeneratorColumnSchema.makeSequential("long1", ValueType.LONG, false, 1, null, 0, 10000),
         GeneratorColumnSchema.makeLazyZipf("long2", ValueType.LONG, false, 1, null, 1, 101, 1.5),

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
@@ -46,6 +46,10 @@ public class ExpressionPlan
       */
     CONSTANT,
     /**
+     * expression is a simple identifier expression, do not transform
+     */
+    IDENTIFIER,
+    /**
      * expression has a single, single valued input, and is dictionary encoded if the value is a string, and does
      * not produce non-scalar output
      */

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlanner.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlanner.java
@@ -69,6 +69,8 @@ public class ExpressionPlanner
     // check and set traits which allow optimized selectors to be created
     if (columns.isEmpty()) {
       traits.add(ExpressionPlan.Trait.CONSTANT);
+    } else if (expression.isIdentifier()) {
+      traits.add(ExpressionPlan.Trait.IDENTIFIER);
     } else if (columns.size() == 1) {
       final String column = Iterables.getOnlyElement(columns);
       final ColumnCapabilities capabilities = inspector.getColumnCapabilities(column);
@@ -105,7 +107,14 @@ public class ExpressionPlanner
 
     // if we didn't eliminate this expression as a single input scalar or mappable expression, it might need
     // automatic transformation to map across multi-valued inputs (or row by row detection in the worst case)
-    if (ExpressionPlan.none(traits, ExpressionPlan.Trait.SINGLE_INPUT_SCALAR)) {
+    if (
+        ExpressionPlan.none(
+            traits,
+            ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
+            ExpressionPlan.Trait.CONSTANT,
+            ExpressionPlan.Trait.IDENTIFIER
+        )
+    ) {
       final Set<String> definitelyMultiValued = new HashSet<>();
       final Set<String> definitelyArray = new HashSet<>();
       for (String column : analysis.getRequiredBindings()) {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -350,7 +350,8 @@ public class ExpressionSelectors
    *
    * @see org.apache.druid.segment.BaseNullableColumnValueSelector#isNull() for why this only works in the numeric case
    */
-  private static <T> Supplier<T> makeNullableNumericSupplier(
+  @VisibleForTesting
+  public static <T> Supplier<T> makeNullableNumericSupplier(
       ColumnValueSelector selector,
       Supplier<T> supplier
   )
@@ -382,7 +383,7 @@ public class ExpressionSelectors
         return selector.lookupName(row.get(0));
       } else {
         // column selector factories hate you and use [] and [null] interchangeably for nullish data
-        if (row.size() == 0) {
+        if (selector.getObject() == null) {
           if (homogenize) {
             return new Object[]{null};
           } else {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -383,7 +383,7 @@ public class ExpressionSelectors
         return selector.lookupName(row.get(0));
       } else {
         // column selector factories hate you and use [] and [null] interchangeably for nullish data
-        if (selector.getObject() == null) {
+        if (row.size() == 0 || (row.size() == 1 && selector.getObject() == null)) {
           if (homogenize) {
             return new Object[]{null};
           } else {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -296,7 +296,8 @@ public class ExpressionSelectors
       } else if (capabilities.is(ValueType.STRING)) {
         supplier = supplierFromDimensionSelector(
             columnSelectorFactory.makeDimensionSelector(new DefaultDimensionSpec(columnName, columnName)),
-            multiVal
+            multiVal,
+            homogenizeNullMultiValueStringArrays
         );
       } else {
         // complex type just pass straight through
@@ -371,7 +372,7 @@ public class ExpressionSelectors
    * arrays if specified.
    */
   @VisibleForTesting
-  static Supplier<Object> supplierFromDimensionSelector(final DimensionSelector selector, boolean coerceArray)
+  static Supplier<Object> supplierFromDimensionSelector(final DimensionSelector selector, boolean coerceArray, boolean homogenize)
   {
     Preconditions.checkNotNull(selector, "selector");
     return () -> {
@@ -382,7 +383,11 @@ public class ExpressionSelectors
       } else {
         // column selector factories hate you and use [] and [null] interchangeably for nullish data
         if (row.size() == 0) {
-          return new Object[]{null};
+          if (homogenize) {
+            return new Object[]{null};
+          } else {
+            return null;
+          }
         }
         final Object[] strings = new Object[row.size()];
         // noinspection SSBasedInspection

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
@@ -64,7 +64,7 @@ public class SingleStringInputCachingExpressionColumnValueSelector implements Co
     this.selector = Preconditions.checkNotNull(selector, "selector");
     this.expression = Preconditions.checkNotNull(expression, "expression");
 
-    final Supplier<Object> inputSupplier = ExpressionSelectors.supplierFromDimensionSelector(selector, false);
+    final Supplier<Object> inputSupplier = ExpressionSelectors.supplierFromDimensionSelector(selector, false, false);
     this.bindings = InputBindings.singleProvider(ExpressionType.STRING, name -> inputSupplier.get());
 
     if (selector.getValueCardinality() == DimensionDictionarySelector.CARDINALITY_UNKNOWN) {

--- a/processing/src/test/java/org/apache/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/MultiValuedDimensionTest.java
@@ -816,10 +816,19 @@ public class MultiValuedDimensionTest extends InitializedNullHandlingTest
         query
     );
 
-    List<ResultRow> expectedResults = Arrays.asList(
-        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", NullHandling.replaceWithDefault() ? -1L : null, "count", 6L),
-        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", 1L, "count", 2L)
-    );
+    List<ResultRow> expectedResults;
+    if (NullHandling.replaceWithDefault()) {
+      expectedResults = Arrays.asList(
+          GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", -1L, "count", 4L),
+          GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", 0L, "count", 2L),
+          GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", 1L, "count", 2L)
+      );
+    } else {
+      expectedResults = Arrays.asList(
+          GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", null, "count", 6L),
+          GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", 1L, "count", 2L)
+      );
+    }
 
     TestHelper.assertExpectedObjects(expectedResults, result.toList(), "expr-auto");
   }
@@ -858,7 +867,7 @@ public class MultiValuedDimensionTest extends InitializedNullHandlingTest
     );
 
     List<ResultRow> expectedResults = Arrays.asList(
-        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foo", "count", 2L),
+        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", NullHandling.replaceWithDefault() ? null : "foo", "count", 2L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foot1, foot2, foot3", "count", 2L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foot3, foot4, foot5", "count", 2L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foot5, foot6, foot7", "count", 2L)
@@ -977,7 +986,7 @@ public class MultiValuedDimensionTest extends InitializedNullHandlingTest
         .setVirtualColumns(
             new ExpressionVirtualColumn(
                 "tt",
-                "fold((tag, acc) -> concat(concat(acc, case_searched(acc == '', '', ', '), concat('foo', tag)))), tags, '')",
+                "fold((tag, acc) -> concat(concat(acc, case_searched(acc == '', '', ', '), concat('foo', tag))), tags, '')",
                 ColumnType.STRING,
                 TestExprMacroTable.INSTANCE
             )
@@ -995,7 +1004,7 @@ public class MultiValuedDimensionTest extends InitializedNullHandlingTest
     );
 
     List<ResultRow> expectedResults = Arrays.asList(
-        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foo", "count", 2L),
+        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", NullHandling.replaceWithDefault() ? null : "foo", "count", 2L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foot1, foot2, foot3", "count", 2L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foot3, foot4, foot5", "count", 2L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "tt", "foot5, foot6, foot7", "count", 2L)

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -153,6 +153,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     final SettableSupplier<String> settableSupplier = new SettableSupplier<>();
     final Supplier<Object> supplier = ExpressionSelectors.supplierFromDimensionSelector(
         dimensionSelectorFromSupplier(settableSupplier),
+        false,
         false
     );
 

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -31,26 +31,42 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import org.apache.druid.segment.BaseSingleValueDimensionSelector;
+import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.QueryableIndexStorageAdapter;
+import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.TestObjectColumnSelector;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.generator.GeneratorBasicSchemas;
+import org.apache.druid.segment.generator.GeneratorSchemaInfo;
+import org.apache.druid.segment.generator.SegmentGenerator;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
 import org.apache.druid.segment.incremental.IndexSizeExceededException;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.LinearShardSpec;
+import org.apache.druid.utils.CloseableUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -59,6 +75,319 @@ import java.util.List;
 
 public class ExpressionSelectorsTest extends InitializedNullHandlingTest
 {
+  private static Closer CLOSER;
+  private static QueryableIndex QUERYABLE_INDEX;
+  private static QueryableIndexStorageAdapter QUERYABLE_INDEX_STORAGE_ADAPTER;
+  private static IncrementalIndex INCREMENTAL_INDEX;
+  private static IncrementalIndexStorageAdapter INCREMENTAL_INDEX_STORAGE_ADAPTER;
+  private static List<StorageAdapter> ADAPTERS;
+
+  @BeforeClass
+  public static void setup()
+  {
+    CLOSER = Closer.create();
+    final GeneratorSchemaInfo schemaInfo = GeneratorBasicSchemas.SCHEMA_MAP.get("expression-testbench");
+
+    final DataSegment dataSegment = DataSegment.builder()
+                                               .dataSource("foo")
+                                               .interval(schemaInfo.getDataInterval())
+                                               .version("1")
+                                               .shardSpec(new LinearShardSpec(0))
+                                               .size(0)
+                                               .build();
+    final SegmentGenerator segmentGenerator = CLOSER.register(new SegmentGenerator());
+
+    final int numRows = 10_000;
+    INCREMENTAL_INDEX = CLOSER.register(
+        segmentGenerator.generateIncrementalIndex(dataSegment, schemaInfo, Granularities.HOUR, numRows)
+    );
+    INCREMENTAL_INDEX_STORAGE_ADAPTER = new IncrementalIndexStorageAdapter(INCREMENTAL_INDEX);
+
+    QUERYABLE_INDEX = CLOSER.register(
+        segmentGenerator.generate(dataSegment, schemaInfo, Granularities.HOUR, numRows)
+    );
+    QUERYABLE_INDEX_STORAGE_ADAPTER = new QueryableIndexStorageAdapter(QUERYABLE_INDEX);
+
+    ADAPTERS = ImmutableList.of(INCREMENTAL_INDEX_STORAGE_ADAPTER, QUERYABLE_INDEX_STORAGE_ADAPTER);
+  }
+
+  @AfterClass
+  public static void teardown()
+  {
+    CloseableUtils.closeAndSuppressExceptions(CLOSER, throwable -> {});
+  }
+
+  @Test
+  public void test_single_value_string_bindings()
+  {
+    final String columnName = "string3";
+    for (StorageAdapter adapter : ADAPTERS) {
+      Sequence<Cursor> cursorSequence = adapter.makeCursors(
+          null,
+          adapter.getInterval(),
+          VirtualColumns.EMPTY,
+          Granularities.ALL,
+          false,
+          null
+      );
+
+      List<Cursor> flatten = cursorSequence.toList();
+
+      for (Cursor cursor : flatten) {
+        ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
+        ExpressionPlan plan = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse("\"string3\"", TestExprMacroTable.INSTANCE)
+        );
+        ExpressionPlan plan2 = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse(
+                "concat(\"string3\", 'foo')",
+                TestExprMacroTable.INSTANCE
+            )
+        );
+
+        Expr.ObjectBinding bindings = ExpressionSelectors.createBindings(factory, plan);
+        Expr.ObjectBinding bindings2 = ExpressionSelectors.createBindings(factory, plan2);
+
+        DimensionSelector dimSelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(columnName));
+        ColumnValueSelector valueSelector = factory.makeColumnValueSelector(columnName);
+
+        // realtime index needs to handle as multi-value in case any new values are added during processing
+        final boolean isMultiVal = factory.getColumnCapabilities(columnName) == null ||
+                                   factory.getColumnCapabilities(columnName).hasMultipleValues().isMaybeTrue();
+        while (!cursor.isDone()) {
+          Object dimSelectorVal = dimSelector.getObject();
+          Object valueSelectorVal = valueSelector.getObject();
+          Object bindingVal = bindings.get(columnName);
+          Object bindingVal2 = bindings2.get(columnName);
+          if (dimSelectorVal == null) {
+            Assert.assertNull(dimSelectorVal);
+            Assert.assertNull(valueSelectorVal);
+            Assert.assertNull(bindingVal);
+            if (isMultiVal) {
+              Assert.assertNull(((Object[]) bindingVal2)[0]);
+            } else {
+              Assert.assertNull(bindingVal2);
+            }
+
+          } else {
+            if (isMultiVal) {
+              Assert.assertEquals(dimSelectorVal, ((Object[]) bindingVal)[0]);
+              Assert.assertEquals(valueSelectorVal, ((Object[]) bindingVal)[0]);
+              Assert.assertEquals(dimSelectorVal, ((Object[]) bindingVal2)[0]);
+              Assert.assertEquals(valueSelectorVal, ((Object[]) bindingVal2)[0]);
+            } else {
+              Assert.assertEquals(dimSelectorVal, bindingVal);
+              Assert.assertEquals(valueSelectorVal, bindingVal);
+              Assert.assertEquals(dimSelectorVal, bindingVal2);
+              Assert.assertEquals(valueSelectorVal, bindingVal2);
+            }
+          }
+
+          cursor.advance();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void test_multi_value_string_bindings()
+  {
+    final String columnName = "multi-string3";
+    for (StorageAdapter adapter : ADAPTERS) {
+      Sequence<Cursor> cursorSequence = adapter.makeCursors(
+          null,
+          adapter.getInterval(),
+          VirtualColumns.EMPTY,
+          Granularities.ALL,
+          false,
+          null
+      );
+
+      List<Cursor> flatten = cursorSequence.toList();
+
+      for (Cursor cursor : flatten) {
+        ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
+
+        // identifier, uses dimension selector supplier supplier, no null coercion
+        ExpressionPlan plan = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse("\"multi-string3\"", TestExprMacroTable.INSTANCE)
+        );
+        // array output, uses object selector supplier, no null coercion
+        ExpressionPlan plan2 = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse(
+                "array_append(\"multi-string3\", 'foo')",
+                TestExprMacroTable.INSTANCE
+            )
+        );
+        // array input, uses dimension selector supplier, no null coercion
+        ExpressionPlan plan3 = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse(
+                "array_length(\"multi-string3\")",
+                TestExprMacroTable.INSTANCE
+            )
+        );
+        // used as scalar, has null coercion
+        ExpressionPlan plan4 = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse(
+                "concat(\"multi-string3\", 'foo')",
+                TestExprMacroTable.INSTANCE
+            )
+        );
+        Expr.ObjectBinding bindings = ExpressionSelectors.createBindings(factory, plan);
+        Expr.ObjectBinding bindings2 = ExpressionSelectors.createBindings(factory, plan2);
+        Expr.ObjectBinding bindings3 = ExpressionSelectors.createBindings(factory, plan3);
+        Expr.ObjectBinding bindings4 = ExpressionSelectors.createBindings(factory, plan4);
+
+        DimensionSelector dimSelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(columnName));
+        ColumnValueSelector valueSelector = factory.makeColumnValueSelector(columnName);
+
+        while (!cursor.isDone()) {
+          Object dimSelectorVal = dimSelector.getObject();
+          Object valueSelectorVal = valueSelector.getObject();
+          Object bindingVal = bindings.get(columnName);
+          Object bindingVal2 = bindings2.get(columnName);
+          Object bindingVal3 = bindings3.get(columnName);
+          Object bindingVal4 = bindings4.get(columnName);
+
+          if (dimSelectorVal == null) {
+            Assert.assertNull(dimSelectorVal);
+            Assert.assertNull(valueSelectorVal);
+            Assert.assertNull(bindingVal);
+            Assert.assertNull(bindingVal2);
+            Assert.assertNull(bindingVal3);
+            // binding4 has null coercion
+            Assert.assertArrayEquals(new Object[]{null}, (Object[]) bindingVal4);
+          } else {
+            Assert.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal);
+            Assert.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal);
+            Assert.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal2);
+            Assert.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal2);
+            Assert.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal3);
+            Assert.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal3);
+          }
+
+          cursor.advance();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void test_long_bindings()
+  {
+    final String columnName = "long3";
+    for (StorageAdapter adapter : ADAPTERS) {
+      Sequence<Cursor> cursorSequence = adapter.makeCursors(
+          null,
+          adapter.getInterval(),
+          VirtualColumns.EMPTY,
+          Granularities.ALL,
+          false,
+          null
+      );
+
+      List<Cursor> flatten = cursorSequence.toList();
+
+      for (Cursor cursor : flatten) {
+        ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
+        // an assortment of plans
+        ExpressionPlan plan = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse("\"long3\"", TestExprMacroTable.INSTANCE)
+        );
+        ExpressionPlan plan2 = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse(
+                "\"long3\" + 3",
+                TestExprMacroTable.INSTANCE
+            )
+        );
+
+        Expr.ObjectBinding bindings = ExpressionSelectors.createBindings(factory, plan);
+        Expr.ObjectBinding bindings2 = ExpressionSelectors.createBindings(factory, plan2);
+
+        ColumnValueSelector valueSelector = factory.makeColumnValueSelector(columnName);
+
+        while (!cursor.isDone()) {
+          Object bindingVal = bindings.get(columnName);
+          Object bindingVal2 = bindings2.get(columnName);
+          if (valueSelector.isNull()) {
+            Assert.assertNull(valueSelector.getObject());
+            Assert.assertNull(bindingVal);
+            Assert.assertNull(bindingVal2);
+          } else {
+            Assert.assertEquals(valueSelector.getObject(), bindingVal);
+            Assert.assertEquals(valueSelector.getLong(), bindingVal);
+            Assert.assertEquals(valueSelector.getObject(), bindingVal2);
+            Assert.assertEquals(valueSelector.getLong(), bindingVal2);
+          }
+          cursor.advance();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void test_double_bindings()
+  {
+    final String columnName = "double3";
+    for (StorageAdapter adapter : ADAPTERS) {
+      Sequence<Cursor> cursorSequence = adapter.makeCursors(
+          null,
+          adapter.getInterval(),
+          VirtualColumns.EMPTY,
+          Granularities.ALL,
+          false,
+          null
+      );
+
+      List<Cursor> flatten = cursorSequence.toList();
+
+      for (Cursor cursor : flatten) {
+        ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
+        // an assortment of plans
+        ExpressionPlan plan = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse("\"double3\"", TestExprMacroTable.INSTANCE)
+        );
+        ExpressionPlan plan2 = ExpressionPlanner.plan(
+            adapter,
+            Parser.parse(
+                "\"double3\" + 3.0",
+                TestExprMacroTable.INSTANCE
+            )
+        );
+
+        Expr.ObjectBinding bindings = ExpressionSelectors.createBindings(factory, plan);
+        Expr.ObjectBinding bindings2 = ExpressionSelectors.createBindings(factory, plan2);
+
+        ColumnValueSelector valueSelector = factory.makeColumnValueSelector(columnName);
+
+        while (!cursor.isDone()) {
+          Object bindingVal = bindings.get(columnName);
+          Object bindingVal2 = bindings2.get(columnName);
+          if (valueSelector.isNull()) {
+            Assert.assertNull(valueSelector.getObject());
+            Assert.assertNull(bindingVal);
+            Assert.assertNull(bindingVal2);
+          } else {
+            Assert.assertEquals(valueSelector.getObject(), bindingVal);
+            Assert.assertEquals(valueSelector.getDouble(), bindingVal);
+            Assert.assertEquals(valueSelector.getObject(), bindingVal2);
+            Assert.assertEquals(valueSelector.getDouble(), bindingVal2);
+          }
+          cursor.advance();
+        }
+      }
+    }
+  }
+
   @Test
   public void test_canMapOverDictionary_oneSingleValueInput()
   {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArraySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArraySqlAggregator.java
@@ -40,7 +40,6 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.query.aggregation.ExpressionLambdaAggregatorFactory;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -118,8 +117,7 @@ public class ArraySqlAggregator implements SqlAggregator
     if (arg.isDirectColumnAccess()) {
       fieldName = arg.getDirectColumn();
     } else {
-      VirtualColumn vc = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(plannerContext, arg, elementType);
-      fieldName = vc.getOutputName();
+      fieldName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(arg, elementType);
     }
 
     if (aggregateCall.isDistinct()) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
@@ -32,7 +32,6 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -116,8 +115,8 @@ public class AvgSqlAggregator implements SqlAggregator
           project,
           Iterables.getOnlyElement(aggregateCall.getArgList())
       );
-      VirtualColumn vc = virtualColumnRegistry.getVirtualColumnByExpression(arg.getExpression(), resolutionArg.getType());
-      fieldName = vc != null ? vc.getOutputName() : null;
+      String vc = virtualColumnRegistry.getVirtualColumnByExpression(arg, resolutionArg.getType());
+      fieldName = vc != null ? vc : null;
       expression = vc != null ? null : arg.getExpression();
     }
     final String sumName = Calcites.makePrefixedName(name, "sum");

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BitwiseSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BitwiseSqlAggregator.java
@@ -38,7 +38,6 @@ import org.apache.druid.query.aggregation.ExpressionLambdaAggregatorFactory;
 import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.filter.NotDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -149,8 +148,7 @@ public class BitwiseSqlAggregator implements SqlAggregator
     if (arg.isDirectColumnAccess()) {
       fieldName = arg.getDirectColumn();
     } else {
-      VirtualColumn vc = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(plannerContext, arg, ColumnType.LONG);
-      fieldName = vc.getOutputName();
+      fieldName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(arg, ColumnType.LONG);
     }
 
     return Aggregation.create(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -41,7 +41,6 @@ import org.apache.druid.query.aggregation.hyperloglog.HyperUniqueFinalizingPostA
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
@@ -118,9 +117,8 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
       if (arg.isSimpleExtraction()) {
         dimensionSpec = arg.getSimpleExtraction().toDimensionSpec(null, inputType);
       } else {
-        VirtualColumn virtualColumn =
-            virtualColumnRegistry.getOrCreateVirtualColumnForExpression(plannerContext, arg, dataType);
-        dimensionSpec = new DefaultDimensionSpec(virtualColumn.getOutputName(), null, inputType);
+        String virtualColumnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(arg, dataType);
+        dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
       }
 
       aggregatorFactory = new CardinalityAggregatorFactory(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestAnySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestAnySqlAggregator.java
@@ -51,7 +51,6 @@ import org.apache.druid.query.aggregation.last.FloatLastAggregatorFactory;
 import org.apache.druid.query.aggregation.last.LongLastAggregatorFactory;
 import org.apache.druid.query.aggregation.last.StringLastAggregatorFactory;
 import org.apache.druid.query.aggregation.post.FinalizingFieldAccessPostAggregator;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -64,7 +63,6 @@ import org.apache.druid.sql.calcite.planner.UnsupportedSQLQueryException;
 import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
 
 import javax.annotation.Nullable;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -239,9 +237,7 @@ public class EarliestLatestAnySqlAggregator implements SqlAggregator
       columnName = arg.getDirectColumn();
     } else {
       final RelDataType dataType = rexNode.getType();
-      final VirtualColumn virtualColumn =
-          virtualColumnRegistry.getOrCreateVirtualColumnForExpression(plannerContext, arg, dataType);
-      columnName = virtualColumn.getOutputName();
+      columnName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(arg, dataType);
     }
     return columnName;
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/GroupingSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/GroupingSqlAggregator.java
@@ -27,7 +27,6 @@ import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.GroupingAggregatorFactory;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
@@ -116,11 +115,10 @@ public class GroupingSqlAggregator implements SqlAggregator
       return expression.getDirectColumn();
     }
 
-    VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-        plannerContext,
+    String virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
         expression,
         node.getType()
     );
-    return virtualColumn.getOutputName();
+    return virtualColumn;
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/StringSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/StringSqlAggregator.java
@@ -43,7 +43,6 @@ import org.apache.druid.query.aggregation.ExpressionLambdaAggregatorFactory;
 import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.filter.NotDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
@@ -135,8 +134,7 @@ public class StringSqlAggregator implements SqlAggregator
     if (arg.isDirectColumnAccess()) {
       fieldName = arg.getDirectColumn();
     } else {
-      VirtualColumn vc = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(plannerContext, arg, elementType);
-      fieldName = vc.getOutputName();
+      fieldName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(arg, elementType);
     }
 
     final String finalizer = StringUtils.format("if(array_length(o) == 0, null, array_to_string(o, '%s'))", separator);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/BinaryOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/BinaryOperatorConversion.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
@@ -58,22 +59,7 @@ public class BinaryOperatorConversion implements SqlOperatorConversion
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> {
-          if (operands.size() < 2) {
-            throw new ISE("Got binary operator[%s] with %s args", operator.getName(), operands.size());
-          }
-
-          return DruidExpression.fromExpression(
-              StringUtils.format(
-                  "(%s)",
-                  joiner.join(
-                      operands.stream()
-                              .map(DruidExpression::getExpression)
-                              .collect(Collectors.toList())
-                  )
-              )
-          );
-        }
+        getOperatorFunction(rexNode)
     );
   }
 
@@ -90,23 +76,30 @@ public class BinaryOperatorConversion implements SqlOperatorConversion
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> {
-          if (operands.size() < 2) {
-            throw new ISE("Got binary operator[%s] with %s args", operator.getName(), operands.size());
-          }
-
-          return DruidExpression.fromExpression(
-              StringUtils.format(
-                  "(%s)",
-                  joiner.join(
-                      operands.stream()
-                              .map(DruidExpression::getExpression)
-                              .collect(Collectors.toList())
-                  )
-              )
-          );
-        },
+        getOperatorFunction(rexNode),
         postAggregatorVisitor
     );
+  }
+
+  private DruidExpression.DruidExpressionBuilder getOperatorFunction(RexNode rexNode)
+  {
+    return operands -> {
+      if (operands.size() < 2) {
+        throw new ISE("Got binary operator[%s] with %s args", operator.getName(), operands.size());
+      }
+
+      return DruidExpression.ofExpression(
+          Calcites.getColumnTypeForRelDataType(rexNode.getType()),
+          (args) -> StringUtils.format(
+              "(%s)",
+              joiner.join(
+                  args.stream()
+                      .map(DruidExpression::getExpression)
+                      .collect(Collectors.toList())
+              )
+          ),
+          operands
+      );
+    };
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/DirectOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/DirectOperatorConversion.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql.calcite.expression;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
@@ -53,11 +54,11 @@ public class DirectOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertSimpleCall(
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> DruidExpression.fromExpression(DruidExpression.functionCall(druidFunctionName, operands))
+        druidFunctionName
     );
   }
 
@@ -79,7 +80,11 @@ public class DirectOperatorConversion implements SqlOperatorConversion
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> DruidExpression.fromExpression(DruidExpression.functionCall(druidFunctionName, operands)),
+        operands -> DruidExpression.ofFunctionCall(
+            Calcites.getColumnTypeForRelDataType(rexNode.getType()),
+            druidFunctionName,
+            operands
+        ),
         postAggregatorVisitor
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/DirectOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/DirectOperatorConversion.java
@@ -54,7 +54,7 @@ public class DirectOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertSimpleCall(
+    return OperatorConversions.convertDirectCall(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
@@ -152,6 +152,11 @@ public class DruidExpression
     );
   }
 
+  public static DruidExpression ofStringLiteral(final String s)
+  {
+    return ofLiteral(ColumnType.STRING, stringLiteral(s));
+  }
+
   public static DruidExpression ofColumn(
       @Nullable final ColumnType columnType,
       final String column,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
@@ -40,12 +40,22 @@ import java.util.Objects;
 import java.util.function.Function;
 
 /**
- * todo(clint): rewrite javadocs
- *
  * Represents two kinds of expression-like concepts that native Druid queries support:
  *
  * (1) SimpleExtractions, which are direct column access, possibly with an extractionFn
- * (2) native Druid expressions.
+ * (2) native Druid expressions and virtual columns
+ *
+ * When added to {@link org.apache.druid.sql.calcite.rel.VirtualColumnRegistry} whenever used by projections, filters,
+ * aggregators, or other query components, these will be converted into native virtual columns using
+ * {@link #toVirtualColumn(String, ColumnType, ExprMacroTable)}
+ *
+ * Approximate expression structure is retained in the {@link #arguments}, which when fed into the
+ * {@link ExpressionBuilder} that all {@link DruidExpression} must be created with will produce the final String
+ * expression (which will be later parsed into {@link Expr} during native processing).
+ *
+ * This allows using the {@link DruidExpressionShuttle} to examine this expression "tree" and potentially rewrite some
+ * or all of the tree as it visits nodes, and the {@link #nodeType} property provides high level classification of
+ * the types of expression which a node produces.
  */
 public class DruidExpression
 {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
@@ -297,7 +297,7 @@ public class Expressions
       final long months = ((Number) RexLiteral.value(rexNode)).longValue();
       return DruidExpression.ofLiteral(columnType, DruidExpression.numberLiteral(months));
     } else if (SqlTypeName.STRING_TYPES.contains(sqlTypeName)) {
-      return DruidExpression.ofLiteral(columnType, DruidExpression.stringLiteral(RexLiteral.stringValue(rexNode)));
+      return DruidExpression.ofStringLiteral(RexLiteral.stringValue(rexNode));
     } else if (SqlTypeName.TIMESTAMP == sqlTypeName || SqlTypeName.DATE == sqlTypeName) {
       if (RexLiteral.isNullLiteral(rexNode)) {
         return DruidExpression.ofLiteral(columnType, DruidExpression.nullLiteral());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
@@ -50,8 +50,8 @@ import org.apache.druid.query.filter.OrDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.ordering.StringComparator;
 import org.apache.druid.query.ordering.StringComparators;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.filtration.BoundRefKey;
 import org.apache.druid.sql.calcite.filtration.Bounds;
@@ -65,6 +65,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A collection of functions for translating from Calcite expressions into Druid objects.
@@ -222,11 +223,12 @@ public class Expressions
     // Translate field references.
     final RexInputRef ref = (RexInputRef) rexNode;
     final String columnName = rowSignature.getColumnName(ref.getIndex());
+    final Optional<ColumnType> columnType = rowSignature.getColumnType(ref.getIndex());
     if (columnName == null) {
       throw new ISE("Expression referred to nonexistent index[%d]", ref.getIndex());
     }
 
-    return DruidExpression.fromColumn(columnName);
+    return DruidExpression.ofColumn(columnType.orElse(null), columnName);
   }
 
   private static DruidExpression rexCallToDruidExpression(
@@ -258,7 +260,7 @@ public class Expressions
         if (postAggregator != null) {
           postAggregatorVisitor.addPostAgg(postAggregator);
           String exprName = postAggregator.getName();
-          return DruidExpression.of(SimpleExtraction.of(exprName, null), exprName);
+          return DruidExpression.ofColumn(postAggregator.getType(rowSignature), exprName);
         }
       }
 
@@ -272,6 +274,7 @@ public class Expressions
     }
   }
 
+  @Nullable
   private static DruidExpression literalToDruidExpression(
       final PlannerContext plannerContext,
       final RexNode rexNode
@@ -280,32 +283,34 @@ public class Expressions
     final SqlTypeName sqlTypeName = rexNode.getType().getSqlTypeName();
 
     // Translate literal.
+    final ColumnType columnType = Calcites.getColumnTypeForRelDataType(rexNode.getType());
     if (RexLiteral.isNullLiteral(rexNode)) {
-      return DruidExpression.fromExpression(DruidExpression.nullLiteral());
+      return DruidExpression.ofLiteral(columnType, DruidExpression.nullLiteral());
     } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
-      return DruidExpression.fromExpression(DruidExpression.numberLiteral((Number) RexLiteral.value(rexNode)));
+      return DruidExpression.ofLiteral(columnType, DruidExpression.numberLiteral((Number) RexLiteral.value(rexNode)));
     } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getFamily()) {
       // Calcite represents DAY-TIME intervals in milliseconds.
       final long milliseconds = ((Number) RexLiteral.value(rexNode)).longValue();
-      return DruidExpression.fromExpression(DruidExpression.numberLiteral(milliseconds));
+      return DruidExpression.ofLiteral(columnType, DruidExpression.numberLiteral(milliseconds));
     } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getFamily()) {
       // Calcite represents YEAR-MONTH intervals in months.
       final long months = ((Number) RexLiteral.value(rexNode)).longValue();
-      return DruidExpression.fromExpression(DruidExpression.numberLiteral(months));
+      return DruidExpression.ofLiteral(columnType, DruidExpression.numberLiteral(months));
     } else if (SqlTypeName.STRING_TYPES.contains(sqlTypeName)) {
-      return DruidExpression.fromExpression(DruidExpression.stringLiteral(RexLiteral.stringValue(rexNode)));
+      return DruidExpression.ofLiteral(columnType, DruidExpression.stringLiteral(RexLiteral.stringValue(rexNode)));
     } else if (SqlTypeName.TIMESTAMP == sqlTypeName || SqlTypeName.DATE == sqlTypeName) {
       if (RexLiteral.isNullLiteral(rexNode)) {
-        return DruidExpression.fromExpression(DruidExpression.nullLiteral());
+        return DruidExpression.ofLiteral(columnType, DruidExpression.nullLiteral());
       } else {
-        return DruidExpression.fromExpression(
+        return DruidExpression.ofLiteral(
+            columnType,
             DruidExpression.numberLiteral(
                 Calcites.calciteDateTimeLiteralToJoda(rexNode, plannerContext.getTimeZone()).getMillis()
             )
         );
       }
     } else if (SqlTypeName.BOOLEAN == sqlTypeName) {
-      return DruidExpression.fromExpression(DruidExpression.numberLiteral(RexLiteral.booleanValue(rexNode) ? 1 : 0));
+      return DruidExpression.ofLiteral(columnType, DruidExpression.numberLiteral(RexLiteral.booleanValue(rexNode) ? 1 : 0));
     } else {
       // Can't translate other literals.
       return null;
@@ -470,14 +475,13 @@ public class Expressions
             druidExpression.getSimpleExtraction().getExtractionFn()
         );
       } else if (virtualColumnRegistry != null) {
-        final VirtualColumn virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-            plannerContext,
+        final String virtualColumn = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
             druidExpression,
             operand.getType()
         );
 
         equalFilter = new SelectorDimFilter(
-            virtualColumn.getOutputName(),
+            virtualColumn,
             NullHandling.defaultStringValue(),
             null
         );
@@ -559,13 +563,10 @@ public class Expressions
         column = lhsExpression.getSimpleExtraction().getColumn();
         extractionFn = lhsExpression.getSimpleExtraction().getExtractionFn();
       } else if (virtualColumnRegistry != null) {
-        VirtualColumn virtualLhs = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-            plannerContext,
+        column = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
             lhsExpression,
             lhs.getType()
         );
-
-        column = virtualLhs.getOutputName();
         extractionFn = null;
       } else {
         return null;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/OperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/OperatorConversions.java
@@ -71,8 +71,9 @@ import java.util.stream.IntStream;
  */
 public class OperatorConversions
 {
+
   @Nullable
-  public static DruidExpression convertSimpleCall(
+  public static DruidExpression convertDirectCall(
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
       final RexNode rexNode,
@@ -92,7 +93,7 @@ public class OperatorConversions
   }
 
   @Nullable
-  public static DruidExpression convertSimpleCallWithExtraction(
+  public static DruidExpression convertDirectCallWithExtraction(
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
       final RexNode rexNode,
@@ -113,6 +114,7 @@ public class OperatorConversions
     );
   }
 
+  @Nullable
   public static DruidExpression convertCallBuilder(
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
@@ -153,6 +155,37 @@ public class OperatorConversions
     }
 
     return expressionFunction.buildExpression(druidExpressions);
+  }
+
+  @Deprecated
+  @Nullable
+  public static DruidExpression convertCall(
+      final PlannerContext plannerContext,
+      final RowSignature rowSignature,
+      final RexNode rexNode,
+      final String functionName
+  )
+  {
+    return convertDirectCall(plannerContext, rowSignature, rexNode, functionName);
+  }
+
+  @Deprecated
+  @Nullable
+  public static DruidExpression convertCall(
+      final PlannerContext plannerContext,
+      final RowSignature rowSignature,
+      final RexNode rexNode,
+      final String functionName,
+      final Function<List<DruidExpression>, SimpleExtraction> simpleExtractionFunction
+  )
+  {
+    return convertDirectCallWithExtraction(
+        plannerContext,
+        rowSignature,
+        rexNode,
+        functionName,
+        simpleExtractionFunction
+    );
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/UnaryFunctionOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/UnaryFunctionOperatorConversion.java
@@ -50,16 +50,14 @@ public class UnaryFunctionOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertCallBuilder(
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> DruidExpression.fromExpression(
-            StringUtils.format(
-                "%s(%s)",
-                druidOperator,
-                Iterables.getOnlyElement(operands).getExpression()
-            )
+        operands -> StringUtils.format(
+            "%s(%s)",
+            druidOperator,
+            Iterables.getOnlyElement(operands).getExpression()
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/UnaryPrefixOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/UnaryPrefixOperatorConversion.java
@@ -50,16 +50,14 @@ public class UnaryPrefixOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertCallBuilder(
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> DruidExpression.fromExpression(
-            StringUtils.format(
-                "(%s %s)",
-                druidOperator,
-                Iterables.getOnlyElement(operands).getExpression()
-            )
+        operands -> StringUtils.format(
+            "(%s %s)",
+            druidOperator,
+            Iterables.getOnlyElement(operands).getExpression()
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/UnarySuffixOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/UnarySuffixOperatorConversion.java
@@ -50,16 +50,14 @@ public class UnarySuffixOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertCallBuilder(
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> DruidExpression.fromExpression(
-            StringUtils.format(
-                "(%s %s)",
-                Iterables.getOnlyElement(operands).getExpression(),
-                druidOperator
-            )
+        operands -> StringUtils.format(
+            "(%s %s)",
+            Iterables.getOnlyElement(operands).getExpression(),
+            druidOperator
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayAppendOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayAppendOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
 import org.apache.druid.sql.calcite.planner.Calcites;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayAppendOperatorConversion implements SqlOperatorConversion
+public class ArrayAppendOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_APPEND")
@@ -53,27 +48,8 @@ public class ArrayAppendOperatorConversion implements SqlOperatorConversion
       .returnTypeInference(Calcites.ARG0_NULLABLE_ARRAY_RETURN_TYPE_INFERENCE)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayAppendOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_append", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_append");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConcatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConcatOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
 import org.apache.druid.sql.calcite.planner.Calcites;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayConcatOperatorConversion implements SqlOperatorConversion
+public class ArrayConcatOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_CONCAT")
@@ -53,27 +48,8 @@ public class ArrayConcatOperatorConversion implements SqlOperatorConversion
       .returnTypeInference(Calcites.ARG0_NULLABLE_ARRAY_RETURN_TYPE_INFERENCE)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayConcatOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_concat", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_concat");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConstructorOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConstructorOperatorConversion.java
@@ -19,40 +19,13 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
-import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 
-public class ArrayConstructorOperatorConversion implements SqlOperatorConversion
+public class ArrayConstructorOperatorConversion extends DirectOperatorConversion
 {
-  private static final SqlOperator SQL_FUNCTION = SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR;
-
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayConstructorOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array", druidExpressions)
-        )
-    );
+    super(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, "array");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayLengthOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayLengthOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayLengthOperatorConversion implements SqlOperatorConversion
+public class ArrayLengthOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_LENGTH")
@@ -46,27 +41,8 @@ public class ArrayLengthOperatorConversion implements SqlOperatorConversion
       .returnTypeCascadeNullable(SqlTypeName.INTEGER)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayLengthOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_length", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_length");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOfOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOfOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayOffsetOfOperatorConversion implements SqlOperatorConversion
+public class ArrayOffsetOfOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_OFFSET_OF")
@@ -50,27 +45,8 @@ public class ArrayOffsetOfOperatorConversion implements SqlOperatorConversion
       .returnTypeNullable(SqlTypeName.INTEGER)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayOffsetOfOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_offset_of", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_offset_of");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOperatorConversion.java
@@ -19,19 +19,14 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayOffsetOperatorConversion implements SqlOperatorConversion
+public class ArrayOffsetOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_OFFSET")
@@ -49,27 +44,8 @@ public class ArrayOffsetOperatorConversion implements SqlOperatorConversion
       .returnTypeInference(ArrayOrdinalOperatorConversion.ARG0_ELEMENT_INFERENCE)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayOffsetOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_offset", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_offset");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOfOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOfOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayOrdinalOfOperatorConversion implements SqlOperatorConversion
+public class ArrayOrdinalOfOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_ORDINAL_OF")
@@ -50,27 +45,8 @@ public class ArrayOrdinalOfOperatorConversion implements SqlOperatorConversion
       .returnTypeCascadeNullable(SqlTypeName.INTEGER)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayOrdinalOfOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_ordinal_of", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_ordinal_of");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOperatorConversion.java
@@ -20,22 +20,17 @@
 package org.apache.druid.sql.calcite.expression.builtin;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeUtil;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayOrdinalOperatorConversion implements SqlOperatorConversion
+public class ArrayOrdinalOperatorConversion extends DirectOperatorConversion
 {
   static final SqlReturnTypeInference ARG0_ELEMENT_INFERENCE = new ArrayElementReturnTypeInference();
 
@@ -55,28 +50,9 @@ public class ArrayOrdinalOperatorConversion implements SqlOperatorConversion
       .returnTypeInference(ARG0_ELEMENT_INFERENCE)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayOrdinalOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_ordinal", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_ordinal");
   }
 
   static class ArrayElementReturnTypeInference implements SqlReturnTypeInference

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayPrependOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayPrependOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
 import org.apache.druid.sql.calcite.planner.Calcites;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayPrependOperatorConversion implements SqlOperatorConversion
+public class ArrayPrependOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_PREPEND")
@@ -53,27 +48,8 @@ public class ArrayPrependOperatorConversion implements SqlOperatorConversion
       .returnTypeInference(Calcites.ARG1_NULLABLE_ARRAY_RETURN_TYPE_INFERENCE)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayPrependOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_prepend", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_prepend");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArraySliceOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArraySliceOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
 import org.apache.druid.sql.calcite.planner.Calcites;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArraySliceOperatorConversion implements SqlOperatorConversion
+public class ArraySliceOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_SLICE")
@@ -61,27 +56,8 @@ public class ArraySliceOperatorConversion implements SqlOperatorConversion
       .returnTypeInference(Calcites.ARG0_NULLABLE_ARRAY_RETURN_TYPE_INFERENCE)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArraySliceOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_slice", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_slice");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToStringOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToStringOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ArrayToStringOperatorConversion implements SqlOperatorConversion
+public class ArrayToStringOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("ARRAY_TO_STRING")
@@ -50,27 +45,8 @@ public class ArrayToStringOperatorConversion implements SqlOperatorConversion
       .returnTypeCascadeNullable(SqlTypeName.VARCHAR)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ArrayToStringOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("array_to_string", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "array_to_string");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BTrimOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BTrimOperatorConversion.java
@@ -26,10 +26,12 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class BTrimOperatorConversion implements SqlOperatorConversion
@@ -64,13 +66,15 @@ public class BTrimOperatorConversion implements SqlOperatorConversion
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.BOTH,
                 druidExpressions.get(0),
-                druidExpressions.get(1)
+                druidExpressions.get(1),
+                Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           } else {
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.BOTH,
                 druidExpressions.get(0),
-                DruidExpression.fromExpression(DruidExpression.stringLiteral(" "))
+                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" ")),
+                Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           }
         }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BTrimOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/BTrimOperatorConversion.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
@@ -73,7 +72,7 @@ public class BTrimOperatorConversion implements SqlOperatorConversion
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.BOTH,
                 druidExpressions.get(0),
-                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" ")),
+                DruidExpression.ofStringLiteral(" "),
                 Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -114,7 +114,7 @@ public class CastOperatorConversion implements SqlOperatorConversion
           Calcites.getColumnTypeForRelDataType(rexNode.getType())
       );
     } else if (SqlTypeName.DATETIME_TYPES.contains(fromType) && SqlTypeName.CHAR_TYPES.contains(toType)) {
-      return castDateTimeToChar(plannerContext, operandExpression, fromType, Calcites.getColumnTypeForRelDataType(operand.getType()));
+      return castDateTimeToChar(plannerContext, operandExpression, fromType, Calcites.getColumnTypeForRelDataType(rexNode.getType()));
     } else {
       // Handle other casts.
       final ExprType fromExprType = EXPRESSION_TYPES.get(fromType);
@@ -185,11 +185,11 @@ public class CastOperatorConversion implements SqlOperatorConversion
       final PlannerContext plannerContext,
       final DruidExpression operand,
       final SqlTypeName fromType,
-      final ColumnType fromDruidType
+      final ColumnType toDruidType
   )
   {
     return DruidExpression.ofFunctionCall(
-        fromDruidType,
+        toDruidType,
         "timestamp_format",
         ImmutableList.of(
             operand,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -164,10 +164,7 @@ public class CastOperatorConversion implements SqlOperatorConversion
         ImmutableList.of(
             operand,
             DruidExpression.ofLiteral(null, DruidExpression.nullLiteral()),
-            DruidExpression.ofLiteral(
-                ColumnType.STRING,
-                DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
-            )
+            DruidExpression.ofStringLiteral(plannerContext.getTimeZone().getID())
         )
     );
 
@@ -196,11 +193,8 @@ public class CastOperatorConversion implements SqlOperatorConversion
         "timestamp_format",
         ImmutableList.of(
             operand,
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(dateTimeFormatString(fromType))),
-            DruidExpression.ofLiteral(
-                ColumnType.STRING,
-                DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
-            )
+            DruidExpression.ofStringLiteral(dateTimeFormatString(fromType)),
+            DruidExpression.ofStringLiteral(plannerContext.getTimeZone().getID())
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -30,10 +30,12 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
 import org.apache.druid.math.expr.ExprType;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.Period;
 
@@ -105,9 +107,14 @@ public class CastOperatorConversion implements SqlOperatorConversion
     final SqlTypeName toType = rexNode.getType().getSqlTypeName();
 
     if (SqlTypeName.CHAR_TYPES.contains(fromType) && SqlTypeName.DATETIME_TYPES.contains(toType)) {
-      return castCharToDateTime(plannerContext, operandExpression, toType);
+      return castCharToDateTime(
+          plannerContext,
+          operandExpression,
+          toType,
+          Calcites.getColumnTypeForRelDataType(rexNode.getType())
+      );
     } else if (SqlTypeName.DATETIME_TYPES.contains(fromType) && SqlTypeName.CHAR_TYPES.contains(toType)) {
-      return castDateTimeToChar(plannerContext, operandExpression, fromType);
+      return castDateTimeToChar(plannerContext, operandExpression, fromType, Calcites.getColumnTypeForRelDataType(operand.getType()));
     } else {
       // Handle other casts.
       final ExprType fromExprType = EXPRESSION_TYPES.get(fromType);
@@ -146,16 +153,21 @@ public class CastOperatorConversion implements SqlOperatorConversion
   private static DruidExpression castCharToDateTime(
       final PlannerContext plannerContext,
       final DruidExpression operand,
-      final SqlTypeName toType
+      final SqlTypeName toType,
+      final ColumnType toDruidType
   )
   {
     // Cast strings to datetimes by parsing them from SQL format.
-    final DruidExpression timestampExpression = DruidExpression.fromFunctionCall(
+    final DruidExpression timestampExpression = DruidExpression.ofFunctionCall(
+        toDruidType,
         "timestamp_parse",
         ImmutableList.of(
             operand,
-            DruidExpression.fromExpression(DruidExpression.nullLiteral()),
-            DruidExpression.fromExpression(DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
+            DruidExpression.ofLiteral(null, DruidExpression.nullLiteral()),
+            DruidExpression.ofLiteral(
+                ColumnType.STRING,
+                DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
+            )
         )
     );
 
@@ -175,15 +187,20 @@ public class CastOperatorConversion implements SqlOperatorConversion
   private static DruidExpression castDateTimeToChar(
       final PlannerContext plannerContext,
       final DruidExpression operand,
-      final SqlTypeName fromType
+      final SqlTypeName fromType,
+      final ColumnType fromDruidType
   )
   {
-    return DruidExpression.fromFunctionCall(
+    return DruidExpression.ofFunctionCall(
+        fromDruidType,
         "timestamp_format",
         ImmutableList.of(
             operand,
-            DruidExpression.fromExpression(DruidExpression.stringLiteral(dateTimeFormatString(fromType))),
-            DruidExpression.fromExpression(DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(dateTimeFormatString(fromType))),
+            DruidExpression.ofLiteral(
+                ColumnType.STRING,
+                DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
+            )
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CeilOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CeilOperatorConversion.java
@@ -28,6 +28,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
@@ -52,10 +53,11 @@ public class CeilOperatorConversion implements SqlOperatorConversion
 
     if (call.getOperands().size() == 1) {
       // CEIL(expr) -- numeric CEIL
-      return OperatorConversions.convertCall(plannerContext, rowSignature, call, "ceil");
+      return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, call, "ceil");
     } else if (call.getOperands().size() == 2) {
       // CEIL(expr TO timeUnit) -- time CEIL
-      return DruidExpression.fromFunctionCall(
+      return DruidExpression.ofFunctionCall(
+          Calcites.getColumnTypeForRelDataType(rexNode.getType()),
           "timestamp_ceil",
           TimeFloorOperatorConversion.toTimestampFloorOrCeilArgs(plannerContext, rowSignature, call.getOperands())
       );

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CeilOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CeilOperatorConversion.java
@@ -53,7 +53,7 @@ public class CeilOperatorConversion implements SqlOperatorConversion
 
     if (call.getOperands().size() == 1) {
       // CEIL(expr) -- numeric CEIL
-      return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, call, "ceil");
+      return OperatorConversions.convertDirectCall(plannerContext, rowSignature, call, "ceil");
     } else if (call.getOperands().size() == 2) {
       // CEIL(expr TO timeUnit) -- time CEIL
       return DruidExpression.ofFunctionCall(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ConcatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ConcatOperatorConversion.java
@@ -19,18 +19,14 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ConcatOperatorConversion implements SqlOperatorConversion
+public class ConcatOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("CONCAT")
@@ -39,27 +35,8 @@ public class ConcatOperatorConversion implements SqlOperatorConversion
       .functionCategory(SqlFunctionCategory.STRING)
       .build();
 
-  @Override
-  public SqlFunction calciteOperator()
+  public ConcatOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("concat", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "concat");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DateTruncOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DateTruncOperatorConversion.java
@@ -31,7 +31,6 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.Parser;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
@@ -113,15 +112,9 @@ public class DateTruncOperatorConversion implements SqlOperatorConversion
               "timestamp_floor",
               ImmutableList.of(
                   arg,
-                  DruidExpression.ofLiteral(
-                      ColumnType.STRING,
-                      DruidExpression.stringLiteral(truncPeriod.toString())
-                  ),
-                  DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(null)),
-                  DruidExpression.ofLiteral(
-                      ColumnType.STRING,
-                      DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
-                  )
+                  DruidExpression.ofStringLiteral(truncPeriod.toString()),
+                  DruidExpression.ofStringLiteral(null),
+                  DruidExpression.ofStringLiteral(plannerContext.getTimeZone().getID())
               )
           );
         }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DateTruncOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DateTruncOperatorConversion.java
@@ -31,10 +31,12 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.Parser;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.Period;
 
@@ -106,13 +108,20 @@ public class DateTruncOperatorConversion implements SqlOperatorConversion
             throw new IAE("Operator[%s] cannot truncate to[%s]", calciteOperator().getName(), truncType);
           }
 
-          return DruidExpression.fromFunctionCall(
+          return DruidExpression.ofFunctionCall(
+              Calcites.getColumnTypeForRelDataType(rexNode.getType()),
               "timestamp_floor",
               ImmutableList.of(
                   arg,
-                  DruidExpression.fromExpression(DruidExpression.stringLiteral(truncPeriod.toString())),
-                  DruidExpression.fromExpression(DruidExpression.stringLiteral(null)),
-                  DruidExpression.fromExpression(DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
+                  DruidExpression.ofLiteral(
+                      ColumnType.STRING,
+                      DruidExpression.stringLiteral(truncPeriod.toString())
+                  ),
+                  DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(null)),
+                  DruidExpression.ofLiteral(
+                      ColumnType.STRING,
+                      DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
+                  )
               )
           );
         }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/FloorOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/FloorOperatorConversion.java
@@ -53,7 +53,7 @@ public class FloorOperatorConversion implements SqlOperatorConversion
 
     if (call.getOperands().size() == 1) {
       // FLOOR(expr) -- numeric FLOOR
-      return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, call, "floor");
+      return OperatorConversions.convertDirectCall(plannerContext, rowSignature, call, "floor");
     } else if (call.getOperands().size() == 2) {
       // FLOOR(expr TO timeUnit) -- time FLOOR
       return DruidExpression.ofFunctionCall(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/FloorOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/FloorOperatorConversion.java
@@ -28,6 +28,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
@@ -52,10 +53,11 @@ public class FloorOperatorConversion implements SqlOperatorConversion
 
     if (call.getOperands().size() == 1) {
       // FLOOR(expr) -- numeric FLOOR
-      return OperatorConversions.convertCall(plannerContext, rowSignature, call, "floor");
+      return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, call, "floor");
     } else if (call.getOperands().size() == 2) {
       // FLOOR(expr TO timeUnit) -- time FLOOR
-      return DruidExpression.fromFunctionCall(
+      return DruidExpression.ofFunctionCall(
+          Calcites.getColumnTypeForRelDataType(rexNode.getType()),
           "timestamp_floor",
           TimeFloorOperatorConversion.toTimestampFloorOrCeilArgs(plannerContext, rowSignature, call.getOperands())
       );

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/HumanReadableFormatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/HumanReadableFormatOperatorConversion.java
@@ -70,7 +70,7 @@ public class HumanReadableFormatOperatorConversion implements SqlOperatorConvers
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, name);
+    return OperatorConversions.convertDirectCall(plannerContext, rowSignature, rexNode, name);
   }
 
   private static class HumanReadableFormatOperandTypeChecker implements SqlOperandTypeChecker

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/HumanReadableFormatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/HumanReadableFormatOperatorConversion.java
@@ -70,7 +70,7 @@ public class HumanReadableFormatOperatorConversion implements SqlOperatorConvers
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(plannerContext, rowSignature, rexNode, name);
+    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, name);
   }
 
   private static class HumanReadableFormatOperandTypeChecker implements SqlOperandTypeChecker

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LPadOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LPadOperatorConversion.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
@@ -79,7 +78,7 @@ public class LPadOperatorConversion implements SqlOperatorConversion
                 ImmutableList.of(
                     druidExpressions.get(0),
                     druidExpressions.get(1),
-                    DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" "))
+                    DruidExpression.ofStringLiteral(" ")
                 )
             );
           }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LPadOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LPadOperatorConversion.java
@@ -26,10 +26,12 @@ import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class LPadOperatorConversion implements SqlOperatorConversion
@@ -61,7 +63,8 @@ public class LPadOperatorConversion implements SqlOperatorConversion
         rexNode,
         druidExpressions -> {
           if (druidExpressions.size() > 2) {
-            return DruidExpression.fromFunctionCall(
+            return DruidExpression.ofFunctionCall(
+                Calcites.getColumnTypeForRelDataType(rexNode.getType()),
                 "lpad",
                 ImmutableList.of(
                     druidExpressions.get(0),
@@ -70,12 +73,13 @@ public class LPadOperatorConversion implements SqlOperatorConversion
                 )
             );
           } else {
-            return DruidExpression.fromFunctionCall(
+            return DruidExpression.ofFunctionCall(
+                Calcites.getColumnTypeForRelDataType(rexNode.getType()),
                 "lpad",
                 ImmutableList.of(
                     druidExpressions.get(0),
                     druidExpressions.get(1),
-                    DruidExpression.fromExpression(DruidExpression.stringLiteral(" "))
+                    DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" "))
                 )
             );
           }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LTrimOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LTrimOperatorConversion.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
@@ -73,7 +72,7 @@ public class LTrimOperatorConversion implements SqlOperatorConversion
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.LEADING,
                 druidExpressions.get(0),
-                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" ")),
+                DruidExpression.ofStringLiteral(" "),
                 Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LTrimOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LTrimOperatorConversion.java
@@ -26,10 +26,12 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class LTrimOperatorConversion implements SqlOperatorConversion
@@ -64,13 +66,15 @@ public class LTrimOperatorConversion implements SqlOperatorConversion
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.LEADING,
                 druidExpressions.get(0),
-                druidExpressions.get(1)
+                druidExpressions.get(1),
+                Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           } else {
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.LEADING,
                 druidExpressions.get(0),
-                DruidExpression.fromExpression(DruidExpression.stringLiteral(" "))
+                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" ")),
+                Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           }
         }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LeftOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LeftOperatorConversion.java
@@ -67,7 +67,7 @@ public class LeftOperatorConversion implements SqlOperatorConversion
     if (call.getOperands().size() != 2) {
       return null;
     }
-    return OperatorConversions.convertSimpleCall(
+    return OperatorConversions.convertDirectCall(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LeftOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LeftOperatorConversion.java
@@ -67,14 +67,11 @@ public class LeftOperatorConversion implements SqlOperatorConversion
     if (call.getOperands().size() != 2) {
       return null;
     }
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertSimpleCall(
         plannerContext,
         rowSignature,
         rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("left", druidExpressions)
-        )
+        "left"
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LikeOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/LikeOperatorConversion.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.LikeDimFilter;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
@@ -79,14 +78,13 @@ public class LikeOperatorConversion extends DirectOperatorConversion
           druidExpression.getSimpleExtraction().getExtractionFn()
       );
     } else if (virtualColumnRegistry != null) {
-      VirtualColumn v = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String v = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           druidExpression,
           operands.get(0).getType()
       );
 
       return new LikeDimFilter(
-          v.getOutputName(),
+          v,
           RexLiteral.stringValue(operands.get(1)),
           operands.size() > 2 ? RexLiteral.stringValue(operands.get(2)) : null,
           null

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringToArrayOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringToArrayOperatorConversion.java
@@ -19,27 +19,20 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
-
-import javax.annotation.Nullable;
 
 /**
  * Function that converts a String or a Multi Value direct column to an array.
  * Input expressions are not supported as one should use the array function for such cases.
  **/
 
-public class MultiValueStringToArrayOperatorConversion implements SqlOperatorConversion
+public class MultiValueStringToArrayOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("MV_TO_ARRAY")
@@ -48,25 +41,8 @@ public class MultiValueStringToArrayOperatorConversion implements SqlOperatorCon
       .returnTypeNullableArray(SqlTypeName.VARCHAR)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public MultiValueStringToArrayOperatorConversion()
   {
-    return SQL_FUNCTION;
+    super(SQL_FUNCTION, "mv_to_array");
   }
-
-  @Nullable
-  @Override
-  public DruidExpression toDruidExpression(PlannerContext plannerContext, RowSignature rowSignature, RexNode rexNode)
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("mv_to_array", druidExpressions)
-        )
-    );
-  }
-
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ParseLongOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ParseLongOperatorConversion.java
@@ -56,6 +56,6 @@ public class ParseLongOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(plannerContext, rowSignature, rexNode, "parse_long");
+    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, "parse_long");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ParseLongOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ParseLongOperatorConversion.java
@@ -56,6 +56,6 @@ public class ParseLongOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, "parse_long");
+    return OperatorConversions.convertDirectCall(plannerContext, rowSignature, rexNode, "parse_long");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
@@ -65,7 +65,7 @@ public class QueryLookupOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertSimpleCallWithExtraction(
+    return OperatorConversions.convertDirectCallWithExtraction(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
@@ -65,7 +65,7 @@ public class QueryLookupOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertSimpleCallWithExtraction(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RPadOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RPadOperatorConversion.java
@@ -26,10 +26,12 @@ import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class RPadOperatorConversion implements SqlOperatorConversion
@@ -61,7 +63,8 @@ public class RPadOperatorConversion implements SqlOperatorConversion
         rexNode,
         druidExpressions -> {
           if (druidExpressions.size() > 2) {
-            return DruidExpression.fromFunctionCall(
+            return DruidExpression.ofFunctionCall(
+                Calcites.getColumnTypeForRelDataType(rexNode.getType()),
                 "rpad",
                 ImmutableList.of(
                     druidExpressions.get(0),
@@ -70,12 +73,13 @@ public class RPadOperatorConversion implements SqlOperatorConversion
                 )
             );
           } else {
-            return DruidExpression.fromFunctionCall(
+            return DruidExpression.ofFunctionCall(
+                Calcites.getColumnTypeForRelDataType(rexNode.getType()),
                 "rpad",
                 ImmutableList.of(
                     druidExpressions.get(0),
                     druidExpressions.get(1),
-                    DruidExpression.fromExpression(DruidExpression.stringLiteral(" "))
+                    DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" "))
                 )
             );
           }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RPadOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RPadOperatorConversion.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
@@ -79,7 +78,7 @@ public class RPadOperatorConversion implements SqlOperatorConversion
                 ImmutableList.of(
                     druidExpressions.get(0),
                     druidExpressions.get(1),
-                    DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" "))
+                    DruidExpression.ofStringLiteral(" ")
                 )
             );
           }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RTrimOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RTrimOperatorConversion.java
@@ -26,10 +26,12 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class RTrimOperatorConversion implements SqlOperatorConversion
@@ -64,13 +66,15 @@ public class RTrimOperatorConversion implements SqlOperatorConversion
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.TRAILING,
                 druidExpressions.get(0),
-                druidExpressions.get(1)
+                druidExpressions.get(1),
+                Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           } else {
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.TRAILING,
                 druidExpressions.get(0),
-                DruidExpression.fromExpression(DruidExpression.stringLiteral(" "))
+                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" ")),
+                Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           }
         }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RTrimOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RTrimOperatorConversion.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
@@ -73,7 +72,7 @@ public class RTrimOperatorConversion implements SqlOperatorConversion
             return TrimOperatorConversion.makeTrimExpression(
                 SqlTrimFunction.Flag.TRAILING,
                 druidExpressions.get(0),
-                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(" ")),
+                DruidExpression.ofStringLiteral(" "),
                 Calcites.getColumnTypeForRelDataType(rexNode.getType())
             );
           }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpExtractOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpExtractOperatorConversion.java
@@ -59,7 +59,7 @@ public class RegexpExtractOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertSimpleCallWithExtraction(
+    return OperatorConversions.convertDirectCallWithExtraction(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpExtractOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpExtractOperatorConversion.java
@@ -59,7 +59,7 @@ public class RegexpExtractOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertSimpleCallWithExtraction(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpLikeOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpLikeOperatorConversion.java
@@ -63,7 +63,7 @@ public class RegexpLikeOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertSimpleCall(
+    return OperatorConversions.convertDirectCall(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpLikeOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RegexpLikeOperatorConversion.java
@@ -28,7 +28,6 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.RegexDimFilter;
-import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
@@ -64,11 +63,11 @@ public class RegexpLikeOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertSimpleCall(
         plannerContext,
         rowSignature,
         rexNode,
-        operands -> DruidExpression.fromFunctionCall("regexp_like", operands)
+        "regexp_like"
     );
   }
 
@@ -102,13 +101,12 @@ public class RegexpLikeOperatorConversion implements SqlOperatorConversion
           null
       );
     } else if (virtualColumnRegistry != null) {
-      VirtualColumn v = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
-          plannerContext,
+      String v = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(
           druidExpression,
           operands.get(0).getType()
       );
 
-      return new RegexDimFilter(v.getOutputName(), pattern, null, null);
+      return new RegexDimFilter(v, pattern, null, null);
     } else {
       return null;
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RepeatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RepeatOperatorConversion.java
@@ -67,14 +67,11 @@ public class RepeatOperatorConversion implements SqlOperatorConversion
     if (call.getOperands().size() != 2) {
       return null;
     }
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertSimpleCall(
         plannerContext,
         rowSignature,
         rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("repeat", druidExpressions)
-        )
+        "repeat"
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RepeatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RepeatOperatorConversion.java
@@ -67,7 +67,7 @@ public class RepeatOperatorConversion implements SqlOperatorConversion
     if (call.getOperands().size() != 2) {
       return null;
     }
-    return OperatorConversions.convertSimpleCall(
+    return OperatorConversions.convertDirectCall(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ReverseOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ReverseOperatorConversion.java
@@ -19,19 +19,14 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class ReverseOperatorConversion implements SqlOperatorConversion
+public class ReverseOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("REVERSE")
@@ -40,27 +35,8 @@ public class ReverseOperatorConversion implements SqlOperatorConversion
       .returnTypeCascadeNullable(SqlTypeName.VARCHAR)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public ReverseOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("reverse", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "reverse");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RightOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RightOperatorConversion.java
@@ -67,7 +67,7 @@ public class RightOperatorConversion implements SqlOperatorConversion
     if (call.getOperands().size() != 2) {
       return null;
     }
-    return OperatorConversions.convertSimpleCall(
+    return OperatorConversions.convertDirectCall(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RightOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RightOperatorConversion.java
@@ -67,14 +67,11 @@ public class RightOperatorConversion implements SqlOperatorConversion
     if (call.getOperands().size() != 2) {
       return null;
     }
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertSimpleCall(
         plannerContext,
         rowSignature,
         rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("right", druidExpressions)
-        )
+        "right"
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RoundOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RoundOperatorConversion.java
@@ -49,11 +49,11 @@ public class RoundOperatorConversion implements SqlOperatorConversion
   @Override
   public DruidExpression toDruidExpression(final PlannerContext plannerContext, final RowSignature rowSignature, final RexNode rexNode)
   {
-    return OperatorConversions.convertCall(plannerContext, rowSignature, rexNode, inputExpressions -> {
-      return DruidExpression.fromFunctionCall(
-        "round",
-        inputExpressions
-      );
-    });
+    return OperatorConversions.convertSimpleCall(
+        plannerContext,
+        rowSignature,
+        rexNode,
+        "round"
+    );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RoundOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/RoundOperatorConversion.java
@@ -49,7 +49,7 @@ public class RoundOperatorConversion implements SqlOperatorConversion
   @Override
   public DruidExpression toDruidExpression(final PlannerContext plannerContext, final RowSignature rowSignature, final RexNode rexNode)
   {
-    return OperatorConversions.convertSimpleCall(
+    return OperatorConversions.convertDirectCall(
         plannerContext,
         rowSignature,
         rexNode,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringFormatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringFormatOperatorConversion.java
@@ -58,7 +58,7 @@ public class StringFormatOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, "format");
+    return OperatorConversions.convertDirectCall(plannerContext, rowSignature, rexNode, "format");
   }
 
   private static class StringFormatOperandTypeChecker implements SqlOperandTypeChecker

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringFormatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringFormatOperatorConversion.java
@@ -58,7 +58,7 @@ public class StringFormatOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(plannerContext, rowSignature, rexNode, "format");
+    return OperatorConversions.convertSimpleCall(plannerContext, rowSignature, rexNode, "format");
   }
 
   private static class StringFormatOperandTypeChecker implements SqlOperandTypeChecker

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringToArrayOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringToArrayOperatorConversion.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class StringToArrayOperatorConversion implements SqlOperatorConversion
+public class StringToArrayOperatorConversion extends DirectOperatorConversion
 {
   // note: since this function produces an array
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
@@ -48,27 +43,8 @@ public class StringToArrayOperatorConversion implements SqlOperatorConversion
       .returnTypeNullableArray(SqlTypeName.VARCHAR)
       .build();
 
-  @Override
-  public SqlOperator calciteOperator()
+  public StringToArrayOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("string_to_array", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "string_to_array");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StrposOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StrposOperatorConversion.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 public class StrposOperatorConversion implements SqlOperatorConversion
@@ -58,12 +59,13 @@ public class StrposOperatorConversion implements SqlOperatorConversion
         plannerContext,
         rowSignature,
         rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            StringUtils.format(
+        druidExpressions -> DruidExpression.ofExpression(
+            Calcites.getColumnTypeForRelDataType(rexNode.getType()),
+            (args) -> StringUtils.format(
                 "(%s + 1)",
-                DruidExpression.functionCall("strpos", druidExpressions)
-            )
+                DruidExpression.functionCall("strpos").buildExpression(args)
+            ),
+            druidExpressions
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TextcatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TextcatOperatorConversion.java
@@ -19,18 +19,14 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
-import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
-public class TextcatOperatorConversion implements SqlOperatorConversion
+public class TextcatOperatorConversion extends DirectOperatorConversion
 {
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("textcat")
@@ -40,27 +36,8 @@ public class TextcatOperatorConversion implements SqlOperatorConversion
       .functionCategory(SqlFunctionCategory.STRING)
       .build();
 
-  @Override
-  public SqlFunction calciteOperator()
+  public TextcatOperatorConversion()
   {
-    return SQL_FUNCTION;
-  }
-
-  @Override
-  public DruidExpression toDruidExpression(
-      final PlannerContext plannerContext,
-      final RowSignature rowSignature,
-      final RexNode rexNode
-  )
-  {
-    return OperatorConversions.convertCall(
-        plannerContext,
-        rowSignature,
-        rexNode,
-        druidExpressions -> DruidExpression.of(
-            null,
-            DruidExpression.functionCall("concat", druidExpressions)
-        )
-    );
+    super(SQL_FUNCTION, "concat");
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeArithmeticOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeArithmeticOperatorConversion.java
@@ -20,6 +20,7 @@
 package org.apache.druid.sql.calcite.expression.builtin;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -30,10 +31,12 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import java.util.List;
@@ -82,12 +85,15 @@ public abstract class TimeArithmeticOperatorConversion implements SqlOperatorCon
       return null;
     }
 
+    final ColumnType outputType = Calcites.getColumnTypeForRelDataType(rexNode.getType());
+
     if (rightRexNode.getType().getFamily() == SqlTypeFamily.INTERVAL_YEAR_MONTH) {
       // timestamp_expr { + | - } <interval_expr> (year-month interval)
       // Period is a value in months.
-      return DruidExpression.fromExpression(
-          DruidExpression.functionCall(
-              "timestamp_shift",
+      return DruidExpression.ofExpression(
+          outputType,
+          DruidExpression.functionCall("timestamp_shift"),
+          ImmutableList.of(
               leftExpr,
               rightExpr.map(
                   simpleExtraction -> null,
@@ -96,20 +102,25 @@ public abstract class TimeArithmeticOperatorConversion implements SqlOperatorCon
                     StringUtils.format("'P%sM'", RexLiteral.value(rightRexNode)) :
                     StringUtils.format("concat('P', %s, 'M')", expression)
               ),
-              DruidExpression.fromExpression(DruidExpression.numberLiteral(direction > 0 ? 1 : -1)),
-              DruidExpression.fromExpression(DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
+              DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(direction > 0 ? 1 : -1)),
+              DruidExpression.ofLiteral(
+                  ColumnType.STRING,
+                  DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
+              )
           )
       );
     } else if (rightRexNode.getType().getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
       // timestamp_expr { + | - } <interval_expr> (day-time interval)
       // Period is a value in milliseconds. Ignore time zone.
-      return DruidExpression.fromExpression(
-          StringUtils.format(
+      return DruidExpression.ofExpression(
+          outputType,
+          (args) -> StringUtils.format(
               "(%s %s %s)",
-              leftExpr.getExpression(),
+              args.get(0).getExpression(),
               direction > 0 ? "+" : "-",
-              rightExpr.getExpression()
-          )
+              args.get(1).getExpression()
+          ),
+          ImmutableList.of(leftExpr, rightExpr)
       );
     } else if ((leftRexNode.getType().getFamily() == SqlTypeFamily.TIMESTAMP ||
         leftRexNode.getType().getFamily() == SqlTypeFamily.DATE) &&
@@ -120,22 +131,25 @@ public abstract class TimeArithmeticOperatorConversion implements SqlOperatorCon
       // the second argument.
       Preconditions.checkState(direction < 0, "Time arithmetic require direction < 0");
       if (call.getType().getFamily() == SqlTypeFamily.INTERVAL_YEAR_MONTH) {
-        return DruidExpression.fromExpression(
-            DruidExpression.functionCall(
-                "subtract_months",
+        return DruidExpression.ofExpression(
+            outputType,
+            DruidExpression.functionCall("subtract_months"),
+            ImmutableList.of(
                 leftExpr,
                 rightExpr,
-                DruidExpression.fromExpression(DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
+                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
             )
         );
       } else {
-        return DruidExpression.fromExpression(
-          StringUtils.format(
-              "(%s %s %s)",
-              leftExpr.getExpression(),
-              "-",
-              rightExpr.getExpression()
-          )
+        return DruidExpression.ofExpression(
+            outputType,
+            (args) -> StringUtils.format(
+                "(%s %s %s)",
+                args.get(0).getExpression(),
+                "-",
+                args.get(1).getExpression()
+            ),
+            ImmutableList.of(leftExpr, rightExpr)
         );
       }
     } else {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeArithmeticOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeArithmeticOperatorConversion.java
@@ -103,10 +103,7 @@ public abstract class TimeArithmeticOperatorConversion implements SqlOperatorCon
                     StringUtils.format("concat('P', %s, 'M')", expression)
               ),
               DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(direction > 0 ? 1 : -1)),
-              DruidExpression.ofLiteral(
-                  ColumnType.STRING,
-                  DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
-              )
+              DruidExpression.ofStringLiteral(plannerContext.getTimeZone().getID())
           )
       );
     } else if (rightRexNode.getType().getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
@@ -137,7 +134,7 @@ public abstract class TimeArithmeticOperatorConversion implements SqlOperatorCon
             ImmutableList.of(
                 leftExpr,
                 rightExpr,
-                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
+                DruidExpression.ofStringLiteral(plannerContext.getTimeZone().getID())
             )
         );
       } else {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeCeilOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeCeilOperatorConversion.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
@@ -70,6 +71,6 @@ public class TimeCeilOperatorConversion implements SqlOperatorConversion
       return null;
     }
 
-    return DruidExpression.fromFunctionCall("timestamp_ceil", functionArgs);
+    return DruidExpression.ofFunctionCall(Calcites.getColumnTypeForRelDataType(rexNode.getType()), "timestamp_ceil", functionArgs);
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeExtractOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeExtractOperatorConversion.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.expression.TimestampExtractExprMacro;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
@@ -54,12 +55,13 @@ public class TimeExtractOperatorConversion implements SqlOperatorConversion
       final DateTimeZone timeZone
   )
   {
-    return DruidExpression.fromFunctionCall(
+    return DruidExpression.ofFunctionCall(
+        timeExpression.getDruidType(),
         "timestamp_extract",
         ImmutableList.of(
             timeExpression,
-            DruidExpression.fromExpression(DruidExpression.stringLiteral(unit.name())),
-            DruidExpression.fromExpression(DruidExpression.stringLiteral(timeZone.getID()))
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(unit.name())),
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeExtractOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeExtractOperatorConversion.java
@@ -30,7 +30,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.expression.TimestampExtractExprMacro;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
@@ -60,8 +59,8 @@ public class TimeExtractOperatorConversion implements SqlOperatorConversion
         "timestamp_extract",
         ImmutableList.of(
             timeExpression,
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(unit.name())),
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
+            DruidExpression.ofStringLiteral(unit.name()),
+            DruidExpression.ofStringLiteral(timeZone.getID())
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFloorOperatorConversion.java
@@ -96,20 +96,14 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
         "timestamp_floor",
         ImmutableList.of(
             input,
-            DruidExpression.ofLiteral(
-                ColumnType.STRING,
-                DruidExpression.stringLiteral(granularity.getPeriod().toString())
-            ),
+            DruidExpression.ofStringLiteral(granularity.getPeriod().toString()),
             DruidExpression.ofLiteral(
                 ColumnType.LONG,
                 DruidExpression.numberLiteral(
                     granularity.getOrigin() == null ? null : granularity.getOrigin().getMillis()
                 )
             ),
-            DruidExpression.ofLiteral(
-                ColumnType.STRING,
-                DruidExpression.stringLiteral(granularity.getTimeZone().toString())
-            )
+            DruidExpression.ofStringLiteral(granularity.getTimeZone().toString())
         )
     );
   }
@@ -143,7 +137,7 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
         return null;
       }
 
-      functionArgs.add(DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(period.toString())));
+      functionArgs.add(DruidExpression.ofStringLiteral(period.toString()));
     } else {
       // Other literal types are used by TIME_FLOOR and TIME_CEIL
       functionArgs.add(Expressions.toDruidExpression(plannerContext, rowSignature, periodOperand));
@@ -176,10 +170,7 @@ public class TimeFloorOperatorConversion implements SqlOperatorConversion
             operands,
             3,
             operand -> Expressions.toDruidExpression(plannerContext, rowSignature, operand),
-            DruidExpression.ofLiteral(
-                ColumnType.STRING,
-                DruidExpression.stringLiteral(plannerContext.getTimeZone().getID())
-            )
+            DruidExpression.ofStringLiteral(plannerContext.getTimeZone().getID())
         )
     );
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFormatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFormatOperatorConversion.java
@@ -30,15 +30,15 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.DateTimeZone;
-
-import java.util.stream.Collectors;
 
 public class TimeFormatOperatorConversion implements SqlOperatorConversion
 {
@@ -93,13 +93,14 @@ public class TimeFormatOperatorConversion implements SqlOperatorConversion
         plannerContext.getTimeZone()
     );
 
-    return DruidExpression.fromFunctionCall(
+    return DruidExpression.ofFunctionCall(
+        Calcites.getColumnTypeForRelDataType(rexNode.getType()),
         "timestamp_format",
         ImmutableList.of(
-            timeExpression.getExpression(),
-            DruidExpression.stringLiteral(pattern),
-            DruidExpression.stringLiteral(timeZone.getID())
-        ).stream().map(DruidExpression::fromExpression).collect(Collectors.toList())
+            timeExpression,
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(pattern)),
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
+        )
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFormatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFormatOperatorConversion.java
@@ -30,7 +30,6 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
@@ -98,8 +97,8 @@ public class TimeFormatOperatorConversion implements SqlOperatorConversion
         "timestamp_format",
         ImmutableList.of(
             timeExpression,
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(pattern)),
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
+            DruidExpression.ofStringLiteral(pattern),
+            DruidExpression.ofStringLiteral(timeZone.getID())
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeParseOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeParseOperatorConversion.java
@@ -29,7 +29,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
@@ -88,8 +87,8 @@ public class TimeParseOperatorConversion implements SqlOperatorConversion
         "timestamp_parse",
         ImmutableList.of(
             timeExpression,
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(pattern)),
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
+            DruidExpression.ofStringLiteral(pattern),
+            DruidExpression.ofStringLiteral(timeZone.getID())
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeParseOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeParseOperatorConversion.java
@@ -29,15 +29,15 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.DateTimeZone;
-
-import java.util.stream.Collectors;
 
 public class TimeParseOperatorConversion implements SqlOperatorConversion
 {
@@ -83,13 +83,14 @@ public class TimeParseOperatorConversion implements SqlOperatorConversion
         plannerContext.getTimeZone()
     );
 
-    return DruidExpression.fromFunctionCall(
+    return DruidExpression.ofFunctionCall(
+        Calcites.getColumnTypeForRelDataType(rexNode.getType()),
         "timestamp_parse",
         ImmutableList.of(
-            timeExpression.getExpression(),
-            DruidExpression.stringLiteral(pattern),
-            DruidExpression.stringLiteral(timeZone.getID())
-        ).stream().map(DruidExpression::fromExpression).collect(Collectors.toList())
+            timeExpression,
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(pattern)),
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
+        )
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeShiftOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeShiftOperatorConversion.java
@@ -29,7 +29,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
@@ -99,7 +98,7 @@ public class TimeShiftOperatorConversion implements SqlOperatorConversion
             timeExpression,
             periodExpression,
             stepExpression,
-            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
+            DruidExpression.ofStringLiteral(timeZone.getID())
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeShiftOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeShiftOperatorConversion.java
@@ -29,15 +29,15 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.DateTimeZone;
-
-import java.util.stream.Collectors;
 
 public class TimeShiftOperatorConversion implements SqlOperatorConversion
 {
@@ -92,14 +92,15 @@ public class TimeShiftOperatorConversion implements SqlOperatorConversion
         plannerContext.getTimeZone()
     );
 
-    return DruidExpression.fromFunctionCall(
+    return DruidExpression.ofFunctionCall(
+        Calcites.getColumnTypeForRelDataType(rexNode.getType()),
         "timestamp_shift",
         ImmutableList.of(
-            timeExpression.getExpression(),
-            periodExpression.getExpression(),
-            stepExpression.getExpression(),
-            DruidExpression.stringLiteral(timeZone.getID())
-        ).stream().map(DruidExpression::fromExpression).collect(Collectors.toList())
+            timeExpression,
+            periodExpression,
+            stepExpression,
+            DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral(timeZone.getID()))
+        )
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TrimOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TrimOperatorConversion.java
@@ -26,10 +26,12 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
@@ -40,7 +42,8 @@ public class TrimOperatorConversion implements SqlOperatorConversion
   public static DruidExpression makeTrimExpression(
       final SqlTrimFunction.Flag trimStyle,
       final DruidExpression stringExpression,
-      final DruidExpression charsExpression
+      final DruidExpression charsExpression,
+      final ColumnType druidType
   )
   {
     final String functionName;
@@ -61,7 +64,7 @@ public class TrimOperatorConversion implements SqlOperatorConversion
     }
 
     // Druid version of trim is multi-function (ltrim/rtrim/trim) and the other two args are swapped.
-    return DruidExpression.fromFunctionCall(functionName, ImmutableList.of(stringExpression, charsExpression));
+    return DruidExpression.ofFunctionCall(druidType, functionName, ImmutableList.of(stringExpression, charsExpression));
   }
 
   @Override
@@ -99,6 +102,11 @@ public class TrimOperatorConversion implements SqlOperatorConversion
       return null;
     }
 
-    return makeTrimExpression(trimStyle, stringExpression, charsExpression);
+    return makeTrimExpression(
+        trimStyle,
+        stringExpression,
+        charsExpression,
+        Calcites.getColumnTypeForRelDataType(rexNode.getType())
+    );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TruncateOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TruncateOperatorConversion.java
@@ -55,7 +55,7 @@ public class TruncateOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(
+    return OperatorConversions.convertCallBuilder(
         plannerContext,
         rowSignature,
         rexNode,
@@ -77,13 +77,11 @@ public class TruncateOperatorConversion implements SqlOperatorConversion
             factorString = StringUtils.format("pow(10,%s)", inputExpressions.get(1));
           }
 
-          return DruidExpression.fromExpression(
-              StringUtils.format(
-                  "(cast(cast(%s * %s,'long'),'double') / %s)",
-                  arg.getExpression(),
-                  factorString,
-                  factorString
-              )
+          return StringUtils.format(
+              "(cast(cast(%s * %s,'long'),'double') / %s)",
+              arg.getExpression(),
+              factorString,
+              factorString
           );
         }
     );

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -163,7 +163,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
 
     final Pair<String, RowSignature> prefixSignaturePair = computeJoinRowSignature(leftSignature, rightSignature);
 
-    VirtualColumnRegistry virtualColumnRegistry = VirtualColumnRegistry.create(prefixSignaturePair.rhs);
+    VirtualColumnRegistry virtualColumnRegistry = VirtualColumnRegistry.create(prefixSignaturePair.rhs, getPlannerContext().getExprMacroTable());
     getPlannerContext().setJoinExpressionVirtualColumnRegistry(virtualColumnRegistry);
 
     // Generate the condition for this join as a Druid expression.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -180,24 +179,11 @@ public class VirtualColumnRegistry
                      .collect(Collectors.toList());
   }
 
-  public void visitAll(DruidExpression.DruidExpressionShuttle shuttle)
-  {
-    final Set<String> keys = virtualColumnsByName.keySet();
-    for (String key : keys) {
-      final ExpressionAndTypeHint wrapped = virtualColumnsByName.get(key);
-      virtualColumnsByExpression.remove(wrapped);
-      final DruidExpression newExpression = shuttle.visit(wrapped.getExpression());
-      final ExpressionAndTypeHint newWrapped = wrap(newExpression, wrapped.getTypeHint());
-      virtualColumnsByName.put(key, newWrapped);
-      virtualColumnsByExpression.put(newWrapped, key);
-    }
-  }
-
   public void visitAllSubExpressions(DruidExpression.DruidExpressionShuttle shuttle)
   {
-    final Set<String> keys = virtualColumnsByName.keySet();
-    for (String key : keys) {
-      final ExpressionAndTypeHint wrapped = virtualColumnsByName.get(key);
+    for (Map.Entry<String, ExpressionAndTypeHint> entry : virtualColumnsByName.entrySet()) {
+      final String key = entry.getKey();
+      final ExpressionAndTypeHint wrapped = entry.getValue();
       virtualColumnsByExpression.remove(wrapped);
       final List<DruidExpression> newArgs = shuttle.visitAll(wrapped.getExpression().getArguments());
       final ExpressionAndTypeHint newWrapped = wrap(wrapped.getExpression().withArguments(newArgs), wrapped.getTypeHint());

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -657,7 +657,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
             new Object[]{"1", 1, 1L},
             new Object[]{"2", 1, 1L},
             new Object[]{"abc", 1, 1L},
-            new Object[]{"def", 1, 1L}
+            new Object[]{"def", useDefault ? 0 : null, 1L}
         )
     );
   }
@@ -785,18 +785,20 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{"foo,null", "null,foo", 3L},
+          new Object[]{"foo,null", "null,foo", 2L},
+          new Object[]{"", "", 1L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
           new Object[]{"foo,d", "d,foo", 1L}
       );
     } else {
       results = ImmutableList.of(
-          new Object[]{"foo,null", "null,foo", 2L},
+          new Object[]{null, null, 1L},
           new Object[]{"foo,", ",foo", 1L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
-          new Object[]{"foo,d", "d,foo", 1L}
+          new Object[]{"foo,d", "d,foo", 1L},
+          new Object[]{"foo,null", "null,foo", 1L}
       );
     }
     testQuery(
@@ -1205,8 +1207,14 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        ImmutableList.of(
-            new Object[]{useDefault ? -1 : null, 4L},
+        useDefault
+        ? ImmutableList.of(
+            new Object[]{-1, 3L},
+            new Object[]{0, 2L},
+            new Object[]{1, 1L}
+        )
+        : ImmutableList.of(
+            new Object[]{null, 4L},
             new Object[]{0, 1L},
             new Object[]{1, 1L}
         )
@@ -1248,8 +1256,15 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        ImmutableList.of(
-            new Object[]{useDefault ? -1 : null, 4L},
+        useDefault
+        ? ImmutableList.of(
+            new Object[]{-1, 3L},
+            new Object[]{0, 1L},
+            new Object[]{1, 1L},
+            new Object[]{2, 1L}
+        )
+        : ImmutableList.of(
+            new Object[]{null, 4L},
             new Object[]{1, 1L},
             new Object[]{2, 1L}
         )
@@ -1321,14 +1336,14 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{ImmutableList.of("", "d"), 3L},
+          new Object[]{ImmutableList.of("", "d"), 2L},
           new Object[]{ImmutableList.of("a", "b", "d"), 1L},
           new Object[]{ImmutableList.of("b", "c", "d"), 1L},
           new Object[]{ImmutableList.of("d", "d"), 1L}
       );
     } else {
       results = ImmutableList.of(
-          new Object[]{null, 2L},
+          new Object[]{null, 1L},
           new Object[]{ImmutableList.of("", "d"), 1L},
           new Object[]{ImmutableList.of("a", "b", "d"), 1L},
           new Object[]{ImmutableList.of("b", "c", "d"), 1L},

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -513,8 +513,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                 .build()
         ),
         ImmutableList.of(
-            new Object[]{"[\"a\",\"b\"]"},
-            new Object[]{useDefault ? "" : null}
+            new Object[]{"[\"a\",\"b\"]"}
         )
     );
   }
@@ -654,9 +653,9 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"", 2, 1L},
             new Object[]{"10.1", 2, 1L},
-            new Object[]{"1", 1, 1L},
-            new Object[]{"2", 1, 1L},
-            new Object[]{"abc", 1, 1L},
+            useDefault ? new Object[]{"2", 1, 1L} : new Object[]{"1", 1, 1L},
+            useDefault ? new Object[]{"1", 0, 1L} : new Object[]{"2", 1, 1L},
+            new Object[]{"abc", useDefault ? 0 : null, 1L},
             new Object[]{"def", useDefault ? 0 : null, 1L}
         )
     );
@@ -785,20 +784,18 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{"foo,null", "null,foo", 2L},
-          new Object[]{"", "", 1L},
+          new Object[]{"", "", 3L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
           new Object[]{"foo,d", "d,foo", 1L}
       );
     } else {
       results = ImmutableList.of(
-          new Object[]{null, null, 1L},
+          new Object[]{null, null, 2L},
           new Object[]{"foo,", ",foo", 1L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
-          new Object[]{"foo,d", "d,foo", 1L},
-          new Object[]{"foo,null", "null,foo", 1L}
+          new Object[]{"foo,d", "d,foo", 1L}
       );
     }
     testQuery(
@@ -1209,8 +1206,8 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         ),
         useDefault
         ? ImmutableList.of(
-            new Object[]{-1, 3L},
-            new Object[]{0, 2L},
+            new Object[]{0, 4L},
+            new Object[]{-1, 1L},
             new Object[]{1, 1L}
         )
         : ImmutableList.of(
@@ -1258,8 +1255,8 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         ),
         useDefault
         ? ImmutableList.of(
-            new Object[]{-1, 3L},
-            new Object[]{0, 1L},
+            new Object[]{0, 3L},
+            new Object[]{-1, 1L},
             new Object[]{1, 1L},
             new Object[]{2, 1L}
         )
@@ -1336,14 +1333,12 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{ImmutableList.of("", "d"), 2L},
           new Object[]{ImmutableList.of("a", "b", "d"), 1L},
           new Object[]{ImmutableList.of("b", "c", "d"), 1L},
           new Object[]{ImmutableList.of("d", "d"), 1L}
       );
     } else {
       results = ImmutableList.of(
-          new Object[]{null, 1L},
           new Object[]{ImmutableList.of("", "d"), 1L},
           new Object[]{ImmutableList.of("a", "b", "d"), 1L},
           new Object[]{ImmutableList.of("b", "c", "d"), 1L},

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteCorrelatedQueryTest.java
@@ -43,7 +43,6 @@ import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -153,8 +152,8 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                 ),
                                 "j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("country"),
-                                    DruidExpression.fromColumn("j0._d0")
+                                    makeColumnExpression("country"),
+                                    makeColumnExpression("j0._d0")
                                 ),
                                 JoinType.LEFT
                             )
@@ -242,8 +241,8 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                 ),
                                 "j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("country"),
-                                    DruidExpression.fromColumn("j0._d0")
+                                    makeColumnExpression("country"),
+                                    makeColumnExpression("j0._d0")
                                 ),
                                 JoinType.LEFT,
                                 selector("city", "B", null)
@@ -335,8 +334,8 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                 ),
                                 "j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("country"),
-                                    DruidExpression.fromColumn("j0._d0")
+                                    makeColumnExpression("country"),
+                                    makeColumnExpression("j0._d0")
                                 ),
                                 JoinType.LEFT
                             )
@@ -428,8 +427,8 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                 ),
                                 "j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("country"),
-                                    DruidExpression.fromColumn("j0._d0")
+                                    makeColumnExpression("country"),
+                                    makeColumnExpression("j0._d0")
                                 ),
                                 JoinType.LEFT,
                                 selector("city", "B", null)
@@ -521,8 +520,8 @@ public class CalciteCorrelatedQueryTest extends BaseCalciteQueryTest
                                 ),
                                 "j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("country"),
-                                    DruidExpression.fromColumn("j0._d0")
+                                    makeColumnExpression("country"),
+                                    makeColumnExpression("j0._d0")
                                 ),
                                 JoinType.LEFT,
                                 selector("city", "B", null)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -177,8 +177,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 ),
                                 "j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("m1"),
-                                    DruidExpression.fromColumn("j0.m1")
+                                    DruidExpression.ofColumn(ColumnType.FLOAT, "m1"),
+                                    DruidExpression.ofColumn(ColumnType.FLOAT, "j0.m1")
                                 ),
                                 JoinType.INNER
                             )
@@ -266,8 +266,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("m1"),
-                            DruidExpression.fromColumn("j0.m1")
+                            DruidExpression.ofColumn(ColumnType.FLOAT, "m1"),
+                            DruidExpression.ofColumn(ColumnType.FLOAT, "j0.m1")
                         ),
                         JoinType.INNER
                     )
@@ -353,8 +353,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("m1"),
-                            DruidExpression.fromColumn("j0.m1")
+                            DruidExpression.ofColumn(ColumnType.FLOAT, "m1"),
+                            DruidExpression.ofColumn(ColumnType.FLOAT, "j0.m1")
                         ),
                         JoinType.INNER
                     )
@@ -549,7 +549,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -585,7 +585,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -633,7 +633,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("k"), DruidExpression.fromColumn("j0.dim2")),
+                        equalsCondition(makeColumnExpression("k"), makeColumnExpression("j0.dim2")),
                         JoinType.RIGHT
                     )
                 )
@@ -673,7 +673,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -719,7 +719,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -758,7 +758,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -805,7 +805,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("d0"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("d0"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -846,7 +846,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -878,7 +878,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -913,12 +913,12 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             new TableDataSource(CalciteTests.DATASOURCE1),
                             new LookupDataSource("lookyloo"),
                             "j0.",
-                            equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                            equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                             JoinType.LEFT
                         ),
                         new LookupDataSource("lookyloo"),
                         "_j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("_j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("_j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -960,12 +960,12 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             new TableDataSource(CalciteTests.DATASOURCE1),
                             new LookupDataSource("lookyloo"),
                             "j0.",
-                            equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                            equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                             JoinType.INNER
                         ),
                         new LookupDataSource("lookyloo"),
                         "_j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("_j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("_j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -1002,12 +1002,12 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             new TableDataSource(CalciteTests.DATASOURCE1),
                             new LookupDataSource("lookyloo"),
                             "j0.",
-                            equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                            equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                             JoinType.INNER
                         ),
                         new LookupDataSource("lookyloo"),
                         "_j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("_j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("_j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -1045,12 +1045,12 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             new TableDataSource(CalciteTests.DATASOURCE1),
                             new LookupDataSource("lookyloo"),
                             "j0.",
-                            equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                            equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                             JoinType.INNER
                         ),
                         new LookupDataSource("lookyloo"),
                         "_j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("_j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("_j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -1088,12 +1088,12 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             new TableDataSource(CalciteTests.DATASOURCE1),
                             new LookupDataSource("lookyloo"),
                             "j0.",
-                            equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                            equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                             JoinType.INNER
                         ),
                         new LookupDataSource("lookyloo"),
                         "_j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("_j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("_j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -1166,9 +1166,9 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                                                                                     "lookyloo"),
                                                                                                 "j0.",
                                                                                                 equalsCondition(
-                                                                                                    DruidExpression.fromColumn(
+                                                                                                    makeColumnExpression(
                                                                                                         "dim2"),
-                                                                                                    DruidExpression.fromColumn(
+                                                                                                    makeColumnExpression(
                                                                                                         "j0.k")
                                                                                                 ),
                                                                                                 JoinType.INNER
@@ -1177,9 +1177,9 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                                                                                 "lookyloo"),
                                                                                             "_j0.",
                                                                                             equalsCondition(
-                                                                                                DruidExpression.fromColumn(
+                                                                                                makeColumnExpression(
                                                                                                     "dim2"),
-                                                                                                DruidExpression.fromColumn(
+                                                                                                makeColumnExpression(
                                                                                                     "_j0.k")
                                                                                             ),
                                                                                             JoinType.INNER
@@ -1187,9 +1187,9 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                                                                         new LookupDataSource("lookyloo"),
                                                                                         "__j0.",
                                                                                         equalsCondition(
-                                                                                            DruidExpression.fromColumn(
+                                                                                            makeColumnExpression(
                                                                                                 "dim2"),
-                                                                                            DruidExpression.fromColumn(
+                                                                                            makeColumnExpression(
                                                                                                 "__j0.k")
                                                                                         ),
                                                                                         JoinType.INNER
@@ -1197,9 +1197,9 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                                                                     new LookupDataSource("lookyloo"),
                                                                                     "___j0.",
                                                                                     equalsCondition(
-                                                                                        DruidExpression.fromColumn(
+                                                                                        makeColumnExpression(
                                                                                             "dim2"),
-                                                                                        DruidExpression.fromColumn(
+                                                                                        makeColumnExpression(
                                                                                             "___j0.k")
                                                                                     ),
                                                                                     JoinType.INNER
@@ -1207,8 +1207,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                                                                 new LookupDataSource("lookyloo"),
                                                                                 "____j0.",
                                                                                 equalsCondition(
-                                                                                    DruidExpression.fromColumn("dim2"),
-                                                                                    DruidExpression.fromColumn(
+                                                                                    makeColumnExpression("dim2"),
+                                                                                    makeColumnExpression(
                                                                                         "____j0.k")
                                                                                 ),
                                                                                 JoinType.INNER
@@ -1216,112 +1216,112 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                                                             new LookupDataSource("lookyloo"),
                                                                             "_____j0.",
                                                                             equalsCondition(
-                                                                                DruidExpression.fromColumn("dim2"),
-                                                                                DruidExpression.fromColumn("_____j0.k")
+                                                                                makeColumnExpression("dim2"),
+                                                                                makeColumnExpression("_____j0.k")
                                                                             ),
                                                                             JoinType.INNER
                                                                         ),
                                                                         new LookupDataSource("lookyloo"),
                                                                         "______j0.",
                                                                         equalsCondition(
-                                                                            DruidExpression.fromColumn("dim2"),
-                                                                            DruidExpression.fromColumn("______j0.k")
+                                                                            makeColumnExpression("dim2"),
+                                                                            makeColumnExpression("______j0.k")
                                                                         ),
                                                                         JoinType.INNER
                                                                     ),
                                                                     new LookupDataSource("lookyloo"),
                                                                     "_______j0.",
                                                                     equalsCondition(
-                                                                        DruidExpression.fromColumn("dim2"),
-                                                                        DruidExpression.fromColumn("_______j0.k")
+                                                                        makeColumnExpression("dim2"),
+                                                                        makeColumnExpression("_______j0.k")
                                                                     ),
                                                                     JoinType.INNER
                                                                 ),
                                                                 new LookupDataSource("lookyloo"),
                                                                 "________j0.",
                                                                 equalsCondition(
-                                                                    DruidExpression.fromColumn("dim2"),
-                                                                    DruidExpression.fromColumn("________j0.k")
+                                                                    makeColumnExpression("dim2"),
+                                                                    makeColumnExpression("________j0.k")
                                                                 ),
                                                                 JoinType.INNER
                                                             ),
                                                             new LookupDataSource("lookyloo"),
                                                             "_________j0.",
                                                             equalsCondition(
-                                                                DruidExpression.fromColumn("dim2"),
-                                                                DruidExpression.fromColumn("_________j0.k")
+                                                                makeColumnExpression("dim2"),
+                                                                makeColumnExpression("_________j0.k")
                                                             ),
                                                             JoinType.INNER
                                                         ),
                                                         new LookupDataSource("lookyloo"),
                                                         "__________j0.",
                                                         equalsCondition(
-                                                            DruidExpression.fromColumn("dim2"),
-                                                            DruidExpression.fromColumn("__________j0.k")
+                                                            makeColumnExpression("dim2"),
+                                                            makeColumnExpression("__________j0.k")
                                                         ),
                                                         JoinType.INNER
                                                     ),
                                                     new LookupDataSource("lookyloo"),
                                                     "___________j0.",
                                                     equalsCondition(
-                                                        DruidExpression.fromColumn("dim2"),
-                                                        DruidExpression.fromColumn("___________j0.k")
+                                                        makeColumnExpression("dim2"),
+                                                        makeColumnExpression("___________j0.k")
                                                     ),
                                                     JoinType.INNER
                                                 ),
                                                 new LookupDataSource("lookyloo"),
                                                 "____________j0.",
                                                 equalsCondition(
-                                                    DruidExpression.fromColumn("dim2"),
-                                                    DruidExpression.fromColumn("____________j0.k")
+                                                    makeColumnExpression("dim2"),
+                                                    makeColumnExpression("____________j0.k")
                                                 ),
                                                 JoinType.INNER
                                             ),
                                             new LookupDataSource("lookyloo"),
                                             "_____________j0.",
                                             equalsCondition(
-                                                DruidExpression.fromColumn("dim2"),
-                                                DruidExpression.fromColumn("_____________j0.k")
+                                                makeColumnExpression("dim2"),
+                                                makeColumnExpression("_____________j0.k")
                                             ),
                                             JoinType.INNER
                                         ),
                                         new LookupDataSource("lookyloo"),
                                         "______________j0.",
                                         equalsCondition(
-                                            DruidExpression.fromColumn("dim2"),
-                                            DruidExpression.fromColumn("______________j0.k")
+                                            makeColumnExpression("dim2"),
+                                            makeColumnExpression("______________j0.k")
                                         ),
                                         JoinType.INNER
                                     ),
                                     new LookupDataSource("lookyloo"),
                                     "_______________j0.",
                                     equalsCondition(
-                                        DruidExpression.fromColumn("dim2"),
-                                        DruidExpression.fromColumn("_______________j0.k")
+                                        makeColumnExpression("dim2"),
+                                        makeColumnExpression("_______________j0.k")
                                     ),
                                     JoinType.INNER
                                 ),
                                 new LookupDataSource("lookyloo"),
                                 "________________j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("dim2"),
-                                    DruidExpression.fromColumn("________________j0.k")
+                                    makeColumnExpression("dim2"),
+                                    makeColumnExpression("________________j0.k")
                                 ),
                                 JoinType.INNER
                             ),
                             new LookupDataSource("lookyloo"),
                             "_________________j0.",
                             equalsCondition(
-                                DruidExpression.fromColumn("dim2"),
-                                DruidExpression.fromColumn("_________________j0.k")
+                                makeColumnExpression("dim2"),
+                                makeColumnExpression("_________________j0.k")
                             ),
                             JoinType.INNER
                         ),
                         new LookupDataSource("lookyloo"),
                         "__________________j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim2"),
-                            DruidExpression.fromColumn("__________________j0.k")
+                            makeColumnExpression("dim2"),
+                            makeColumnExpression("__________________j0.k")
                         ),
                         JoinType.INNER
                     )
@@ -1375,7 +1375,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.d0")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.d0")),
                         JoinType.INNER
                     )
                 )
@@ -1411,7 +1411,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -1467,14 +1467,14 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             ),
                             "j0.",
                             equalsCondition(
-                                DruidExpression.fromColumn("m1"),
-                                DruidExpression.fromColumn("j0.v0")
+                                DruidExpression.ofColumn(ColumnType.FLOAT, "m1"),
+                                DruidExpression.ofColumn(ColumnType.FLOAT, "j0.v0")
                             ),
                             JoinType.INNER
                         ),
                         new LookupDataSource("lookyloo"),
                         "_j0.",
-                        equalsCondition(DruidExpression.fromColumn("j0.k"), DruidExpression.fromColumn("_j0.k")),
+                        equalsCondition(makeColumnExpression("j0.k"), makeColumnExpression("_j0.k")),
                         JoinType.INNER
                     )
                 )
@@ -1514,8 +1514,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             new LookupDataSource("lookyloo"),
                             "j0.",
                             equalsCondition(
-                                DruidExpression.fromColumn("k"),
-                                DruidExpression.fromColumn("j0.k")
+                                makeColumnExpression("k"),
+                                makeColumnExpression("j0.k")
                             ),
                             JoinType.INNER
                         ),
@@ -1529,8 +1529,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "_j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("CAST(\"j0.k\", 'DOUBLE')"),
-                            DruidExpression.fromColumn("_j0.m1")
+                            makeExpression(ColumnType.DOUBLE, "CAST(\"j0.k\", 'DOUBLE')"),
+                            DruidExpression.ofColumn(ColumnType.DOUBLE, "_j0.m1")
                         ),
                         JoinType.INNER
                     )
@@ -1579,8 +1579,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             ),
                             "j0.",
                             equalsCondition(
-                                DruidExpression.fromColumn("k"),
-                                DruidExpression.fromColumn("j0.dim1")
+                                makeColumnExpression("k"),
+                                makeColumnExpression("j0.dim1")
                             ),
                             JoinType.INNER
                         ),
@@ -1594,8 +1594,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "_j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("k"),
-                            DruidExpression.fromColumn("_j0.dim1")
+                            makeColumnExpression("k"),
+                            makeColumnExpression("_j0.dim1")
                         ),
                         JoinType.INNER
                     )
@@ -1659,8 +1659,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             ),
                             "j0.",
                             equalsCondition(
-                                DruidExpression.fromColumn("k"),
-                                DruidExpression.fromColumn("j0.dim1")
+                                makeColumnExpression("k"),
+                                makeColumnExpression("j0.dim1")
                             ),
                             JoinType.INNER
                         ),
@@ -1674,8 +1674,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "_j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("j0.dim1"),
-                            DruidExpression.fromColumn("_j0.dim1")
+                            makeColumnExpression("j0.dim1"),
+                            makeColumnExpression("_j0.dim1")
                         ),
                         JoinType.INNER
                     )
@@ -1736,7 +1736,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.d0")),
                         JoinType.INNER
                     )
                 )
@@ -1767,8 +1767,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new LookupDataSource("lookyloo"),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("substring(\"dim2\", 0, 1)"),
-                            DruidExpression.fromColumn("j0.k")
+                            makeExpression("substring(\"dim2\", 0, 1)"),
+                            makeColumnExpression("j0.k")
                         ),
                         JoinType.INNER
                     )
@@ -1877,8 +1877,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             ),
                             "j0.",
                             equalsCondition(
-                                DruidExpression.fromColumn("cnt"),
-                                DruidExpression.fromColumn("j0.v0")
+                                DruidExpression.ofColumn(ColumnType.LONG, "cnt"),
+                                DruidExpression.ofColumn(ColumnType.LONG, "j0.v0")
                             ),
                             JoinType.INNER
                         ),
@@ -1893,8 +1893,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "_j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("CAST(\"j0.k\", 'LONG')"),
-                            DruidExpression.fromColumn("_j0.cnt")
+                            makeExpression(ColumnType.LONG, "CAST(\"j0.k\", 'LONG')"),
+                            DruidExpression.ofColumn(ColumnType.LONG, "_j0.cnt")
                         ),
                         JoinType.INNER
                     )
@@ -1930,8 +1930,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new LookupDataSource("lookyloo"),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("CAST(\"m1\", 'STRING')"),
-                            DruidExpression.fromColumn("j0.k")
+                            makeExpression("CAST(\"m1\", 'STRING')"),
+                            makeColumnExpression("j0.k")
                         ),
                         JoinType.INNER
                     )
@@ -1974,7 +1974,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("m1"), DruidExpression.fromColumn("j0.v0")),
+                        equalsCondition(DruidExpression.ofColumn(ColumnType.FLOAT, "m1"), DruidExpression.ofColumn(ColumnType.FLOAT, "j0.v0")),
                         JoinType.INNER
                     )
                 )
@@ -2018,7 +2018,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("m1"), DruidExpression.fromColumn("j0.v0")),
+                        equalsCondition(DruidExpression.ofColumn(ColumnType.FLOAT, "m1"), DruidExpression.ofColumn(ColumnType.FLOAT, "j0.v0")),
                         JoinType.INNER
                     )
                 )
@@ -2050,8 +2050,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new LookupDataSource("lookyloo"),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("substring(\"dim2\", 0, 1)"),
-                            DruidExpression.fromColumn("j0.k")
+                            makeExpression("substring(\"dim2\", 0, 1)"),
+                            makeColumnExpression("j0.k")
                         ),
                         JoinType.INNER
                     )
@@ -2096,7 +2096,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.v0")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.v0")),
                         JoinType.INNER
                     )
                 )
@@ -2130,12 +2130,12 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             new TableDataSource(CalciteTests.DATASOURCE1),
                             new LookupDataSource("lookyloo"),
                             "j0.",
-                            equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.k")),
+                            equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
                             JoinType.LEFT
                         ),
                         new LookupDataSource("lookyloo"),
                         "_j0.",
-                        equalsCondition(DruidExpression.fromColumn("j0.k"), DruidExpression.fromColumn("_j0.k")),
+                        equalsCondition(makeColumnExpression("j0.k"), makeColumnExpression("_j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -2175,17 +2175,17 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 new TableDataSource(CalciteTests.DATASOURCE1),
                                 new LookupDataSource("lookyloo"),
                                 "j0.",
-                                equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                                equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                                 JoinType.LEFT
                             ),
                             new LookupDataSource("lookyloo"),
                             "_j0.",
-                            equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("_j0.k")),
+                            equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("_j0.k")),
                             JoinType.LEFT
                         ),
                         new LookupDataSource("lookyloo"),
                         "__j0.",
-                        equalsCondition(DruidExpression.fromColumn("_j0.k"), DruidExpression.fromColumn("__j0.k")),
+                        equalsCondition(makeColumnExpression("_j0.k"), makeColumnExpression("__j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -2221,7 +2221,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -2258,7 +2258,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.RIGHT
                     )
                 )
@@ -2293,7 +2293,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.FULL
                     )
                 )
@@ -2346,8 +2346,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("__time"),
-                            DruidExpression.fromColumn("j0.a0")
+                            DruidExpression.ofColumn(ColumnType.LONG, "__time"),
+                            DruidExpression.ofColumn(ColumnType.LONG, "j0.a0")
                         ),
                         JoinType.INNER
                     )
@@ -2486,8 +2486,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("substring(\"dim2\", 0, 1)"),
-                            DruidExpression.fromColumn("j0.d0")
+                            makeExpression("substring(\"dim2\", 0, 1)"),
+                            makeColumnExpression("j0.d0")
                         ),
                         JoinType.INNER
                     )
@@ -2521,8 +2521,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new LookupDataSource("lookyloo"),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim1"),
-                            DruidExpression.fromColumn("j0.k")
+                            makeColumnExpression("dim1"),
+                            makeColumnExpression("j0.k")
                         ),
                         JoinType.INNER
                     )
@@ -2556,8 +2556,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new LookupDataSource("lookyloo"),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim3"),
-                            DruidExpression.fromColumn("j0.k")
+                            makeColumnExpression("dim3"),
+                            makeColumnExpression("j0.k")
                         ),
                         JoinType.INNER
                     )
@@ -2631,7 +2631,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.v0")),
+                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.v0")),
                         JoinType.LEFT
                     )
                 )
@@ -2685,7 +2685,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromExpression("'10.1'"), DruidExpression.fromColumn("j0.v0")),
+                        equalsCondition(makeExpression("'10.1'"), makeColumnExpression("j0.v0")),
                         JoinType.LEFT,
                         selector("dim1", "10.1", null)
                     )
@@ -2744,7 +2744,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
+                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.dim1")),
                         JoinType.LEFT
                     )
                 )
@@ -2791,8 +2791,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("'10.1'"),
-                            DruidExpression.fromColumn("j0.dim1")
+                            makeExpression("'10.1'"),
+                            makeColumnExpression("j0.dim1")
                         ),
                         JoinType.LEFT,
                         selector("dim1", "10.1", null)
@@ -2847,7 +2847,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
+                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.dim1")),
                         JoinType.LEFT
                     )
                 )
@@ -2892,8 +2892,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("'10.1'"),
-                            DruidExpression.fromColumn("j0.dim1")
+                            makeExpression("'10.1'"),
+                            makeColumnExpression("j0.dim1")
                         ),
                         JoinType.LEFT,
                         selector("dim1", "10.1", null)
@@ -2940,7 +2940,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         .build()
                 ),
                 "j0.",
-                equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
+                equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.dim1")),
                 JoinType.INNER
             )
         )
@@ -2995,8 +2995,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("'10.1'"),
-                            DruidExpression.fromColumn("j0.dim1")
+                            makeExpression("'10.1'"),
+                            makeColumnExpression("j0.dim1")
                         ),
                         JoinType.INNER,
                         selector("dim1", "10.1", null)
@@ -3051,7 +3051,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.dim1")),
+                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.dim1")),
                         JoinType.INNER
                     )
                 )
@@ -3097,8 +3097,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromExpression("'10.1'"),
-                            DruidExpression.fromColumn("j0.dim1")
+                            makeExpression("'10.1'"),
+                            makeColumnExpression("j0.dim1")
                         ),
                         JoinType.INNER,
                         selector("dim1", "10.1", null)
@@ -3238,7 +3238,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         .build()
                 ),
                 "j0.",
-                equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
+                equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.d0")),
                 JoinType.INNER
             )
         )
@@ -3264,7 +3264,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         .build()
                 ),
                 "j0.",
-                equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
+                equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.d0")),
                 JoinType.LEFT
             )
         )
@@ -3334,7 +3334,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.d0")),
                         JoinType.LEFT
                     )
                 )
@@ -3374,7 +3374,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                             .context(QUERY_CONTEXT_DEFAULT)
                             .build()),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.dim1")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.dim1")),
                         JoinType.LEFT
                     )
                 )
@@ -3428,10 +3428,13 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         "j0.",
                         StringUtils.format(
                             "(%s && %s)",
-                            equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
                             equalsCondition(
-                                DruidExpression.fromExpression("'abc'"),
-                                DruidExpression.fromColumn("j0.d0")
+                                makeColumnExpression("dim1"),
+                                makeColumnExpression("j0.d0")
+                            ),
+                            equalsCondition(
+                                makeExpression("'abc'"),
+                                makeColumnExpression("j0.d0")
                             )
                         ),
                         JoinType.INNER
@@ -3474,7 +3477,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.d0")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.d0")),
                         JoinType.INNER
                     )
                 )
@@ -3757,7 +3760,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.d0")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.d0")),
                         JoinType.INNER
                     )
                 )
@@ -3838,7 +3841,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.INNER
                     ))
                 .intervals(querySegmentSpec(Filtration.eternity()))
@@ -3887,7 +3890,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.INNER
                     ))
                 .intervals(querySegmentSpec(Filtration.eternity()))
@@ -3919,7 +3922,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -3934,7 +3937,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.INNER
                     ))
                 .intervals(querySegmentSpec(Filtration.eternity()))
@@ -3991,8 +3994,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim2"),
-                            DruidExpression.fromColumn("j0.d0")
+                            makeColumnExpression("dim2"),
+                            makeColumnExpression("j0.d0")
                         ),
                         JoinType.INNER
                     )
@@ -4065,8 +4068,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim2"),
-                            DruidExpression.fromColumn("j0.d0")
+                            makeColumnExpression("dim2"),
+                            makeColumnExpression("j0.d0")
                         ),
                         JoinType.INNER
                     )
@@ -4167,7 +4170,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new TableDataSource(CalciteTests.DATASOURCE1),
                         new LookupDataSource("lookyloo"),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.k")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.k")),
                         JoinType.LEFT
                     )
                 )
@@ -4223,8 +4226,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim2"),
-                            DruidExpression.fromColumn("j0.d0")
+                            makeColumnExpression("dim2"),
+                            makeColumnExpression("j0.d0")
                         ),
                         JoinType.INNER
                     )
@@ -4304,8 +4307,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         ),
                         "_j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim2"),
-                            DruidExpression.fromColumn("_j0.d0")
+                            makeColumnExpression("dim2"),
+                            makeColumnExpression("_j0.d0")
                         ),
                         JoinType.LEFT
                     )
@@ -4395,8 +4398,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 ),
                                 "j0.",
                                 equalsCondition(
-                                    DruidExpression.fromColumn("dim1"),
-                                    DruidExpression.fromColumn("j0.dim1")
+                                    makeColumnExpression("dim1"),
+                                    makeColumnExpression("j0.dim1")
                                 ),
                                 JoinType.INNER
                             )
@@ -4469,8 +4472,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                 ),
                 "j0.",
                 equalsCondition(
-                    DruidExpression.fromColumn("dim1"),
-                    DruidExpression.fromColumn("j0.dim1")
+                    makeColumnExpression("dim1"),
+                    makeColumnExpression("j0.dim1")
                 ),
                 JoinType.INNER
             )
@@ -4521,7 +4524,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
+                        equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.d0")),
                         JoinType.INNER
                     )
                 )
@@ -4555,8 +4558,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new GlobalTableDataSource(CalciteTests.BROADCAST_DATASOURCE),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim4"),
-                            DruidExpression.fromColumn("j0.dim4")
+                            makeColumnExpression("dim4"),
+                            makeColumnExpression("j0.dim4")
                         ),
                         JoinType.INNER
 
@@ -4596,8 +4599,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                         new GlobalTableDataSource(CalciteTests.BROADCAST_DATASOURCE),
                         "j0.",
                         equalsCondition(
-                            DruidExpression.fromColumn("dim4"),
-                            DruidExpression.fromColumn("j0.dim4")
+                            makeColumnExpression("dim4"),
+                            makeColumnExpression("j0.dim4")
                         ),
                         JoinType.INNER
                     )
@@ -4647,7 +4650,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.v0")),
+                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.v0")),
                         JoinType.INNER
                     )
                 )
@@ -4703,7 +4706,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                                 .build()
                                         ),
                                         "j0.",
-                                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.v0")),
+                                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.v0")),
                                         JoinType.INNER
                                     )
                                 )
@@ -4719,7 +4722,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("v0"), DruidExpression.fromColumn("j0.v0")),
+                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.v0")),
                         JoinType.INNER
                     )
                 )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -406,7 +406,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
             new Object[]{"1", 1, 1L},
             new Object[]{"2", 1, 1L},
             new Object[]{"abc", 1, 1L},
-            new Object[]{"def", 1, 1L}
+            new Object[]{"def", useDefault ? 0 : null, 1L}
         )
     );
   }
@@ -540,18 +540,20 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{"foo,null", "null,foo", 3L},
+          new Object[]{"foo,null", "null,foo", 2L},
+          new Object[]{"", "", 1L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
           new Object[]{"foo,d", "d,foo", 1L}
       );
     } else {
       results = ImmutableList.of(
-          new Object[]{"foo,null", "null,foo", 2L},
+          new Object[]{null, null, 1L},
           new Object[]{"foo,", ",foo", 1L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
-          new Object[]{"foo,d", "d,foo", 1L}
+          new Object[]{"foo,d", "d,foo", 1L},
+          new Object[]{"foo,null", "null,foo", 1L}
       );
     }
     testQuery(
@@ -830,8 +832,14 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        ImmutableList.of(
-            new Object[]{useDefault ? -1 : null, 4L},
+        useDefault
+        ? ImmutableList.of(
+            new Object[]{-1, 3L},
+            new Object[]{0, 2L},
+            new Object[]{1, 1L}
+        )
+        : ImmutableList.of(
+            new Object[]{null, 4L},
             new Object[]{0, 1L},
             new Object[]{1, 1L}
         )
@@ -873,8 +881,15 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        ImmutableList.of(
-            new Object[]{useDefault ? -1 : null, 4L},
+        useDefault
+        ? ImmutableList.of(
+            new Object[]{-1, 3L},
+            new Object[]{0, 1L},
+            new Object[]{1, 1L},
+            new Object[]{2, 1L}
+        )
+        : ImmutableList.of(
+            new Object[]{null, 4L},
             new Object[]{1, 1L},
             new Object[]{2, 1L}
         )
@@ -946,8 +961,8 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{"d", 7L},
-          new Object[]{"", 3L},
+          new Object[]{"d", 6L},
+          new Object[]{"", 2L},
           new Object[]{"b", 2L},
           new Object[]{"a", 1L},
           new Object[]{"c", 1L}
@@ -955,8 +970,8 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
     } else {
       results = ImmutableList.of(
           new Object[]{"d", 5L},
-          new Object[]{null, 2L},
           new Object[]{"b", 2L},
+          new Object[]{null, 1L},
           new Object[]{"", 1L},
           new Object[]{"a", 1L},
           new Object[]{"c", 1L}
@@ -1116,8 +1131,14 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "array_length(filter((x) -> array_contains(array('b'), x), \"dim3\"))",
+                                "array_length(\"v1\")",
                                 ColumnType.LONG
+                            ),
+                            new ListFilteredVirtualColumn(
+                                "v1",
+                                DefaultDimensionSpec.of("dim3"),
+                                ImmutableSet.of("b"),
+                                true
                             )
                         )
                         .setDimensions(
@@ -1138,7 +1159,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{0, 4L},
+            new Object[]{useDefault ? 0 : null, 4L},
             new Object[]{1, 2L}
         )
     );
@@ -1160,8 +1181,14 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .setVirtualColumns(
                             expressionVirtualColumn(
                                 "v0",
-                                "array_length(filter((x) -> !array_contains(array('b'), x), \"dim3\"))",
+                                "array_length(\"v1\")",
                                 ColumnType.LONG
+                            ),
+                            new ListFilteredVirtualColumn(
+                                "v1",
+                                DefaultDimensionSpec.of("dim3"),
+                                ImmutableSet.of("b"),
+                                false
                             )
                         )
                         .setDimensions(
@@ -1181,7 +1208,9 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        useDefault ? ImmutableList.of(new Object[]{1, 6L}) : ImmutableList.of(new Object[]{1, 4L}, new Object[]{0, 2L})
+        useDefault
+        ? ImmutableList.of(new Object[]{1, 5L}, new Object[]{0, 1L})
+        : ImmutableList.of(new Object[]{1, 5L}, new Object[]{null, 1L})
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -263,10 +263,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                 .context(QUERY_CONTEXT_DEFAULT)
                 .build()
         ),
-        ImmutableList.of(
-            new Object[]{"[\"a\",\"b\"]"},
-            new Object[]{useDefault ? "" : null}
-        )
+        ImmutableList.of(new Object[]{"[\"a\",\"b\"]"})
     );
   }
 
@@ -403,9 +400,9 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"", 2, 1L},
             new Object[]{"10.1", 2, 1L},
-            new Object[]{"1", 1, 1L},
-            new Object[]{"2", 1, 1L},
-            new Object[]{"abc", 1, 1L},
+            useDefault ? new Object[]{"2", 1, 1L} : new Object[]{"1", 1, 1L},
+            useDefault ? new Object[]{"1", 0, 1L} : new Object[]{"2", 1, 1L},
+            new Object[]{"abc", useDefault ? 0 : null, 1L},
             new Object[]{"def", useDefault ? 0 : null, 1L}
         )
     );
@@ -540,20 +537,18 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{"foo,null", "null,foo", 2L},
-          new Object[]{"", "", 1L},
+          new Object[]{"", "", 3L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
           new Object[]{"foo,d", "d,foo", 1L}
       );
     } else {
       results = ImmutableList.of(
-          new Object[]{null, null, 1L},
+          new Object[]{null, null, 2L},
           new Object[]{"foo,", ",foo", 1L},
           new Object[]{"foo,a,b", "a,b,foo", 1L},
           new Object[]{"foo,b,c", "b,c,foo", 1L},
-          new Object[]{"foo,d", "d,foo", 1L},
-          new Object[]{"foo,null", "null,foo", 1L}
+          new Object[]{"foo,d", "d,foo", 1L}
       );
     }
     testQuery(
@@ -834,8 +829,8 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ),
         useDefault
         ? ImmutableList.of(
-            new Object[]{-1, 3L},
-            new Object[]{0, 2L},
+            new Object[]{0, 4L},
+            new Object[]{-1, 1L},
             new Object[]{1, 1L}
         )
         : ImmutableList.of(
@@ -883,8 +878,8 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ),
         useDefault
         ? ImmutableList.of(
-            new Object[]{-1, 3L},
-            new Object[]{0, 1L},
+            new Object[]{0, 3L},
+            new Object[]{-1, 1L},
             new Object[]{1, 1L},
             new Object[]{2, 1L}
         )
@@ -961,8 +956,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
     ImmutableList<Object[]> results;
     if (useDefault) {
       results = ImmutableList.of(
-          new Object[]{"d", 6L},
-          new Object[]{"", 2L},
+          new Object[]{"d", 4L},
           new Object[]{"b", 2L},
           new Object[]{"a", 1L},
           new Object[]{"c", 1L}
@@ -971,7 +965,6 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
       results = ImmutableList.of(
           new Object[]{"d", 5L},
           new Object[]{"b", 2L},
-          new Object[]{null, 1L},
           new Object[]{"", 1L},
           new Object[]{"a", 1L},
           new Object[]{"c", 1L}
@@ -1158,8 +1151,12 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        ImmutableList.of(
-            new Object[]{useDefault ? 0 : null, 4L},
+        useDefault ? ImmutableList.of(
+            new Object[]{0, 4L},
+            new Object[]{1, 2L}
+        ) : ImmutableList.of(
+            new Object[]{null, 2L},
+            new Object[]{0, 2L},
             new Object[]{1, 2L}
         )
     );
@@ -1209,8 +1206,8 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         useDefault
-        ? ImmutableList.of(new Object[]{1, 5L}, new Object[]{0, 1L})
-        : ImmutableList.of(new Object[]{1, 5L}, new Object[]{null, 1L})
+        ? ImmutableList.of(new Object[]{0, 3L}, new Object[]{1, 3L})
+        : ImmutableList.of(new Object[]{1, 4L}, new Object[]{null, 2L})
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -1155,8 +1155,11 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
             new Object[]{0, 4L},
             new Object[]{1, 2L}
         ) : ImmutableList.of(
-            new Object[]{null, 2L},
-            new Object[]{0, 2L},
+            // the fallback expression would actually produce 3 rows, 2 nulls, 2 0's, and 2 1s
+            // instead of 4 nulls and two 1's we get when using the 'native' list filtered virtual column
+            // this is because of slight differences between filter and the native
+            // selector, which treats a 0 length array as null instead of an empty array like is produced by filter
+            new Object[]{null, 4L},
             new Object[]{1, 2L}
         )
     );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6858,8 +6858,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                                     ),
                                                     "j0.",
                                                     equalsCondition(
-                                                        DruidExpression.fromExpression("substring(\"dim2\", 0, 1)"),
-                                                        DruidExpression.fromColumn("j0.d0")
+                                                        makeExpression("substring(\"dim2\", 0, 1)"),
+                                                        DruidExpression.ofColumn(ColumnType.STRING, "j0.d0")
                                                     ),
                                                     JoinType.INNER
                                                 )
@@ -10852,8 +10852,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         "j0.",
                         StringUtils.format(
                             "(%s && %s)",
-                            equalsCondition(DruidExpression.fromColumn("dim1"), DruidExpression.fromColumn("j0.d0")),
-                            equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.p0"))
+                            equalsCondition(makeColumnExpression("dim1"), makeColumnExpression("j0.d0")),
+                            equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.p0"))
                         ),
                         JoinType.INNER
                     )
@@ -10899,7 +10899,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                                         .build()
                         ),
                         "j0.",
-                        equalsCondition(DruidExpression.fromColumn("dim2"), DruidExpression.fromColumn("j0.d0")),
+                        equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.d0")),
                         JoinType.INNER
                     )
                 )
@@ -11629,8 +11629,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                           ),
                           "j0.",
                           equalsCondition(
-                              DruidExpression.fromExpression("substring(\"dim2\", 0, 1)"),
-                              DruidExpression.fromColumn("j0.d0")
+                              makeExpression("substring(\"dim2\", 0, 1)"),
+                              DruidExpression.ofColumn(ColumnType.STRING, "j0.d0")
                           ),
                           JoinType.INNER
                       )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
@@ -255,17 +255,45 @@ class ExpressionTestHelper
     testExpression(rexBuilder.makeCall(op, exprs), expectedExpression, expectedResult);
   }
 
+  /**
+   * @deprecated use {@link #testExpression(SqlOperator, RexNode, DruidExpression, Object)} instead which does a
+   * deep comparison of {@link DruidExpression} instead of just comparing the output of
+   * {@link DruidExpression#getExpression()}
+   */
+  @Deprecated
+  void testExpressionString(
+      final SqlOperator op,
+      final List<? extends RexNode> exprs,
+      final DruidExpression expectedExpression,
+      final Object expectedResult
+  )
+  {
+    testExpression(rexBuilder.makeCall(op, exprs), expectedExpression, expectedResult, false);
+  }
+
   void testExpression(
       final RexNode rexNode,
       final DruidExpression expectedExpression,
       final Object expectedResult
   )
   {
+    testExpression(rexNode, expectedExpression, expectedResult, true);
+  }
+
+  void testExpression(
+      final RexNode rexNode,
+      final DruidExpression expectedExpression,
+      final Object expectedResult,
+      final boolean deepCompare
+  )
+  {
     DruidExpression expression = Expressions.toDruidExpression(PLANNER_CONTEXT, rowSignature, rexNode);
     Assert.assertNotNull(expression);
-    // todo(clint): it would be way more cool to compare DruidExpression to validate the expected tree structure
-    // only compare the built expression so that test writers do not need to match the tree structure perfectly
-    Assert.assertEquals("Expression for: " + rexNode, expectedExpression.getExpression(), expression.getExpression());
+    if (deepCompare) {
+      Assert.assertEquals("Expression for: " + rexNode, expectedExpression, expression);
+    } else {
+      Assert.assertEquals("Expression for: " + rexNode, expectedExpression.getExpression(), expression.getExpression());
+    }
 
     ExprEval<?> result = Parser.parse(expression.getExpression(), PLANNER_CONTEXT.getExprMacroTable())
                                .eval(InputBindings.withMap(bindings));

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -138,7 +138,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("bar")
         ),
-        DruidExpression.fromExpression("concat(\"s\",'bar')"),
+        makeExpression("concat(\"s\",'bar')"),
         "foobar"
     );
   }
@@ -149,7 +149,7 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         SqlStdOperatorTable.CHARACTER_LENGTH,
         testHelper.makeInputRef("s"),
-        DruidExpression.fromExpression("strlen(\"s\")"),
+        makeExpression("strlen(\"s\")"),
         3L
     );
   }
@@ -164,7 +164,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("x(.)"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.of(
+        makeExpression(
             SimpleExtraction.of("s", new RegexDimExtractionFn("x(.)", 1, true, null)),
             "regexp_extract(\"s\",'x(.)',1)"
         ),
@@ -178,7 +178,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("(o)"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.of(
+        makeExpression(
             SimpleExtraction.of("s", new RegexDimExtractionFn("(o)", 1, true, null)),
             "regexp_extract(\"s\",'(o)',1)"
         ),
@@ -197,7 +197,7 @@ public class ExpressionsTest extends ExpressionTestBase
             ),
             testHelper.makeLiteral("Zf(.)")
         ),
-        DruidExpression.fromExpression("regexp_extract(concat('Z',\"s\"),'Zf(.)')"),
+        makeExpression("regexp_extract(concat('Z',\"s\"),'Zf(.)')"),
         "Zfo"
     );
 
@@ -208,7 +208,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("f(.)"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.of(
+        makeExpression(
             SimpleExtraction.of("s", new RegexDimExtractionFn("f(.)", 1, true, null)),
             "regexp_extract(\"s\",'f(.)',1)"
         ),
@@ -221,7 +221,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("f(.)")
         ),
-        DruidExpression.of(
+        makeExpression(
             SimpleExtraction.of("s", new RegexDimExtractionFn("f(.)", 0, true, null)),
             "regexp_extract(\"s\",'f(.)')"
         ),
@@ -234,7 +234,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("")
         ),
-        DruidExpression.of(
+        makeExpression(
             SimpleExtraction.of("s", new RegexDimExtractionFn("", 0, true, null)),
             "regexp_extract(\"s\",'')"
         ),
@@ -247,7 +247,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("")
         ),
-        DruidExpression.of(
+        makeExpression(
             SimpleExtraction.of("s", new RegexDimExtractionFn("", 0, true, null)),
             "regexp_extract(\"s\",'')"
         ),
@@ -260,7 +260,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
             testHelper.makeLiteral("(.)")
         ),
-        DruidExpression.fromExpression("regexp_extract(null,'(.)')"),
+        makeExpression("regexp_extract(null,'(.)')"),
         null
     );
 
@@ -270,7 +270,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
             testHelper.makeLiteral("")
         ),
-        DruidExpression.fromExpression("regexp_extract(null,'')"),
+        makeExpression("regexp_extract(null,'')"),
         null
     );
 
@@ -280,7 +280,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
             testHelper.makeLiteral("null")
         ),
-        DruidExpression.fromExpression("regexp_extract(null,'null')"),
+        makeExpression("regexp_extract(null,'null')"),
         null
     );
   }
@@ -294,7 +294,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("f.")
         ),
-        DruidExpression.fromExpression("regexp_like(\"s\",'f.')"),
+        makeExpression("regexp_like(\"s\",'f.')"),
         1L
     );
 
@@ -304,7 +304,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("o")
         ),
-        DruidExpression.fromExpression("regexp_like(\"s\",'o')"),
+        makeExpression("regexp_like(\"s\",'o')"),
 
         // Column "s" contains an 'o', but not at the beginning; we do match this.
         1L
@@ -316,7 +316,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("x.")
         ),
-        DruidExpression.fromExpression("regexp_like(\"s\",'x.')"),
+        makeExpression("regexp_like(\"s\",'x.')"),
         0L
     );
 
@@ -326,7 +326,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("")
         ),
-        DruidExpression.fromExpression("regexp_like(\"s\",'')"),
+        makeExpression("regexp_like(\"s\",'')"),
         1L
     );
 
@@ -336,7 +336,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("beep\nboop"),
             testHelper.makeLiteral("^beep$")
         ),
-        DruidExpression.fromExpression("regexp_like('beep\\u000Aboop','^beep$')"),
+        makeExpression("regexp_like('beep\\u000Aboop','^beep$')"),
         0L
     );
 
@@ -346,7 +346,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("beep\nboop"),
             testHelper.makeLiteral("^beep\\nboop$")
         ),
-        DruidExpression.fromExpression("regexp_like('beep\\u000Aboop','^beep\\u005Cnboop$')"),
+        makeExpression("regexp_like('beep\\u000Aboop','^beep\\u005Cnboop$')"),
         1L
     );
 
@@ -356,7 +356,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("newliney"),
             testHelper.makeLiteral("^beep$")
         ),
-        DruidExpression.fromExpression("regexp_like(\"newliney\",'^beep$')"),
+        makeExpression("regexp_like(\"newliney\",'^beep$')"),
         0L
     );
 
@@ -366,7 +366,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("newliney"),
             testHelper.makeLiteral("^beep\\nboop$")
         ),
-        DruidExpression.fromExpression("regexp_like(\"newliney\",'^beep\\u005Cnboop$')"),
+        makeExpression("regexp_like(\"newliney\",'^beep\\u005Cnboop$')"),
         1L
     );
 
@@ -376,7 +376,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("newliney"),
             testHelper.makeLiteral("boo")
         ),
-        DruidExpression.fromExpression("regexp_like(\"newliney\",'boo')"),
+        makeExpression("regexp_like(\"newliney\",'boo')"),
         1L
     );
 
@@ -386,7 +386,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("newliney"),
             testHelper.makeLiteral("^boo")
         ),
-        DruidExpression.fromExpression("regexp_like(\"newliney\",'^boo')"),
+        makeExpression("regexp_like(\"newliney\",'^boo')"),
         0L
     );
 
@@ -400,7 +400,7 @@ public class ExpressionsTest extends ExpressionTestBase
             ),
             testHelper.makeLiteral("x(.)")
         ),
-        DruidExpression.fromExpression("regexp_like(concat('Z',\"s\"),'x(.)')"),
+        makeExpression("regexp_like(concat('Z',\"s\"),'x(.)')"),
         0L
     );
 
@@ -410,7 +410,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
             testHelper.makeLiteral("(.)")
         ),
-        DruidExpression.fromExpression("regexp_like(null,'(.)')"),
+        makeExpression("regexp_like(null,'(.)')"),
         0L
     );
 
@@ -420,7 +420,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
             testHelper.makeLiteral("")
         ),
-        DruidExpression.fromExpression("regexp_like(null,'')"),
+        makeExpression("regexp_like(null,'')"),
 
         // In SQL-compatible mode, nulls don't match anything. Otherwise, they match like empty strings.
         NullHandling.sqlCompatible() ? 0L : 1L
@@ -432,7 +432,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
             testHelper.makeLiteral("null")
         ),
-        DruidExpression.fromExpression("regexp_like(null,'null')"),
+        makeExpression("regexp_like(null,'null')"),
         0L
     );
   }
@@ -539,7 +539,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("%x"),
             testHelper.makeInputRef("b")
         ),
-        DruidExpression.fromExpression("format('%x',\"b\")"),
+        makeExpression("format('%x',\"b\")"),
         "19"
     );
 
@@ -550,7 +550,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(1234)
         ),
-        DruidExpression.fromExpression("format('%s %,d',\"s\",1234)"),
+        makeExpression("format('%s %,d',\"s\",1234)"),
         "foo 1,234"
     );
 
@@ -560,7 +560,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("%s %,d"),
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("format('%s %,d',\"s\")"),
+        makeExpression("format('%s %,d',\"s\")"),
         "%s %,d; foo"
     );
 
@@ -572,7 +572,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(1234),
             testHelper.makeLiteral(6789)
         ),
-        DruidExpression.fromExpression("format('%s %,d',\"s\",1234,6789)"),
+        makeExpression("format('%s %,d',\"s\",1234,6789)"),
         "foo 1,234"
     );
   }
@@ -586,7 +586,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("oo")
         ),
-        DruidExpression.fromExpression("(strpos(\"s\",'oo') + 1)"),
+        makeExpression("(strpos(\"s\",'oo') + 1)"),
         2L
     );
 
@@ -596,7 +596,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("ax")
         ),
-        DruidExpression.fromExpression("(strpos(\"s\",'ax') + 1)"),
+        makeExpression("(strpos(\"s\",'ax') + 1)"),
         0L
     );
 
@@ -606,7 +606,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
             testHelper.makeLiteral("ax")
         ),
-        DruidExpression.fromExpression("(strpos(null,'ax') + 1)"),
+        makeExpression("(strpos(null,'ax') + 1)"),
         NullHandling.replaceWithDefault() ? 0L : null
     );
   }
@@ -617,7 +617,7 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         new ParseLongOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("intstr"),
-        DruidExpression.fromExpression("parse_long(\"intstr\")"),
+        makeExpression(ColumnType.LONG, "parse_long(\"intstr\")"),
         -100L
     );
 
@@ -627,7 +627,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("hexstr"),
             testHelper.makeLiteral(BigDecimal.valueOf(16))
         ),
-        DruidExpression.fromExpression("parse_long(\"hexstr\",16)"),
+        makeExpression(ColumnType.LONG, "parse_long(\"hexstr\",16)"),
         239L
     );
 
@@ -641,14 +641,14 @@ public class ExpressionsTest extends ExpressionTestBase
             ),
             testHelper.makeLiteral(BigDecimal.valueOf(16))
         ),
-        DruidExpression.fromExpression("parse_long(concat('0x',\"hexstr\"),16)"),
+        makeExpression(ColumnType.LONG, "parse_long(concat('0x',\"hexstr\"),16)"),
         239L
     );
 
     testHelper.testExpression(
         new ParseLongOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("hexstr"),
-        DruidExpression.fromExpression("parse_long(\"hexstr\")"),
+        makeExpression(ColumnType.LONG, "parse_long(\"hexstr\")"),
         NullHandling.sqlCompatible() ? null : 0L
     );
   }
@@ -662,7 +662,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("oo"),
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("(strpos(\"s\",'oo',0) + 1)"),
+        makeExpression(ColumnType.LONG, "(strpos(\"s\",'oo',0) + 1)"),
         2L
     );
 
@@ -673,7 +673,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(BigDecimal.valueOf(2))
         ),
-        DruidExpression.fromExpression("(strpos(\"s\",'oo',(2 - 1)) + 1)"),
+        makeExpression(ColumnType.LONG, "(strpos(\"s\",'oo',(2 - 1)) + 1)"),
         2L
     );
 
@@ -684,7 +684,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(BigDecimal.valueOf(3))
         ),
-        DruidExpression.fromExpression("(strpos(\"s\",'oo',(3 - 1)) + 1)"),
+        makeExpression(ColumnType.LONG, "(strpos(\"s\",'oo',(3 - 1)) + 1)"),
         0L
     );
   }
@@ -698,7 +698,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("a"),
             testHelper.makeLiteral(2)
         ),
-        DruidExpression.fromExpression("pow(\"a\",2)"),
+        makeExpression(ColumnType.DOUBLE, "pow(\"a\",2)"),
         100.0
     );
   }
@@ -709,28 +709,28 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("a"),
-        DruidExpression.fromExpression("floor(\"a\")"),
+        makeExpression(ColumnType.DOUBLE, "floor(\"a\")"),
         10.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("x"),
-        DruidExpression.fromExpression("floor(\"x\")"),
+        makeExpression(ColumnType.DOUBLE, "floor(\"x\")"),
         2.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("y"),
-        DruidExpression.fromExpression("floor(\"y\")"),
+        makeExpression(ColumnType.DOUBLE, "floor(\"y\")"),
         3.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("z"),
-        DruidExpression.fromExpression("floor(\"z\")"),
+        makeExpression(ColumnType.DOUBLE, "floor(\"z\")"),
         -3.0
     );
   }
@@ -741,28 +741,28 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("a"),
-        DruidExpression.fromExpression("ceil(\"a\")"),
+        makeExpression(ColumnType.DOUBLE, "ceil(\"a\")"),
         10.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("x"),
-        DruidExpression.fromExpression("ceil(\"x\")"),
+        makeExpression(ColumnType.DOUBLE, "ceil(\"x\")"),
         3.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("y"),
-        DruidExpression.fromExpression("ceil(\"y\")"),
+        makeExpression(ColumnType.DOUBLE, "ceil(\"y\")"),
         3.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("z"),
-        DruidExpression.fromExpression("ceil(\"z\")"),
+        makeExpression(ColumnType.DOUBLE, "ceil(\"z\")"),
         -2.0
     );
   }
@@ -775,28 +775,28 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("a"),
-        DruidExpression.fromExpression("(cast(cast(\"a\" * 1,'long'),'double') / 1)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"a\" * 1,'long'),'double') / 1)"),
         10.0
     );
 
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("x"),
-        DruidExpression.fromExpression("(cast(cast(\"x\" * 1,'long'),'double') / 1)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"x\" * 1,'long'),'double') / 1)"),
         2.0
     );
 
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("y"),
-        DruidExpression.fromExpression("(cast(cast(\"y\" * 1,'long'),'double') / 1)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"y\" * 1,'long'),'double') / 1)"),
         3.0
     );
 
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("z"),
-        DruidExpression.fromExpression("(cast(cast(\"z\" * 1,'long'),'double') / 1)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"z\" * 1,'long'),'double') / 1)"),
         -2.0
     );
 
@@ -806,7 +806,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("x"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("(cast(cast(\"x\" * 10.0,'long'),'double') / 10.0)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"x\" * 10.0,'long'),'double') / 10.0)"),
         2.2
     );
 
@@ -816,7 +816,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("z"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("(cast(cast(\"z\" * 10.0,'long'),'double') / 10.0)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"z\" * 10.0,'long'),'double') / 10.0)"),
         -2.2
     );
 
@@ -826,7 +826,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("b"),
             testHelper.makeLiteral(-1)
         ),
-        DruidExpression.fromExpression("(cast(cast(\"b\" * 0.1,'long'),'double') / 0.1)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"b\" * 0.1,'long'),'double') / 0.1)"),
         20.0
     );
 
@@ -836,7 +836,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("z"),
             testHelper.makeLiteral(-1)
         ),
-        DruidExpression.fromExpression("(cast(cast(\"z\" * 0.1,'long'),'double') / 0.1)"),
+        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"z\" * 0.1,'long'),'double') / 0.1)"),
         0.0
     );
   }
@@ -849,14 +849,14 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("a"),
-        DruidExpression.fromExpression("round(\"a\")"),
+        makeExpression(ColumnType.LONG, "round(\"a\")"),
         10L
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("b"),
-        DruidExpression.fromExpression("round(\"b\")"),
+        makeExpression(ColumnType.LONG, "round(\"b\")"),
         25L
     );
 
@@ -866,14 +866,14 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("b"),
             testHelper.makeLiteral(-1)
         ),
-        DruidExpression.fromExpression("round(\"b\",-1)"),
+        makeExpression(ColumnType.LONG, "round(\"b\",-1)"),
         30L
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("x"),
-        DruidExpression.fromExpression("round(\"x\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"x\")"),
         2.0
     );
 
@@ -883,21 +883,21 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("x"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("round(\"x\",1)"),
+        makeExpression(ColumnType.DOUBLE, "round(\"x\",1)"),
         2.3
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("y"),
-        DruidExpression.fromExpression("round(\"y\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"y\")"),
         3.0
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("z"),
-        DruidExpression.fromExpression("round(\"z\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"z\")"),
         -2.0
     );
   }
@@ -916,7 +916,7 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("s"),
-        DruidExpression.fromExpression("round(\"s\")"),
+        makeExpression("round(\"s\")"),
         NullHandling.sqlCompatible() ? null : "IAE Exception"
     );
   }
@@ -936,7 +936,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("x"),
             testHelper.makeLiteral("foo")
         ),
-        DruidExpression.fromExpression("round(\"x\",'foo')"),
+        makeExpression("round(\"x\",'foo')"),
         "IAE Exception"
     );
   }
@@ -949,13 +949,13 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("nan"),
-        DruidExpression.fromExpression("round(\"nan\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"nan\")"),
         0D
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("fnan"),
-        DruidExpression.fromExpression("round(\"fnan\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"fnan\")"),
         0D
     );
   }
@@ -969,25 +969,25 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("inf"),
-        DruidExpression.fromExpression("round(\"inf\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"inf\")"),
         Double.MAX_VALUE
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("-inf"),
-        DruidExpression.fromExpression("round(\"-inf\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"-inf\")"),
         -1 * Double.MAX_VALUE
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("finf"),
-        DruidExpression.fromExpression("round(\"finf\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"finf\")"),
         Double.MAX_VALUE
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("-finf"),
-        DruidExpression.fromExpression("round(\"-finf\")"),
+        makeExpression(ColumnType.DOUBLE, "round(\"-finf\")"),
         -1 * Double.MAX_VALUE
     );
     //CHECKSTYLE.ON: Regexp
@@ -1002,7 +1002,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("hour"),
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z"))
         ),
-        DruidExpression.fromExpression("timestamp_floor(949550706000,'PT1H',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_floor(949550706000,'PT1H',null,'UTC')"),
         DateTimes.of("2000-02-03T04:00:00").getMillis()
     );
 
@@ -1012,7 +1012,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("DAY"),
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z"))
         ),
-        DruidExpression.fromExpression("timestamp_floor(949550706000,'P1D',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_floor(949550706000,'P1D',null,'UTC')"),
         DateTimes.of("2000-02-03T00:00:00").getMillis()
     );
   }
@@ -1027,7 +1027,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(" "),
             testHelper.makeInputRef("spacey")
         ),
-        DruidExpression.fromExpression("trim(\"spacey\",' ')"),
+        makeExpression("trim(\"spacey\",' ')"),
         "hey there"
     );
 
@@ -1038,7 +1038,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(" h"),
             testHelper.makeInputRef("spacey")
         ),
-        DruidExpression.fromExpression("ltrim(\"spacey\",' h')"),
+        makeExpression("ltrim(\"spacey\",' h')"),
         "ey there  "
     );
 
@@ -1049,7 +1049,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(" e"),
             testHelper.makeInputRef("spacey")
         ),
-        DruidExpression.fromExpression("rtrim(\"spacey\",' e')"),
+        makeExpression("rtrim(\"spacey\",' e')"),
         "  hey ther"
     );
   }
@@ -1064,7 +1064,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(5),
             testHelper.makeLiteral("x")
         ),
-        DruidExpression.fromExpression("lpad(\"s\",5,'x')"),
+        makeExpression("lpad(\"s\",5,'x')"),
         "xxfoo"
     );
 
@@ -1075,7 +1075,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(5),
             testHelper.makeLiteral("x")
         ),
-        DruidExpression.fromExpression("rpad(\"s\",5,'x')"),
+        makeExpression("rpad(\"s\",5,'x')"),
         "fooxx"
     );
   }
@@ -1089,7 +1089,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("spacey"),
             testHelper.makeLiteral("there")
         ),
-        DruidExpression.fromExpression("contains_string(\"spacey\",'there')"),
+        makeExpression("contains_string(\"spacey\",'there')"),
         1L
     );
 
@@ -1099,7 +1099,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("spacey"),
             testHelper.makeLiteral("There")
         ),
-        DruidExpression.fromExpression("contains_string(\"spacey\",'There')"),
+        makeExpression(ColumnType.LONG, "contains_string(\"spacey\",'There')"),
         0L
     );
 
@@ -1109,7 +1109,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("spacey"),
             testHelper.makeLiteral("There")
         ),
-        DruidExpression.fromExpression("icontains_string(\"spacey\",'There')"),
+        makeExpression(ColumnType.LONG, "icontains_string(\"spacey\",'There')"),
         1L
     );
 
@@ -1123,7 +1123,7 @@ public class ExpressionsTest extends ExpressionTestBase
             ),
             testHelper.makeLiteral("what")
         ),
-        DruidExpression.fromExpression("contains_string(concat('what is',\"spacey\"),'what')"),
+        makeExpression(ColumnType.LONG, "contains_string(concat('what is',\"spacey\"),'what')"),
         1L
     );
 
@@ -1137,7 +1137,7 @@ public class ExpressionsTest extends ExpressionTestBase
             ),
             testHelper.makeLiteral("there")
         ),
-        DruidExpression.fromExpression("contains_string(concat('what is',\"spacey\"),'there')"),
+        makeExpression(ColumnType.LONG, "contains_string(concat('what is',\"spacey\"),'there')"),
         1L
     );
 
@@ -1151,7 +1151,7 @@ public class ExpressionsTest extends ExpressionTestBase
             ),
             testHelper.makeLiteral("There")
         ),
-        DruidExpression.fromExpression("icontains_string(concat('what is',\"spacey\"),'There')"),
+        makeExpression(ColumnType.LONG, "icontains_string(concat('what is',\"spacey\"),'There')"),
         1L
     );
 
@@ -1169,7 +1169,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeLiteral("yes")
             )
         ),
-        DruidExpression.fromExpression("(contains_string(\"spacey\",'there') && ('yes' == 'yes'))"),
+        makeExpression(ColumnType.LONG, "(contains_string(\"spacey\",'there') && ('yes' == 'yes'))"),
         1L
     );
 
@@ -1187,7 +1187,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeLiteral("yes")
             )
         ),
-        DruidExpression.fromExpression("(icontains_string(\"spacey\",'There') && ('yes' == 'yes'))"),
+        makeExpression(ColumnType.LONG, "(icontains_string(\"spacey\",'There') && ('yes' == 'yes'))"),
         1L
     );
   }
@@ -1315,7 +1315,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z")),
             testHelper.makeLiteral("PT1H")
         ),
-        DruidExpression.fromExpression("timestamp_floor(949550706000,'PT1H',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_floor(949550706000,'PT1H',null,'UTC')"),
         DateTimes.of("2000-02-03T04:00:00").getMillis()
     );
 
@@ -1327,7 +1327,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.TIMESTAMP),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D',null,'America/Los_Angeles')"),
+        makeExpression(ColumnType.LONG, "timestamp_floor(\"t\",'P1D',null,'America/Los_Angeles')"),
         DateTimes.of("2000-02-02T08:00:00").getMillis()
     );
   }
@@ -1343,7 +1343,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("t"),
             testHelper.makeFlag(TimeUnitRange.YEAR)
         ),
-        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1Y',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_floor(\"t\",'P1Y',null,'UTC')"),
         DateTimes.of("2000").getMillis()
     );
   }
@@ -1357,7 +1357,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z")),
             testHelper.makeLiteral("PT1H")
         ),
-        DruidExpression.fromExpression("timestamp_ceil(949550706000,'PT1H',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_ceil(949550706000,'PT1H',null,'UTC')"),
         DateTimes.of("2000-02-03T05:00:00").getMillis()
     );
 
@@ -1369,7 +1369,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeNullLiteral(SqlTypeName.TIMESTAMP),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_ceil(\"t\",'P1D',null,'America/Los_Angeles')"),
+        makeExpression(ColumnType.LONG, "timestamp_ceil(\"t\",'P1D',null,'America/Los_Angeles')"),
         DateTimes.of("2000-02-03T08:00:00").getMillis()
     );
   }
@@ -1385,7 +1385,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("t"),
             testHelper.makeFlag(TimeUnitRange.YEAR)
         ),
-        DruidExpression.fromExpression("timestamp_ceil(\"t\",'P1Y',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_ceil(\"t\",'P1Y',null,'UTC')"),
         DateTimes.of("2001").getMillis()
     );
   }
@@ -1400,7 +1400,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("PT2H"),
             testHelper.makeLiteral(-3)
         ),
-        DruidExpression.fromExpression("timestamp_shift(\"t\",'PT2H',-3,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_shift(\"t\",'PT2H',-3,'UTC')"),
         DateTimes.of("2000-02-02T22:05:06").getMillis()
     );
 
@@ -1412,7 +1412,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral(-3),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_shift(\"t\",'PT2H',-3,'America/Los_Angeles')"),
+        makeExpression(ColumnType.LONG, "timestamp_shift(\"t\",'PT2H',-3,'America/Los_Angeles')"),
         DateTimes.of("2000-02-02T22:05:06").getMillis()
     );
   }
@@ -1426,7 +1426,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("t"),
             testHelper.makeLiteral("QUARTER")
         ),
-        DruidExpression.fromExpression("timestamp_extract(\"t\",'QUARTER','UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_extract(\"t\",'QUARTER','UTC')"),
         1L
     );
 
@@ -1437,7 +1437,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("DAY"),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_extract(\"t\",'DAY','America/Los_Angeles')"),
+        makeExpression(ColumnType.LONG, "timestamp_extract(\"t\",'DAY','America/Los_Angeles')"),
         2L
     );
   }
@@ -1456,10 +1456,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.MINUTE, SqlParserPos.ZERO)
             )
         ),
-        DruidExpression.of(
-            null,
-            "(\"t\" + 90060000)"
-        ),
+        makeExpression(ColumnType.LONG, "(\"t\" + 90060000)"),
         DateTimes.of("2000-02-03T04:05:06").plus(period).getMillis()
     );
   }
@@ -1478,10 +1475,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)
             )
         ),
-        DruidExpression.of(
-            null,
-            "timestamp_shift(\"t\",'P13M',1,'UTC')"
-        ),
+        makeExpression(ColumnType.LONG, "timestamp_shift(\"t\",'P13M',1,'UTC')"),
         DateTimes.of("2000-02-03T04:05:06").plus(period).getMillis()
     );
   }
@@ -1501,10 +1495,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.MINUTE, SqlParserPos.ZERO)
             )
         ),
-        DruidExpression.of(
-            null,
-            "(\"t\" - 90060000)"
-        ),
+        makeExpression(ColumnType.LONG, "(\"t\" - 90060000)"),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
     );
   }
@@ -1524,10 +1515,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)
             )
         ),
-        DruidExpression.of(
-            null,
-            "timestamp_shift(\"t\",'P13M',-1,'UTC')"
-        ),
+        makeExpression(ColumnType.LONG, "timestamp_shift(\"t\",'P13M',-1,'UTC')"),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
     );
   }
@@ -1541,7 +1529,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("tstr"),
             testHelper.makeLiteral("yyyy-MM-dd HH:mm:ss")
         ),
-        DruidExpression.fromExpression("timestamp_parse(\"tstr\",'yyyy-MM-dd HH:mm:ss','UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_parse(\"tstr\",'yyyy-MM-dd HH:mm:ss','UTC')"),
         DateTimes.of("2000-02-03T04:05:06").getMillis()
     );
 
@@ -1552,7 +1540,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("yyyy-MM-dd HH:mm:ss"),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_parse(\"tstr\",'yyyy-MM-dd HH:mm:ss','America/Los_Angeles')"),
+        makeExpression(ColumnType.LONG, "timestamp_parse(\"tstr\",'yyyy-MM-dd HH:mm:ss','America/Los_Angeles')"),
         DateTimes.of("2000-02-03T04:05:06-08:00").getMillis()
     );
   }
@@ -1566,7 +1554,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("t"),
             testHelper.makeLiteral("yyyy-MM-dd HH:mm:ss")
         ),
-        DruidExpression.fromExpression("timestamp_format(\"t\",'yyyy-MM-dd HH:mm:ss','UTC')"),
+        makeExpression("timestamp_format(\"t\",'yyyy-MM-dd HH:mm:ss','UTC')"),
         "2000-02-03 04:05:06"
     );
 
@@ -1577,7 +1565,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeLiteral("yyyy-MM-dd HH:mm:ss"),
             testHelper.makeLiteral("America/Los_Angeles")
         ),
-        DruidExpression.fromExpression("timestamp_format(\"t\",'yyyy-MM-dd HH:mm:ss','America/Los_Angeles')"),
+        makeExpression("timestamp_format(\"t\",'yyyy-MM-dd HH:mm:ss','America/Los_Angeles')"),
         "2000-02-02 20:05:06"
     );
   }
@@ -1591,7 +1579,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeFlag(TimeUnitRange.QUARTER),
             testHelper.makeInputRef("t")
         ),
-        DruidExpression.fromExpression("timestamp_extract(\"t\",'QUARTER','UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_extract(\"t\",'QUARTER','UTC')"),
         1L
     );
 
@@ -1601,7 +1589,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeFlag(TimeUnitRange.DAY),
             testHelper.makeInputRef("t")
         ),
-        DruidExpression.fromExpression("timestamp_extract(\"t\",'DAY','UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_extract(\"t\",'DAY','UTC')"),
         3L
     );
   }
@@ -1614,10 +1602,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.TIMESTAMP),
             testHelper.makeInputRef("t")
         ),
-        DruidExpression.of(
-            SimpleExtraction.of("t", null),
-            "\"t\""
-        ),
+        makeExpression(ColumnType.LONG, SimpleExtraction.of("t", null), "\"t\""),
         DateTimes.of("2000-02-03T04:05:06Z").getMillis()
     );
 
@@ -1626,10 +1611,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.TIMESTAMP),
             testHelper.makeInputRef("tstr")
         ),
-        DruidExpression.of(
-            null,
-            "timestamp_parse(\"tstr\",null,'UTC')"
-        ),
+        makeExpression(ColumnType.LONG, "timestamp_parse(\"tstr\",null,'UTC')"),
         DateTimes.of("2000-02-03T04:05:06Z").getMillis()
     );
   }
@@ -1645,9 +1627,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        DruidExpression.fromExpression(
-            "timestamp_format(\"t\",'yyyy-MM-dd HH:mm:ss','UTC')"
-        ),
+        makeExpression(ColumnType.LONG, "timestamp_format(\"t\",'yyyy-MM-dd HH:mm:ss','UTC')"),
         "2000-02-03 04:05:06"
     );
 
@@ -1659,7 +1639,8 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        DruidExpression.of(
+        makeExpression(
+            ColumnType.LONG,
             SimpleExtraction.of("t", null),
             "\"t\""
         ),
@@ -1675,7 +1656,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.DATE),
             testHelper.makeInputRef("t")
         ),
-        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_floor(\"t\",'P1D',null,'UTC')"),
         DateTimes.of("2000-02-03").getMillis()
     );
 
@@ -1684,7 +1665,8 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.DATE),
             testHelper.makeInputRef("dstr")
         ),
-        DruidExpression.fromExpression(
+        makeExpression(
+            ColumnType.LONG,
             "timestamp_floor(timestamp_parse(\"dstr\",null,'UTC'),'P1D',null,'UTC')"
         ),
         DateTimes.of("2000-02-03").getMillis()
@@ -1702,7 +1684,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        DruidExpression.fromExpression(
+        makeExpression(
             "timestamp_format(timestamp_floor(\"t\",'P1D',null,'UTC'),'yyyy-MM-dd','UTC')"
         ),
         "2000-02-03"
@@ -1716,7 +1698,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        DruidExpression.fromExpression("timestamp_floor(\"t\",'P1D',null,'UTC')"),
+        makeExpression(ColumnType.LONG, "timestamp_floor(\"t\",'P1D',null,'UTC')"),
         DateTimes.of("2000-02-03").getMillis()
     );
   }
@@ -1727,28 +1709,28 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("s"),
-        DruidExpression.fromExpression("reverse(\"s\")"),
+        makeExpression("reverse(\"s\")"),
         "oof"
     );
 
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("spacey"),
-        DruidExpression.fromExpression("reverse(\"spacey\")"),
+        makeExpression("reverse(\"spacey\")"),
         "  ereht yeh  "
     );
 
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("tstr"),
-        DruidExpression.fromExpression("reverse(\"tstr\")"),
+        makeExpression("reverse(\"tstr\")"),
         "60:50:40 30-20-0002"
     );
 
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("dstr"),
-        DruidExpression.fromExpression("reverse(\"dstr\")"),
+        makeExpression("reverse(\"dstr\")"),
         "30-20-0002"
     );
   }
@@ -1761,7 +1743,7 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("a"),
-        DruidExpression.fromExpression("reverse(\"a\")"),
+        makeExpression("reverse(\"a\")"),
         null
     );
   }
@@ -1775,7 +1757,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("right(\"s\",1)"),
+        makeExpression("right(\"s\",1)"),
         "o"
     );
 
@@ -1785,7 +1767,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(2)
         ),
-        DruidExpression.fromExpression("right(\"s\",2)"),
+        makeExpression("right(\"s\",2)"),
         "oo"
     );
 
@@ -1795,7 +1777,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(3)
         ),
-        DruidExpression.fromExpression("right(\"s\",3)"),
+        makeExpression("right(\"s\",3)"),
         "foo"
     );
 
@@ -1805,7 +1787,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(4)
         ),
-        DruidExpression.fromExpression("right(\"s\",4)"),
+        makeExpression("right(\"s\",4)"),
         "foo"
     );
 
@@ -1815,7 +1797,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("tstr"),
             testHelper.makeLiteral(5)
         ),
-        DruidExpression.fromExpression("right(\"tstr\",5)"),
+        makeExpression("right(\"tstr\",5)"),
         "05:06"
     );
   }
@@ -1831,7 +1813,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(-1)
         ),
-        DruidExpression.fromExpression("right(\"s\",-1)"),
+        makeExpression("right(\"s\",-1)"),
         null
     );
   }
@@ -1847,7 +1829,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("right(\"s\",\"s\")"),
+        makeExpression("right(\"s\",\"s\")"),
         null
     );
   }
@@ -1861,7 +1843,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("left(\"s\",1)"),
+        makeExpression("left(\"s\",1)"),
         "f"
     );
 
@@ -1871,7 +1853,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(2)
         ),
-        DruidExpression.fromExpression("left(\"s\",2)"),
+        makeExpression("left(\"s\",2)"),
         "fo"
     );
 
@@ -1881,7 +1863,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(3)
         ),
-        DruidExpression.fromExpression("left(\"s\",3)"),
+        makeExpression("left(\"s\",3)"),
         "foo"
     );
 
@@ -1891,7 +1873,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(4)
         ),
-        DruidExpression.fromExpression("left(\"s\",4)"),
+        makeExpression("left(\"s\",4)"),
         "foo"
     );
 
@@ -1901,7 +1883,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("tstr"),
             testHelper.makeLiteral(10)
         ),
-        DruidExpression.fromExpression("left(\"tstr\",10)"),
+        makeExpression("left(\"tstr\",10)"),
         "2000-02-03"
     );
   }
@@ -1917,7 +1899,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(-1)
         ),
-        DruidExpression.fromExpression("left(\"s\",-1)"),
+        makeExpression("left(\"s\",-1)"),
         null
     );
   }
@@ -1933,7 +1915,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("left(\"s\",\"s\")"),
+        makeExpression("left(\"s\",\"s\")"),
         null
     );
   }
@@ -1947,7 +1929,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("repeat(\"s\",1)"),
+        makeExpression("repeat(\"s\",1)"),
         "foo"
     );
 
@@ -1957,7 +1939,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(3)
         ),
-        DruidExpression.fromExpression("repeat(\"s\",3)"),
+        makeExpression("repeat(\"s\",3)"),
         "foofoofoo"
     );
 
@@ -1967,7 +1949,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral(-1)
         ),
-        DruidExpression.fromExpression("repeat(\"s\",-1)"),
+        makeExpression("repeat(\"s\",-1)"),
         null
     );
   }
@@ -1983,7 +1965,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("repeat(\"s\",\"s\")"),
+        makeExpression("repeat(\"s\",\"s\")"),
         null
     );
   }
@@ -1996,7 +1978,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeInputRef("a")
         ),
-        DruidExpression.fromExpression("bitwiseComplement(\"a\")"),
+        makeExpression(ColumnType.LONG, "bitwiseComplement(\"a\")"),
         -11L
     );
 
@@ -2005,7 +1987,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeInputRef("x")
         ),
-        DruidExpression.fromExpression("bitwiseComplement(\"x\")"),
+        makeExpression(ColumnType.LONG, "bitwiseComplement(\"x\")"),
         -3L
     );
 
@@ -2014,7 +1996,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("bitwiseComplement(\"s\")"),
+        makeExpression(ColumnType.LONG, "bitwiseComplement(\"s\")"),
         null
     );
   }
@@ -2027,7 +2009,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeInputRef("a")
         ),
-        DruidExpression.fromExpression("bitwiseConvertLongBitsToDouble(\"a\")"),
+        makeExpression(ColumnType.LONG, "bitwiseConvertLongBitsToDouble(\"a\")"),
         4.9E-323
     );
 
@@ -2036,7 +2018,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeInputRef("x")
         ),
-        DruidExpression.fromExpression("bitwiseConvertLongBitsToDouble(\"x\")"),
+        makeExpression(ColumnType.LONG, "bitwiseConvertLongBitsToDouble(\"x\")"),
         1.0E-323
     );
 
@@ -2045,7 +2027,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("bitwiseConvertLongBitsToDouble(\"s\")"),
+        makeExpression(ColumnType.LONG, "bitwiseConvertLongBitsToDouble(\"s\")"),
         null
     );
   }
@@ -2059,7 +2041,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("a"),
             testHelper.makeInputRef("b")
         ),
-        DruidExpression.fromExpression("bitwiseAnd(\"a\",\"b\")"),
+        makeExpression(ColumnType.LONG, "bitwiseAnd(\"a\",\"b\")"),
         8L
     );
 
@@ -2069,7 +2051,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("x"),
             testHelper.makeInputRef("y")
         ),
-        DruidExpression.fromExpression("bitwiseAnd(\"x\",\"y\")"),
+        makeExpression(ColumnType.LONG, "bitwiseAnd(\"x\",\"y\")"),
         2L
     );
 
@@ -2079,7 +2061,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeInputRef("s")
         ),
-        DruidExpression.fromExpression("bitwiseAnd(\"s\",\"s\")"),
+        makeExpression(ColumnType.LONG, "bitwiseAnd(\"s\",\"s\")"),
         null
     );
   }
@@ -2095,7 +2077,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeLiteral(1000)
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(1000)"),
+        makeExpression("human_readable_binary_byte_format(1000)"),
         "1000 B"
     );
     testHelper.testExpression(
@@ -2103,7 +2085,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeLiteral(1024)
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(1024)"),
+        makeExpression("human_readable_binary_byte_format(1024)"),
         "1.00 KiB"
     );
     testHelper.testExpression(
@@ -2111,7 +2093,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeLiteral(Long.MAX_VALUE)
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(9223372036854775807)"),
+        makeExpression("human_readable_binary_byte_format(9223372036854775807)"),
         "8.00 EiB"
     );
 
@@ -2129,7 +2111,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("b"),
             testHelper.makeInputRef("p")
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(\"b\",\"p\")"),
+        makeExpression("human_readable_binary_byte_format(\"b\",\"p\")"),
         "25 B"
     );
 
@@ -2143,7 +2125,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 0
             testHelper.makeLiteral(0)
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(45000,0)"),
+        makeExpression("human_readable_binary_byte_format(45000,0)"),
         "44 KiB"
     );
     testHelper.testExpression(
@@ -2153,7 +2135,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 1
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(45000,1)"),
+        makeExpression("human_readable_binary_byte_format(45000,1)"),
         "43.9 KiB"
     );
     testHelper.testExpression(
@@ -2163,7 +2145,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 2
             testHelper.makeLiteral(2)
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(45000,2)"),
+        makeExpression("human_readable_binary_byte_format(45000,2)"),
         "43.95 KiB"
     );
     testHelper.testExpression(
@@ -2173,7 +2155,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 3
             testHelper.makeLiteral(3)
         ),
-        DruidExpression.fromExpression("human_readable_binary_byte_format(45000,3)"),
+        makeExpression("human_readable_binary_byte_format(45000,3)"),
         "43.945 KiB"
     );
   }
@@ -2189,7 +2171,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeLiteral(999)
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(999)"),
+        makeExpression("human_readable_decimal_byte_format(999)"),
         "999 B"
     );
     testHelper.testExpression(
@@ -2197,7 +2179,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeLiteral(1024)
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(1024)"),
+        makeExpression("human_readable_decimal_byte_format(1024)"),
         "1.02 KB"
     );
     testHelper.testExpression(
@@ -2205,7 +2187,7 @@ public class ExpressionsTest extends ExpressionTestBase
         ImmutableList.of(
             testHelper.makeLiteral(Long.MAX_VALUE)
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(9223372036854775807)"),
+        makeExpression("human_readable_decimal_byte_format(9223372036854775807)"),
         "9.22 EB"
     );
 
@@ -2222,7 +2204,7 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("b"),
             testHelper.makeInputRef("p")
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(\"b\",\"p\")"),
+        makeExpression("human_readable_decimal_byte_format(\"b\",\"p\")"),
         "25 B"
     );
 
@@ -2236,7 +2218,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 0
             testHelper.makeLiteral(0)
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(45678,0)"),
+        makeExpression("human_readable_decimal_byte_format(45678,0)"),
         "46 KB"
     );
     testHelper.testExpression(
@@ -2246,7 +2228,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 1
             testHelper.makeLiteral(1)
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(45678,1)"),
+        makeExpression("human_readable_decimal_byte_format(45678,1)"),
         "45.7 KB"
     );
     testHelper.testExpression(
@@ -2256,7 +2238,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 2
             testHelper.makeLiteral(2)
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(45678,2)"),
+        makeExpression("human_readable_decimal_byte_format(45678,2)"),
         "45.68 KB"
     );
     testHelper.testExpression(
@@ -2266,7 +2248,7 @@ public class ExpressionsTest extends ExpressionTestBase
             //precision 3
             testHelper.makeLiteral(3)
         ),
-        DruidExpression.fromExpression("human_readable_decimal_byte_format(45678,3)"),
+        makeExpression("human_readable_decimal_byte_format(45678,3)"),
         "45.678 KB"
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -138,7 +138,14 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.makeInputRef("s"),
             testHelper.makeLiteral("bar")
         ),
-        makeExpression("concat(\"s\",'bar')"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("concat"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "s"),
+                DruidExpression.ofStringLiteral("bar")
+            )
+        ),
         "foobar"
     );
   }
@@ -149,7 +156,13 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         SqlStdOperatorTable.CHARACTER_LENGTH,
         testHelper.makeInputRef("s"),
-        makeExpression("strlen(\"s\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("strlen"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "s")
+            )
+        ),
         3L
     );
   }
@@ -157,7 +170,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testRegexpExtract()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -171,7 +184,7 @@ public class ExpressionsTest extends ExpressionTestBase
         null
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -187,7 +200,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "o"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
@@ -201,7 +214,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "Zfo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -215,7 +228,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "o"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -228,7 +241,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "fo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -241,7 +254,7 @@ public class ExpressionsTest extends ExpressionTestBase
         NullHandling.emptyToNullIfNeeded("")
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -254,7 +267,7 @@ public class ExpressionsTest extends ExpressionTestBase
         NullHandling.emptyToNullIfNeeded("")
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
@@ -264,7 +277,7 @@ public class ExpressionsTest extends ExpressionTestBase
         null
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
@@ -274,7 +287,7 @@ public class ExpressionsTest extends ExpressionTestBase
         null
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
@@ -288,7 +301,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testRegexpLike()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -298,7 +311,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -310,7 +323,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -320,7 +333,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -330,7 +343,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("beep\nboop"),
@@ -340,7 +353,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("beep\nboop"),
@@ -350,7 +363,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("newliney"),
@@ -360,7 +373,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("newliney"),
@@ -370,7 +383,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("newliney"),
@@ -380,7 +393,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("newliney"),
@@ -390,7 +403,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
@@ -404,7 +417,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
@@ -414,7 +427,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
@@ -426,7 +439,7 @@ public class ExpressionsTest extends ExpressionTestBase
         NullHandling.sqlCompatible() ? 0L : 1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RegexpLikeOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
@@ -533,7 +546,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testStringFormat()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new StringFormatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("%x"),
@@ -543,7 +556,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "19"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new StringFormatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("%s %,d"),
@@ -554,7 +567,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "foo 1,234"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new StringFormatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("%s %,d"),
@@ -564,7 +577,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "%s %,d; foo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new StringFormatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("%s %,d"),
@@ -580,7 +593,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testStrpos()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new StrposOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -590,7 +603,7 @@ public class ExpressionsTest extends ExpressionTestBase
         2L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new StrposOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -600,7 +613,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new StrposOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeNullLiteral(SqlTypeName.VARCHAR),
@@ -617,21 +630,34 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         new ParseLongOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("intstr"),
-        makeExpression(ColumnType.LONG, "parse_long(\"intstr\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("parse_long"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "intstr")
+            )
+        ),
         -100L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new ParseLongOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("hexstr"),
             testHelper.makeLiteral(BigDecimal.valueOf(16))
         ),
-        makeExpression(ColumnType.LONG, "parse_long(\"hexstr\",16)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("parse_long"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "hexstr"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(16))
+            )
+        ),
         239L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new ParseLongOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
@@ -641,14 +667,34 @@ public class ExpressionsTest extends ExpressionTestBase
             ),
             testHelper.makeLiteral(BigDecimal.valueOf(16))
         ),
-        makeExpression(ColumnType.LONG, "parse_long(concat('0x',\"hexstr\"),16)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("parse_long"),
+            ImmutableList.of(
+                DruidExpression.ofExpression(
+                    ColumnType.STRING,
+                    DruidExpression.functionCall("concat"),
+                    ImmutableList.of(
+                        DruidExpression.ofStringLiteral("0x"),
+                        DruidExpression.ofColumn(ColumnType.STRING, "hexstr")
+                    )
+                ),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(16))
+            )
+        ),
         239L
     );
 
     testHelper.testExpression(
         new ParseLongOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("hexstr"),
-        makeExpression(ColumnType.LONG, "parse_long(\"hexstr\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("parse_long"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "hexstr")
+            )
+        ),
         NullHandling.sqlCompatible() ? null : 0L
     );
   }
@@ -656,7 +702,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testPosition()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.POSITION,
         ImmutableList.of(
             testHelper.makeLiteral("oo"),
@@ -666,7 +712,7 @@ public class ExpressionsTest extends ExpressionTestBase
         2L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.POSITION,
         ImmutableList.of(
             testHelper.makeLiteral("oo"),
@@ -677,7 +723,7 @@ public class ExpressionsTest extends ExpressionTestBase
         2L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.POSITION,
         ImmutableList.of(
             testHelper.makeLiteral("oo"),
@@ -692,7 +738,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testPower()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.POWER,
         ImmutableList.of(
             testHelper.makeInputRef("a"),
@@ -709,28 +755,52 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("a"),
-        makeExpression(ColumnType.DOUBLE, "floor(\"a\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("floor"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "a")
+            )
+        ),
         10.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("x"),
-        makeExpression(ColumnType.DOUBLE, "floor(\"x\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("floor"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "x")
+            )
+        ),
         2.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("y"),
-        makeExpression(ColumnType.DOUBLE, "floor(\"y\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("floor"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "y")
+            )
+        ),
         3.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.FLOOR,
         testHelper.makeInputRef("z"),
-        makeExpression(ColumnType.DOUBLE, "floor(\"z\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("floor"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "z")
+            )
+        ),
         -3.0
     );
   }
@@ -741,28 +811,52 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("a"),
-        makeExpression(ColumnType.DOUBLE, "ceil(\"a\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("ceil"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "a")
+            )
+        ),
         10.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("x"),
-        makeExpression(ColumnType.DOUBLE, "ceil(\"x\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("ceil"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "x")
+            )
+        ),
         3.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("y"),
-        makeExpression(ColumnType.DOUBLE, "ceil(\"y\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("ceil"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "y")
+            )
+        ),
         3.0
     );
 
     testHelper.testExpression(
         SqlStdOperatorTable.CEIL,
         testHelper.makeInputRef("z"),
-        makeExpression(ColumnType.DOUBLE, "ceil(\"z\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("ceil"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "z")
+            )
+        ),
         -2.0
     );
   }
@@ -775,68 +869,120 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("a"),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"a\" * 1,'long'),'double') / 1)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 1,'long'),'double') / 1)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "a")
+            )
+        ),
         10.0
     );
 
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("x"),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"x\" * 1,'long'),'double') / 1)"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 1,'long'),'double') / 1)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "x")
+            )
+        ),
         2.0
     );
 
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("y"),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"y\" * 1,'long'),'double') / 1)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 1,'long'),'double') / 1)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "y")
+            )
+        ),
         3.0
     );
 
     testHelper.testExpression(
         truncateFunction,
         testHelper.makeInputRef("z"),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"z\" * 1,'long'),'double') / 1)"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 1,'long'),'double') / 1)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "z")
+            )
+        ),
         -2.0
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         truncateFunction,
         ImmutableList.of(
             testHelper.makeInputRef("x"),
             testHelper.makeLiteral(1)
         ),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"x\" * 10.0,'long'),'double') / 10.0)"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 10.0,'long'),'double') / 10.0)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "x"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(1))
+            )
+        ),
         2.2
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         truncateFunction,
         ImmutableList.of(
             testHelper.makeInputRef("z"),
             testHelper.makeLiteral(1)
         ),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"z\" * 10.0,'long'),'double') / 10.0)"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 10.0,'long'),'double') / 10.0)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "z"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(1))
+            )
+        ),
         -2.2
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         truncateFunction,
         ImmutableList.of(
             testHelper.makeInputRef("b"),
             testHelper.makeLiteral(-1)
         ),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"b\" * 0.1,'long'),'double') / 0.1)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 0.1,'long'),'double') / 0.1)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "b"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(-1))
+            )
+        ),
         20.0
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         truncateFunction,
         ImmutableList.of(
             testHelper.makeInputRef("z"),
             testHelper.makeLiteral(-1)
         ),
-        makeExpression(ColumnType.DOUBLE, "(cast(cast(\"z\" * 0.1,'long'),'double') / 0.1)"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            (args) -> "(cast(cast(" + args.get(0).getExpression() + " * 0.1,'long'),'double') / 0.1)",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "z"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(-1))
+            )
+        ),
         0.0
     );
   }
@@ -849,55 +995,99 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("a"),
-        makeExpression(ColumnType.LONG, "round(\"a\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "a")
+            )
+        ),
         10L
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("b"),
-        makeExpression(ColumnType.LONG, "round(\"b\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "b")
+            )
+        ),
         25L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         roundFunction,
         ImmutableList.of(
             testHelper.makeInputRef("b"),
             testHelper.makeLiteral(-1)
         ),
-        makeExpression(ColumnType.LONG, "round(\"b\",-1)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "b"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(-1))
+            )
+        ),
         30L
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("x"),
-        makeExpression(ColumnType.DOUBLE, "round(\"x\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "x")
+            )
+        ),
         2.0
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         roundFunction,
         ImmutableList.of(
             testHelper.makeInputRef("x"),
             testHelper.makeLiteral(1)
         ),
-        makeExpression(ColumnType.DOUBLE, "round(\"x\",1)"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "x"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(1))
+            )
+        ),
         2.3
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("y"),
-        makeExpression(ColumnType.DOUBLE, "round(\"y\")"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "y")
+            )
+        ),
         3.0
     );
 
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("z"),
-        makeExpression(ColumnType.DOUBLE, "round(\"z\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "z")
+            )
+        ),
         -2.0
     );
   }
@@ -916,7 +1106,13 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("s"),
-        makeExpression("round(\"s\")"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "s")
+            )
+        ),
         NullHandling.sqlCompatible() ? null : "IAE Exception"
     );
   }
@@ -930,13 +1126,20 @@ public class ExpressionsTest extends ExpressionTestBase
         IAE.class,
         "The second argument to the function[round] should be integer type but got the type: STRING"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         roundFunction,
         ImmutableList.of(
             testHelper.makeInputRef("x"),
             testHelper.makeLiteral("foo")
         ),
-        makeExpression("round(\"x\",'foo')"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "x"),
+                DruidExpression.ofStringLiteral("foo")
+            )
+        ),
         "IAE Exception"
     );
   }
@@ -949,13 +1152,25 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("nan"),
-        makeExpression(ColumnType.DOUBLE, "round(\"nan\")"),
+        DruidExpression.ofExpression(
+            ColumnType.DOUBLE,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.DOUBLE, "nan")
+            )
+        ),
         0D
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("fnan"),
-        makeExpression(ColumnType.DOUBLE, "round(\"fnan\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "fnan")
+            )
+        ),
         0D
     );
   }
@@ -969,25 +1184,49 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("inf"),
-        makeExpression(ColumnType.DOUBLE, "round(\"inf\")"),
+        DruidExpression.ofExpression(
+            ColumnType.DOUBLE,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.DOUBLE, "inf")
+            )
+        ),
         Double.MAX_VALUE
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("-inf"),
-        makeExpression(ColumnType.DOUBLE, "round(\"-inf\")"),
+        DruidExpression.ofExpression(
+            ColumnType.DOUBLE,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.DOUBLE, "-inf")
+            )
+        ),
         -1 * Double.MAX_VALUE
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("finf"),
-        makeExpression(ColumnType.DOUBLE, "round(\"finf\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "finf")
+            )
+        ),
         Double.MAX_VALUE
     );
     testHelper.testExpression(
         roundFunction,
         testHelper.makeInputRef("-finf"),
-        makeExpression(ColumnType.DOUBLE, "round(\"-finf\")"),
+        DruidExpression.ofExpression(
+            ColumnType.FLOAT,
+            DruidExpression.functionCall("round"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.FLOAT, "-finf")
+            )
+        ),
         -1 * Double.MAX_VALUE
     );
     //CHECKSTYLE.ON: Regexp
@@ -996,7 +1235,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testDateTrunc()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new DateTruncOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("hour"),
@@ -1006,7 +1245,7 @@ public class ExpressionsTest extends ExpressionTestBase
         DateTimes.of("2000-02-03T04:00:00").getMillis()
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new DateTruncOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral("DAY"),
@@ -1020,7 +1259,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testTrim()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.TRIM,
         ImmutableList.of(
             testHelper.makeFlag(SqlTrimFunction.Flag.BOTH),
@@ -1031,7 +1270,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "hey there"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.TRIM,
         ImmutableList.of(
             testHelper.makeFlag(SqlTrimFunction.Flag.LEADING),
@@ -1042,7 +1281,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "ey there  "
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.TRIM,
         ImmutableList.of(
             testHelper.makeFlag(SqlTrimFunction.Flag.TRAILING),
@@ -1057,7 +1296,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testPad()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LPadOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1068,7 +1307,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "xxfoo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RPadOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1083,7 +1322,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testContains()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("spacey"),
@@ -1093,7 +1332,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("spacey"),
@@ -1103,7 +1342,7 @@ public class ExpressionsTest extends ExpressionTestBase
         0L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         ContainsOperatorConversion.caseInsensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("spacey"),
@@ -1113,7 +1352,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
@@ -1127,7 +1366,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         ContainsOperatorConversion.caseSensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
@@ -1141,7 +1380,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         ContainsOperatorConversion.caseInsensitive().calciteOperator(),
         ImmutableList.of(
             testHelper.makeCall(
@@ -1155,7 +1394,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.AND,
         ImmutableList.of(
             testHelper.makeCall(
@@ -1173,7 +1412,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.AND,
         ImmutableList.of(
             testHelper.makeCall(
@@ -1309,7 +1548,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testTimeFloor()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeFloorOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z")),
@@ -1319,7 +1558,7 @@ public class ExpressionsTest extends ExpressionTestBase
         DateTimes.of("2000-02-03T04:00:00").getMillis()
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeFloorOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1337,7 +1576,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     // FLOOR(__time TO unit)
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.FLOOR,
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1351,7 +1590,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testTimeCeil()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeCeilOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(DateTimes.of("2000-02-03T04:05:06Z")),
@@ -1361,7 +1600,7 @@ public class ExpressionsTest extends ExpressionTestBase
         DateTimes.of("2000-02-03T05:00:00").getMillis()
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeCeilOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1379,7 +1618,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     // CEIL(__time TO unit)
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.CEIL,
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1393,7 +1632,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testTimeShift()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeShiftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1404,7 +1643,7 @@ public class ExpressionsTest extends ExpressionTestBase
         DateTimes.of("2000-02-02T22:05:06").getMillis()
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeShiftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1420,7 +1659,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testTimeExtract()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1430,7 +1669,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeExtractOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1447,7 +1686,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     final Period period = new Period("P1DT1H1M");
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.DATETIME_PLUS,
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1466,7 +1705,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     final Period period = new Period("P1Y1M");
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.DATETIME_PLUS,
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1495,7 +1734,15 @@ public class ExpressionsTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.MINUTE, SqlParserPos.ZERO)
             )
         ),
-        makeExpression(ColumnType.LONG, "(\"t\" - 90060000)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            (args) -> "(" + args.get(0).getExpression() + " - " + args.get(1).getExpression() + ")",
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "t"),
+                // RexNode type of "interval day to minute" is not converted to druid long... yet
+                DruidExpression.ofLiteral(null, "90060000")
+            )
+        ),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
     );
   }
@@ -1515,7 +1762,17 @@ public class ExpressionsTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)
             )
         ),
-        makeExpression(ColumnType.LONG, "timestamp_shift(\"t\",'P13M',-1,'UTC')"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("timestamp_shift"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "t"),
+                // RexNode type "interval year to month" is not reported as ColumnType.STRING
+                DruidExpression.ofLiteral(null, DruidExpression.stringLiteral("P13M")),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.numberLiteral(-1)),
+                DruidExpression.ofStringLiteral("UTC")
+            )
+        ),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
     );
   }
@@ -1523,7 +1780,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testTimeParse()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeParseOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("tstr"),
@@ -1533,7 +1790,7 @@ public class ExpressionsTest extends ExpressionTestBase
         DateTimes.of("2000-02-03T04:05:06").getMillis()
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeParseOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("tstr"),
@@ -1548,7 +1805,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testTimeFormat()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeFormatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1558,7 +1815,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "2000-02-03 04:05:06"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new TimeFormatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("t"),
@@ -1573,7 +1830,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testExtract()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.EXTRACT,
         ImmutableList.of(
             testHelper.makeFlag(TimeUnitRange.QUARTER),
@@ -1583,7 +1840,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         SqlStdOperatorTable.EXTRACT,
         ImmutableList.of(
             testHelper.makeFlag(TimeUnitRange.DAY),
@@ -1602,7 +1859,11 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.TIMESTAMP),
             testHelper.makeInputRef("t")
         ),
-        makeExpression(ColumnType.LONG, SimpleExtraction.of("t", null), "\"t\""),
+        DruidExpression.ofColumn(
+            ColumnType.LONG,
+            "t",
+            SimpleExtraction.of("t", null)
+        ),
         DateTimes.of("2000-02-03T04:05:06Z").getMillis()
     );
 
@@ -1611,7 +1872,15 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.TIMESTAMP),
             testHelper.makeInputRef("tstr")
         ),
-        makeExpression(ColumnType.LONG, "timestamp_parse(\"tstr\",null,'UTC')"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("timestamp_parse"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "tstr"),
+                DruidExpression.ofLiteral(null, DruidExpression.nullLiteral()),
+                DruidExpression.ofStringLiteral("UTC")
+            )
+        ),
         DateTimes.of("2000-02-03T04:05:06Z").getMillis()
     );
   }
@@ -1627,7 +1896,15 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        makeExpression(ColumnType.LONG, "timestamp_format(\"t\",'yyyy-MM-dd HH:mm:ss','UTC')"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("timestamp_format"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "t"),
+                DruidExpression.ofStringLiteral("yyyy-MM-dd HH:mm:ss"),
+                DruidExpression.ofStringLiteral("UTC")
+            )
+        ),
         "2000-02-03 04:05:06"
     );
 
@@ -1639,11 +1916,7 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        makeExpression(
-            ColumnType.LONG,
-            SimpleExtraction.of("t", null),
-            "\"t\""
-        ),
+        DruidExpression.ofColumn(ColumnType.LONG, "t", SimpleExtraction.of("t", null)),
         DateTimes.of("2000-02-03T04:05:06").getMillis()
     );
   }
@@ -1656,7 +1929,16 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.DATE),
             testHelper.makeInputRef("t")
         ),
-        makeExpression(ColumnType.LONG, "timestamp_floor(\"t\",'P1D',null,'UTC')"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("timestamp_floor"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "t"),
+                DruidExpression.ofStringLiteral("P1D"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.nullLiteral()),
+                DruidExpression.ofStringLiteral("UTC")
+            )
+        ),
         DateTimes.of("2000-02-03").getMillis()
     );
 
@@ -1665,9 +1947,23 @@ public class ExpressionsTest extends ExpressionTestBase
             testHelper.createSqlType(SqlTypeName.DATE),
             testHelper.makeInputRef("dstr")
         ),
-        makeExpression(
+        DruidExpression.ofExpression(
             ColumnType.LONG,
-            "timestamp_floor(timestamp_parse(\"dstr\",null,'UTC'),'P1D',null,'UTC')"
+            DruidExpression.functionCall("timestamp_floor"),
+            ImmutableList.of(
+                DruidExpression.ofExpression(
+                    ColumnType.LONG,
+                    DruidExpression.functionCall("timestamp_parse"),
+                    ImmutableList.of(
+                        DruidExpression.ofColumn(ColumnType.STRING, "dstr"),
+                        DruidExpression.ofLiteral(null, DruidExpression.nullLiteral()),
+                        DruidExpression.ofStringLiteral("UTC")
+                    )
+                ),
+                DruidExpression.ofStringLiteral("P1D"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.nullLiteral()),
+                DruidExpression.ofStringLiteral("UTC")
+            )
         ),
         DateTimes.of("2000-02-03").getMillis()
     );
@@ -1684,8 +1980,23 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        makeExpression(
-            "timestamp_format(timestamp_floor(\"t\",'P1D',null,'UTC'),'yyyy-MM-dd','UTC')"
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("timestamp_format"),
+            ImmutableList.of(
+                DruidExpression.ofExpression(
+                    ColumnType.LONG,
+                    DruidExpression.functionCall("timestamp_floor"),
+                    ImmutableList.of(
+                        DruidExpression.ofColumn(ColumnType.LONG, "t"),
+                        DruidExpression.ofStringLiteral("P1D"),
+                        DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.nullLiteral()),
+                        DruidExpression.ofStringLiteral("UTC")
+                    )
+                ),
+                DruidExpression.ofStringLiteral("yyyy-MM-dd"),
+                DruidExpression.ofStringLiteral("UTC")
+            )
         ),
         "2000-02-03"
     );
@@ -1698,7 +2009,16 @@ public class ExpressionsTest extends ExpressionTestBase
                 testHelper.makeInputRef("t")
             )
         ),
-        makeExpression(ColumnType.LONG, "timestamp_floor(\"t\",'P1D',null,'UTC')"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG,
+            DruidExpression.functionCall("timestamp_floor"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "t"),
+                DruidExpression.ofStringLiteral("P1D"),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.nullLiteral()),
+                DruidExpression.ofStringLiteral("UTC")
+            )
+        ),
         DateTimes.of("2000-02-03").getMillis()
     );
   }
@@ -1709,28 +2029,52 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("s"),
-        makeExpression("reverse(\"s\")"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("reverse"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "s")
+            )
+        ),
         "oof"
     );
 
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("spacey"),
-        makeExpression("reverse(\"spacey\")"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("reverse"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "spacey")
+            )
+        ),
         "  ereht yeh  "
     );
 
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("tstr"),
-        makeExpression("reverse(\"tstr\")"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("reverse"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "tstr")
+            )
+        ),
         "60:50:40 30-20-0002"
     );
 
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("dstr"),
-        makeExpression("reverse(\"dstr\")"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("reverse"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.STRING, "dstr")
+            )
+        ),
         "30-20-0002"
     );
   }
@@ -1743,7 +2087,13 @@ public class ExpressionsTest extends ExpressionTestBase
     testHelper.testExpression(
         new ReverseOperatorConversion().calciteOperator(),
         testHelper.makeInputRef("a"),
-        makeExpression("reverse(\"a\")"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("reverse"),
+            ImmutableList.of(
+                DruidExpression.ofColumn(ColumnType.LONG, "a")
+            )
+        ),
         null
     );
   }
@@ -1751,7 +2101,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testRight()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RightOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1761,7 +2111,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "o"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RightOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1771,7 +2121,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "oo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RightOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1781,7 +2131,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "foo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RightOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1791,7 +2141,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "foo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RightOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("tstr"),
@@ -1807,7 +2157,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     expectException(IAE.class, "Function[right] needs a postive integer as second argument");
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RightOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1823,7 +2173,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     expectException(IAE.class, "Function[right] needs a string as first argument and an integer as second argument");
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RightOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1837,7 +2187,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testLeft()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LeftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1847,7 +2197,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "f"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LeftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1857,7 +2207,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "fo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LeftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1867,7 +2217,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "foo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LeftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1877,7 +2227,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "foo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LeftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("tstr"),
@@ -1893,7 +2243,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     expectException(IAE.class, "Function[left] needs a postive integer as second argument");
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LeftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1909,7 +2259,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     expectException(IAE.class, "Function[left] needs a string as first argument and an integer as second argument");
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new LeftOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1923,7 +2273,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testRepeat()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RepeatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1933,7 +2283,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "foo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RepeatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1943,7 +2293,7 @@ public class ExpressionsTest extends ExpressionTestBase
         "foofoofoo"
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RepeatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1959,7 +2309,7 @@ public class ExpressionsTest extends ExpressionTestBase
   {
     expectException(IAE.class, "Function[repeat] needs a string as first argument and an integer as second argument");
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         new RepeatOperatorConversion().calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -1973,7 +2323,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testOperatorConversionsDruidUnaryLongFn()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidUnaryLongFn("BITWISE_COMPLEMENT", "bitwiseComplement").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("a")
@@ -1982,7 +2332,7 @@ public class ExpressionsTest extends ExpressionTestBase
         -11L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidUnaryLongFn("BITWISE_COMPLEMENT", "bitwiseComplement").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("x")
@@ -1991,7 +2341,7 @@ public class ExpressionsTest extends ExpressionTestBase
         -3L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidUnaryLongFn("BITWISE_COMPLEMENT", "bitwiseComplement").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s")
@@ -2004,7 +2354,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testOperatorConversionsDruidUnaryDoubleFn()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidUnaryDoubleFn("BITWISE_CONVERT_LONG_BITS_TO_DOUBLE", "bitwiseConvertLongBitsToDouble").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("a")
@@ -2013,7 +2363,7 @@ public class ExpressionsTest extends ExpressionTestBase
         4.9E-323
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidUnaryDoubleFn("BITWISE_CONVERT_LONG_BITS_TO_DOUBLE", "bitwiseConvertLongBitsToDouble").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("x")
@@ -2022,7 +2372,7 @@ public class ExpressionsTest extends ExpressionTestBase
         1.0E-323
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidUnaryDoubleFn("BITWISE_CONVERT_LONG_BITS_TO_DOUBLE", "bitwiseConvertLongBitsToDouble").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s")
@@ -2035,7 +2385,7 @@ public class ExpressionsTest extends ExpressionTestBase
   @Test
   public void testOperatorConversionsDruidBinaryLongFn()
   {
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidBinaryLongFn("BITWISE_AND", "bitwiseAnd").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("a"),
@@ -2045,7 +2395,7 @@ public class ExpressionsTest extends ExpressionTestBase
         8L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidBinaryLongFn("BITWISE_AND", "bitwiseAnd").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("x"),
@@ -2055,7 +2405,7 @@ public class ExpressionsTest extends ExpressionTestBase
         2L
     );
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         OperatorConversions.druidBinaryLongFn("BITWISE_AND", "bitwiseAnd").calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("s"),
@@ -2072,7 +2422,7 @@ public class ExpressionsTest extends ExpressionTestBase
     /*
      * Basic Test
      */
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(1000)
@@ -2080,7 +2430,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_binary_byte_format(1000)"),
         "1000 B"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(1024)
@@ -2088,7 +2438,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_binary_byte_format(1024)"),
         "1.00 KiB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(Long.MAX_VALUE)
@@ -2105,7 +2455,7 @@ public class ExpressionsTest extends ExpressionTestBase
     /*
      * test input with variable reference
      */
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("b"),
@@ -2118,7 +2468,7 @@ public class ExpressionsTest extends ExpressionTestBase
     /*
      * test different precision
      */
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45000),
@@ -2128,7 +2478,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_binary_byte_format(45000,0)"),
         "44 KiB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45000),
@@ -2138,7 +2488,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_binary_byte_format(45000,1)"),
         "43.9 KiB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45000),
@@ -2148,7 +2498,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_binary_byte_format(45000,2)"),
         "43.95 KiB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.BINARY_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45000),
@@ -2166,7 +2516,7 @@ public class ExpressionsTest extends ExpressionTestBase
     /*
      * Basic Test
      */
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(999)
@@ -2174,7 +2524,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_decimal_byte_format(999)"),
         "999 B"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(1024)
@@ -2182,7 +2532,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_decimal_byte_format(1024)"),
         "1.02 KB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(Long.MAX_VALUE)
@@ -2198,7 +2548,7 @@ public class ExpressionsTest extends ExpressionTestBase
     /*
      * test input with variable reference
      */
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeInputRef("b"),
@@ -2211,7 +2561,7 @@ public class ExpressionsTest extends ExpressionTestBase
     /*
      * test different precision
      */
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45678),
@@ -2221,7 +2571,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_decimal_byte_format(45678,0)"),
         "46 KB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45678),
@@ -2231,7 +2581,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_decimal_byte_format(45678,1)"),
         "45.7 KB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45678),
@@ -2241,7 +2591,7 @@ public class ExpressionsTest extends ExpressionTestBase
         makeExpression("human_readable_decimal_byte_format(45678,2)"),
         "45.68 KB"
     );
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         HumanReadableFormatOperatorConversion.DECIMAL_BYTE_FORMAT.calciteOperator(),
         ImmutableList.of(
             testHelper.makeLiteral(45678),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
@@ -268,7 +268,7 @@ public class GreatestExpressionTest extends ExpressionTestBase
       final Object expectedResult
   )
   {
-    testHelper.testExpression(target.calciteOperator(), exprs, expectedExpression, expectedResult);
+    testHelper.testExpressionString(target.calciteOperator(), exprs, expectedExpression, expectedResult);
   }
 
   private DruidExpression buildExpectedExpression(Object... args)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/IPv4AddressMatchExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/IPv4AddressMatchExpressionTest.java
@@ -259,7 +259,7 @@ public class IPv4AddressMatchExpressionTest extends ExpressionTestBase
       final Object expectedResult
   )
   {
-    testHelper.testExpression(target.calciteOperator(), exprs, expectedExpression, expectedResult);
+    testHelper.testExpressionString(target.calciteOperator(), exprs, expectedExpression, expectedResult);
   }
 
   private DruidExpression buildExpectedExpression(Object... args)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/IPv4AddressParseExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/IPv4AddressParseExpressionTest.java
@@ -225,7 +225,7 @@ public class IPv4AddressParseExpressionTest extends ExpressionTestBase
       final Object expectedResult
   )
   {
-    testHelper.testExpression(target.calciteOperator(), exprs, expectedExpression, expectedResult);
+    testHelper.testExpressionString(target.calciteOperator(), exprs, expectedExpression, expectedResult);
   }
 
   private DruidExpression buildExpectedExpression(Object... args)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/IPv4AddressStringifyExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/IPv4AddressStringifyExpressionTest.java
@@ -224,7 +224,7 @@ public class IPv4AddressStringifyExpressionTest extends ExpressionTestBase
       final Object expectedResult
   )
   {
-    testHelper.testExpression(target.calciteOperator(), exprs, expectedExpression, expectedResult);
+    testHelper.testExpressionString(target.calciteOperator(), exprs, expectedExpression, expectedResult);
   }
 
   private DruidExpression buildExpectedExpression(Object... args)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
@@ -269,7 +269,7 @@ public class LeastExpressionTest extends ExpressionTestBase
       final Object expectedResult
   )
   {
-    testHelper.testExpression(target.calciteOperator(), exprs, expectedExpression, expectedResult);
+    testHelper.testExpressionString(target.calciteOperator(), exprs, expectedExpression, expectedResult);
   }
 
   private DruidExpression buildExpectedExpression(Object... args)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/TimeFormatOperatorConversionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/TimeFormatOperatorConversionTest.java
@@ -119,7 +119,7 @@ public class TimeFormatOperatorConversionTest extends ExpressionTestBase
     testHelper.testExpression(
         target.calciteOperator(),
         exprsBuilder.build(),
-        DruidExpression.fromExpression(expectedExpression),
+        makeExpression(expectedExpression),
         expectedResult
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/TimeFormatOperatorConversionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/TimeFormatOperatorConversionTest.java
@@ -116,7 +116,7 @@ public class TimeFormatOperatorConversionTest extends ExpressionTestBase
       exprsBuilder.add(testHelper.makeLiteral(timezone));
     }
 
-    testHelper.testExpression(
+    testHelper.testExpressionString(
         target.calciteOperator(),
         exprsBuilder.build(),
         makeExpression(expectedExpression),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
@@ -42,7 +42,6 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.builtin.MultiValueStringOperatorConversions;
@@ -52,6 +51,7 @@ import org.apache.druid.sql.calcite.schema.NamedDruidSchema;
 import org.apache.druid.sql.calcite.schema.NamedViewSchema;
 import org.apache.druid.sql.calcite.schema.ViewSchema;
 import org.apache.druid.sql.calcite.table.RowSignatures;
+import org.apache.druid.sql.calcite.util.CalciteTestBase;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
@@ -133,7 +133,7 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
     Assert.assertEquals(1, reduced.size());
     Assert.assertEquals(SqlKind.OTHER_FUNCTION, reduced.get(0).getKind());
     Assert.assertEquals(
-        DruidExpression.fromExpression("hyper_unique()"),
+        CalciteTestBase.makeExpression(ColumnType.ofComplex("hyperUnique"), "hyper_unique()"),
         Expressions.toDruidExpression(
             PLANNER_CONTEXT,
             RowSignature.builder().build(),
@@ -154,7 +154,7 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
     rexy.reduce(rexBuilder, ImmutableList.of(literal), reduced);
     Assert.assertEquals(1, reduced.size());
     Assert.assertEquals(
-        DruidExpression.fromExpression("array(50.12,12.1)"),
+        CalciteTestBase.makeExpression(ColumnType.DOUBLE_ARRAY, "array(50.12,12.1)"),
         Expressions.toDruidExpression(
             PLANNER_CONTEXT,
             RowSignature.empty(),
@@ -175,7 +175,7 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
     rexy.reduce(rexBuilder, ImmutableList.of(literal), reduced);
     Assert.assertEquals(1, reduced.size());
     Assert.assertEquals(
-        DruidExpression.fromExpression("array(50,12)"),
+        CalciteTestBase.makeExpression(ColumnType.LONG_ARRAY, "array(50,12)"),
         Expressions.toDruidExpression(
             PLANNER_CONTEXT,
             RowSignature.empty(),
@@ -198,7 +198,7 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
     Assert.assertEquals(1, reduced.size());
     Assert.assertEquals(SqlKind.OTHER_FUNCTION, reduced.get(0).getKind());
     Assert.assertEquals(
-        DruidExpression.fromExpression("string_to_array('a,b,c',',')"),
+        CalciteTestBase.makeExpression(ColumnType.STRING, "string_to_array('a,b,c',',')"),
         Expressions.toDruidExpression(
             PLANNER_CONTEXT,
             RowSignature.builder().build(),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
@@ -42,6 +42,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.builtin.MultiValueStringOperatorConversions;
@@ -154,7 +155,14 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
     rexy.reduce(rexBuilder, ImmutableList.of(literal), reduced);
     Assert.assertEquals(1, reduced.size());
     Assert.assertEquals(
-        CalciteTestBase.makeExpression(ColumnType.DOUBLE_ARRAY, "array(50.12,12.1)"),
+        DruidExpression.ofExpression(
+            ColumnType.DOUBLE_ARRAY,
+            DruidExpression.functionCall("array"),
+            ImmutableList.of(
+                DruidExpression.ofLiteral(ColumnType.DOUBLE, "50.12"),
+                DruidExpression.ofLiteral(ColumnType.DOUBLE, "12.1")
+            )
+        ),
         Expressions.toDruidExpression(
             PLANNER_CONTEXT,
             RowSignature.empty(),
@@ -175,7 +183,14 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
     rexy.reduce(rexBuilder, ImmutableList.of(literal), reduced);
     Assert.assertEquals(1, reduced.size());
     Assert.assertEquals(
-        CalciteTestBase.makeExpression(ColumnType.LONG_ARRAY, "array(50,12)"),
+        DruidExpression.ofExpression(
+            ColumnType.LONG_ARRAY,
+            DruidExpression.functionCall("array"),
+            ImmutableList.of(
+                DruidExpression.ofLiteral(ColumnType.LONG, "50"),
+                DruidExpression.ofLiteral(ColumnType.LONG, "12")
+            )
+        ),
         Expressions.toDruidExpression(
             PLANNER_CONTEXT,
             RowSignature.empty(),
@@ -198,7 +213,14 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
     Assert.assertEquals(1, reduced.size());
     Assert.assertEquals(SqlKind.OTHER_FUNCTION, reduced.get(0).getKind());
     Assert.assertEquals(
-        CalciteTestBase.makeExpression(ColumnType.STRING, "string_to_array('a,b,c',',')"),
+        DruidExpression.ofExpression(
+            ColumnType.STRING,
+            DruidExpression.functionCall("string_to_array"),
+            ImmutableList.of(
+                DruidExpression.ofStringLiteral("a,b,c"),
+                DruidExpression.ofStringLiteral(",")
+            )
+        ),
         Expressions.toDruidExpression(
             PLANNER_CONTEXT,
             RowSignature.builder().build(),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rel/DruidQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rel/DruidQueryTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.JoinDataSource;
 import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.filter.AndDimFilter;
 import org.apache.druid.query.filter.BoundDimFilter;
 import org.apache.druid.query.filter.DimFilter;
@@ -61,7 +62,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         selectorFilter,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, dataSource, selectorFilter, Intervals.ETERNITY);
   }
@@ -73,7 +74,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         filterWithInterval,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, dataSource, selectorFilter, Intervals.utc(100, 200));
   }
@@ -85,7 +86,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         filterWithInterval,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, dataSource, selectorFilter, Intervals.utc(100, 200));
   }
@@ -98,7 +99,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         otherFilter,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
   }
@@ -111,7 +112,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         otherFilter,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
   }
@@ -124,7 +125,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         otherFilter,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
   }
@@ -137,7 +138,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         otherFilter,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, expectedDataSource, otherFilter, Intervals.utc(100, 200));
   }
@@ -155,7 +156,7 @@ public class DruidQueryTest
     Pair<DataSource, Filtration> pair = DruidQuery.getFiltration(
         dataSource,
         queryFilter,
-        VirtualColumnRegistry.create(RowSignature.empty())
+        VirtualColumnRegistry.create(RowSignature.empty(), TestExprMacroTable.INSTANCE)
     );
     verify(pair, expectedDataSource, otherFilter, Intervals.utc(150, 200));
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rel/GroupingTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rel/GroupingTest.java
@@ -19,7 +19,11 @@
 
 package org.apache.druid.sql.calcite.rel;
 
+import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.junit.Test;
 
 public class GroupingTest
@@ -30,6 +34,18 @@ public class GroupingTest
     EqualsVerifier.forClass(Grouping.class)
                   .usingGetClass()
                   .withNonnullFields("dimensions", "subtotals", "aggregations", "outputRowSignature")
+                  .withPrefabValues(
+                      DruidExpression.class,
+                      DruidExpression.ofLiteral(ColumnType.LONG, "100"),
+                      DruidExpression.ofExpression(
+                          ColumnType.LONG,
+                          (args) -> StringUtils.format("%s + %s", args.get(0), args.get(1)),
+                          ImmutableList.of(
+                              DruidExpression.ofLiteral(ColumnType.LONG, "100"),
+                              DruidExpression.ofLiteral(ColumnType.LONG, "200")
+                          )
+                      )
+                  )
                   .verify();
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestBase.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestBase.java
@@ -44,26 +44,51 @@ public abstract class CalciteTestBase
     ExpressionProcessing.initializeForTests(null);
   }
 
+  /**
+   * @deprecated prefer to make {@link DruidExpression} directly to ensure expression tests accurately test the full
+   * expression structure, this method is just to have a convenient way to fix a very large number of existing tests
+   */
+  @Deprecated
   public static DruidExpression makeColumnExpression(final String column)
   {
     return DruidExpression.ofColumn(ColumnType.STRING, column);
   }
 
+  /**
+   * @deprecated prefer to make {@link DruidExpression} directly to ensure expression tests accurately test the full
+   * expression structure, this method is just to have a convenient way to fix a very large number of existing tests
+   */
+  @Deprecated
   public static DruidExpression makeExpression(final String staticExpression)
   {
     return makeExpression(ColumnType.STRING, staticExpression);
   }
 
+  /**
+   * @deprecated prefer to make {@link DruidExpression} directly to ensure expression tests accurately test the full
+   * expression structure, this method is just to have a convenient way to fix a very large number of existing tests
+   */
+  @Deprecated
   public static DruidExpression makeExpression(final ColumnType columnType, final String staticExpression)
   {
     return makeExpression(columnType, null, staticExpression);
   }
 
+  /**
+   * @deprecated prefer to make {@link DruidExpression} directly to ensure expression tests accurately test the full
+   * expression structure, this method is just to have a convenient way to fix a very large number of existing tests
+   */
+  @Deprecated
   public static DruidExpression makeExpression(final SimpleExtraction simpleExtraction, final String staticExpression)
   {
     return makeExpression(ColumnType.STRING, simpleExtraction, staticExpression);
   }
 
+  /**
+   * @deprecated prefer to make {@link DruidExpression} directly to ensure expression tests accurately test the full
+   * expression structure, this method is just to have a convenient way to fix a very large number of existing tests
+   */
+  @Deprecated
   public static DruidExpression makeExpression(
       final ColumnType columnType,
       final SimpleExtraction simpleExtraction,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestBase.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestBase.java
@@ -22,10 +22,14 @@ package org.apache.druid.sql.calcite.util;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.math.expr.ExpressionProcessing;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.SimpleExtraction;
 import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.http.SqlParameter;
 import org.junit.BeforeClass;
 
+import java.util.Collections;
 import java.util.List;
 
 public abstract class CalciteTestBase
@@ -38,5 +42,39 @@ public abstract class CalciteTestBase
     Calcites.setSystemProperties();
     NullHandling.initializeForTests();
     ExpressionProcessing.initializeForTests(null);
+  }
+
+  public static DruidExpression makeColumnExpression(final String column)
+  {
+    return DruidExpression.ofColumn(ColumnType.STRING, column);
+  }
+
+  public static DruidExpression makeExpression(final String staticExpression)
+  {
+    return makeExpression(ColumnType.STRING, staticExpression);
+  }
+
+  public static DruidExpression makeExpression(final ColumnType columnType, final String staticExpression)
+  {
+    return makeExpression(columnType, null, staticExpression);
+  }
+
+  public static DruidExpression makeExpression(final SimpleExtraction simpleExtraction, final String staticExpression)
+  {
+    return makeExpression(ColumnType.STRING, simpleExtraction, staticExpression);
+  }
+
+  public static DruidExpression makeExpression(
+      final ColumnType columnType,
+      final SimpleExtraction simpleExtraction,
+      final String staticExpression
+  )
+  {
+    return DruidExpression.ofExpression(
+        columnType,
+        simpleExtraction,
+        (args) -> staticExpression,
+        Collections.emptyList()
+    );
   }
 }


### PR DESCRIPTION
### Description

This PR reworks how the SQL planner constructs `DruidExpression` and how it translates them into `VirtualColumn` when constructing the native query.

Prior to the changes in this PR, `DruidExpression` were flattened string expressions, eagerly constructed into a `VirtualColumn` via the `VirtualColumnRegistry`, whenever required for use in projections, aggregations, filters, etc. This meant that basically all of the expression structure was lost after converting to the string expression, making it impossible to modify them to try to optimize the query prior to conversion the the native JSON query.

Now, `DruidExpression` retains the expression tree structure, each containing a `List<DruidExpression>` that contains any sub-expressions which at the time of virtual column creation is built into the string expression, using a newly added interface
```
  public interface ExpressionBuilder
  {
    String buildExpression(List<DruidExpression> arguments);
  }
```
which is added to the `DruidExpression` when it is created. Another new interface has been added to aid in rewriting `DruidExpression` trees before planning into a native `Query`

```
  public interface DruidExpressionShuttle
  {
    DruidExpression visit(DruidExpression expression);

    default List<DruidExpression> visitAll(List<DruidExpression> expressions)
    {
      List<DruidExpression> list = new ArrayList<>(expressions.size());
      for (DruidExpression expr : expressions) {
        list.add(visit(expr));
      }
      return list;
    }
  }
```

(along with a `visit` method on `DruidExpression` to accept the shuttle).

`DruidExpression` are also now annotated, with one of 4 roles, `LITERAL`, `IDENTIFIER`, `EXPRESSION`, and `SPECIALIZED`, the last of which, coupled with the shuttle visitor, is the primary motivator of this PR.

Using `MV_FILTER_ONLY`/`MV_FILTER_NONE` as an example, which has a "native" specialized `VirtualColumn` implementation, any expression which supplies such a specialized implementation will now always use it.

Prior to this PR, when used in some composition, e.g.

```
SELECT MV_LENGTH(MV_FILTER_ONLY(dim3, ARRAY['b'])), SUM(cnt) FROM druid.numfoo GROUP BY 1 ORDER BY 2 DESC
```

this function would use a fall-back expression
```
"virtualColumns" : [ {
    "type" : "expression",
    "name" : "v0",
    "expression" : "array_length(filter((x) -> array_contains(array('b'), x), "dim3"))",
    "outputType" : "LONG"
  } ],
```

but now plans to this instead
```
"virtualColumns" : [ {
    "type" : "expression",
    "name" : "v0",
    "expression" : "array_length(\"v1\")",
    "outputType" : "LONG"
  }, {
    "type" : "mv-filtered",
    "name" : "v1",
    "delegate" : {
      "type" : "default",
      "dimension" : "dim3",
      "outputName" : "dim3",
      "outputType" : "STRING"
    },
    "values" : [ "b" ],
    "isAllowList" : true
  } ],
```

<hr>

In the process, I uncovered additional bugs with multi-value string array expressions, similar to the bugs fixed #12078 (and controlled by the flag #12210)

Noteworthy: in addition to the behavior change of fixing the remaining bugs of `MV_` functions, specifically `MV_FILTER_ONLY` and `MV_FILTER_NONE` might have subtle behavior differences due to the new specialization code compared to the fall-back expression. the `filter` function used as the fall-back expression would return empty arrays where `ListFilteredVirtualColumn` would return `null`, so something like `MV_LENGTH(MV_FILTER_ONLY(...))` would report `0` as the length for rows which contained no values. However, using `MV_FILTER_ONLY(..)` directly would return `null` for these rows since it did previously plan to the `ListFilteredVirtualColumn`. This is fixed now, so `MV_LENGTH` will be `null` for these rows without values now.

We might want to consider adjusting the fallback `filter` expression of `MV_FILTER_*` to coerce empty arrays to nulls to behave consistently with `ListFilteredVirtualColumn`, but I did not do that in this PR.

##### Key changed/added classes in this PR
 * `DruidExpression`
 * `VirtualColumnRegistry`
 * `DruidQuery`
 * `OperatorConversions`
 * `ExpressionSelectors` (bug fix)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
