### PR TITLE
Surface a user friendly error when PARTITIONED BY is omitted

### DIFF
--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -21,13 +21,15 @@
 SqlNode DruidSqlInsert() :
 {
   SqlNode insertNode;
-  org.apache.druid.java.util.common.Pair<Granularity, String> partitionedBy = null;
+  org.apache.druid.java.util.common.Pair<Granularity, String> partitionedBy = new org.apache.druid.java.util.common.Pair(null, null);
   SqlNodeList clusteredBy = null;
 }
 {
   insertNode = SqlInsert()
-  <PARTITIONED> <BY>
-  partitionedBy = PartitionGranularity()
+  [
+    <PARTITIONED> <BY>
+    partitionedBy = PartitionGranularity()
+  ]
   [
     <CLUSTERED> <BY>
     clusteredBy = ClusterItems()
@@ -65,7 +67,7 @@ SqlNodeList ClusterItems() :
 org.apache.druid.java.util.common.Pair<Granularity, String> PartitionGranularity() :
 {
   SqlNode e = null;
-  org.apache.druid.java.util.common.granularity.Granularity granularity = null;
+  Granularity granularity = null;
   String unparseString = null;
 }
 {

--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -96,11 +96,17 @@ org.apache.druid.java.util.common.Pair<Granularity, String> PartitionGranularity
       unparseString = "YEAR";
     }
   |
-    <ALL> <TIME>
+    <ALL>
     {
       granularity = Granularities.ALL;
-      unparseString = "ALL TIME";
+      unparseString = "ALL";
     }
+    [
+      <TIME>
+      {
+        unparseString += " TIME";
+      }
+    ]
   |
     e = Expression(ExprContext.ACCEPT_SUB_QUERY)
     {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlInsert.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlInsert.java
@@ -52,7 +52,7 @@ public class DruidSqlInsert extends SqlInsert
    * While partitionedBy and partitionedByStringForUnparse can be null as arguments to the constructor, this is
    * disallowed (semantically) and the constructor performs checks to ensure that. This helps in producing friendly
    * errors when the PARTITIONED BY custom clause is not present, and keeps its error separate from JavaCC/Calcite's
-   * custom errors which can be cryptic when someone accidentaly forgets to explicitly specify the PARTITIONED BY clause
+   * custom errors which can be cryptic when someone accidentally forgets to explicitly specify the PARTITIONED BY clause
    */
   public DruidSqlInsert(
       @Nonnull SqlInsert insertNode,
@@ -69,7 +69,7 @@ public class DruidSqlInsert extends SqlInsert
         insertNode.getTargetColumnList()
     );
     if (partitionedBy == null) {
-      throw new ParseException("INSERT statements should specify PARTITIONED BY clause explictly");
+      throw new ParseException("INSERT statements must specify PARTITIONED BY clause explictly");
     }
     this.partitionedBy = partitionedBy;
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlInsert.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlInsert.java
@@ -48,12 +48,18 @@ public class DruidSqlInsert extends SqlInsert
   @Nullable
   private final SqlNodeList clusteredBy;
 
+  /**
+   * While partitionedBy and partitionedByStringForUnparse can be null as arguments to the constructor, this is
+   * disallowed (semantically) and the constructor performs checks to ensure that. This helps in producing friendly
+   * errors when the PARTITIONED BY custom clause is not present, and keeps its error separate from JavaCC/Calcite's
+   * custom errors which can be cryptic when someone accidentaly forgets to explicitly specify the PARTITIONED BY clause
+   */
   public DruidSqlInsert(
       @Nonnull SqlInsert insertNode,
-      @Nonnull Granularity partitionedBy,
-      @Nonnull String partitionedByStringForUnparse,
+      @Nullable Granularity partitionedBy,
+      @Nullable String partitionedByStringForUnparse,
       @Nullable SqlNodeList clusteredBy
-  )
+  ) throws ParseException
   {
     super(
         insertNode.getParserPosition(),
@@ -62,10 +68,14 @@ public class DruidSqlInsert extends SqlInsert
         insertNode.getSource(),
         insertNode.getTargetColumnList()
     );
-    Preconditions.checkNotNull(partitionedBy); // Shouldn't hit due to how the parser is written
+    if (partitionedBy == null) {
+      throw new ParseException("INSERT statements should specify PARTITIONED BY clause explictly");
+    }
     this.partitionedBy = partitionedBy;
+
     Preconditions.checkNotNull(partitionedByStringForUnparse);
     this.partitionedByStringForUnparse = partitionedByStringForUnparse;
+
     this.clusteredBy = clusteredBy;
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -542,6 +542,22 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
     }
   }
 
+  @Test
+  public void testInsertWithoutPartitionedBy()
+  {
+    SqlPlanningException e = Assert.assertThrows(
+        SqlPlanningException.class,
+        () ->
+            testQuery(
+                StringUtils.format("INSERT INTO dst SELECT * FROM %s", externSql(externalDataSource)),
+                ImmutableList.of(),
+                ImmutableList.of()
+            )
+    );
+    Assert.assertEquals("INSERT statements should specify PARTITIONED BY clause explictly", e.getMessage());
+    didTest = true;
+  }
+
   // Currently EXPLAIN PLAN FOR doesn't work with the modified syntax
   @Ignore
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -334,6 +334,7 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
                     .put("DAY", Granularities.DAY)
                     .put("MONTH", Granularities.MONTH)
                     .put("YEAR", Granularities.YEAR)
+                    .put("ALL", Granularities.ALL)
                     .put("ALL TIME", Granularities.ALL)
                     .put("FLOOR(__time TO QUARTER)", Granularities.QUARTER)
                     .put("TIME_FLOOR(__time, 'PT1H')", Granularities.HOUR)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -555,7 +555,7 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
                 ImmutableList.of()
             )
     );
-    Assert.assertEquals("INSERT statements should specify PARTITIONED BY clause explictly", e.getMessage());
+    Assert.assertEquals("INSERT statements must specify PARTITIONED BY clause explictly", e.getMessage());
     didTest = true;
   }
 


### PR DESCRIPTION
### Description

https://github.com/apache/druid/pull/12163 makes `PARTITIONED BY` a required clause in INSERT queries. While this is required, if a user accidentally omits the clause, it emits a JavaCC/Calcite error, since it's syntactically incorrect. The error message is cryptic. Since it's a custom clause, this PR aims to make the clause optional on the syntactic side, but move the validation to `DruidSqlInsert` where we can surface a friendlier error. 
```
Older error message:
Was expecting one of: "PARTITIONED" ... "ORDER" ... "LIMIT" ... "OFFSET" ... "FETCH" ... "NATURAL" ... "JOIN" ... "INNER" ... "LEFT" ... "RIGHT" ... "FULL" ... "CROSS" ... "," ... "OUTER" ... "EXTEND" ... "(" ... "FOR" ... "MATCH_RECOGNIZE" ... "." ... "AS" ... <IDENTIFIER> ... <QUOTED_IDENTIFIER> ... <BACK_QUOTED_IDENTIFIER> ... <BRACKET_QUOTED_IDENTIFIER> ... <UNICODE_QUOTED_IDENTIFIER> ... "TABLESAMPLE" ... "WHERE" ... "GROUP" ... "HAVING" ... "WINDOW" ... "UNION" ... "INTERSECT" ... "EXCEPT" ... "MINUS"

Newer error message:
INSERT statements should specify PARTITIONED BY clause explicitly.
```

Also, to specify insert granularity as ALL, one can either mention `ALL TIME` (as in the original proposal) or `ALL` (after the change). 

<hr>

##### Key changed/added classes in this PR
 * `insert.ftl`
 * `DruidSqlInsert`

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
