### PR TITLE
use virtual columns for sql simple aggregators instead of inline expressions

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
@@ -115,9 +115,13 @@ public class AvgSqlAggregator implements SqlAggregator
           project,
           Iterables.getOnlyElement(aggregateCall.getArgList())
       );
-      String vc = virtualColumnRegistry.getVirtualColumnByExpression(arg, resolutionArg.getType());
-      fieldName = vc != null ? vc : null;
-      expression = vc != null ? null : arg.getExpression();
+      if (arg.getType() == DruidExpression.NodeType.LITERAL) {
+        fieldName = null;
+        expression = arg.getExpression();
+      } else {
+        fieldName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(arg, resolutionArg.getType());
+        expression = null;
+      }
     }
     final String sumName = Calcites.makePrefixedName(name, "sum");
     final AggregatorFactory sum = SumSqlAggregator.createSumAggregatorFactory(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SimpleSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SimpleSqlAggregator.java
@@ -84,8 +84,14 @@ public abstract class SimpleSqlAggregator implements SqlAggregator
       fieldName = arg.getDirectColumn();
       expression = null;
     } else {
-      fieldName = null;
-      expression = arg.getExpression();
+      // sharing is caring, make a virtual column for anything more complicated than a literal to maximize re-use
+      if (arg.getType() == DruidExpression.NodeType.LITERAL) {
+        fieldName = null;
+        expression = arg.getExpression();
+      } else {
+        fieldName = virtualColumnRegistry.getOrCreateVirtualColumnForExpression(arg, aggregateCall.getType());
+        expression = null;
+      }
     }
 
     return getAggregation(name, aggregateCall, macroTable, fieldName, expression);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/BinaryOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/BinaryOperatorConversion.java
@@ -81,7 +81,7 @@ public class BinaryOperatorConversion implements SqlOperatorConversion
     );
   }
 
-  private DruidExpression.DruidExpressionBuilder getOperatorFunction(RexNode rexNode)
+  private DruidExpression.DruidExpressionCreator getOperatorFunction(RexNode rexNode)
   {
     return operands -> {
       if (operands.size() < 2) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/OperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/OperatorConversions.java
@@ -119,7 +119,7 @@ public class OperatorConversions
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
       final RexNode rexNode,
-      final DruidExpression.ExpressionBuilder expressionBuilder
+      final DruidExpression.ExpressionGenerator expressionGenerator
   )
   {
     return convertCall(
@@ -128,7 +128,7 @@ public class OperatorConversions
         rexNode,
         (operands) -> DruidExpression.ofExpression(
             Calcites.getColumnTypeForRelDataType(rexNode.getType()),
-            expressionBuilder,
+            expressionGenerator,
             operands
         )
     );
@@ -139,7 +139,7 @@ public class OperatorConversions
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
       final RexNode rexNode,
-      final DruidExpression.DruidExpressionBuilder expressionFunction
+      final DruidExpression.DruidExpressionCreator expressionFunction
   )
   {
     final RexCall call = (RexCall) rexNode;
@@ -154,7 +154,7 @@ public class OperatorConversions
       return null;
     }
 
-    return expressionFunction.buildExpression(druidExpressions);
+    return expressionFunction.create(druidExpressions);
   }
 
   @Deprecated
@@ -211,7 +211,7 @@ public class OperatorConversions
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
       final RexNode rexNode,
-      final DruidExpression.DruidExpressionBuilder expressionFunction,
+      final DruidExpression.DruidExpressionCreator expressionFunction,
       final PostAggregatorVisitor postAggregatorVisitor
   )
   {
@@ -228,7 +228,7 @@ public class OperatorConversions
       return null;
     }
 
-    return expressionFunction.buildExpression(druidExpressions);
+    return expressionFunction.create(druidExpressions);
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
@@ -341,7 +341,7 @@ public class MultiValueStringOperatorConversions
         return null;
       }
 
-      final DruidExpression.ExpressionBuilder builder = (args) -> {
+      final DruidExpression.ExpressionGenerator builder = (args) -> {
         final StringBuilder expressionBuilder;
         if (isAllowList()) {
           expressionBuilder = new StringBuilder("filter((x) -> array_contains(");

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StrposOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StrposOperatorConversion.java
@@ -63,7 +63,7 @@ public class StrposOperatorConversion implements SqlOperatorConversion
             Calcites.getColumnTypeForRelDataType(rexNode.getType()),
             (args) -> StringUtils.format(
                 "(%s + 1)",
-                DruidExpression.functionCall("strpos").buildExpression(args)
+                DruidExpression.functionCall("strpos").compile(args)
             ),
             druidExpressions
         )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
@@ -262,6 +262,19 @@ public class VirtualColumnRegistry
     return new ExpressionAndTypeHint(expression, typeHint);
   }
 
+  /**
+   * Wrapper class for a {@link DruidExpression} and the output {@link ColumnType} "hint" that callers can specify when
+   * adding a virtual column with {@link #getOrCreateVirtualColumnForExpression(DruidExpression, RelDataType)} or
+   * {@link #getOrCreateVirtualColumnForExpression(DruidExpression, ColumnType)}. This "hint"  will be passed into
+   * {@link DruidExpression#toVirtualColumn(String, ColumnType, ExprMacroTable)}.
+   *
+   * The type hint might be different than {@link DruidExpression#getDruidType()} since that value is the captured value
+   * of {@link org.apache.calcite.rex.RexNode#getType()} converted to the Druid type system, while callers might still
+   * explicitly specify a different type to use for the hint. Additionally, the method used to convert Calcite types to
+   * Druid types does not completely map the former to the latter, and the method typically used to do the conversion,
+   * {@link Calcites#getColumnTypeForRelDataType(RelDataType)}, might return null, where the caller might know what
+   * the type should be.
+   */
   private static class ExpressionAndTypeHint
   {
     private final DruidExpression expression;


### PR DESCRIPTION
### Description

Follow-up to #12241, this PR updates the "simple" SQL aggregators, such as `SUM`, `MIN`, and `MAX` to use `VirtualColumn` instead of the inline `expression` to maximize expression re-use for anything more complicated than a literal value.

`CalciteQueryTest.testExpressionAggregations` has been update to have aggregators which share a common expression, which will now be shared between these two aggregators instead of each specifying it inline. Additionally, this allows these aggregators to participate in the 'specialization' added in #12241.

Finally, did some follow-up javadoc and naming adjustments per comments in the previous PR.

<hr>

##### Key changed/added classes in this PR
 * `SimpleSqlAggregator`
 * `DruidExpression`
 * `VirtualColumnRegistry`

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
