### PR TITLE
Re-enable segment metadata cache when using external schema

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -228,9 +228,7 @@ public class DruidSchema extends AbstractSchema
     this.brokerInternalQueryConfig = brokerInternalQueryConfig;
     this.druidSchemaManager = druidSchemaManager;
 
-    if (druidSchemaManager == null || druidSchemaManager instanceof NoopDruidSchemaManager) {
-      initServerViewTimelineCallback(serverView);
-    }
+    initServerViewTimelineCallback(serverView);
   }
 
   private void initServerViewTimelineCallback(final TimelineServerView serverView)
@@ -375,11 +373,7 @@ public class DruidSchema extends AbstractSchema
   @LifecycleStart
   public void start() throws InterruptedException
   {
-    if (druidSchemaManager == null || druidSchemaManager instanceof NoopDruidSchemaManager) {
-      startCacheExec();
-    } else {
-      initialized.countDown();
-    }
+    startCacheExec();
 
     if (config.isAwaitInitializationOnStart()) {
       final long startNanos = System.nanoTime();


### PR DESCRIPTION
This PR re-enables the segment metadata caching within `DruidSchema` when using an external schema provider, as the `sys.segments` table relies on this information for determining segment availability.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
