### PR TITLE
Adding Shared Access resource support for azure

### DIFF
--- a/docs/development/extensions-core/azure.md
+++ b/docs/development/extensions-core/azure.md
@@ -33,7 +33,8 @@ To use this Apache Druid extension, [include](../../development/extensions.md#lo
 |--------|---------------|-----------|-------|
 |`druid.storage.type`|azure||Must be set.|
 |`druid.azure.account`||Azure Storage account name.|Must be set.|
-|`druid.azure.key`||Azure Storage account key.|Must be set.|
+|`druid.azure.key`||Azure Storage account key.|Optional. Either set key or sharedAccessStorageToken but not both.|
+|`druid.azure.sharedAccessStorageToken`||Azure Shared Storage access token|Optional. Either set key or sharedAccessStorageToken but not both.| 
 |`druid.azure.container`||Azure Storage container name.|Must be set.|
 |`druid.azure.prefix`|A prefix string that will be prepended to the blob names for the segments published to Azure deep storage| |""|
 |`druid.azure.protocol`|the protocol to use|http or https|https|

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
@@ -41,8 +41,10 @@ public class AzureAccountConfig
   private String account;
 
   @JsonProperty
-  @NotNull
   private String key;
+
+  @JsonProperty
+  private String sharedAccessStorageToken;
 
   @SuppressWarnings("unused") // Used by Jackson deserialization?
   public void setProtocol(String protocol)
@@ -85,5 +87,15 @@ public class AzureAccountConfig
   public String getKey()
   {
     return key;
+  }
+
+  public String getSharedAccessStorageToken()
+  {
+    return sharedAccessStorageToken;
+  }
+
+  public void setSharedAccessStorageToken(String sharedAccessStorageToken)
+  {
+    this.sharedAccessStorageToken = sharedAccessStorageToken;
   }
 }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
@@ -94,6 +94,7 @@ public class AzureAccountConfig
     return sharedAccessStorageToken;
   }
 
+  @SuppressWarnings("unused") // Used by Jackson deserialization?
   public void setSharedAccessStorageToken(String sharedAccessStorageToken)
   {
     this.sharedAccessStorageToken = sharedAccessStorageToken;

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
@@ -157,7 +157,7 @@ public class AzureStorageDruidModule implements DruidModule
           ));
           return account.createCloudBlobClient();
         } else {
-          throw new ISE("Either set 'key' or 'sharedAccessStorageToken' in the azure config but not both");
+          throw new ISE("None of 'key' or 'sharedAccessStorageToken' is set in the azure config.  Please refer to azure extension documentation.");
         }
       }
       catch (URISyntaxException | InvalidKeyException e) {

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
@@ -38,6 +38,7 @@ import org.apache.druid.guice.Binders;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.storage.azure.blob.ListBlobItemHolderFactory;
 
@@ -52,7 +53,10 @@ public class AzureStorageDruidModule implements DruidModule
 {
 
   static final String SCHEME = "azure";
-  public static final String STORAGE_CONNECTION_STRING = "DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s";
+  public static final String
+      STORAGE_CONNECTION_STRING_WITH_KEY = "DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s";
+  public static final String
+      STORAGE_CONNECTION_STRING_WITH_TOKEN = "DefaultEndpointsProtocol=%s;AccountName=%s;SharedAccessSignature=%s";
   public static final String INDEX_ZIP_FILE_NAME = "index.zip";
 
   @Override
@@ -125,17 +129,36 @@ public class AzureStorageDruidModule implements DruidModule
   @LazySingleton
   public Supplier<CloudBlobClient> getCloudBlobClient(final AzureAccountConfig config)
   {
+    if ((config.getKey() != null && config.getSharedAccessStorageToken() != null)
+        ||
+        (config.getKey() == null && config.getSharedAccessStorageToken() == null)) {
+      throw new ISE("Either set 'key' or 'sharedAccessStorageToken' in the azure config but not both");
+    }
     return Suppliers.memoize(() -> {
       try {
-        CloudStorageAccount account = CloudStorageAccount.parse(
-            StringUtils.format(
-                STORAGE_CONNECTION_STRING,
-                config.getProtocol(),
-                config.getAccount(),
-                config.getKey()
-            )
-        );
-        return account.createCloudBlobClient();
+        final CloudStorageAccount account;
+        if (config.getKey() != null) {
+          account = CloudStorageAccount.parse(
+              StringUtils.format(
+                  STORAGE_CONNECTION_STRING_WITH_KEY,
+                  config.getProtocol(),
+                  config.getAccount(),
+                  config.getKey()
+              )
+
+          );
+          return account.createCloudBlobClient();
+        } else if (config.getSharedAccessStorageToken() != null) {
+          account = CloudStorageAccount.parse(StringUtils.format(
+              STORAGE_CONNECTION_STRING_WITH_TOKEN,
+              config.getProtocol(),
+              config.getAccount(),
+              config.getSharedAccessStorageToken()
+          ));
+          return account.createCloudBlobClient();
+        } else {
+          throw new ISE("Either set 'key' or 'sharedAccessStorageToken' in the azure config but not both");
+        }
       }
       catch (URISyntaxException | InvalidKeyException e) {
         throw new RuntimeException(e);

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
@@ -132,7 +132,8 @@ public class AzureStorageDruidModule implements DruidModule
     if ((config.getKey() != null && config.getSharedAccessStorageToken() != null)
         ||
         (config.getKey() == null && config.getSharedAccessStorageToken() == null)) {
-      throw new ISE("Either set 'key' or 'sharedAccessStorageToken' in the azure config but not both");
+      throw new ISE("Either set 'key' or 'sharedAccessStorageToken' in the azure config but not both."
+                    + " Please refer to azure documentation.");
     }
     return Suppliers.memoize(() -> {
       try {
@@ -157,7 +158,9 @@ public class AzureStorageDruidModule implements DruidModule
           ));
           return account.createCloudBlobClient();
         } else {
-          throw new ISE("None of 'key' or 'sharedAccessStorageToken' is set in the azure config.  Please refer to azure extension documentation.");
+          throw new ISE(
+              "None of 'key' or 'sharedAccessStorageToken' is set in the azure config."
+              + " Please refer to azure extension documentation.");
         }
       }
       catch (URISyntaxException | InvalidKeyException e) {

--- a/website/.spelling
+++ b/website/.spelling
@@ -629,6 +629,7 @@ maxFetchCapacityBytes
 maxFetchRetry
 prefetchTriggerBytes
 shardSpecs
+sharedAccessStorageToken
  - ../docs/development/extensions-contrib/cloudfiles.md
 StaticCloudFilesFirehose
 cloudfiles


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Azure Blob storage has multiple modes of authentication. One of them is [Shared access resource
](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#create-a-connection-string-using-a-shared-access-signature) . This is very useful in cases when we do not want to add the account key in the druid properties .

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

Added a new config ``sharedAccessStorageToken`` which can be passed as part of azure properties to enable this behavior. Users can either set the `key` or the  `sharedAccessStorageToken` but not both for authenticating with azure blob storage.

##### Key changed/added classes in this PR
 * `extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java`
 * `extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
