### PR TITLE
Performance fixes in proto readers

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
@@ -65,7 +65,7 @@ public class JsonInputFormat extends NestedInputFormat
   }
 
   public JsonInputFormat(
-      JSONPathSpec flattenSpec,
+      @Nullable JSONPathSpec flattenSpec,
       Map<String, Boolean> featureSpec,
       Boolean keepNullColumns,
       boolean lineSplittable

--- a/core/src/main/java/org/apache/druid/data/input/impl/NestedInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/NestedInputFormat.java
@@ -37,7 +37,7 @@ public abstract class NestedInputFormat implements InputFormat
 
   protected NestedInputFormat(@Nullable JSONPathSpec flattenSpec)
   {
-    this.flattenSpec = flattenSpec == null ? JSONPathSpec.DEFAULT : flattenSpec;
+    this.flattenSpec = flattenSpec;
   }
 
   @Nullable

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -24,6 +24,7 @@ import com.jayway.jsonpath.spi.json.JsonProvider;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.UOE;
 
+import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,12 +45,12 @@ public class ObjectFlatteners
   }
 
   public static <T> ObjectFlattener<T> create(
-      final JSONPathSpec flattenSpec,
+      @Nullable final JSONPathSpec flattenSpecInput,
       final FlattenerMaker<T> flattenerMaker
   )
   {
     final Map<String, Function<T, Object>> extractors = new LinkedHashMap<>();
-
+    final JSONPathSpec flattenSpec = flattenSpecInput == null ? JSONPathSpec.DEFAULT : flattenSpecInput;
     for (final JSONPathFieldSpec fieldSpec : flattenSpec.getFields()) {
       final Function<T, Object> extractor;
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroOCFReader.java
@@ -55,7 +55,7 @@ public class AvroOCFReader extends IntermediateRowParsingReader<GenericRecord>
       InputEntity source,
       File temporaryDirectory,
       @Nullable Schema readerSchema,
-      JSONPathSpec flattenSpec,
+      @Nullable JSONPathSpec flattenSpec,
       boolean binaryAsString,
       boolean extractUnionsByType
   )

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamReader.java
@@ -34,6 +34,7 @@ import org.apache.druid.java.util.common.parsers.ObjectFlattener;
 import org.apache.druid.java.util.common.parsers.ObjectFlatteners;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -51,7 +52,7 @@ public class AvroStreamReader extends IntermediateRowParsingReader<GenericRecord
       InputRowSchema inputRowSchema,
       InputEntity source,
       AvroBytesDecoder avroBytesDecoder,
-      JSONPathSpec flattenSpec,
+      @Nullable JSONPathSpec flattenSpec,
       boolean binaryAsString,
       boolean extractUnionsByType
   )

--- a/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcReader.java
+++ b/extensions-core/orc-extensions/src/main/java/org/apache/druid/data/input/orc/OrcReader.java
@@ -41,6 +41,7 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.mapred.OrcMapredRecordReader;
 import org.apache.orc.mapred.OrcStruct;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -61,7 +62,7 @@ public class OrcReader extends IntermediateRowParsingReader<OrcStruct>
       InputRowSchema inputRowSchema,
       InputEntity source,
       File temporaryDirectory,
-      JSONPathSpec flattenSpec,
+      @Nullable JSONPathSpec flattenSpec,
       boolean binaryAsString
   )
   {

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetReader.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetReader.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.hadoop.example.GroupReadSupport;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -57,7 +58,7 @@ public class ParquetReader extends IntermediateRowParsingReader<Group>
       InputRowSchema inputRowSchema,
       InputEntity source,
       File temporaryDirectory,
-      JSONPathSpec flattenSpec,
+      @Nullable JSONPathSpec flattenSpec,
       boolean binaryAsString
   )
   {

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
@@ -49,7 +49,7 @@ import java.util.Map;
 
 public class ProtobufReader extends IntermediateRowParsingReader<DynamicMessage>
 {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final InputRowSchema inputRowSchema;
   private final InputEntity source;
   private final JSONPathSpec flattenSpec;
@@ -99,7 +99,7 @@ public class ProtobufReader extends IntermediateRowParsingReader<DynamicMessage>
     } else {
       try {
         String json = JsonFormat.printer().print(intermediateRow);
-        record = recordFlattener.flatten(objectMapper.readValue(json, JsonNode.class));
+        record = recordFlattener.flatten(OBJECT_MAPPER.readValue(json, JsonNode.class));
       }
       catch (InvalidProtocolBufferException e) {
         throw new ParseException(null, e, "Protobuf message could not be parsed");

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java
@@ -63,7 +63,7 @@ public class ProtobufReader extends IntermediateRowParsingReader<DynamicMessage>
       JSONPathSpec flattenSpec
   )
   {
-    if (flattenSpec == null || JSONPathSpec.DEFAULT.equals(flattenSpec)) {
+    if (flattenSpec == null) {
       this.inputRowSchema = new ProtobufInputRowSchema(inputRowSchema);
       this.recordFlattener = null;
     } else {

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufReaderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufReaderTest.java
@@ -122,4 +122,25 @@ public class ProtobufReaderTest
 
     ProtobufInputRowParserTest.verifyFlatDataWithComplexTimestamp(row, dateTime);
   }
+
+  @Test
+  public void testParseFlatDataWithComplexTimestampWithDefaultFlattenSpec() throws Exception
+  {
+    ProtobufReader reader = new ProtobufReader(
+        inputRowSchemaWithComplexTimestamp,
+        null,
+        decoder,
+        JSONPathSpec.DEFAULT
+    );
+
+    //create binary of proto test event
+    DateTime dateTime = new DateTime(2012, 7, 12, 9, 30, ISOChronology.getInstanceUTC());
+    ProtoTestEventWrapper.ProtoTestEvent event = ProtobufInputRowParserTest.buildFlatDataWithComplexTimestamp(dateTime);
+
+    ByteBuffer buffer = ProtobufInputRowParserTest.toByteBuffer(event);
+
+    InputRow row = reader.parseInputRows(decoder.parse(buffer)).get(0);
+
+    ProtobufInputRowParserTest.verifyFlatDataWithComplexTimestamp(row, dateTime);
+  }
 }

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufReaderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufReaderTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.common.parsers.ParseException;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
 import org.junit.Before;
@@ -126,6 +127,8 @@ public class ProtobufReaderTest
   @Test
   public void testParseFlatDataWithComplexTimestampWithDefaultFlattenSpec() throws Exception
   {
+    expectedException.expect(ParseException.class);
+    expectedException.expectMessage("is unparseable!");
     ProtobufReader reader = new ProtobufReader(
         inputRowSchemaWithComplexTimestamp,
         null,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->



<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Looking at some flame graph's for streaming proto file readers with ingestion flatten spec set to null, 
![image](https://user-images.githubusercontent.com/2260045/154551975-a04d3bdb-7be4-4f40-8291-f50a53890105.png)

I realized the optimized proto reader path was not getting used. Looks like proto readers will never have null `flattenSpec` outside unit test cases as in 

```java
 protected NestedInputFormat(@Nullable JSONPathSpec flattenSpec)
  {
    this.flattenSpec = flattenSpec == null ? JSONPathSpec.DEFAULT : flattenSpec;
  }
```
if the `flattenSpec` is null, its replaced with `JSONPathSpec.DEFAULT`  and that is passed to the `parseInputRows` .


Also in `ProtobufReader` we were creating the `objectMapper` per invocation of `parseInputRows`. Changed the `objecMapper`  to a  class level static member as `objectMapper` is threadsafe.



Running `ProtobufParserBenchmark` benchmark pre change 
```
Benchmark                                  (rowsPerSegment)  Mode  Cnt       Score       Error  Units
ProtobufParserBenchmark.consumeFlatData               75000  avgt   10  237032.878 ± 10393.225  us/op
ProtobufParserBenchmark.consumeNestedData             75000  avgt   10  904688.838 ± 68144.032  us/op

```
and post the changes
```
Benchmark                                  (rowsPerSegment)  Mode  Cnt       Score       Error  Units
ProtobufParserBenchmark.consumeFlatData               75000  avgt   10  232640.798 ± 12513.626  us/op
ProtobufParserBenchmark.consumeNestedData             75000  avgt   10  941895.245 ± 45837.099  us/op
```
we see an 4.5 % improvement
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufReader.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
