### PR TITLE
update airline dependency to 2.x

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -172,7 +172,7 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>io.airlift</groupId>
+      <groupId>com.github.rvesse</groupId>
       <artifactId>airline</artifactId>
     </dependency>
     <dependency>

--- a/core/src/main/java/org/apache/druid/cli/CliCommandCreator.java
+++ b/core/src/main/java/org/apache/druid/cli/CliCommandCreator.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.cli;
 
-import io.airlift.airline.Cli;
+import com.github.rvesse.airline.builder.CliBuilder;
 import org.apache.druid.guice.annotations.ExtensionPoint;
 
 /**
@@ -32,5 +32,5 @@ import org.apache.druid.guice.annotations.ExtensionPoint;
 @ExtensionPoint
 public interface CliCommandCreator
 {
-  void addCommands(Cli.CliBuilder builder);
+  void addCommands(CliBuilder builder);
 }

--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -106,8 +106,8 @@
             <artifactId>jsr311-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -104,10 +108,6 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -62,7 +62,7 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.airlift</groupId>
+            <groupId>com.github.rvesse</groupId>
             <artifactId>airline</artifactId>
         </dependency>
         <dependency>
@@ -602,7 +602,7 @@
                                         <KAFKA_VERSION>${apache.kafka.version}</KAFKA_VERSION>
                                         <ZK_VERSION>${zookeeper.version}</ZK_VERSION>
                                         <HADOOP_VERSION>${hadoop.compile.version}</HADOOP_VERSION>
-                                        <DRUID_VERSION>${parent.version}</DRUID_VERSION>
+                                        <DRUID_VERSION>${project.parent.version}</DRUID_VERSION>
                                     </environmentVariables>
                                     <executable>${project.basedir}/build_run_cluster.sh</executable>
                                 </configuration>
@@ -619,7 +619,7 @@
                                         <DRUID_INTEGRATION_TEST_GROUP>${groups}</DRUID_INTEGRATION_TEST_GROUP>
                                         <DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH>${override.config.path}</DRUID_INTEGRATION_TEST_OVERRIDE_CONFIG_PATH>
                                         <DRUID_INTEGRATION_TEST_INDEXER>${it.indexer}</DRUID_INTEGRATION_TEST_INDEXER>
-                                        <DRUID_VERSION>${parent.version}</DRUID_VERSION>
+                                        <DRUID_VERSION>${project.parent.version}</DRUID_VERSION>
                                     </environmentVariables>
                                     <executable>${project.basedir}/stop_cluster.sh</executable>
                                 </configuration>

--- a/integration-tests/src/main/java/org/apache/druid/cli/CliCustomNodeRole.java
+++ b/integration-tests/src/main/java/org/apache/druid/cli/CliCustomNodeRole.java
@@ -20,6 +20,7 @@
 package org.apache.druid.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -28,7 +29,6 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.google.inject.servlet.GuiceFilter;
-import io.airlift.airline.Command;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.Jerseys;

--- a/integration-tests/src/main/java/org/apache/druid/cli/CliHistoricalForQueryErrorTest.java
+++ b/integration-tests/src/main/java/org/apache/druid/cli/CliHistoricalForQueryErrorTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
-import io.airlift.airline.Command;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.QuerySegmentWalker;

--- a/integration-tests/src/main/java/org/apache/druid/cli/CustomNodeRoleCommandCreator.java
+++ b/integration-tests/src/main/java/org/apache/druid/cli/CustomNodeRoleCommandCreator.java
@@ -19,12 +19,12 @@
 
 package org.apache.druid.cli;
 
-import io.airlift.airline.Cli;
+import com.github.rvesse.airline.builder.CliBuilder;
 
 public class CustomNodeRoleCommandCreator implements CliCommandCreator
 {
   @Override
-  public void addCommands(Cli.CliBuilder builder)
+  public void addCommands(CliBuilder builder)
   {
     builder.withGroup("server").withCommands(CliCustomNodeRole.class);
   }

--- a/integration-tests/src/main/java/org/apache/druid/cli/QueryRetryTestCommandCreator.java
+++ b/integration-tests/src/main/java/org/apache/druid/cli/QueryRetryTestCommandCreator.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.cli;
 
-import io.airlift.airline.Cli.CliBuilder;
+import com.github.rvesse.airline.builder.CliBuilder;
 
 public class QueryRetryTestCommandCreator implements CliCommandCreator
 {

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -732,14 +732,17 @@ name: Airline
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 0.7
+version: 2.8.4
 libraries:
-  - io.airlift: airline
+  - com.github.rvesse: airline
 notices:
   - airline: |
       Copyright Notices
       =================
 
+      Copyright 2013-18 Rob Vesse <rvesse@dotnetrdf.org>
+      Copyright 2013 Fernando Hernandez <fernando@clarkparsia.com>
+      Copyright 2013 Michael Grove <mike@clarkparsia.com>
       Copyright 2011 Dain Sundstrom <dain@iq80.com>
       Copyright 2010 Cedric Beust <cedric@beust.com>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1505,13 +1505,13 @@ libraries:
 
 ---
 
-name: Javax Inject
+name: Jakarta Dependency Injection
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1
+version: 1.0.3
 libraries:
-  - javax.inject: javax.inject
+  - jakarta.inject: jakarta.inject-api
 
 ---
 
@@ -3516,16 +3516,6 @@ license_name: Eclipse Public License 2.0
 libraries:
   - org.glassfish.hk2: osgi-resource-locator
   
----
-
-name: jakarta.inject
-version: 1.0.3
-license_category: binary
-module: java-core
-license_name: Apache License version 2.0
-libraries:
-  - org.jakarta: jakarta.inject-api
-
 ---
 
 name: jakarta.inject

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1515,6 +1515,16 @@ libraries:
 
 ---
 
+name: Javax Inject
+license_category: binary
+module: java-core
+license_name: Apache License version 2.0
+version: 1
+libraries:
+  - javax.inject: javax.inject
+
+---
+
 name: Bean Validation API
 license_category: binary
 module: java-core

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -735,6 +735,7 @@ license_name: Apache License version 2.0
 version: 2.8.4
 libraries:
   - com.github.rvesse: airline
+  - com.github.rvesse: airline-io
 notices:
   - airline: |
       Copyright Notices
@@ -3515,6 +3516,16 @@ license_name: Eclipse Public License 2.0
 libraries:
   - org.glassfish.hk2: osgi-resource-locator
   
+---
+
+name: jakarta.inject
+version: 1.0.3
+license_category: binary
+module: java-core
+license_name: Apache License version 2.0
+libraries:
+  - org.jakarta: jakarta.inject-api
+
 ---
 
 name: jakarta.inject

--- a/pom.xml
+++ b/pom.xml
@@ -465,9 +465,9 @@
                 <version>1.1.0.Final</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>1</version>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>1.0.3</version>
             </dependency>
             <dependency>
                 <groupId>javax.el</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -278,16 +278,9 @@
                 <version>1.0.4</version>
             </dependency>
             <dependency>
-                <groupId>io.airlift</groupId>
+                <groupId>com.github.rvesse</groupId>
                 <artifactId>airline</artifactId>
-                <version>0.7</version>
-                <exclusions>
-                    <exclusion>
-                        <!--LGPL licenced library-->
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>annotations</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>2.8.4</version>
             </dependency>
             <dependency>
                 <groupId>org.skife.config</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -145,12 +145,12 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -149,8 +149,8 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -67,8 +67,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -32,7 +32,7 @@
 
     <dependencies>
         <!-- include druid-core to prevent older versions of dependencies
-        from being pulled in by airline and dependencies of druid-server -->
+        from being pulled in by dependencies of druid-server -->
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-core</artifactId>
@@ -70,7 +70,7 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.airlift</groupId>
+            <groupId>com.github.rvesse</groupId>
             <artifactId>airline</artifactId>
         </dependency>
         <dependency>

--- a/services/src/main/java/org/apache/druid/cli/CliBroker.java
+++ b/services/src/main/java/org/apache/druid/cli/CliBroker.java
@@ -19,13 +19,13 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
-import io.airlift.airline.Command;
 import org.apache.druid.client.BrokerInternalQueryConfig;
 import org.apache.druid.client.BrokerSegmentWatcherConfig;
 import org.apache.druid.client.BrokerServerView;

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -21,6 +21,7 @@ package org.apache.druid.cli;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
@@ -33,7 +34,6 @@ import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
 import com.google.inject.util.Providers;
-import io.airlift.airline.Command;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.druid.audit.AuditManager;
 import org.apache.druid.client.CoordinatorSegmentWatcherConfig;

--- a/services/src/main/java/org/apache/druid/cli/CliHadoopIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliHadoopIndexer.java
@@ -19,11 +19,12 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import org.apache.druid.guice.ExtensionsConfig;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.initialization.Initialization;
@@ -50,7 +51,8 @@ public class CliHadoopIndexer implements Runnable
 
   private static final Logger log = new Logger(CliHadoopIndexer.class);
 
-  @Arguments(description = "A JSON object or the path to a file that contains a JSON object", required = true)
+  @Arguments(description = "A JSON object or the path to a file that contains a JSON object")
+  @Required
   private String argumentSpec;
 
   @Option(name = {"-c", "--coordinate", "hadoopDependencies"},
@@ -58,8 +60,7 @@ public class CliHadoopIndexer implements Runnable
   private List<String> coordinates;
 
   @Option(name = "--no-default-hadoop",
-          description = "don't pull down the default hadoop version",
-          required = false)
+          description = "don't pull down the default hadoop version")
   public boolean noDefaultHadoop;
 
   @Inject

--- a/services/src/main/java/org/apache/druid/cli/CliHadoopIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliHadoopIndexer.java
@@ -57,6 +57,7 @@ public class CliHadoopIndexer implements Runnable
 
   @Option(name = {"-c", "--coordinate", "hadoopDependencies"},
           description = "extra dependencies to pull down (e.g. non-default hadoop coordinates or extra hadoop jars)")
+  @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
   private List<String> coordinates;
 
   @Option(name = "--no-default-hadoop",

--- a/services/src/main/java/org/apache/druid/cli/CliHistorical.java
+++ b/services/src/main/java/org/apache/druid/cli/CliHistorical.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -27,7 +28,6 @@ import com.google.inject.Inject;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
-import io.airlift.airline.Command;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.curator.ZkEnablementConfig;
 import org.apache.druid.discovery.NodeRole;

--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
@@ -27,7 +28,6 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
-import io.airlift.airline.Command;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.client.DruidServerConfig;
 import org.apache.druid.curator.ZkEnablementConfig;

--- a/services/src/main/java/org/apache/druid/cli/CliInternalHadoopIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliInternalHadoopIndexer.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
@@ -26,8 +29,6 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Command;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.indexer.HadoopDruidDetermineConfigurationJob;
 import org.apache.druid.indexer.HadoopDruidIndexerConfig;
@@ -61,7 +62,8 @@ public class CliInternalHadoopIndexer extends GuiceRunnable
 {
   private static final Logger log = new Logger(CliHadoopIndexer.class);
 
-  @Arguments(description = "A JSON object or the path to a file that contains a JSON object", required = true)
+  @Arguments(description = "A JSON object or the path to a file that contains a JSON object")
+  @Required
   private String argumentSpec;
 
   private HadoopDruidIndexerConfig config;

--- a/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
@@ -30,7 +31,6 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
 import com.google.inject.util.Providers;
-import io.airlift.airline.Command;
 import org.apache.druid.client.indexing.HttpIndexingServiceClient;
 import org.apache.druid.client.indexing.IndexingServiceClient;
 import org.apache.druid.curator.ZkEnablementConfig;

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -20,6 +20,7 @@
 package org.apache.druid.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
@@ -33,7 +34,6 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.google.inject.servlet.GuiceFilter;
 import com.google.inject.util.Providers;
-import io.airlift.airline.Command;
 import org.apache.druid.audit.AuditManager;
 import org.apache.druid.client.indexing.HttpIndexingServiceClient;
 import org.apache.druid.client.indexing.IndexingService;

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -20,6 +20,10 @@
 package org.apache.druid.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
@@ -33,9 +37,6 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import io.netty.util.SuppressForbidden;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.client.coordinator.CoordinatorClient;
@@ -143,7 +144,8 @@ import java.util.Set;
 public class CliPeon extends GuiceRunnable
 {
   @SuppressWarnings("WeakerAccess")
-  @Arguments(description = "task.json status.json report.json", required = true)
+  @Arguments(description = "task.json status.json report.json")
+  @Required
   public List<String> taskAndStatusFile;
 
   // path to store the task's stdout log

--- a/services/src/main/java/org/apache/druid/cli/CliRouter.java
+++ b/services/src/main/java/org/apache/druid/cli/CliRouter.java
@@ -19,13 +19,13 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
-import io.airlift.airline.Command;
 import org.apache.druid.curator.discovery.DiscoveryModule;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.Jerseys;

--- a/services/src/main/java/org/apache/druid/cli/CreateTables.java
+++ b/services/src/main/java/org/apache/druid/cli/CreateTables.java
@@ -19,12 +19,13 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import org.apache.druid.guice.DruidProcessingModule;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
@@ -44,13 +45,16 @@ import java.util.List;
 )
 public class CreateTables extends GuiceRunnable
 {
-  @Option(name = "--connectURI", description = "Database JDBC connection string", required = true)
+  @Option(name = "--connectURI", description = "Database JDBC connection string")
+  @Required
   private String connectURI;
 
-  @Option(name = "--user", description = "Database username", required = true)
+  @Option(name = "--user", description = "Database username")
+  @Required
   private String user;
 
-  @Option(name = "--password", description = "Database password", required = true)
+  @Option(name = "--password", description = "Database password")
+  @Required
   private String password;
 
   @Option(name = "--base", description = "Base table name")

--- a/services/src/main/java/org/apache/druid/cli/DumpSegment.java
+++ b/services/src/main/java/org/apache/druid/cli/DumpSegment.java
@@ -21,6 +21,9 @@ package org.apache.druid.cli;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -32,8 +35,6 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import io.netty.util.SuppressForbidden;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ConciseBitmapFactory;
@@ -120,48 +121,42 @@ public class DumpSegment extends GuiceRunnable
   @Option(
       name = {"-d", "--directory"},
       title = "directory",
-      description = "Directory containing segment data.",
-      required = true)
+      description = "Directory containing segment data.")
+  @Required
   public String directory;
 
   @Option(
       name = {"-o", "--out"},
       title = "file",
-      description = "File to write to, or omit to write to stdout.",
-      required = false)
+      description = "File to write to, or omit to write to stdout.")
   public String outputFileName;
 
   @Option(
       name = {"--filter"},
       title = "json",
-      description = "Filter, JSON encoded, or omit to include all rows. Only used if dumping rows.",
-      required = false)
+      description = "Filter, JSON encoded, or omit to include all rows. Only used if dumping rows.")
   public String filterJson = null;
 
   @Option(
       name = {"-c", "--column"},
       title = "column",
-      description = "Column to include, specify multiple times for multiple columns, or omit to include all columns.",
-      required = false)
+      description = "Column to include, specify multiple times for multiple columns, or omit to include all columns.")
   public List<String> columnNamesFromCli = new ArrayList<>();
 
   @Option(
       name = "--time-iso8601",
-      title = "Format __time column in ISO8601 format rather than long. Only used if dumping rows.",
-      required = false)
+      title = "Format __time column in ISO8601 format rather than long. Only used if dumping rows.")
   public boolean timeISO8601 = false;
 
   @Option(
       name = "--dump",
       title = "type",
-      description = "Dump either 'rows' (default), 'metadata', or 'bitmaps'",
-      required = false)
+      description = "Dump either 'rows' (default), 'metadata', or 'bitmaps'")
   public String dumpTypeString = DumpType.ROWS.toString();
 
   @Option(
       name = "--decompress-bitmaps",
-      title = "Dump bitmaps as arrays rather than base64-encoded compressed bitmaps. Only used if dumping bitmaps.",
-      required = false)
+      title = "Dump bitmaps as arrays rather than base64-encoded compressed bitmaps. Only used if dumping bitmaps.")
   public boolean decompressBitmaps = false;
 
   @Override

--- a/services/src/main/java/org/apache/druid/cli/ExportMetadata.java
+++ b/services/src/main/java/org/apache/druid/cli/ExportMetadata.java
@@ -21,14 +21,15 @@ package org.apache.druid.cli;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.opencsv.CSVParser;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import org.apache.druid.guice.DruidProcessingModule;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
@@ -64,7 +65,8 @@ import java.util.UUID;
 )
 public class ExportMetadata extends GuiceRunnable
 {
-  @Option(name = "--connectURI", description = "Database JDBC connection string", required = true)
+  @Option(name = "--connectURI", description = "Database JDBC connection string")
+  @Required
   private String connectURI;
 
   @Option(name = "--user", description = "Database username")
@@ -79,50 +81,43 @@ public class ExportMetadata extends GuiceRunnable
   @Option(
       name = {"-b", "--s3bucket"},
       title = "s3bucket",
-      description = "S3 bucket of the migrated segments",
-      required = false)
+      description = "S3 bucket of the migrated segments")
   public String s3Bucket = null;
 
   @Option(
       name = {"-k", "--s3baseKey"},
       title = "s3baseKey",
-      description = "S3 baseKey of the migrated segments",
-      required = false)
+      description = "S3 baseKey of the migrated segments")
   public String s3baseKey = null;
 
   @Option(
       name = {"-h", "--hadoopStorageDirectory"},
       title = "hadoopStorageDirectory",
-      description = "hadoopStorageDirectory of the migrated segments",
-      required = false)
+      description = "hadoopStorageDirectory of the migrated segments")
   public String hadoopStorageDirectory = null;
 
   @Option(
       name = {"-n", "--newLocalPath"},
       title = "newLocalPath",
-      description = "newLocalPath of the migrated segments",
-      required = false)
+      description = "newLocalPath of the migrated segments")
   public String newLocalPath = null;
 
   @Option(
       name = {"-o", "--output-path"},
       title = "output-path",
-      description = "CSV output path",
-      required = false)
+      description = "CSV output path")
   public String outputPath = null;
 
   @Option(
       name = {"-x", "--use-hex-blobs"},
       title = "use-hex-blobs",
-      description = "Write BLOB payloads as hex strings",
-      required = false)
+      description = "Write BLOB payloads as hex strings")
   public boolean useHexBlobs = false;
 
   @Option(
       name = {"-t", "--booleans-as-strings"},
       title = "booleans-as-strings",
-      description = "Write boolean values as true/false strings instead of 1/0",
-      required = false)
+      description = "Write boolean values as true/false strings instead of 1/0")
   public boolean booleansAsStrings = false;
 
   private static final Logger log = new Logger(ExportMetadata.class);

--- a/services/src/main/java/org/apache/druid/cli/Main.java
+++ b/services/src/main/java/org/apache/druid/cli/Main.java
@@ -19,10 +19,11 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.Cli;
+import com.github.rvesse.airline.builder.CliBuilder;
+import com.github.rvesse.airline.help.Help;
+import com.github.rvesse.airline.parser.errors.ParseException;
 import com.google.inject.Injector;
-import io.airlift.airline.Cli;
-import io.airlift.airline.Help;
-import io.airlift.airline.ParseException;
 import io.netty.util.SuppressForbidden;
 import org.apache.druid.cli.validate.DruidJsonValidator;
 import org.apache.druid.guice.ExtensionsConfig;
@@ -49,7 +50,7 @@ public class Main
   @SuppressForbidden(reason = "System#out")
   public static void main(String[] args)
   {
-    final Cli.CliBuilder<Runnable> builder = Cli.builder("druid");
+    final CliBuilder<Runnable> builder = Cli.builder("druid");
 
     builder.withDescription("Druid command-line runner.")
            .withDefaultCommand(Help.class)

--- a/services/src/main/java/org/apache/druid/cli/PullDependencies.java
+++ b/services/src/main/java/org/apache/druid/cli/PullDependencies.java
@@ -19,14 +19,14 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.inject.Inject;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import io.netty.util.SuppressForbidden;
 import io.tesla.aether.Repository;
 import io.tesla.aether.TeslaAether;
@@ -253,7 +253,7 @@ public class PullDependencies implements Runnable
   )
   public String proxyPassword = "";
 
-  @SuppressWarnings("unused")  // used by io.airlift:airline
+  @SuppressWarnings("unused")  // used by com.github.rvesse.airline
   public PullDependencies()
   {
     hadoopExclusions = Dependencies.builder()

--- a/services/src/main/java/org/apache/druid/cli/ResetCluster.java
+++ b/services/src/main/java/org/apache/druid/cli/ResetCluster.java
@@ -19,12 +19,12 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import org.apache.druid.guice.DruidProcessingModule;
 import org.apache.druid.guice.IndexingServiceTaskLogsModule;
 import org.apache.druid.guice.JsonConfigProvider;

--- a/services/src/main/java/org/apache/druid/cli/ValidateSegments.java
+++ b/services/src/main/java/org/apache/druid/cli/ValidateSegments.java
@@ -19,13 +19,14 @@
 
 package org.apache.druid.cli;
 
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Command;
 import org.apache.druid.guice.DruidProcessingModule;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
 import org.apache.druid.guice.QueryableModule;
@@ -51,9 +52,8 @@ public class ValidateSegments extends GuiceRunnable
     super(log);
   }
 
-  @Arguments(
-      description = "Two directories where each directory contains segment files to validate.",
-      required = true)
+  @Arguments(description = "Two directories where each directory contains segment files to validate.")
+  @Required
   public List<String> directories;
 
   @Override

--- a/services/src/main/java/org/apache/druid/cli/Version.java
+++ b/services/src/main/java/org/apache/druid/cli/Version.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.cli;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import io.netty.util.SuppressForbidden;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.initialization.Initialization;

--- a/services/src/main/java/org/apache/druid/cli/validate/DruidJsonValidator.java
+++ b/services/src/main/java/org/apache/druid/cli/validate/DruidJsonValidator.java
@@ -21,6 +21,9 @@ package org.apache.druid.cli.validate;
 
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -30,8 +33,6 @@ import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import io.netty.util.SuppressForbidden;
 import org.apache.commons.io.output.NullWriter;
 import org.apache.druid.cli.GuiceRunnable;
@@ -76,16 +77,18 @@ public class DruidJsonValidator extends GuiceRunnable
   private static final Logger LOG = new Logger(DruidJsonValidator.class);
   private Writer logWriter = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8));
 
-  @Option(name = "-f", title = "file", description = "file to validate", required = true)
+  @Option(name = "-f", title = "file", description = "file to validate")
+  @Required
   public String jsonFile;
 
-  @Option(name = "-t", title = "type", description = "the type of schema to validate", required = true)
+  @Option(name = "-t", title = "type", description = "the type of schema to validate")
+  @Required
   public String type;
 
-  @Option(name = "-r", title = "resource", description = "optional resources required for validation", required = false)
+  @Option(name = "-r", title = "resource", description = "optional resources required for validation")
   public String resource;
 
-  @Option(name = "--log", title = "toLogger", description = "redirects any outputs to logger", required = false)
+  @Option(name = "--log", title = "toLogger", description = "redirects any outputs to logger")
   public boolean toLogger;
 
   public DruidJsonValidator()

--- a/services/src/test/java/org/apache/druid/cli/CliMainTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliMainTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.cli;
+
+import org.junit.Test;
+
+public class CliMainTest
+{
+  @Test
+  public void testHelp()
+  {
+    Main.main(new String[]{"help"});
+  }
+}

--- a/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.cli.validate;
 
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rvesse.airline.Cli;
 import com.google.inject.Injector;
-import io.airlift.airline.Cli;
 import org.apache.druid.guice.FirehoseModule;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.indexing.common.task.RealtimeIndexTask;

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -114,6 +114,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
     </dependency>
@@ -132,10 +136,6 @@
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-multibindings</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.inject</groupId>
-      <artifactId>jakarta.inject-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -134,8 +134,8 @@
       <artifactId>guice-multibindings</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
* upgrade Airline to Airline 2
https://github.com/airlift/airline is no longer maintained, updating to
https://github.com/rvesse/airline (Airline 2) to use an actively
maintained version, while minimizing breaking changes.

Note, this is a backwards incompatible change, and extensions relying on
the CliCommandCreator extension point will also need to be updated.

* fix dependency checks where jakart.inject is now resolved first instead
  of java.inject, due to Airline 2 using jakarta