### PR TITLE
Stop altering the query timeout in ScanQueryEngine

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
@@ -408,7 +408,6 @@ public abstract class ResponseContext
 
     /**
      * Query fail time (current time + timeout).
-     * It is not updated continuously as {@link Keys#TIMEOUT_AT}.
      */
     public static final Key QUERY_FAIL_DEADLINE_MILLIS = new LongKey(
         "queryFailTime",
@@ -417,8 +416,6 @@ public abstract class ResponseContext
     /**
      * This variable indicates when a running query should be expired,
      * and is effective only when 'timeout' of queryContext has a positive value.
-     * Continuously updated by {@link org.apache.druid.query.scan.ScanQueryEngine}
-     * by reducing its value on the time of every scan iteration.
      */
     public static final Key TIMEOUT_AT = new LongKey(
         "timeoutAt",

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
@@ -73,7 +73,6 @@ public class ScanQueryEngine
     }
     final boolean hasTimeout = QueryContexts.hasTimeout(query);
     final Long timeoutAt = responseContext.getTimeoutTime();
-    final long start = System.currentTimeMillis();
     final StorageAdapter adapter = segment.asStorageAdapter();
 
     if (adapter == null) {
@@ -185,11 +184,6 @@ public class ScanQueryEngine
                               throw new UOE("resultFormat[%s] is not supported", resultFormat.toString());
                             }
                             responseContext.addRowScanCount(offset - lastOffset);
-                            if (hasTimeout) {
-                              responseContext.putTimeoutTime(
-                                  timeoutAt - (System.currentTimeMillis() - start)
-                              );
-                            }
                             return new ScanResultValue(segmentId.toString(), allColumns, events);
                           }
 

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryRunnerTest.java
@@ -896,7 +896,8 @@ public class ScanQueryRunnerTest extends InitializedNullHandlingTest
         .context(ImmutableMap.of(QueryContexts.TIMEOUT_KEY, 1))
         .build();
     ResponseContext responseContext = DefaultResponseContext.createEmpty();
-    responseContext.putTimeoutTime(System.currentTimeMillis());
+    final long timeoutAt = System.currentTimeMillis();
+    responseContext.putTimeoutTime(timeoutAt);
     try {
       runner.run(QueryPlus.wrap(query), responseContext).toList();
       Assert.fail("didn't timeout");
@@ -904,6 +905,7 @@ public class ScanQueryRunnerTest extends InitializedNullHandlingTest
     catch (RuntimeException e) {
       Assert.assertTrue(e instanceof QueryTimeoutException);
       Assert.assertEquals("Query timeout", ((QueryTimeoutException) e).getErrorCode());
+      Assert.assertEquals(timeoutAt, responseContext.getTimeoutTime().longValue());
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/12197.

### Description

See https://github.com/apache/druid/issues/12197#issuecomment-1025143613 for details.

I'll squash the commits later, it's just to let you check that the current code fails on the added test.


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
