### PR TITLE
partially run tests with Java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,8 +110,10 @@ jobs:
       # who watches the watchers?
       script: ./check_test_suite_test.py
 
-    - name: "(openjdk8) strict compilation"
+    - name: "(openjdk11) strict compilation"
       install: skip
+      # errorprone requires JDK 11
+      jdk: openjdk11
       # Strict compilation requires more than 2 GB
       script: >
         ./check_test_suite.py && travis_terminate 0 || MAVEN_OPTS='-Xmx3000m' ${MVN} clean -DstrictCompile compile test-compile --fail-at-end

--- a/.travis.yml
+++ b/.travis.yml
@@ -324,9 +324,9 @@ jobs:
       jdk: openjdk11
 
     - <<: *test_server_module
-      name: "(openjdk15) server module test"
+      name: "(openjdk17) server module test"
       stage: Tests - phase 2
-      jdk: openjdk15
+      jdk: openjdk17
 
     - &test_server_module_sqlcompat
       <<: *test_server_module

--- a/.travis.yml
+++ b/.travis.yml
@@ -188,9 +188,13 @@ jobs:
       jdk: openjdk11
     
     - <<: *package
-      name: "(openjdk17) packaging check"
+      name: "(openjdk17) packaging check (no dist)"
       stage: Tests - phase 2
       jdk: openjdk17
+      # disable "dist" profile until we can upgrade guice
+      script: >
+        MAVEN_OPTS='-Xmx3000m' ${MVN} clean install -Prat -Pbundle-contrib-exts --fail-at-end
+        -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Ddruid.console.skip=false -T1C
 
     - &test_processing_module
       name: "(openjdk8) processing module test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -186,9 +186,9 @@ jobs:
       jdk: openjdk11
     
     - <<: *package
-      name: "(openjdk15) packaging check"
+      name: "(openjdk17) packaging check"
       stage: Tests - phase 2
-      jdk: openjdk15
+      jdk: openjdk17
 
     - &test_processing_module
       name: "(openjdk8) processing module test"
@@ -257,9 +257,9 @@ jobs:
       jdk: openjdk11
 
     - <<: *test_processing_module
-      name: "(openjdk15) processing module test"
+      name: "(openjdk17) processing module test"
       stage: Tests - phase 2
-      jdk: openjdk15
+      jdk: openjdk17
 
     - &test_processing_module_sqlcompat
       <<: *test_processing_module
@@ -274,9 +274,9 @@ jobs:
       jdk: openjdk11
 
     - <<: *test_processing_module_sqlcompat
-      name: "(openjdk15) processing module test (SQL Compatibility)"
+      name: "(openjdk17) processing module test (SQL Compatibility)"
       stage: Tests - phase 2
-      jdk: openjdk15
+      jdk: openjdk17
 
     - &test_indexing_module
       <<: *test_processing_module
@@ -337,9 +337,9 @@ jobs:
       jdk: openjdk11
 
     - <<: *test_server_module_sqlcompat
-      name: "(openjdk15) server module test (SQL Compatibility)"
+      name: "(openjdk17) server module test (SQL Compatibility)"
       stage: Tests - phase 2
-      jdk: openjdk15
+      jdk: openjdk17
 
     - &test_other_modules
       <<: *test_processing_module

--- a/core/src/main/java/org/apache/druid/guice/JsonConfigurator.java
+++ b/core/src/main/java/org/apache/druid/guice/JsonConfigurator.java
@@ -235,6 +235,7 @@ public class JsonConfigurator
   }
 
   @VisibleForTesting
+  @SuppressWarnings("ReturnValueIgnored")
   public static <T> void verifyClazzIsConfigurable(
       ObjectMapper mapper,
       Class<T> clazz,

--- a/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
+++ b/core/src/main/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProvider.java
@@ -21,6 +21,7 @@ package org.apache.druid.metadata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
@@ -51,9 +52,15 @@ public class EnvironmentVariableDynamicConfigProvider implements DynamicConfigPr
   {
     HashMap<String, String> map = new HashMap<>();
     for (Map.Entry<String, String> entry : variables.entrySet()) {
-      map.put(entry.getKey(), System.getenv(entry.getValue()));
+      map.put(entry.getKey(), getEnv(entry.getValue()));
     }
     return map;
+  }
+
+  @VisibleForTesting
+  protected String getEnv(String var)
+  {
+    return System.getenv(var);
   }
 
   @Override

--- a/core/src/test/java/org/apache/druid/java/util/common/RetryUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/RetryUtilsTest.java
@@ -96,7 +96,7 @@ public class RetryUtilsTest
   }
 
   @Test
-  public void testExceptionPredicateNotMatching() throws Exception
+  public void testExceptionPredicateNotMatching()
   {
     final AtomicInteger count = new AtomicInteger();
     Assert.assertThrows("uhh", IOException.class, () -> {
@@ -116,7 +116,7 @@ public class RetryUtilsTest
   }
 
   @Test(timeout = 5000L)
-  public void testInterruptWhileSleepingBetweenTries() throws ExecutionException, InterruptedException
+  public void testInterruptWhileSleepingBetweenTries()
   {
     ExecutorService exec = Execs.singleThreaded("test-interrupt");
     try {
@@ -141,7 +141,7 @@ public class RetryUtilsTest
   }
 
   @Test(timeout = 5000L)
-  public void testInterruptRetryLoop() throws ExecutionException, InterruptedException
+  public void testInterruptRetryLoop()
   {
     ExecutorService exec = Execs.singleThreaded("test-interrupt");
     try {

--- a/core/src/test/java/org/apache/druid/java/util/common/RetryUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/RetryUtilsTest.java
@@ -24,11 +24,8 @@ import com.google.common.base.Predicates;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.druid.java.util.RetryableException;
 import org.apache.druid.java.util.common.concurrent.Execs;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -38,17 +35,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class RetryUtilsTest
 {
-  private static final Predicate<Throwable> IS_TRANSIENT = new Predicate<Throwable>()
-  {
-    @Override
-    public boolean apply(Throwable e)
-    {
-      return e instanceof IOException && e.getMessage().equals("what");
-    }
-  };
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  private static final Predicate<Throwable> IS_TRANSIENT =
+      e -> e instanceof IOException && e.getMessage().equals("what");
 
   @Test
   public void testImmediateSuccess() throws Exception
@@ -111,8 +99,7 @@ public class RetryUtilsTest
   public void testExceptionPredicateNotMatching() throws Exception
   {
     final AtomicInteger count = new AtomicInteger();
-    boolean threwExpectedException = false;
-    try {
+    Assert.assertThrows("uhh", IOException.class, () -> {
       RetryUtils.retry(
           () -> {
             if (count.incrementAndGet() >= 2) {
@@ -124,11 +111,7 @@ public class RetryUtilsTest
           IS_TRANSIENT,
           3
       );
-    }
-    catch (IOException e) {
-      threwExpectedException = e.getMessage().equals("uhh");
-    }
-    Assert.assertTrue("threw expected exception", threwExpectedException);
+    });
     Assert.assertEquals("count", 1, count.get());
   }
 
@@ -150,10 +133,7 @@ public class RetryUtilsTest
           Integer.MAX_VALUE
       ));
 
-      expectedException.expect(ExecutionException.class);
-      expectedException.expectCause(CoreMatchers.instanceOf(InterruptedException.class));
-      expectedException.expectMessage("sleep interrupted");
-      future.get();
+      Assert.assertThrows("sleep interrupted", ExecutionException.class, future::get);
     }
     finally {
       exec.shutdownNow();
@@ -181,10 +161,7 @@ public class RetryUtilsTest
           true
       ));
 
-      expectedException.expect(ExecutionException.class);
-      expectedException.expectCause(CoreMatchers.instanceOf(RuntimeException.class));
-      expectedException.expectMessage("Current thread is interrupted after [2] tries");
-      future.get();
+      Assert.assertThrows("Current thread is interrupted after [2] tries", ExecutionException.class, future::get);
     }
     finally {
       exec.shutdownNow();

--- a/core/src/test/java/org/apache/druid/java/util/emitter/core/HttpEmitterTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/core/HttpEmitterTest.java
@@ -24,8 +24,8 @@ import com.google.common.primitives.Ints;
 import org.asynchttpclient.ListenableFuture;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -79,7 +79,7 @@ public class HttpEmitterTest
     emitter.emitAndReturnBatch(new IntEvent());
     emitter.flush();
     long fillTimeMs = System.currentTimeMillis() - startMs;
-    Assert.assertThat((double) timeoutUsed.get(), Matchers.lessThan(fillTimeMs * (timeoutAllowanceFactor + 0.5)));
+    MatcherAssert.assertThat((double) timeoutUsed.get(), Matchers.lessThan(fillTimeMs * (timeoutAllowanceFactor + 0.5)));
 
     startMs = System.currentTimeMillis();
     final Batch batch = emitter.emitAndReturnBatch(new IntEvent());
@@ -87,6 +87,6 @@ public class HttpEmitterTest
     batch.seal();
     emitter.flush();
     fillTimeMs = System.currentTimeMillis() - startMs;
-    Assert.assertThat((double) timeoutUsed.get(), Matchers.lessThan(fillTimeMs * (timeoutAllowanceFactor + 0.5)));
+    MatcherAssert.assertThat((double) timeoutUsed.get(), Matchers.lessThan(fillTimeMs * (timeoutAllowanceFactor + 0.5)));
   }
 }

--- a/core/src/test/java/org/apache/druid/java/util/metrics/ClockDriftSafeMonitorSchedulerTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/ClockDriftSafeMonitorSchedulerTest.java
@@ -58,18 +58,20 @@ public class ClockDriftSafeMonitorSchedulerTest
   private ExecutorService cronTaskRunner;
   @Mock
   private CronScheduler cronScheduler;
-  
+  private AutoCloseable mocks;
+
   @Before
   public void setUp()
   {
     cronTaskRunner = Execs.singleThreaded("monitor-scheduler-test");
-    MockitoAnnotations.initMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
   }
 
   @After
-  public void tearDown()
+  public void tearDown() throws Exception
   {
     cronTaskRunner.shutdownNow();
+    mocks.close();
   }
   
   @Test

--- a/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
+++ b/core/src/test/java/org/apache/druid/metadata/EnvironmentVariableDynamicConfigProviderTest.java
@@ -21,89 +21,48 @@ package org.apache.druid.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class EnvironmentVariableDynamicConfigProviderTest
 {
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-  private static final Map<String, String> CHANGED_ENV_MAP = new HashMap<>();
-
-  @BeforeClass
-  public static void setupTest() throws Exception
-  {
-    Map<String, String> oldEnvMap = getENVMap();
-    Map<String, String> addEnvMap = ImmutableMap.of("DRUID_USER", "druid", "DRUID_PASSWORD", "123");
-    for (Map.Entry<String, String> entry : addEnvMap.entrySet()) {
-      CHANGED_ENV_MAP.put(entry.getKey(), oldEnvMap.get(entry.getKey()));
-      oldEnvMap.put(entry.getKey(), entry.getValue());
-    }
-  }
-
-  @AfterClass
-  public static void tearDownTest() throws Exception
-  {
-    Map<String, String> oldEnvMap = getENVMap();
-    for (Map.Entry<String, String> entry : CHANGED_ENV_MAP.entrySet()) {
-      if (entry.getValue() == null) {
-        oldEnvMap.remove(entry.getKey());
-      } else {
-        oldEnvMap.put(entry.getKey(), entry.getValue());
-      }
-    }
-  }
-
   @Test
   public void testSerde() throws IOException
   {
+    final ObjectMapper objectMapper = new ObjectMapper();
+
     String providerString = "{\"type\": \"environment\", \"variables\" : {\"testKey\":\"testValue\"}}";
-    DynamicConfigProvider provider = JSON_MAPPER.readValue(providerString, DynamicConfigProvider.class);
+    DynamicConfigProvider provider = objectMapper.readValue(providerString, DynamicConfigProvider.class);
     Assert.assertTrue(provider instanceof EnvironmentVariableDynamicConfigProvider);
     Assert.assertEquals("testValue", ((EnvironmentVariableDynamicConfigProvider) provider).getVariables().get("testKey"));
-    DynamicConfigProvider serde = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(provider), DynamicConfigProvider.class);
+    DynamicConfigProvider serde = objectMapper.readValue(objectMapper.writeValueAsString(provider), DynamicConfigProvider.class);
     Assert.assertEquals(provider, serde);
   }
 
   @Test
-  public void testGetConfig() throws Exception
+  public void testGetConfig()
   {
-    String providerString = "{\"type\": \"environment\", \"variables\" : {\"user\":\"DRUID_USER\",\"password\":\"DRUID_PASSWORD\"}}";
-    DynamicConfigProvider provider = JSON_MAPPER.readValue(providerString, DynamicConfigProvider.class);
-    Assert.assertTrue(provider instanceof EnvironmentVariableDynamicConfigProvider);
-    Assert.assertEquals("druid", ((EnvironmentVariableDynamicConfigProvider) provider).getConfig().get("user"));
-    Assert.assertEquals("123", ((EnvironmentVariableDynamicConfigProvider) provider).getConfig().get("password"));
-  }
+    final ImmutableMap<String, String> env = ImmutableMap.of(
+        "DRUID_USER",
+        "druid",
+        "DRUID_PASSWORD",
+        "123"
+    );
 
-  /**
-   * This method use reflection to get system environment variables map in runtime JVM
-   * which can be changed.
-   *
-   * @return system environment variables map.
-   */
-  private static Map<String, String> getENVMap() throws Exception
-  {
-    Map<String, String> envMap = null;
-    Class[] classes = Collections.class.getDeclaredClasses();
-    Map<String, String> systemEnv = System.getenv();
-    for (Class cl : classes) {
-      if ("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
-        Field field = cl.getDeclaredField("m");
-        field.setAccessible(true);
-        Object object = field.get(systemEnv);
-        envMap = (Map<String, String>) object;
+    Map<String, String> config = ImmutableMap.of("user", "DRUID_USER", "password", "DRUID_PASSWORD");
+    EnvironmentVariableDynamicConfigProvider provider = new EnvironmentVariableDynamicConfigProvider(config)
+    {
+      @Override
+      protected String getEnv(String var)
+      {
+        return env.containsKey(var) ? env.get(var) : super.getEnv(var);
       }
-    }
-    if (envMap == null) {
-      throw new RuntimeException("Failed to get environment map.");
-    }
-    return envMap;
+    };
+
+    Assert.assertEquals("druid", provider.getConfig().get("user"));
+    Assert.assertEquals("123", provider.getConfig().get("password"));
   }
 }

--- a/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftInputRowParser.java
+++ b/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftInputRowParser.java
@@ -74,6 +74,7 @@ public class ThriftInputRowParser implements InputRowParser<Object>
     this.dimensions = parseSpec.getDimensionsSpec().getDimensionNames();
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public Class<TBase> getThriftClass()
       throws IOException, ClassNotFoundException, IllegalAccessException, InstantiationException
   {

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -343,7 +343,7 @@ name: Error Prone Annotations
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.8.0
+version: 2.11.0
 libraries:
   - com.google.errorprone: error_prone_annotations
 
@@ -3731,7 +3731,7 @@ name: DataSketches
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 3.0.0
+version: 3.1.0
 libraries:
   - org.apache.datasketches: datasketches-java
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3731,7 +3731,7 @@ name: DataSketches
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 3.1.0
+version: 3.0.0
 libraries:
   - org.apache.datasketches: datasketches-java
 

--- a/pom.xml
+++ b/pom.xml
@@ -1488,7 +1488,10 @@
               <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <!--- stay on M4 until M6 is released with a fix for
+                    https://issues.apache.org/jira/browse/SUREFIRE-1815
+                    causing issues in RetryUtilsTest -->
+                    <version>3.0.0-M4</version>
                     <configuration>
                         <!-- locale settings must be set on the command line before startup -->
                         <!-- set default options -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,19 @@
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
 
+        <common.test.jvm.args>
+          -Xmx1500m
+          -XX:MaxDirectMemorySize=2500m
+          <!-- locale settings must be set on the command line before startup -->
+          -Dfile.encoding=UTF-8
+          -Duser.language=en
+          -Duser.timezone=UTC
+          -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+          -Duser.GroupByQueryRunnerTest.javacountry=US
+          -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
+          <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
+          -Ddruid.indexing.doubleStorage=double
+        </common.test.jvm.args>
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
     </properties>
@@ -1493,22 +1506,9 @@
                     causing issues in RetryUtilsTest -->
                     <version>3.0.0-M4</version>
                     <configuration>
-                        <!-- locale settings must be set on the command line before startup -->
-                        <!-- set default options -->
                         <argLine>
                             @{jacocoArgLine}
-                            <!-- for datasketches-memory access to DirectByteBuffer until Java 17 is supported -->
-                            --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-                            -Xmx1500m
-                            -XX:MaxDirectMemorySize=512m
-                            -Duser.language=en
-                            -Duser.GroupByQueryRunnerTest.javacountry=US
-                            -Dfile.encoding=UTF-8
-                            -Duser.timezone=UTC
-                            -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
-                            -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
-                            <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
-                            -Ddruid.indexing.doubleStorage=double
+                            ${common.test.jvm.args}
                         </argLine>
                         <trimStackTrace>false</trimStackTrace>
                         <!-- our tests are very verbose, let's keep the volume down -->
@@ -1651,6 +1651,20 @@
                             <release>${java.version}</release>
                         </configuration>
                     </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-surefire-plugin</artifactId>
+                      <configuration>
+                          <argLine>
+                            @{jacocoArgLine}
+                            <!-- for datasketches-memory access to DirectByteBuffer until Java 17 is supported -->
+                            --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                            <!-- for EqualsVerifier in org.apache.druid.segment.filter tests with Java 17 -->
+                            --add-opens java.base/java.util=ALL-UNNAMED
+                            ${common.test.jvm.args}
+                          </argLine>
+                      </configuration>
+                    </plugin>
                 </plugins>
             </build>
           </profile>
@@ -1702,7 +1716,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                  <release>${java.version}</release>
                   <compilerArgs combine.children="append">
                     <!-- Error Prone requires exemptions for Java >= 16, see https://errorprone.info/docs/installation#maven -->
                     <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <!-- sql/src/main/codegen/config.fmpp is based on a file from calcite-core, and needs to be
           updated when upgrading Calcite. Refer to the top-level comments in that file for details. -->
         <calcite.version>1.21.0</calcite.version>
-        <datasketches.version>3.1.0</datasketches.version>
+        <datasketches.version>3.0.0</datasketches.version>
         <datasketches.memory.version>2.0.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1106,7 +1106,7 @@
             <dependency>
                 <groupId>nl.jqno.equalsverifier</groupId>
                 <artifactId>equalsverifier</artifactId>
-                <version>3.5.5</version>
+                <version>3.9</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1262,7 +1262,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.15.0</version>
+                <version>3.16.0</version>
                 <configuration>
                     <linkXRef>false</linkXRef> <!-- prevent "Unable to locate Source XRef to link to" warning -->
                     <printFailingErrors>true</printFailingErrors>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <datasketches.memory.version>2.0.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
-        <errorprone.version>2.8.0</errorprone.version>
+        <errorprone.version>2.11.0</errorprone.version>
         <fastutil.version>8.5.4</fastutil.version>
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1705,7 +1705,7 @@
                 <configuration>
                   <release>${java.version}</release>
                   <compilerArgs combine.children="append">
-                    <!-- Error Prone requires exemptions for Java 16, see https://errorprone.info/docs/installation#jdk-16 -->
+                    <!-- Error Prone requires exemptions for Java >= 16, see https://errorprone.info/docs/installation#maven -->
                     <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                     <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                     <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <!-- sql/src/main/codegen/config.fmpp is based on a file from calcite-core, and needs to be
           updated when upgrading Calcite. Refer to the top-level comments in that file for details. -->
         <calcite.version>1.21.0</calcite.version>
-        <datasketches.version>3.0.0</datasketches.version>
+        <datasketches.version>3.1.0</datasketches.version>
         <datasketches.memory.version>2.0.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1689,6 +1689,17 @@
                             <compilerArgs>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-(test-)?sources/.* -XepDisableWarningsInGeneratedCode -Xep:ClassCanBeStatic:ERROR -Xep:PreconditionsInvalidPlaceholder:ERROR -Xep:MissingOverride:ERROR -Xep:DefaultCharset:ERROR -Xep:QualifierOrScopeOnInjectMethod:ERROR -Xep:AssistedInjectAndInjectOnSameConstructor -Xep:AutoFactoryAtInject -Xep:ClassName -Xep:ComparisonContractViolated -Xep:DepAnn -Xep:DivZero -Xep:EmptyIf -Xep:InjectInvalidTargetingOnScopingAnnotation  -Xep:InjectMoreThanOneQualifier -Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass -Xep:InjectScopeOrQualifierAnnotationRetention -Xep:InjectedConstructorAnnotations -Xep:InsecureCryptoUsage -Xep:JMockTestWithoutRunWithOrRuleAnnotation -Xep:JavaxInjectOnFinalField -Xep:LockMethodChecker -Xep:LongLiteralLowerCaseSuffix -Xep:NoAllocation -Xep:NonRuntimeAnnotation -Xep:NumericEquality -Xep:ProtoStringFieldReferenceEquality -Xep:UnlockMethod</arg>
+                                <!-- Error Prone requires exemptions for Java >= 16, see https://errorprone.info/docs/installation#maven -->
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                               </compilerArgs>
                               <annotationProcessorPaths>
                                 <path>
@@ -1701,38 +1712,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-          <id>strict-java-15+</id>
-          <activation>
-            <jdk>[15,)</jdk>
-            <property>
-              <name>strictCompile</name>
-            </property>
-          </activation>
-          <build>
-            <plugins>
-              <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                  <compilerArgs combine.children="append">
-                    <!-- Error Prone requires exemptions for Java >= 16, see https://errorprone.info/docs/installation#maven -->
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                  </compilerArgs>
-                </configuration>
-              </plugin>
-            </plugins>
-          </build>
         </profile>
         <profile>
             <id>parallel-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1497,6 +1497,8 @@
                         <!-- set default options -->
                         <argLine>
                             @{jacocoArgLine}
+                            <!-- for datasketches-memory access to DirectByteBuffer until Java 17 is supported -->
+                            --add-opens java.base/sun.nio.ch=ALL-UNNAMED
                             -Xmx1500m
                             -XX:MaxDirectMemorySize=512m
                             -Duser.language=en
@@ -1774,6 +1776,7 @@
                                 -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
                                 <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
                                 -Ddruid.indexing.doubleStorage=double
+                                --illegal-access=warn
                             </argLine>
                             <!-- our tests are very verbose, let's keep the volume down -->
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/pom.xml
+++ b/pom.xml
@@ -1670,9 +1670,8 @@
                             <fork>true</fork>
                             <meminitial>1024m</meminitial>
                             <maxmem>3000m</maxmem>
-                            <source>${maven.compiler.source}</source>
-                            <target>${maven.compiler.target}</target>
-                            <showWarnings>false</showWarnings>
+                          <release>${java.version}</release>
+                          <showWarnings>false</showWarnings>
                             <compilerArgs>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-(test-)?sources/.* -XepDisableWarningsInGeneratedCode -Xep:ClassCanBeStatic:ERROR -Xep:PreconditionsInvalidPlaceholder:ERROR -Xep:MissingOverride:ERROR -Xep:DefaultCharset:ERROR -Xep:QualifierOrScopeOnInjectMethod:ERROR -Xep:AssistedInjectAndInjectOnSameConstructor -Xep:AutoFactoryAtInject -Xep:ClassName -Xep:ComparisonContractViolated -Xep:DepAnn -Xep:DivZero -Xep:EmptyIf -Xep:InjectInvalidTargetingOnScopingAnnotation  -Xep:InjectMoreThanOneQualifier -Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass -Xep:InjectScopeOrQualifierAnnotationRetention -Xep:InjectedConstructorAnnotations -Xep:InsecureCryptoUsage -Xep:JMockTestWithoutRunWithOrRuleAnnotation -Xep:JavaxInjectOnFinalField -Xep:LockMethodChecker -Xep:LongLiteralLowerCaseSuffix -Xep:NoAllocation -Xep:NonRuntimeAnnotation -Xep:NumericEquality -Xep:ProtoStringFieldReferenceEquality -Xep:UnlockMethod</arg>
@@ -1716,31 +1715,6 @@
                     <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                     <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                     <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                  </compilerArgs>
-                </configuration>
-              </plugin>
-            </plugins>
-          </build>
-        </profile>
-        <!-- using github.com/google/error-prone-javac is required when running on JDK 8
-             see https://errorprone.info/docs/installation#jdk-8 -->
-        <profile>
-          <id>strict-java-8</id>
-          <activation>
-            <jdk>1.8</jdk>
-            <property>
-              <name>strictCompile</name>
-            </property>
-          </activation>
-          <build>
-            <plugins>
-              <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                  <fork>true</fork>
-                  <compilerArgs combine.children="append">
-                    <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/9+181-r4173-1/javac-9+181-r4173-1.jar</arg>
                   </compilerArgs>
                 </configuration>
               </plugin>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -282,33 +282,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- locale settings must be set on the command line before startup -->
-                    <!-- set default options -->
-                    <argLine>
-                        @{jacocoArgLine}
-                        <!-- for datasketches-memory access to DirectByteBuffer until Java 17 is supported -->
-                        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-                        <!-- for EqualsVerifier in org.apache.druid.segment.filter tests -->
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                        -Xmx512m
-                        -XX:MaxDirectMemorySize=2500m
-                        -Duser.language=en
-                        -Duser.GroupByQueryRunnerTest.javacountry=US
-                        -Dfile.encoding=UTF-8
-                        -Duser.timezone=UTC
-                        -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
-                        <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
-                        -Ddruid.indexing.doubleStorage=double
-                    </argLine>
-                    <!-- our tests are very verbose, let's keep the volume down -->
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <excludedGroups>org.apache.druid.collections.test.annotation.Benchmark</excludedGroups>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -290,6 +290,10 @@
                     <!-- set default options -->
                     <argLine>
                         @{jacocoArgLine}
+                        <!-- for datasketches-memory access to DirectByteBuffer until Java 17 is supported -->
+                        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                        <!-- for EqualsVerifier in org.apache.druid.segment.filter tests -->
+                        --add-opens java.base/java.util=ALL-UNNAMED
                         -Xmx512m
                         -XX:MaxDirectMemorySize=2500m
                         -Duser.language=en

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcherTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcherTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.data.ArrayBasedIndexedInts;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,22 +61,26 @@ public class IndexedTableJoinMatcherTest
   {
     public static class MakeLongProcessorTest extends InitializedNullHandlingTest
     {
-      @Rule
-      public ExpectedException expectedException = ExpectedException.none();
-
       @Mock
       private BaseLongColumnValueSelector selector;
+      private AutoCloseable mocks;
 
       @Before
       public void setUp()
       {
-        MockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
 
         if (NullHandling.sqlCompatible()) {
           Mockito.doReturn(false).when(selector).isNull();
         }
 
         Mockito.doReturn(1L).when(selector).getLong();
+      }
+
+      @After
+      public void tearDown() throws Exception
+      {
+        mocks.close();
       }
 
       @Test
@@ -115,8 +120,7 @@ public class IndexedTableJoinMatcherTest
             new IndexedTableJoinMatcher.ConditionMatcherFactory(longAlwaysOneTwoThreeIndex());
         final IndexedTableJoinMatcher.ConditionMatcher processor = conditionMatcherFactory.makeLongProcessor(selector);
 
-        expectedException.expect(UnsupportedOperationException.class);
-        processor.matchSingleRow();
+        Assert.assertThrows(UnsupportedOperationException.class, processor::matchSingleRow);
       }
 
       @Test
@@ -147,11 +151,18 @@ public class IndexedTableJoinMatcherTest
 
       @Mock
       private BaseObjectColumnValueSelector<?> selector;
+      private AutoCloseable mocks;
 
       @Before
       public void setUp()
       {
-        MockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
+      }
+
+      @After
+      public void tearDown() throws Exception
+      {
+        mocks.close();
       }
 
       @Test
@@ -190,85 +201,93 @@ public class IndexedTableJoinMatcherTest
       private static final String KEY = "key";
 
       @Test
-      public void testMatchMultiValuedRowCardinalityUnknownShouldThrowException()
+      public void testMatchMultiValuedRowCardinalityUnknownShouldThrowException() throws Exception
       {
-        MockitoAnnotations.initMocks(this);
-        ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{2, 4, 6});
-        Mockito.doReturn(row).when(dimensionSelector).getRow();
-        Mockito.doReturn(DimensionDictionarySelector.CARDINALITY_UNKNOWN).when(dimensionSelector).getValueCardinality();
+        try (final AutoCloseable mocks = MockitoAnnotations.openMocks(this)) {
+          ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{2, 4, 6});
+          Mockito.doReturn(row).when(dimensionSelector).getRow();
+          Mockito.doReturn(DimensionDictionarySelector.CARDINALITY_UNKNOWN)
+                 .when(dimensionSelector)
+                 .getValueCardinality();
 
-        IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
-            new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
-        IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
-            dimensionSelector,
-            false
-        );
+          IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
+              new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
+          IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
+              dimensionSelector,
+              false
+          );
 
-        // Test match should throw exception
-        expectedException.expect(QueryUnsupportedException.class);
-        dimensionProcessor.match();
+          // Test match should throw exception
+          expectedException.expect(QueryUnsupportedException.class);
+          dimensionProcessor.match();
+        }
       }
 
       @Test
-      public void testMatchMultiValuedRowCardinalityKnownShouldThrowException()
+      public void testMatchMultiValuedRowCardinalityKnownShouldThrowException() throws Exception
       {
-        MockitoAnnotations.initMocks(this);
-        ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{2, 4, 6});
-        Mockito.doReturn(row).when(dimensionSelector).getRow();
-        Mockito.doReturn(3).when(dimensionSelector).getValueCardinality();
+        try (final AutoCloseable mocks = MockitoAnnotations.openMocks(this)) {
+          ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{2, 4, 6});
+          Mockito.doReturn(row).when(dimensionSelector).getRow();
+          Mockito.doReturn(3).when(dimensionSelector).getValueCardinality();
 
-        IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
-            new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
-        IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
-            dimensionSelector,
-            false
-        );
+          IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
+              new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
+          IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
+              dimensionSelector,
+              false
+          );
 
-        // Test match should throw exception
-        expectedException.expect(QueryUnsupportedException.class);
-        dimensionProcessor.match();
+          // Test match should throw exception
+          expectedException.expect(QueryUnsupportedException.class);
+          dimensionProcessor.match();
+        }
       }
 
       @Test
-      public void testMatchEmptyRowCardinalityUnknown()
+      public void testMatchEmptyRowCardinalityUnknown() throws Exception
       {
-        MockitoAnnotations.initMocks(this);
-        ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{});
-        Mockito.doReturn(row).when(dimensionSelector).getRow();
-        Mockito.doReturn(DimensionDictionarySelector.CARDINALITY_UNKNOWN).when(dimensionSelector).getValueCardinality();
+        try (final AutoCloseable mocks = MockitoAnnotations.openMocks(this)) {
+          ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{});
+          Mockito.doReturn(row).when(dimensionSelector).getRow();
+          Mockito.doReturn(DimensionDictionarySelector.CARDINALITY_UNKNOWN)
+                 .when(dimensionSelector)
+                 .getValueCardinality();
 
-        IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
-            new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
-        IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
-            dimensionSelector,
-            false
-        );
+          IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
+              new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
+          IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
+              dimensionSelector,
+              false
+          );
 
-        Assert.assertNotNull(dimensionProcessor.match());
-        Assert.assertFalse(dimensionProcessor.match().hasNext());
+          Assert.assertNotNull(dimensionProcessor.match());
+          Assert.assertFalse(dimensionProcessor.match().hasNext());
 
-        Assert.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
+          Assert.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
+        }
       }
 
       @Test
-      public void testMatchEmptyRowCardinalityKnown()
+      public void testMatchEmptyRowCardinalityKnown() throws Exception
       {
-        MockitoAnnotations.initMocks(this);
-        ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{});
-        Mockito.doReturn(row).when(dimensionSelector).getRow();
-        Mockito.doReturn(0).when(dimensionSelector).getValueCardinality();
+        try (final AutoCloseable mocks = MockitoAnnotations.openMocks(this)) {
+          ArrayBasedIndexedInts row = new ArrayBasedIndexedInts(new int[]{});
+          Mockito.doReturn(row).when(dimensionSelector).getRow();
+          Mockito.doReturn(0).when(dimensionSelector).getValueCardinality();
 
-        IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
-            new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
-        IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
-            dimensionSelector,
-            false
-        );
+          IndexedTableJoinMatcher.ConditionMatcherFactory conditionMatcherFactory =
+              new IndexedTableJoinMatcher.ConditionMatcherFactory(stringToLengthIndex());
+          IndexedTableJoinMatcher.ConditionMatcher dimensionProcessor = conditionMatcherFactory.makeDimensionProcessor(
+              dimensionSelector,
+              false
+          );
 
-        Assert.assertNotNull(dimensionProcessor.match());
-        Assert.assertFalse(dimensionProcessor.match().hasNext());
+          Assert.assertNotNull(dimensionProcessor.match());
+          Assert.assertFalse(dimensionProcessor.match().hasNext());
 
-        Assert.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
+          Assert.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
+        }
       }
 
       @Test


### PR DESCRIPTION
* update maven-surefire-plugin to 3.0.0-M4 for improved compatibility with Java >= 11
   Due to https://issues.apache.org/jira/browse/SUREFIRE-1815 we need to stay on surefire 3.0.0-M4
   until we can upgrade to 3.0.0-M6, since this is causing issues in RetryUtilsTest.
* upgrade equalsverifier to fix warnings
* modify EnvironmentVariableDynamicConfigProvider test to not use reflection,
   since those classes are no longer accessible in Java 17
* add necessary `--add-opens` flags to pass tests when datasketches-memory is involved
* fix use of deprecated initMocks method
* fix mocks not getting closed
* switch some build steps from Java 15 to Java 17

Note: This doesn't mean we can run with Java 17 yet. While a good portion of the tests pass, we first need to update guice (and by extension guava) in order for dependency injection to work with 17 at runtime.