### PR TITLE
adjust topn heap operation when string is dictionary encoded, but not uniquely

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
@@ -54,7 +54,7 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
   {
     // only report the underlying selector cardinality if the column the selector is for is dictionary encoded, and
     // the dictionary values are unique, that is they have a 1:1 mapping between dictionaryId and column value
-    if (capabilities.isDictionaryEncoded().and(capabilities.areDictionaryValuesUnique()).isTrue()) {
+    if (capabilities.isDictionaryEncoded().isTrue()) {
       return selector.getValueCardinality();
     }
     return DimensionDictionarySelector.CARDINALITY_UNKNOWN;

--- a/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
@@ -135,8 +135,9 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
   }
 
   /**
-   * this method uses array aggregation since dictionaryIds are unique and value cardinality is known up front, so
-   * values are aggregated into an array position specified by the dictionaryid
+   * scan and aggregate when column is dictionary encoded and value cardinality is known up front, so values are
+   * aggregated into an array position specified by the dictionaryid, which if not already present, are translated
+   * into the key and fetched (or created if they key hasn't been encountered) from the {@link #aggregatesStore}
    */
   private long scanAndAggregateWithCardinalityKnown(
       TopNQuery query,

--- a/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
@@ -52,8 +52,7 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
   @Override
   public int getCardinality(DimensionSelector selector)
   {
-    // only report the underlying selector cardinality if the column the selector is for is dictionary encoded, and
-    // the dictionary values are unique, that is they have a 1:1 mapping between dictionaryId and column value
+    // only report the underlying selector cardinality if the column the selector is for is dictionary encoded
     if (capabilities.isDictionaryEncoded().isTrue()) {
       return selector.getValueCardinality();
     }

--- a/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.topn.types;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.topn.BaseTopNAlgorithm;
 import org.apache.druid.query.topn.TopNParams;
@@ -117,7 +118,8 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
   )
   {
     final boolean notUnknown = selector.getValueCardinality() != DimensionDictionarySelector.CARDINALITY_UNKNOWN;
-    final boolean unique = capabilities.isDictionaryEncoded().and(capabilities.areDictionaryValuesUnique()).isTrue();
+    final boolean hasDictionary = capabilities.isDictionaryEncoded().isTrue();
+    final boolean unique = capabilities.areDictionaryValuesUnique().isTrue();
     // we must know cardinality to use array based aggregation
     // we check for uniquely dictionary encoded values because non-unique (meaning dictionary ids do not have a 1:1
     // relation with values) negates many of the benefits of array aggregation:
@@ -127,8 +129,10 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
     // - in cases where the same dictionary ids map to different values (1:* or *:*), results can be entirely
     //   incorrect since an aggregator for a different value might be chosen from the array based on the re-used
     //   dictionary id
-    if (notUnknown && unique) {
-      return scanAndAggregateWithCardinalityKnown(query, cursor, selector, rowSelector);
+    if (notUnknown && hasDictionary && unique) {
+      return scanAndAggregateWithUniqueDictionary(query, cursor, selector, rowSelector);
+    } else if (hasDictionary) {
+      return scanAndAggregateWithDictionary(query, cursor, selector);
     } else {
       return scanAndAggregateWithCardinalityUnknown(query, cursor, selector);
     }
@@ -140,7 +144,11 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
     this.aggregatesStore = new HashMap<>();
   }
 
-  private long scanAndAggregateWithCardinalityKnown(
+  /**
+   * this method uses array aggregation since dictionaryIds are unique and value cardinality is known up front, so
+   * values are aggregated into an array position specified by the dictionaryid
+   */
+  private long scanAndAggregateWithUniqueDictionary(
       TopNQuery query,
       Cursor cursor,
       DimensionSelector selector,
@@ -172,6 +180,54 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
     return processedRows;
   }
 
+  /**
+   * this method uses hash table to store aggregate values ({@link #aggregatesStore}) and is geared towards selectors
+   * which have a dictionary, but those dictionary ids do not necessarily uniquely map to the value of
+   * {@link DimensionSelector#lookupName(int)}. This method keeps a cache of dictionary id to aggregators, which it uses
+   * to skip name lookup if that id has already been encountered, avoiding decoding utf8 bytes, or worse, recomputing
+   * an expression virtual column or some lookup value.
+   *
+   */
+  private long scanAndAggregateWithDictionary(
+      TopNQuery query,
+      Cursor cursor,
+      DimensionSelector selector
+  )
+  {
+    Int2ObjectOpenHashMap<Aggregator[]> aggsCache = new Int2ObjectOpenHashMap<>();
+
+    long processedRows = 0;
+    while (!cursor.isDone()) {
+      final IndexedInts dimValues = selector.getRow();
+      for (int i = 0, size = dimValues.size(); i < size; ++i) {
+        final int dimIndex = dimValues.get(i);
+        Aggregator[] aggs = aggsCache.get(dimIndex);
+        if (aggs == null) {
+          final Comparable<?> key = dimensionValueConverter.apply(selector.lookupName(dimIndex));
+          aggs = aggregatesStore.computeIfAbsent(
+              key,
+              k -> BaseTopNAlgorithm.makeAggregators(cursor, query.getAggregatorSpecs())
+          );
+          aggsCache.put(dimIndex, aggs);
+        }
+        for (Aggregator aggregator : aggs) {
+          aggregator.aggregate();
+        }
+      }
+      cursor.advance();
+      processedRows++;
+    }
+    return processedRows;
+  }
+
+  /**
+   * this method is to allow scan and aggregate when values are not dictionary encoded
+   * (e.g. {@link DimensionSelector#nameLookupPossibleInAdvance()} is false and/or when
+   * {@link ColumnCapabilities#isDictionaryEncoded()} is false). This mode also uses hash table aggregation, storing
+   * results in {@link #aggregatesStore}, and must call {@link DimensionSelector#lookupName(int)} for every row which
+   * is processed and cannot cache lookups, or use the dictionary id in any way other than to lookup the current row
+   * value.
+   */
   private long scanAndAggregateWithCardinalityUnknown(
       TopNQuery query,
       Cursor cursor,


### PR DESCRIPTION
### Description
This PR switches `StringTopNColumnAggregatesProcessor`, the string processor used for heap based topN, to use `scanAndAggregateWithCardinalityKnown` for the case where a column is dictionary encoded, but not uniquely, so avoid duplicate decoding of `utf8` bytes from the segment or recomputing expression virtual columns that occur on lookupName in some types of expression selectors. This is potentially worse for things like `IndexedTable`, where dictionaryId might be the row number, so will still have to access the `aggregatesStore` map for every row, but better for things like extractions and expressions on top of "normal" dictionary encoded columns.

The existing topn tests should provide adequate coverage for this change, but will confirm this with the coverage bot once it runs in travis.

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
