### PR TITLE
Improve dictionary#indexOf routine with sparse index

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/DictionaryWrapperBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/DictionaryWrapperBenchmark.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.google.common.collect.Iterables;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.GenericIndexedWriter;
+import org.apache.druid.segment.data.Indexed;
+import org.apache.druid.segment.data.SparseArrayIndexed;
+import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+public class DictionaryWrapperBenchmark
+{
+  @Param({"1000000"})
+  public int cardinality = 1 << 20;
+
+  @Param({"10000"})
+  public int searchNum = 10000;
+
+  @Param({"16"})
+  public int strLen = 16;
+
+  @Param({"0", "512", "1024", "2048", "4096", "8192"})
+  public int indexGranularity = 1024;
+
+  @Param({"array"})
+  public String sparseType = "array";
+
+  private File file;
+  private File smooshDir;
+  private Indexed<String> dictionary;
+
+  private String[] strings;
+  private List<String> elementsToSearch;
+
+  @Setup
+  public void setup() throws IOException
+  {
+    NullHandling.initializeForTests();
+
+    strings = Iterables.toArray(getStringSet(cardinality, strLen, 0, 128), String.class);
+    Arrays.sort(strings, GenericIndexed.STRING_STRATEGY);
+    double prob = 1.0D * searchNum / cardinality;
+    elementsToSearch = new ArrayList<>(searchNum);
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (String str : strings) {
+      if (random.nextDouble() < prob) {
+        elementsToSearch.add(NullHandling.emptyToNullIfNeeded(str));
+      }
+    }
+    setupDictionary();
+  }
+
+  private void setupDictionary() throws IOException
+  {
+    String filename = UUID.randomUUID().toString();
+    GenericIndexedWriter<String> genericIndexedWriter = new GenericIndexedWriter<>(
+        new OffHeapMemorySegmentWriteOutMedium(),
+        filename,
+        GenericIndexed.STRING_STRATEGY
+    );
+    genericIndexedWriter.open();
+
+    for (String str : strings) {
+      genericIndexedWriter.write(str);
+    }
+    smooshDir = FileUtils.createTempDir();
+    file = File.createTempFile(filename, "meta");
+
+    try (FileChannel fileChannel =
+             FileChannel.open(file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+         FileSmoosher fileSmoosher = new FileSmoosher(smooshDir)) {
+      genericIndexedWriter.writeTo(fileChannel, fileSmoosher);
+    }
+
+    FileChannel fileChannel = FileChannel.open(file.toPath());
+    MappedByteBuffer byteBuffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, file.length());
+    GenericIndexed<String> genericIndexes = GenericIndexed.read(
+        byteBuffer,
+        GenericIndexed.STRING_STRATEGY,
+        SmooshedFileMapper.load(smooshDir)
+    );
+
+    if (indexGranularity > 0) {
+      this.dictionary = new SparseArrayIndexed<>(genericIndexes, indexGranularity);
+    } else {
+      dictionary = genericIndexes;
+    }
+  }
+
+  @Benchmark
+  public int indexOf()
+  {
+    int r = 0;
+    for (String elementToSearch : elementsToSearch) {
+      r ^= dictionary.indexOf(elementToSearch);
+    }
+    return r;
+  }
+
+  private static Set<String> getStringSet(int n, int size, int min, int max)
+  {
+    Set<String> strings = new HashSet<>();
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    while (strings.size() < n) {
+      strings.add(getString(random.nextInt(size), min, max));
+    }
+    return strings;
+  }
+
+  @Nullable
+  private static String getString(int len, int min, int max)
+  {
+    Random random = ThreadLocalRandom.current();
+    if (len == 0 && random.nextBoolean()) {
+      return null;
+    }
+    StringBuilder builder = new StringBuilder(len);
+    for (int i = 0; i < len; i++) {
+      builder.append(Character.toChars(random.nextInt(max - min) + min));
+    }
+    return builder.toString();
+  }
+
+  /**
+   * This main() is for debugging from the IDE.
+   */
+  public static void main(String[] args) throws RunnerException, IOException
+  {
+    NullHandling.initializeForTests();
+
+    DictionaryWrapperBenchmark benchmark = new DictionaryWrapperBenchmark();
+    benchmark.setup();
+
+    for (String str : benchmark.elementsToSearch) {
+      int expect = benchmark.dictionary.indexOf(str);
+      int actual = Arrays.binarySearch(benchmark.strings, str, GenericIndexed.STRING_STRATEGY);
+      if (expect < 0 || expect != actual) {
+        throw new ISE("index of %s fail, expect:%d, actual:%d", str, expect, actual);
+      }
+    }
+
+    Options opt = new OptionsBuilder()
+        .include(DictionaryWrapperBenchmark.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/guice/ConfigModule.java
+++ b/processing/src/main/java/org/apache/druid/guice/ConfigModule.java
@@ -19,10 +19,13 @@
 
 package org.apache.druid.guice;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import org.apache.druid.java.util.common.config.Config;
+import org.apache.druid.segment.column.DictionaryWrapStrategy;
+import org.apache.druid.segment.data.DictionaryDummyWrapStrategy;
 import org.skife.config.ConfigurationObjectFactory;
 
 import javax.validation.Validation;
@@ -43,6 +46,13 @@ public class ConfigModule implements Module
   @Provides @LazySingleton
   public ConfigurationObjectFactory makeFactory(Properties props)
   {
-    return Config.createFactory(props);
+    ConfigurationObjectFactory factory = Config.createFactory(props);
+    JsonMapperCoercible jsonMapperCoercible = new JsonMapperCoercible(
+        new ObjectMapper(),
+        DictionaryWrapStrategy.class,
+        new DictionaryDummyWrapStrategy<>()
+    );
+    factory.addCoercible(jsonMapperCoercible);
+    return factory;
   }
 }

--- a/processing/src/main/java/org/apache/druid/guice/JsonMapperCoercible.java
+++ b/processing/src/main/java/org/apache/druid/guice/JsonMapperCoercible.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.guice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.skife.config.Coercer;
+import org.skife.config.Coercible;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class JsonMapperCoercible<T> implements Coercible<T>
+{
+  private static final Logger log = new Logger(JsonMapperCoercible.class);
+  private final ObjectMapper mapper;
+  private final Class<T> clazz;
+  private final T defaultVal;
+
+  public JsonMapperCoercible(ObjectMapper mapper, Class<T> clazz, T defaultVal)
+  {
+    this.mapper = mapper;
+    this.clazz = clazz;
+    this.defaultVal = defaultVal;
+  }
+
+  @Override
+  public Coercer<T> accept(Class<?> clazz)
+  {
+    if (this.clazz != clazz) {
+      return null;
+    }
+    return new Coercer<T>()
+    {
+      @Override
+      public T coerce(String value)
+      {
+        if (Strings.isNullOrEmpty(value)) {
+          return defaultVal;
+        }
+        try {
+          return mapper.readValue(value, JsonMapperCoercible.this.clazz);
+        }
+        catch (IOException e) {
+          log.warn(e, "coerce %s error,will use default value", JsonMapperCoercible.this.clazz.getSimpleName());
+        }
+        return defaultVal;
+      }
+    };
+  }
+}
+

--- a/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
@@ -25,6 +25,8 @@ import org.apache.druid.java.util.common.concurrent.ExecutorServiceConfig;
 import org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.column.ColumnConfig;
+import org.apache.druid.segment.column.DictionaryWrapStrategy;
+import org.apache.druid.segment.data.DictionaryDummyWrapStrategy;
 import org.apache.druid.utils.JvmUtils;
 import org.skife.config.Config;
 
@@ -39,6 +41,7 @@ public abstract class DruidProcessingConfig extends ExecutorServiceConfig implem
   public static final int MAX_DEFAULT_PROCESSING_BUFFER_SIZE_BYTES = 1024 * 1024 * 1024;
   public static final int DEFAULT_MERGE_POOL_AWAIT_SHUTDOWN_MILLIS = 60_000;
   public static final int DEFAULT_INITIAL_BUFFERS_FOR_INTERMEDIATE_POOL = 0;
+  public static final DictionaryWrapStrategy<Object> DEFAULT_DICTIONARY_WRAP_STRATEGY = new DictionaryDummyWrapStrategy<>();
 
   private AtomicReference<Integer> computedBufferSizeBytes = new AtomicReference<>();
 
@@ -148,6 +151,13 @@ public abstract class DruidProcessingConfig extends ExecutorServiceConfig implem
   public int columnCacheSizeBytes()
   {
     return 0;
+  }
+
+  @Override
+  @Config(value = "${base_path}.dictionary.wrapper")
+  public DictionaryWrapStrategy dictionaryWrapStrategy()
+  {
+    return DEFAULT_DICTIONARY_WRAP_STRATEGY;
   }
 
   @Config(value = "${base_path}.fifo")

--- a/processing/src/main/java/org/apache/druid/segment/IndexIO.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexIO.java
@@ -456,7 +456,7 @@ public class IndexIO
                 new StringBitmapIndexColumnPartSupplier(
                     new ConciseBitmapFactory(),
                     index.getBitmapIndexes().get(dimension),
-                    index.getDimValueLookup(dimension)
+                    columnConfig.<String>dictionaryWrapStrategy().wrap(index.getDimValueLookup(dimension))
                 )
             );
         if (index.getSpatialIndexes().get(dimension) != null) {

--- a/processing/src/main/java/org/apache/druid/segment/column/DictionaryWrapStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/DictionaryWrapStrategy.java
@@ -19,14 +19,19 @@
 
 package org.apache.druid.segment.column;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.segment.data.DictionaryDummyWrapStrategy;
+import org.apache.druid.segment.data.DictionarySparseIndexWrapStrategy;
+import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.Indexed;
 
-public interface ColumnConfig
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = DictionaryDummyWrapStrategy.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "default", value = DictionaryDummyWrapStrategy.class),
+    @JsonSubTypes.Type(name = "sparseIndex", value = DictionarySparseIndexWrapStrategy.class),
+})
+public interface DictionaryWrapStrategy<T>
 {
-  int columnCacheSizeBytes();
-
-  default <T> DictionaryWrapStrategy<T> dictionaryWrapStrategy()
-  {
-    return new DictionaryDummyWrapStrategy<>();
-  }
+  Indexed<T> wrap(GenericIndexed<T> indexed);
 }

--- a/processing/src/main/java/org/apache/druid/segment/data/DictionaryDummyWrapStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/DictionaryDummyWrapStrategy.java
@@ -17,16 +17,15 @@
  * under the License.
  */
 
-package org.apache.druid.segment.column;
+package org.apache.druid.segment.data;
 
-import org.apache.druid.segment.data.DictionaryDummyWrapStrategy;
+import org.apache.druid.segment.column.DictionaryWrapStrategy;
 
-public interface ColumnConfig
+public class DictionaryDummyWrapStrategy<T> implements DictionaryWrapStrategy<T>
 {
-  int columnCacheSizeBytes();
-
-  default <T> DictionaryWrapStrategy<T> dictionaryWrapStrategy()
+  @Override
+  public Indexed<T> wrap(GenericIndexed<T> indexed)
   {
-    return new DictionaryDummyWrapStrategy<>();
+    return indexed;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/data/DictionarySparseIndexWrapStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/DictionarySparseIndexWrapStrategy.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.segment.column.DictionaryWrapStrategy;
+
+import java.util.Objects;
+
+public class DictionarySparseIndexWrapStrategy<T> implements DictionaryWrapStrategy<T>
+{
+  private final int rowThreshold;
+  private final int indexLimit;
+  private final int defaultGranularity;
+
+  @JsonCreator
+  public DictionarySparseIndexWrapStrategy(
+      @JsonProperty("defaultGranularity") int defaultGranularity,
+      @JsonProperty("rowThreshold") int rowThreshold,
+      @JsonProperty("indexLimit") int indexLimit
+  )
+  {
+    this.defaultGranularity = defaultGranularity > 0 ? defaultGranularity : 1024;
+    this.rowThreshold = rowThreshold > 0 ? rowThreshold : 64 << 10;
+    this.indexLimit = indexLimit > 0 ? indexLimit : 512;
+  }
+
+  @Override
+  public Indexed<T> wrap(GenericIndexed<T> indexed)
+  {
+    if (indexed.size() >= rowThreshold) {
+      int indexGranularity = Math.min(defaultGranularity, indexed.size() / indexLimit);
+      return new SparseArrayIndexed<>(indexed, indexGranularity);
+    }
+    return indexed;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DictionarySparseIndexWrapStrategy<?> that = (DictionarySparseIndexWrapStrategy<?>) o;
+    return rowThreshold == that.rowThreshold
+           && indexLimit == that.indexLimit
+           && defaultGranularity == that.defaultGranularity;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(rowThreshold, indexLimit, defaultGranularity);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DictionarySparseArrayIndexWrapper{" +
+           "rowThreshold=" + rowThreshold +
+           ", indexLimit=" + indexLimit +
+           ", defaultGranularity=" + defaultGranularity +
+           '}';
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
@@ -43,6 +43,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 
 /**
@@ -140,6 +141,8 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
 
   public static final ObjectStrategy<String> STRING_STRATEGY = new ObjectStrategy<String>()
   {
+    final Comparator<String> comparator = Comparators.naturalNullsFirst();
+
     @Override
     public Class<String> getClazz()
     {
@@ -162,7 +165,7 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
     @Override
     public int compare(String o1, String o2)
     {
-      return Comparators.<String>naturalNullsFirst().compare(o1, o2);
+      return comparator.compare(o1, o2);
     }
   };
 
@@ -323,6 +326,11 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
     return strategy.getClazz();
   }
 
+  public ObjectStrategy<T> getStrategy()
+  {
+    return strategy;
+  }
+
   @Override
   public int size()
   {
@@ -350,12 +358,25 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
     return indexOf(this, value);
   }
 
+  public int indexOf(@Nullable T value, int minIndex, int maxIndex)
+  {
+    return indexOf(this, value, minIndex, maxIndex);
+  }
+
   private int indexOf(Indexed<T> indexed, @Nullable T value)
   {
     if (!allowReverseLookup) {
       throw new UnsupportedOperationException("Reverse lookup not allowed.");
     }
     return Indexed.indexOf(indexed::get, size, strategy, value);
+  }
+
+  private int indexOf(Indexed<T> indexed, @Nullable T value, int minIndex, int maxIndex)
+  {
+    if (!allowReverseLookup) {
+      throw new UnsupportedOperationException("Reverse lookup not allowed.");
+    }
+    return Indexed.indexOf(indexed::get, strategy, value, minIndex, maxIndex);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
@@ -69,6 +69,17 @@ public interface Indexed<T> extends Iterable<T>, HotLoopCallee
   {
     int minIndex = 0;
     int maxIndex = size - 1;
+    return indexOf(indexed, comparator, value, minIndex, maxIndex);
+  }
+
+  static <T> int indexOf(
+      IndexedGetter<T> indexed,
+      Comparator<T> comparator,
+      @Nullable T value,
+      int minIndex,
+      int maxIndex
+  )
+  {
     while (minIndex <= maxIndex) {
       int currIndex = (minIndex + maxIndex) >>> 1;
 

--- a/processing/src/main/java/org/apache/druid/segment/data/SparseArrayIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/SparseArrayIndexed.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+
+public class SparseArrayIndexed<T> implements Indexed<T>, Closeable
+{
+  private final GenericIndexed<T> delegate;
+  private final Object[] cacheValues;
+  private final int indexGranularity;
+
+  public SparseArrayIndexed(GenericIndexed<T> delegate, final int indexGranularity)
+  {
+    this.delegate = delegate;
+
+    this.indexGranularity = indexGranularity;
+    final int size = delegate.size();
+    final int len = (size + indexGranularity - 1) / indexGranularity;
+
+    cacheValues = new Object[len];
+    for (int i = 0; i < cacheValues.length; i++) {
+      cacheValues[i] = delegate.get(getValueIndex(i));
+    }
+  }
+
+  @Override
+  public int size()
+  {
+    return delegate.size();
+  }
+
+  @Override
+  public T get(int index)
+  {
+    return delegate.get(index);
+  }
+
+  @Override
+  public int indexOf(@Nullable T value)
+  {
+    int index = Arrays.binarySearch(cacheValues, value, (Comparator) delegate.getStrategy());
+    if (index >= 0) {
+      return getValueIndex(index);
+    }
+    int insertPos = -index - 1;
+    if (insertPos == 0) {
+      return -1;
+    }
+
+    int maxIndex = Math.min(size() - 1, getValueIndex(insertPos));
+    int minIndex = Math.max(0, getValueIndex(insertPos - 1));
+    return delegate.indexOf(value, minIndex, maxIndex);
+  }
+
+  private int getValueIndex(int cacheIndex)
+  {
+    return indexGranularity * cacheIndex;
+  }
+
+  @Override
+  public Iterator<T> iterator()
+  {
+    return delegate.iterator();
+  }
+
+  @Override
+  public void close()
+  {
+  }
+
+  @Override
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+  {
+    inspector.visit("cachedValues", cacheValues.length);
+    inspector.visit("delegate", delegate);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
@@ -353,7 +353,7 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
               new StringBitmapIndexColumnPartSupplier(
                   bitmapSerdeFactory.getBitmapFactory(),
                   rBitmaps,
-                  rDictionary
+                  columnConfig.<String>dictionaryWrapStrategy().wrap(rDictionary)
               )
           );
         }

--- a/processing/src/main/java/org/apache/druid/segment/serde/StringBitmapIndexColumnPartSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/StringBitmapIndexColumnPartSupplier.java
@@ -24,6 +24,7 @@ import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.segment.column.BitmapIndex;
 import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.Indexed;
 
 import javax.annotation.Nullable;
 
@@ -35,12 +36,12 @@ public class StringBitmapIndexColumnPartSupplier implements Supplier<BitmapIndex
 {
   private final BitmapFactory bitmapFactory;
   private final GenericIndexed<ImmutableBitmap> bitmaps;
-  private final GenericIndexed<String> dictionary;
+  private final Indexed<String> dictionary;
 
   public StringBitmapIndexColumnPartSupplier(
       BitmapFactory bitmapFactory,
       GenericIndexed<ImmutableBitmap> bitmaps,
-      GenericIndexed<String> dictionary
+      Indexed<String> dictionary
   )
   {
     this.bitmapFactory = bitmapFactory;

--- a/processing/src/test/java/org/apache/druid/segment/SparseArrayIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SparseArrayIndexedTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import com.google.common.collect.Iterables;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.segment.data.DictionaryDummyWrapStrategy;
+import org.apache.druid.segment.data.DictionarySparseIndexWrapStrategy;
+import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.Indexed;
+import org.apache.druid.segment.data.SparseArrayIndexed;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class SparseArrayIndexedTest
+{
+  int cardinality = 64 << 10;
+  int searchNum = 10000;
+  int strLen = 16;
+  int indexGranularity = 1024;
+  Comparator<String> comparator = GenericIndexed.STRING_STRATEGY;
+  GenericIndexed<String> genericIndexed;
+  Indexed<String> dictionary;
+  String[] strings;
+  Set<String> strSet;
+  List<String> elementsToSearch;
+
+  @Before
+  public void setup()
+  {
+    NullHandling.initializeForTests();
+
+    strSet = getStringSet(cardinality, strLen);
+    strings = Iterables.toArray(strSet, String.class);
+    Arrays.sort(strings, comparator);
+
+    double prob = 1.0D * searchNum / cardinality;
+    elementsToSearch = new ArrayList<>(searchNum);
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (String str : strings) {
+      if (random.nextDouble() < prob) {
+        elementsToSearch.add(str);
+      }
+    }
+    genericIndexed = GenericIndexed.fromArray(strings, GenericIndexed.STRING_STRATEGY);
+    this.dictionary = new SparseArrayIndexed<>(genericIndexed, indexGranularity);
+  }
+
+  @Test
+  public void testGet()
+  {
+    Assert.assertEquals(strings.length, dictionary.size());
+    Assert.assertEquals(GenericIndexed.STRING_STRATEGY, genericIndexed.getStrategy());
+    for (int i = 0; i < dictionary.size(); i++) {
+      Assert.assertEquals(
+          String.format(
+              Locale.getDefault(),
+              "index:%d not equal, expect:%s, actual:%s",
+              i,
+              strings[i],
+              dictionary.get(i)
+          ),
+          strings[i],
+          dictionary.get(i)
+      );
+    }
+  }
+
+  @Test
+  public void testIndexOf()
+  {
+    for (String str : elementsToSearch) {
+      int expect = Arrays.binarySearch(strings, str, comparator);
+      int actual = dictionary.indexOf(str);
+      Assert.assertTrue(
+          String.format(Locale.getDefault(), "index should be positive, str:%s, index:%d", str, expect),
+          expect >= 0
+      );
+      Assert.assertEquals(
+          String.format(Locale.getDefault(), "exepect index:%d not equals actual index:%d", expect, actual),
+          expect,
+          actual
+      );
+    }
+  }
+
+  @Test
+  public void testStrategy()
+  {
+    DictionaryDummyWrapStrategy dummyWrapStrategy = new DictionaryDummyWrapStrategy();
+    Assert.assertEquals(genericIndexed, dummyWrapStrategy.wrap(genericIndexed));
+
+    DictionarySparseIndexWrapStrategy sparseIndexWrapStrategy = new DictionarySparseIndexWrapStrategy(
+        256,
+        8 << 10,
+        512
+    );
+    Assert.assertTrue(sparseIndexWrapStrategy.wrap(genericIndexed) instanceof SparseArrayIndexed);
+  }
+
+  private static Set<String> getStringSet(int n, int size)
+  {
+    Set<String> strings = new HashSet<>();
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    while (strings.size() < n) {
+      strings.add(NullHandling.emptyToNullIfNeeded(getString(random.nextInt(size))));
+    }
+    return strings;
+  }
+
+  @Nullable
+  private static String getString(int len)
+  {
+    Random random = ThreadLocalRandom.current();
+    if (len == 0 && random.nextBoolean()) {
+      return null;
+    }
+    StringBuilder builder = new StringBuilder(len);
+    for (int i = 0; i < len; i++) {
+      builder.append(Character.toChars(random.nextInt(Short.MAX_VALUE)));
+    }
+    return builder.toString();
+  }
+}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Use sparse index to improve GenericIndexed#indexOf performance, especially for large dictionary.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

The sorted GenericalIndexed#indexOf use binary search to get index of one object value. This routine will call ObjectStrategy#fromByteBuffer to decode value from the byteBuffer, which is expensive.  I suggest build a sparse index for large dictionary when load it. this can get 40+% performance improvement. I made a benchmark here.

|Benchmark                           |(cardinality)  |(indexGranularity)  |(searchNum)  |(sparseType) | (strLen)  |Mode  |Cnt   |Score   |Error |  Units|
|----|---|---|---|---|---|---|---|---|---|---|
|DictionaryWrapperBenchmark.indexOf   |     1000000         |          0     |   10000     |    array     |   16 | avgt  | 10 | 23.760 |  ±2.310  | ms/op |
|DictionaryWrapperBenchmark.indexOf    |    1000000         |        512   |     10000    |     array    |    16 | avgt |  10 | 17.015 | ±4.904 | ms/op |
|DictionaryWrapperBenchmark.indexOf    |   1000000          |     1024    |    10000    |     array     |   16 | avgt  | 10 | 14.533 | ±3.370  | ms/op |
|DictionaryWrapperBenchmark.indexOf    |    1000000         |       2048   |     10000  |       array    |    16 | avgt |  10 | 13.390 | ±0.748  | ms/op |
|DictionaryWrapperBenchmark.indexOf    |    1000000         |       4096   |     10000   |      array   |     16 | avgt |  10 | 14.672 | ±1.223  | ms/op |
|DictionaryWrapperBenchmark.indexOf    |    1000000         |       8192   |     10000    |     array    |    16 | avgt  | 10 | 15.090 | ±0.721  | ms/op |


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `SparseArrayIndexed`
 * `GenericIndexed`
 * `DictionaryWrapStrategy`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
