### PR TITLE
Added support in urls, and grouped metrics

### DIFF
--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
@@ -21,6 +21,7 @@ package org.apache.druid.emitter.prometheus;
 
 
 import com.google.common.collect.ImmutableMap;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
@@ -32,6 +33,8 @@ import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -78,9 +81,24 @@ public class PrometheusEmitter implements Emitter
         log.error("HTTPServer is already started");
       }
     } else if (strategy.equals(PrometheusEmitterConfig.Strategy.pushgateway)) {
-      pushGateway = new PushGateway(config.getPushGatewayAddress());
+      String address = config.getPushGatewayAddress();
+      if (address.startsWith("https") || address.startsWith("http")) {
+        URL myURL = createURLSneakily(address);
+        pushGateway = new PushGateway(myURL);
+      } else {
+        pushGateway = new PushGateway(address);
+      }
     }
+  }
 
+  private static URL createURLSneakily(final String urlString)
+  {
+    try {
+      return new URL(urlString);
+    }
+    catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -127,15 +145,17 @@ public class PrometheusEmitter implements Emitter
   private void pushMetric()
   {
     Map<String, DimensionsAndCollector> map = metrics.getRegisteredMetrics();
-    try {
-      for (DimensionsAndCollector collector : map.values()) {
-        if (config.getNamespace() != null) {
-          pushGateway.push(collector.getCollector(), config.getNamespace(), ImmutableMap.of(config.getNamespace(), identifier));
+    CollectorRegistry metrics = new CollectorRegistry();
+    if (config.getNamespace() != null) {
+      try {
+        for (DimensionsAndCollector collector : map.values()) {
+          metrics.register(collector.getCollector());
         }
+        pushGateway.push(metrics, config.getNamespace(), ImmutableMap.of(config.getNamespace(), identifier));
       }
-    }
-    catch (IOException e) {
-      log.error(e, "Unable to push prometheus metrics to pushGateway");
+      catch (IOException e) {
+        log.error(e, "Unable to push prometheus metrics to pushGateway");
+      }
     }
   }
 

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -68,6 +68,9 @@ public class PrometheusEmitterConfig
     Preconditions.checkArgument(PATTERN.matcher(this.namespace).matches(), "Invalid namespace " + this.namespace);
     this.dimensionMapPath = dimensionMapPath;
     this.port = port;
+    if (this.strategy == Strategy.pushgateway) {
+      Preconditions.checkNotNull(pushGatewayAddress, "Invalid pushGateway address");
+    }
     this.pushGatewayAddress = pushGatewayAddress;
   }
 

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
- 
+
 package org.apache.druid.emitter.prometheus;
 
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,7 @@ import static org.easymock.EasyMock.mock;
 public class PrometheusEmitterTest
 {
   @Test
-  public void testEmitter() 
+  public void testEmitter()
   {
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, null, null, 0, null);
     PrometheusEmitterModule prometheusEmitterModule = new PrometheusEmitterModule();
@@ -108,5 +108,29 @@ public class PrometheusEmitterTest
             .build(ImmutableMap.of("service", "peon"));
     emitter.emit(build);
     emitter.flush();
+  }
+
+  @Test
+  public void testEmitterConfigCreationWithNullAsAddress()
+  {
+    Assert.assertThrows(NullPointerException.class, () -> new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, null));
+  }
+
+  @Test
+  public void testEmitterStartWithHttpUrl()
+  {
+    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, "http://pushgateway");
+    PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
+    pushEmitter.start();
+    Assert.assertNotNull(pushEmitter.getPushGateway());
+  }
+
+  @Test
+  public void testEmitterStartWithHttpsUrl()
+  {
+    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace5", null, 0, "https://pushgateway");
+    PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
+    pushEmitter.start();
+    Assert.assertNotNull(pushEmitter.getPushGateway());
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description

**In Prometheus-emitter:**
Added support in "https" and "http" pushgateway addresses which means now, users will be able to send URL as pushgateway address.
Also, we faced a problem in which we saw only the last metrics.
Apparently, each metric was sent separately and deleted the previous message.
The solution was to group all metrics and push them together.

### Related Issue - #12199 
<hr>

##### Key changed/added classes in this PR
 * `Prometheus Emitter`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage is met.