### PR TITLE
Introducing new config to make errors in jetty layer return by defaul…

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -651,7 +651,7 @@ You can configure Druid API error responses to hide internal information like th
 |--------|-----------|-------|
 |`druid.server.http.showDetailedJettyErrors`|When set to true, any error from the Jetty layer / Jetty filter includes the following fields  in the JSON response: `servlet`, `message`, `url`, `status`, and `cause`, if it exists. When set to false, the JSON response only includes `message`, `url`, and `status`. The field values remain unchanged.|true|
 |`druid.server.http.errorResponseTransform.strategy`|Error response transform strategy. The strategy controls how Druid transforms error responses from Druid services. When unset or set to `none`, Druid leaves error responses unchanged.|`none`|
-
+|`druid.server.http.returnJettyErrorsInJson`|When set to true, any error from the Jetty layer / Jetty filter is returned as a JSON response. If set to false, the error response is returned as HTML.|true|
 ##### Error response transform strategy
 
 You can use an error response transform strategy to transform error responses from within Druid services to hide internal information.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -651,7 +651,7 @@ You can configure Druid API error responses to hide internal information like th
 |--------|-----------|-------|
 |`druid.server.http.showDetailedJettyErrors`|When set to true, any error from the Jetty layer / Jetty filter includes the following fields  in the JSON response: `servlet`, `message`, `url`, `status`, and `cause`, if it exists. When set to false, the JSON response only includes `message`, `url`, and `status`. The field values remain unchanged.|true|
 |`druid.server.http.errorResponseTransform.strategy`|Error response transform strategy. The strategy controls how Druid transforms error responses from Druid services. When unset or set to `none`, Druid leaves error responses unchanged.|`none`|
-|`druid.server.http.returnJettyErrorsInJson`|When set to true, any error from the Jetty layer / Jetty filter is returned as a JSON response. If set to false, the error response is returned as HTML.|true|
+|`druid.server.http.returnJettyErrorsInJson`|When set to true, any error from the Jetty layer / Jetty filter is returned as a JSON response. If set to false, the error response is returned as HTML.|false|
 ##### Error response transform strategy
 
 You can use an error response transform strategy to transform error responses from within Druid services to hide internal information.

--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -158,6 +158,9 @@ public class ServerConfig
   @JsonProperty
   private boolean showDetailedJettyErrors = true;
 
+  @JsonProperty
+  private boolean returnJettyErrorsInJson = true;
+
   public int getNumThreads()
   {
     return numThreads;
@@ -233,6 +236,11 @@ public class ServerConfig
     return showDetailedJettyErrors;
   }
 
+  public boolean isDefaultJettyErrorResponseInJson()
+  {
+    return returnJettyErrorsInJson;
+  }
+
   public ErrorResponseTransformStrategy getErrorResponseTransformStrategy()
   {
     return errorResponseTransformStrategy;
@@ -265,6 +273,7 @@ public class ServerConfig
            compressionLevel == that.compressionLevel &&
            enableForwardedRequestCustomizer == that.enableForwardedRequestCustomizer &&
            showDetailedJettyErrors == that.showDetailedJettyErrors &&
+           returnJettyErrorsInJson == that.returnJettyErrorsInJson &&
            maxIdleTime.equals(that.maxIdleTime) &&
            maxScatterGatherBytes.equals(that.maxScatterGatherBytes) &&
            gracefulShutdownTimeout.equals(that.gracefulShutdownTimeout) &&
@@ -293,7 +302,8 @@ public class ServerConfig
         enableForwardedRequestCustomizer,
         allowedHttpMethods,
         errorResponseTransformStrategy,
-        showDetailedJettyErrors
+        showDetailedJettyErrors,
+        returnJettyErrorsInJson
     );
   }
 
@@ -318,6 +328,7 @@ public class ServerConfig
            ", allowedHttpMethods=" + allowedHttpMethods +
            ", errorResponseTransformStrategy=" + errorResponseTransformStrategy +
            ", showDetailedJettyErrors=" + showDetailedJettyErrors +
+           ", defaultJettyAcceptHeaderSetStatus=" + returnJettyErrorsInJson +
            '}';
   }
 

--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -159,7 +159,7 @@ public class ServerConfig
   private boolean showDetailedJettyErrors = true;
 
   @JsonProperty
-  private boolean returnJettyErrorsInJson = true;
+  private boolean returnJettyErrorsInJson = false;
 
   public int getNumThreads()
   {

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -417,6 +417,12 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
           }
 
           @Override
+          public boolean isDefaultJettyErrorResponseInJson()
+          {
+            return false;
+          }
+
+          @Override
           public ErrorResponseTransformStrategy getErrorResponseTransformStrategy()
           {
             return new AllowedRegexErrorResponseTransformStrategy(ImmutableList.of());

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -1381,6 +1381,12 @@ public class SqlResourceTest extends CalciteTestBase
           }
 
           @Override
+          public boolean isDefaultJettyErrorResponseInJson()
+          {
+            return false;
+          }
+
+          @Override
           public ErrorResponseTransformStrategy getErrorResponseTransformStrategy()
           {
             return new AllowedRegexErrorResponseTransformStrategy(ImmutableList.of());

--- a/website/.spelling
+++ b/website/.spelling
@@ -1338,6 +1338,7 @@ cpuName
 cpuTime
 druid.server.http.numThreads
 druid.server.http.queueSize
+druid.server.http.returnJettyErrorsInJson
 fsDevName
 fsDirName
 fsOptions


### PR DESCRIPTION
…t in json

Introduced a new config called `druid.server.http.returnJettyErrorsInJson` which by default is set to `false`. When set to true any error from the Jetty layer is returned as a JSON. In case it is set to `false`, the return type is HTML. The following combinations of `druid.server.http.showDetailedJettyErrors` and `druid.server.http.returnJettyErrorsInJson` are tested as in the table below:



druid.server.http.showDetailedJettyErrors | druid.server.http.returnJettyErrorsInJson | Query result
-- | -- | --
false | false | 1curl -X POST http://localhost:8888/druid/v2/sql -H "Content-Type:application/json" -d '{"query": "SELECT COUNT(*) from \""testNumbers\""}' 2<html> 3<head> 4<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/> 5<title>Error 500 javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 6 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</title> 7</head> 8<body><h2>HTTP ERROR 500 javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 9 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</h2> 10<table> 11<tr><th>URI:</th><td>/druid/v2/sql</td></tr> 12<tr><th>STATUS:</th><td>500</td></tr> 13<tr><th>MESSAGE:</th><td>javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 14 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</td></tr> 15</table> 16 17</body> 18</html>
false | true | 1$ curl -X POST http://localhost:8888/druid/v2/sql -H "Content-Type:application/json" -d '{"query": "SELECT COUNT(*) from \""testNumbers\""}' 2{ 3"message":"javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]", 4"url":"/druid/v2/sql", 5"status":"500" 6}
true | false | 1curl -X POST http://localhost:8888/druid/v2/sql -H "Content-Type:application/json" -d '{"query": "SELECT COUNT(*) from \""testNumbers\""}' 2<html> 3<head> 4<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/> 5<title>Error 500 javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 6 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</title> 7</head> 8<body><h2>HTTP ERROR 500 javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 9 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</h2> 10<table> 11<tr><th>URI:</th><td>/druid/v2/sql</td></tr> 12<tr><th>STATUS:</th><td>500</td></tr> 13<tr><th>MESSAGE:</th><td>javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 14 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</td></tr> 15<tr><th>SERVLET:</th><td>org.eclipse.jetty.servlet.DefaultServlet-528e5e38</td></tr> 16<tr><th>CAUSED BY:</th><td>javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 17 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</td></tr> 18<tr><th>CAUSED BY:</th><td>com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 19 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]</td></tr> 20</table> 21<h3>Caused by:</h3><pre>javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries 22 at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37] 23	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:420) 24	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:558) 25	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:733) 26	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) 27	at com.google.inject.servlet.ServletDefinition.doServiceImpl(ServletDefinition.java:286) 28	at com.google.inject.servlet.ServletDefinition.doService(ServletDefinition.java:276) 29	at com.google.inject.servlet.ServletDefinition.service(ServletDefinition.java:181) 30	at com.google.inject.servlet.ManagedServletPipeline.service(ManagedServletPipeline.java:91) 31	at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:120) 32	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:135)
true | true | 1$ curl -X POST http://localhost:8888/druid/v2/sql -H "Content-Type:application/json" -d '{"query": "SELECT COUNT(*) from \""testNumbers\""}' 2{ 3"cause1":"com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]", 4"servlet":"org.eclipse.jetty.servlet.DefaultServlet-528e5e38", 5"cause0":"javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]", 6"message":"javax.servlet.ServletException: com.fasterxml.jackson.core.JsonParseException: Unexpected character (&apos;t&apos; (code 116)): was expecting comma to separate Object entries\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 37]", 7"url":"/druid/v2/sql", 8"status":"500" 9}



This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
