### PR TITLE
Add git hooks that can run multiple scripts

### DIFF
--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -47,7 +47,7 @@ will generate a report to show the current code coverage on the code (not just y
 ## Git Checkstyle Verification Hook (Optional)
 Git Checkstyle pre-commit hook can be installed to automatically run checkstyle verification before committing, 
 saving cycle from avoiding the checkstyle failing later in Travis/CI environment.
-The hook can be setup easily by running the <DRUID_HOME>/setup-hooks.sh script.
+The hook can be setup easily by running the <DRUID_HOME>/hooks/install-hooks.sh script.
 
 ## Metadata
 The installation of a MySQL metadata store is outside the scope of this document, but instructions on setting up MySQL can be found at [docs/development/extensions-core/mysql.md](/docs/development/extensions-core/mysql.md). This assumes you followed the example there and have a database named `druid` with proper permissions for a user named `druid` and a password of `diurd`.

--- a/hooks/install-hooks.sh
+++ b/hooks/install-hooks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -eu
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,4 +15,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ln -s ../../hooks/pre-push.sh .git/hooks/pre-push
+function cp_if_not_exist(){
+  if [ -e "$2" ]
+    then
+      echo "$2 already exists!"
+      exit 1
+  else
+    cp -r "$1" "$2"
+  fi
+}
+
+if [ $# != 1 ]
+  then
+    echo 'usage: program {$DRUID_ROOT}'
+    exit 1
+fi
+
+DRUID_ROOT=$1
+
+cp_if_not_exist ${DRUID_ROOT}/hooks/run-all-in-dir.py ${DRUID_ROOT}/.git/hooks/run-all-in-dir.py
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-commit ${DRUID_ROOT}/.git/hooks/pre-commit
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-push ${DRUID_ROOT}/.git/hooks/pre-push
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-commits ${DRUID_ROOT}/.git/hooks/pre-commits
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-pushes ${DRUID_ROOT}/.git/hooks/pre-pushes

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/bash -eu
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,5 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# set thread count to 2 times of cores to speed up checking
-mvn checkstyle:checkstyle -T 2C --fail-at-end
+./run-all-in-dir.py pre-commits

--- a/hooks/pre-commits/_pre-commit.sample
+++ b/hooks/pre-commits/_pre-commit.sample
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo 'pre-commit sample'

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -19,4 +19,4 @@
 # under the License.
 #
 
-.git/hooks/run-all-in-dir.py .git/hooks/pre-pushes
+.git/hooks/run-all-in-dir.py .git/hooks/pre-pushes $1 $2

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+./run-all-in-dir.py pre-pushes

--- a/hooks/pre-pushes/_pre-push.sample
+++ b/hooks/pre-pushes/_pre-push.sample
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set thread count to 2 times of cores to speed up checking
+mvn checkstyle:checkstyle -T 2C --fail-at-end

--- a/hooks/pre-pushes/_pre-push.sample
+++ b/hooks/pre-pushes/_pre-push.sample
@@ -15,5 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# set thread count to 2 times of cores to speed up checking
-mvn checkstyle:checkstyle -T 2C --fail-at-end
+echo 'pre-push sample'

--- a/hooks/pre-pushes/checkstyle-check
+++ b/hooks/pre-pushes/checkstyle-check
@@ -15,4 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.git/hooks/run-all-in-dir.py .git/hooks/pre-commits
+# set thread count to 2 times of cores to speed up checking
+mvn checkstyle:checkstyle -T 2C --fail-at-end

--- a/hooks/run-all-in-dir.py
+++ b/hooks/run-all-in-dir.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import subprocess
+
+
+if len(sys.argv) != 2:
+	sys.stderr.write('usage: program <hooks directory>\n')
+	sys.exit(1)
+
+hooks_dir = sys.argv[1]
+
+for hook in os.listdir(hooks_dir):
+	if not hook.startswith("_"):
+		print("Running {}".format(hook))
+		subprocess.run(os.path.join(hooks_dir, hook), shell=True)

--- a/hooks/run-all-in-dir.py
+++ b/hooks/run-all-in-dir.py
@@ -20,13 +20,15 @@ import sys
 import subprocess
 
 
-if len(sys.argv) != 2:
+if len(sys.argv) < 2:
 	sys.stderr.write('usage: program <hooks directory>\n')
 	sys.exit(1)
 
 hooks_dir = sys.argv[1]
+args = sys.argv[2:]
 
 for hook in os.listdir(hooks_dir):
 	if not hook.startswith("_"):
-		print("Running {}".format(hook))
-		subprocess.run(os.path.join(hooks_dir, hook), shell=True)
+		command = [os.path.join(hooks_dir, hook)] + args
+		print("Running {}".format(command))
+		subprocess.run(command, shell=True)

--- a/hooks/uninstall-hooks.sh
+++ b/hooks/uninstall-hooks.sh
@@ -33,3 +33,5 @@ DRUID_ROOT=$1
 rm -f ${DRUID_ROOT}/.git/hooks/run-all-in-dir.py
 rm -rf ${DRUID_ROOT}/.git/hooks/pre-commits
 rm -rf ${DRUID_ROOT}/.git/hooks/pre-pushes
+
+echo "This script does not remove or modify the git hook script files in .git/hooks, such as 'pre-commit' or 'pre-push'. Those scripts should be removed or modified manually."

--- a/hooks/uninstall-hooks.sh
+++ b/hooks/uninstall-hooks.sh
@@ -19,4 +19,17 @@
 # under the License.
 #
 
-.git/hooks/run-all-in-dir.py .git/hooks/pre-pushes
+if [ $# != 1 ]
+  then
+    echo 'usage: program {$DRUID_ROOT}'
+    exit 1
+fi
+
+DRUID_ROOT=$1
+
+# This script does not remove .git/hooks/pre-commit, .git/hooks/pre-push, or any other git hook scripts
+# because those files may have user-custom hooks.
+# Instead, we remove only the files and directories that we are sure it is safe to remove.
+rm -f ${DRUID_ROOT}/.git/hooks/run-all-in-dir.py
+rm -rf ${DRUID_ROOT}/.git/hooks/pre-commits
+rm -rf ${DRUID_ROOT}/.git/hooks/pre-pushes


### PR DESCRIPTION
### Description

This PR adds new scripts that can be used as git hooks. To do this, this PR changes the directory structure in https://github.com/apache/druid/tree/master/hooks by adding 2 new directories, `pre-commits` and `pre-pushes`. It also adds 2 new scripts, `pre-commit` and `pre-push`, each of which runs all scripts in `pre-commits` and `pre-pushes` directories, respectively, unless the script name starts with `_`. I didn't add other git hook scripts than pre-commit and pre-push, but they can be added later if necessary.

<hr>

##### Key changed/added classes in this PR
 * `pre-commits`
 * `pre-pushes`

<hr>

This PR has:
- [x] been self-reviewed.
