### PR TITLE
Switches to writable memory to support write operations 

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchOperations.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchOperations.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.query.aggregation.datasketches.quantiles;
 
-import org.apache.datasketches.memory.Memory;
+import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.quantiles.DoublesSketch;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -53,7 +53,7 @@ public class DoublesSketchOperations
 
   public static DoublesSketch deserializeFromByteArray(final byte[] data)
   {
-    return DoublesSketch.wrap(Memory.wrap(data));
+    return DoublesSketch.wrap(WritableMemory.writableWrap(data));
   }
 
 }


### PR DESCRIPTION
Fixes #10364

### Description

The method getPMF in DoublesSketch performs a sort operation when the number of split points is greater than 50. It looks like the sort is for performance reasons and if it changes the memory, will generate this error in a query:

```
Error: Unknown exception

MemoryImpl is read-only.

org.apache.datasketches.memory.ReadOnlyException
```

This is because the `deserialize` methods currently wrap with read-only memory.

Modified the method to use `WritableMemory.writableWrap` when deserializing from byte array.

<hr>

This PR has:
- [x ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ x] been tested in a test Druid cluster.
