### PR TITLE
perf: core TextReader use a smaller default buffer

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/TextReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/TextReader.java
@@ -26,6 +26,7 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.java.util.common.parsers.ParserUtils;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -55,7 +56,8 @@ public abstract class TextReader extends IntermediateRowParsingReader<String>
       throws IOException
   {
     final LineIterator delegate = new LineIterator(
-        new InputStreamReader(source.open(), StringUtils.UTF8_STRING)
+        // create a small buffer, otherwise LineIterator creates a default 8KB buffer
+        new BufferedReader(new InputStreamReader(source.open(), StringUtils.UTF8_STRING), 256)
     );
     final int numHeaderLines = getNumHeaderLinesToSkip();
     for (int i = 0; i < numHeaderLines && delegate.hasNext(); i++) {


### PR DESCRIPTION
### Description

Use a smaller default buffer in the TextReader during parsing. By default, the [LineIterator creates a BufferedReader if one is not provided](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/LineIterator.java#L84-L88); the default [BufferedReader creates an 8KB buffer](https://github.com/AdoptOpenJDK/openjdk-jdk8u/blob/9a751dc19fae78ce58fb0eb176522070c992fb6f/jdk/src/share/classes/java/io/BufferedReader.java#L88). This is unnecessary for most parsing.

Improve this by creating our own BufferedReader with a custom line length.

### Questions

- Should this be configurable?

### Checklist

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.
