### PR TITLE
Break up parallel indexing unit test to reduce test times

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -177,8 +177,13 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @MonotonicNonNull
   private volatile TaskToolbox toolbox;
 
+  /**
+   * Row stats for index generate phase of parallel indexing. This variable is
+   * lazily initialized in {@link #runTask}.
+   * Volatile since HTTP API calls can use this variable while this task is running.
+   */
   @MonotonicNonNull
-  private Pair<Map<String, Object>, Map<String, Object>> indexGenerateRowStats;
+  private volatile Pair<Map<String, Object>, Map<String, Object>> indexGenerateRowStats;
 
   private IngestionState ingestionState;
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
@@ -36,7 +36,6 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.scan.ScanResultValue;
-import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
@@ -197,39 +197,6 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
     assertHashedPartition(publishedSegments, expectedIntervalToNumSegments);
   }
 
-  @Test
-  public void testRowStats()
-  {
-    final Integer maxRowsPerSegment = numShards == null ? 10 : null;
-    ParallelIndexSupervisorTask task = createTask(
-        new HashedPartitionsSpec(
-            maxRowsPerSegment,
-            numShards,
-            ImmutableList.of("dim1", "dim2"),
-            HashPartitionFunction.MURMUR3_32_ABS),
-        false);
-    RowIngestionMetersTotals expectedTotals = new RowIngestionMetersTotals(200, 0, 0, 0);
-    Map<String, Object> expectedReports;
-    if (maxNumConcurrentSubTasks <= 1) {
-      expectedReports = buildExpectedTaskReportSequential(
-          task.getId(),
-          ImmutableList.of(),
-          numShards == null ? expectedTotals : new RowIngestionMetersTotals(0, 0, 0, 0),
-          expectedTotals
-      );
-    } else {
-      // when useInputFormatApi is false, maxConcurrentSubTasks=2 and it uses the single phase runner
-      // instead of sequential runner
-      expectedReports = buildExpectedTaskReportParallel(
-          task.getId(),
-          ImmutableList.of(),
-          expectedTotals
-      );
-    }
-    Map<String, Object> actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
-    compareTaskReports(expectedReports, actualReports);
-  }
-
   private Map<Interval, Integer> computeExpectedIntervalToNumSegments(
       @Nullable Integer maxRowsPerSegment,
       @Nullable Integer numShards

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
@@ -45,7 +45,6 @@ import java.util.Map;
 
 public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhaseParallelIndexingTest
 {
-
   private static final String TIME = "ts";
   private static final String DIM1 = "dim1";
   private static final String DIM2 = "dim2";

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task.batch.parallel;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.impl.CSVParseSpec;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.ParseSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
+import org.apache.druid.indexing.common.LockGranularity;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
+import org.joda.time.Interval;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Map;
+
+public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhaseParallelIndexingTest
+{
+
+  private static final String TIME = "ts";
+  private static final String DIM1 = "dim1";
+  private static final String DIM2 = "dim2";
+
+  private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec(TIME, "auto", null);
+  private static final DimensionsSpec DIMENSIONS_SPEC = new DimensionsSpec(
+      DimensionsSpec.getDefaultSchemas(Arrays.asList(TIME, DIM1, DIM2))
+  );
+  private static final ParseSpec PARSE_SPEC = new CSVParseSpec(
+      TIMESTAMP_SPEC,
+      DIMENSIONS_SPEC,
+      null,
+      Arrays.asList("ts", "dim1", "dim2", "val"),
+      false,
+      0
+  );
+
+  private static final Interval INTERVAL_TO_INDEX = Intervals.of("2017-12/P1M");
+
+  private File inputDir;
+
+  public MultiPhaseParallelIndexingRowStatsTest()
+  {
+    super(
+        LockGranularity.SEGMENT,
+        false,
+        DEFAULT_TRANSIENT_TASK_FAILURE_RATE,
+        DEFAULT_TRANSIENT_API_FAILURE_RATE
+    );
+  }
+
+  @Before
+  public void setup() throws IOException
+  {
+    inputDir = temporaryFolder.newFolder("data");
+
+    // set up data
+    for (int i = 0; i < 10; i++) {
+      try (final Writer writer =
+               Files.newBufferedWriter(new File(inputDir, "test_" + i).toPath(), StandardCharsets.UTF_8)) {
+        for (int j = 0; j < 10; j++) {
+          writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 1, i + 10, i));
+          writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 2, i + 11, i));
+        }
+      }
+    }
+
+    for (int i = 0; i < 5; i++) {
+      try (final Writer writer =
+               Files.newBufferedWriter(new File(inputDir, "filtered_" + i).toPath(), StandardCharsets.UTF_8)) {
+        writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", i + 1, i + 10, i));
+      }
+    }
+  }
+
+  @Test
+  public void testHashPartitionRowStats()
+  {
+    testHashPartitionRowStats(2);
+  }
+
+  @Test
+  public void testHashPartitionRowStats_concurrentSubTasks_1()
+  {
+    testHashPartitionRowStats(1);
+  }
+
+  private void testHashPartitionRowStats(int maxNumConcurrentSubTasks)
+  {
+    final Integer numShards = 10;
+
+    ParallelIndexSupervisorTask task = createTask(
+        null,
+        null,
+        null,
+        PARSE_SPEC,
+        INTERVAL_TO_INDEX,
+        inputDir,
+        "test_*",
+        new HashedPartitionsSpec(null, numShards, ImmutableList.of("dim1", "dim2"), null),
+        maxNumConcurrentSubTasks,
+        false
+    );
+
+    final RowIngestionMetersTotals expectedTotals = new RowIngestionMetersTotals(200, 0, 0, 0);
+    final Map<String, Object> expectedReports =
+        maxNumConcurrentSubTasks <= 1
+        ? buildExpectedTaskReportSequential(
+            task.getId(),
+            ImmutableList.of(),
+            new RowIngestionMetersTotals(0, 0, 0, 0),
+            expectedTotals
+        )
+        : buildExpectedTaskReportParallel(
+            task.getId(),
+            ImmutableList.of(),
+            expectedTotals
+        );
+
+    Map<String, Object> actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
+    compareTaskReports(expectedReports, actualReports);
+  }
+
+  @Test
+  public void testRangePartitionRowStats()
+  {
+    final int targetRowsPerSegment = 20;
+    ParallelIndexSupervisorTask task = createTask(
+        null,
+        null,
+        null,
+        PARSE_SPEC,
+        INTERVAL_TO_INDEX,
+        inputDir,
+        "test_*",
+        //new DimensionRangePartitionsSpec(targetRowsPerSegment, null, DIMS, false),
+        new SingleDimensionPartitionsSpec(targetRowsPerSegment, null, DIM1, false),
+        10,
+        false
+    );
+    Map<String, Object> expectedReports = buildExpectedTaskReportParallel(
+        task.getId(),
+        ImmutableList.of(),
+        new RowIngestionMetersTotals(200, 0, 0, 0)
+    );
+    Map<String, Object> actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
+    compareTaskReports(expectedReports, actualReports);
+  }
+
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
@@ -41,7 +41,6 @@ import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.scan.ScanResultValue;
-import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
@@ -242,24 +242,6 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
   }
 
   @Test
-  public void testRowStats()
-  {
-    if (useMultivalueDim) {
-      return;
-    }
-    final int targetRowsPerSegment = NUM_ROW / DIM_FILE_CARDINALITY / NUM_PARTITION;
-    ParallelIndexSupervisorTask task = runTestTask(
-        new SingleDimensionPartitionsSpec(targetRowsPerSegment, null, DIM1, false),
-        false);
-    Map<String, Object> expectedReports = buildExpectedTaskReportParallel(
-        task.getId(),
-        ImmutableList.of(),
-        new RowIngestionMetersTotals(600, 0, 0, 0));
-    Map<String, Object> actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
-    compareTaskReports(expectedReports, actualReports);
-  }
-
-  @Test
   public void testAppendLinearlyPartitionedSegmentsToHashPartitionedDatasourceSuccessfullyAppend()
   {
     if (useMultivalueDim) {


### PR DESCRIPTION
### Description
This PR moves out the row stats tests for multi phase parallel indexing into a new class.

The following unit tests are failing on Travis as they take too long to finish:
- `RangePartitionMultiPhaseParallelIndexingTest`
- `HashPartitionMultiPhaseParallelIndexingTest`

Changes in this PR:
- Add `MultiPhaseParallelIndexingRowStatsTest`
- Make `ParallelIndexSupervisorTask.indexGenerateRowStats` volatile, change missed in the original PR #12280 .

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
