### PR TITLE
Guard against exponential increase of filters during CNF conversion

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
@@ -66,6 +66,7 @@ import org.apache.druid.segment.filter.DimensionPredicateFilter;
 import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.filter.OrFilter;
 import org.apache.druid.segment.filter.SelectorFilter;
+import org.apache.druid.segment.filter.cnf.CNFFilterExplosionException;
 import org.apache.druid.segment.generator.DataGenerator;
 import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
@@ -370,7 +371,7 @@ public class FilterPartitionBenchmark
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void readOrFilterCNF(Blackhole blackhole)
+  public void readOrFilterCNF(Blackhole blackhole) throws CNFFilterExplosionException
   {
     Filter filter = new NoBitmapSelectorFilter("dimSequential", "199");
     Filter filter2 = new AndFilter(Arrays.asList(new SelectorFilter("dimMultivalEnumerated2", "Corundum"), new NoBitmapSelectorFilter("dimMultivalEnumerated", "Bar")));
@@ -421,7 +422,7 @@ public class FilterPartitionBenchmark
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void readComplexOrFilterCNF(Blackhole blackhole)
+  public void readComplexOrFilterCNF(Blackhole blackhole) throws CNFFilterExplosionException
   {
     DimFilter dimFilter1 = new OrDimFilter(Arrays.asList(
         new SelectorDimFilter("dimSequential", "199", null),

--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -438,7 +438,7 @@ public class Filters
       return useCNF ? Filters.toCnf(filter) : filter;
     }
     catch (CNFFilterExplosionException cnfFilterExplosionException) {
-      throw new RuntimeException(cnfFilterExplosionException);
+      return filter; // cannot convert to CNF, return the filter as is
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -45,6 +45,7 @@ import org.apache.druid.segment.column.BitmapIndex;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.data.Indexed;
+import org.apache.druid.segment.filter.cnf.CNFFilterExplosionException;
 import org.apache.druid.segment.filter.cnf.CalciteCnfHelper;
 import org.apache.druid.segment.filter.cnf.HiveCnfHelper;
 import org.apache.druid.segment.join.filter.AllNullColumnSelectorFactory;
@@ -433,10 +434,15 @@ public class Filters
       return null;
     }
     boolean useCNF = query.getContextBoolean(QueryContexts.USE_FILTER_CNF_KEY, QueryContexts.DEFAULT_USE_FILTER_CNF);
-    return useCNF ? Filters.toCnf(filter) : filter;
+    try {
+      return useCNF ? Filters.toCnf(filter) : filter;
+    }
+    catch (CNFFilterExplosionException cnfFilterExplosionException) {
+      throw new RuntimeException(cnfFilterExplosionException);
+    }
   }
 
-  public static Filter toCnf(Filter current)
+  public static Filter toCnf(Filter current) throws CNFFilterExplosionException
   {
     // Push down NOT filters to leaves if possible to remove NOT on NOT filters and reduce hierarchy.
     // ex) ~(a OR ~b) => ~a AND b
@@ -578,7 +584,7 @@ public class Filters
    *
    * @return The normalized or clauses for the provided filter.
    */
-  public static List<Filter> toNormalizedOrClauses(Filter filter)
+  public static List<Filter> toNormalizedOrClauses(Filter filter) throws CNFFilterExplosionException
   {
     Filter normalizedFilter = Filters.toCnf(filter);
 

--- a/processing/src/main/java/org/apache/druid/segment/filter/cnf/CNFFilterExplosionException.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/cnf/CNFFilterExplosionException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.filter.cnf;
+
+import org.apache.druid.java.util.common.StringUtils;
+
+public class CNFFilterExplosionException extends Exception
+{
+  public CNFFilterExplosionException(String formatText, Object... arguments)
+  {
+    super(StringUtils.nonStrictFormat(formatText, arguments));
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/filter/cnf/HiveCnfHelper.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/cnf/HiveCnfHelper.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.segment.filter.cnf;
 
-import org.apache.druid.query.QueryContexts;
+import org.apache.druid.java.util.common.NonnullPair;
 import org.apache.druid.query.filter.BooleanFilter;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.filter.AndFilter;
@@ -38,6 +38,8 @@ import java.util.List;
  */
 public class HiveCnfHelper
 {
+  private static final int CNF_MAX_FILTER_THRESHOLD = 10_000;
+
   public static Filter pushDownNot(Filter current)
   {
     if (current instanceof NotFilter) {
@@ -81,15 +83,35 @@ public class HiveCnfHelper
 
   public static Filter convertToCnf(Filter current) throws CNFFilterExplosionException
   {
+    return convertToCnfWithLimit(current, CNF_MAX_FILTER_THRESHOLD).lhs;
+  }
+
+  /**
+   * Converts a filter to CNF form with a limit on filter count
+   * @param maxCNFFilterLimit the maximum number of filters allowed in CNF conversion
+   * @return a pair of the CNF converted filter and the new remaining filter limit
+   * @throws CNFFilterExplosionException is thrown if the filters in CNF representation go beyond maxCNFFilterLimit
+   */
+  private static NonnullPair<Filter, Integer> convertToCnfWithLimit(
+      Filter current,
+      int maxCNFFilterLimit
+  ) throws CNFFilterExplosionException
+  {
     if (current instanceof NotFilter) {
-      return new NotFilter(convertToCnf(((NotFilter) current).getBaseFilter()));
+      NonnullPair<Filter, Integer> result = convertToCnfWithLimit(((NotFilter) current).getBaseFilter(), maxCNFFilterLimit);
+      return new NonnullPair<>(new NotFilter(result.lhs), result.rhs);
     }
     if (current instanceof AndFilter) {
       List<Filter> children = new ArrayList<>();
       for (Filter child : ((AndFilter) current).getFilters()) {
-        children.add(convertToCnf(child));
+        NonnullPair<Filter, Integer> result = convertToCnfWithLimit(child, maxCNFFilterLimit);
+        children.add(result.lhs);
+        maxCNFFilterLimit = result.rhs;
+        if (maxCNFFilterLimit < 0) {
+          throw new CNFFilterExplosionException("Exceeded maximum allowed filters for CNF (conjunctive normal form) conversion");
+        }
       }
-      return Filters.and(children);
+      return new NonnullPair<>(Filters.and(children), maxCNFFilterLimit);
     }
     if (current instanceof OrFilter) {
       // a list of leaves that weren't under AND expressions
@@ -108,11 +130,11 @@ public class HiveCnfHelper
       }
       if (!andList.isEmpty()) {
         List<Filter> result = new ArrayList<>();
-        generateAllCombinations(result, andList, nonAndList);
-        return Filters.and(result);
+        generateAllCombinations(result, andList, nonAndList, maxCNFFilterLimit);
+        return new NonnullPair<>(Filters.and(result), maxCNFFilterLimit - result.size());
       }
     }
-    return current;
+    return new NonnullPair<>(current, maxCNFFilterLimit);
   }
 
   public static Filter flatten(Filter root)
@@ -159,7 +181,8 @@ public class HiveCnfHelper
   private static void generateAllCombinations(
       List<Filter> result,
       List<Filter> andList,
-      List<Filter> nonAndList
+      List<Filter> nonAndList,
+      int maxAllowedFilters
   ) throws CNFFilterExplosionException
   {
     List<Filter> children = new ArrayList<>(((AndFilter) andList.get(0)).getFilters());
@@ -169,6 +192,9 @@ public class HiveCnfHelper
         a.add(child);
         // Result must receive an actual OrFilter, so wrap if Filters.or managed to un-OR it.
         result.add(idempotentOr(Filters.or(a)));
+        if (result.size() > maxAllowedFilters) {
+          throw new CNFFilterExplosionException("Exceeded maximum allowed filters for CNF (conjunctive normal form) conversion");
+        }
       }
     } else {
       List<Filter> work = new ArrayList<>(result);
@@ -179,16 +205,14 @@ public class HiveCnfHelper
           a.add(child);
           // Result must receive an actual OrFilter.
           result.add(idempotentOr(Filters.or(a)));
-          if (result.size() >= 10_000) {
-            throw new CNFFilterExplosionException(
-                "Atleast 10,000 filters created by CNF (conjunctive normal form) conversion of the filter. "
-                + "Please disable %s flag if enabled", QueryContexts.USE_FILTER_CNF_KEY);
+          if (result.size() > maxAllowedFilters) {
+            throw new CNFFilterExplosionException("Exceeded maximum allowed filters for CNF (conjunctive normal form) conversion");
           }
         }
       }
     }
     if (andList.size() > 1) {
-      generateAllCombinations(result, andList.subList(1, andList.size()), nonAndList);
+      generateAllCombinations(result, andList.subList(1, andList.size()), nonAndList, maxAllowedFilters);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -81,6 +81,7 @@ import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.ConciseBitmapSerdeFactory;
 import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
+import org.apache.druid.segment.filter.cnf.CNFFilterExplosionException;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
@@ -367,7 +368,12 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
 
     final DimFilter maybeOptimized = optimize ? dimFilter.optimize() : dimFilter;
     final Filter filter = maybeOptimized.toFilter();
-    return cnf ? Filters.toCnf(filter) : filter;
+    try {
+      return cnf ? Filters.toCnf(filter) : filter;
+    }
+    catch (CNFFilterExplosionException cnfFilterExplosionException) {
+      throw new RuntimeException(cnfFilterExplosionException);
+    }
   }
 
   private DimFilter maybeOptimize(final DimFilter dimFilter)

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterPartitionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterPartitionTest.java
@@ -43,6 +43,7 @@ import org.apache.druid.segment.ColumnSelectorBitmapIndexSelector;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.QueryableIndexStorageAdapter;
 import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.filter.cnf.CNFFilterExplosionException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
@@ -609,7 +610,7 @@ public class FilterPartitionTest extends BaseFilterTest
   }
 
   @Test
-  public void testDistributeOrCNF()
+  public void testDistributeOrCNF() throws CNFFilterExplosionException
   {
     DimFilter dimFilter1 = new OrDimFilter(Arrays.asList(
         new SelectorDimFilter("dim0", "6", null),
@@ -663,7 +664,7 @@ public class FilterPartitionTest extends BaseFilterTest
   }
 
   @Test
-  public void testDistributeOrCNFExtractionFn()
+  public void testDistributeOrCNFExtractionFn() throws CNFFilterExplosionException
   {
     DimFilter dimFilter1 = new OrDimFilter(Arrays.asList(
         new SelectorDimFilter("dim0", "super-6", JS_EXTRACTION_FN),


### PR DESCRIPTION
Fixes #12311 

Currently, the CNF conversion of a filter is unbounded, which means that it can create as many filters as possible thereby also leading to OOMs in historical heap. We should throw an error or disable CNF conversion if the filter count starts getting out of hand. There are ways to do CNF conversion with linear increase in filters as well but that has been left out of the scope of this change since those algorithms add new variables in the predicate - which can be contentious. Any improved algorithm for conversion can be taken up later upon discussion.  

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
