### PR TITLE
push value range and set index get operations into BitmapIndex

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ExpressionVectorSelectorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ExpressionVectorSelectorBenchmark.java
@@ -30,13 +30,11 @@ import org.apache.druid.math.expr.ExprType;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.expression.TestExprMacroTable;
-import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexStorageAdapter;
 import org.apache.druid.segment.VirtualColumns;
-import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.generator.SegmentGenerator;
@@ -126,17 +124,7 @@ public class ExpressionVectorSelectorBenchmark
     );
 
     Expr parsed = Parser.parse(expression, ExprMacroTable.nil());
-    outputType = parsed.getOutputType(
-        new ColumnInspector()
-        {
-          @Nullable
-          @Override
-          public ColumnCapabilities getColumnCapabilities(String column)
-          {
-            return QueryableIndexStorageAdapter.getColumnCapabilities(index, column);
-          }
-        }
-    );
+    outputType = parsed.getOutputType(index);
     checkSanity();
   }
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/MockBitmapIndexSelector.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/MockBitmapIndexSelector.java
@@ -28,6 +28,8 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.data.GenericIndexed;
 
+import javax.annotation.Nullable;
+
 public class MockBitmapIndexSelector implements BitmapIndexSelector
 {
   private final GenericIndexed<String> dictionary;
@@ -71,7 +73,7 @@ public class MockBitmapIndexSelector implements BitmapIndexSelector
   @Override
   public ImmutableBitmap getBitmapIndex(String dimension, String value)
   {
-    return bitmapIndex.getBitmap(bitmapIndex.getIndex(value));
+    return bitmapIndex.getBitmapForValue(value);
   }
 
   @Override
@@ -84,5 +86,12 @@ public class MockBitmapIndexSelector implements BitmapIndexSelector
   public ImmutableRTree getSpatialIndex(String dimension)
   {
     throw new UnsupportedOperationException();
+  }
+
+  @Nullable
+  @Override
+  public ColumnCapabilities getColumnCapabilities(String column)
+  {
+    return null;
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/dimension/PredicateFilteredDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/query/dimension/PredicateFilteredDimensionSelector.java
@@ -64,6 +64,7 @@ final class PredicateFilteredDimensionSelector extends AbstractDimensionSelector
   @Override
   public ValueMatcher makeValueMatcher(final String value)
   {
+    final boolean matchNull = predicate.apply(null);
     return new ValueMatcher()
     {
       @Override
@@ -82,7 +83,7 @@ final class PredicateFilteredDimensionSelector extends AbstractDimensionSelector
           }
         }
         // null should match empty rows in multi-value columns if predicate matches null
-        return nullRow && value == null && predicate.apply(null);
+        return nullRow && value == null && matchNull;
       }
 
       @Override

--- a/processing/src/main/java/org/apache/druid/query/dimension/PredicateFilteredDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/query/dimension/PredicateFilteredDimensionSelector.java
@@ -81,8 +81,8 @@ final class PredicateFilteredDimensionSelector extends AbstractDimensionSelector
             nullRow = false;
           }
         }
-        // null should match empty rows in multi-value columns
-        return nullRow && value == null;
+        // null should match empty rows in multi-value columns if predicate matches null
+        return nullRow && predicate.apply(null);
       }
 
       @Override
@@ -97,7 +97,7 @@ final class PredicateFilteredDimensionSelector extends AbstractDimensionSelector
   @Override
   public ValueMatcher makeValueMatcher(final Predicate<String> matcherPredicate)
   {
-    final boolean matchNull = predicate.apply(null);
+    final boolean matchNull = predicate.apply(null) && matcherPredicate.apply(null);
     return new ValueMatcher()
     {
       @Override

--- a/processing/src/main/java/org/apache/druid/query/dimension/PredicateFilteredDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/query/dimension/PredicateFilteredDimensionSelector.java
@@ -82,7 +82,7 @@ final class PredicateFilteredDimensionSelector extends AbstractDimensionSelector
           }
         }
         // null should match empty rows in multi-value columns if predicate matches null
-        return nullRow && predicate.apply(null);
+        return nullRow && value == null && predicate.apply(null);
       }
 
       @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/BitmapIndexSelector.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/BitmapIndexSelector.java
@@ -23,6 +23,7 @@ import com.google.errorprone.annotations.MustBeClosed;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.spatial.ImmutableRTree;
+import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.column.BitmapIndex;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.data.CloseableIndexed;
@@ -31,12 +32,15 @@ import javax.annotation.Nullable;
 
 /**
  */
-public interface BitmapIndexSelector
+public interface BitmapIndexSelector extends ColumnInspector
 {
   @MustBeClosed
   @Nullable
   CloseableIndexed<String> getDimensionValues(String dimension);
+
+  @Deprecated
   ColumnCapabilities.Capable hasMultipleValues(String dimension);
+
   int getNumRows();
   BitmapFactory getBitmapFactory();
   @Nullable

--- a/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
@@ -32,7 +32,6 @@ import com.google.common.primitives.Chars;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.extraction.ExtractionFn;
-import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.filter.LikeFilter;
 
 import javax.annotation.Nullable;
@@ -299,17 +298,15 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
      * of s are ignored. This method is useful if you've already independently verified the prefix. This method
      * evalutes strings.get(i) lazily to save time when it isn't necessary to actually look at the string.
      */
-    public boolean matchesSuffixOnly(final Indexed<String> strings, final int i)
+    public boolean matchesSuffixOnly(@Nullable String value)
     {
       if (suffixMatch == SuffixMatch.MATCH_ANY) {
         return true;
       } else if (suffixMatch == SuffixMatch.MATCH_EMPTY) {
-        final String s = strings.get(i);
-        return s == null ? matches(null) : s.length() == prefix.length();
+        return value == null ? matches(null) : value.length() == prefix.length();
       } else {
         // suffixMatch is MATCH_PATTERN
-        final String s = strings.get(i);
-        return matches(s);
+        return matches(value);
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -209,7 +209,7 @@ public class SegmentAnalyzer
           String value = bitmapIndex.getValue(i);
           if (value != null) {
             size += StringUtils.estimatedBinaryLengthAsUTF8(value) *
-                    ((long) bitmapIndex.getBitmap(bitmapIndex.getIndex(value)).size());
+                    ((long) bitmapIndex.getBitmapForValue(value).size());
           }
         }
       }

--- a/processing/src/main/java/org/apache/druid/segment/ColumnInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnInspector.java
@@ -39,7 +39,7 @@ public interface ColumnInspector extends Expr.InputBindingInspector
 
   default ColumnCapabilities getColumnCapabilitiesWithDefault(String column, ColumnCapabilities defaultCapabilites)
   {
-    final ColumnCapabilities capabilities  = getColumnCapabilities(column);
+    final ColumnCapabilities capabilities = getColumnCapabilities(column);
     if (capabilities != null) {
       return capabilities;
     }

--- a/processing/src/main/java/org/apache/druid/segment/ColumnInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnInspector.java
@@ -37,6 +37,15 @@ public interface ColumnInspector extends Expr.InputBindingInspector
   @Nullable
   ColumnCapabilities getColumnCapabilities(String column);
 
+  default ColumnCapabilities getColumnCapabilitiesWithDefault(String column, ColumnCapabilities defaultCapabilites)
+  {
+    final ColumnCapabilities capabilities  = getColumnCapabilities(column);
+    if (capabilities != null) {
+      return capabilities;
+    }
+    return defaultCapabilites;
+  }
+
   @Nullable
   @Override
   default ExpressionType getType(String name)

--- a/processing/src/main/java/org/apache/druid/segment/ColumnSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnSelector.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment;
 
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 
 import javax.annotation.Nullable;
@@ -26,10 +27,21 @@ import java.util.List;
 
 /**
  */
-public interface ColumnSelector
+public interface ColumnSelector extends ColumnInspector
 {
   List<String> getColumnNames();
 
   @Nullable
   ColumnHolder getColumnHolder(String columnName);
+
+  @Nullable
+  @Override
+  default ColumnCapabilities getColumnCapabilities(String column)
+  {
+    final ColumnHolder columnHolder = getColumnHolder(column);
+    if (columnHolder == null) {
+      return null;
+    }
+    return columnHolder.getCapabilities();
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelector.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 /**
  */
@@ -282,7 +282,7 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
             boolean startStrict,
             @Nullable String endValue,
             boolean endStrict,
-            IntPredicate matcher
+            Predicate<String> matcher
         )
         {
           final int startIndex; // inclusive
@@ -308,8 +308,8 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
             }
           }
 
-          endIndex = startIndex > endIndex || !matcher.test(endIndex) ? startIndex : endIndex;
-          if (matcher.test(startIndex)) {
+          endIndex = startIndex > endIndex || !matcher.test(getValue(endIndex)) ? startIndex : endIndex;
+          if (matcher.test(getValue(startIndex))) {
             final IntIterator rangeIterator = IntListUtils.fromTo(startIndex, endIndex).iterator();
             return () -> new Iterator<ImmutableBitmap>()
             {

--- a/processing/src/main/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelector.java
@@ -20,7 +20,6 @@
 package org.apache.druid.segment;
 
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.spatial.ImmutableRTree;
@@ -40,6 +39,7 @@ import org.apache.druid.segment.serde.StringBitmapIndexColumnPartSupplier;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -308,23 +308,12 @@ public class ColumnSelectorBitmapIndexSelector implements BitmapIndexSelector
             }
           }
 
-          endIndex = startIndex > endIndex || !matcher.test(getValue(endIndex)) ? startIndex : endIndex;
-          if (matcher.test(getValue(startIndex))) {
-            final IntIterator rangeIterator = IntListUtils.fromTo(startIndex, endIndex).iterator();
-            return () -> new Iterator<ImmutableBitmap>()
-            {
-              @Override
-              public boolean hasNext()
-              {
-                return rangeIterator.hasNext();
-              }
-
-              @Override
-              public ImmutableBitmap next()
-              {
-                return getBitmap(rangeIterator.nextInt());
-              }
-            };
+          endIndex = Math.max(startIndex, endIndex);
+          if (startIndex == endIndex) {
+            return Collections.emptyList();
+          }
+          if (matcher.test(null)) {
+            return ImmutableList.of(getBitmap(0));
           }
           return ImmutableList.of(bitmapFactory.makeEmptyImmutableBitmap());
         }

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexColumnSelectorFactory.java
@@ -198,12 +198,9 @@ public class QueryableIndexColumnSelectorFactory implements ColumnSelectorFactor
   public ColumnCapabilities getColumnCapabilities(String columnName)
   {
     if (virtualColumns.exists(columnName)) {
-      return virtualColumns.getColumnCapabilities(
-          QueryableIndexStorageAdapter.getColumnInspectorForIndex(index),
-          columnName
-      );
+      return virtualColumns.getColumnCapabilities(index, columnName);
     }
 
-    return QueryableIndexStorageAdapter.getColumnCapabilities(index, columnName);
+    return index.getColumnCapabilities(columnName);
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexIndexableAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexIndexableAdapter.java
@@ -397,7 +397,7 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
       return BitmapValues.EMPTY;
     }
 
-    return new ImmutableBitmapValues(bitmaps.getBitmap(bitmaps.getIndex(value)));
+    return new ImmutableBitmapValues(bitmaps.getBitmapForValue(value));
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexStorageAdapter.java
@@ -168,7 +168,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
   @Nullable
   public ColumnCapabilities getColumnCapabilities(String column)
   {
-    return getColumnCapabilities(index, column);
+    return index.getColumnCapabilities(column);
   }
 
   @Override
@@ -278,21 +278,6 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
         ).build(gran),
         Objects::nonNull
     );
-  }
-
-  @Nullable
-  public static ColumnCapabilities getColumnCapabilities(ColumnSelector index, String columnName)
-  {
-    final ColumnHolder columnHolder = index.getColumnHolder(columnName);
-    if (columnHolder == null) {
-      return null;
-    }
-    return columnHolder.getCapabilities();
-  }
-
-  public static ColumnInspector getColumnInspectorForIndex(ColumnSelector index)
-  {
-    return column -> getColumnCapabilities(index, column);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
@@ -387,11 +387,7 @@ public class VirtualColumns implements Cacheable
   {
     final VirtualColumn virtualColumn = getVirtualColumn(columnName);
     if (virtualColumn != null) {
-      return Preconditions.checkNotNull(
-          virtualColumn.capabilities(column -> getColumnCapabilitiesWithFallback(inspector, column), columnName),
-          "capabilities for column[%s]",
-          columnName
-      );
+      return virtualColumn.capabilities(column -> getColumnCapabilitiesWithFallback(inspector, column), columnName);
     } else {
       return null;
     }

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
@@ -174,10 +174,9 @@ public class VirtualColumns implements Cacheable
   public BitmapIndex getBitmapIndex(String columnName, ColumnSelector columnSelector)
   {
     final VirtualColumn virtualColumn = getVirtualColumnForSelector(columnName);
-    return virtualColumn.capabilities(columnName).hasBitmapIndexes() ? virtualColumn.getBitmapIndex(
-        columnName,
-        columnSelector
-    ) : null;
+    return virtualColumn.capabilities(columnSelector, columnName).hasBitmapIndexes()
+           ? virtualColumn.getBitmapIndex(columnName, columnSelector)
+           : null;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/column/BitmapIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/BitmapIndex.java
@@ -23,6 +23,8 @@ import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 
 import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.function.IntPredicate;
 
 /**
  */
@@ -47,4 +49,26 @@ public interface BitmapIndex
   int getIndex(@Nullable String value);
 
   ImmutableBitmap getBitmap(int idx);
+
+  ImmutableBitmap getBitmapForValue(@Nullable String value);
+
+  default Iterable<ImmutableBitmap> getBitmapsInRange(
+      @Nullable String startValue,
+      boolean startStrict,
+      @Nullable String endValue,
+      boolean endStrict
+  )
+  {
+    return getBitmapsInRange(startValue, startStrict, endValue, endStrict, (index) -> true);
+  }
+
+  Iterable<ImmutableBitmap> getBitmapsInRange(
+      @Nullable String startValue,
+      boolean startStrict,
+      @Nullable String endValue,
+      boolean endStrict,
+      IntPredicate matcher
+  );
+
+  Iterable<ImmutableBitmap> getBitmapsForValues(Set<String> values);
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/BitmapIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/BitmapIndex.java
@@ -24,34 +24,59 @@ import org.apache.druid.collections.bitmap.ImmutableBitmap;
 
 import javax.annotation.Nullable;
 import java.util.Set;
-import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 /**
+ * Provides a mechanism to get {@link ImmutableBitmap} for a value, or {@link Iterable} of {@link ImmutableBitmap}
+ * for a range or exact set of values, the set bits of which correspond to which rows contain the matching values.
+ *
+ * Used to power {@link org.apache.druid.segment.BitmapOffset} and
+ * {@link org.apache.druid.segment.vector.BitmapVectorOffset} which are used with column cursors for fast filtering
+ * of indexed values.
+ *
+ * The column must be ingested with a bitmap index for filters to use them and to participate in this "pre-filtering"
+ * step when scanning segments
+ *
+ * @see org.apache.druid.segment.QueryableIndexStorageAdapter#analyzeFilter
  */
 public interface BitmapIndex
 {
+  /**
+   * Get the cardinality of the underlying value dictionary
+   */
   int getCardinality();
 
+  /**
+   * Get the value in the underlying value dictionary of the specified dictionary id
+   */
   @Nullable
   String getValue(int index);
 
+  /**
+   * Returns true if the underlying value dictionary has nulls
+   */
   boolean hasNulls();
 
   BitmapFactory getBitmapFactory();
 
   /**
-   * Returns the index of "value" in this BitmapIndex, or (-(insertion point) - 1) if the value is not
-   * present, in the manner of Arrays.binarySearch.
-   *
-   * @param value value to search for
-   * @return index of value, or negative number equal to (-(insertion point) - 1).
+   * Returns the index of "value" in this BitmapIndex, or a negative value, if not present in the underlying dictionary
    */
   int getIndex(@Nullable String value);
 
+  /**
+   * Get the {@link ImmutableBitmap} for dictionary id of the underlying dictionary
+   */
   ImmutableBitmap getBitmap(int idx);
 
+  /**
+   * Get the {@link ImmutableBitmap} corresponding to the supplied value
+   */
   ImmutableBitmap getBitmapForValue(@Nullable String value);
 
+  /**
+   * Get an {@link Iterable} of {@link ImmutableBitmap} corresponding to the values supplied in the specified range
+   */
   default Iterable<ImmutableBitmap> getBitmapsInRange(
       @Nullable String startValue,
       boolean startStrict,
@@ -62,13 +87,21 @@ public interface BitmapIndex
     return getBitmapsInRange(startValue, startStrict, endValue, endStrict, (index) -> true);
   }
 
+  /**
+   * Get an {@link Iterable} of {@link ImmutableBitmap} corresponding to the values supplied in the specified range
+   * whose dictionary ids also match some predicate
+   */
   Iterable<ImmutableBitmap> getBitmapsInRange(
       @Nullable String startValue,
       boolean startStrict,
       @Nullable String endValue,
       boolean endStrict,
-      IntPredicate matcher
+      Predicate<String> matcher
   );
 
+  /**
+   * Get an {@link Iterable} of {@link ImmutableBitmap} corresponding to the specified set of values (if they are
+   * contained in the underlying column)
+   */
   Iterable<ImmutableBitmap> getBitmapsForValues(Set<String> values);
 }

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
@@ -350,12 +350,17 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
     if (!allowReverseLookup) {
       throw new UnsupportedOperationException("Reverse lookup not allowed.");
     }
+    return indexOf(this, value);
+  }
+
+  private int indexOf(Indexed<T> indexed, @Nullable T value)
+  {
     int minIndex = 0;
     int maxIndex = size - 1;
     while (minIndex <= maxIndex) {
       int currIndex = (minIndex + maxIndex) >>> 1;
 
-      T currValue = get(currIndex);
+      T currValue = indexed.get(currIndex);
       int comparison = strategy.compare(currValue, value);
       if (comparison == 0) {
         return currIndex;

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
@@ -355,7 +355,7 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
     if (!allowReverseLookup) {
       throw new UnsupportedOperationException("Reverse lookup not allowed.");
     }
-    return Indexed.indexOf(indexed::get, size, strategy, value);
+    return Indexed.indexOf(indexed, size, strategy, value);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
@@ -347,15 +347,28 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
   @Override
   public int indexOf(@Nullable T value)
   {
-    return indexOf(this, value);
-  }
-
-  private int indexOf(Indexed<T> indexed, @Nullable T value)
-  {
     if (!allowReverseLookup) {
       throw new UnsupportedOperationException("Reverse lookup not allowed.");
     }
-    return Indexed.indexOf(indexed, size, strategy, value);
+    int minIndex = 0;
+    int maxIndex = size - 1;
+    while (minIndex <= maxIndex) {
+      int currIndex = (minIndex + maxIndex) >>> 1;
+
+      T currValue = get(currIndex);
+      int comparison = strategy.compare(currValue, value);
+      if (comparison == 0) {
+        return currIndex;
+      }
+
+      if (comparison < 0) {
+        minIndex = currIndex + 1;
+      } else {
+        maxIndex = currIndex - 1;
+      }
+    }
+
+    return -(minIndex + 1);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
@@ -24,7 +24,6 @@ import org.apache.druid.query.monomorphicprocessing.CalledFromHotLoop;
 import org.apache.druid.query.monomorphicprocessing.HotLoopCallee;
 
 import javax.annotation.Nullable;
-import java.util.Comparator;
 
 /**
  * Indexed is a fixed-size, immutable, indexed set of values which allows
@@ -53,40 +52,6 @@ public interface Indexed<T> extends Iterable<T>, HotLoopCallee
    * @return index of value, or a negative number
    */
   int indexOf(@Nullable T value);
-
-  /**
-   * Returns the index of "value" in some object in the {@link Indexed}, or (-(insertion point) - 1) if the value is
-   * not present, in the manner of Arrays.binarySearch.
-   *
-   * This is used by {@link GenericIndexed} to strengthen the contract of {@link #indexOf(Object)}, which only
-   * guarantees that values-not-found will return some negative number.
-   *
-   * @param value value to search for
-   *
-   * @return index of value, or negative number equal to (-(insertion point) - 1).
-   */
-  static <T> int indexOf(Indexed<T> indexed, int size, Comparator<T> comparator, @Nullable T value)
-  {
-    int minIndex = 0;
-    int maxIndex = size - 1;
-    while (minIndex <= maxIndex) {
-      int currIndex = (minIndex + maxIndex) >>> 1;
-
-      T currValue = indexed.get(currIndex);
-      int comparison = comparator.compare(currValue, value);
-      if (comparison == 0) {
-        return currIndex;
-      }
-
-      if (comparison < 0) {
-        minIndex = currIndex + 1;
-      } else {
-        maxIndex = currIndex - 1;
-      }
-    }
-
-    return -(minIndex + 1);
-  }
 
   @FunctionalInterface
   interface IndexedGetter<T>

--- a/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
@@ -55,8 +55,8 @@ public interface Indexed<T> extends Iterable<T>, HotLoopCallee
   int indexOf(@Nullable T value);
 
   /**
-   * Returns the index of "value" in some object whose values are accessible by index some {@link IndexedGetter}, or
-   * (-(insertion point) - 1) if the value is not present, in the manner of Arrays.binarySearch.
+   * Returns the index of "value" in some object in the {@link Indexed}, or (-(insertion point) - 1) if the value is
+   * not present, in the manner of Arrays.binarySearch.
    *
    * This is used by {@link GenericIndexed} to strengthen the contract of {@link #indexOf(Object)}, which only
    * guarantees that values-not-found will return some negative number.

--- a/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
@@ -65,7 +65,7 @@ public interface Indexed<T> extends Iterable<T>, HotLoopCallee
    *
    * @return index of value, or negative number equal to (-(insertion point) - 1).
    */
-  static <T> int indexOf(IndexedGetter<T> indexed, int size, Comparator<T> comparator, @Nullable T value)
+  static <T> int indexOf(Indexed<T> indexed, int size, Comparator<T> comparator, @Nullable T value)
   {
     int minIndex = 0;
     int maxIndex = size - 1;

--- a/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
@@ -47,6 +47,7 @@ import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
@@ -229,8 +230,9 @@ public class ExpressionFilter implements Filter
       // Single-column expression. We can use bitmap indexes if this column has an index and the expression can
       // map over the values of the index.
       final String column = Iterables.getOnlyElement(details.getRequiredBindings());
+      final ColumnCapabilities capabilities = selector.getColumnCapabilities(column);
       return selector.getBitmapIndex(column) != null
-             && ExpressionSelectors.canMapOverDictionary(details, selector.hasMultipleValues(column));
+             && ExpressionSelectors.canMapOverDictionary(details, capabilities);
     } else {
       // Multi-column expression.
       return false;

--- a/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
@@ -230,9 +230,14 @@ public class ExpressionFilter implements Filter
       // Single-column expression. We can use bitmap indexes if this column has an index and the expression can
       // map over the values of the index.
       final String column = Iterables.getOnlyElement(details.getRequiredBindings());
-      final ColumnCapabilities capabilities = selector.getColumnCapabilities(column);
-      return selector.getBitmapIndex(column) != null
-             && ExpressionSelectors.canMapOverDictionary(details, capabilities);
+      // we use a default 'all false' capabilities here because if the column has a bitmap index, but the capabilities
+      // are null, it means that the column is missing and should take the single valued path, while truly unknown
+      // things will not have a bitmap index available
+      final ColumnCapabilities capabilities = selector.getColumnCapabilitiesWithDefault(
+          column,
+          ColumnCapabilitiesImpl.createDefault()
+      );
+      return selector.getBitmapIndex(column) != null && ExpressionSelectors.canMapOverDictionary(details, capabilities);
     } else {
       // Multi-column expression.
       return false;

--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -246,6 +246,7 @@ public class Filters
     // Missing dimension -> match all rows if the predicate matches null; match no rows otherwise
     try (final CloseableIndexed<String> dimValues = selector.getDimensionValues(dimension)) {
       if (dimValues == null || dimValues.size() == 0) {
+
         return ImmutableList.of(predicate.apply(null) ? allTrue(selector) : allFalse(selector));
       }
 

--- a/processing/src/main/java/org/apache/druid/segment/serde/StringBitmapIndexColumnPartSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/StringBitmapIndexColumnPartSupplier.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 /**
  * Provides {@link BitmapIndex} for some dictionary encoded column, where the dictionary and bitmaps are stored in some
@@ -164,7 +164,7 @@ public class StringBitmapIndexColumnPartSupplier implements Supplier<BitmapIndex
           boolean startStrict,
           @Nullable String endValue,
           boolean endStrict,
-          IntPredicate indexMatcher
+          Predicate<String> indexMatcher
       )
       {
         int startIndex, endIndex;
@@ -202,7 +202,7 @@ public class StringBitmapIndexColumnPartSupplier implements Supplier<BitmapIndex
 
           private int findNext()
           {
-            while (currIndex < end && !indexMatcher.test(currIndex)) {
+            while (currIndex < end && !indexMatcher.test(dictionary.get(currIndex))) {
               currIndex++;
             }
 

--- a/processing/src/main/java/org/apache/druid/segment/serde/StringBitmapIndexColumnPartSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/StringBitmapIndexColumnPartSupplier.java
@@ -20,12 +20,19 @@
 package org.apache.druid.segment.serde;
 
 import com.google.common.base.Supplier;
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.segment.IntListUtils;
 import org.apache.druid.segment.column.BitmapIndex;
 import org.apache.druid.segment.data.GenericIndexed;
 
 import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.IntPredicate;
 
 /**
  * Provides {@link BitmapIndex} for some dictionary encoded column, where the dictionary and bitmaps are stored in some
@@ -93,6 +100,179 @@ public class StringBitmapIndexColumnPartSupplier implements Supplier<BitmapIndex
 
         final ImmutableBitmap bitmap = bitmaps.get(idx);
         return bitmap == null ? bitmapFactory.makeEmptyImmutableBitmap() : bitmap;
+      }
+
+      @Override
+      public ImmutableBitmap getBitmapForValue(@Nullable String value)
+      {
+        final int idx = dictionary.indexOf(value);
+        return getBitmap(idx);
+      }
+
+      @Override
+      public Iterable<ImmutableBitmap> getBitmapsInRange(
+          @Nullable String startValue,
+          boolean startStrict,
+          @Nullable String endValue,
+          boolean endStrict
+      )
+      {
+        int startIndex, endIndex;
+        if (startValue == null) {
+          startIndex = 0;
+        } else {
+          final int found = dictionary.indexOf(NullHandling.emptyToNullIfNeeded(startValue));
+          if (found >= 0) {
+            startIndex = startStrict ? found + 1 : found;
+          } else {
+            startIndex = -(found + 1);
+          }
+        }
+
+        if (endValue == null) {
+          endIndex = dictionary.size();
+        } else {
+          final int found = dictionary.indexOf(NullHandling.emptyToNullIfNeeded(endValue));
+          if (found >= 0) {
+            endIndex = endStrict ? found : found + 1;
+          } else {
+            endIndex = -(found + 1);
+          }
+        }
+
+        endIndex = startIndex > endIndex ? startIndex : endIndex;
+        final IntIterator rangeIterator = IntListUtils.fromTo(startIndex, endIndex).iterator();
+        return () -> new Iterator<ImmutableBitmap>()
+        {
+          @Override
+          public boolean hasNext()
+          {
+            return rangeIterator.hasNext();
+          }
+
+          @Override
+          public ImmutableBitmap next()
+          {
+            return getBitmap(rangeIterator.nextInt());
+          }
+        };
+      }
+
+      @Override
+      public Iterable<ImmutableBitmap> getBitmapsInRange(
+          @Nullable String startValue,
+          boolean startStrict,
+          @Nullable String endValue,
+          boolean endStrict,
+          IntPredicate indexMatcher
+      )
+      {
+        int startIndex, endIndex;
+        if (startValue == null) {
+          startIndex = 0;
+        } else {
+          final int found = dictionary.indexOf(NullHandling.emptyToNullIfNeeded(startValue));
+          if (found >= 0) {
+            startIndex = startStrict ? found + 1 : found;
+          } else {
+            startIndex = -(found + 1);
+          }
+        }
+
+        if (endValue == null) {
+          endIndex = dictionary.size();
+        } else {
+          final int found = dictionary.indexOf(NullHandling.emptyToNullIfNeeded(endValue));
+          if (found >= 0) {
+            endIndex = endStrict ? found : found + 1;
+          } else {
+            endIndex = -(found + 1);
+          }
+        }
+
+        endIndex = startIndex > endIndex ? startIndex : endIndex;
+        final int start = startIndex, end = endIndex;
+        return () -> new Iterator<ImmutableBitmap>()
+        {
+          int currIndex = start;
+          int found;
+          {
+            found = findNext();
+          }
+
+          private int findNext()
+          {
+            while (currIndex < end && !indexMatcher.test(currIndex)) {
+              currIndex++;
+            }
+
+            if (currIndex < end) {
+              return currIndex++;
+            } else {
+              return -1;
+            }
+          }
+
+          @Override
+          public boolean hasNext()
+          {
+            return found != -1;
+          }
+
+          @Override
+          public ImmutableBitmap next()
+          {
+            int cur = found;
+
+            if (cur == -1) {
+              throw new NoSuchElementException();
+            }
+
+            found = findNext();
+            return getBitmap(cur);
+          }
+        };
+      }
+
+      @Override
+      public Iterable<ImmutableBitmap> getBitmapsForValues(Set<String> values)
+      {
+        return () -> new Iterator<ImmutableBitmap>()
+        {
+          final Iterator<String> iterator = values.iterator();
+          int next = -1;
+
+          @Override
+          public boolean hasNext()
+          {
+            if (next < 0) {
+              findNext();
+            }
+            return next >= 0;
+          }
+
+          @Override
+          public ImmutableBitmap next()
+          {
+            if (next < 0) {
+              findNext();
+              if (next < 0) {
+                throw new NoSuchElementException();
+              }
+            }
+            final int swap = next;
+            next = -1;
+            return getBitmap(swap);
+          }
+
+          private void findNext()
+          {
+            while (next < 0 && iterator.hasNext()) {
+              String nextValue = iterator.next();
+              next = dictionary.indexOf(nextValue);
+            }
+          }
+        };
       }
     };
   }

--- a/processing/src/main/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactory.java
@@ -23,7 +23,6 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.QueryableIndex;
-import org.apache.druid.segment.QueryableIndexStorageAdapter;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.BaseColumn;
 import org.apache.druid.segment.column.ColumnCapabilities;
@@ -266,11 +265,8 @@ public class QueryableIndexVectorColumnSelectorFactory implements VectorColumnSe
   public ColumnCapabilities getColumnCapabilities(final String columnName)
   {
     if (virtualColumns.exists(columnName)) {
-      return virtualColumns.getColumnCapabilities(
-          QueryableIndexStorageAdapter.getColumnInspectorForIndex(index),
-          columnName
-      );
+      return virtualColumns.getColumnCapabilities(index, columnName);
     }
-    return QueryableIndexStorageAdapter.getColumnCapabilities(index, columnName);
+    return index.getColumnCapabilities(columnName);
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
@@ -270,6 +270,7 @@ public class ExpressionPlan
                                          .setType(ColumnType.STRING)
                                          .setDictionaryValuesSorted(false)
                                          .setDictionaryValuesUnique(false)
+                                         .setHasBitmapIndexes(false)
                                          .setHasNulls(true);
           }
         }

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -233,7 +233,7 @@ public class ExpressionSelectors
    * and that single column has a dictionary.
    *
    * @param bindingAnalysis       result of calling {@link Expr#analyzeInputs()} on an expression
-   * @param hasMultipleValues result of calling {@link ColumnCapabilities#hasMultipleValues()}
+   * @param columnCapabilities    {@link ColumnCapabilities} for the input binding
    */
   public static boolean canMapOverDictionary(
       final Expr.BindingAnalysis bindingAnalysis,

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -237,11 +237,14 @@ public class ExpressionSelectors
    */
   public static boolean canMapOverDictionary(
       final Expr.BindingAnalysis bindingAnalysis,
-      final ColumnCapabilities.Capable hasMultipleValues
+      final ColumnCapabilities columnCapabilities
   )
   {
     Preconditions.checkState(bindingAnalysis.getRequiredBindings().size() == 1, "requiredBindings.size == 1");
-    return !hasMultipleValues.isUnknown() && !bindingAnalysis.hasInputArrays() && !bindingAnalysis.isOutputArray();
+    return columnCapabilities != null &&
+           !columnCapabilities.hasMultipleValues().isUnknown() &&
+           !bindingAnalysis.hasInputArrays() &&
+           !bindingAnalysis.isOutputArray();
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
@@ -24,11 +24,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
-import org.apache.druid.java.util.common.guava.Comparators;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.dimension.ListFilteredDimensionSpec;
+import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
@@ -40,13 +41,16 @@ import org.apache.druid.segment.column.BitmapIndex;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
-import org.apache.druid.segment.data.Indexed;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.IntPredicate;
 
 /**
  * {@link VirtualColumn} form of {@link ListFilteredDimensionSpec}, powered by
@@ -253,12 +257,6 @@ public class ListFilteredVirtualColumn implements VirtualColumn
     }
 
     @Override
-    public ImmutableBitmap getBitmap(int idx)
-    {
-      return delegate.getBitmap(idMapping.getReverseId(idx));
-    }
-
-    @Override
     public int getCardinality()
     {
       return idMapping.getValueCardinality();
@@ -267,7 +265,163 @@ public class ListFilteredVirtualColumn implements VirtualColumn
     @Override
     public int getIndex(@Nullable String value)
     {
-      return Indexed.indexOf(this::getValue, getCardinality(), Comparators.naturalNullsFirst(), value);
+      return getReverseIndex(value);
+    }
+
+    @Override
+    public ImmutableBitmap getBitmap(int idx)
+    {
+      return delegate.getBitmap(idMapping.getReverseId(idx));
+    }
+
+    @Override
+    public ImmutableBitmap getBitmapForValue(@Nullable String value)
+    {
+      if (getReverseIndex(value) < 0) {
+        return delegate.getBitmap(-1);
+      }
+      return delegate.getBitmapForValue(value);
+    }
+
+    @Override
+    public Iterable<ImmutableBitmap> getBitmapsInRange(
+        @Nullable String startValue,
+        boolean startStrict,
+        @Nullable String endValue,
+        boolean endStrict,
+        IntPredicate matcher
+    )
+    {
+      int startIndex, endIndex;
+      if (startValue == null) {
+        startIndex = 0;
+      } else {
+        final int found = getReverseIndex(NullHandling.emptyToNullIfNeeded(startValue));
+        if (found >= 0) {
+          startIndex = startStrict ? found + 1 : found;
+        } else {
+          startIndex = -(found + 1);
+        }
+      }
+
+      if (endValue == null) {
+        endIndex = idMapping.getValueCardinality();
+      } else {
+        final int found = getReverseIndex(NullHandling.emptyToNullIfNeeded(endValue));
+        if (found >= 0) {
+          endIndex = endStrict ? found : found + 1;
+        } else {
+          endIndex = -(found + 1);
+        }
+      }
+
+      endIndex = startIndex > endIndex ? startIndex : endIndex;
+      final int start = startIndex, end = endIndex;
+      return () -> new Iterator<ImmutableBitmap>()
+      {
+        int currIndex = start;
+        int found;
+        {
+          found = findNext();
+        }
+
+        private int findNext()
+        {
+          while (currIndex < end && !matcher.test(currIndex)) {
+            currIndex++;
+          }
+
+          if (currIndex < end) {
+            return currIndex++;
+          } else {
+            return -1;
+          }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+          return found != -1;
+        }
+
+        @Override
+        public ImmutableBitmap next()
+        {
+          int cur = found;
+
+          if (cur == -1) {
+            throw new NoSuchElementException();
+          }
+
+          found = findNext();
+          return getBitmap(cur);
+        }
+      };
+    }
+
+    @Override
+    public Iterable<ImmutableBitmap> getBitmapsForValues(Set<String> values)
+    {
+      return () -> new Iterator<ImmutableBitmap>()
+      {
+        final Iterator<String> iterator = values.iterator();
+        int next = -1;
+
+        @Override
+        public boolean hasNext()
+        {
+          if (next < 0) {
+            findNext();
+          }
+          return next >= 0;
+        }
+
+        @Override
+        public ImmutableBitmap next()
+        {
+          if (next < 0) {
+            findNext();
+            if (next < 0) {
+              throw new NoSuchElementException();
+            }
+          }
+          final int swap = next;
+          next = -1;
+          return getBitmap(swap);
+        }
+
+        private void findNext()
+        {
+          while (next < 0 && iterator.hasNext()) {
+            String nextValue = iterator.next();
+            next = getReverseIndex(nextValue);
+          }
+        }
+      };
+    }
+
+    private int getReverseIndex(@Nullable String value)
+    {
+      int minIndex = 0;
+      int maxIndex = idMapping.getValueCardinality() - 1;
+      final Comparator<String> comparator = StringComparators.LEXICOGRAPHIC;
+      while (minIndex <= maxIndex) {
+        int currIndex = (minIndex + maxIndex) >>> 1;
+
+        String currValue = delegate.getValue(idMapping.getReverseId(currIndex));
+        int comparison = comparator.compare(currValue, value);
+        if (comparison == 0) {
+          return currIndex;
+        }
+
+        if (comparison < 0) {
+          minIndex = currIndex + 1;
+        } else {
+          maxIndex = currIndex - 1;
+        }
+      }
+
+      return -(minIndex + 1);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
@@ -50,7 +50,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 /**
  * {@link VirtualColumn} form of {@link ListFilteredDimensionSpec}, powered by
@@ -289,7 +289,7 @@ public class ListFilteredVirtualColumn implements VirtualColumn
         boolean startStrict,
         @Nullable String endValue,
         boolean endStrict,
-        IntPredicate matcher
+        Predicate<String> matcher
     )
     {
       int startIndex, endIndex;
@@ -327,7 +327,7 @@ public class ListFilteredVirtualColumn implements VirtualColumn
 
         private int findNext()
         {
-          while (currIndex < end && !matcher.test(currIndex)) {
+          while (currIndex < end && !matcher.test(delegate.getValue(idMapping.getReverseId(currIndex)))) {
             currIndex++;
           }
 

--- a/processing/src/test/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/ColumnSelectorBitmapIndexSelectorTest.java
@@ -71,6 +71,7 @@ public class ColumnSelectorBitmapIndexSelectorTest
     ImmutableBitmap someBitmap = EasyMock.createMock(ImmutableBitmap.class);
     EasyMock.expect(someIndex.getIndex("foo")).andReturn(0).anyTimes();
     EasyMock.expect(someIndex.getBitmap(0)).andReturn(someBitmap).anyTimes();
+    EasyMock.expect(someIndex.getBitmapForValue("foo")).andReturn(someBitmap).anyTimes();
 
 
     ColumnHolder nonStringHolder = EasyMock.createMock(ColumnHolder.class);

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerNullHandlingTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerNullHandlingTest.java
@@ -196,7 +196,7 @@ public class IndexMergerNullHandlingTest
             if (expectedNullRows.size() > 0) {
               Assert.assertEquals(subsetList.toString(), 0, bitmapIndex.getIndex(null));
 
-              final ImmutableBitmap nullBitmap = bitmapIndex.getBitmap(bitmapIndex.getIndex(null));
+              final ImmutableBitmap nullBitmap = bitmapIndex.getBitmapForValue(null);
               final List<Integer> actualNullRows = new ArrayList<>();
               final IntIterator iterator = nullBitmap.iterator();
               while (iterator.hasNext()) {

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -23,6 +23,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import org.apache.druid.common.config.NullHandling;
@@ -90,6 +91,7 @@ import org.apache.druid.segment.vector.VectorCursor;
 import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.vector.VectorValueSelector;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.segment.virtual.ListFilteredVirtualColumn;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
@@ -125,7 +127,11 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
           new ExpressionVirtualColumn("vdim1", "dim1", ColumnType.STRING, TestExprMacroTable.INSTANCE),
           new ExpressionVirtualColumn("vd0", "d0", ColumnType.DOUBLE, TestExprMacroTable.INSTANCE),
           new ExpressionVirtualColumn("vf0", "f0", ColumnType.FLOAT, TestExprMacroTable.INSTANCE),
-          new ExpressionVirtualColumn("vl0", "l0", ColumnType.LONG, TestExprMacroTable.INSTANCE)
+          new ExpressionVirtualColumn("vl0", "l0", ColumnType.LONG, TestExprMacroTable.INSTANCE),
+          new ListFilteredVirtualColumn("allow-dim0", DefaultDimensionSpec.of("dim0"), ImmutableSet.of("3", "4"), true),
+          new ListFilteredVirtualColumn("deny-dim0", DefaultDimensionSpec.of("dim0"), ImmutableSet.of("3", "4"), false),
+          new ListFilteredVirtualColumn("allow-dim2", DefaultDimensionSpec.of("dim2"), ImmutableSet.of("a"), true),
+          new ListFilteredVirtualColumn("deny-dim2", DefaultDimensionSpec.of("dim2"), ImmutableSet.of("a"), false)
       )
   );
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/BoundFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BoundFilterTest.java
@@ -440,6 +440,45 @@ public class BoundFilterTest extends BaseFilterTest
   }
 
   @Test
+  public void testListFilteredVirtualColumn()
+  {
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("allow-dim0", "0", "2", false, false, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of()
+    );
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("allow-dim0", "0", "6", false, false, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of("3", "4")
+    );
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("deny-dim0", "0", "6", false, false, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of("0", "1", "2", "5", "6")
+    );
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("deny-dim0", "3", "4", false, false, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of()
+    );
+
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("allow-dim2", "a", "c", false, false, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of("0", "3", "6")
+    );
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("allow-dim2", "c", "z", false, false, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of()
+    );
+
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("deny-dim2", "a", "b", false, true, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of()
+    );
+    assertFilterMatchesSkipVectorize(
+        new BoundDimFilter("deny-dim2", "c", "z", false, false, false, null, StringComparators.LEXICOGRAPHIC),
+        ImmutableList.of("4", "7")
+    );
+  }
+
+  @Test
   public void testNumericMatchExactlySingleValue()
   {
     assertFilterMatches(

--- a/processing/src/test/java/org/apache/druid/segment/filter/ExtractionDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/ExtractionDimFilterTest.java
@@ -37,6 +37,8 @@ import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import org.apache.druid.segment.column.BitmapIndex;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.data.ConciseBitmapSerdeFactory;
@@ -95,6 +97,13 @@ public class ExtractionDimFilterTest
 
   private final BitmapIndexSelector BITMAP_INDEX_SELECTOR = new BitmapIndexSelector()
   {
+    @Nullable
+    @Override
+    public ColumnCapabilities getColumnCapabilities(String column)
+    {
+      return ColumnCapabilitiesImpl.createDefault().setType(ColumnType.STRING).setHasMultipleValues(true);
+    }
+
     @Override
     public CloseableIndexed<String> getDimensionValues(String dimension)
     {

--- a/processing/src/test/java/org/apache/druid/segment/filter/FiltersTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FiltersTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
-import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 public class FiltersTest extends InitializedNullHandlingTest
 {
@@ -111,7 +111,7 @@ public class FiltersTest extends InitializedNullHandlingTest
           boolean startStrict,
           @Nullable String endValue,
           boolean endStrict,
-          IntPredicate matcher
+          Predicate<String> matcher
       )
       {
         throw new UnsupportedOperationException();

--- a/processing/src/test/java/org/apache/druid/segment/filter/FiltersTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FiltersTest.java
@@ -31,7 +31,10 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
+import java.util.function.IntPredicate;
 
 public class FiltersTest extends InitializedNullHandlingTest
 {
@@ -81,6 +84,41 @@ public class FiltersTest extends InitializedNullHandlingTest
 
       @Override
       public int getIndex(String value)
+      {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public ImmutableBitmap getBitmapForValue(@Nullable String value)
+      {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Iterable<ImmutableBitmap> getBitmapsInRange(
+          @Nullable String startValue,
+          boolean startStrict,
+          @Nullable String endValue,
+          boolean endStrict
+      )
+      {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Iterable<ImmutableBitmap> getBitmapsInRange(
+          @Nullable String startValue,
+          boolean startStrict,
+          @Nullable String endValue,
+          boolean endStrict,
+          IntPredicate matcher
+      )
+      {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Iterable<ImmutableBitmap> getBitmapsForValues(Set<String> values)
       {
         throw new UnsupportedOperationException();
       }

--- a/processing/src/test/java/org/apache/druid/segment/filter/SelectorFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SelectorFilterTest.java
@@ -116,6 +116,20 @@ public class SelectorFilterTest extends BaseFilterTest
   }
 
   @Test
+  public void testListFilteredVirtualColumn()
+  {
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("allow-dim0", "1", null), ImmutableList.of());
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("allow-dim0", "4", null), ImmutableList.of("4"));
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("deny-dim0", "0", null), ImmutableList.of("0"));
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("deny-dim0", "4", null), ImmutableList.of());
+
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("allow-dim2", "b", null), ImmutableList.of());
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("allow-dim2", "a", null), ImmutableList.of("0", "3"));
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("deny-dim2", "b", null), ImmutableList.of("0"));
+    assertFilterMatchesSkipVectorize(new SelectorDimFilter("deny-dim2", "a", null), ImmutableList.of());
+  }
+
+  @Test
   public void testSingleValueStringColumnWithNulls()
   {
     // testSingleValueStringColumnWithoutNulls but with virtual column selector

--- a/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentStorageAdapterTest.java
@@ -39,6 +39,7 @@ import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
 import org.junit.After;
 import org.junit.Assert;
@@ -52,7 +53,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-public class BaseHashJoinSegmentStorageAdapterTest
+public class BaseHashJoinSegmentStorageAdapterTest extends InitializedNullHandlingTest
 {
   public static JoinFilterRewriteConfig DEFAULT_JOIN_FILTER_REWRITE_CONFIG = new JoinFilterRewriteConfig(
       true,

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
@@ -369,7 +369,7 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
     Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
     Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertTrue(inferred.hasBitmapIndexes());
+    Assert.assertFalse(inferred.hasBitmapIndexes());
     Assert.assertFalse(inferred.hasSpatialIndexes());
 
     // multiple input columns
@@ -463,7 +463,7 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
     Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
     Assert.assertTrue(inferred.hasMultipleValues().isTrue());
-    Assert.assertTrue(inferred.hasBitmapIndexes());
+    Assert.assertFalse(inferred.hasBitmapIndexes());
     Assert.assertFalse(inferred.hasSpatialIndexes());
 
     thePlan = plan("concat(scalar_string, multi_dictionary_string_nonunique)");

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -52,6 +52,8 @@ import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.TestObjectColumnSelector;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.generator.SegmentGenerator;
@@ -81,6 +83,19 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   private static IncrementalIndex INCREMENTAL_INDEX;
   private static IncrementalIndexStorageAdapter INCREMENTAL_INDEX_STORAGE_ADAPTER;
   private static List<StorageAdapter> ADAPTERS;
+
+  private static final ColumnCapabilities SINGLE_VALUE = new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                                                                     .setDictionaryEncoded(true)
+                                                                                     .setDictionaryValuesUnique(true)
+                                                                                     .setDictionaryValuesSorted(true)
+                                                                                     .setHasMultipleValues(false)
+                                                                                     .setHasNulls(true);
+  private static final ColumnCapabilities MULTI_VAL = new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                                                                  .setDictionaryEncoded(true)
+                                                                                  .setDictionaryValuesUnique(true)
+                                                                                  .setDictionaryValuesSorted(true)
+                                                                                  .setHasMultipleValues(true)
+                                                                                  .setHasNulls(true);
 
   @BeforeClass
   public static void setup()
@@ -394,7 +409,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.FALSE
+            SINGLE_VALUE
         )
     );
   }
@@ -405,7 +420,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("concat(dim1, dim1) == 2", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.FALSE
+            SINGLE_VALUE
         )
     );
   }
@@ -416,7 +431,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.TRUE
+            MULTI_VAL
         )
     );
   }
@@ -427,7 +442,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.UNKNOWN
+            new ColumnCapabilitiesImpl()
         )
     );
   }
@@ -438,7 +453,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("array_contains(dim1, 2)", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.FALSE
+            ColumnCapabilitiesImpl.createDefault().setType(ColumnType.STRING_ARRAY)
         )
     );
   }
@@ -449,7 +464,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("array_contains(dim1, 2)", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.TRUE
+            MULTI_VAL
         )
     );
   }
@@ -460,7 +475,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("array_contains(dim1, 2)", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.UNKNOWN
+            new ColumnCapabilitiesImpl()
         )
     );
   }
@@ -471,7 +486,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     Assert.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
-            ColumnCapabilities.Capable.FALSE
+            SINGLE_VALUE
         )
     );
   }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVectorSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVectorSelectorsTest.java
@@ -30,7 +30,6 @@ import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.expression.TestExprMacroTable;
-import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.QueryableIndex;
@@ -145,17 +144,7 @@ public class ExpressionVectorSelectorsTest
   public void setup()
   {
     Expr parsed = Parser.parse(expression, ExprMacroTable.nil());
-    outputType = parsed.getOutputType(
-        new ColumnInspector()
-        {
-          @Nullable
-          @Override
-          public ColumnCapabilities getColumnCapabilities(String column)
-          {
-            return QueryableIndexStorageAdapter.getColumnCapabilities(INDEX, column);
-          }
-        }
-    );
+    outputType = parsed.getOutputType(INDEX);
     if (outputType == null) {
       outputType = ExpressionType.STRING;
     }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnSelectorTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.segment.RowBasedColumnSelectorFactory;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.BitmapIndex;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -172,6 +173,13 @@ public class ListFilteredVirtualColumnSelectorTest extends InitializedNullHandli
     BitmapFactory bitmapFactory = EasyMock.createMock(BitmapFactory.class);
 
     EasyMock.expect(selector.getColumnHolder(COLUMN_NAME)).andReturn(holder).atLeastOnce();
+    EasyMock.expect(selector.getColumnCapabilities(COLUMN_NAME))
+            .andReturn(new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                                   .setDictionaryEncoded(true)
+                                                   .setDictionaryValuesUnique(true)
+                                                   .setDictionaryValuesSorted(true)
+                                                   .setHasBitmapIndexes(true)
+            ).anyTimes();
 
     EasyMock.expect(holder.getBitmapIndex()).andReturn(index).atLeastOnce();
 
@@ -227,7 +235,13 @@ public class ListFilteredVirtualColumnSelectorTest extends InitializedNullHandli
     BitmapFactory bitmapFactory = EasyMock.createMock(BitmapFactory.class);
 
     EasyMock.expect(selector.getColumnHolder(COLUMN_NAME)).andReturn(holder).atLeastOnce();
-
+    EasyMock.expect(selector.getColumnCapabilities(COLUMN_NAME))
+            .andReturn(new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                                   .setDictionaryEncoded(true)
+                                                   .setDictionaryValuesUnique(true)
+                                                   .setDictionaryValuesSorted(true)
+                                                   .setHasBitmapIndexes(true)
+            ).anyTimes();
     EasyMock.expect(holder.getBitmapIndex()).andReturn(index).atLeastOnce();
 
     EasyMock.expect(index.getCardinality()).andReturn(3).atLeastOnce();


### PR DESCRIPTION
### Description
This PR updates the `BitmapIndex` interface to add several "value" based bitmap retrieval methods, to push the logic of how these are collected into the `BitmapIndex` implementation, instead of leaking details about the underlying dictionaries (such as GenericIndexed.indexOf returning position or -insertion point).

```
  ImmutableBitmap getBitmapForValue(@Nullable String value);

  default Iterable<ImmutableBitmap> getBitmapsInRange(
      @Nullable String startValue,
      boolean startStrict,
      @Nullable String endValue,
      boolean endStrict
  )
  {
    return getBitmapsInRange(startValue, startStrict, endValue, endStrict, (index) -> true);
  }

  Iterable<ImmutableBitmap> getBitmapsInRange(
      @Nullable String startValue,
      boolean startStrict,
      @Nullable String endValue,
      boolean endStrict,
      IntPredicate matcher
  );

  Iterable<ImmutableBitmap> getBitmapsForValues(Set<String> values);
```

The major changes of adding these methods is that now "in", "bound", and "like" filters push this logic into `BitmapIndex`, so they don't have to know things about the underlying selectors indexes, such as whether or not they are sorted, etc, and now simply call these methods to get a set of `ImmutableBitmap` to do whatever with.

I consider this the first step of some work I'd like to do on allowing indexes on other types of values, such as numbers and complex types.

This PR also fixes an unrelated bug with `PredicateFilteredDimensionSelector`, where it would return a "match" for null rows, even if the predicate didn't match null, meaning sometimes rows which were meant to be filtered out would be considered a match inappropriately.

<hr>

##### Key changed/added classes in this PR
 * `BitmapIndex`
 * `BitmapIndexSelector`
 * `ColumnSelectorBitmapIndexSelector`
 * `StringBitmapIndexColumnPartSupplier`
 * `InDimFilter`
 * `BoundFilter`
 * `LikeFilter`

<hr>


This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
