### PR TITLE
Adding k8s support for human readable parsing

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/HumanReadableBytes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/HumanReadableBytes.java
@@ -170,7 +170,6 @@ public class HumanReadableBytes
       isBinaryByte = true;
     }
 
-
     long base = 1;
     switch (unit) {
       case 'k':
@@ -235,12 +234,7 @@ public class HumanReadableBytes
      * simplified SI format without 'B' indicator
      * eg: K, M, G ...
      */
-    DECIMAL,
-    /**
-     * same as binary byte format, that k8s uses
-     * eg: Ki, Mi, Gi ...
-     */
-    KUBERNETES_BYTE
+    DECIMAL
   }
 
   /**
@@ -264,8 +258,6 @@ public class HumanReadableBytes
         return DecimalFormatter.format(bytes, pattern, "B");
       case DECIMAL:
         return DecimalFormatter.format(bytes, pattern, "").trim();
-      case KUBERNETES_BYTE:
-        return BinaryFormatter.format(bytes, pattern, "").trim();
       default:
         throw new IAE("Unkonwn unit system[%s]", unitSystem);
     }

--- a/core/src/main/java/org/apache/druid/java/util/common/HumanReadableBytes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/HumanReadableBytes.java
@@ -164,7 +164,7 @@ public class HumanReadableBytes
     } else if (unit == 'i') {
       //unit ends with 'i' must be format of Ki/Mi/Gi/Ti/Pi, so at least 2 extra characters are required
       if (lastDigitIndex < 1) {
-        throw new IAE("Invalid format of number: %s", rawNumber);
+        throw new IAE("Invalid format of number [%s]. The unit should be one of Pi/Ti/Gi/Mi/Ki", rawNumber);
       }
       unit = number.charAt(lastDigitIndex--);
       isBinaryByte = true;

--- a/core/src/main/java/org/apache/druid/java/util/common/HumanReadableBytes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/HumanReadableBytes.java
@@ -115,11 +115,11 @@ public class HumanReadableBytes
    * g - gigabyte = 1,000,000,000
    * t - terabyte = 1,000,000,000,000
    * p - petabyte = 1,000,000,000,000,000
-   * KiB - kilo binary byte = 1024
-   * MiB - mega binary byte = 1024*1204
-   * GiB - giga binary byte = 1024*1024*1024
-   * TiB - tera binary byte = 1024*1024*1024*1024
-   * PiB - peta binary byte = 1024*1024*1024*1024*1024
+   * Ki(B) - kilo binary byte = 1024
+   * Mi(B) - mega binary byte = 1024*1204
+   * Gi(B) - giga binary byte = 1024*1024*1024
+   * Ti(B) - tera binary byte = 1024*1024*1024*1024
+   * Pi(B) - peta binary byte = 1024*1024*1024*1024*1024
    * <p>
    *
    * @param nullValue to be returned when given number is null or empty
@@ -161,7 +161,15 @@ public class HumanReadableBytes
 
       unit = number.charAt(lastDigitIndex--);
       isBinaryByte = true;
+    } else if (unit == 'i') {
+      //unit ends with 'i' must be format of Ki/Mi/Gi/Ti/Pi, so at least 2 extra characters are required
+      if (lastDigitIndex < 1) {
+        throw new IAE("Invalid format of number: %s", rawNumber);
+      }
+      unit = number.charAt(lastDigitIndex--);
+      isBinaryByte = true;
     }
+
 
     long base = 1;
     switch (unit) {
@@ -227,7 +235,12 @@ public class HumanReadableBytes
      * simplified SI format without 'B' indicator
      * eg: K, M, G ...
      */
-    DECIMAL
+    DECIMAL,
+    /**
+     * same as binary byte format, that k8s uses
+     * eg: Ki, Mi, Gi ...
+     */
+    KUBERNETES_BYTE
   }
 
   /**
@@ -251,6 +264,8 @@ public class HumanReadableBytes
         return DecimalFormatter.format(bytes, pattern, "B");
       case DECIMAL:
         return DecimalFormatter.format(bytes, pattern, "").trim();
+      case KUBERNETES_BYTE:
+        return BinaryFormatter.format(bytes, pattern, "").trim();
       default:
         throw new IAE("Unkonwn unit system[%s]", unitSystem);
     }

--- a/core/src/test/java/org/apache/druid/java/util/common/HumanReadableBytesTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/HumanReadableBytesTest.java
@@ -91,6 +91,7 @@ public class HumanReadableBytesTest
     Assert.assertEquals(1024, HumanReadableBytes.parse("1kib"));
     Assert.assertEquals(9 * 1024, HumanReadableBytes.parse("9KiB"));
     Assert.assertEquals(9 * 1024, HumanReadableBytes.parse("9Kib"));
+    Assert.assertEquals(9 * 1024, HumanReadableBytes.parse("9Ki"));
   }
 
   @Test
@@ -99,6 +100,7 @@ public class HumanReadableBytesTest
     Assert.assertEquals(1024 * 1024, HumanReadableBytes.parse("1mib"));
     Assert.assertEquals(9 * 1024 * 1024, HumanReadableBytes.parse("9MiB"));
     Assert.assertEquals(9 * 1024 * 1024, HumanReadableBytes.parse("9Mib"));
+    Assert.assertEquals(9 * 1024 * 1024, HumanReadableBytes.parse("9Mi"));
   }
 
   @Test
@@ -107,6 +109,7 @@ public class HumanReadableBytesTest
     Assert.assertEquals(1024 * 1024 * 1024, HumanReadableBytes.parse("1gib"));
     Assert.assertEquals(1024 * 1024 * 1024, HumanReadableBytes.parse("1GiB"));
     Assert.assertEquals(9L * 1024 * 1024 * 1024, HumanReadableBytes.parse("9Gib"));
+    Assert.assertEquals(9L * 1024 * 1024 * 1024, HumanReadableBytes.parse("9Gi"));
   }
 
   @Test
@@ -115,6 +118,7 @@ public class HumanReadableBytesTest
     Assert.assertEquals(1024L * 1024 * 1024 * 1024, HumanReadableBytes.parse("1tib"));
     Assert.assertEquals(9L * 1024 * 1024 * 1024 * 1024, HumanReadableBytes.parse("9TiB"));
     Assert.assertEquals(9L * 1024 * 1024 * 1024 * 1024, HumanReadableBytes.parse("9Tib"));
+    Assert.assertEquals(9L * 1024 * 1024 * 1024 * 1024, HumanReadableBytes.parse("9Ti"));
   }
 
   @Test
@@ -123,6 +127,7 @@ public class HumanReadableBytesTest
     Assert.assertEquals(1024L * 1024 * 1024 * 1024 * 1024, HumanReadableBytes.parse("1pib"));
     Assert.assertEquals(9L * 1024 * 1024 * 1024 * 1024 * 1024, HumanReadableBytes.parse("9PiB"));
     Assert.assertEquals(9L * 1024 * 1024 * 1024 * 1024 * 1024, HumanReadableBytes.parse("9Pib"));
+    Assert.assertEquals(9L * 1024 * 1024 * 1024 * 1024 * 1024, HumanReadableBytes.parse("9Pi"));
   }
 
   @Test
@@ -207,6 +212,13 @@ public class HumanReadableBytesTest
   }
 
   @Test
+  public void testInvalidFormatOneCharK8s()
+  {
+    expectedException.expect(ExceptionMatcher.INVALIDFORMAT);
+    HumanReadableBytes.parse("i");
+  }
+
+  @Test
   public void testInvalidFormatOneChar2()
   {
     expectedException.expect(ExceptionMatcher.INVALIDFORMAT);
@@ -235,11 +247,26 @@ public class HumanReadableBytesTest
   }
 
   @Test
+  public void testInvalidFormatMiExtraSpace()
+  {
+    expectedException.expect(ExceptionMatcher.INVALIDFORMAT);
+    HumanReadableBytes.parse("1 mi");
+  }
+
+  @Test
   public void testInvalidFormatTiB()
   {
     expectedException.expect(ExceptionMatcher.INVALIDFORMAT);
     HumanReadableBytes.parse("tib");
   }
+
+  @Test
+  public void testInvalidFormatTi()
+  {
+    expectedException.expect(ExceptionMatcher.INVALIDFORMAT);
+    HumanReadableBytes.parse("ti");
+  }
+
 
   @Test
   public void testInvalidFormatGiB()
@@ -415,6 +442,28 @@ public class HumanReadableBytesTest
     Assert.assertEquals("1.00 TiB", HumanReadableBytes.format(1024L * 1024 * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.BINARY_BYTE));
     Assert.assertEquals("1.00 PiB", HumanReadableBytes.format(1024L * 1024 * 1024 * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.BINARY_BYTE));
     Assert.assertEquals("8.00 EiB", HumanReadableBytes.format(Long.MAX_VALUE, 2, HumanReadableBytes.UnitSystem.BINARY_BYTE));
+  }
+
+  @Test
+  public void testFormatInBinaryK8sByte()
+  {
+    Assert.assertEquals("-8.00 Ei", HumanReadableBytes.format(Long.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("-8.000 Ei", HumanReadableBytes.format(Long.MIN_VALUE, 3, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+
+    Assert.assertEquals("-2.00 Gi", HumanReadableBytes.format(Integer.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("-32.00 Ki", HumanReadableBytes.format(Short.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+
+    Assert.assertEquals("-128", HumanReadableBytes.format(Byte.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("-1", HumanReadableBytes.format(-1, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("0", HumanReadableBytes.format(0, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("1", HumanReadableBytes.format(1, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+
+    Assert.assertEquals("1.00 Ki", HumanReadableBytes.format(1024L, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("1.00 Mi", HumanReadableBytes.format(1024L * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("1.00 Gi", HumanReadableBytes.format(1024L * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("1.00 Ti", HumanReadableBytes.format(1024L * 1024 * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("1.00 Pi", HumanReadableBytes.format(1024L * 1024 * 1024 * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
+    Assert.assertEquals("8.00 Ei", HumanReadableBytes.format(Long.MAX_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/java/util/common/HumanReadableBytesTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/HumanReadableBytesTest.java
@@ -445,28 +445,6 @@ public class HumanReadableBytesTest
   }
 
   @Test
-  public void testFormatInBinaryK8sByte()
-  {
-    Assert.assertEquals("-8.00 Ei", HumanReadableBytes.format(Long.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("-8.000 Ei", HumanReadableBytes.format(Long.MIN_VALUE, 3, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-
-    Assert.assertEquals("-2.00 Gi", HumanReadableBytes.format(Integer.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("-32.00 Ki", HumanReadableBytes.format(Short.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-
-    Assert.assertEquals("-128", HumanReadableBytes.format(Byte.MIN_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("-1", HumanReadableBytes.format(-1, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("0", HumanReadableBytes.format(0, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("1", HumanReadableBytes.format(1, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-
-    Assert.assertEquals("1.00 Ki", HumanReadableBytes.format(1024L, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("1.00 Mi", HumanReadableBytes.format(1024L * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("1.00 Gi", HumanReadableBytes.format(1024L * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("1.00 Ti", HumanReadableBytes.format(1024L * 1024 * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("1.00 Pi", HumanReadableBytes.format(1024L * 1024 * 1024 * 1024 * 1024, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-    Assert.assertEquals("8.00 Ei", HumanReadableBytes.format(Long.MAX_VALUE, 2, HumanReadableBytes.UnitSystem.KUBERNETES_BYTE));
-  }
-
-  @Test
   public void testPrecisionInBinaryFormat()
   {
     Assert.assertEquals("1 KiB", HumanReadableBytes.format(1500, 0, HumanReadableBytes.UnitSystem.BINARY_BYTE));

--- a/docs/configuration/human-readable-byte.md
+++ b/docs/configuration/human-readable-byte.md
@@ -77,7 +77,7 @@ To make it clear, the base of units are defined in Druid as below
 
 Unit is case-insensitive. `k`, `kib`, `ki`, `KiB`, `Ki`, `kiB` are all acceptable.
 
-Here are two examples
+Here are some examples
 
 ```properties
 # 1G bytes = 1_000_000_000 bytes

--- a/docs/configuration/human-readable-byte.md
+++ b/docs/configuration/human-readable-byte.md
@@ -90,7 +90,7 @@ druid.cache.sizeInBytes=256MiB
 ```
 
 ```properties
-# 256MiB bytes = 256 * 1024 * 1024 bytes
+# 256Mi = 256MiB = 256 * 1024 * 1024 bytes
 druid.cache.sizeInBytes=256Mi
 ```
 

--- a/docs/configuration/human-readable-byte.md
+++ b/docs/configuration/human-readable-byte.md
@@ -64,13 +64,18 @@ To make it clear, the base of units are defined in Druid as below
 | G | Giga Decimal Byte | 1_000_000_000 |
 | T | Tera Decimal Byte | 1_000_000_000_000 |
 | P | Peta Decimal Byte | 1_000_000_000_000_000 |
+| Ki | Kilo Binary Byte | 1024 |
+| Mi  | Mega Binary Byte | 1024 * 1024 |
+| Gi | Giga Binary Byte | 1024 * 1024 * 1024 |
+| Ti  | Tera Binary Byte | 1024 * 1024 * 1024 * 1024 |
+| Pi  | Peta Binary Byte | 1024 * 1024 * 1024 * 1024 * 1024 |
 | KiB | Kilo Binary Byte | 1024 |
 | MiB  | Mega Binary Byte | 1024 * 1024 |
 | GiB | Giga Binary Byte | 1024 * 1024 * 1024 |
 | TiB  | Tera Binary Byte | 1024 * 1024 * 1024 * 1024 |
 | PiB  | Peta Binary Byte | 1024 * 1024 * 1024 * 1024 * 1024 |
 
-Unit is case-insensitive. `k`, `kib`, `KiB`, `kiB` are all acceptable.
+Unit is case-insensitive. `k`, `kib`, `ki`, `KiB`, `Ki`, `kiB` are all acceptable.
 
 Here are two examples
 
@@ -82,6 +87,11 @@ druid.cache.sizeInBytes=1g
 ```properties
 # 256MiB bytes = 256 * 1024 * 1024 bytes
 druid.cache.sizeInBytes=256MiB 
+```
+
+```properties
+# 256MiB bytes = 256 * 1024 * 1024 bytes
+druid.cache.sizeInBytes=256Mi
 ```
 
 


### PR DESCRIPTION
currently druid only supports decimal format 'k', 'm', 'g', etc...
or
binary byte format 'kib', 'mib', 'gib', etc....

When dealing with kubernetes they use the format with the decimal format + `i` only no `b` suffix for binary format. 

We encountered this problem when having a volume of some size configured in helm like `500Gi`
Then wanted to programatically assign the `druid.segmentCache.locations` by taking the volumeclaimtemplate's size and using it for the `maxSize` parameter.  This failed because in k8s you don't refer to it as `500GiB` instead its just `500Gi`  

Would be nice to have druid be able to parse input in this format as well. 