### PR TITLE
Graceful null handling and correctness in DoubleMean Aggregator

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregator.java
@@ -43,8 +43,8 @@ public class DoubleMeanAggregator implements Aggregator
   public void aggregate()
   {
     Object update = selector.getObject();
-    boolean status = selector.isNull();
-    if (status == true && NullHandling.replaceWithDefault() == false) {
+
+    if (update == null && NullHandling.replaceWithDefault() == false) {
       return;
     }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregator.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.mean;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Numbers;
 import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.segment.ColumnValueSelector;
@@ -42,6 +43,10 @@ public class DoubleMeanAggregator implements Aggregator
   public void aggregate()
   {
     Object update = selector.getObject();
+    boolean status = selector.isNull();
+    if (status == true && NullHandling.replaceWithDefault() == false) {
+      return;
+    }
 
     if (update instanceof DoubleMeanHolder) {
       value.update((DoubleMeanHolder) update);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanBufferAggregator.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.mean;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Numbers;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
@@ -50,10 +51,10 @@ public class DoubleMeanBufferAggregator implements BufferAggregator
   public void aggregate(ByteBuffer buf, int position)
   {
     Object update = selector.getObject();
-    if (selector.isNull()) {
+
+    if (update == null && NullHandling.replaceWithDefault()==false) {
       return;
     }
-
     if (update instanceof DoubleMeanHolder) {
       DoubleMeanHolder.update(buf, position, (DoubleMeanHolder) update);
     } else if (update instanceof List) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanBufferAggregator.java
@@ -50,6 +50,9 @@ public class DoubleMeanBufferAggregator implements BufferAggregator
   public void aggregate(ByteBuffer buf, int position)
   {
     Object update = selector.getObject();
+    if (selector.isNull()) {
+      return;
+    }
 
     if (update instanceof DoubleMeanHolder) {
       DoubleMeanHolder.update(buf, position, (DoubleMeanHolder) update);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanBufferAggregator.java
@@ -52,7 +52,7 @@ public class DoubleMeanBufferAggregator implements BufferAggregator
   {
     Object update = selector.getObject();
 
-    if (update == null && NullHandling.replaceWithDefault()==false) {
+    if (update == null && NullHandling.replaceWithDefault() == false) {
       return;
     }
     if (update instanceof DoubleMeanHolder) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
@@ -44,8 +44,15 @@ public class DoubleMeanVectorAggregator implements VectorAggregator
   @Override
   public void aggregate(final ByteBuffer buf, final int position, final int startRow, final int endRow)
   {
+    final boolean[] nullVector = selector.getNullVector();
+
     final double[] vector = selector.getDoubleVector();
     for (int i = startRow; i < endRow; i++) {
+      if (nullVector != null) {
+        if (nullVector[i]) {
+          continue;
+        }
+      }
       DoubleMeanHolder.update(buf, position, vector[i]);
     }
   }
@@ -59,9 +66,15 @@ public class DoubleMeanVectorAggregator implements VectorAggregator
       final int positionOffset
   )
   {
+    final boolean[] nullVector = selector.getNullVector();
     final double[] vector = selector.getDoubleVector();
 
     for (int i = 0; i < numRows; i++) {
+      if (nullVector != null) {
+        if (nullVector[i]) {
+          continue;
+        }
+      }
       final double val = vector[rows != null ? rows[i] : i];
       DoubleMeanHolder.update(buf, positions[i] + positionOffset, val);
     }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
@@ -53,7 +53,7 @@ public class DoubleMeanVectorAggregator implements VectorAggregator
         for (int i = startRow; i < endRow; i++) {
           DoubleMeanHolder.update(buf, position, vector[i]);
         }
-      }else {
+      } else {
         for (int i = startRow; i < endRow; i++) {
           if (!nulls[i]) {
             DoubleMeanHolder.update(buf, position, vector[i]);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
@@ -86,8 +86,7 @@ public class DoubleMeanVectorAggregator implements VectorAggregator
           final double val = vector[rows != null ? rows[i] : i];
           DoubleMeanHolder.update(buf, positions[i] + positionOffset, val);
         }
-      }
-      else {
+      } else {
         for (int j = 0; j < numRows; j++) {
           if (!nulls[j]) {
             final double val = vector[rows != null ? rows[j] : j];

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanVectorAggregator.java
@@ -81,10 +81,18 @@ public class DoubleMeanVectorAggregator implements VectorAggregator
     final boolean[] nulls = selector.getNullVector();
 
     if (nulls != null) {
-      for (int j = 0; j < numRows; j++) {
-        if (!nulls[j]) {
-          final double val = vector[rows != null ? rows[j] : j];
-          DoubleMeanHolder.update(buf, positions[j] + positionOffset, val);
+      if (NullHandling.replaceWithDefault()) {
+        for (int i = 0; i < numRows; i++) {
+          final double val = vector[rows != null ? rows[i] : i];
+          DoubleMeanHolder.update(buf, positions[i] + positionOffset, val);
+        }
+      }
+      else {
+        for (int j = 0; j < numRows; j++) {
+          if (!nulls[j]) {
+            final double val = vector[rows != null ? rows[j] : j];
+            DoubleMeanHolder.update(buf, positions[j] + positionOffset, val);
+          }
         }
       }
     } else {

--- a/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -46,6 +47,7 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.TestIndex;
 import org.apache.druid.timeline.SegmentId;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -72,6 +74,7 @@ public class DoubleMeanAggregationTest
   private final AggregationTestHelper timeseriesQueryTestHelper;
 
   private final List<Segment> segments;
+  private final List<Segment> biggerSegments;
 
   public DoubleMeanAggregationTest()
   {
@@ -90,6 +93,11 @@ public class DoubleMeanAggregationTest
     segments = ImmutableList.of(
         new IncrementalIndexSegment(SimpleTestIndex.getIncrementalTestIndex(), SegmentId.dummy("test1")),
         new QueryableIndexSegment(SimpleTestIndex.getMMappedTestIndex(), SegmentId.dummy("test2"))
+    );
+
+    biggerSegments = ImmutableList.of(
+        new IncrementalIndexSegment(TestIndex.getIncrementalTestIndex(), SegmentId.dummy("test1")),
+        new QueryableIndexSegment(TestIndex.getMMappedTestIndex(), SegmentId.dummy("test2"))
     );
   }
 
@@ -126,7 +134,7 @@ public class DoubleMeanAggregationTest
   public void testVectorAggretatorUsingGroupByQueryOnDoubleColumn(boolean doVectorize) throws Exception
   {
     GroupByQuery query = new GroupByQuery.Builder()
-        .setDataSource("doubleNumericNull")
+        .setDataSource("test")
         .setGranularity(Granularities.ALL)
         .setInterval("1970/2050")
         .setAggregatorSpecs(
@@ -143,6 +151,33 @@ public class DoubleMeanAggregationTest
     Row result = Iterables.getOnlyElement(seq.toList()).toMapBasedRow(query);
 
     Assert.assertEquals(6.2d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+  }
+
+  @Test
+  @Parameters(method = "doVectorize")
+  public void testVectorAggretatorUsingGroupByQueryOnDoubleColumnOnBiggerSegments(boolean doVectorize) throws Exception
+  {
+    GroupByQuery query = new GroupByQuery.Builder()
+        .setDataSource("blah")
+        .setGranularity(Granularities.ALL)
+        .setInterval("1970/2050")
+        .setAggregatorSpecs(
+            new DoubleMeanAggregatorFactory("meanOnDouble", TestIndex.COLUMNS[9])
+        )
+        .setContext(Collections.singletonMap(QueryContexts.VECTORIZE_KEY, doVectorize))
+        .build();
+
+    // do json serialization and deserialization of query to ensure there are no serde issues
+    ObjectMapper jsonMapper = groupByQueryTestHelper.getObjectMapper();
+    query = (GroupByQuery) jsonMapper.readValue(jsonMapper.writeValueAsString(query), Query.class);
+
+    Sequence<ResultRow> seq = groupByQueryTestHelper.runQueryOnSegmentsObjs(biggerSegments, query);
+    Row result = Iterables.getOnlyElement(seq.toList()).toMapBasedRow(query);
+    if (NullHandling.replaceWithDefault()) {
+      Assert.assertEquals(39.2307d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+    } else {
+      Assert.assertEquals(51.0d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+    }
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
@@ -126,12 +126,11 @@ public class DoubleMeanAggregationTest
   public void testVectorAggretatorUsingGroupByQueryOnDoubleColumn(boolean doVectorize) throws Exception
   {
     GroupByQuery query = new GroupByQuery.Builder()
-        .setDataSource("test")
+        .setDataSource("doubleNumericNull")
         .setGranularity(Granularities.ALL)
         .setInterval("1970/2050")
         .setAggregatorSpecs(
-            new DoubleMeanAggregatorFactory("meanOnDouble", SimpleTestIndex.DOUBLE_COL),
-            new DoubleMeanAggregatorFactory("meanOnMultiValue", SimpleTestIndex.MULTI_VALUE_DOUBLE_AS_STRING_DIM)
+            new DoubleMeanAggregatorFactory("meanOnDouble", SimpleTestIndex.DOUBLE_COL)
         )
         .setContext(Collections.singletonMap(QueryContexts.VECTORIZE_KEY, doVectorize))
         .build();
@@ -144,7 +143,6 @@ public class DoubleMeanAggregationTest
     Row result = Iterables.getOnlyElement(seq.toList()).toMapBasedRow(query);
 
     Assert.assertEquals(6.2d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
-    Assert.assertEquals(4.1333d, result.getMetric("meanOnMultiValue").doubleValue(), 0.0001d);
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregationTest.java
@@ -130,7 +130,8 @@ public class DoubleMeanAggregationTest
         .setGranularity(Granularities.ALL)
         .setInterval("1970/2050")
         .setAggregatorSpecs(
-            new DoubleMeanAggregatorFactory("meanOnDouble", SimpleTestIndex.DOUBLE_COL)
+            new DoubleMeanAggregatorFactory("meanOnDouble", SimpleTestIndex.DOUBLE_COL),
+            new DoubleMeanAggregatorFactory("meanOnMultiValue", SimpleTestIndex.MULTI_VALUE_DOUBLE_AS_STRING_DIM)
         )
         .setContext(Collections.singletonMap(QueryContexts.VECTORIZE_KEY, doVectorize))
         .build();
@@ -143,6 +144,7 @@ public class DoubleMeanAggregationTest
     Row result = Iterables.getOnlyElement(seq.toList()).toMapBasedRow(query);
 
     Assert.assertEquals(6.2d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+    Assert.assertEquals(4.1333d, result.getMetric("meanOnMultiValue").doubleValue(), 0.0001d);
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -5853,7 +5853,7 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
         .setGranularity(Granularities.ALL)
         .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
         .setAggregatorSpecs(
-            new DoubleMeanAggregatorFactory("meanOnDouble", "index")
+            new DoubleMeanAggregatorFactory("meanOnDouble", "doubleNumericNull")
         )
         .build();
 
@@ -5864,7 +5864,7 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
     } else {
       Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
       Row result = Iterables.getOnlyElement(results).toMapBasedRow(query);
-      Assert.assertEquals(479.2062d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+      Assert.assertEquals(39.2307d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Sets;
 import org.apache.druid.collections.CloseableDefaultBlockingPool;
 import org.apache.druid.collections.CloseableStupidPool;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.Rows;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
@@ -82,6 +83,7 @@ import org.apache.druid.query.aggregation.first.LongFirstAggregatorFactory;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniqueFinalizingPostAggregator;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
 import org.apache.druid.query.aggregation.last.LongLastAggregatorFactory;
+import org.apache.druid.query.aggregation.mean.DoubleMeanAggregatorFactory;
 import org.apache.druid.query.aggregation.post.ArithmeticPostAggregator;
 import org.apache.druid.query.aggregation.post.ConstantPostAggregator;
 import org.apache.druid.query.aggregation.post.ExpressionPostAggregator;
@@ -5841,6 +5843,29 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
 
     Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "subquery-different-intervals");
+  }
+
+  @Test
+  public void testDoubleMeanQuery()
+  {
+    GroupByQuery query = new GroupByQuery.Builder()
+        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .setGranularity(Granularities.ALL)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setAggregatorSpecs(
+            new DoubleMeanAggregatorFactory("meanOnDouble", "index")
+        )
+        .build();
+
+    if (config.getDefaultStrategy().equals(GroupByStrategySelector.STRATEGY_V1)) {
+      expectedException.expect(ISE.class);
+      expectedException.expectMessage("Unable to handle complex type");
+      GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+    } else {
+      Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
+      Row result = Iterables.getOnlyElement(results).toMapBasedRow(query);
+      Assert.assertEquals(479.2062d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+    }
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -5864,7 +5864,11 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
     } else {
       Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
       Row result = Iterables.getOnlyElement(results).toMapBasedRow(query);
-      Assert.assertEquals(39.2307d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+      if (NullHandling.replaceWithDefault()) {
+        Assert.assertEquals(39.2307d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+      } else {
+        Assert.assertEquals(51.0d, result.getMetric("meanOnDouble").doubleValue(), 0.0001d);
+      }
     }
   }
 


### PR DESCRIPTION
The null handling was absent in the previous version. Added it to guarantee correct results. 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
