### PR TITLE
Ingestion view task query optimization

### DIFF
--- a/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
+++ b/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
@@ -315,6 +315,19 @@ exports[`IngestionView matches snapshot 1`] = `
           localStorageKey="task-refresh-rate"
           onRefresh={[Function]}
         />
+        <Blueprint3.Tooltip2
+          content="Turning on the toggle will prefer overlord followed by sql for task listing. Turning off will reverse the order."
+          hoverCloseDelay={0}
+          hoverOpenDelay={800}
+          minimal={false}
+          transitionDuration={100}
+        >
+          <Blueprint3.Switch
+            checked={true}
+            label="Prefer Overlord"
+            onChange={[Function]}
+          />
+        </Blueprint3.Tooltip2>
         <Memo(MoreButton)>
           <Blueprint3.MenuItem
             disabled={false}


### PR DESCRIPTION
Added a toggle button that steers queries to overlord or sql. We will default it to overlord to reduce metadata stress.

Fixes #12318

This PR fixes the first part of the solution recommended using UI (https://github.com/apache/druid/issues/12318)

### Description
As tasks increases, UI start putting a lot of stress on metadata store as its required to fetch the whole table to parse the status of the task for filtering and displaying in the UI.

We have seen an upward of 3x network throughput on our metadata store and resulting in degraded performance.

This PR fixes this issue in the UI by introducing a toggle switch that defaults to overlord for fetching task listing and thus avoiding such stress on metadata store.

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar 
- [x] been tested in a test Druid cluster.
