### PR TITLE
Git hooks should fail on errors; pass args to git hooks

### DIFF
--- a/hooks/run-all-in-dir.py
+++ b/hooks/run-all-in-dir.py
@@ -31,4 +31,4 @@ for hook in os.listdir(hooks_dir):
 	if not hook.startswith("_"):
 		command = [os.path.join(hooks_dir, hook)] + args
 		print("Running {}".format(command))
-		subprocess.run(command, shell=True, check=True)
+		subprocess.run(command, check=True)

--- a/hooks/run-all-in-dir.py
+++ b/hooks/run-all-in-dir.py
@@ -31,4 +31,4 @@ for hook in os.listdir(hooks_dir):
 	if not hook.startswith("_"):
 		command = [os.path.join(hooks_dir, hook)] + args
 		print("Running {}".format(command))
-		subprocess.run(command, shell=True)
+		subprocess.run(command, shell=True, check=True)


### PR DESCRIPTION
### Description

Fixes two bugs in the script added in #12300. 

- It should fail when one of the scripts it calls fails.
- Arguments should pass to the script especially when it is called in the `pre-push` hook.

<hr>

This PR has:
- [x] been self-reviewed.
