### PR TITLE
improve FileWriteOutBytes.readFully

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
@@ -132,8 +132,8 @@ final class FileWriteOutBytes extends WriteOutBytes
   public void readFully(long pos, ByteBuffer buffer) throws IOException
   {
     flush();
-    if (pos < 0 || pos > ch.size()) {
-      throw new IAE("pos %d out of range [%d, %d]", pos, 0, ch.size());
+    if (pos < 0 || pos > writeOutBytes) {
+      throw new IAE("pos %d out of range [%d, %d]", pos, 0, writeOutBytes);
     }
     ch.read(buffer, pos);
     if (buffer.remaining() > 0) {

--- a/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
@@ -131,10 +131,10 @@ final class FileWriteOutBytes extends WriteOutBytes
   @Override
   public void readFully(long pos, ByteBuffer buffer) throws IOException
   {
-    flush();
     if (pos < 0 || pos > writeOutBytes) {
       throw new IAE("pos %d out of range [%d, %d]", pos, 0, writeOutBytes);
     }
+    flush();
     ch.read(buffer, pos);
     if (buffer.remaining() > 0) {
       throw new BufferUnderflowException();

--- a/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.writeout;
 
+import org.apache.druid.java.util.common.IAE;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -138,5 +139,63 @@ public class FileWriteOutBytesTest
     fileWriteOutBytes.writeInt(10);
     size = fileWriteOutBytes.size();
     Assert.assertEquals(4, size);
+  }
+
+  @Test
+  public void testReadFullyWorks() throws IOException
+  {
+    int fileSize = 4096;
+    int numOfInt = fileSize / Integer.BYTES;
+    ByteBuffer destination = ByteBuffer.allocate(Integer.BYTES);
+    ByteBuffer underlying = ByteBuffer.allocate(fileSize);
+    // Write 4KiB of ints and expect the write operation of the file channel will be triggered only once.
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              underlying.position(0);
+              underlying.put(buffer);
+              return 0;
+            }).times(1);
+    EasyMock.expect(mockFileChannel.read(EasyMock.eq(destination), EasyMock.eq(100L * Integer.BYTES)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              long pos = (long) EasyMock.getCurrentArguments()[1];
+              buffer.putInt(underlying.getInt((int) pos));
+              return Integer.BYTES;
+            }).times(1);
+    EasyMock.replay(mockFileChannel);
+    for (int i = 0; i < numOfInt; i++) {
+      fileWriteOutBytes.writeInt(i);
+    }
+    Assert.assertEquals(underlying.capacity(), fileWriteOutBytes.size());
+
+    destination.position(0);
+    fileWriteOutBytes.readFully(100L * Integer.BYTES, destination);
+    destination.position(0);
+    Assert.assertEquals(100, destination.getInt());
+    EasyMock.verify(mockFileChannel);
+  }
+
+  @Test
+  public void testReadFullyOutOfBoundsDoesnt() throws IOException
+  {
+    int fileSize = 4096;
+    int numOfInt = fileSize / Integer.BYTES;
+    ByteBuffer destination = ByteBuffer.allocate(Integer.BYTES);
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              buffer.position(buffer.remaining());
+              return 0;
+            }).times(1);
+    EasyMock.replay(mockFileChannel);
+    for (int i = 0; i < numOfInt; i++) {
+      fileWriteOutBytes.writeInt(i);
+    }
+    Assert.assertEquals(fileSize, fileWriteOutBytes.size());
+
+    destination.position(0);
+    Assert.assertThrows(IAE.class, () -> fileWriteOutBytes.readFully(5000, destination));
+    EasyMock.verify(mockFileChannel);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
@@ -182,12 +182,6 @@ public class FileWriteOutBytesTest
     int fileSize = 4096;
     int numOfInt = fileSize / Integer.BYTES;
     ByteBuffer destination = ByteBuffer.allocate(Integer.BYTES);
-    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
-            .andAnswer(() -> {
-              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
-              buffer.position(buffer.remaining());
-              return 0;
-            }).times(1);
     EasyMock.replay(mockFileChannel);
     for (int i = 0; i < numOfInt; i++) {
       fileWriteOutBytes.writeInt(i);


### PR DESCRIPTION

### Description

Improves the performance of `FileWriteOutBytes.readFully` by using the tracked byte size added in #9722, instead of calling the channel size() method, which ends up in a native syscall to check the size of the file on disk. This `readFully` method is used by `GenericIndexedWriter.get` which is currently only used when merging spatial indexes, but would be an improvement for anything looking to read stuff out of the channel.

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
