### PR TITLE
Remove redundant annotation from start methods of several emitters

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/ComposingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/ComposingEmitter.java
@@ -20,7 +20,6 @@
 package org.apache.druid.java.util.emitter.core;
 
 import com.google.common.base.Preconditions;
-import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/ComposingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/ComposingEmitter.java
@@ -39,7 +39,6 @@ public class ComposingEmitter implements Emitter
   }
 
   @Override
-  @LifecycleStart
   public void start()
   {
     log.info("Starting Composing Emitter.");

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
@@ -29,7 +29,6 @@ import org.apache.druid.concurrent.ConcurrentAwaitableCounter;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.asynchttpclient.AsyncHttpClient;

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
@@ -183,7 +183,6 @@ public class HttpPostEmitter implements Flushable, Closeable, Emitter
   }
 
   @Override
-  @LifecycleStart
   public void start()
   {
     synchronized (startLock) {

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/LoggingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/LoggingEmitter.java
@@ -24,7 +24,6 @@ package org.apache.druid.java.util.emitter.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/LoggingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/LoggingEmitter.java
@@ -54,7 +54,6 @@ public class LoggingEmitter implements Emitter
   }
 
   @Override
-  @LifecycleStart
   public void start()
   {
     final boolean alreadyStarted = started.getAndSet(true);

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitter.java
@@ -124,7 +124,7 @@ public class ParametrizedUriEmitter implements Flushable, Closeable, Emitter
         try {
           emitter = emitters.computeIfAbsent(uri, u -> {
             try {
-              return innerLifecycle.addMaybeStartManagedInstance(
+              return innerLifecycle.addMaybeStartStartCloseInstance(
                   new HttpPostEmitter(config.buildHttpEmitterConfig(u.toString()), client, jsonMapper)
               );
             }

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitter.java
@@ -92,7 +92,6 @@ public class ParametrizedUriEmitter implements Flushable, Closeable, Emitter
   }
 
   @Override
-  @LifecycleStart
   public void start()
   {
     // Use full synchronized instead of atomic flag, because otherwise some thread may think that the emitter is already

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitter.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
-import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.asynchttpclient.AsyncHttpClient;

--- a/core/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
@@ -73,6 +73,7 @@ public class ParametrizedUriEmitterTest
     lifecycle = new Lifecycle();
     Emitter emitter = Emitters.create(props, httpClient, lifecycle);
     Assert.assertEquals(ParametrizedUriEmitter.class, emitter.getClass());
+    lifecycle.addMaybeStartStartCloseInstance(emitter);
     lifecycle.start();
     return emitter;
   }


### PR DESCRIPTION
### Description
This is a simple PR to remove the redundant annotation from start methods of several emitters. 

Note that the ServiceEmitter wraps the user configured emitter and starts it.
https://github.com/apache/druid/blob/db91961af70c61ebe1cbe7c42c12309e85c477fb/server/src/main/java/org/apache/druid/server/emitter/EmitterModule.java#L98

Currently, emitters with the redundant annotations will be started twice.

This PR has:
- [X] been self-reviewed.
- [X] been tested in a test Druid cluster.
