### PR TITLE
Include daily segment stats in segment timeline view

### DIFF
--- a/web-console/src/components/segment-timeline/bar-group.tsx
+++ b/web-console/src/components/segment-timeline/bar-group.tsx
@@ -56,6 +56,7 @@ export class BarGroup extends React.Component<BarGroupProps> {
         datasource: entry.datasource,
         xValue: entry.x,
         yValue: entry.y,
+        dailySize: entry.dailySize,
       };
       return (
         <BarUnit

--- a/web-console/src/components/segment-timeline/segment-timeline.tsx
+++ b/web-console/src/components/segment-timeline/segment-timeline.tsx
@@ -193,6 +193,7 @@ ORDER BY "start" DESC`;
             y0,
             datasource,
             color: SegmentTimeline.getColor(i),
+            dailySize: d.total,
           };
           y0 += d[datasource] === undefined ? 0 : d[datasource];
           return barUnitData;

--- a/web-console/src/components/segment-timeline/stacked-bar-chart.tsx
+++ b/web-console/src/components/segment-timeline/stacked-bar-chart.tsx
@@ -31,6 +31,7 @@ export interface BarUnitData {
   width: number;
   datasource: string;
   color: string;
+  dailySize?: number;
 }
 
 export interface BarChartMargin {
@@ -48,6 +49,7 @@ export interface HoveredBarInfo {
   datasource?: string;
   xValue?: number;
   yValue?: number;
+  dailySize?: number;
 }
 
 interface StackedBarChartProps {
@@ -151,6 +153,11 @@ export const StackedBarChart = React.memo(function StackedBarChart(props: Stacke
           <div className="bar-chart-tooltip">
             <div>Datasource: {hoverOn.datasource}</div>
             <div>Time: {hoverOn.xValue}</div>
+            <div>
+              {`${
+                activeDataType === 'countData' ? 'Daily total count:' : 'Daily total size:'
+              } ${formatTick(hoverOn.dailySize!)}`}
+            </div>
             <div>
               {`${activeDataType === 'countData' ? 'Count:' : 'Size:'} ${formatTick(
                 hoverOn.yValue!,


### PR DESCRIPTION
### Description
Adds daily total segment size/ daily total segment count to the segment timeline view of the webconsole.
![Screen Shot 2022-03-11 at 3 26 17 PM](https://user-images.githubusercontent.com/4603202/158096378-60dd5d51-5343-4de5-9cfe-0fdd5a02b899.png)
![Screen Shot 2022-03-11 at 4 11 56 PM](https://user-images.githubusercontent.com/4603202/158096393-ebda8780-a1fa-4bfd-995a-905bd15c65f9.png)

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
