### PR TITLE
Reduce OOM failures in dim distribution phase of parallel indexing

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/StringTuple.java
+++ b/core/src/main/java/org/apache/druid/data/input/StringTuple.java
@@ -65,6 +65,27 @@ public class StringTuple implements Comparable<StringTuple>
     return values.length;
   }
 
+  /**
+   * Esimated heap size of this {@code StringTuple} in bytes including JVM
+   * object overhead.
+   */
+  public long sizeInBytes()
+  {
+    // Size = 16B (object header) + 8B (array ref) + array size
+    long bytes = 16L + 8L;
+
+    // Add size of array
+    bytes += Integer.BYTES;
+    for (String value : values) {
+      bytes += Long.BYTES;
+      if (value != null) {
+        bytes += 28 + 16 + (2L * value.length());
+      }
+    }
+
+    return bytes;
+  }
+
   @JsonValue
   public String[] toArray()
   {

--- a/core/src/test/java/org/apache/druid/data/input/StringTupleTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/StringTupleTest.java
@@ -145,4 +145,14 @@ public class StringTupleTest
         StringTuple.create("c", "b")
     );
   }
+
+  @Test
+  public void testSizeInBytes()
+  {
+    assertEquals(44L, StringTuple.create(null, null).sizeInBytes());
+    assertEquals(90L, StringTuple.create(null, "b").sizeInBytes());
+    assertEquals(136L, StringTuple.create("a", "b").sizeInBytes());
+    assertEquals(154L, StringTuple.create("apple", "banana").sizeInBytes());
+    assertEquals(194L, StringTuple.create("apple apple apple", "banana nana na").sizeInBytes());
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionParallelIndexTaskRunner.java
@@ -21,8 +21,21 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 
 import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringDistribution;
+import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringDistributionMerger;
+import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringSketchMerger;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.utils.CollectionUtils;
+import org.apache.druid.utils.JvmUtils;
+import org.joda.time.Interval;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * {@link ParallelIndexTaskRunner} for the phase to determine distribution of dimension values in
@@ -31,7 +44,13 @@ import java.util.Map;
 class PartialDimensionDistributionParallelIndexTaskRunner
     extends InputSourceSplitParallelIndexTaskRunner<PartialDimensionDistributionTask, DimensionDistributionReport>
 {
+  private static final Logger log = new Logger(PartialDimensionDistributionParallelIndexTaskRunner.class);
   private static final String PHASE_NAME = "partial dimension distribution";
+
+  private final ExecutorService executor = Execs.singleThreaded("DimDistributionMerger-%s");
+  private final ConcurrentHashMap<Interval, StringDistributionMerger> intervalToDistributionMerger
+      = new ConcurrentHashMap<>();
+  private final AtomicLong totalSketchHeapSize = new AtomicLong();
 
   PartialDimensionDistributionParallelIndexTaskRunner(
       TaskToolbox toolbox,
@@ -56,6 +75,119 @@ class PartialDimensionDistributionParallelIndexTaskRunner
   public String getName()
   {
     return PHASE_NAME;
+  }
+
+  @Override
+  public void collectReport(DimensionDistributionReport report)
+  {
+    // TODO: keep an md5 hash of the report to implement the same validation as in taskMonitor
+
+    // Send an empty report to TaskMonitor
+    super.collectReport(new DimensionDistributionReport(report.getTaskId(), null));
+
+    // Update the distributions in a separate thread to unblock HTTP requests
+    if (executor.isShutdown()) {
+      // this should never happen
+      throw new ISE("Executor is already shutdown. Cannot merge more reports.");
+    }
+    executor.submit(() -> extractDistributionsFromReport(report));
+  }
+
+  /**
+   * Map from an Interval to StringDistribution obtained by merging all the
+   * StringDistributions reported by different sub-tasks for that Interval.
+   */
+  public Map<Interval, StringDistribution> getIntervalToDistribution()
+  {
+    waitForDistributionsToMerge();
+    return CollectionUtils.mapValues(
+        intervalToDistributionMerger,
+        StringDistributionMerger::getResult
+    );
+  }
+
+  /**
+   * Extracts the distributions from the given report and merges them to the
+   * distributions in memory.
+   */
+  private void extractDistributionsFromReport(DimensionDistributionReport report)
+  {
+    log.debug("Started merging distributions from Task ID [%s]", report.getTaskId());
+    report.getIntervalToDistribution().forEach(
+        (interval, distribution) -> intervalToDistributionMerger.compute(interval, (i, existingMerger) -> {
+          final long oldSketchSize;
+          final StringDistributionMerger merger;
+          if (existingMerger == null) {
+            merger = new StringSketchMerger();
+            oldSketchSize = 0L;
+          } else {
+            merger = existingMerger;
+            oldSketchSize = existingMerger.getResult().sizeInBytes();
+          }
+
+          merger.merge(distribution);
+
+          final long newSketchSize = merger.getResult().sizeInBytes();
+          totalSketchHeapSize.addAndGet(newSketchSize - oldSketchSize);
+
+          return merger;
+        })
+    );
+
+    log.debug("Finished merging distributions from Task ID [%s]", report.getTaskId());
+    validateSketchesHeapSize();
+  }
+
+  /**
+   * Validates the total heap size of all the distribution sketches. The task is
+   * failed if the total size exceeds the threshold.
+   */
+  private void validateSketchesHeapSize()
+  {
+    // TODO: finalize the correct value of maxSketchHeapSize to use here
+    final long maxSketchHeapSize = JvmUtils.getRuntimeInfo().getTotalHeapSizeBytes() / 6L;
+    if (totalSketchHeapSize.get() > maxSketchHeapSize) {
+      final String errorMsg = String.format(
+          "Too many interval distributions to process [%s]. Estimated Size [%s], Max Heap Size [%s].\n"
+          + "Try one of the following:\n"
+          + "(1) Increase the task JVM heap size.\n"
+          + "(2) Reduce time range of input dataset.\n"
+          + "(3) Use a coarser segment granularity.",
+          intervalToDistributionMerger.size(),
+          totalSketchHeapSize.get(),
+          maxSketchHeapSize
+      );
+      log.error(errorMsg);
+
+      // This code can be executed in two cases:
+      // Case 1: There are sub-tasks pending execution
+      //   Calling stopGracefully() fails this phase and the supervisor task.
+      // Case 2: All sub-tasks have finished
+      //   Calling stopGracefully() has no effect. This is okay as all task reports
+      //   have been received and process is still running fine.
+      // TODO: include the correct error message in the task status
+      stopGracefully(errorMsg);
+    }
+  }
+
+  /**
+   * Waits for distributions from pending reports (if any) to be merged.
+   */
+  private void waitForDistributionsToMerge()
+  {
+    log.info("Waiting for distributions to be merged");
+    try {
+      executor.shutdown();
+      executor.awaitTermination(10, TimeUnit.SECONDS);
+    }
+    catch (InterruptedException e) {
+      throw new ISE(e, "Interrupted while waiting for distributions to merge");
+    }
+    finally {
+      if (!executor.isTerminated()) {
+        log.error("Executor was not terminated. There are pending distributions to be merged.");
+      }
+    }
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringDistribution.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringDistribution.java
@@ -65,4 +65,13 @@ public interface StringDistribution
    * sorted elements.
    */
   PartitionBoundaries getEvenPartitionsByTargetSize(int targetSize);
+
+  /**
+   * Estimated heap size of this StringDistribution in bytes. The estimated value
+   * must inlude JVM object overheads.
+   *
+   * @return Estimated heap size of this {@code StringDistribution} in bytes including
+   * JVM object overhead.
+   */
+  long sizeInBytes();
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
@@ -133,6 +133,20 @@ public class StringSketchTest
       Assert.assertEquals(MAX_STRING, target.getDelegate().getMaxValue());
     }
 
+    @Test
+    public void testSizeInBytes()
+    {
+      Assert.assertEquals(92L, target.sizeInBytes());
+      for (int i = 0; i < 1_000_000; ++i) {
+        target.put(
+            StringTuple.create("dim0-" + i, "dim1-" + i, "dim2-" + i)
+        );
+      }
+      final long sketchSize = target.sizeInBytes();
+      Assert.assertTrue(sketchSize > 5_400_000L);
+      Assert.assertTrue(sketchSize < 5_450_000L);
+    }
+
     private long getCount()
     {
       return target.getDelegate().getN();


### PR DESCRIPTION
### Description
Parallel indexing with range partitioning can often cause OOM in the
`ParallelIndexSupervisorTask` during the dimension distribution phase.
This typically happens because of too many `StringSketch` objects
obtained from the different `partial_dimension_distribution` sub-tasks.

We can reduce the number of sketches in memory by merging them to the existing distribution for
the respective interval.

### Changes
- Extract `StringDistribution` from `DimensionDistributionReport`s when they are received and merge to the existing `StringDistributionMerger`
- Add size estimation in `StringTuple` and `StringDistribution`
- Check the estimated size whenever a new sketch is added to memory
- Fail the task if the estimated size exceeds the amount of heap space allocated for reports

### Comparison
For an example dataset where each sub-task processed about 1 GB of data for the same interval, the heap usage of the `ParallelIndexSupervisorTask` is typically as below.

__Before__
<img width="874" alt="before" src="https://user-images.githubusercontent.com/18635897/158237039-117ea10d-646e-415f-b0c8-c03aaa25a7f7.png">

__After__
<img width="875" alt="after" src="https://user-images.githubusercontent.com/18635897/158237205-09c9351a-f449-44b6-bf09-d0adb9464c7f.png">


### Other possible approaches
(a) Write the merged distribution for a given interval to disk and read back only when required.
- Possible future work?
- Need to evaluate impact of the increased disk I/O on the execution of the `ParallelIndexSupervisorTask`

(b) Streaming merge
- Sub-tasks send back reports in the order of their intervals
- This would be most effective if the input dataset is sorted by time
- Sub-tasks would then stream their reports to the supervisor task in the right order of intervals.
-  The supervisor task needs to keep in memory only a single merged distribution for the current interval being processed, thus completely eliminating the memory pressure.
- Relatively more involved implementation

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
