### PR TITLE
Improve exception message for native binary operators

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/BinaryOperatorExpr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/BinaryOperatorExpr.java
@@ -21,6 +21,7 @@ package org.apache.druid.math.expr;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.Types;
 
@@ -151,7 +152,11 @@ abstract class BinaryEvalOpExprBase extends BinaryOpExprBase
 
   protected ExprEval evalString(@Nullable String left, @Nullable String right)
   {
-    throw new IllegalArgumentException("unsupported type " + ExprType.STRING);
+    throw new IAE("operator '%s' in expression (%s %s %s) is not supported on type of string.",
+                  this.op,
+                  this.left.stringify(),
+                  this.op,
+                  this.right.stringify());
   }
 
   protected abstract long evalLong(long left, long right);

--- a/core/src/main/java/org/apache/druid/math/expr/BinaryOperatorExpr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/BinaryOperatorExpr.java
@@ -152,7 +152,7 @@ abstract class BinaryEvalOpExprBase extends BinaryOpExprBase
 
   protected ExprEval evalString(@Nullable String left, @Nullable String right)
   {
-    throw new IAE("operator '%s' in expression (%s %s %s) is not supported on type of string.",
+    throw new IAE("operator '%s' in expression (%s %s %s) is not supported on type 'string'.",
                   this.op,
                   this.left.stringify(),
                   this.op,

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -80,7 +80,9 @@ public class FunctionTest extends InitializedNullHandlingTest
                     .put("a", new String[] {"foo", "bar", "baz", "foobar"})
                     .put("b", new Long[] {1L, 2L, 3L, 4L, 5L})
                     .put("c", new Double[] {3.1, 4.2, 5.3})
-                    .put("someComplex", new TypeStrategiesTest.NullableLongPair(1L, 2L));
+                    .put("someComplex", new TypeStrategiesTest.NullableLongPair(1L, 2L))
+                    .put("str1", "v1")
+                    .put("str2", "v2");
     bindings = InputBindings.withMap(builder.build());
   }
 
@@ -971,6 +973,36 @@ public class FunctionTest extends InitializedNullHandlingTest
     expectedException.expect(IAE.class);
     expectedException.expectMessage("needs exactly 1 argument of type String");
     assertArrayExpr("mv_to_array()", null);
+  }
+
+  @Test
+  public void testPlusOnString()
+  {
+    assertExpr("str1 + str2", "v1v2");
+  }
+
+  @Test
+  public void testMultiplyOnString()
+  {
+    expectedException.expect(IAE.class);
+    expectedException.expectMessage("operator '*' in expression (\"str1\" * \"str2\") is not supported on type of string.");
+    assertExpr("str1 * str2", null);
+  }
+
+  @Test
+  public void testMinusOnString()
+  {
+    expectedException.expect(IAE.class);
+    expectedException.expectMessage("operator '-' in expression (\"str1\" - \"str2\") is not supported on type of string.");
+    assertExpr("str1 - str2", null);
+  }
+
+  @Test
+  public void testDivOnString()
+  {
+    expectedException.expect(IAE.class);
+    expectedException.expectMessage("operator '/' in expression (\"str1\" / \"str2\") is not supported on type of string.");
+    assertExpr("str1 / str2", null);
   }
 
   private void assertExpr(final String expression, @Nullable final Object expectedResult)

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -985,7 +985,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   public void testMultiplyOnString()
   {
     expectedException.expect(IAE.class);
-    expectedException.expectMessage("operator '*' in expression (\"str1\" * \"str2\") is not supported on type of string.");
+    expectedException.expectMessage("operator '*' in expression (\"str1\" * \"str2\") is not supported on type 'string'.");
     assertExpr("str1 * str2", null);
   }
 
@@ -993,7 +993,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   public void testMinusOnString()
   {
     expectedException.expect(IAE.class);
-    expectedException.expectMessage("operator '-' in expression (\"str1\" - \"str2\") is not supported on type of string.");
+    expectedException.expectMessage("operator '-' in expression (\"str1\" - \"str2\") is not supported on type 'string'.");
     assertExpr("str1 - str2", null);
   }
 
@@ -1001,7 +1001,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   public void testDivOnString()
   {
     expectedException.expect(IAE.class);
-    expectedException.expectMessage("operator '/' in expression (\"str1\" / \"str2\") is not supported on type of string.");
+    expectedException.expectMessage("operator '/' in expression (\"str1\" / \"str2\") is not supported on type 'string'.");
     assertExpr("str1 / str2", null);
   }
 


### PR DESCRIPTION
### Description

For native query, binary operator(`\`, `*`, `-`) is not supported on string expressions. If that happens, it throws exception with message as below

```text
unsupported type STRING
```

This message is helpless for user to quickly find out where the wrong expression is especially when the native query is dynamically generated at runtime.

So this PR improves the exception message by adding the whole binary operator expression which causes this problem. For example:
```
operator '*' in expression ("str1" * "str2") is not supported on type of string.
```

SQL query has no such problem because SQL engine will cast the both operands to numbers first if the operands are not type of number.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
