### PR TITLE
fix messageGap metric

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
@@ -263,7 +263,8 @@ public class FireDepartmentMetrics
     retVal.messageMaxTimestamp.set(messageMaxTimestamp.get());
     retVal.messageProcessingCompletionTime.set(messageProcessingCompletionTime.get());
     retVal.messageProcessingCompletionTime.compareAndSet(DEFAULT_PROCESSING_COMPLETION_TIME, System.currentTimeMillis());
-    retVal.messageGap.set(retVal.messageProcessingCompletionTime.get() - messageMaxTimestamp.get());
+    long maxTimestamp = retVal.messageMaxTimestamp.get();
+    retVal.messageGap.set(maxTimestamp > 0 ? retVal.messageProcessingCompletionTime.get() - maxTimestamp : 0L);
     return retVal;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/FireDepartmentMetricsTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/FireDepartmentMetricsTest.java
@@ -34,6 +34,12 @@ public class FireDepartmentMetricsTest
   }
 
   @Test
+  public void testSnapshotBeforeProcessing()
+  {
+    Assert.assertEquals(0L, metrics.snapshot().messageGap());
+  }
+
+  @Test
   public void testSnapshotAfterProcessingOver()
   {
     metrics.reportMessageMaxTimestamp(10);


### PR DESCRIPTION
### Description
This is a simple PR to fix the `ingest/events/messageGap` metric.

If there's a task to ingest a listless trickle of events from an upstream Kafka topic, the metrics monitor may take snapshot before starting processing events. In this case, the `messageMaxTimestamp` is unset and the `messageGap` should be the initial value (0L). Below panel shows the invalid metric data points

<img width="1299" alt="Screenshot 2022-03-16 at 12 16 05" src="https://user-images.githubusercontent.com/44718283/158515789-b5823bbc-c76c-4bb9-8bd9-55941844d059.png">



<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

