### PR TITLE
Make AWS WebIdentityToken actually working and usable from inside EKS.

### DIFF
--- a/cloud/aws-common/pom.xml
+++ b/cloud/aws-common/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
             <version>${checkerframework.version}</version>

--- a/extensions-core/s3-extensions/pom.xml
+++ b/extensions-core/s3-extensions/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>${aws.sdk.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- Tests -->
     <dependency>

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
@@ -110,9 +110,9 @@ public class S3InputSource extends CloudObjectInputSource
             // If both static key-pair and assume role ARN are defined, use the static key-pair to assume role.
             if (s3InputSourceConfig.isCredentialsConfigured() && s3InputSourceConfig.isAssumeRoleArnConfigured()) {
               applyAssumeRole(
-                s3ClientBuilder,
-                s3InputSourceConfig,
-                createStaticCredentialsProvider(s3InputSourceConfig)
+                  s3ClientBuilder,
+                  s3InputSourceConfig,
+                  createStaticCredentialsProvider(s3InputSourceConfig)
               );
 
             // If only static key-pair is defined, build the S3 client with the static key-pair

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
@@ -28,6 +28,9 @@ import org.apache.druid.metadata.PasswordProvider;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
+import static com.amazonaws.SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR;
+import static com.amazonaws.SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR;
+
 /**
  * Contains properties for s3 input source.
  * Properties can be specified by ingestionSpec which will override system default.
@@ -88,6 +91,24 @@ public class S3InputSourceConfig
   {
     return accessKeyId != null &&
            secretAccessKey != null;
+  }
+
+  @JsonIgnore
+  public boolean isAssumeRoleArnConfigured()
+  {
+    return assumeRoleArn != null && !assumeRoleArn.trim().isEmpty();
+  }
+
+  @JsonIgnore
+  public boolean isAssumeRoleArnEnvConfigured()
+  {
+    return !System.getenv(AWS_ROLE_ARN_ENV_VAR).trim().isEmpty();
+  }
+
+  @JsonIgnore
+  public boolean isWebIdentityTokenEnvConfigured()
+  {
+    return !System.getenv(AWS_WEB_IDENTITY_ENV_VAR).trim().isEmpty();
   }
 
   @Override

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
@@ -94,19 +94,19 @@ public class S3InputSourceConfig
   @JsonIgnore
   public boolean isAssumeRoleArnConfigured()
   {
-    return assumeRoleArn != null && !assumeRoleArn.trim().isEmpty();
+    return assumeRoleArn != null && !assumeRoleArn.isEmpty();
   }
 
   @JsonIgnore
   public boolean isAssumeRoleArnEnvConfigured()
   {
-    return !System.getenv(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR).trim().isEmpty();
+    return !System.getenv(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR).isEmpty();
   }
 
   @JsonIgnore
   public boolean isWebIdentityTokenEnvConfigured()
   {
-    return !System.getenv(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR).trim().isEmpty();
+    return !System.getenv(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR).isEmpty();
   }
 
   @Override

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
@@ -100,13 +100,17 @@ public class S3InputSourceConfig
   @JsonIgnore
   public boolean isAssumeRoleArnEnvConfigured()
   {
-    return !System.getenv(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR).isEmpty();
+    String conf = null;
+    conf = System.getenv(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR);
+    return conf != null && !conf.isEmpty();
   }
 
   @JsonIgnore
   public boolean isWebIdentityTokenEnvConfigured()
   {
-    return !System.getenv(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR).isEmpty();
+    String conf = null;
+    conf = System.getenv(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR);
+    return conf != null && !conf.isEmpty();
   }
 
   @Override

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.s3;
 
+import com.amazonaws.SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR;
+import com.amazonaws.SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,9 +29,6 @@ import org.apache.druid.metadata.PasswordProvider;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
-
-import static com.amazonaws.SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR;
-import static com.amazonaws.SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR;
 
 /**
  * Contains properties for s3 input source.

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
@@ -19,8 +19,7 @@
 
 package org.apache.druid.data.input.s3;
 
-import com.amazonaws.SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR;
-import com.amazonaws.SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR;
+import com.amazonaws.SDKGlobalConfiguration;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -101,13 +100,13 @@ public class S3InputSourceConfig
   @JsonIgnore
   public boolean isAssumeRoleArnEnvConfigured()
   {
-    return !System.getenv(AWS_ROLE_ARN_ENV_VAR).trim().isEmpty();
+    return !System.getenv(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR).trim().isEmpty();
   }
 
   @JsonIgnore
   public boolean isWebIdentityTokenEnvConfigured()
   {
-    return !System.getenv(AWS_WEB_IDENTITY_ENV_VAR).trim().isEmpty();
+    return !System.getenv(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR).trim().isEmpty();
   }
 
   @Override

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -236,12 +236,12 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
 
     // Mock setting the AWS's environment variables.
     String oldRoleARN = System.getProperty(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR);
-    if(oldRoleARN == "") {
+    if(oldRoleARN.equals("")) {
         System.setProperty(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR, "mockROLEARN");
     }
 
     String oldIdentityFile = System.getProperty(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR);
-    if(oldIdentityFile == "") {
+    if(oldIdentityFile.equals("")) {
         System.setProperty(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR, "mockIdentityFile");
     }
 
@@ -269,10 +269,10 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
 
     Assert.assertEquals(withPrefixes, serdeWithPrefixes);
 
-    if(oldRoleARN == "") {
+    if(oldRoleARN.equals("")) {
         System.clearProperty(SDKGlobalConfiguration.AWS_ROLE_ARN_ENV_VAR);
     }
-    if(oldIdentityFile == "") {
+    if(oldIdentityFile.equals("")) {
         System.clearProperty(SDKGlobalConfiguration.AWS_WEB_IDENTITY_ENV_VAR);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1835,6 +1835,8 @@
                                 <exclude>.editorconfig</exclude>
                                 <exclude>**/hadoop.indexer.libs.version</exclude>
                                 <exclude>**/codegen/**</exclude>
+                                <exclude>website/target/**</exclude>
+                                <exclude>website/node_modules/**</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1835,8 +1835,6 @@
                                 <exclude>.editorconfig</exclude>
                                 <exclude>**/hadoop.indexer.libs.version</exclude>
                                 <exclude>**/codegen/**</exclude>
-                                <exclude>website/target/**</exclude>
-                                <exclude>website/node_modules/**</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
### Description

Originally, this PR: https://github.com/apache/druid/pull/10541 tried to add a new support for WebIdentityToken, allowing Druid to authenticate to AWS S3 via EKS ServiceAccount + annotated IAM role.

But that PR doesn't work. Let me elaborate why:

1. Druid master branch uses the following AWS SDK `<aws.sdk.version>1.12.37</aws.sdk.version>`, which is recent enough to be able to use WebIdentityToken to authenticate. Without doing anything, the default S3ClientBuilder should just work.

2. Unfortunately, `S3InputSource.applyAssumeRole` function interferes that default behavior and does its own thing (That functionality is added by this PR: https://github.com/apache/druid/pull/10995). That function is triggered because `S3InputSourceConfig` somehow picked up the `AWS_ROLE_ARN` from the environment variable and inject it into the object. I have not been able to figure out how it did it.

That is what I mean by "it doesn't work".  

This PR addresses its issues, there are 2 of them:

1. Missing aws-java-sdk-sts.jar

2. applyAssumeRole function interferes with default s3Builder client behavior.

<hr>

##### Key changed/added classes in this PR
 * Updated `S3InputSource` and `S3InputSourceConfig`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
