### PR TITLE
Fix the other 2 python scripts that generates license.

### DIFF
--- a/distribution/bin/generate-binary-license.py
+++ b/distribution/bin/generate-binary-license.py
@@ -102,7 +102,7 @@ def print_license(license):
                     license_phrase += "see {}".format(each_file)
                 else:
                     license_phrase += ", {}".format(each_file)
-    
+
     license_phrase += "."
 
     print_license_phrase(license_phrase)
@@ -133,11 +133,11 @@ def print_license_name_underbar(license_name):
 
 def generate_license(apache_license_v2, license_yaml):
     print_log_to_stderr("=== Generating the contents of LICENSE.BINARY file ===\n")
-    
+
     # Print Apache license first.
     print_outfile(apache_license_v2)
     with open(license_yaml, encoding='utf-8') as registry_file:
-        licenses_list = list(yaml.load_all(registry_file))
+        licenses_list = list(yaml.load_all(registry_file, Loader=yaml.Loader))
 
     # Group licenses by license_name, license_category, and then module.
     licenses_map = {}
@@ -172,7 +172,7 @@ if __name__ == "__main__":
         parser.add_argument('license_yaml', metavar='<path to license.yaml>', type=str)
         parser.add_argument('out_path', metavar='<path to output file>', type=str)
         args = parser.parse_args()
-        
+
         with open(args.apache_license, encoding="ascii") as apache_license_file:
             apache_license_v2 = apache_license_file.read()
         license_yaml = args.license_yaml

--- a/distribution/bin/generate-binary-notice.py
+++ b/distribution/bin/generate-binary-notice.py
@@ -57,7 +57,7 @@ def generate_notice(source_notice, dependences_yaml):
     # Print Apache license first.
     print_outfile(source_notice)
     with open(dependences_yaml, encoding='utf-8') as registry_file:
-        dependencies = list(yaml.load_all(registry_file))
+        dependencies = list(yaml.load_all(registry_file, Loader=yaml.Loader))
 
     # Group dependencies by module
     modules_map = defaultdict(list)

--- a/pom.xml
+++ b/pom.xml
@@ -1835,6 +1835,8 @@
                                 <exclude>.editorconfig</exclude>
                                 <exclude>**/hadoop.indexer.libs.version</exclude>
                                 <exclude>**/codegen/**</exclude>
+                                <exclude>website/target/**</exclude>
+                                <exclude>website/node_modules/**</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1835,8 +1835,6 @@
                                 <exclude>.editorconfig</exclude>
                                 <exclude>**/hadoop.indexer.libs.version</exclude>
                                 <exclude>**/codegen/**</exclude>
-                                <exclude>website/target/**</exclude>
-                                <exclude>website/node_modules/**</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
### Description

Fixes YAML.load_all issues on two of the Python scripts that generate license.

The broken Python files interfere with some of the Maven tasks.

<hr>

##### Key changed/added classes in this PR
 * `generate-binary-notice.py`
 * `generate-binary-license.py`

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
