### PR TITLE
update surefire plugin to 3.0.0-M4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1488,7 +1488,10 @@
               <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <!--- stay on M4 until M6 is released with a fix for
+                    https://issues.apache.org/jira/browse/SUREFIRE-1815
+                    causing issues in RetryUtilsTest -->
+                    <version>3.0.0-M4</version>
                     <configuration>
                         <!-- locale settings must be set on the command line before startup -->
                         <!-- set default options -->


### PR DESCRIPTION
Update surefire plugin for improved compatibility with recent Java versions.

For now we have to stay on surefire 3.0.0-M4 until we can upgrade to 3.0.0-M6
which will have a fix for https://issues.apache.org/jira/browse/SUREFIRE-1815
causing issues in RetryUtilsTest.
