### PR TITLE
Introducing a new config to ignore nulls while computing String Cardinality

### DIFF
--- a/core/src/main/java/org/apache/druid/common/config/NullHandling.java
+++ b/core/src/main/java/org/apache/druid/common/config/NullHandling.java
@@ -58,7 +58,7 @@ public class NullHandling
   @VisibleForTesting
   public static void initializeForTests()
   {
-    INSTANCE = new NullValueHandlingConfig(null);
+    INSTANCE = new NullValueHandlingConfig(null, null);
   }
 
   /**
@@ -71,6 +71,18 @@ public class NullHandling
       throw new IllegalStateException("NullHandling module not initialized, call NullHandling.initializeForTests()");
     }
     return INSTANCE.isUseDefaultValuesForNull();
+  }
+
+  /**
+   * whether nulls should be counted during String cardinality
+   */
+  public static boolean ignoreNullsForStringCardinality()
+  {
+    // this should only be null in a unit test context, in production this will be injected by the null handling module
+    if (INSTANCE == null) {
+      throw new IllegalStateException("NullHandling module not initialized, call NullHandling.initializeForTests()");
+    }
+    return INSTANCE.isIgnoreNullsForStringCardinality();
   }
 
   public static boolean sqlCompatible()

--- a/core/src/main/java/org/apache/druid/common/config/NullHandling.java
+++ b/core/src/main/java/org/apache/druid/common/config/NullHandling.java
@@ -61,6 +61,12 @@ public class NullHandling
     INSTANCE = new NullValueHandlingConfig(null, null);
   }
 
+  @VisibleForTesting
+  public static void initializeForTestsWithValues(Boolean useDefForNull, Boolean ignoreNullForString)
+  {
+    INSTANCE = new NullValueHandlingConfig(useDefForNull, ignoreNullForString);
+  }
+
   /**
    * whether nulls should be replaced with default value.
    */

--- a/core/src/main/java/org/apache/druid/common/config/NullValueHandlingConfig.java
+++ b/core/src/main/java/org/apache/druid/common/config/NullValueHandlingConfig.java
@@ -26,13 +26,22 @@ public class NullValueHandlingConfig
 {
   public static final String NULL_HANDLING_CONFIG_STRING = "druid.generic.useDefaultValueForNull";
 
+  //added to preserve backward compatibility
+  //and not count nulls during cardinality aggrgation over strings
+
+  public static final String NULL_HANDLING_DURING_STRING_CARDINALITY = "druid.generic.ignoreNullsForStringCardinality";
+
   @JsonProperty("useDefaultValueForNull")
   private final boolean useDefaultValuesForNull;
+
+  @JsonProperty("ignoreNullsForStringCardinality")
+  private final boolean ignoreNullsForStringCardinality;
 
 
   @JsonCreator
   public NullValueHandlingConfig(
-      @JsonProperty("useDefaultValueForNull") Boolean useDefaultValuesForNull
+      @JsonProperty("useDefaultValueForNull") Boolean useDefaultValuesForNull,
+      @JsonProperty("ignoreNullsForStringCardinality") Boolean ignoreNullsForStringCardinality
   )
   {
     if (useDefaultValuesForNull == null) {
@@ -40,6 +49,19 @@ public class NullValueHandlingConfig
     } else {
       this.useDefaultValuesForNull = useDefaultValuesForNull;
     }
+    if (ignoreNullsForStringCardinality == null) {
+      this.ignoreNullsForStringCardinality = Boolean.valueOf(System.getProperty(
+          NULL_HANDLING_DURING_STRING_CARDINALITY,
+          "false"
+      ));
+    } else {
+      this.ignoreNullsForStringCardinality = ignoreNullsForStringCardinality;
+    }
+  }
+
+  public boolean isIgnoreNullsForStringCardinality()
+  {
+    return ignoreNullsForStringCardinality;
   }
 
   public boolean isUseDefaultValuesForNull()

--- a/core/src/main/java/org/apache/druid/common/config/NullValueHandlingConfig.java
+++ b/core/src/main/java/org/apache/druid/common/config/NullValueHandlingConfig.java
@@ -55,7 +55,11 @@ public class NullValueHandlingConfig
           "false"
       ));
     } else {
-      this.ignoreNullsForStringCardinality = ignoreNullsForStringCardinality;
+      if (this.useDefaultValuesForNull) {
+        this.ignoreNullsForStringCardinality = ignoreNullsForStringCardinality;
+      } else {
+        this.ignoreNullsForStringCardinality = false;
+      }
     }
   }
 

--- a/core/src/test/java/org/apache/druid/common/config/NullHandlingTest.java
+++ b/core/src/test/java/org/apache/druid/common/config/NullHandlingTest.java
@@ -94,10 +94,10 @@ public class NullHandlingTest
   @Test
   public void test_ignoreNullsStrings()
   {
-    NullHandling.initializeForTestsWithValues(false,true);
+    NullHandling.initializeForTestsWithValues(false, true);
     Assert.assertFalse(NullHandling.ignoreNullsForStringCardinality());
 
-    NullHandling.initializeForTestsWithValues(true,false);
+    NullHandling.initializeForTestsWithValues(true, false);
     Assert.assertFalse(NullHandling.ignoreNullsForStringCardinality());
 
   }

--- a/core/src/test/java/org/apache/druid/common/config/NullHandlingTest.java
+++ b/core/src/test/java/org/apache/druid/common/config/NullHandlingTest.java
@@ -90,4 +90,15 @@ public class NullHandlingTest
   {
     Assert.assertNull(NullHandling.defaultValueForClass(Object.class));
   }
+
+  @Test
+  public void test_ignoreNullsStrings()
+  {
+    NullHandling.initializeForTestsWithValues(false,true);
+    Assert.assertFalse(NullHandling.ignoreNullsForStringCardinality());
+
+    NullHandling.initializeForTestsWithValues(true,false);
+    Assert.assertFalse(NullHandling.ignoreNullsForStringCardinality());
+
+  }
 }

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -750,6 +750,7 @@ Prior to version 0.13.0, Druid string columns treated `''` and `null` values as 
 |Property|Description|Default|
 |---|---|---|
 |`druid.generic.useDefaultValueForNull`|When set to `true`, `null` values will be stored as `''` for string columns and `0` for numeric columns. Set to `false` to store and query data in SQL compatible mode.|`true`|
+|`druid.generic.ignoreNullsForStringCardinality`|When set to `true`, `null` values will be ignored for cardinality aggregation over string columns. Set to `false` to include `null` values while estimating cardinality of string columns|`false`|
 
 This mode does have a storage size and query performance cost, see [segment documentation](../design/segments.md#sql-compatible-null-handling) for more details.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -750,7 +750,7 @@ Prior to version 0.13.0, Druid string columns treated `''` and `null` values as 
 |Property|Description|Default|
 |---|---|---|
 |`druid.generic.useDefaultValueForNull`|When set to `true`, `null` values will be stored as `''` for string columns and `0` for numeric columns. Set to `false` to store and query data in SQL compatible mode.|`true`|
-|`druid.generic.ignoreNullsForStringCardinality`|When set to `true`, `null` values will be ignored for the built-in cardinality aggregator over string columns. Set to `false` to include `null` values while estimating cardinality of only string columns using the built-in cardinality aggregator|`false`|
+|`druid.generic.ignoreNullsForStringCardinality`|When set to `true`, `null` values will be ignored for the built-in cardinality aggregator over string columns. Set to `false` to include `null` values while estimating cardinality of only string columns using the built-in cardinality aggregator. This setting takes effect only when `druid.generic.useDefaultValueForNull` is set to `true` and is ignored in SQL compatibility mode. Additionally, empty strings (equivalent to null) are not counted when this is set to `true`. |`false`|
 This mode does have a storage size and query performance cost, see [segment documentation](../design/segments.md#sql-compatible-null-handling) for more details.
 
 ### HTTP Client

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -750,8 +750,7 @@ Prior to version 0.13.0, Druid string columns treated `''` and `null` values as 
 |Property|Description|Default|
 |---|---|---|
 |`druid.generic.useDefaultValueForNull`|When set to `true`, `null` values will be stored as `''` for string columns and `0` for numeric columns. Set to `false` to store and query data in SQL compatible mode.|`true`|
-|`druid.generic.ignoreNullsForStringCardinality`|When set to `true`, `null` values will be ignored for cardinality aggregation over string columns. Set to `false` to include `null` values while estimating cardinality of string columns|`false`|
-
+|`druid.generic.ignoreNullsForStringCardinality`|When set to `true`, `null` values will be ignored for the built-in cardinality aggregator over string columns. Set to `false` to include `null` values while estimating cardinality of only string columns using the built-in cardinality aggregator|`false`|
 This mode does have a storage size and query performance cost, see [segment documentation](../design/segments.md#sql-compatible-null-handling) for more details.
 
 ### HTTP Client

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/types/StringCardinalityAggregatorColumnSelectorStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/types/StringCardinalityAggregatorColumnSelectorStrategy.java
@@ -88,11 +88,24 @@ public class StringCardinalityAggregatorColumnSelectorStrategy implements Cardin
   public void hashValues(DimensionSelector dimSelector, HyperLogLogCollector collector)
   {
     IndexedInts row = dimSelector.getRow();
-    for (int i = 0, rowSize = row.size(); i < rowSize; i++) {
-      int index = row.get(i);
-      final String value = dimSelector.lookupName(index);
-      addStringToCollector(collector, value);
+    if (NullHandling.ignoreNullsForStringCardinality()) {
+      //check and do not count nulls for Strings
+      for (int i = 0, rowSize = row.size(); i < rowSize; i++) {
+        int index = row.get(i);
+        final String value = dimSelector.lookupName(index);
+        if (value != null) {
+          addStringToCollector(collector, value);
+        }
+      }
+    } else {
+      //count everything
+      for (int i = 0, rowSize = row.size(); i < rowSize; i++) {
+        int index = row.get(i);
+        final String value = dimSelector.lookupName(index);
+        addStringToCollector(collector, value);
+      }
     }
+
   }
 
   private static String nullToSpecial(String value)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/types/StringCardinalityAggregatorColumnSelectorStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/types/StringCardinalityAggregatorColumnSelectorStrategy.java
@@ -53,7 +53,7 @@ public class StringCardinalityAggregatorColumnSelectorStrategy implements Cardin
     // nothing to add to hasher if size == 0, only handle size == 1 and size != 0 cases.
     if (size == 1) {
       final String value = dimSelector.lookupName(row.get(0));
-      if ((NullHandling.replaceWithDefault() && !NullHandling.ignoreNullsForStringCardinality()) || value != null) {
+      if (NullHandling.replaceWithDefault() || value != null) {
         hasher.putUnencodedChars(nullToSpecial(value));
       }
     } else if (size != 0) {
@@ -72,7 +72,7 @@ public class StringCardinalityAggregatorColumnSelectorStrategy implements Cardin
       // SQL standard spec does not count null values,
       // Skip counting null values when we are not replacing null with default value.
       // A special value for null in case null handling is configured to use empty string for null.
-      if ((NullHandling.replaceWithDefault() && !NullHandling.ignoreNullsForStringCardinality()) || hasNonNullValue) {
+      if (NullHandling.replaceWithDefault() || hasNonNullValue) {
         // Values need to be sorted to ensure consistent multi-value ordering across different segments
         Arrays.sort(values);
         for (int i = 0; i < size; ++i) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/vector/SingleValueStringCardinalityVectorProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/vector/SingleValueStringCardinalityVectorProcessor.java
@@ -51,9 +51,18 @@ public class SingleValueStringCardinalityVectorProcessor implements CardinalityV
 
       final HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(buf);
 
-      for (int i = startRow; i < endRow; i++) {
-        final String value = selector.lookupName(vector[i]);
-        StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, value);
+      if (NullHandling.ignoreNullsForStringCardinality()) {
+        for (int i = startRow; i < endRow; i++) {
+          final String value = selector.lookupName(vector[i]);
+          if (value != null) {
+            StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, value);
+          }
+        }
+      } else {
+        for (int i = startRow; i < endRow; i++) {
+          final String value = selector.lookupName(vector[i]);
+          StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, value);
+        }
       }
     }
     finally {
@@ -75,7 +84,7 @@ public class SingleValueStringCardinalityVectorProcessor implements CardinalityV
       for (int i = 0; i < numRows; i++) {
         final String s = selector.lookupName(vector[rows != null ? rows[i] : i]);
 
-        if (NullHandling.replaceWithDefault() || s != null) {
+        if (s != null) {
           final int position = positions[i] + positionOffset;
           buf.limit(position + HyperLogLogCollector.getLatestNumBytesForDenseStorage());
           buf.position(position);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/vector/SingleValueStringCardinalityVectorProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/vector/SingleValueStringCardinalityVectorProcessor.java
@@ -51,18 +51,10 @@ public class SingleValueStringCardinalityVectorProcessor implements CardinalityV
 
       final HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(buf);
 
-      if (NullHandling.ignoreNullsForStringCardinality()) {
-        for (int i = startRow; i < endRow; i++) {
-          final String value = selector.lookupName(vector[i]);
-          if (value != null) {
-            StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, value);
-          }
-        }
-      } else {
-        for (int i = startRow; i < endRow; i++) {
-          final String value = selector.lookupName(vector[i]);
-          StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, value);
-        }
+
+      for (int i = startRow; i < endRow; i++) {
+        final String value = selector.lookupName(vector[i]);
+        StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, value);
       }
     }
     finally {
@@ -80,27 +72,15 @@ public class SingleValueStringCardinalityVectorProcessor implements CardinalityV
 
     try {
       final int[] vector = selector.getRowVector();
-      if (NullHandling.ignoreNullsForStringCardinality()) {
-        for (int i = 0; i < numRows; i++) {
-          final String s = selector.lookupName(vector[rows != null ? rows[i] : i]);
-          if (s != null) {
-            final int position = positions[i] + positionOffset;
-            buf.limit(position + HyperLogLogCollector.getLatestNumBytesForDenseStorage());
-            buf.position(position);
-            final HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(buf);
-            StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, s);
-          }
-        }
-      } else {
-        for (int i = 0; i < numRows; i++) {
-          final String s = selector.lookupName(vector[rows != null ? rows[i] : i]);
-          if (NullHandling.replaceWithDefault() || s != null) {
-            final int position = positions[i] + positionOffset;
-            buf.limit(position + HyperLogLogCollector.getLatestNumBytesForDenseStorage());
-            buf.position(position);
-            final HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(buf);
-            StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, s);
-          }
+
+      for (int i = 0; i < numRows; i++) {
+        final String s = selector.lookupName(vector[rows != null ? rows[i] : i]);
+        if (NullHandling.replaceWithDefault() || s != null) {
+          final int position = positions[i] + positionOffset;
+          buf.limit(position + HyperLogLogCollector.getLatestNumBytesForDenseStorage());
+          buf.position(position);
+          final HyperLogLogCollector collector = HyperLogLogCollector.makeCollector(buf);
+          StringCardinalityAggregatorColumnSelectorStrategy.addStringToCollector(collector, s);
         }
       }
     }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -49,7 +49,6 @@ import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.DimensionSelectorUtils;
 import org.apache.druid.segment.IdLookup;
 import org.apache.druid.segment.data.IndexedInts;
-import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -60,7 +59,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CardinalityAggregatorTest extends InitializedNullHandlingTest
+public class CardinalityAggregatorTest
 {
   public static class TestDimensionSelector extends AbstractDimensionSelector
   {
@@ -387,11 +386,11 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
   @Test
   public void testAggregateRows()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     CardinalityAggregator agg = new CardinalityAggregator(
         dimInfoList,
         true
     );
-
 
     for (int i = 0; i < VALUES1.size(); ++i) {
       aggregate(selectorList, agg);
@@ -403,6 +402,7 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
   @Test
   public void testAggregateValues()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     CardinalityAggregator agg = new CardinalityAggregator(
         dimInfoList,
         false
@@ -411,32 +411,22 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
     for (int i = 0; i < VALUES1.size(); ++i) {
       aggregate(selectorList, agg);
     }
-    if (NullHandling.ignoreNullsForStringCardinality()) {
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 6.0 : 6.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg.get()),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 6L : 6L,
-          rowAggregatorFactoryRounded.finalizeComputation(agg.get())
-      );
-    } else {
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 7.0 : 6.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg.get()),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 7L : 6L,
-          rowAggregatorFactoryRounded.finalizeComputation(agg.get())
-      );
-    }
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 7.0 : 6.0,
+        (Double) valueAggregatorFactory.finalizeComputation(agg.get()),
+        0.05
+    );
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 7L : 6L,
+        rowAggregatorFactoryRounded.finalizeComputation(agg.get())
+    );
+
   }
 
   @Test
   public void testBufferAggregateRows()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     CardinalityBufferAggregator agg = new CardinalityBufferAggregator(
         dimInfoList.toArray(new ColumnSelectorPlus[0]),
         true
@@ -459,6 +449,7 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
   @Test
   public void testBufferAggregateValues()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     CardinalityBufferAggregator agg = new CardinalityBufferAggregator(
         dimInfoList.toArray(new ColumnSelectorPlus[0]),
         false
@@ -474,32 +465,21 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
     for (int i = 0; i < VALUES1.size(); ++i) {
       bufferAggregate(selectorList, agg, buf, pos);
     }
-    if (NullHandling.ignoreNullsForStringCardinality()) {
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 6.0 : 6.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos)),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 6L : 6L,
-          rowAggregatorFactoryRounded.finalizeComputation(agg.get(buf, pos))
-      );
-    } else {
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 7.0 : 6.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos)),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 7L : 6L,
-          rowAggregatorFactoryRounded.finalizeComputation(agg.get(buf, pos))
-      );
-    }
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 7.0 : 6.0,
+        (Double) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos)),
+        0.05
+    );
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 7L : 6L,
+        rowAggregatorFactoryRounded.finalizeComputation(agg.get(buf, pos))
+    );
   }
 
   @Test
   public void testCombineRows()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     List<DimensionSelector> selector1 = Collections.singletonList(dim1);
     List<DimensionSelector> selector2 = Collections.singletonList(dim2);
     List<ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>> dimInfo1 = Collections.singletonList(
@@ -545,6 +525,7 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
   @Test
   public void testCombineValues()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     List<DimensionSelector> selector1 = Collections.singletonList(dim1);
     List<DimensionSelector> selector2 = Collections.singletonList(dim2);
 
@@ -572,57 +553,32 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
     for (int i = 0; i < VALUES2.size(); ++i) {
       aggregate(selector2, agg2);
     }
-    if (NullHandling.ignoreNullsForStringCardinality()) {
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 3.0 : 3.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg1.get()),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 6.0 : 6.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg2.get()),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 6.0 : 6.0,
-          (Double) rowAggregatorFactory.finalizeComputation(
-              rowAggregatorFactory.combine(
-                  agg1.get(),
-                  agg2.get()
-              )
-          ),
-          0.05
-      );
-    } else {
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 4.0 : 3.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg1.get()),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 7.0 : 6.0,
-          (Double) valueAggregatorFactory.finalizeComputation(agg2.get()),
-          0.05
-      );
-      Assert.assertEquals(
-          NullHandling.replaceWithDefault() ? 7.0 : 6.0,
-          (Double) rowAggregatorFactory.finalizeComputation(
-              rowAggregatorFactory.combine(
-                  agg1.get(),
-                  agg2.get()
-              )
-          ),
-          0.05
-      );
-    }
-
-
-
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 4.0 : 3.0,
+        (Double) valueAggregatorFactory.finalizeComputation(agg1.get()),
+        0.05
+    );
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 7.0 : 6.0,
+        (Double) valueAggregatorFactory.finalizeComputation(agg2.get()),
+        0.05
+    );
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 7.0 : 6.0,
+        (Double) rowAggregatorFactory.finalizeComputation(
+            rowAggregatorFactory.combine(
+                agg1.get(),
+                agg2.get()
+            )
+        ),
+        0.05
+    );
   }
 
   @Test
   public void testAggregateRowsWithExtraction()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     CardinalityAggregator agg = new CardinalityAggregator(
         dimInfoListWithExtraction,
         true
@@ -645,6 +601,7 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
   @Test
   public void testAggregateValuesWithExtraction()
   {
+    NullHandling.initializeForTestsWithValues(null, null);
     CardinalityAggregator agg = new CardinalityAggregator(
         dimInfoListWithExtraction,
         false
@@ -709,6 +666,106 @@ public class CardinalityAggregatorTest extends InitializedNullHandlingTest
     Assert.assertEquals(
         factory2,
         objectMapper.readValue(objectMapper.writeValueAsString(factory2), AggregatorFactory.class)
+    );
+  }
+
+  //ignoreNullsForStringCardinality tests
+  @Test
+  public void testBufferAggregateRowsIgnoreNulls()
+  {
+    NullHandling.initializeForTestsWithValues(null, true);
+    CardinalityBufferAggregator agg = new CardinalityBufferAggregator(
+        dimInfoList.toArray(new ColumnSelectorPlus[0]),
+        true
+    );
+
+    int maxSize = rowAggregatorFactory.getMaxIntermediateSizeWithNulls();
+    ByteBuffer buf = ByteBuffer.allocate(maxSize + 64);
+    int pos = 10;
+    buf.limit(pos + maxSize);
+
+    agg.init(buf, pos);
+
+    for (int i = 0; i < VALUES1.size(); ++i) {
+      bufferAggregate(selectorList, agg, buf, pos);
+    }
+    Assert.assertEquals(7.0, (Double) rowAggregatorFactory.finalizeComputation(agg.get(buf, pos)), 0.05);
+    Assert.assertEquals(7L, rowAggregatorFactoryRounded.finalizeComputation(agg.get(buf, pos)));
+  }
+
+  @Test
+  public void testAggregateValuesIgnoreNulls()
+  {
+    NullHandling.initializeForTestsWithValues(null, true);
+    CardinalityAggregator agg = new CardinalityAggregator(
+        dimInfoList,
+        false
+    );
+
+    for (int i = 0; i < VALUES1.size(); ++i) {
+      aggregate(selectorList, agg);
+    }
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 6.0 : 6.0,
+        (Double) valueAggregatorFactory.finalizeComputation(agg.get()),
+        0.05
+    );
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 6L : 6L,
+        rowAggregatorFactoryRounded.finalizeComputation(agg.get())
+    );
+  }
+
+  @Test
+  public void testCombineValuesIgnoreNulls()
+  {
+    NullHandling.initializeForTestsWithValues(null, true);
+    List<DimensionSelector> selector1 = Collections.singletonList(dim1);
+    List<DimensionSelector> selector2 = Collections.singletonList(dim2);
+
+    List<ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>> dimInfo1 = Collections.singletonList(
+        new ColumnSelectorPlus<>(
+            dimSpec1.getDimension(),
+            dimSpec1.getOutputName(),
+            new StringCardinalityAggregatorColumnSelectorStrategy(), dim1
+        )
+    );
+    List<ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>> dimInfo2 = Collections.singletonList(
+        new ColumnSelectorPlus<>(
+            dimSpec1.getDimension(),
+            dimSpec1.getOutputName(),
+            new StringCardinalityAggregatorColumnSelectorStrategy(), dim2
+        )
+    );
+
+    CardinalityAggregator agg1 = new CardinalityAggregator(dimInfo1, false);
+    CardinalityAggregator agg2 = new CardinalityAggregator(dimInfo2, false);
+
+    for (int i = 0; i < VALUES1.size(); ++i) {
+      aggregate(selector1, agg1);
+    }
+    for (int i = 0; i < VALUES2.size(); ++i) {
+      aggregate(selector2, agg2);
+    }
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 3.0 : 3.0,
+        (Double) valueAggregatorFactory.finalizeComputation(agg1.get()),
+        0.05
+    );
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 6.0 : 6.0,
+        (Double) valueAggregatorFactory.finalizeComputation(agg2.get()),
+        0.05
+    );
+    Assert.assertEquals(
+        NullHandling.replaceWithDefault() ? 6.0 : 6.0,
+        (Double) rowAggregatorFactory.finalizeComputation(
+            rowAggregatorFactory.combine(
+                agg1.get(),
+                agg2.get()
+            )
+        ),
+        0.05
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -225,11 +225,6 @@ public class CardinalityAggregatorTest
       new String[]{"x", "y", "a"}
   );
 
-  public Object[] countNulls()
-  {
-    return Lists.newArrayList(true, false).toArray();
-  }
-
   private static List<String[]> dimensionValues(Object... values)
   {
     return Lists.transform(
@@ -671,26 +666,19 @@ public class CardinalityAggregatorTest
 
   //ignoreNullsForStringCardinality tests
   @Test
-  public void testBufferAggregateRowsIgnoreNulls()
+  public void testAggregateRowsIgnoreNulls()
   {
     NullHandling.initializeForTestsWithValues(null, true);
-    CardinalityBufferAggregator agg = new CardinalityBufferAggregator(
-        dimInfoList.toArray(new ColumnSelectorPlus[0]),
+    CardinalityAggregator agg = new CardinalityAggregator(
+        dimInfoList,
         true
     );
 
-    int maxSize = rowAggregatorFactory.getMaxIntermediateSizeWithNulls();
-    ByteBuffer buf = ByteBuffer.allocate(maxSize + 64);
-    int pos = 10;
-    buf.limit(pos + maxSize);
-
-    agg.init(buf, pos);
-
     for (int i = 0; i < VALUES1.size(); ++i) {
-      bufferAggregate(selectorList, agg, buf, pos);
+      aggregate(selectorList, agg);
     }
-    Assert.assertEquals(7.0, (Double) rowAggregatorFactory.finalizeComputation(agg.get(buf, pos)), 0.05);
-    Assert.assertEquals(7L, rowAggregatorFactoryRounded.finalizeComputation(agg.get(buf, pos)));
+    Assert.assertEquals(9.0, (Double) rowAggregatorFactory.finalizeComputation(agg.get()), 0.05);
+    Assert.assertEquals(9L, rowAggregatorFactoryRounded.finalizeComputation(agg.get()));
   }
 
   @Test
@@ -705,6 +693,7 @@ public class CardinalityAggregatorTest
     for (int i = 0; i < VALUES1.size(); ++i) {
       aggregate(selectorList, agg);
     }
+    //setting is not applied when druid.generic.useDefaultValueForNull=false
     Assert.assertEquals(
         NullHandling.replaceWithDefault() ? 6.0 : 6.0,
         (Double) valueAggregatorFactory.finalizeComputation(agg.get()),

--- a/website/.spelling
+++ b/website/.spelling
@@ -693,6 +693,7 @@ doubleMeanNoNulls
 doubleMin
 doubleSum
 druid.generic.useDefaultValueForNull
+druid.generic.ignoreNullsForStringCardinality
 limitSpec
 longMax
 longAny


### PR DESCRIPTION
Introduced a new config flag `druid.generic.ignoreNullsForStringCardinality` which is by default set to `false`. When set to true the nulls in a string column are not counted towards cardinality.

For example in this `testTable` column
<html>
<body>

stringVal |
-- |
null | 
null | 
null | 
abc | 
abc |
abc |

</body>
</html>

In the default case (when the config is set to `false`) the query
`select COUNT(DISTINCT stringVal) from testTable` will return a value of 2

When set to `true` the same query will ignore the nulls and give a value of 1.


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
