### PR TITLE
fix build due to com.nimbusds:lang-tag update

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -793,7 +793,7 @@ name: com.nimbusds lang-tag
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 1.5
+version: 1.6
 libraries:
   - com.nimbusds: lang-tag
 


### PR DESCRIPTION
the version of com.nimbusds:oauth2-oidc-sdk we depend on does not
specific an exact version dependency for com.nimbusds:lang-tag, and
instead uses a version range (see
    https://search.maven.org/artifact/com.nimbusds/oauth2-oidc-sdk/6.5/jar)

Recently a new version of lang-tag was released requiring us to update
the license file accordingly.