### PR TITLE
Duties in Indexing group (such as Auto Compaction) does not report metrics

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -964,6 +964,12 @@ public class DruidCoordinator
         log.makeAlert(e, "Caught exception, ignoring so that schedule keeps going.").emit();
       }
     }
+
+    @VisibleForTesting
+    public List<? extends CoordinatorDuty> getDuties()
+    {
+      return duties;
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -840,14 +840,17 @@ public class DruidCoordinator
 
     protected DutiesRunnable(List<? extends CoordinatorDuty> duties, final int startingLeaderCounter, String alias)
     {
+      // Automatically add EmitClusterStatsAndMetrics duty to the group if it does not already exists
+      // This is to avoid human coding error (forgetting to add the EmitClusterStatsAndMetrics duty to the group)
+      // causing metrics from the duties to not being emitted.
       if (duties.stream().noneMatch(duty -> duty instanceof EmitClusterStatsAndMetrics)) {
+        boolean isContainCompactSegmentDuty = duties.stream().anyMatch(duty -> duty instanceof CompactSegments);
         List<CoordinatorDuty> allDuties = new ArrayList<>(duties);
-        allDuties.add(new EmitClusterStatsAndMetrics(DruidCoordinator.this, alias, duties));
+        allDuties.add(new EmitClusterStatsAndMetrics(DruidCoordinator.this, alias, isContainCompactSegmentDuty));
         this.duties = allDuties;
       } else {
         this.duties = duties;
       }
-      //Auto add emit
       this.startingLeaderCounter = startingLeaderCounter;
       this.dutiesRunnableAlias = alias;
     }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -36,8 +36,6 @@ import org.apache.druid.server.coordinator.rules.LoadRule;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 
-import java.util.List;
-
 /**
  * Emits stats of the cluster and metrics of the coordination (including segment balancing) process.
  */
@@ -51,13 +49,13 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
 
   private final DruidCoordinator coordinator;
   private final String groupName;
-  private final List<? extends CoordinatorDuty> dutyList;
+  private final boolean isContainCompactSegmentDuty;
 
-  public EmitClusterStatsAndMetrics(DruidCoordinator coordinator, String groupName, List<? extends CoordinatorDuty> duties)
+  public EmitClusterStatsAndMetrics(DruidCoordinator coordinator, String groupName, boolean isContainCompactSegmentDuty)
   {
     this.coordinator = coordinator;
     this.groupName = groupName;
-    this.dutyList = duties;
+    this.isContainCompactSegmentDuty = isContainCompactSegmentDuty;
   }
 
   private void emitTieredStat(
@@ -145,7 +143,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     if (DruidCoordinator.HISTORICAL_MANAGEMENT_DUTIES_DUTY_GROUP.equals(groupName)) {
       emitStatsForHistoricalManagementDuties(cluster, stats, emitter, params);
     }
-    if (dutyList.stream().anyMatch(duty -> duty instanceof CompactSegments)) {
+    if (isContainCompactSegmentDuty) {
       emitStatsForCompactSegments(cluster, stats, emitter);
     }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -38,8 +38,6 @@ import org.apache.druid.timeline.VersionedIntervalTimeline;
 
 import java.util.List;
 
-import static org.apache.druid.server.coordinator.DruidCoordinator.HISTORICAL_MANAGEMENT_DUTIES_DUTY_GROUP;
-
 /**
  * Emits stats of the cluster and metrics of the coordination (including segment balancing) process.
  */

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -72,6 +72,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     emitter.emit(
         new ServiceMetricEvent.Builder()
             .setDimension(DruidMetrics.TIER, tier)
+            .setDimension(DruidMetrics.DUTY_GROUP, groupName)
             .build(metricName, value)
     );
   }
@@ -86,6 +87,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     emitter.emit(
         new ServiceMetricEvent.Builder()
             .setDimension(DruidMetrics.TIER, tier)
+            .setDimension(DruidMetrics.DUTY_GROUP, groupName)
             .build(metricName, value)
     );
   }
@@ -115,6 +117,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     emitter.emit(
         new ServiceMetricEvent.Builder()
             .setDimension(DruidMetrics.DUTY, duty)
+            .setDimension(DruidMetrics.DUTY_GROUP, groupName)
             .build(metricName, value)
     );
   }
@@ -213,7 +216,9 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     );
 
     emitter.emit(
-        new ServiceMetricEvent.Builder().build(
+        new ServiceMetricEvent.Builder()
+            .setDimension(DruidMetrics.DUTY_GROUP, groupName)
+            .build(
             "segment/overShadowed/count",
             stats.getGlobalStat("overShadowedCount")
         )
@@ -292,24 +297,28 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         .forEach((final String serverName, final LoadQueuePeon queuePeon) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.SERVER, serverName).build(
                   "segment/loadQueue/size", queuePeon.getLoadQueueSize()
               )
           );
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.SERVER, serverName).build(
                   "segment/loadQueue/failed", queuePeon.getAndResetFailedAssignCount()
               )
           );
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.SERVER, serverName).build(
                   "segment/loadQueue/count", queuePeon.getSegmentsToLoad().size()
               )
           );
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.SERVER, serverName).build(
                   "segment/dropQueue/count", queuePeon.getSegmentsToDrop().size()
               )
@@ -322,6 +331,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
           final int numUnavailableUsedSegmentsInDataSource = entry.getIntValue();
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource).build(
                   "segment/unavailable/count", numUnavailableUsedSegmentsInDataSource
               )
@@ -337,6 +347,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
 
             emitter.emit(
                 new ServiceMetricEvent.Builder()
+                    .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                     .setDimension(DruidMetrics.TIER, tier)
                     .setDimension(DruidMetrics.DATASOURCE, dataSource).build(
                     "segment/underReplicated/count", underReplicationCount
@@ -356,11 +367,13 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
               .sum();
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/size", totalSizeOfUsedSegments)
           );
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/count", dataSourceWithUsedSegments.getNumObjects())
           );
@@ -371,21 +384,27 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
   private void emitStatsForCompactSegments(DruidCluster cluster, CoordinatorStats stats, ServiceEmitter emitter)
   {
     emitter.emit(
-        new ServiceMetricEvent.Builder().build(
+        new ServiceMetricEvent.Builder()
+            .setDimension(DruidMetrics.DUTY_GROUP, groupName)
+            .build(
             "compact/task/count",
             stats.getGlobalStat(CompactSegments.COMPACTION_TASK_COUNT)
         )
     );
 
     emitter.emit(
-        new ServiceMetricEvent.Builder().build(
+        new ServiceMetricEvent.Builder()
+            .setDimension(DruidMetrics.DUTY_GROUP, groupName)
+            .build(
             "compactTask/maxSlot/count",
             stats.getGlobalStat(CompactSegments.MAX_COMPACTION_TASK_SLOT)
         )
     );
 
     emitter.emit(
-        new ServiceMetricEvent.Builder().build(
+        new ServiceMetricEvent.Builder()
+            .setDimension(DruidMetrics.DUTY_GROUP, groupName)
+            .build(
             "compactTask/availableSlot/count",
             stats.getGlobalStat(CompactSegments.AVAILABLE_COMPACTION_TASK_SLOT)
         )
@@ -396,6 +415,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/waitCompact/bytes", count)
           );
@@ -407,6 +427,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/waitCompact/count", count)
           );
@@ -418,6 +439,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("interval/waitCompact/count", count)
           );
@@ -429,6 +451,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/skipCompact/bytes", count)
           );
@@ -440,6 +463,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/skipCompact/count", count)
           );
@@ -451,6 +475,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("interval/skipCompact/count", count)
           );
@@ -462,6 +487,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/compacted/bytes", count)
           );
@@ -473,6 +499,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("segment/compacted/count", count)
           );
@@ -484,6 +511,7 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
         (final String dataSource, final long count) -> {
           emitter.emit(
               new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DUTY_GROUP, groupName)
                   .setDimension(DruidMetrics.DATASOURCE, dataSource)
                   .build("interval/compacted/count", count)
           );

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -1152,7 +1152,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
   @Test
   public void testEmitClusterStatsAndMetricsNotAddedAgainWhenInDutyList()
   {
-    DruidCoordinator.DutiesRunnable dutyRunnable = coordinator.new DutiesRunnable(ImmutableList.of(new LogUsedSegments(), new EmitClusterStatsAndMetrics(coordinator, "TEST", ImmutableList.of(new LogUsedSegments()))), 0, "TEST");
+    DruidCoordinator.DutiesRunnable dutyRunnable = coordinator.new DutiesRunnable(ImmutableList.of(new LogUsedSegments(), new EmitClusterStatsAndMetrics(coordinator, "TEST", false)), 0, "TEST");
     List<? extends CoordinatorDuty> duties = dutyRunnable.getDuties();
     int emitDutyFound = 0;
     for (CoordinatorDuty duty : duties) {

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -77,7 +77,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -88,7 +87,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 /**
  */

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.coordinator.duty;
 
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
-import org.apache.druid.client.indexing.IndexingServiceClient;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -29,7 +28,6 @@ import org.apache.druid.metadata.MetadataRuleManager;
 import org.apache.druid.server.coordinator.CoordinatorStats;
 import org.apache.druid.server.coordinator.DruidCluster;
 import org.apache.druid.server.coordinator.DruidCoordinator;
-import org.apache.druid.server.coordinator.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.junit.Assert;
 import org.junit.Test;

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.druid.server.coordinator.duty;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import org.apache.druid.client.indexing.IndexingServiceClient;
@@ -58,11 +56,6 @@ public class EmitClusterStatsAndMetricsTest
   DruidCluster mockDruidCluster;
   @Mock
   MetadataRuleManager mockMetadataRuleManager;
-  @Mock
-  DruidCoordinatorConfig mockConfig;
-  @Mock
-  IndexingServiceClient mockIndexingServiceClient;
-
 
   @Test
   public void testRunOnlyEmitStatsForHistoricalDuties()
@@ -74,7 +67,7 @@ public class EmitClusterStatsAndMetricsTest
     Mockito.when(mockDruidCoordinatorRuntimeParams.getDatabaseRuleManager()).thenReturn(mockMetadataRuleManager);
     Mockito.when(mockDruidCoordinator.computeNumsUnavailableUsedSegmentsPerDataSource()).thenReturn(Object2IntMaps.emptyMap());
     Mockito.when(mockDruidCoordinator.computeUnderReplicationCountsPerDataSourcePerTier()).thenReturn(ImmutableMap.of());
-    CoordinatorDuty duty = new EmitClusterStatsAndMetrics(mockDruidCoordinator, DruidCoordinator.HISTORICAL_MANAGEMENT_DUTIES_DUTY_GROUP, ImmutableList.of());
+    CoordinatorDuty duty = new EmitClusterStatsAndMetrics(mockDruidCoordinator, DruidCoordinator.HISTORICAL_MANAGEMENT_DUTIES_DUTY_GROUP, false);
     duty.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockServiceEmitter, Mockito.atLeastOnce()).emit(argumentCaptor.capture());
     List<ServiceEventBuilder> emittedEvents = argumentCaptor.getAllValues();
@@ -104,7 +97,7 @@ public class EmitClusterStatsAndMetricsTest
     Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
     Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(mockCoordinatorStats);
     Mockito.when(mockDruidCoordinatorRuntimeParams.getDruidCluster()).thenReturn(mockDruidCluster);
-    CoordinatorDuty duty = new EmitClusterStatsAndMetrics(mockDruidCoordinator, groupName, ImmutableList.of(new CompactSegments(mockConfig, new ObjectMapper(), mockIndexingServiceClient)));
+    CoordinatorDuty duty = new EmitClusterStatsAndMetrics(mockDruidCoordinator, groupName, true);
     duty.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockServiceEmitter, Mockito.atLeastOnce()).emit(argumentCaptor.capture());
     List<ServiceEventBuilder> emittedEvents = argumentCaptor.getAllValues();

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMaps;
+import org.apache.druid.client.indexing.IndexingServiceClient;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.metadata.MetadataRuleManager;
+import org.apache.druid.server.coordinator.CoordinatorStats;
+import org.apache.druid.server.coordinator.DruidCluster;
+import org.apache.druid.server.coordinator.DruidCoordinator;
+import org.apache.druid.server.coordinator.DruidCoordinatorConfig;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EmitClusterStatsAndMetricsTest
+{
+  @Mock
+  private ServiceEmitter mockServiceEmitter;
+  @Mock
+  private DruidCoordinator mockDruidCoordinator;
+  @Mock
+  private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
+  @Mock
+  CoordinatorStats mockCoordinatorStats;
+  @Mock
+  DruidCluster mockDruidCluster;
+  @Mock
+  MetadataRuleManager mockMetadataRuleManager;
+  @Mock
+  DruidCoordinatorConfig mockConfig;
+  @Mock
+  IndexingServiceClient mockIndexingServiceClient;
+
+
+  @Test
+  public void testRunOnlyEmitStatsForHistoricalDuties()
+  {
+    ArgumentCaptor<ServiceEventBuilder> argumentCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(mockCoordinatorStats);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getDruidCluster()).thenReturn(mockDruidCluster);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getDatabaseRuleManager()).thenReturn(mockMetadataRuleManager);
+    Mockito.when(mockDruidCoordinator.computeNumsUnavailableUsedSegmentsPerDataSource()).thenReturn(Object2IntMaps.emptyMap());
+    Mockito.when(mockDruidCoordinator.computeUnderReplicationCountsPerDataSourcePerTier()).thenReturn(ImmutableMap.of());
+    CoordinatorDuty duty = new EmitClusterStatsAndMetrics(mockDruidCoordinator, DruidCoordinator.HISTORICAL_MANAGEMENT_DUTIES_DUTY_GROUP, ImmutableList.of());
+    duty.run(mockDruidCoordinatorRuntimeParams);
+    Mockito.verify(mockServiceEmitter, Mockito.atLeastOnce()).emit(argumentCaptor.capture());
+    List<ServiceEventBuilder> emittedEvents = argumentCaptor.getAllValues();
+    boolean foundCompactMetric = false;
+    boolean foundHistoricalDutyMetric = false;
+    for (ServiceEventBuilder eventBuilder : emittedEvents) {
+      ServiceMetricEvent serviceMetricEvent = ((ServiceMetricEvent) eventBuilder.build("x", "x"));
+      String metric = serviceMetricEvent.getMetric();
+      if ("segment/overShadowed/count".equals(metric)) {
+        foundHistoricalDutyMetric = true;
+      } else if ("compact/task/count".equals(metric)) {
+        foundCompactMetric = true;
+      }
+      String dutyGroup = (String) serviceMetricEvent.getUserDims().get("dutyGroup");
+      Assert.assertNotNull(dutyGroup);
+      Assert.assertEquals(DruidCoordinator.HISTORICAL_MANAGEMENT_DUTIES_DUTY_GROUP, dutyGroup);
+    }
+    Assert.assertTrue(foundHistoricalDutyMetric);
+    Assert.assertFalse(foundCompactMetric);
+  }
+
+  @Test
+  public void testRunEmitStatsForCompactionWhenHaveCompactSegmentDuty()
+  {
+    String groupName = "blah";
+    ArgumentCaptor<ServiceEventBuilder> argumentCaptor = ArgumentCaptor.forClass(ServiceEventBuilder.class);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getEmitter()).thenReturn(mockServiceEmitter);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(mockCoordinatorStats);
+    Mockito.when(mockDruidCoordinatorRuntimeParams.getDruidCluster()).thenReturn(mockDruidCluster);
+    CoordinatorDuty duty = new EmitClusterStatsAndMetrics(mockDruidCoordinator, groupName, ImmutableList.of(new CompactSegments(mockConfig, new ObjectMapper(), mockIndexingServiceClient)));
+    duty.run(mockDruidCoordinatorRuntimeParams);
+    Mockito.verify(mockServiceEmitter, Mockito.atLeastOnce()).emit(argumentCaptor.capture());
+    List<ServiceEventBuilder> emittedEvents = argumentCaptor.getAllValues();
+    boolean foundCompactMetric = false;
+    boolean foundHistoricalDutyMetric = false;
+    for (ServiceEventBuilder eventBuilder : emittedEvents) {
+      ServiceMetricEvent serviceMetricEvent = ((ServiceMetricEvent) eventBuilder.build("x", "x"));
+      String metric = serviceMetricEvent.getMetric();
+      if ("segment/overShadowed/count".equals(metric)) {
+        foundHistoricalDutyMetric = true;
+      } else if ("compact/task/count".equals(metric)) {
+        foundCompactMetric = true;
+      }
+      String dutyGroup = (String) serviceMetricEvent.getUserDims().get("dutyGroup");
+      Assert.assertNotNull(dutyGroup);
+      Assert.assertEquals(groupName, dutyGroup);
+    }
+    Assert.assertFalse(foundHistoricalDutyMetric);
+    Assert.assertTrue(foundCompactMetric);
+  }
+}


### PR DESCRIPTION
Duties in Indexing group (such as Auto Compaction) does not report metrics

### Description

Duties emit metrics via the EmitClusterStatsAndMetrics class which is run as the last duty in the group. However, this duty is only added to the HistoricalManagementDuties group and not other groups such as IndexingServiceDuties group. This PR changes the following:
- EmitClusterStatsAndMetrics is automatically added to all duty group via the constructor of the DutiesRunnable (if not already exist)
-  EmitClusterStatsAndMetrics is change to check for list of duty and group name to only emits relevant metrics.
- Add dutyGroup to metrics emitted from EmitClusterStatsAndMetrics indicating which dutyGroup those metrics came from.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
