### PR TITLE
apache-rat-plugin license checker always break on website artifacts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1838,6 +1838,8 @@
                                 <exclude>.editorconfig</exclude>
                                 <exclude>**/hadoop.indexer.libs.version</exclude>
                                 <exclude>**/codegen/**</exclude>
+                                <exclude>website/target/**</exclude>
+                                <exclude>website/node_modules/**</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
### Description

apache-rat-plugin always breaks when checking licenses on website's artifacts.

I think they should be excluded.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
