### PR TITLE
Metrics for shenandoah

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/metrics/JvmMonitor.java
+++ b/core/src/main/java/org/apache/druid/java/util/metrics/JvmMonitor.java
@@ -300,6 +300,8 @@ public class JvmMonitor extends FeedDefiningMonitor
           return "cms";
         case "G1 incremental collections":
           return "g1";
+        case "Shenandoah partial":
+          return "shenandoah";
 
         // Old gen
         case "MCS":
@@ -310,6 +312,8 @@ public class JvmMonitor extends FeedDefiningMonitor
           return "cms";
         case "G1 stop-the-world full collections":
           return "g1";
+        case "Shenandoah full":
+          return "shenandoah";
 
         default:
           return name;


### PR DESCRIPTION
Based on this source code: 

https://github.com/openjdk/jdk/blob/554caf33a01ac9ca2e3e9170557e8348750f3971/src/hotspot/share/gc/shenandoah/shenandoahMonitoringSupport.cpp#L65

Partially fixes #6424 by generating metrics for Shenandoah. Too bad ZGC does not have similar MonitoringSupport.cpp file.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
