### PR TITLE
Handling planning error for sort outer queries (Stage 1)

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
@@ -36,7 +36,6 @@ import org.apache.druid.query.QueryDataSource;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
-import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import java.util.List;
 import java.util.Set;
@@ -69,6 +68,7 @@ public class DruidOuterQueryRel extends DruidRel<DruidOuterQueryRel>
       final PartialDruidQuery partialQuery
   )
   {
+
     return new DruidOuterQueryRel(
         sourceRel.getCluster(),
         sourceRel.getTraitSet().plusAll(partialQuery.getRelTraits()),
@@ -114,7 +114,8 @@ public class DruidOuterQueryRel extends DruidRel<DruidOuterQueryRel>
   @Override
   public DruidQuery toDruidQueryForExplaining()
   {
-    return partialQuery.build(
+    return toDruidQuery(false);
+    /*return partialQuery.build(
         DUMMY_DATA_SOURCE,
         RowSignatures.fromRelDataType(
             sourceRel.getRowType().getFieldNames(),
@@ -123,7 +124,7 @@ public class DruidOuterQueryRel extends DruidRel<DruidOuterQueryRel>
         getPlannerContext(),
         getCluster().getRexBuilder(),
         false
-    );
+    );*/
   }
 
   @Override

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -11104,7 +11104,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   public void testProjectAfterSort() throws Exception
   {
     testQuery(
-        "select dim1 from (select dim1, dim2, count(*) cnt from druid.foo group by dim1, dim2 order by cnt)",
+        "select dim1 from (select dim1 as \"d\", dim2, count(*) cnt from druid.foo group by dim1, dim2 order by cnt)",
         ImmutableList.of(
             GroupByQuery.builder()
                         .setDataSource(CalciteTests.DATASOURCE1)
@@ -11126,6 +11126,99 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             new Object[]{"2"},
             new Object[]{"abc"},
             new Object[]{"def"}
+        )
+    );
+  }
+
+  //This passes
+  @Test
+  public void testOrderByAlongWithAliasOrderByNonTime() throws Exception
+  {
+    testQuery(
+        "select __time as bug, dim2 from druid.foo group by __time, dim2 order by dim2 limit 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("__time", "d0", ColumnType.LONG),
+                                new DefaultDimensionSpec("dim2", "d1", ColumnType.STRING)
+                            )
+                        )
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                Collections.singletonList(
+                                    new OrderByColumnSpec("d1", Direction.ASCENDING, StringComparators.LEXICOGRAPHIC)
+                                ),
+                                1
+                            )
+                        )
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{946771200000L, ""}
+        )
+    );
+  }
+
+  // This fails
+  @Test
+  public void testOrderByAlongWithAliasOrderByTimeGroupByMulti() throws Exception
+  {
+    testQuery(
+        "select __time as bug, dim2 from druid.foo group by __time, dim2 order by __time limit 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.DATASOURCE1)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("__time", "d0", ColumnType.LONG),
+                                new DefaultDimensionSpec("dim2", "d1", ColumnType.STRING)
+                            )
+                        )
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                Collections.singletonList(
+                                    new OrderByColumnSpec("d0", Direction.ASCENDING, StringComparators.NUMERIC)
+                                ),
+                                1
+                            )
+                        )
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{946684800000L, "a"}
+        )
+    );
+  }
+
+  //This fails
+  @Test
+  public void testOrderByAlongWithAliasOrderByTimeGroupByOneCol() throws Exception
+  {
+    testQuery(
+        "select __time as bug from druid.foo group by __time order by __time limit 1",
+        ImmutableList.of(
+            new TopNQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE1)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .granularity(Granularities.ALL)
+                .dimension(
+                    new DefaultDimensionSpec("__time", "d0", ColumnType.LONG)
+                )
+                .threshold(1)
+                .metric(new DimensionTopNMetricSpec(null, StringComparators.NUMERIC))
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{946684800000L}
         )
     );
   }


### PR DESCRIPTION
This is a work in progress. More commits to follow.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
