### PR TITLE
complex metrics -> complex types

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
@@ -73,6 +73,7 @@ import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.joda.time.Interval;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -153,7 +154,7 @@ public class FilterPartitionBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     schemaInfo = GeneratorBasicSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
@@ -72,7 +72,6 @@ import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.joda.time.Interval;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -74,6 +74,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -158,7 +159,7 @@ public class FilteredAggregatorBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     schemaInfo = GeneratorBasicSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -73,7 +73,6 @@ import org.apache.druid.segment.incremental.AppendableIndexSpec;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -72,6 +72,7 @@ import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -271,7 +272,7 @@ public class GroupByTypeInterfaceBenchmark
   {
     log.info("SETUP CALLED AT %d", System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     setupQueries();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -71,7 +71,6 @@ import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/TopNTypeInterfaceBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/TopNTypeInterfaceBenchmark.java
@@ -68,7 +68,6 @@ import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/TopNTypeInterfaceBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/TopNTypeInterfaceBenchmark.java
@@ -69,6 +69,7 @@ import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -238,7 +239,7 @@ public class TopNTypeInterfaceBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     setupQueries();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -47,7 +47,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -103,7 +103,7 @@ public class IncrementalIndexReadBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     schemaInfo = GeneratorBasicSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexIngestionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexIngestionBenchmark.java
@@ -31,7 +31,7 @@ import org.apache.druid.segment.incremental.AppendableIndexSpec;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -86,7 +86,7 @@ public class IndexIngestionBenchmark
   @Setup
   public void setup() throws JsonProcessingException
   {
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     schemaInfo = GeneratorBasicSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -37,7 +37,6 @@ import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMediumFactory;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -38,6 +38,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
@@ -117,7 +118,7 @@ public class IndexMergeBenchmark
 
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
     indexMergerV9 = new IndexMergerV9(JSON_MAPPER, INDEX_IO, getSegmentWriteOutMediumFactory(factoryType));
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     indexesToMerge = new ArrayList<>();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -37,7 +37,6 @@ import org.apache.druid.segment.incremental.AppendableIndexSpec;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -38,6 +38,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -107,7 +108,7 @@ public class IndexPersistBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     schemaInfo = GeneratorBasicSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
@@ -90,7 +90,6 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
@@ -91,6 +91,7 @@ import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -432,7 +433,7 @@ public class GroupByBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     setupQueries();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/ScanBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/ScanBenchmark.java
@@ -72,6 +72,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -244,7 +245,7 @@ public class ScanBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     setupQueries();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/ScanBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/ScanBenchmark.java
@@ -71,7 +71,6 @@ import org.apache.druid.segment.incremental.AppendableIndexSpec;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SearchBenchmark.java
@@ -79,6 +79,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -317,7 +318,7 @@ public class SearchBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     setupQueries();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SearchBenchmark.java
@@ -78,7 +78,6 @@ import org.apache.druid.segment.incremental.AppendableIndexSpec;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
@@ -73,6 +73,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -245,7 +246,7 @@ public class TimeseriesBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     setupQueries();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
@@ -72,7 +72,6 @@ import org.apache.druid.segment.incremental.AppendableIndexSpec;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/TopNBenchmark.java
@@ -69,7 +69,6 @@ import org.apache.druid.segment.incremental.AppendableIndexSpec;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/TopNBenchmark.java
@@ -70,6 +70,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCreator;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -216,7 +217,7 @@ public class TopNBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     setupQueries();
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
@@ -74,7 +74,6 @@ import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
@@ -75,6 +75,7 @@ import org.apache.druid.segment.generator.GeneratorSchemaInfo;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.Interval;
@@ -285,7 +286,7 @@ public class TimeCompareBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     executorService = Execs.multiThreaded(numSegments, "TopNThreadPool");
 

--- a/docs/development/modules.md
+++ b/docs/development/modules.md
@@ -40,7 +40,7 @@ Druid's extensions leverage Guice in order to add things at runtime.  Basically,
    and `org.apache.druid.query.aggregation.BufferAggregator`.
 1. Add PostAggregators by extending `org.apache.druid.query.aggregation.PostAggregator`.
 1. Add ExtractionFns by extending `org.apache.druid.query.extraction.ExtractionFn`.
-1. Add Complex metrics by extending `org.apache.druid.segment.serde.ComplexMetricSerde`.
+1. Add Complex types by extending `org.apache.druid.segment.serde.ComplexTypeSerde`.
 1. Add new Query types by extending `org.apache.druid.query.QueryRunnerFactory`, `org.apache.druid.query.QueryToolChest`, and
    `org.apache.druid.query.Query`.
 1. Add new Jersey resources by calling `Jerseys.addResource(binder, clazz)`.

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/MomentSketchModule.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/MomentSketchModule.java
@@ -31,7 +31,7 @@ import org.apache.druid.query.aggregation.momentsketch.aggregator.MomentSketchMa
 import org.apache.druid.query.aggregation.momentsketch.aggregator.MomentSketchMergeAggregatorFactory;
 import org.apache.druid.query.aggregation.momentsketch.aggregator.MomentSketchMinPostAggregator;
 import org.apache.druid.query.aggregation.momentsketch.aggregator.MomentSketchQuantilePostAggregator;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 
 import java.util.List;
 
@@ -81,6 +81,6 @@ public class MomentSketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    ComplexMetrics.registerSerde(MomentSketchAggregatorFactory.TYPE_NAME, new MomentSketchComplexMetricSerde());
+    ComplexTypes.registerSerde(MomentSketchAggregatorFactory.TYPE_NAME, new MomentSketchComplexMetricSerde());
   }
 }

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchModule.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchModule.java
@@ -29,7 +29,7 @@ import com.tdunning.math.stats.MergingDigest;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.query.aggregation.tdigestsketch.sql.TDigestGenerateSketchSqlAggregator;
 import org.apache.druid.query.aggregation.tdigestsketch.sql.TDigestSketchQuantileSqlAggregator;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.sql.guice.SqlBindings;
 
 import java.util.List;
@@ -73,7 +73,7 @@ public class TDigestSketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    ComplexMetrics.registerSerde(TDigestSketchAggregatorFactory.TYPE_NAME, new TDigestSketchComplexMetricSerde());
-    ComplexMetrics.registerSerde("TDIGEST_GENERATE_SKETCH", new TDigestSketchComplexMetricSerde());
+    ComplexTypes.registerSerde(TDigestSketchAggregatorFactory.TYPE_NAME, new TDigestSketchComplexMetricSerde());
+    ComplexTypes.registerSerde("TDIGEST_GENERATE_SKETCH", new TDigestSketchComplexMetricSerde());
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
@@ -32,7 +32,7 @@ import org.apache.druid.query.aggregation.datasketches.hll.sql.HllSketchEstimate
 import org.apache.druid.query.aggregation.datasketches.hll.sql.HllSketchObjectSqlAggregator;
 import org.apache.druid.query.aggregation.datasketches.hll.sql.HllSketchSetUnionOperatorConversion;
 import org.apache.druid.query.aggregation.datasketches.hll.sql.HllSketchToStringOperatorConversion;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.sql.guice.SqlBindings;
 
 import java.util.Collections;
@@ -92,8 +92,8 @@ public class HllSketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    ComplexMetrics.registerSerde(TYPE_NAME, new HllSketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(BUILD_TYPE_NAME, new HllSketchBuildComplexMetricSerde());
-    ComplexMetrics.registerSerde(MERGE_TYPE_NAME, new HllSketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(TYPE_NAME, new HllSketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(BUILD_TYPE_NAME, new HllSketchBuildComplexMetricSerde());
+    ComplexTypes.registerSerde(MERGE_TYPE_NAME, new HllSketchMergeComplexMetricSerde());
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchModule.java
@@ -35,7 +35,7 @@ import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSket
 import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchSummaryOperatorConversion;
 import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchToHistogramOperatorConversion;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.sql.guice.SqlBindings;
 
 import java.util.Collections;
@@ -92,6 +92,6 @@ public class DoublesSketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    ComplexMetrics.registerSerde(DOUBLES_SKETCH, new DoublesSketchComplexMetricSerde());
+    ComplexTypes.registerSerde(DOUBLES_SKETCH, new DoublesSketchComplexMetricSerde());
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchModule.java
@@ -33,7 +33,7 @@ import org.apache.druid.query.aggregation.datasketches.theta.sql.ThetaSketchSetI
 import org.apache.druid.query.aggregation.datasketches.theta.sql.ThetaSketchSetNotOperatorConversion;
 import org.apache.druid.query.aggregation.datasketches.theta.sql.ThetaSketchSetUnionOperatorConversion;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.sql.guice.SqlBindings;
 
 import java.util.Collections;
@@ -93,8 +93,8 @@ public class SketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    ComplexMetrics.registerSerde(THETA_SKETCH, new SketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(THETA_SKETCH_MERGE_AGG, new SketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(THETA_SKETCH_BUILD_AGG, new SketchBuildComplexMetricSerde());
+    ComplexTypes.registerSerde(THETA_SKETCH, new SketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(THETA_SKETCH_MERGE_AGG, new SketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(THETA_SKETCH_BUILD_AGG, new SketchBuildComplexMetricSerde());
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchModule.java
@@ -29,7 +29,7 @@ import org.apache.druid.query.aggregation.datasketches.theta.SketchHolder;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchHolderJsonSerializer;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchMergeComplexMetricSerde;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchModule;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 
 import java.util.Collections;
 import java.util.List;
@@ -44,12 +44,12 @@ public class OldApiSketchModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
-    ComplexMetrics.registerSerde(SKETCH_BUILD, new SketchBuildComplexMetricSerde());
-    ComplexMetrics.registerSerde(SET_SKETCH, new SketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(SKETCH_MERGE, new SketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH, new SketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH_MERGE_AGG, new SketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH_BUILD_AGG, new SketchBuildComplexMetricSerde());
+    ComplexTypes.registerSerde(SKETCH_BUILD, new SketchBuildComplexMetricSerde());
+    ComplexTypes.registerSerde(SET_SKETCH, new SketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(SKETCH_MERGE, new SketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(SketchModule.THETA_SKETCH, new SketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(SketchModule.THETA_SKETCH_MERGE_AGG, new SketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(SketchModule.THETA_SKETCH_BUILD_AGG, new SketchBuildComplexMetricSerde());
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchModule.java
@@ -26,7 +26,7 @@ import com.google.inject.Binder;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesSketch;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 
 import java.util.Collections;
 import java.util.List;
@@ -51,9 +51,9 @@ public class ArrayOfDoublesSketchModule implements DruidModule
   @Override
   public void configure(final Binder binder)
   {
-    ComplexMetrics.registerSerde(ARRAY_OF_DOUBLES_SKETCH, new ArrayOfDoublesSketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(ARRAY_OF_DOUBLES_SKETCH_MERGE_AGG, new ArrayOfDoublesSketchMergeComplexMetricSerde());
-    ComplexMetrics.registerSerde(ARRAY_OF_DOUBLES_SKETCH_BUILD_AGG, new ArrayOfDoublesSketchBuildComplexMetricSerde());
+    ComplexTypes.registerSerde(ARRAY_OF_DOUBLES_SKETCH, new ArrayOfDoublesSketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(ARRAY_OF_DOUBLES_SKETCH_MERGE_AGG, new ArrayOfDoublesSketchMergeComplexMetricSerde());
+    ComplexTypes.registerSerde(ARRAY_OF_DOUBLES_SKETCH_BUILD_AGG, new ArrayOfDoublesSketchBuildComplexMetricSerde());
   }
 
   @Override

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
@@ -32,7 +32,7 @@ import org.apache.druid.query.aggregation.bloom.BloomFilterSerde;
 import org.apache.druid.query.filter.BloomDimFilter;
 import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.query.filter.BloomKFilterHolder;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -52,7 +52,7 @@ public class BloomFilterSerializersModule extends SimpleModule
     addDeserializer(BloomKFilter.class, new BloomKFilterDeserializer());
     addDeserializer(BloomKFilterHolder.class, new BloomKFilterHolderDeserializer());
 
-    ComplexMetrics.registerSerde(BLOOM_FILTER_TYPE_NAME, new BloomFilterSerde());
+    ComplexTypes.registerSerde(BLOOM_FILTER_TYPE_NAME, new BloomFilterSerde());
   }
 
   private static class BloomKFilterSerializer extends StdSerializer<BloomKFilter>

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterSerde.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterSerde.java
@@ -24,8 +24,9 @@ import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.segment.GenericColumnSerializer;
 import org.apache.druid.segment.column.ColumnBuilder;
 import org.apache.druid.segment.data.ObjectStrategy;
-import org.apache.druid.segment.serde.ComplexMetricExtractor;
 import org.apache.druid.segment.serde.ComplexMetricSerde;
+import org.apache.druid.segment.serde.ComplexTypeExtractor;
+import org.apache.druid.segment.serde.ComplexTypeSerde;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
@@ -37,7 +38,7 @@ import java.nio.ByteBuffer;
  * {@link org.apache.druid.query.groupby.GroupByQueryEngine} will work, but isn't actually used because bloom filter
  * aggregators are currently only implemented for use at query time
  */
-public class BloomFilterSerde extends ComplexMetricSerde
+public class BloomFilterSerde extends ComplexTypeSerde
 {
   private static final BloomFilterObjectStrategy STRATEGY = new BloomFilterObjectStrategy();
 
@@ -48,7 +49,7 @@ public class BloomFilterSerde extends ComplexMetricSerde
   }
 
   @Override
-  public ComplexMetricExtractor getExtractor()
+  public ComplexTypeExtractor getExtractor()
   {
     throw new UnsupportedOperationException("Bloom filter aggregators are query-time only");
   }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
@@ -27,7 +27,7 @@ import com.google.inject.Binder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.query.aggregation.histogram.sql.FixedBucketsHistogramQuantileSqlAggregator;
 import org.apache.druid.query.aggregation.histogram.sql.QuantileSqlAggregator;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.sql.guice.SqlBindings;
 
 import java.util.List;
@@ -66,7 +66,7 @@ public class ApproximateHistogramDruidModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    ComplexMetrics.registerSerde("approximateHistogram", new ApproximateHistogramFoldingSerde());
-    ComplexMetrics.registerSerde(FixedBucketsHistogramAggregator.TYPE_NAME, new FixedBucketsHistogramSerde());
+    ComplexTypes.registerSerde("approximateHistogram", new ApproximateHistogramFoldingSerde());
+    ComplexTypes.registerSerde(FixedBucketsHistogramAggregator.TYPE_NAME, new FixedBucketsHistogramSerde());
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerdeTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerdeTest.java
@@ -21,7 +21,7 @@ package org.apache.druid.query.aggregation.histogram;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.MapBasedInputRow;
-import org.apache.druid.segment.serde.ComplexMetricExtractor;
+import org.apache.druid.segment.serde.ComplexTypeExtractor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,7 +34,7 @@ public class ApproximateHistogramFoldingSerdeTest
   public void testExtractor()
   {
     final ApproximateHistogramFoldingSerde serde = new ApproximateHistogramFoldingSerde();
-    final ComplexMetricExtractor extractor = serde.getExtractor();
+    final ComplexTypeExtractor extractor = serde.getExtractor();
 
     final Map<String, Object> theMap = new HashMap<>();
     theMap.put("nullValue", null);

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/stats/DruidStatsModule.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/stats/DruidStatsModule.java
@@ -31,7 +31,7 @@ import org.apache.druid.query.aggregation.variance.VarianceAggregatorFactory;
 import org.apache.druid.query.aggregation.variance.VarianceFoldingAggregatorFactory;
 import org.apache.druid.query.aggregation.variance.VarianceSerde;
 import org.apache.druid.query.aggregation.variance.sql.BaseVarianceSqlAggregator;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.sql.guice.SqlBindings;
 
 import java.util.List;
@@ -65,6 +65,6 @@ public class DruidStatsModule implements DruidModule
       SqlBindings.addAggregator(binder, BaseVarianceSqlAggregator.StdDevSampSqlAggregator.class);
       SqlBindings.addAggregator(binder, BaseVarianceSqlAggregator.StdDevSqlAggregator.class);
     }
-    ComplexMetrics.registerSerde("variance", new VarianceSerde());
+    ComplexTypes.registerSerde("variance", new VarianceSerde());
   }
 }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
@@ -41,8 +41,8 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.incremental.IncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetricSerde;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypeSerde;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.hadoop.io.WritableUtils;
 
 import javax.annotation.Nullable;
@@ -355,7 +355,7 @@ public class InputRowSerde
               out.writeDouble(agg.getDouble());
             } else if (type.is(ValueType.COMPLEX)) {
               Object val = agg.get();
-              ComplexMetricSerde serde = getComplexMetricSerde(type.getComplexTypeName());
+              ComplexTypeSerde serde = getComplexMetricSerde(type.getComplexTypeName());
               writeBytes(serde.toBytes(val), out);
             } else {
               throw new IAE("Unable to serialize type[%s]", type.asTypeString());
@@ -486,7 +486,7 @@ public class InputRowSerde
         } else if (type.is(ValueType.DOUBLE)) {
           event.put(metric, in.readDouble());
         } else {
-          ComplexMetricSerde serde = getComplexMetricSerde(agg.getIntermediateType().getComplexTypeName());
+          ComplexTypeSerde serde = getComplexMetricSerde(agg.getIntermediateType().getComplexTypeName());
           byte[] value = readBytes(in);
           event.put(metric, serde.fromBytes(value, 0, value.length));
         }
@@ -514,9 +514,9 @@ public class InputRowSerde
     return null;
   }
 
-  private static ComplexMetricSerde getComplexMetricSerde(String type)
+  private static ComplexTypeSerde getComplexMetricSerde(String type)
   {
-    ComplexMetricSerde serde = ComplexMetrics.getSerdeForType(type);
+    ComplexTypeSerde serde = ComplexTypes.getSerdeForType(type);
     if (serde == null) {
       throw new IAE("Unknown type[%s]", type);
     }

--- a/processing/src/main/java/org/apache/druid/jackson/AggregatorsModule.java
+++ b/processing/src/main/java/org/apache/druid/jackson/AggregatorsModule.java
@@ -71,7 +71,7 @@ import org.apache.druid.query.aggregation.post.FinalizingFieldAccessPostAggregat
 import org.apache.druid.query.aggregation.post.JavaScriptPostAggregator;
 import org.apache.druid.query.aggregation.post.LongGreatestPostAggregator;
 import org.apache.druid.query.aggregation.post.LongLeastPostAggregator;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 
 public class AggregatorsModule extends SimpleModule
 {
@@ -79,9 +79,9 @@ public class AggregatorsModule extends SimpleModule
   {
     super("AggregatorFactories");
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
-    ComplexMetrics.registerSerde("preComputedHyperUnique", new PreComputedHyperUniquesSerde());
-    ComplexMetrics.registerSerde("serializablePairLongString", new SerializablePairLongStringSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("preComputedHyperUnique", new PreComputedHyperUniquesSerde());
+    ComplexTypes.registerSerde("serializablePairLongString", new SerializablePairLongStringSerde());
 
     setMixInAnnotation(AggregatorFactory.class, AggregatorFactoryMixin.class);
     setMixInAnnotation(PostAggregator.class, PostAggregatorMixin.class);

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -49,8 +49,8 @@ import org.apache.druid.segment.column.TypeSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import org.apache.druid.segment.serde.ComplexMetricSerde;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypeSerde;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -341,7 +341,7 @@ public class SegmentAnalyzer
       long size = 0;
 
       if (analyzingSize() && complexColumn != null) {
-        final ComplexMetricSerde serde = typeName == null ? null : ComplexMetrics.getSerdeForType(typeName);
+        final ComplexTypeSerde serde = typeName == null ? null : ComplexTypes.getSerdeForType(typeName);
         if (serde == null) {
           return ColumnAnalysis.error(StringUtils.format("unknown_complex_%s", typeName));
         }

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -53,8 +53,8 @@ import org.apache.druid.segment.loading.MMappedQueryableSegmentizerFactory;
 import org.apache.druid.segment.loading.SegmentizerFactory;
 import org.apache.druid.segment.serde.ColumnPartSerde;
 import org.apache.druid.segment.serde.ComplexColumnPartSerde;
-import org.apache.druid.segment.serde.ComplexMetricSerde;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypeSerde;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.serde.DoubleNumericColumnPartSerde;
 import org.apache.druid.segment.serde.DoubleNumericColumnPartSerdeV2;
 import org.apache.druid.segment.serde.FloatNumericColumnPartSerde;
@@ -794,7 +794,7 @@ public class IndexMergerV9 implements IndexMerger
           break;
         case COMPLEX:
           final String typeName = metricTypeNames.get(metric);
-          ComplexMetricSerde serde = ComplexMetrics.getSerdeForType(typeName);
+          ComplexTypeSerde serde = ComplexTypes.getSerdeForType(typeName);
           if (serde == null) {
             throw new ISE("Unknown type[%s]", typeName);
           }

--- a/processing/src/main/java/org/apache/druid/segment/MetricHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/MetricHolder.java
@@ -23,11 +23,10 @@ import org.apache.druid.common.utils.SerializerUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.data.CompressedColumnarFloatsSupplier;
 import org.apache.druid.segment.data.GenericIndexed;
-import org.apache.druid.segment.serde.ComplexMetricSerde;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypeSerde;
+import org.apache.druid.segment.serde.ComplexTypes;
 
 import javax.annotation.Nullable;
-
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -54,7 +53,7 @@ public class MetricHolder
         holder.floatType = CompressedColumnarFloatsSupplier.fromByteBuffer(buf, ByteOrder.nativeOrder());
         break;
       case COMPLEX:
-        final ComplexMetricSerde serdeForType = ComplexMetrics.getSerdeForType(holder.getTypeName());
+        final ComplexTypeSerde serdeForType = ComplexTypes.getSerdeForType(holder.getTypeName());
 
         if (serdeForType == null) {
           throw new ISE("Unknown type[%s], cannot load.", holder.getTypeName());
@@ -70,7 +69,7 @@ public class MetricHolder
     return holder;
   }
 
-  private static <T> GenericIndexed<T> read(ByteBuffer buf, ComplexMetricSerde serde)
+  private static <T> GenericIndexed<T> read(ByteBuffer buf, ComplexTypeSerde serde)
   {
     return GenericIndexed.read(buf, serde.getObjectStrategy());
   }

--- a/processing/src/main/java/org/apache/druid/segment/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowBasedColumnSelectorFactory.java
@@ -508,8 +508,8 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
     if (capabilities != null && capabilities.is(ValueType.COMPLEX) && capabilities.getComplexTypeName() != null) {
       try {
         final ComplexTypeSerde serde = ComplexTypes.getSerdeForType(capabilities.getComplexTypeName());
-        final ComplexTypeExtractor extractor = serde.getExtractor();
         if (serde != null) {
+          final ComplexTypeExtractor<?> extractor = serde.getExtractor();
           return in -> extractor.coerceValue(adapter.columnFunction(columnName).apply(in));
         }
       }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -75,8 +75,9 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.serde.ComplexMetricExtractor;
-import org.apache.druid.segment.serde.ComplexMetricSerde;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypeExtractor;
+import org.apache.druid.segment.serde.ComplexTypeSerde;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.transform.Transformer;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -145,12 +146,12 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
           // For complex aggregators that read from multiple columns, we wrap all of them. This is not ideal but it
           // has worked so far.
           final String complexTypeName = agg.getIntermediateType().getComplexTypeName();
-          final ComplexMetricSerde serde = ComplexMetrics.getSerdeForType(complexTypeName);
+          final ComplexTypeSerde serde = ComplexTypes.getSerdeForType(complexTypeName);
           if (serde == null) {
             throw new ISE("Don't know how to handle type[%s]", complexTypeName);
           }
 
-          final ComplexMetricExtractor extractor = serde.getExtractor();
+          final ComplexTypeExtractor extractor = serde.getExtractor();
           return new ColumnValueSelector()
           {
             @Override
@@ -1003,7 +1004,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
       } else if (valueType.is(ValueType.COMPLEX)) {
         capabilities = ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(valueType)
                                              .setHasNulls(ColumnCapabilities.Capable.TRUE);
-        ComplexMetricSerde serde = ComplexMetrics.getSerdeForType(valueType.getComplexTypeName());
+        ComplexTypeSerde serde = ComplexTypes.getSerdeForType(valueType.getComplexTypeName());
         if (serde != null) {
           this.type = serde.getTypeName();
         } else {
@@ -1416,7 +1417,7 @@ public abstract class IncrementalIndex extends AbstractIndex implements Iterable
     {
       this.currEntry = currEntry;
       this.metricIndex = metricIndex;
-      classOfObject = ComplexMetrics.getSerdeForType(metricDesc.getType()).getObjectStrategy().getClazz();
+      classOfObject = ComplexTypes.getSerdeForType(metricDesc.getType()).getObjectStrategy().getClazz();
     }
 
     @Nullable

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexColumnPartSerde.java
@@ -32,7 +32,7 @@ public class ComplexColumnPartSerde implements ColumnPartSerde
 {
   private final String typeName;
   @Nullable
-  private final ComplexMetricSerde serde;
+  private final ComplexTypeSerde serde;
   @Nullable
   private final Serializer serializer;
   private static final Logger log = new Logger(ComplexColumnPartSerde.class);
@@ -40,7 +40,7 @@ public class ComplexColumnPartSerde implements ColumnPartSerde
   private ComplexColumnPartSerde(String typeName, @Nullable Serializer serializer)
   {
     this.typeName = typeName;
-    this.serde = ComplexMetrics.getSerdeForType(typeName);
+    this.serde = ComplexTypes.getSerdeForType(typeName);
     if (this.serde == null) {
       // Not choosing to fail here since this gets handled as
       // an UnknownTypeComplexColumn. See SimpleColumnHolder#getColumn.

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetricExtractor.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetricExtractor.java
@@ -19,25 +19,12 @@
 
 package org.apache.druid.segment.serde;
 
-import org.apache.druid.data.input.InputRow;
 import org.apache.druid.guice.annotations.ExtensionPoint;
-import org.apache.druid.query.aggregation.AggregatorFactory;
-
-import javax.annotation.Nullable;
 
 /**
  */
 @ExtensionPoint
-public interface ComplexMetricExtractor<T>
+@Deprecated
+public interface ComplexMetricExtractor<T> extends ComplexTypeExtractor<T>
 {
-  Class<? extends T> extractedClass();
-
-  @Nullable
-  T extractValue(InputRow inputRow, String metricName);
-
-  @Nullable
-  default T extractValue(InputRow inputRow, String metricName, AggregatorFactory agg)
-  {
-    return extractValue(inputRow, metricName);
-  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetricSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetricSerde.java
@@ -19,136 +19,15 @@
 
 package org.apache.druid.segment.serde;
 
-import com.google.common.base.Function;
-import it.unimi.dsi.fastutil.bytes.ByteArrays;
 import org.apache.druid.guice.annotations.ExtensionPoint;
-import org.apache.druid.segment.GenericColumnSerializer;
-import org.apache.druid.segment.column.ColumnBuilder;
-import org.apache.druid.segment.column.ColumnConfig;
-import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.column.ObjectStrategyComplexTypeStrategy;
-import org.apache.druid.segment.column.TypeStrategy;
-import org.apache.druid.segment.data.ObjectStrategy;
-import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
-
-import javax.annotation.Nullable;
-import java.nio.ByteBuffer;
 
 /**
+ * Use {@link ComplexTypeSerde} instead
  */
 @ExtensionPoint
-public abstract class ComplexMetricSerde
+@Deprecated
+public abstract class ComplexMetricSerde extends ComplexTypeSerde
 {
-  public abstract String getTypeName();
-
+  @Override
   public abstract ComplexMetricExtractor getExtractor();
-
-  /**
-   * Deserializes a ByteBuffer and adds it to the ColumnBuilder.  This method allows for the ComplexMetricSerde
-   * to implement it's own versioning scheme to allow for changes of binary format in a forward-compatible manner.
-   *
-   * @param buffer  the buffer to deserialize
-   * @param builder ColumnBuilder to add the column to
-   * @param columnConfig ColumnConfiguration used during deserialization
-   */
-  public void deserializeColumn(
-      ByteBuffer buffer,
-      ColumnBuilder builder,
-      @SuppressWarnings("unused") ColumnConfig columnConfig
-  )
-  {
-    deserializeColumn(buffer, builder);
-  }
-
-  /**
-   * {@link ComplexMetricSerde#deserializeColumn(ByteBuffer, ColumnBuilder, ColumnConfig)} should be used instead of this.
-   * This method is left for backward compatibility.
-   */
-  @Deprecated
-  public abstract void deserializeColumn(ByteBuffer buffer, ColumnBuilder builder);
-
-  /**
-   * This is deprecated because its usage is going to be removed from the code.
-   * <p>
-   * It was introduced before deserializeColumn() existed.  This method creates the assumption that Druid knows
-   * how to interpret the actual column representation of the data, but I would much prefer that the ComplexMetricSerde
-   * objects be in charge of creating and interpreting the whole column, which is what deserializeColumn lets
-   * them do.
-   *
-   * @return an ObjectStrategy as used by GenericIndexed
-   */
-  @Deprecated
-  public abstract ObjectStrategy getObjectStrategy();
-
-  /**
-   * Get a {@link TypeStrategy} to assist with writing individual complex values to a {@link ByteBuffer}.
-   *
-   * @see TypeStrategy
-   */
-  public <T extends Comparable<T>> TypeStrategy<T> getTypeStrategy()
-  {
-    return new ObjectStrategyComplexTypeStrategy<>(getObjectStrategy(), ColumnType.ofComplex(getTypeName()));
-  }
-
-  /**
-   * Returns a function that can convert the Object provided by the ComplexColumn created through deserializeColumn
-   * into a number of expected input bytes to produce that object.
-   * <p>
-   * This is used to approximate the size of the input data via the SegmentMetadataQuery and does not need to be
-   * overridden if you do not care about the query.
-   *
-   * @return A function that can compute the size of the complex object or null if you cannot/do not want to compute it
-   */
-  @Nullable
-  public Function<Object, Long> inputSizeFn()
-  {
-    return null;
-  }
-
-  /**
-   * Converts intermediate representation of aggregate to byte[].
-   *
-   * @param val intermediate representation of aggregate
-   *
-   * @return serialized intermediate representation of aggregate in byte[]
-   */
-  public byte[] toBytes(@Nullable Object val)
-  {
-    if (val != null) {
-      byte[] bytes = getObjectStrategy().toBytes(val);
-      return bytes != null ? bytes : ByteArrays.EMPTY_ARRAY;
-    } else {
-      return ByteArrays.EMPTY_ARRAY;
-    }
-  }
-
-  /**
-   * Converts byte[] to intermediate representation of the aggregate.
-   *
-   * @param data     array
-   * @param start    offset in the byte array where to start reading
-   * @param numBytes number of bytes to read in given array
-   *
-   * @return intermediate representation of the aggregate
-   */
-  public Object fromBytes(byte[] data, int start, int numBytes)
-  {
-    ByteBuffer bb = ByteBuffer.wrap(data);
-    if (start > 0) {
-      bb.position(start);
-    }
-    return getObjectStrategy().fromByteBuffer(bb, numBytes);
-  }
-
-  /**
-   * This method provides the ability for a ComplexMetricSerde to control its own serialization.
-   * For large column (i.e columns greater than {@link Integer#MAX_VALUE}) use
-   * {@link LargeColumnSupportedComplexColumnSerializer}
-   *
-   * @return an instance of GenericColumnSerializer used for serialization.
-   */
-  public GenericColumnSerializer getSerializer(SegmentWriteOutMedium segmentWriteOutMedium, String column)
-  {
-    return ComplexColumnSerializer.create(segmentWriteOutMedium, column, this.getObjectStrategy());
-  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
@@ -58,6 +58,7 @@ public class ComplexMetrics
    *
    * Only expected to be used in tests.
    */
+  //noinspection unused
   public static void unregisterSerde(String type)
   {
     ComplexTypes.unregisterSerde(type);

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexTypeExtractor.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexTypeExtractor.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.serde;
+
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+
+import javax.annotation.Nullable;
+
+public interface ComplexTypeExtractor<T>
+{
+  Class<? extends T> extractedClass();
+
+  /**
+   * 'Extract' a complex value type from an {@link InputRow} for the specified metric name, for complex 'metric' types.
+   * This method is only called when by the default implementation of
+   * {@link #extractValue(InputRow, String, AggregatorFactory)}, and may be implemented by any complex 'metric' whose
+   * initialization is not dependent on the {@link AggregatorFactory}, and is used to allow coercion of values
+   * into the correct complex type expected by the complex aggregator when making column selectors for queries on
+   * {@link org.apache.druid.segment.incremental.IncrementalIndex}.
+   */
+  @Nullable
+  T extractValue(InputRow inputRow, String metricName);
+
+  /**
+   * 'Extract' a complex value type from an {@link InputRow} for the specified metric name, for complex 'metric' types
+   * which must be initialized based on some information available in their {@link AggregatorFactory}. This method
+   * is called when creating column selectors for {@link org.apache.druid.segment.incremental.IncrementalIndex} on top
+   * of a base {@link org.apache.druid.segment.RowBasedColumnSelectorFactory}, to allow coercion of values into the
+   * correct complex type expected by the complex aggregator.
+   */
+  @Nullable
+  default T extractValue(InputRow inputRow, String metricName, AggregatorFactory agg)
+  {
+    return extractValue(inputRow, metricName);
+  }
+
+  /**
+   * 'Coerce' a complex value type for use when creating column selectors for queries on a
+   * {@link org.apache.druid.segment.RowBasedColumnSelectorFactory}. By default, this method is a direct value
+   * passthrough.
+   *
+   * This method is used for selectors for all complex types from a
+   * {@link org.apache.druid.segment.RowBasedColumnSelectorFactory}, but for 'realtime' queries for complex 'metrics'
+   * (on {@link org.apache.druid.segment.incremental.IncrementalIndex}), this method will be not be used in favor of a
+   * customized selector which uses {@link #extractValue(InputRow, String, AggregatorFactory)} instead.
+   *
+   * Realtime queries on complex types which are not metrics (e.g. dimensions) will still use this method even for
+   * realtime queries.
+   */
+  @Nullable
+  default T coerceValue(@Nullable Object value)
+  {
+    return (T) value;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexTypeExtractor.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexTypeExtractor.java
@@ -51,23 +51,4 @@ public interface ComplexTypeExtractor<T>
   {
     return extractValue(inputRow, metricName);
   }
-
-  /**
-   * 'Coerce' a complex value type for use when creating column selectors for queries on a
-   * {@link org.apache.druid.segment.RowBasedColumnSelectorFactory}. By default, this method is a direct value
-   * passthrough.
-   *
-   * This method is used for selectors for all complex types from a
-   * {@link org.apache.druid.segment.RowBasedColumnSelectorFactory}, but for 'realtime' queries for complex 'metrics'
-   * (on {@link org.apache.druid.segment.incremental.IncrementalIndex}), this method will be not be used in favor of a
-   * customized selector which uses {@link #extractValue(InputRow, String, AggregatorFactory)} instead.
-   *
-   * Realtime queries on complex types which are not metrics (e.g. dimensions) will still use this method even for
-   * realtime queries.
-   */
-  @Nullable
-  default T coerceValue(@Nullable Object value)
-  {
-    return (T) value;
-  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexTypeSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexTypeSerde.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.serde;
+
+import com.google.common.base.Function;
+import it.unimi.dsi.fastutil.bytes.ByteArrays;
+import org.apache.druid.guice.annotations.ExtensionPoint;
+import org.apache.druid.segment.GenericColumnSerializer;
+import org.apache.druid.segment.column.ColumnBuilder;
+import org.apache.druid.segment.column.ColumnConfig;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.ObjectStrategyComplexTypeStrategy;
+import org.apache.druid.segment.column.TypeStrategy;
+import org.apache.druid.segment.data.ObjectStrategy;
+import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+@ExtensionPoint
+public abstract class ComplexTypeSerde
+{
+  public abstract String getTypeName();
+
+  public abstract ComplexTypeExtractor getExtractor();
+
+  /**
+   * Deserializes a ByteBuffer and adds it to the ColumnBuilder.  This method allows for the ComplexMetricSerde
+   * to implement it's own versioning scheme to allow for changes of binary format in a forward-compatible manner.
+   *
+   * @param buffer  the buffer to deserialize
+   * @param builder ColumnBuilder to add the column to
+   * @param columnConfig ColumnConfiguration used during deserialization
+   */
+  public void deserializeColumn(
+      ByteBuffer buffer,
+      ColumnBuilder builder,
+      @SuppressWarnings("unused") ColumnConfig columnConfig
+  )
+  {
+    deserializeColumn(buffer, builder);
+  }
+
+  /**
+   * {@link ComplexMetricSerde#deserializeColumn(ByteBuffer, ColumnBuilder, ColumnConfig)} should be used instead of this.
+   * This method is left for backward compatibility.
+   */
+  @Deprecated
+  public abstract void deserializeColumn(ByteBuffer buffer, ColumnBuilder builder);
+
+  /**
+   * This is deprecated because its usage is going to be removed from the code.
+   * <p>
+   * It was introduced before deserializeColumn() existed.  This method creates the assumption that Druid knows
+   * how to interpret the actual column representation of the data, but I would much prefer that the ComplexMetricSerde
+   * objects be in charge of creating and interpreting the whole column, which is what deserializeColumn lets
+   * them do.
+   *
+   * @return an ObjectStrategy as used by GenericIndexed
+   */
+  @Deprecated
+  public abstract ObjectStrategy getObjectStrategy();
+
+  /**
+   * Get a {@link TypeStrategy} to assist with writing individual complex values to a {@link ByteBuffer}.
+   *
+   * @see TypeStrategy
+   */
+  public <T extends Comparable<T>> TypeStrategy<T> getTypeStrategy()
+  {
+    return new ObjectStrategyComplexTypeStrategy<>(getObjectStrategy(), ColumnType.ofComplex(getTypeName()));
+  }
+
+  /**
+   * Returns a function that can convert the Object provided by the ComplexColumn created through deserializeColumn
+   * into a number of expected input bytes to produce that object.
+   * <p>
+   * This is used to approximate the size of the input data via the SegmentMetadataQuery and does not need to be
+   * overridden if you do not care about the query.
+   *
+   * @return A function that can compute the size of the complex object or null if you cannot/do not want to compute it
+   */
+  @Nullable
+  public Function<Object, Long> inputSizeFn()
+  {
+    return null;
+  }
+
+  /**
+   * Converts intermediate representation of aggregate to byte[].
+   *
+   * @param val intermediate representation of aggregate
+   *
+   * @return serialized intermediate representation of aggregate in byte[]
+   */
+  public byte[] toBytes(@Nullable Object val)
+  {
+    if (val != null) {
+      byte[] bytes = getObjectStrategy().toBytes(val);
+      return bytes != null ? bytes : ByteArrays.EMPTY_ARRAY;
+    } else {
+      return ByteArrays.EMPTY_ARRAY;
+    }
+  }
+
+  /**
+   * Converts byte[] to intermediate representation of the aggregate.
+   *
+   * @param data     array
+   * @param start    offset in the byte array where to start reading
+   * @param numBytes number of bytes to read in given array
+   *
+   * @return intermediate representation of the aggregate
+   */
+  public Object fromBytes(byte[] data, int start, int numBytes)
+  {
+    ByteBuffer bb = ByteBuffer.wrap(data);
+    if (start > 0) {
+      bb.position(start);
+    }
+    return getObjectStrategy().fromByteBuffer(bb, numBytes);
+  }
+
+  /**
+   * This method provides the ability for a ComplexMetricSerde to control its own serialization.
+   * For large column (i.e columns greater than {@link Integer#MAX_VALUE}) use
+   * {@link LargeColumnSupportedComplexColumnSerializer}
+   *
+   * @return an instance of GenericColumnSerializer used for serialization.
+   */
+  public GenericColumnSerializer getSerializer(SegmentWriteOutMedium segmentWriteOutMedium, String column)
+  {
+    return ComplexColumnSerializer.create(segmentWriteOutMedium, column, this.getObjectStrategy());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/aggregation/first/StringFirstTimeseriesQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/first/StringFirstTimeseriesQueryTest.java
@@ -43,7 +43,7 @@ import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
 import org.apache.druid.segment.incremental.IndexSizeExceededException;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -68,7 +68,7 @@ public class StringFirstTimeseriesQueryTest extends InitializedNullHandlingTest
   public void setUp() throws IndexSizeExceededException
   {
     final SerializablePairLongStringSerde serde = new SerializablePairLongStringSerde();
-    ComplexMetrics.registerSerde(serde.getTypeName(), serde);
+    ComplexTypes.registerSerde(serde.getTypeName(), serde);
 
     incrementalIndex = new OnheapIncrementalIndex.Builder()
         .setIndexSchema(

--- a/processing/src/test/java/org/apache/druid/query/aggregation/last/StringLastTimeseriesQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/last/StringLastTimeseriesQueryTest.java
@@ -43,7 +43,7 @@ import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
 import org.apache.druid.segment.incremental.IndexSizeExceededException;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +67,7 @@ public class StringLastTimeseriesQueryTest
   public void setUp() throws IndexSizeExceededException
   {
     final SerializablePairLongStringSerde serde = new SerializablePairLongStringSerde();
-    ComplexMetrics.registerSerde(serde.getTypeName(), serde);
+    ComplexTypes.registerSerde(serde.getTypeName(), serde);
 
     incrementalIndex = new OnheapIncrementalIndex.Builder()
         .setIndexSchema(

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
@@ -52,9 +52,9 @@ import org.apache.druid.segment.data.ObjectStrategy;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetricExtractor;
-import org.apache.druid.segment.serde.ComplexMetricSerde;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypeExtractor;
+import org.apache.druid.segment.serde.ComplexTypeSerde;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
 import org.junit.Assert;
@@ -224,7 +224,7 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
   }
 
   static {
-    ComplexMetrics.registerSerde(InvalidAggregatorFactory.TYPE, new ComplexMetricSerde()
+    ComplexTypes.registerSerde(InvalidAggregatorFactory.TYPE, new ComplexTypeSerde()
     {
       @Override
       public String getTypeName()
@@ -233,7 +233,7 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
       }
 
       @Override
-      public ComplexMetricExtractor getExtractor()
+      public ComplexTypeExtractor getExtractor()
       {
         return null;
       }
@@ -304,7 +304,7 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     );
 
     // Unload the complex serde, then analyze the persisted segment.
-    ComplexMetrics.unregisterSerde(InvalidAggregatorFactory.TYPE);
+    ComplexTypes.unregisterSerde(InvalidAggregatorFactory.TYPE);
     {
       SegmentAnalyzer analyzer = new SegmentAnalyzer(EnumSet.of(SegmentMetadataQuery.AnalysisType.SIZE));
       QueryableIndexSegment segment = new QueryableIndexSegment(

--- a/processing/src/test/java/org/apache/druid/segment/RowBasedStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/RowBasedStorageAdapterTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.GuavaUtils;
-import org.apache.druid.data.input.InputRow;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
@@ -31,26 +30,20 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.math.expr.ExprMacroTable;
-import org.apache.druid.query.aggregation.SerializablePairLongString;
-import org.apache.druid.query.aggregation.SerializablePairLongStringSerde;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
-import org.apache.druid.segment.serde.ComplexMetricExtractor;
-import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.joda.time.Duration;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,8 +58,6 @@ import java.util.stream.Collectors;
 public class RowBasedStorageAdapterTest
 {
   private static final String UNKNOWN_TYPE_NAME = "unknownType";
-  private static final String CUSTOM_TYPE_COLUMN_NAME = "customType";
-  private static final ColumnType CUSTOM_TYPE = ColumnType.ofComplex("long-string-pair");
 
   private static final RowSignature ROW_SIGNATURE =
       RowSignature.builder()
@@ -76,7 +67,6 @@ public class RowBasedStorageAdapterTest
                   .add(ValueType.STRING.name(), ColumnType.STRING)
                   .add(ValueType.COMPLEX.name(), ColumnType.UNKNOWN_COMPLEX)
                   .add(UNKNOWN_TYPE_NAME, null)
-                  .add(CUSTOM_TYPE_COLUMN_NAME, CUSTOM_TYPE)
                   .build();
 
   private static final List<Function<Cursor, Supplier<Object>>> READ_STRING =
@@ -105,39 +95,6 @@ public class RowBasedStorageAdapterTest
   public static void setUpClass()
   {
     NullHandling.initializeForTests();
-    ComplexTypes.registerSerde(CUSTOM_TYPE.getComplexTypeName(), new SerializablePairLongStringSerde()
-    {
-      @Override
-      public ComplexMetricExtractor getExtractor()
-      {
-        final ComplexMetricExtractor delegate = super.getExtractor();
-        return new ComplexMetricExtractor()
-        {
-          @Override
-          public Class extractedClass()
-          {
-            return delegate.getClass();
-          }
-
-          @Nullable
-          @Override
-          public Object extractValue(InputRow inputRow, String metricName)
-          {
-            return delegate.extractValue(inputRow, metricName);
-          }
-
-          @Nullable
-          @Override
-          public Object coerceValue(@Nullable Object value)
-          {
-            if (value instanceof String) {
-              return new SerializablePairLongString(0L, (String) value);
-            }
-            return value;
-          }
-        };
-      }
-    });
 
     PROCESSORS.clear();
 
@@ -212,12 +169,6 @@ public class RowBasedStorageAdapterTest
           }
       );
     }
-  }
-
-  @AfterClass
-  public static void teardown()
-  {
-    ComplexTypes.unregisterSerde(CUSTOM_TYPE.getComplexTypeName());
   }
 
   /**
@@ -469,8 +420,6 @@ public class RowBasedStorageAdapterTest
     for (String columnName : ROW_SIGNATURE.getColumnNames()) {
       if (UNKNOWN_TYPE_NAME.equals(columnName)) {
         Assert.assertNull(columnName, adapter.getColumnCapabilities(columnName));
-      } else if (CUSTOM_TYPE_COLUMN_NAME.equals(columnName)) {
-        Assert.assertEquals(columnName, CUSTOM_TYPE, adapter.getColumnCapabilities(columnName).toColumnType());
       } else {
         Assert.assertEquals(
             columnName,
@@ -885,52 +834,6 @@ public class RowBasedStorageAdapterTest
     );
 
     Assert.assertEquals(1, numCloses.get());
-  }
-
-  @Test
-  public void test_makeCursors_customTypeCoercion()
-  {
-    final RowBasedStorageAdapter<String> adapter = new RowBasedStorageAdapter<>(
-        Sequences.simple(Lists.newArrayList(null, "a", "b")).withBaggage(numCloses::incrementAndGet),
-        new RowAdapter<String>()
-        {
-          @Override
-          public ToLongFunction<String> timestampFunction()
-          {
-            return i -> 0L;
-          }
-
-          @Override
-          public Function<String, Object> columnFunction(String columnName)
-          {
-            return i -> i;
-          }
-        },
-        ROW_SIGNATURE
-    );
-    final Sequence<Cursor> cursors = adapter.makeCursors(
-        null,
-        Intervals.ETERNITY,
-        VirtualColumns.EMPTY,
-        Granularities.ALL,
-        false,
-        null
-    );
-
-    Assert.assertEquals(
-        ImmutableList.of(
-            Collections.singletonList(null),
-            ImmutableList.of(new SerializablePairLongString(0L, "a")),
-            ImmutableList.of(new SerializablePairLongString(0L, "b"))
-        ),
-        walkCursors(cursors, ImmutableList.of(
-            cursor -> {
-              final BaseObjectColumnValueSelector selector =
-                  cursor.getColumnSelectorFactory().makeColumnValueSelector(CUSTOM_TYPE_COLUMN_NAME);
-              return selector::getObject;
-            }
-        ))
-    );
   }
 
   private static List<List<Object>> walkCursors(

--- a/processing/src/test/java/org/apache/druid/segment/SchemalessIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessIndexTest.java
@@ -39,7 +39,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.IndexSizeExceededException;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.Overshadowable;
 import org.joda.time.DateTime;
@@ -88,7 +88,7 @@ public class SchemalessIndexTest
   private static QueryableIndex mergedIndex = null;
 
   static {
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
   }
 
   private final IndexMerger indexMerger;

--- a/processing/src/test/java/org/apache/druid/segment/TestIndex.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestIndex.java
@@ -51,7 +51,7 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.joda.time.Interval;
@@ -151,7 +151,7 @@ public class TestIndex
   public static final IndexIO INDEX_IO = TestHelper.getTestIndexIO();
 
   static {
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
   }
 
   private static Supplier<IncrementalIndex> realtimeIndex = Suppliers.memoize(

--- a/processing/src/test/java/org/apache/druid/segment/generator/SegmentGenerator.java
+++ b/processing/src/test/java/org/apache/druid/segment/generator/SegmentGenerator.java
@@ -37,7 +37,7 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
-import org.apache.druid.segment.serde.ComplexMetrics;
+import org.apache.druid.segment.serde.ComplexTypes;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
@@ -106,7 +106,7 @@ public class SegmentGenerator implements Closeable
   )
   {
     // In case we need to generate hyperUniques.
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     final String dataHash = Hashing.sha256()
                                    .newHasher()
@@ -221,7 +221,7 @@ public class SegmentGenerator implements Closeable
   )
   {
     // In case we need to generate hyperUniques.
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     final String dataHash = Hashing.sha256()
                                    .newHasher()

--- a/processing/src/test/java/org/apache/druid/segment/serde/ComplexTypesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/serde/ComplexTypesTest.java
@@ -24,14 +24,14 @@ import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ComplexMetricsTest
+public class ComplexTypesTest
 {
   @Test
   public void testRegister()
   {
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
-    ComplexMetricSerde serde = ComplexMetrics.getSerdeForType("hyperUnique");
+    ComplexTypeSerde serde = ComplexTypes.getSerdeForType("hyperUnique");
     Assert.assertNotNull(serde);
     Assert.assertTrue(serde instanceof HyperUniquesSerde);
   }
@@ -39,15 +39,15 @@ public class ComplexMetricsTest
   @Test
   public void testRegisterDuplicate()
   {
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
-    ComplexMetricSerde serde = ComplexMetrics.getSerdeForType("hyperUnique");
+    ComplexTypeSerde serde = ComplexTypes.getSerdeForType("hyperUnique");
     Assert.assertNotNull(serde);
     Assert.assertTrue(serde instanceof HyperUniquesSerde);
 
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
-    serde = ComplexMetrics.getSerdeForType("hyperUnique");
+    serde = ComplexTypes.getSerdeForType("hyperUnique");
     Assert.assertNotNull(serde);
     Assert.assertTrue(serde instanceof HyperUniquesSerde);
   }
@@ -55,19 +55,19 @@ public class ComplexMetricsTest
   @Test
   public void testConflicting()
   {
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
+    ComplexTypes.registerSerde("hyperUnique", new HyperUniquesSerde());
 
-    ComplexMetricSerde serde = ComplexMetrics.getSerdeForType("hyperUnique");
+    ComplexTypeSerde serde = ComplexTypes.getSerdeForType("hyperUnique");
     Assert.assertNotNull(serde);
     Assert.assertTrue(serde instanceof HyperUniquesSerde);
 
     Assert.assertThrows(
         "Incompatible serializer for type[hyperUnique] already exists. Expected [org.apache.druid.query.aggregation.SerializablePairLongStringSerde], found [org.apache.druid.query.aggregation.hyperloglog.HyperUniquesSerde",
         IllegalStateException.class,
-        () -> ComplexMetrics.registerSerde("hyperUnique", new SerializablePairLongStringSerde())
+        () -> ComplexTypes.registerSerde("hyperUnique", new SerializablePairLongStringSerde())
     );
 
-    serde = ComplexMetrics.getSerdeForType("hyperUnique");
+    serde = ComplexTypes.getSerdeForType("hyperUnique");
     Assert.assertNotNull(serde);
     Assert.assertTrue(serde instanceof HyperUniquesSerde);
   }


### PR DESCRIPTION

### Description
This PR rebrands `ComplexMetricSerde` as `ComplexTypeSerde`, `ComplexMetrics` as `ComplexTypes`, and `ComplexMetricExtractor` as `ComplexTypeExtractor`. All of the former are marked as deprecated, and their logic moved to (and implement) the latter to minimize disruption. All current serdes still implement `ComplexMetricSerde` rather than the new type, to allow anything using `ComplexMetrics.getSerdeForType` to continue functioning until their future removal, at which point the implementations shall be moved to extend `ComplexTypeSerde` directly.

I tested that this change is minimally disruptive by doing some tests using extensions (datasketches specifically, for my complex types) built against the master branch without the changes in this PR, and everything was still functioning correctly as far as I can tell, so I think it should be relatively chill despite changing stuff marked `@ExtensionPoint`.

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] been tested in a test Druid cluster.
