### PR TITLE
Bump PostgreSQL JDBC driver to 42.3.3 (CVE-2022-21724)

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4142,7 +4142,7 @@ name: PostgreSQL JDBC Driver
 license_category: binary
 module: extensions/druid-lookups-cached-single
 license_name: BSD-2-Clause License
-version: 42.2.14
+version: 42.3.3
 copyright: PostgreSQL Global Development Group
 license_file_path: licenses/bin/postgresql.BSD2
 libraries:
@@ -4154,7 +4154,7 @@ name: PostgreSQL JDBC Driver
 license_category: binary
 module: extensions/druid-lookups-cached-global
 license_name: BSD-2-Clause License
-version: 42.2.14
+version: 42.3.3
 copyright: PostgreSQL Global Development Group
 license_file_path: licenses/bin/postgresql.BSD2
 libraries:
@@ -4166,7 +4166,7 @@ name: PostgreSQL JDBC Driver
 license_category: binary
 module: extensions/postgresql-metadata-storage
 license_name: BSD-2-Clause License
-version: 42.2.14
+version: 42.3.3
 copyright: PostgreSQL Global Development Group
 license_file_path: licenses/bin/postgresql.BSD2
 libraries:

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <netty4.version>4.1.68.Final</netty4.version>
-        <postgresql.version>42.2.14</postgresql.version>
+        <postgresql.version>42.3.3</postgresql.version>
         <protobuf.version>3.11.0</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
### Description

Bump PostgreSQL JDBC driver to 42.3.3 that has a fix for https://nvd.nist.gov/vuln/detail/CVE-2022-21724. Druid seems safe from this vulnerability by default as the connection properties used in the attack are not allowed by default.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
