### PR TITLE
Bump Jackson to 2.12.6.20220326 (CVE-2020-36518)

### DIFF
--- a/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
+++ b/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
@@ -58,9 +58,9 @@ public class GuiceAnnotationIntrospector extends NopAnnotationIntrospector
       if (m instanceof AnnotatedMethod) {
         throw new IAE("Annotated methods don't work very well yet...");
       }
-      return Key.get(m.getGenericType());
+      return Key.get(m.getRawType());
     }
-    return Key.get(m.getGenericType(), guiceAnnotation);
+    return Key.get(m.getRawType(), guiceAnnotation);
   }
 
   /**

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.emitter.kafka;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.AlertEvent;
@@ -85,7 +85,7 @@ public class KafkaEmitterTest
     final KafkaProducer<String, String> producer = mock(KafkaProducer.class);
     final KafkaEmitter kafkaEmitter = new KafkaEmitter(
         new KafkaEmitterConfig("", "metrics", "alerts", requestTopic, "test-cluster", null),
-        new ObjectMapper()
+        new DefaultObjectMapper()
     )
     {
       @Override

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -237,7 +237,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.10.5
+version: 2.13.2
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core
@@ -278,7 +278,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.10.5.1
+version: 2.13.2
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -237,7 +237,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.6.20220326
+version: 2.12.6
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core
@@ -278,7 +278,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.6.20220326
+version: 2.12.6.1
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -237,7 +237,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.13.2
+version: 2.12.6.20220326
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core
@@ -278,7 +278,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.13.2
+version: 2.12.6.20220326
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.40.v20210413</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.10.5.20201202</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.17.1</log4j.version>
         <mysql.version>5.1.48</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.40.v20210413</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.12.6.20220326</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.17.1</log4j.version>
         <mysql.version>5.1.48</mysql.version>

--- a/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
@@ -130,22 +130,22 @@ public class CacheConfigTest
     throw new IllegalStateException("Should have already failed");
   }
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testTRUE()
   {
     properties.put(PROPERTY_PREFIX + ".populateCache", "TRUE");
     configProvider.inject(properties, configurator);
     CacheConfig config = configProvider.get().get();
-    throw new IllegalStateException("Should have already failed");
+    Assert.assertTrue(config.isPopulateCache());
   }
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testFALSE()
   {
     properties.put(PROPERTY_PREFIX + ".populateCache", "FALSE");
     configProvider.inject(properties, configurator);
     CacheConfig config = configProvider.get().get();
-    throw new IllegalStateException("Should have already failed");
+    Assert.assertFalse(config.isPopulateCache());
   }
 
 


### PR DESCRIPTION
### Description

Another attempt to address https://nvd.nist.gov/vuln/detail/CVE-2020-36518. This PR bumps Jackson to `2.12.6.20220326` which has the fix for the CVE (https://github.com/FasterXML/jackson-databind/issues/2816). It seems not possible to upgrade Jackson to 2.13.2 with no change because of https://github.com/FasterXML/jackson-jaxrs-providers/issues/134.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
