### PR TITLE
Make error messages for insert statements consistent with select statements

### DIFF
--- a/sql/src/main/codegen/config.fmpp
+++ b/sql/src/main/codegen/config.fmpp
@@ -382,7 +382,7 @@ data: {
     # Return type of method implementation should be 'SqlNode'.
     # Example: SqlShowDatabases(), SqlShowTables().
     statementParserMethods: [
-      "DruidSqlInsert()"
+      "DruidSqlInsertEof()"
       "DruidSqlExplain()"
     ]
 

--- a/sql/src/main/codegen/includes/explain.ftl
+++ b/sql/src/main/codegen/includes/explain.ftl
@@ -61,7 +61,7 @@ SqlNode DruidQueryOrSqlQueryOrDml() :
 }
 {
   (
-    stmt = DruidSqlInsert()
+    stmt = DruidSqlInsertEof()
   |
     stmt = SqlQueryOrDml()
   )

--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -18,7 +18,7 @@
  */
 
 // Using fully qualified name for Pair class, since Calcite also has a same class name being used in the Parser.jj
-SqlNode DruidSqlInsert() :
+SqlNode DruidSqlInsertEof() :
 {
   SqlNode insertNode;
   org.apache.druid.java.util.common.Pair<Granularity, String> partitionedBy = new org.apache.druid.java.util.common.Pair(null, null);
@@ -34,6 +34,8 @@ SqlNode DruidSqlInsert() :
     <CLUSTERED> <BY>
     clusteredBy = ClusterItems()
   ]
+  // EOF is also present in SqlStmtEof but is a special case and multiple occurances together are valid with one token
+  <EOF>
   {
     if (!(insertNode instanceof SqlInsert)) {
       // This shouldn't be encountered, but done as a defensive practice. SqlInsert() always returns a node of type

--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -26,6 +26,8 @@ SqlNode DruidSqlInsertEof() :
 }
 {
   insertNode = SqlInsert()
+  // PARTITIONED BY is necessary, but is kept optional in the grammar. It is asserted that it is not missing in the
+  // DruidSqlInsert constructor so that we can return a custom error message.
   [
     <PARTITIONED> <BY>
     partitionedBy = PartitionGranularity()
@@ -34,7 +36,10 @@ SqlNode DruidSqlInsertEof() :
     <CLUSTERED> <BY>
     clusteredBy = ClusterItems()
   ]
-  // EOF is also present in SqlStmtEof but EOF is a special case and a single EOF can be consumed multiple times. The reason for adding EOF here is to ensure that we create a DruidSqlInsert node after the syntax has been validated and throw SQL syntax errors before performing validations in the DruidSqlInsert which can overshadow the actual error message```
+  // EOF is also present in SqlStmtEof but EOF is a special case and a single EOF can be consumed multiple times.
+  // The reason for adding EOF here is to ensure that we create a DruidSqlInsert node after the syntax has been
+  // validated and throw SQL syntax errors before performing validations in the DruidSqlInsert which can overshadow the
+  // actual error message.
   <EOF>
   {
     if (!(insertNode instanceof SqlInsert)) {

--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -34,7 +34,7 @@ SqlNode DruidSqlInsertEof() :
     <CLUSTERED> <BY>
     clusteredBy = ClusterItems()
   ]
-  // EOF is also present in SqlStmtEof but is a special case and multiple occurances together are valid with one token
+  // EOF is also present in SqlStmtEof but EOF is a special case and a single EOF can be consumed multiple times. The reason for adding EOF here is to ensure that we create a DruidSqlInsert node after the syntax has been validated and throw SQL syntax errors before performing validations in the DruidSqlInsert which can overshadow the actual error message```
   <EOF>
   {
     if (!(insertNode instanceof SqlInsert)) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlInsert.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlInsert.java
@@ -69,7 +69,7 @@ public class DruidSqlInsert extends SqlInsert
         insertNode.getTargetColumnList()
     );
     if (partitionedBy == null) {
-      throw new ParseException("INSERT statements must specify PARTITIONED BY clause explictly");
+      throw new ParseException("INSERT statements must specify PARTITIONED BY clause explicitly");
     }
     this.partitionedBy = partitionedBy;
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -733,7 +733,7 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
   public void testInsertWithInvalidSelectStatement()
   {
     testInsertQuery()
-        .sql("INSERT INTO t SELECT channel, added as count FROM foo PARTITIONED BY ALL")
+        .sql("INSERT INTO t SELECT channel, added as count FROM foo PARTITIONED BY ALL") // count is a keyword
         .expectValidationError(
             CoreMatchers.allOf(
                 CoreMatchers.instanceOf(SqlPlanningException.class),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -554,7 +554,7 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
                 ImmutableList.of()
             )
     );
-    Assert.assertEquals("INSERT statements must specify PARTITIONED BY clause explictly", e.getMessage());
+    Assert.assertEquals("INSERT statements must specify PARTITIONED BY clause explicitly", e.getMessage());
     didTest = true;
   }
 
@@ -730,7 +730,7 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testInsertAndSelectReturnsConsistentErrorMessage()
+  public void testInsertWithInvalidSelectStatement()
   {
     testInsertQuery()
         .sql("INSERT INTO t SELECT channel, added as count FROM foo PARTITIONED BY ALL")

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -729,6 +729,20 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
         .verify();
   }
 
+  @Test
+  public void testInsertAndSelectReturnsConsistentErrorMessage()
+  {
+    testInsertQuery()
+        .sql("INSERT INTO t SELECT channel, added as count FROM foo PARTITIONED BY ALL")
+        .expectValidationError(
+            CoreMatchers.allOf(
+                CoreMatchers.instanceOf(SqlPlanningException.class),
+                ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Encountered \"as count\""))
+            )
+        )
+        .verify();
+  }
+
   private String externSql(final ExternalDataSource externalDataSource)
   {
     try {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

For a query like 
`INSERT INTO tablename SELECT channel, added as count FROM wikipedia` the error message is `Encountered "as count"`. However, for the insert statement
 `INSERT INTO t
SELECT
  channel,
  added as count
FROM wikipedia
PARTITIONED BY ALL`
returns `INSERT statements must specify PARTITIONED BY clause explictly` (incorrectly). This PR corrects this.


<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->
- Add EOF to end of Druid SQL Insert statements
- Rename SQL Insert statements in the parser to reflect the behaviour change

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
