### PR TITLE
issue-12426 upgrade k8s client due to cve

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>10.0.1</kubernetes.client.version>
+    <kubernetes.client.version>11.0.1</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -80,7 +80,7 @@ public class DefaultK8sApiClient implements K8sApiClient
   )
   {
     try {
-      V1PodList podList = coreV1Api.listNamespacedPod(podNamespace, null, null, null, null, labelSelector, 0, null, null, null);
+      V1PodList podList = coreV1Api.listNamespacedPod(podNamespace, null, null, null, null, labelSelector, 0, null, null, null, null);
       Preconditions.checkState(podList != null, "WTH: NULL podList");
 
       Map<String, DiscoveryDruidNode> allNodes = new HashMap();
@@ -114,7 +114,7 @@ public class DefaultK8sApiClient implements K8sApiClient
           Watch.createWatch(
               realK8sClient,
               coreV1Api.listNamespacedPodCall(namespace, null, true, null, null,
-                                              labelSelector, null, lastKnownResourceVersion, 0, true, null
+                                              labelSelector, null, lastKnownResourceVersion, null, 0, true, null
               ),
               new TypeReference<Watch.Response<V1Pod>>()
               {

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -864,7 +864,7 @@ name: kubernetes official java client
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.1
+version: 11.0.1
 libraries:
   - io.kubernetes: client-java
 
@@ -874,7 +874,7 @@ name: kubernetes official java client api
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.1
+version: 11.0.1
 libraries:
   - io.kubernetes: client-java-api
 
@@ -884,7 +884,7 @@ name: kubernetes official java client extended
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.1
+version: 11.0.1
 libraries:
   - io.kubernetes: client-java-extended
 
@@ -934,7 +934,7 @@ name: io.gsonfire gson-fire
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 1.8.4
+version: 1.8.5
 libraries:
   - io.gsonfire: gson-fire
 
@@ -964,7 +964,7 @@ name: org.bitbucket.b_c jose4j
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 0.7.2
+version: 0.7.3
 libraries:
   - org.bitbucket.b_c: jose4j
 
@@ -1004,7 +1004,7 @@ name: io.kubernetes client-java-proto
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 10.0.1
+version: 11.0.1
 libraries:
   - io.kubernetes: client-java-proto
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


cve in k8s jar 

Fixes #12426.

https://github.com/advisories/GHSA-m8wh-mqgf-rr8g

Needs upgrade from 10.0.1 to 11.0.1

## Motivation

It is not good practice to rely on jars with publicly disclosed security issues - and if you do you should make public why you think your project is not affected

2 changes in the k8s java client cause compile problems for druid:

```
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR] /opt/src/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java:[83,36] method listNamespacedPod in class io.kubernetes.client.openapi.apis.CoreV1Api cannot be applied to given types;
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR]   required: java.lang.String,java.lang.String,java.lang.Boolean,java.lang.String,java.lang.String,java.lang.String,java.lang.Integer,java.lang.String,java.lang.String,java.lang.Integer,java.lang.Boolean
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR]   found: java.lang.String,<nulltype>,<nulltype>,<nulltype>,<nulltype>,java.lang.String,int,<nulltype>,<nulltype>,<nulltype>
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR]   reason: actual and formal argument lists differ in length
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR] /opt/src/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java:[116,24] method listNamespacedPodCall in class io.kubernetes.client.openapi.apis.CoreV1Api cannot be applied to given types;
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR]   required: java.lang.String,java.lang.String,java.lang.Boolean,java.lang.String,java.lang.String,java.lang.String,java.lang.Integer,java.lang.String,java.lang.String,java.lang.Integer,java.lang.Boolean,io.kubernetes.client.openapi.ApiCallback
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR]   found: java.lang.String,<nulltype>,boolean,<nulltype>,<nulltype>,java.lang.String,<nulltype>,java.lang.String,int,boolean,<nulltype>
[2022-04-11 23:16:03] [build-stdout] [2022-04-11 23:16:03] [autobuild] [ERROR]   reason: actual and formal argument lists differ in length
```

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
