### PR TITLE
Fix indexMerger to respect the includeAllDimensions flag

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
@@ -74,7 +74,11 @@ public class JsonInputFormat extends NestedInputFormat
     super(flattenSpec);
     this.featureSpec = featureSpec == null ? Collections.emptyMap() : featureSpec;
     this.objectMapper = new ObjectMapper();
-    this.keepNullColumns = keepNullColumns == null ? false : keepNullColumns;
+    if (keepNullColumns != null) {
+      this.keepNullColumns = keepNullColumns;
+    } else {
+      this.keepNullColumns = flattenSpec != null && flattenSpec.isUseFieldDiscovery();
+    }
     for (Entry<String, Boolean> entry : this.featureSpec.entrySet()) {
       Feature feature = Feature.valueOf(entry.getKey());
       objectMapper.configure(feature, entry.getValue());
@@ -86,6 +90,12 @@ public class JsonInputFormat extends NestedInputFormat
   public Map<String, Boolean> getFeatureSpec()
   {
     return featureSpec;
+  }
+
+  @JsonProperty
+  public boolean isKeepNullColumns()
+  {
+    return keepNullColumns;
   }
 
   @Override

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
@@ -41,7 +41,7 @@ public class JsonInputFormatTest
     final ObjectMapper mapper = new ObjectMapper();
     final JsonInputFormat format = new JsonInputFormat(
         new JSONPathSpec(
-            false,
+            true,
             ImmutableList.of(
                 new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz", "baz"),
                 new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz2", "baz2"),
@@ -52,7 +52,7 @@ public class JsonInputFormatTest
             )
         ),
         ImmutableMap.of(Feature.ALLOW_COMMENTS.name(), true, Feature.ALLOW_UNQUOTED_FIELD_NAMES.name(), false),
-        false
+        true
     );
     final byte[] bytes = mapper.writeValueAsBytes(format);
     final JsonInputFormat fromJson = (JsonInputFormat) mapper.readValue(bytes, InputFormat.class);
@@ -71,5 +71,27 @@ public class JsonInputFormatTest
               )
               .withIgnoredFields("objectMapper")
               .verify();
+  }
+
+  @Test
+  public void testUseFieldDiscovery_setKeepNullColumnsByDefault()
+  {
+    final JsonInputFormat format = new JsonInputFormat(
+        new JSONPathSpec(true, null),
+        null,
+        null
+    );
+    Assert.assertTrue(format.isKeepNullColumns());
+  }
+
+  @Test
+  public void testUseFieldDiscovery_doNotChangeKeepNullColumnsUserSets()
+  {
+    final JsonInputFormat format = new JsonInputFormat(
+        new JSONPathSpec(true, null),
+        null,
+        false
+    );
+    Assert.assertFalse(format.isKeepNullColumns());
   }
 }

--- a/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/JsonInputFormatTest.java
@@ -74,6 +74,17 @@ public class JsonInputFormatTest
   }
 
   @Test
+  public void test_unsetUseFieldDiscovery_unsetKeepNullColumnsByDefault()
+  {
+    final JsonInputFormat format = new JsonInputFormat(
+        new JSONPathSpec(false, null),
+        null,
+        null
+    );
+    Assert.assertFalse(format.isKeepNullColumns());
+  }
+
+  @Test
   public void testUseFieldDiscovery_setKeepNullColumnsByDefault()
   {
     final JsonInputFormat format = new JsonInputFormat(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingWithNullColumnTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingWithNullColumnTest.java
@@ -19,37 +19,61 @@
 
 package org.apache.druid.indexing.common.task.batch.parallel;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
+import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.SplitHintSpec;
+import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.InlineInputSource;
+import org.apache.druid.data.input.impl.InputEntityIteratingReader;
 import org.apache.druid.data.input.impl.JsonInputFormat;
+import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
+@RunWith(Parameterized.class)
 public class HashPartitionMultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiPhaseParallelIndexingTest
 {
   private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec("ts", "auto", null);
@@ -59,9 +83,35 @@ public class HashPartitionMultiPhaseParallelIndexingWithNullColumnTest extends A
   private static final InputFormat JSON_FORMAT = new JsonInputFormat(null, null, null);
   private static final List<Interval> INTERVAL_TO_INDEX = Collections.singletonList(Intervals.of("2022-01/P1M"));
 
-  public HashPartitionMultiPhaseParallelIndexingWithNullColumnTest()
+  @Parameterized.Parameters
+  public static Iterable<Object[]> constructorFeeder()
+  {
+    return ImmutableList.of(
+        new Object[]{
+            new HashedPartitionsSpec(
+                10,
+                null,
+                ImmutableList.of("ts", "unknownDim")
+            )
+        },
+        new Object[]{
+            new DimensionRangePartitionsSpec(
+                10,
+                null,
+                Collections.singletonList("unknownDim"),
+                false
+            )
+        }
+    );
+  }
+
+  private final PartitionsSpec partitionsSpec;
+
+  public HashPartitionMultiPhaseParallelIndexingWithNullColumnTest(PartitionsSpec partitionsSpec)
   {
     super(LockGranularity.TIME_CHUNK, true, 0., 0.);
+    this.partitionsSpec = partitionsSpec;
+    getObjectMapper().registerSubtypes(SplittableInlineDataSource.class);
   }
 
   @Test
@@ -95,11 +145,7 @@ public class HashPartitionMultiPhaseParallelIndexingWithNullColumnTest extends A
                 null
             ),
             newTuningConfig(
-                new HashedPartitionsSpec(
-                    10,
-                    null,
-                    ImmutableList.of("ts", "unknownDim")
-                ),
+                partitionsSpec,
                 2,
                 true
             )
@@ -112,10 +158,138 @@ public class HashPartitionMultiPhaseParallelIndexingWithNullColumnTest extends A
     Set<DataSegment> segments = getIndexingServiceClient().getPublishedSegments(task);
     Assert.assertFalse(segments.isEmpty());
     for (DataSegment segment : segments) {
+      Assert.assertEquals(dimensionSchemas.size(), segment.getDimensions().size());
       for (int i = 0; i < dimensionSchemas.size(); i++) {
         Assert.assertEquals(dimensionSchemas.get(i).getName(), segment.getDimensions().get(i));
       }
     }
+  }
+
+  @Test
+  public void testIngestNullColumn_useFieldDiscovery_includeAllDimensions_shouldStoreAllColumns() throws JsonProcessingException
+  {
+    final List<DimensionSchema> dimensionSchemas = DimensionsSpec.getDefaultSchemas(
+        Arrays.asList("ts", "unknownDim", "dim1")
+    );
+    ParallelIndexSupervisorTask task = new ParallelIndexSupervisorTask(
+        null,
+        null,
+        null,
+        new ParallelIndexIngestionSpec(
+            new DataSchema(
+                DATASOURCE,
+                TIMESTAMP_SPEC,
+                new DimensionsSpec.Builder().setDimensions(dimensionSchemas).setIncludeAllDimensions(true).build(),
+                DEFAULT_METRICS_SPEC,
+                new UniformGranularitySpec(
+                    Granularities.DAY,
+                    Granularities.MINUTE,
+                    INTERVAL_TO_INDEX
+                ),
+                null
+            ),
+            new ParallelIndexIOConfig(
+                null,
+                getInputSource(),
+                new JsonInputFormat(
+                    new JSONPathSpec(true, null),
+                    null,
+                    null
+                ),
+                false,
+                null
+            ),
+            newTuningConfig(
+                partitionsSpec,
+                2,
+                true
+            )
+        ),
+        null
+    );
+
+    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+
+    Set<DataSegment> segments = getIndexingServiceClient().getPublishedSegments(task);
+    Assert.assertFalse(segments.isEmpty());
+    final List<String> expectedExplicitDimensions = ImmutableList.of("ts", "unknownDim", "dim1");
+    final Set<String> expectedImplicitDimensions = ImmutableSet.of("dim2", "dim3");
+    for (DataSegment segment : segments) {
+      Assert.assertEquals(
+          expectedExplicitDimensions,
+          segment.getDimensions().subList(0, expectedExplicitDimensions.size())
+      );
+      Assert.assertEquals(
+          expectedImplicitDimensions,
+          new HashSet<>(segment.getDimensions().subList(expectedExplicitDimensions.size(), segment.getDimensions().size()))
+      );
+    }
+  }
+
+  @Test
+  public void testIngestNullColumn_explicitPathSpec_useFieldDiscovery_includeAllDimensions_shouldStoreAllColumns()
+      throws JsonProcessingException
+  {
+    ParallelIndexSupervisorTask task = new ParallelIndexSupervisorTask(
+        null,
+        null,
+        null,
+        new ParallelIndexIngestionSpec(
+            new DataSchema(
+                DATASOURCE,
+                TIMESTAMP_SPEC,
+                new DimensionsSpec.Builder().setIncludeAllDimensions(true).build(),
+                DEFAULT_METRICS_SPEC,
+                new UniformGranularitySpec(
+                    Granularities.DAY,
+                    Granularities.MINUTE,
+                    null
+                ),
+                null
+            ),
+            new ParallelIndexIOConfig(
+                null,
+                getInputSource(),
+                new JsonInputFormat(
+                    new JSONPathSpec(
+                        true,
+                        ImmutableList.of(
+                            new JSONPathFieldSpec(JSONPathFieldType.PATH, "dim1", "$.dim1"),
+                            new JSONPathFieldSpec(JSONPathFieldType.PATH, "k", "$.dim4.k")
+                        )
+                    ),
+                    null,
+                    null
+                ),
+                false,
+                null
+            ),
+            newTuningConfig(
+                partitionsSpec,
+                2,
+                true
+            )
+        ),
+        null
+    );
+
+    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+
+    Set<DataSegment> segments = getIndexingServiceClient().getPublishedSegments(task);
+    Assert.assertFalse(segments.isEmpty());
+    final List<String> expectedExplicitDimensions = ImmutableList.of("dim1", "k");
+    final Set<String> expectedImplicitDimensions = ImmutableSet.of("dim2", "dim3");
+    for (DataSegment segment : segments) {
+      Assert.assertEquals(
+          expectedExplicitDimensions,
+          segment.getDimensions().subList(0, expectedExplicitDimensions.size())
+      );
+      Assert.assertEquals(
+          expectedImplicitDimensions,
+          new HashSet<>(segment.getDimensions().subList(expectedExplicitDimensions.size(), segment.getDimensions().size()))
+      );
+    }
+
   }
 
   @Test
@@ -148,11 +322,7 @@ public class HashPartitionMultiPhaseParallelIndexingWithNullColumnTest extends A
                 null
             ),
             newTuningConfig(
-                new HashedPartitionsSpec(
-                    10,
-                    null,
-                    ImmutableList.of("ts", "unknownDim")
-                ),
+                partitionsSpec,
                 2,
                 true
             )
@@ -165,37 +335,105 @@ public class HashPartitionMultiPhaseParallelIndexingWithNullColumnTest extends A
 
     Set<DataSegment> segments = getIndexingServiceClient().getPublishedSegments(task);
     Assert.assertFalse(segments.isEmpty());
+    final List<DimensionSchema> expectedDimensions = DimensionsSpec.getDefaultSchemas(
+        Collections.singletonList("ts")
+    );
     for (DataSegment segment : segments) {
-      Assert.assertFalse(segment.getDimensions().contains("unknownDim"));
+      Assert.assertEquals(expectedDimensions.size(), segment.getDimensions().size());
+      for (int i = 0; i < expectedDimensions.size(); i++) {
+        Assert.assertEquals(expectedDimensions.get(i).getName(), segment.getDimensions().get(i));
+      }
     }
   }
 
   private InputSource getInputSource() throws JsonProcessingException
   {
     final ObjectMapper mapper = getObjectMapper();
-    final List<Map<String, Object>> rows = ImmutableList.of(
-        ImmutableMap.of(
-            "ts", "2022-01-01",
-            "dim1", "val1",
-            "dim2", "val11"
-        ),
-        ImmutableMap.of(
-            "ts", "2022-01-02",
-            "dim1", "val2",
-            "dim2", "val12"
-        ),
-        ImmutableMap.of(
-            "ts", "2022-01-03",
-            "dim1", "val3",
-            "dim2", "val13"
-        )
-    );
+    final List<Map<String, Object>> rows = new ArrayList<>();
+    Map<String, Object> row;
+    for (int i = 0; i < 3; i++) {
+      row = new HashMap<>();
+      row.put("ts", StringUtils.format("2022-01-%02d", i + 1));
+      for (int j = 0; j < 2; j++) {
+        row.put("dim" + (j + 1), "val" + (j + 1));
+      }
+      row.put("dim3", null);
+      rows.add(row);
+    }
+    row = new HashMap<>();
+    row.put("ts", "2022-01-04");
+    row.put("dim1", null);
+    row.put("dim2", null);
+    row.put("dim3", null);
+    row.put("nested", ImmutableMap.of("k", "v"));
+    rows.add(row);
     final String data = StringUtils.format(
-        "%s\n%s\n%s\n",
+        "%s\n%s\n%s\n%s\n",
         mapper.writeValueAsString(rows.get(0)),
         mapper.writeValueAsString(rows.get(1)),
-        mapper.writeValueAsString(rows.get(2))
+        mapper.writeValueAsString(rows.get(2)),
+        mapper.writeValueAsString(rows.get(3))
     );
-    return new InlineInputSource(data);
+
+    return new SplittableInlineDataSource(ImmutableList.of(data));
+  }
+
+  /**
+   * Splittable inlineDataSource to run tests with range partitioning which requires the inputSource to be splittable.
+   */
+  private static final class SplittableInlineDataSource implements SplittableInputSource<String>
+  {
+    private final List<String> data;
+
+    @JsonCreator
+    public SplittableInlineDataSource(@JsonProperty("data") List<String> data)
+    {
+      this.data = data;
+    }
+
+    @JsonProperty
+    public List<String> getData()
+    {
+      return data;
+    }
+
+    @Override
+    public Stream<InputSplit<String>> createSplits(InputFormat inputFormat, @Nullable SplitHintSpec splitHintSpec)
+    {
+      return data.stream().map(InputSplit::new);
+    }
+
+    @Override
+    public int estimateNumSplits(InputFormat inputFormat, @Nullable SplitHintSpec splitHintSpec)
+    {
+      return data.size();
+    }
+
+    @Override
+    public InputSource withSplit(InputSplit<String> split)
+    {
+      return new SplittableInlineDataSource(ImmutableList.of(split.get()));
+    }
+
+    @Override
+    public boolean needsFormat()
+    {
+      return true;
+    }
+
+    @Override
+    public InputSourceReader reader(
+        InputRowSchema inputRowSchema,
+        @Nullable InputFormat inputFormat,
+        File temporaryDirectory
+    )
+    {
+      return new InputEntityIteratingReader(
+          inputRowSchema,
+          inputFormat,
+          data.stream().map(str -> new ByteEntity(StringUtils.toUtf8(str))).iterator(),
+          temporaryDirectory
+      );
+    }
   }
 }


### PR DESCRIPTION
### Description

`includeAllDimensions` was added recently in https://github.com/apache/druid/pull/12276. When `useFieldDiscovery` and `includeAllDimensions` are both set, `IndexMerger` should store every column even if it is empty. However, it currently doesn't respect the `includeAllDimensions` flag but only checks if the given column is explicitly specified in the dimensionsSpec. This PR fixes this bug by checking the flag properly.

This PR also fixes another bug in `JsonInputFormat` that implicitly filters null fields out even when `useFieldDiscovery` is set. Instead of filtering them out in an early stage in ingestion, `keepNullColumns` will be set automatically if `useFieldDiscovery` is set, so that `MapInputRowParser` can check the dimensionsSpec to decide whether to keep the null fields or not. This change will not make any user-facing change as 1) `keepNullColumns` is undocumented and used only in the sampler and 2) even if there is someone using `keepNullColumns`, the existing behavior should remain the same. The behavior changes only when `includeAllDimensions` is set as well as `useFieldDiscovery`.

<hr>

##### Key changed/added classes in this PR
 * `IndexMergerV9`
 * `JsonInputFormat`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
