### PR TITLE
Validate select columns for insert statement

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -380,12 +380,12 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
                                                   .add("__time", ColumnType.LONG)
                                                   .add("floor_m1", ColumnType.FLOAT)
                                                   .add("dim1", ColumnType.STRING)
-                                                  .add("EXPR$3", ColumnType.DOUBLE)
+                                                  .add("ciel_m2", ColumnType.DOUBLE)
                                                   .build();
     testInsertQuery()
         .sql(
             "INSERT INTO druid.dst "
-            + "SELECT __time, FLOOR(m1) as floor_m1, dim1, CEIL(m2) FROM foo "
+            + "SELECT __time, FLOOR(m1) as floor_m1, dim1, CEIL(m2) as ciel_m2 FROM foo "
             + "PARTITIONED BY FLOOR(__time TO DAY) CLUSTERED BY 2, dim1 DESC, CEIL(m2)"
         )
         .expectTarget("dst", targetRowSignature)
@@ -739,6 +739,18 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
                 CoreMatchers.instanceOf(SqlPlanningException.class),
                 ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Encountered \"as count\""))
             )
+        )
+        .verify();
+  }
+
+  @Test
+  public void testInsertWithUnnamedColumnInSelectStatement()
+  {
+    testInsertQuery()
+        .sql("INSERT INTO t SELECT added, channel || '-lol' FROM foo PARTITIONED BY ALL")
+        .expectValidationError(
+            SqlPlanningException.class,
+            "Cannot ingest unnamed column"
         )
         .verify();
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -750,7 +750,22 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
         .sql("INSERT INTO t SELECT dim1, dim2 || '-lol' FROM foo PARTITIONED BY ALL")
         .expectValidationError(
             SqlPlanningException.class,
-            "Cannot ingest unnamed expressions that do not have an alias "
+            "Cannot ingest expressions that do not have an alias "
+            + "or columns with names like EXPR$[digit]."
+            + "E.g. if you are ingesting \"func(X)\", then you can rewrite it as "
+            + "\"func(X) as myColumn\""
+        )
+        .verify();
+  }
+
+  @Test
+  public void testInsertWithInvalidColumnNameInIngest()
+  {
+    testInsertQuery()
+        .sql("INSERT INTO t SELECT __time, dim1 AS EXPR$0 FROM foo PARTITIONED BY ALL")
+        .expectValidationError(
+            SqlPlanningException.class,
+            "Cannot ingest expressions that do not have an alias "
             + "or columns with names like EXPR$[digit]."
             + "E.g. if you are ingesting \"func(X)\", then you can rewrite it as "
             + "\"func(X) as myColumn\""
@@ -767,7 +782,7 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
              + "(SELECT __time, LOWER(dim1) FROM foo) PARTITIONED BY ALL TIME")
         .expectValidationError(
             SqlPlanningException.class,
-            "Cannot ingest unnamed expressions that do not have an alias "
+            "Cannot ingest expressions that do not have an alias "
             + "or columns with names like EXPR$[digit]."
             + "E.g. if you are ingesting \"func(X)\", then you can rewrite it as "
             + "\"func(X) as myColumn\""

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -750,7 +750,8 @@ public class CalciteInsertDmlTest extends BaseCalciteQueryTest
         .sql("INSERT INTO t SELECT added, channel || '-lol' FROM foo PARTITIONED BY ALL")
         .expectValidationError(
             SqlPlanningException.class,
-            "Cannot ingest unnamed column"
+            "throw new ValidationException(\"Cannot ingest unnamed expressions that do not have an alias."
+            + " E.g. if you are ingesting \\\"func(X)\\\", then you can rewrite it as \\\"func(X) as myColumn\\\"\");"
         )
         .verify();
   }


### PR DESCRIPTION
### Description

Unnamed columns in the select part of insert SQL statements currently create a table with the column name such as "EXPR$3". This PR adds a check for this.

- Add check for columns with names of the form "EXPR$[digit]+" after converting to RelNodes for ingestion.

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
