### PR TITLE
Fix NOTES.txt tooltips when adding a LoadBalancer service

### DIFF
--- a/helm/druid/templates/NOTES.txt
+++ b/helm/druid/templates/NOTES.txt
@@ -28,8 +28,8 @@
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.router.serviceType }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ include "druid.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "druid.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "druid.fullname" . }}-router'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "druid.fullname" . }}-router -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
   echo http://$SERVICE_IP:{{ .Values.router.port }}
 {{- else if contains "ClusterIP" .Values.router.serviceType }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "druid.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")


### PR DESCRIPTION
### Description

Fixes some errors in NOTES.txt when installing or upgrading with a `LoadBalancer` service.
1. Add the namespace arg in two commands where it was missing
2. Append `-router` to the end of the "fullnames".  For example, with a basic install/upgrade, `kubectl get svc --namespace dev -w druid` fails but `kubectl get svc --namespace dev -w druid-router` works as intended.
3. Corrects the jsonpath search by changing `ip` to `hostname`.

Given a basic installation that does not change the configuration too much, and assuming that the service changed to a `LoadBalancer` is the router, the commands in this section of the notes now work as intended.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
