### PR TITLE
Suppress CVE-2021-43138

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -288,20 +288,6 @@
     <cve>CVE-2019-17571</cve>
   </suppress>
   <suppress>
-    <!--
-      - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
-      -->
-    <notes><![CDATA[
-    file name: ambari-metrics-common-2.7.0.0.0.jar (shaded: io.netty:netty:3.10.5.Final)
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.netty/netty@3.10.5.Final$</packageUrl>
-    <cve>CVE-2019-16869</cve>
-    <cve>CVE-2019-20444</cve>
-    <cve>CVE-2019-20445</cve>
-    <cve>CVE-2021-37136</cve>
-    <cve>CVE-2021-37137</cve>
-  </suppress>
-  <suppress>
        <!--
          - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
          -->
@@ -469,5 +455,14 @@
     file name: avro-1.9.2.jar or avro-ipc-jetty-1.9.2.jar
     ]]></notes>
     <cve>CVE-2021-43045</cve>
+  </suppress>
+
+  <suppress>
+    <!-- False alarm for the Async javascript library (https://github.com/caolan/async) which is a dev dependency for the web console -->
+    <notes><![CDATA[
+   file name: async-http-client-netty-utils-2.5.3.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.asynchttpclient/async-http-client-netty-utils@2.5.3$</packageUrl>
+    <cve>CVE-2021-43138</cve>
   </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -288,6 +288,20 @@
     <cve>CVE-2019-17571</cve>
   </suppress>
   <suppress>
+    <!--
+      - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
+      -->
+    <notes><![CDATA[
+    file name: ambari-metrics-common-2.7.0.0.0.jar (shaded: io.netty:netty:3.10.5.Final)
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty@3.10.5.Final$</packageUrl>
+    <cve>CVE-2019-16869</cve>
+    <cve>CVE-2019-20444</cve>
+    <cve>CVE-2019-20445</cve>
+    <cve>CVE-2021-37136</cve>
+    <cve>CVE-2021-37137</cve>
+  </suppress>
+  <suppress>
        <!--
          - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
          -->


### PR DESCRIPTION
### Description

The Travis CI cron job flagged https://nvd.nist.gov/vuln/detail/CVE-2021-43138. This failure is a false alarm as the CVE is about the Async javascript library (https://github.com/caolan/async), not `async-http-client-netty-utils`. Even though we do use the Async library for the web console development, I think we can still suppress this CVE as the Async library is a [dev dependency](https://github.com/apache/druid/blob/master/web-console/package-lock.json#L6394-L6402).

This PR also cleans up a stale suppression for netty-3.10.5.Final which we no longer use.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
