### PR TITLE
Deal with potential cardinality estimate being negative and add logging to hash determine partitions phase

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -706,7 +706,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         );
 
         // This is for potential debugging in case we suspect bad estimation of cardinalities etc,
-        LOG.info("intervalToNumShards: %s", intervalToNumShards.toString());
+        LOG.debug("intervalToNumShards: %s", intervalToNumShards.toString());
 
       } else {
         intervalToNumShards = CollectionUtils.mapValues(
@@ -933,9 +933,16 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
             // determine numShards based on maxRowsPerSegment and the cardinality
             estimatedNumShards = Math.round(estimatedCardinality / maxRowsPerSegment);
           }
-          LOG.info("estimatedNumShards %d given estimated cardinality %.2f and maxRowsPerSegment %d",
-                   estimatedNumShards, estimatedCardinality, maxRowsPerSegment
+          LOG.debug("estimatedNumShards %d given estimated cardinality %.2f and maxRowsPerSegment %d",
+                    estimatedNumShards, estimatedCardinality, maxRowsPerSegment
           );
+          // We have seen this before in the wild in situations where more shards should have been created,
+          // log it if it happens with some information & context
+          if (estimatedNumShards == 1) {
+            LOG.info("estimatedNumShards is ONE (%d) given estimated cardinality %.2f and maxRowsPerSegment %d",
+                      estimatedNumShards, estimatedCardinality, maxRowsPerSegment
+            );
+          }
           try {
             return Math.max(Math.toIntExact(estimatedNumShards), 1);
           }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -933,7 +933,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
             // determine numShards based on maxRowsPerSegment and the cardinality
             estimatedNumShards = Math.round(estimatedCardinality / maxRowsPerSegment);
           }
-          LOG.debug("estimatedNumShards %d given estimated cardinality %.2f and maxRowsPerSegment %d",
+          LOG.info("estimatedNumShards %d given estimated cardinality %.2f and maxRowsPerSegment %d",
                     estimatedNumShards, estimatedCardinality, maxRowsPerSegment
           );
           // We have seen this before in the wild in situations where more shards should have been created,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
@@ -314,10 +314,10 @@ public class DimensionCardinalityReportTest
   @Test
   public void testSupervisorDeterminePositiveNumShardsFromCardinalityReport()
   {
-    Union negativeUnion = mock(Union.class);
-    Mockito.when(negativeUnion.getEstimate()).thenReturn(24.0);
+    Union union = mock(Union.class);
+    Mockito.when(union.getEstimate()).thenReturn(24.0);
     Interval interval = Intervals.of("2001-01-01/P1D");
-    Map<Interval, Union> intervalToUnion = ImmutableMap.of(interval, negativeUnion);
+    Map<Interval, Union> intervalToUnion = ImmutableMap.of(interval, union);
     Map<Interval, Integer> intervalToNumShards =
         ParallelIndexSupervisorTask.computeIntervalToNumShards(6, intervalToUnion);
     Assert.assertEquals(new Integer(4), intervalToNumShards.get(interval));


### PR DESCRIPTION
We have seen rare instances on the wild where during hash partitions the determine cardinality phase produces a single shard with a large segment without regards to the value of `maxRowsPerSegment`.  Attempts to reproduce have not been successful so adding some defensive programming and logging in case this happens again would be helpful. This PR deals with the improbable case where the estimate from a `Union` `HLLSketch` that is used in the code returns negative. It also adds some logging to report the values used to come up with the final determination.



This PR has:
- [X ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X ] been tested in a test Druid cluster.
