### PR TITLE
Fixes GCS based ingestion

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
@@ -71,7 +71,7 @@ public class CloudObjectLocation
 
   public CloudObjectLocation(URI uri)
   {
-    this(uri.getAuthority(), uri.getPath());
+    this(uri.getHost() != null ? uri.getHost() : uri.getAuthority(), uri.getPath());
   }
 
   /**

--- a/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
@@ -71,7 +71,7 @@ public class CloudObjectLocation
 
   public CloudObjectLocation(URI uri)
   {
-    this(uri.getHost(), uri.getPath());
+    this(uri.getAuthority(), uri.getPath());
   }
 
   /**

--- a/core/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
@@ -115,13 +115,27 @@ public class CloudObjectLocationTest
   }
 
   @Test
-  public void testInvalidBucketName()
+  public void testBucketNameWithoutUnderscores()
   {
-    expectedException.expect(NullPointerException.class);
-    expectedException.expectMessage("bucket name cannot be null. Please verify if bucket name adheres to naming rules");
-    // Underscore(_) character is not valid for bucket names
-    CloudObjectLocation invalidBucket1 = new CloudObjectLocation("test_bucket", "path/to/path");
-    CloudObjectLocation invalidBucket2 = new CloudObjectLocation(invalidBucket1.toUri(SCHEME));
-    Assert.assertEquals("test_bucket", new CloudObjectLocation(invalidBucket2.toUri(SCHEME)));
+    CloudObjectLocation gsValidBucket = new CloudObjectLocation(URI.create("gs://1test.bucket-value/path/to/path"));
+    Assert.assertEquals("1test.bucket-value", gsValidBucket.getBucket());
+    Assert.assertEquals("path/to/path", gsValidBucket.getPath());
+
+    CloudObjectLocation s3ValidBucket = new CloudObjectLocation(URI.create("s3://2test.bucket-value/path/to/path"));
+    Assert.assertEquals("2test.bucket-value", s3ValidBucket.getBucket());
+    Assert.assertEquals("path/to/path", s3ValidBucket.getPath());
+  }
+
+  @Test
+  public void testBucketNameWithUnderscores()
+  {
+    // Underscore(_) character is allowed for bucket names by GCP
+    CloudObjectLocation gsValidBucket = new CloudObjectLocation(URI.create("gs://test_bucket/path/to/path"));
+    Assert.assertEquals("test_bucket", gsValidBucket.getBucket());
+    Assert.assertEquals("path/to/path", gsValidBucket.getPath());
+
+    CloudObjectLocation s3ValidBucket = new CloudObjectLocation(URI.create("s3://test_bucket/path/to/path"));
+    Assert.assertEquals("test_bucket", s3ValidBucket.getBucket());
+    Assert.assertEquals("path/to/path", s3ValidBucket.getPath());
   }
 }


### PR DESCRIPTION
GCP allows buckets in GCS to contain underscores in their names. When this location is mapped to `java.net.URI`, `URI#host` comes out to be null as `URI` doesn't allow it to contain underscores which is being translated to bucket name hence mapping `URI#authority` to bucket name.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed `CloudObjectLocation` constructor from `URI`

- Previously bucket variable of the `CloudObjectLocation` is being set by `uri.getHost()` value (but `java.net.URI` refuses to handle underscore in host since it's not a valid character and gcs allows underscores in bucket naming)

- This modification allows `uri.getAuthority()` to be mapped to bucket name which is allowing underscores to be present (Since all 3 S3, GCS, Azure Cloud buckets uris won't contain port or user information it is assumed that authority will return nothing more than the bucket name)

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `CloudObjectLocation `

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
