### PR TITLE
Introduce a monitor to report detailed segment metrics

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -383,6 +383,7 @@ Metric monitoring is an essential part of Druid operations.  The following monit
 |`org.apache.druid.server.metrics.QueryCountStatsMonitor`|Reports how many queries have been successful/failed/interrupted.|
 |`org.apache.druid.server.emitter.HttpEmittingMonitor`|Reports internal metrics of `http` or `parametrized` emitter (see below). Must not be used with another emitter type. See the description of the metrics here: https://github.com/apache/druid/pull/4973.|
 |`org.apache.druid.server.metrics.TaskCountStatsMonitor`|Reports how many ingestion tasks are currently running/pending/waiting and also the number of successful/failed tasks per emission period.|
+|`org.apache.druid.sql.calcite.schema.SchemaStatsMonitor`|Reports detailed metrics about segments that are visible in the broker.|
 
 For example, you might configure monitors on all processes for system and JVM information within `common.runtime.properties` as follows:
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -58,6 +58,13 @@ Metrics may have additional dimensions beyond those listed above.
 |`query/priority`|Assigned lane and priority, only if Laning strategy is enabled. Refer to [Laning strategies](../configuration/index.md#laning-strategies)|lane, dataSource, type|0|
 |`sqlQuery/time`|Milliseconds taken to complete a SQL query.|id, nativeQueryIds, dataSource, remoteAddress, success.|< 1s|
 |`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
+|`segment/detailed/numRows`|Number of rows in a segment. Only reported if `SchemaStatsMonitor` is enabled.|`dataSource`, `segment/binaryVersion`, `segment/hasLastCompactedState`| Varies. Good sized segments should be around 5M rows.|
+|`segment/detailed/numReplicas`|Number servers that this segment is available on. Only reported if `SchemaStatsMonitor` is enabled.|`dataSource`, `segment/binaryVersion`, `segment/hasLastCompactedState`| Varies. Should be the number of replicas configured.|
+|`segment/detailed/sizeBytes`|Size of the segment in bytes. Only reported if `SchemaStatsMonitor` is enabled.|`dataSource`, `segment/binaryVersion`, `segment/hasLastCompactedState`| Varies.|
+|`segment/detailed/numDimensions`|Number of dimensions in the segment metadata. Only reported if `SchemaStatsMonitor` is enabled.|`dataSource`, `segment/binaryVersion`, `segment/hasLastCompactedState`| Varies.|
+|`segment/detailed/numMetrics`|Number of metrics in the segment metadata. Only reported if `SchemaStatsMonitor` is enabled.|`dataSource`, `segment/binaryVersion`, `segment/hasLastCompactedState`| Varies.|
+|`segment/detailed/durationMillis`|The size of the interval that the segment covers in millis. Only reported if `SchemaStatsMonitor` is enabled.|`dataSource`, `segment/binaryVersion`, `segment/hasLastCompactedState`| Varies.|
+
 
 ### Historical
 
@@ -244,7 +251,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`segment/loadQueue/count`|Number of segments to load.|server.|Varies.|
 |`segment/dropQueue/count`|Number of segments to drop.|server.|Varies.|
 |`segment/size`|Total size of used segments in a data source. Emitted only for data sources to which at least one used segment belongs.|dataSource.|Varies.|
-|`segment/count`|Number of used segments belonging to a data source. Emitted only for data sources to which at least one used segment belongs.|dataSource.|< max|
+|`segsegment/count`|Number of used segments belonging to a data source. Emitted only for data sources to which at least one used segment belongs.|dataSource.|< max|
 |`segment/overShadowed/count`|Number of overshadowed segments.| |Varies.|
 |`segment/unavailable/count`|Number of segments (not including replicas) left to load until segments that should be loaded in the cluster are available for queries.|dataSource.|0|
 |`segment/underReplicated/count`|Number of segments (including replicas) left to load until segments that should be loaded in the cluster are available for queries.|tier, dataSource.|0|

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SchemaStatsMonitor.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SchemaStatsMonitor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.schema;
+
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.metrics.AbstractMonitor;
+import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.timeline.SegmentId;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * A monitor that provides stats on segments that are visible to the {@link DruidSchema}
+ */
+public class SchemaStatsMonitor extends AbstractMonitor
+{
+  private final DruidSchema druidSchema;
+
+  @Inject
+  SchemaStatsMonitor(DruidSchema druidSchema)
+  {
+    this.druidSchema = druidSchema;
+  }
+
+  @Override
+  public boolean doMonitor(ServiceEmitter emitter)
+  {
+    final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
+    for (Map.Entry<String, ConcurrentSkipListMap<SegmentId, AvailableSegmentMetadata>> datasourceAndSegmentsMetadata : druidSchema.getSegmentMetadataInfoUnsafe().entrySet()) {
+      builder.setDimension(DruidMetrics.DATASOURCE, datasourceAndSegmentsMetadata.getKey());
+      for (AvailableSegmentMetadata metadata : datasourceAndSegmentsMetadata.getValue().values()) {
+        builder.setDimension("segment/binaryVersion", metadata.getSegment().getBinaryVersion());
+        builder.setDimension("segment/hasLastCompactedState", metadata.getSegment().getLastCompactionState() != null);
+
+        emitter.emit(builder.build("segment/detailed/numRows", metadata.getNumRows()));
+        emitter.emit(builder.build("segment/detailed/numReplicas", metadata.getNumReplicas()));
+        emitter.emit(builder.build("segment/detailed/size", metadata.getSegment().getSize()));
+        emitter.emit(builder.build("segment/detailed/numDimensions", metadata.getSegment().getDimensions().size()));
+        emitter.emit(builder.build("segment/detailed/numMetrics", metadata.getSegment().getMetrics().size()));
+        emitter.emit(builder.build("segment/detailed/durationMillis", metadata.getSegment().getInterval().toDurationMillis()));
+      }
+    }
+    return true;
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SchemaStatsMonitorTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SchemaStatsMonitorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.schema;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SchemaStatsMonitorTest
+{
+  private static final StubServiceEmitter EMITTER = new StubServiceEmitter("service", "host");
+  @Mock
+  private DruidSchema druidSchema;
+
+  private SchemaStatsMonitor target;
+
+  @Before
+  public void setUp()
+  {
+    Mockito.doReturn(ImmutableMap.of()).when(druidSchema.getSegmentMetadataInfoUnsafe());
+    target = new SchemaStatsMonitor(druidSchema);
+  }
+}


### PR DESCRIPTION
### Description

The SchemaStatsMonitor reports detailed metrics for each segment in the cluster.

A user will need to enable this since I am not yet certain what the impact will
be if this operation happens on large clusters.

The metric naming scheme of segment/detailed/* is because there are already
metrics named segment/* which have a similar use, but are reported differently.

I had considered reporting the number of rows per segment via the
EmitClusterStatsAndMetricsModule since we have access to the DataSegment object
in the coordinator when running through the details to decide which segments
need compaction. This proved challenging since the number of rows wasn't
readily available.

<hr>

This PR is still missing unit tests, but I was hoping to get an initial round of feedback before I go too far down this path.

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
