### PR TITLE
docs(fix): clarify how worker.version and minWorkerVersion comparison works

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1078,7 +1078,7 @@ The following configs only apply if the Overlord is running in remote mode. For 
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.indexer.runner.taskAssignmentTimeout`|How long to wait after a task as been assigned to a MiddleManager before throwing an error.|PT5M|
-|`druid.indexer.runner.minWorkerVersion`|The minimum MiddleManager version to send tasks to. |"0"|
+|`druid.indexer.runner.minWorkerVersion`|The minimum MiddleManager version to send tasks to. Note that the version number is a string. This affects the expected behavior during certain operations like when it's compared against `druid.worker.version`. Specifically, the version comparison follows dictionary order . Use ISO8601 date format for the version so that later versions are recognized as being more recent. |"0"|
 | `druid.indexer.runner.parallelIndexTaskSlotRatio`| The ratio of task slots available for parallel indexing supervisor tasks per worker. The specified value must be in the range [0, 1]. |1|
 |`druid.indexer.runner.compressZnodes`|Indicates whether or not the Overlord should expect MiddleManagers to compress Znodes.|true|
 |`druid.indexer.runner.maxZnodeBytes`|The maximum size Znode in bytes that can be created in Zookeeper, should be in the range of [10KiB, 2GiB). [Human-readable format](human-readable-byte.md) is supported.| 512 KiB |
@@ -1369,7 +1369,7 @@ Middle managers pass their configurations down to their child peons. The MiddleM
 |`druid.indexer.runner.endPort`|Ending port used for peon processes, should be greater than or equal to `druid.indexer.runner.startPort` and less than 65536.|65535|
 |`druid.indexer.runner.ports`|A JSON array of integers to specify ports that used for peon processes. If provided and non-empty, ports for peon processes will be chosen from these ports. And `druid.indexer.runner.startPort/druid.indexer.runner.endPort` will be completely ignored.|`[]`|
 |`druid.worker.ip`|The IP of the worker.|localhost|
-|`druid.worker.version`|Version identifier for the MiddleManager.|0|
+|`druid.worker.version`|Version identifier for the MiddleManager. Note that the version number is a string. This affects the expected behavior during certain operations like when it's compared against `druid.indexer.runner.minWorkerVersion`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version so that later versions are recognized as being more recent.|0|
 |`druid.worker.capacity`|Maximum number of tasks the MiddleManager can accept.|Number of CPUs on the machine - 1|
 |`druid.worker.category`|A string to name the category that the MiddleManager node belongs to.|`_default_worker_category`|
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1369,7 +1369,7 @@ Middle managers pass their configurations down to their child peons. The MiddleM
 |`druid.indexer.runner.endPort`|Ending port used for peon processes, should be greater than or equal to `druid.indexer.runner.startPort` and less than 65536.|65535|
 |`druid.indexer.runner.ports`|A JSON array of integers to specify ports that used for peon processes. If provided and non-empty, ports for peon processes will be chosen from these ports. And `druid.indexer.runner.startPort/druid.indexer.runner.endPort` will be completely ignored.|`[]`|
 |`druid.worker.ip`|The IP of the worker.|localhost|
-|`druid.worker.version`|Version identifier for the MiddleManager. The version number is a string. This affects the expected behavior during certain operations like comparison against `druid.indexer.runner.minWorkerVersion`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version to accomodate date comparisons.|0|
+|`druid.worker.version`|Version identifier for the MiddleManager. The version number is a string. This affects the expected behavior during certain operations like comparison against `druid.indexer.runner.minWorkerVersion`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version to accommodate date comparisons.|0|
 |`druid.worker.capacity`|Maximum number of tasks the MiddleManager can accept.|Number of CPUs on the machine - 1|
 |`druid.worker.category`|A string to name the category that the MiddleManager node belongs to.|`_default_worker_category`|
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1078,7 +1078,7 @@ The following configs only apply if the Overlord is running in remote mode. For 
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.indexer.runner.taskAssignmentTimeout`|How long to wait after a task as been assigned to a MiddleManager before throwing an error.|PT5M|
-|`druid.indexer.runner.minWorkerVersion`|The minimum MiddleManager version to send tasks to. Note that the version number is a string. This affects the expected behavior during certain operations like when it's compared against `druid.worker.version`. Specifically, the version comparison follows dictionary order . Use ISO8601 date format for the version so that later versions are recognized as being more recent. |"0"|
+|`druid.indexer.runner.minWorkerVersion`|The minimum MiddleManager version to send tasks to. The version number is a string. This affects the expected behavior during certain operations like comparison against `druid.worker.version`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version to accommodate date comparisons. |"0"|
 | `druid.indexer.runner.parallelIndexTaskSlotRatio`| The ratio of task slots available for parallel indexing supervisor tasks per worker. The specified value must be in the range [0, 1]. |1|
 |`druid.indexer.runner.compressZnodes`|Indicates whether or not the Overlord should expect MiddleManagers to compress Znodes.|true|
 |`druid.indexer.runner.maxZnodeBytes`|The maximum size Znode in bytes that can be created in Zookeeper, should be in the range of [10KiB, 2GiB). [Human-readable format](human-readable-byte.md) is supported.| 512 KiB |
@@ -1369,7 +1369,7 @@ Middle managers pass their configurations down to their child peons. The MiddleM
 |`druid.indexer.runner.endPort`|Ending port used for peon processes, should be greater than or equal to `druid.indexer.runner.startPort` and less than 65536.|65535|
 |`druid.indexer.runner.ports`|A JSON array of integers to specify ports that used for peon processes. If provided and non-empty, ports for peon processes will be chosen from these ports. And `druid.indexer.runner.startPort/druid.indexer.runner.endPort` will be completely ignored.|`[]`|
 |`druid.worker.ip`|The IP of the worker.|localhost|
-|`druid.worker.version`|Version identifier for the MiddleManager. Note that the version number is a string. This affects the expected behavior during certain operations like when it's compared against `druid.indexer.runner.minWorkerVersion`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version so that later versions are recognized as being more recent.|0|
+|`druid.worker.version`|Version identifier for the MiddleManager. The version number is a string. This affects the expected behavior during certain operations like comparison against `druid.indexer.runner.minWorkerVersion`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version to accomodate date comparisons.|0|
 |`druid.worker.capacity`|Maximum number of tasks the MiddleManager can accept.|Number of CPUs on the machine - 1|
 |`druid.worker.category`|A string to name the category that the MiddleManager node belongs to.|`_default_worker_category`|
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -214,7 +214,15 @@
       },
       "development/extensions-core/kafka-ingestion": {
         "title": "Apache Kafka ingestion",
-        "sidebar_label": "Apache Kafka"
+        "sidebar_label": "Apache Kafka ingestion"
+      },
+      "development/extensions-core/kafka-supervisor-operations": {
+        "title": "Apache Kafka supervisor operations reference",
+        "sidebar_label": "Apache Kafka operations"
+      },
+      "development/extensions-core/kafka-supervisor-reference": {
+        "title": "Apache Kafka supervisor reference",
+        "sidebar_label": "Apache Kafka supervisor"
       },
       "development/extensions-core/kinesis-ingestion": {
         "title": "Amazon Kinesis ingestion",
@@ -301,6 +309,18 @@
         "title": "Ingestion spec reference",
         "sidebar_label": "Ingestion spec"
       },
+      "ingestion/native-batch-firehose": {
+        "title": "Native batch ingestion with firehose",
+        "sidebar_label": "Firehose"
+      },
+      "ingestion/native-batch-input-sources": {
+        "title": "Native batch input sources",
+        "sidebar_label": "Input sources"
+      },
+      "ingestion/native-batch-simple-task": {
+        "title": "Native batch simple task indexing",
+        "sidebar_label": "Simple task indexing"
+      },
       "ingestion/native-batch": {
         "title": "Native batch ingestion",
         "sidebar_label": "Native batch"
@@ -386,6 +406,10 @@
       "operations/metrics": {
         "title": "Metrics"
       },
+      "operations/mixed-workloads": {
+        "title": "Configure Druid for mixed workloads",
+        "sidebar_label": "Mixed workloads"
+      },
       "operations/other-hadoop": {
         "title": "Working with different versions of Apache Hadoop"
       },
@@ -394,6 +418,10 @@
       },
       "operations/pull-deps": {
         "title": "pull-deps tool"
+      },
+      "operations/request-logging": {
+        "title": "Request logging",
+        "sidebar_label": "Request logging"
       },
       "operations/reset-cluster": {
         "title": "reset-cluster tool"
@@ -478,7 +506,7 @@
       },
       "querying/query-context": {
         "title": "Query context",
-        "sidebar_label": "Context parameters"
+        "sidebar_label": "Query context"
       },
       "querying/query-execution": {
         "title": "Query execution"
@@ -505,9 +533,53 @@
       "querying/sorting-orders": {
         "title": "String comparators"
       },
+      "querying/sql-aggregations": {
+        "title": "SQL aggregation functions",
+        "sidebar_label": "Aggregation functions"
+      },
+      "querying/sql-api": {
+        "title": "Druid SQL API",
+        "sidebar_label": "Druid SQL API"
+      },
+      "querying/sql-connection-context": {
+        "title": "SQL connection context",
+        "sidebar_label": "SQL connection context"
+      },
+      "querying/sql-data-types": {
+        "title": "SQL data types",
+        "sidebar_label": "SQL data types"
+      },
+      "querying/sql-jdbc": {
+        "title": "SQL JDBC Driver API",
+        "sidebar_label": "JDBC Driver API"
+      },
+      "querying/sql-metadata-tables": {
+        "title": "SQL metadata tables",
+        "sidebar_label": "SQL metadata tables"
+      },
+      "querying/sql-multivalue-string-functions": {
+        "title": "SQL multi-value string functions",
+        "sidebar_label": "Multi-value string functions"
+      },
+      "querying/sql-operators": {
+        "title": "Druid SQL Operators",
+        "sidebar_label": "Operators"
+      },
+      "querying/sql-scalar": {
+        "title": "SQL scalar functions",
+        "sidebar_label": "Scalar functions"
+      },
+      "querying/sql-syntax": {
+        "title": "SQL query syntax",
+        "sidebar_label": "SQL query syntax"
+      },
+      "querying/sql-translation": {
+        "title": "SQL query translation",
+        "sidebar_label": "SQL query translation"
+      },
       "querying/sql": {
-        "title": "SQL",
-        "sidebar_label": "Druid SQL"
+        "title": "Druid SQL overview",
+        "sidebar_label": "Druid SQL overview"
       },
       "querying/timeboundaryquery": {
         "title": "TimeBoundary queries",
@@ -523,6 +595,10 @@
       "querying/topnquery": {
         "title": "TopN queries",
         "sidebar_label": "TopN"
+      },
+      "querying/troubleshooting": {
+        "title": "Troubleshooting query execution in Druid",
+        "sidebar_label": "Troubleshooting"
       },
       "querying/using-caching": {
         "title": "Using query caching"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -214,15 +214,7 @@
       },
       "development/extensions-core/kafka-ingestion": {
         "title": "Apache Kafka ingestion",
-        "sidebar_label": "Apache Kafka ingestion"
-      },
-      "development/extensions-core/kafka-supervisor-operations": {
-        "title": "Apache Kafka supervisor operations reference",
-        "sidebar_label": "Apache Kafka operations"
-      },
-      "development/extensions-core/kafka-supervisor-reference": {
-        "title": "Apache Kafka supervisor reference",
-        "sidebar_label": "Apache Kafka supervisor"
+        "sidebar_label": "Apache Kafka"
       },
       "development/extensions-core/kinesis-ingestion": {
         "title": "Amazon Kinesis ingestion",
@@ -309,18 +301,6 @@
         "title": "Ingestion spec reference",
         "sidebar_label": "Ingestion spec"
       },
-      "ingestion/native-batch-firehose": {
-        "title": "Native batch ingestion with firehose",
-        "sidebar_label": "Firehose"
-      },
-      "ingestion/native-batch-input-sources": {
-        "title": "Native batch input sources",
-        "sidebar_label": "Input sources"
-      },
-      "ingestion/native-batch-simple-task": {
-        "title": "Native batch simple task indexing",
-        "sidebar_label": "Simple task indexing"
-      },
       "ingestion/native-batch": {
         "title": "Native batch ingestion",
         "sidebar_label": "Native batch"
@@ -406,10 +386,6 @@
       "operations/metrics": {
         "title": "Metrics"
       },
-      "operations/mixed-workloads": {
-        "title": "Configure Druid for mixed workloads",
-        "sidebar_label": "Mixed workloads"
-      },
       "operations/other-hadoop": {
         "title": "Working with different versions of Apache Hadoop"
       },
@@ -418,10 +394,6 @@
       },
       "operations/pull-deps": {
         "title": "pull-deps tool"
-      },
-      "operations/request-logging": {
-        "title": "Request logging",
-        "sidebar_label": "Request logging"
       },
       "operations/reset-cluster": {
         "title": "reset-cluster tool"
@@ -506,7 +478,7 @@
       },
       "querying/query-context": {
         "title": "Query context",
-        "sidebar_label": "Query context"
+        "sidebar_label": "Context parameters"
       },
       "querying/query-execution": {
         "title": "Query execution"
@@ -533,53 +505,9 @@
       "querying/sorting-orders": {
         "title": "String comparators"
       },
-      "querying/sql-aggregations": {
-        "title": "SQL aggregation functions",
-        "sidebar_label": "Aggregation functions"
-      },
-      "querying/sql-api": {
-        "title": "Druid SQL API",
-        "sidebar_label": "Druid SQL API"
-      },
-      "querying/sql-connection-context": {
-        "title": "SQL connection context",
-        "sidebar_label": "SQL connection context"
-      },
-      "querying/sql-data-types": {
-        "title": "SQL data types",
-        "sidebar_label": "SQL data types"
-      },
-      "querying/sql-jdbc": {
-        "title": "SQL JDBC Driver API",
-        "sidebar_label": "JDBC Driver API"
-      },
-      "querying/sql-metadata-tables": {
-        "title": "SQL metadata tables",
-        "sidebar_label": "SQL metadata tables"
-      },
-      "querying/sql-multivalue-string-functions": {
-        "title": "SQL multi-value string functions",
-        "sidebar_label": "Multi-value string functions"
-      },
-      "querying/sql-operators": {
-        "title": "Druid SQL Operators",
-        "sidebar_label": "Operators"
-      },
-      "querying/sql-scalar": {
-        "title": "SQL scalar functions",
-        "sidebar_label": "Scalar functions"
-      },
-      "querying/sql-syntax": {
-        "title": "SQL query syntax",
-        "sidebar_label": "SQL query syntax"
-      },
-      "querying/sql-translation": {
-        "title": "SQL query translation",
-        "sidebar_label": "SQL query translation"
-      },
       "querying/sql": {
-        "title": "Druid SQL overview",
-        "sidebar_label": "Druid SQL overview"
+        "title": "SQL",
+        "sidebar_label": "Druid SQL"
       },
       "querying/timeboundaryquery": {
         "title": "TimeBoundary queries",
@@ -595,10 +523,6 @@
       "querying/topnquery": {
         "title": "TopN queries",
         "sidebar_label": "TopN"
-      },
-      "querying/troubleshooting": {
-        "title": "Troubleshooting query execution in Druid",
-        "sidebar_label": "Troubleshooting"
       },
       "querying/using-caching": {
         "title": "Using query caching"


### PR DESCRIPTION
Add explanation that the value is treated as a string, so it works unintuitively if you don't provide the version in ISO format.


This PR has:
- [x] been self-reviewed.