### PR TITLE
Emit vectorized metric dimension by default

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -201,7 +201,7 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   @Override
   public void vectorized(final boolean vectorized)
   {
-    // Emit nothing by default.
+    setDimension("vectorized", vectorized);
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
@@ -156,4 +156,23 @@ public class DefaultQueryMetricsTest
     Assert.assertEquals("query/node/bytes", actualEvent.get("metric"));
     Assert.assertEquals(10L, actualEvent.get("value"));
   }
+
+  @Test
+  public void testVectorizedDimensionInMetrics()
+  {
+    CachingEmitter cachingEmitter = new CachingEmitter();
+    ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
+    DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
+    queryMetrics.vectorized(true);
+    queryMetrics.reportSegmentTime(0).emit(serviceEmitter);
+    Map<String, Object> actualEvent = cachingEmitter.getLastEmittedEvent().toMap();
+    Assert.assertEquals(7, actualEvent.size());
+    Assert.assertTrue(actualEvent.containsKey("feed"));
+    Assert.assertTrue(actualEvent.containsKey("timestamp"));
+    Assert.assertEquals("", actualEvent.get("host"));
+    Assert.assertEquals("", actualEvent.get("service"));
+    Assert.assertEquals("query/segment/time", actualEvent.get("metric"));
+    Assert.assertEquals(0L, actualEvent.get("value"));
+    Assert.assertEquals(true, actualEvent.get("vectorized"));
+  }
 }


### PR DESCRIPTION
Vectorized metric will help in knowing more information about the performance profile of a workload

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
