### PR TITLE
QueryScheduler: Log per-query message at DEBUG level.

### DIFF
--- a/server/src/main/java/org/apache/druid/server/QueryScheduler.java
+++ b/server/src/main/java/org/apache/druid/server/QueryScheduler.java
@@ -159,7 +159,12 @@ public class QueryScheduler implements QueryWatcher
     Optional<Integer> priority = prioritizationStrategy.computePriority(queryPlus, segments);
     query = priority.map(query::withPriority).orElse(query);
     Optional<String> lane = laningStrategy.computeLane(queryPlus.withQuery(query), segments);
-    LOGGER.info("[%s] lane assigned to [%s] query with [%,d] priority", lane.orElse("default"), query.getType(), priority.orElse(Integer.valueOf(0)));
+    LOGGER.debug(
+        "[%s] lane assigned to [%s] query with [%,d] priority",
+        lane.orElse("default"),
+        query.getType(),
+        priority.orElse(0)
+    );
     final ServiceMetricEvent.Builder builderUsr = ServiceMetricEvent.builder().setFeed("metrics")
                                                                     .setDimension("lane", lane.orElse("default"))
                                                                     .setDimension("dataSource", query.getDataSource().getTableNames())


### PR DESCRIPTION
We want to avoid having routine per-query messages at INFO level, because they pollute logs.