### PR TITLE
WIP: Enable usage of multiple base task directories

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
@@ -243,12 +243,12 @@ public class TaskConfig
                                     .collect(Collectors.toList());
   }
 
-  public File getChildFileFromLocation(StorageLocationConfig location, String child)
+  private File getChildFileFromLocation(StorageLocationConfig location, String child)
   {
     return new File(location.getPath(), child);
   }
 
-  public StorageLocationConfig getBaseTaskDirLocationForId(String taskId)
+  private StorageLocationConfig getBaseTaskDirLocationForId(String taskId)
   {
     if (taskId == null) {
       return null;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
@@ -255,7 +255,10 @@ public class TaskConfig
     }
     // TODO: consider the size of each of the base locations for distribution
     // use uniformly RANDOM assignment
-    int index = Math.abs(taskId.hashCode()) % baseTaskDirLocations.size();
+    int index = taskId.hashCode() % baseTaskDirLocations.size();
+    if (index < 0) {
+      index = -(index + 1);
+    }
     return baseTaskDirLocations.get(index);
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
@@ -262,9 +262,14 @@ public class TaskConfig
     return baseTaskDirLocations.get(index);
   }
 
-  public File getTaskDir(String taskId)
+  public File getTaskBaseDir(String taskId)
   {
     return getBaseTaskDirLocationForId(taskId).getPath();
+  }
+
+  public File getTaskDir(String taskId)
+  {
+    return new File(getTaskBaseDir(taskId), taskId);
   }
 
   public File getTaskWorkDir(String taskId)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
@@ -255,13 +255,13 @@ public class TaskConfig
     }
     // TODO: consider the size of each of the base locations for distribution
     // use uniformly RANDOM assignment
-    int index = taskId.hashCode() % baseTaskDirLocations.size();
+    int index = Math.abs(taskId.hashCode()) % baseTaskDirLocations.size();
     return baseTaskDirLocations.get(index);
   }
 
   public File getTaskDir(String taskId)
   {
-    return new File(getBaseTaskDirLocationForId(taskId).getPath(), taskId);
+    return getBaseTaskDirLocationForId(taskId).getPath();
   }
 
   public File getTaskWorkDir(String taskId)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
@@ -181,15 +181,15 @@ public abstract class BaseRestorableTaskRunner<WorkItemType extends TaskRunnerWo
   @GuardedBy("tasks")
   protected void saveRunningTasks()
   {
-    final Map<StorageLocationConfig, List<String>> fileToTasksMap = new HashMap<>();
+    final Map<File, List<String>> fileToTasksMap = new HashMap<>();
 
     for (TaskRunnerWorkItem taskRunnerWorkItem : tasks.values()) {
       String taskId = taskRunnerWorkItem.getTaskId();
-      StorageLocationConfig location = taskConfig.getBaseTaskDirLocationForId(taskId);
-      fileToTasksMap.computeIfAbsent(location, k -> new ArrayList<>()).add(taskId);
+      File baseDir = taskConfig.getTaskBaseDir(taskId);
+      fileToTasksMap.computeIfAbsent(baseDir, k -> new ArrayList<>()).add(taskId);
     }
 
-    for (Map.Entry<StorageLocationConfig, List<String>> entry : fileToTasksMap.entrySet()) {
+    for (Map.Entry<File, List<String>> entry : fileToTasksMap.entrySet()) {
       File restoreFile = getRestoreFile(entry.getKey());
       try {
         Files.createParentDirs(restoreFile);
@@ -206,9 +206,9 @@ public abstract class BaseRestorableTaskRunner<WorkItemType extends TaskRunnerWo
     return taskConfig.getBaseTaskDirChildrenLocations(TASK_RESTORE_FILENAME);
   }
 
-  private File getRestoreFile(StorageLocationConfig location)
+  private File getRestoreFile(File baseTaskDir)
   {
-    return taskConfig.getChildFileFromLocation(location, TASK_RESTORE_FILENAME);
+    return new File(baseTaskDir, TASK_RESTORE_FILENAME);
   }
 
   protected static class TaskRestoreInfo

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
@@ -186,8 +186,7 @@ public abstract class BaseRestorableTaskRunner<WorkItemType extends TaskRunnerWo
     for (TaskRunnerWorkItem taskRunnerWorkItem : tasks.values()) {
       String taskId = taskRunnerWorkItem.getTaskId();
       StorageLocationConfig location = taskConfig.getBaseTaskDirLocationForId(taskId);
-      fileToTasksMap.putIfAbsent(location, new ArrayList<>());
-      fileToTasksMap.get(location).add(taskId);
+      fileToTasksMap.computeIfAbsent(location, k -> new ArrayList<>()).add(taskId);
     }
 
     for (Map.Entry<StorageLocationConfig, List<String>> entry : fileToTasksMap.entrySet()) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -285,7 +285,7 @@ public class WorkerTaskManager
 
       try {
         FileUtils.writeAtomically(
-            new File(getAssignedTaskDir(task.getId()), task.getId()),
+            getAssignedTaskFile(task.getId()),
             getTmpTaskDir(task.getId()),
             os -> {
               jsonMapper.writeValue(os, task);
@@ -315,7 +315,7 @@ public class WorkerTaskManager
 
   private File getTmpTaskDir(String taskId)
   {
-    return new File(taskConfig.getTaskDir(taskId), TEMP_WORKER);
+    return new File(taskConfig.getTaskBaseDir(taskId), TEMP_WORKER);
   }
 
   private void cleanupAndMakeTmpTaskDirs() throws IOException
@@ -342,9 +342,9 @@ public class WorkerTaskManager
     }
   }
 
-  public File getAssignedTaskDir(String taskId)
+  public File getAssignedTaskFile(String taskId)
   {
-    return new File(taskConfig.getTaskDir(taskId), ASSIGNED);
+    return new File(new File(taskConfig.getTaskBaseDir(taskId), ASSIGNED), taskId);
   }
 
   public List<File> getAssignedTaskDirs()
@@ -402,7 +402,7 @@ public class WorkerTaskManager
   private void cleanupAssignedTask(Task task)
   {
     assignedTasks.remove(task.getId());
-    File taskFile = new File(getAssignedTaskDir(task.getId()), task.getId());
+    File taskFile = getAssignedTaskFile(task.getId());
     try {
       Files.delete(taskFile.toPath());
     }
@@ -466,9 +466,9 @@ public class WorkerTaskManager
                      .collect(Collectors.toList());
   }
 
-  public File getCompletedTaskDir(String taskId)
+  public File getCompletedTaskFile(String taskId)
   {
-    return new File(taskConfig.getTaskDir(taskId), COMPLETED);
+    return new File(new File(taskConfig.getTaskBaseDir(taskId), COMPLETED), taskId);
   }
 
   private void moveFromRunningToCompleted(String taskId, TaskAnnouncement taskAnnouncement)
@@ -479,7 +479,7 @@ public class WorkerTaskManager
 
       try {
         FileUtils.writeAtomically(
-            new File(getCompletedTaskDir(taskId), taskId), getTmpTaskDir(taskId),
+            getCompletedTaskFile(taskId), getTmpTaskDir(taskId),
             os -> {
               jsonMapper.writeValue(os, taskAnnouncement);
               return null;
@@ -599,7 +599,7 @@ public class WorkerTaskManager
                 );
 
                 completedTasks.remove(taskId);
-                File taskFile = new File(getCompletedTaskDir(taskId), taskId);
+                File taskFile = getCompletedTaskFile(taskId);
                 try {
                   Files.deleteIfExists(taskFile.toPath());
                   changeHistory.addChangeRequest(new WorkerHistoryItem.TaskRemoval(taskId));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -285,7 +285,7 @@ public class WorkerTaskManager
 
       try {
         FileUtils.writeAtomically(
-            new File(getAssignedTaskDirs(task.getId()), task.getId()),
+            new File(getAssignedTaskDir(task.getId()), task.getId()),
             getTmpTaskDir(task.getId()),
             os -> {
               jsonMapper.writeValue(os, task);
@@ -342,7 +342,7 @@ public class WorkerTaskManager
     }
   }
 
-  public File getAssignedTaskDirs(String taskId)
+  public File getAssignedTaskDir(String taskId)
   {
     return new File(taskConfig.getTaskDir(taskId), ASSIGNED);
   }
@@ -402,7 +402,7 @@ public class WorkerTaskManager
   private void cleanupAssignedTask(Task task)
   {
     assignedTasks.remove(task.getId());
-    File taskFile = new File(getAssignedTaskDirs(task.getId()), task.getId());
+    File taskFile = new File(getAssignedTaskDir(task.getId()), task.getId());
     try {
       Files.delete(taskFile.toPath());
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -190,11 +190,11 @@ public class WorkerTaskManagerTest
     }
 
     // create a task in assigned task directory, to simulate MM shutdown right after a task was assigned.
-    jsonMapper.writeValue(new File(workerTaskManager.getAssignedTaskDir(task1.getId()), task1.getId()), task1);
+    jsonMapper.writeValue(workerTaskManager.getAssignedTaskFile(task1.getId()), task1);
 
     // simulate an already completed task
     jsonMapper.writeValue(
-        new File(workerTaskManager.getCompletedTaskDir(task2.getId()), task2.getId()),
+        workerTaskManager.getCompletedTaskFile(task2.getId()),
         TaskAnnouncement.create(
             task2,
             TaskStatus.success(task2.getId()),
@@ -210,8 +210,8 @@ public class WorkerTaskManagerTest
       Thread.sleep(100);
     }
     Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task1.getId()).getTaskStatus().isSuccess());
-    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(task1.getId()), task1.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(task1.getId()), task1.getId()).exists());
+    Assert.assertTrue(workerTaskManager.getCompletedTaskFile(task1.getId()).exists());
+    Assert.assertFalse(workerTaskManager.getAssignedTaskFile(task1.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> baseHistory = workerTaskManager
         .getChangesSince(new ChangeRequestHistory.Counter(-1, 0))
@@ -243,8 +243,8 @@ public class WorkerTaskManagerTest
     }
 
     Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task3.getId()).getTaskStatus().isSuccess());
-    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(task3.getId()), task3.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(task3.getId()), task3.getId()).exists());
+    Assert.assertTrue(workerTaskManager.getCompletedTaskFile(task3.getId()).exists());
+    Assert.assertFalse(workerTaskManager.getAssignedTaskFile(task3.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> changes = workerTaskManager.getChangesSince(baseHistory.getCounter())
                                                                          .get();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -182,15 +182,19 @@ public class WorkerTaskManagerTest
     Task task2 = createNoopTask("task2-completed-already");
     Task task3 = createNoopTask("task3-assigned-explicitly");
 
-    FileUtils.mkdirp(workerTaskManager.getAssignedTaskDir());
-    FileUtils.mkdirp(workerTaskManager.getCompletedTaskDir());
+    for (File assignedTaskDir : workerTaskManager.getAssignedTaskDirs()) {
+      FileUtils.mkdirp(assignedTaskDir);
+    }
+    for (File completedTaskDir : workerTaskManager.getCompletedTaskDirs()) {
+      FileUtils.mkdirp(completedTaskDir);
+    }
 
     // create a task in assigned task directory, to simulate MM shutdown right after a task was assigned.
-    jsonMapper.writeValue(new File(workerTaskManager.getAssignedTaskDir(), task1.getId()), task1);
+    jsonMapper.writeValue(new File(workerTaskManager.getAssignedTaskDirs(task1.getId()), task1.getId()), task1);
 
     // simulate an already completed task
     jsonMapper.writeValue(
-        new File(workerTaskManager.getCompletedTaskDir(), task2.getId()),
+        new File(workerTaskManager.getCompletedTaskDir(task2.getId()), task2.getId()),
         TaskAnnouncement.create(
             task2,
             TaskStatus.success(task2.getId()),
@@ -206,8 +210,8 @@ public class WorkerTaskManagerTest
       Thread.sleep(100);
     }
     Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task1.getId()).getTaskStatus().isSuccess());
-    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(), task1.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(), task1.getId()).exists());
+    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(task1.getId()), task1.getId()).exists());
+    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDirs(task1.getId()), task1.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> baseHistory = workerTaskManager
         .getChangesSince(new ChangeRequestHistory.Counter(-1, 0))
@@ -239,8 +243,8 @@ public class WorkerTaskManagerTest
     }
 
     Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task3.getId()).getTaskStatus().isSuccess());
-    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(), task3.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(), task3.getId()).exists());
+    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(task3.getId()), task3.getId()).exists());
+    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDirs(task3.getId()), task3.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> changes = workerTaskManager.getChangesSince(baseHistory.getCounter())
                                                                          .get();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -190,7 +190,7 @@ public class WorkerTaskManagerTest
     }
 
     // create a task in assigned task directory, to simulate MM shutdown right after a task was assigned.
-    jsonMapper.writeValue(new File(workerTaskManager.getAssignedTaskDirs(task1.getId()), task1.getId()), task1);
+    jsonMapper.writeValue(new File(workerTaskManager.getAssignedTaskDir(task1.getId()), task1.getId()), task1);
 
     // simulate an already completed task
     jsonMapper.writeValue(
@@ -211,7 +211,7 @@ public class WorkerTaskManagerTest
     }
     Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task1.getId()).getTaskStatus().isSuccess());
     Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(task1.getId()), task1.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDirs(task1.getId()), task1.getId()).exists());
+    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(task1.getId()), task1.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> baseHistory = workerTaskManager
         .getChangesSince(new ChangeRequestHistory.Counter(-1, 0))
@@ -244,7 +244,7 @@ public class WorkerTaskManagerTest
 
     Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task3.getId()).getTaskStatus().isSuccess());
     Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(task3.getId()), task3.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDirs(task3.getId()), task3.getId()).exists());
+    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(task3.getId()), task3.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> changes = workerTaskManager.getChangesSince(baseHistory.getCounter())
                                                                          .get();


### PR DESCRIPTION
### Description

Enable usage of multiple base task directories for task data using List<StorageTaskLocation> instead of a single File.

The current change uses uniformly random assignment based on taskId to one of the locations.

TODO: Distribute tasks to Locations with count proportional to their maxSize.
TODO: Add tests to validate the behaviour with multiple disks
TODO: Documentation changes

Question: When the task directories change, is it necessary to ensure that restored tasks belong to the same disk they were restored from after being restored?


<br/>

NOTE: Enforcement of task data to Location maxSize limits has not been implemented


<hr>

##### Key changed/added classes in this PR
 * `TaskConfig`
 * `WorkerTaskManager`

<hr>


This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
