### PR TITLE
For the various Yielder objects, don't create new Yielders and instead mutate state.

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/guava/WrappingYielder.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/guava/WrappingYielder.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 final class WrappingYielder<OutType> implements Yielder<OutType>
 {
-  private final Yielder<OutType> baseYielder;
+  private Yielder<OutType> baseYielder;
   private final SequenceWrapper wrapper;
 
   WrappingYielder(Yielder<OutType> baseYielder, SequenceWrapper wrapper)
@@ -50,7 +50,8 @@ final class WrappingYielder<OutType> implements Yielder<OutType>
         @Override
         public Yielder<OutType> get()
         {
-          return new WrappingYielder<>(baseYielder.next(initValue), wrapper);
+          baseYielder = baseYielder.next(initValue);
+          return WrappingYielder.this;
         }
       });
     }

--- a/core/src/main/java/org/apache/druid/java/util/common/guava/Yielder.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/guava/Yielder.java
@@ -26,9 +26,13 @@ import java.io.Closeable;
  * necessarily good at this job, but it works.  I think.
  *
  * Essentially, you can think of a Yielder as a linked list of items where the Yielder gives you access to the current
- * head via get() and it will give you another Yielder representing the next item in the chain via next().  A Yielder
- * that isDone() may return anything from both get() and next(), there is no contract and depending on those return
- * values will likely lead to bugs.
+ * head via get() and it will give you another Yielder representing the next item in the chain via next().  When using
+ * a yielder object, a call to yield() on the yielding accumulator will result in a new Yielder being returned whose
+ * get() method will return the return value of the accumulator from the call that called yield().
+ *
+ * When a call to next() exhausts the underlying data stream without having a yield() call, various implementations
+ * of Sequences and Yielders assume that they will receive a Yielder where isDone() is true and get() will return the
+ * accumulated value up until that point.
  *
  * Once next is called, there is no guarantee and no requirement that references to old Yielder objects will continue
  * to obey the contract.
@@ -60,9 +64,8 @@ public interface Yielder<T> extends Closeable
   Yielder<T> next(T initValue);
 
   /**
-   * Returns true if this is the last Yielder in the chain.  A Yielder that isDone() may return anything
-   * from both get() and next(), there is no contract and depending on those return values will likely lead to bugs.
-   * It will probably break your code to call next() on a Yielder that is done and expect something good from it.
+   * Returns true if this is the last Yielder in the chain.  Review the class level javadoc for an understanding
+   * of the contract for other methods when isDone() is true.
    *
    * Once next() is called on this Yielder object, all further operations on this object are undefined.
    *


### PR DESCRIPTION
@cheddar wrote this patch, so I can't take credit for it. But I did test it, and it seems to work as advertised. It's part of a series of work we were doing to reduce allocations in the query path, which also includes #12468 and #12474.