### PR TITLE
Improve build performance of modules

### DIFF
--- a/extensions-core/druid-basic-security/pom.xml
+++ b/extensions-core/druid-basic-security/pom.xml
@@ -41,12 +41,12 @@
       <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-services</artifactId>
       <version>${project.parent.version}</version>
       <scope>provided</scope>
-    </dependency>
+    </dependency> -->
     <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-server</artifactId>

--- a/extensions-core/druid-basic-security/pom.xml
+++ b/extensions-core/druid-basic-security/pom.xml
@@ -41,12 +41,6 @@
       <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- <dependency>
-      <groupId>org.apache.druid</groupId>
-      <artifactId>druid-services</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>provided</scope>
-    </dependency> -->
     <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-server</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -49,12 +49,12 @@
             <version>${project.parent.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-console</artifactId>
             <version>${project.parent.version}</version>
             <scope>runtime</scope>
-        </dependency>
+        </dependency> -->
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-core</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -49,12 +49,6 @@
             <version>${project.parent.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <!-- <dependency>
-            <groupId>org.apache.druid</groupId>
-            <artifactId>druid-console</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>runtime</scope>
-        </dependency> -->
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-core</artifactId>


### PR DESCRIPTION
Fixes #12485

### Description
Removing unused dependencies between modules can improved parallelism of parallel builds.

This PR has:
- [ ] been self-reviewed.
