### PR TITLE
Update maven assembly plugin for druid-benchmarks

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -200,7 +200,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -210,7 +210,9 @@
             <configuration>
               <finalName>${uberjar.name}</finalName>
               <appendAssemblyId>false</appendAssemblyId>
-              <descriptor>assembly.xml</descriptor>
+              <descriptors>
+                <descriptor>assembly.xml</descriptor>
+              </descriptors>
               <archive>
                 <manifest>
                   <mainClass>org.openjdk.jmh.Main</mainClass>


### PR DESCRIPTION
### Description

Druid build was failing with on M1 machine with below Java and mvn version  - 

> nishant@Nishants-MacBook-Pro druid % java --version
> openjdk 11.0.15 2022-04-19
> OpenJDK Runtime Environment Homebrew (build 11.0.15+0)
> OpenJDK 64-Bit Server VM Homebrew (build 11.0.15+0, mixed mode)
> nishant@Nishants-MacBook-Pro druid % mvn -version
> Apache Maven 3.8.5 (3599d3414f046de2324203b78ddcf9b5e4388aa0)
> Maven home: /opt/homebrew/Cellar/maven/3.8.5/libexec
> Java version: 18, vendor: Homebrew, runtime: /opt/homebrew/Cellar/openjdk/18/libexec/openjdk.jdk/Contents/Home
> Default locale: en_IN, platform encoding: UTF-8
> OS name: "mac os x", version: "12.3.1", arch: "aarch64", family: "mac"

Error of issue faced - 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single (default) on project druid-benchmarks: Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-assembly-plugin:2.6:single: java.lang.ExceptionInInitializerError: null
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-assembly-plugin:2.6
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/nishant/.m2/repository/org/apache/maven/plugins/maven-assembly-plugin/2.6/maven-assembly-plugin-2.6.jar
[ERROR] urls[1] = file:/Users/nishant/.m2/repository/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.jar
[ERROR] urls[2] = file:/Users/nishant/.m2/repository/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.jar
[ERROR] urls[3] = file:/Users/nishant/.m2/repository/org/apache/maven/reporting/maven-reporting-api/2.2.1/maven-reporting-api-2.2.1.jar
[ERROR] urls[4] = file:/Users/nishant/.m2/repository/org/apache/maven/doxia/doxia-sink-api/1.1/doxia-sink-api-1.1.jar
[ERROR] urls[5] = file:/Users/nishant/.m2/repository/org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.jar
[ERROR] urls[6] = file:/Users/nishant/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
[ERROR] urls[7] = file:/Users/nishant/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar
[ERROR] urls[8] = file:/Users/nishant/.m2/repository/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar
[ERROR] urls[9] = file:/Users/nishant/.m2/repository/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar
[ERROR] urls[10] = file:/Users/nishant/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[11] = file:/Users/nishant/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[12] = file:/Users/nishant/.m2/repository/org/apache/maven/shared/maven-common-artifact-filters/1.4/maven-common-artifact-filters-1.4.jar
[ERROR] urls[13] = file:/Users/nishant/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.22/plexus-interpolation-1.22.jar
[ERROR] urls[14] = file:/Users/nishant/.m2/repository/org/codehaus/plexus/plexus-archiver/3.0.1/plexus-archiver-3.0.1.jar
[ERROR] urls[15] = file:/Users/nishant/.m2/repository/org/iq80/snappy/snappy/0.3/snappy-0.3.jar
[ERROR] urls[16] = file:/Users/nishant/.m2/repository/org/apache/maven/shared/file-management/1.1/file-management-1.1.jar
[ERROR] urls[17] = file:/Users/nishant/.m2/repository/org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.jar
[ERROR] urls[18] = file:/Users/nishant/.m2/repository/commons-io/commons-io/2.2/commons-io-2.2.jar
[ERROR] urls[19] = file:/Users/nishant/.m2/repository/org/apache/maven/shared/maven-filtering/1.3/maven-filtering-1.3.jar
[ERROR] urls[20] = file:/Users/nishant/.m2/repository/org/apache/maven/shared/maven-shared-utils/0.6/maven-shared-utils-0.6.jar
[ERROR] urls[21] = file:/Users/nishant/.m2/repository/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar
[ERROR] urls[22] = file:/Users/nishant/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar
[ERROR] urls[23] = file:/Users/nishant/.m2/repository/org/codehaus/plexus/plexus-io/2.6/plexus-io-2.6.jar
[ERROR] urls[24] = file:/Users/nishant/.m2/repository/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar
[ERROR] urls[25] = file:/Users/nishant/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.21/plexus-utils-3.0.21.jar
[ERROR] urls[26] = file:/Users/nishant/.m2/repository/org/apache/maven/shared/maven-repository-builder/1.0/maven-repository-builder-1.0.jar
[ERROR] urls[27] = file:/Users/nishant/.m2/repository/commons-codec/commons-codec/1.6/commons-codec-1.6.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
```

This PR updates the mvn-assembly plugin which seems to have resolved the build error. 

This PR has:
- [* ] been self-reviewed.
