### PR TITLE
Improve error messages when URI points to a file that doesn't exist

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/InputEntityIteratingReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/InputEntityIteratingReader.java
@@ -78,7 +78,9 @@ public class InputEntityIteratingReader implements InputSourceReader
         return reader.read();
       }
       catch (IOException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException(entity.getUri() != null ?
+                                   "Error occured while trying to read uri: " + entity.getUri() :
+                                   "Error occured while reading input", e);
       }
     });
   }

--- a/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
@@ -35,6 +35,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -94,5 +96,34 @@ public class InputEntityIteratingReaderTest
       }
       Assert.assertEquals(numFiles, i);
     }
+  }
+
+  @Test
+  public void testIncorrectURI() throws IOException, URISyntaxException
+  {
+    final InputEntityIteratingReader firehose = new InputEntityIteratingReader(
+        new InputRowSchema(
+            new TimestampSpec(null, null, null),
+            new DimensionsSpec(
+                DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "name", "score"))
+            ),
+            ColumnsFilter.all()
+        ),
+        new CsvInputFormat(
+            ImmutableList.of("time", "name", "score"),
+            null,
+            null,
+            false,
+            0
+        ),
+        ImmutableList.of(
+            new HttpEntity(new URI("http://test/path"), null, null)
+        ).iterator(),
+        temporaryFolder.newFolder()
+    );
+    String expectedMessage = "Error occured while trying to read uri: http://test/path";
+    Exception exception = Assert.assertThrows(RuntimeException.class, firehose::read);
+
+    Assert.assertTrue(exception.getMessage().contains(expectedMessage));
   }
 }

--- a/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.data.input.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
@@ -29,11 +28,9 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,12 +46,6 @@ public class InputEntityIteratingReaderTest
 {
   @Rule
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Before
-  public void setup()
-  {
-    NullHandling.initializeForTests();
-  }
 
   @Test
   public void test() throws IOException

--- a/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
@@ -28,9 +29,11 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,6 +49,12 @@ public class InputEntityIteratingReaderTest
 {
   @Rule
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void setup()
+  {
+    NullHandling.initializeForTests();
+  }
 
   @Test
   public void test() throws IOException
@@ -117,11 +126,11 @@ public class InputEntityIteratingReaderTest
             0
         ),
         ImmutableList.of(
-            new HttpEntity(new URI("http://test/path"), null, null)
+            new HttpEntity(new URI("testscheme://some/path"), null, null)
         ).iterator(),
         temporaryFolder.newFolder()
     );
-    String expectedMessage = "Error occured while trying to read uri: http://test/path";
+    String expectedMessage = "Error occured while trying to read uri: testscheme://some/path";
     Exception exception = Assert.assertThrows(RuntimeException.class, firehose::read);
 
     Assert.assertTrue(exception.getMessage().contains(expectedMessage));


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->
### GCS
`Before`
```
java.lang.RuntimeException: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found\nNo such object: gs_ingestion_test/wikipedia-2016-06-27-smpled.json
```

`After`
```
java.lang.RuntimeException: Error occured while trying to read uri: gs://gs_ingestion_test/wikipedia-2016-06-27-smpled.json"
...
...
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
No such object: gs_ingestion_test/wikipedia-2016-06-27-smpled.json
```

### S3
`Before`
```
java.io.IOException: com.amazonaws.services.s3.model.AmazonS3Exception: The specified key does not exist.
```

`After`
```
java.lang.RuntimeException: Error occured while trying to read uri: s3://s3-ingestion-test/wikipedia-2016-06-27-smpled.json"
...
...
java.io.IOException: com.amazonaws.services.s3.model.AmazonS3Exception: The specified key does not exist.
```
Fixes the error message thrown with input `uri` when `IOException` while converting `InputEntity` to `CloseableIterator<InputRow>`
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `InputEntityIteratingReader`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
