### PR TITLE
Refactor the testIsTaskCurrent test case to improve the test experience

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -3885,26 +3885,26 @@ public class KinesisSupervisorTest extends EasyMockSupport
   public KinesisSupervisor isCurrentSetup(DateTime minMessageTime, DateTime maxMessageTime)
   {
     KinesisSupervisor supervisor = getSupervisor(
-            1,
-            1,
-            true,
-            "PT1H",
-            new Period("P1D"),
-            new Period("P1D"),
-            false,
-            42,
-            42,
-            dataSchema,
-            tuningConfig
+        1,
+        1,
+        true,
+        "PT1H",
+        new Period("P1D"),
+        new Period("P1D"),
+        false,
+        42,
+        42,
+        dataSchema,
+        tuningConfig
     );
 
     supervisor.addTaskGroupToActivelyReadingTaskGroup(
-            42,
-            ImmutableMap.of(SHARD_ID1, "3"),
-            Optional.of(minMessageTime),
-            Optional.of(maxMessageTime),
-            ImmutableSet.of("id1", "id2", "id3", "id4"),
-            ImmutableSet.of()
+        42,
+        ImmutableMap.of(SHARD_ID1, "3"),
+        Optional.of(minMessageTime),
+        Optional.of(maxMessageTime),
+        ImmutableSet.of("id1", "id2", "id3", "id4"),
+        ImmutableSet.of()
     );
 
     return supervisor;
@@ -3916,22 +3916,22 @@ public class KinesisSupervisorTest extends EasyMockSupport
     DateTime minMessageTime = DateTimes.nowUtc();
     DateTime maxMessageTime = DateTimes.nowUtc().plus(10000);
 
-    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime,maxMessageTime);
+    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime, maxMessageTime);
 
     KinesisIndexTask taskFromStorage = createKinesisIndexTask(
-            "id1",
-            0,
-            new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of(
-                    SHARD_ID1,
-                    "3"
-            ), ImmutableSet.of()),
-            new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
-                    SHARD_ID1,
-                    KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
-            )),
-            minMessageTime,
-            maxMessageTime,
-            dataSchema
+        "id1",
+        0,
+        new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of(
+            SHARD_ID1,
+            "3"
+        ), ImmutableSet.of()),
+        new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
+            SHARD_ID1,
+            KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
+        )),
+        minMessageTime,
+        maxMessageTime,
+        dataSchema
     );
 
     EasyMock.expect(taskStorage.getTask("id1"))
@@ -3950,24 +3950,24 @@ public class KinesisSupervisorTest extends EasyMockSupport
     DateTime minMessageTime = DateTimes.nowUtc();
     DateTime maxMessageTime = DateTimes.nowUtc().plus(10000);
 
-    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime,maxMessageTime);
+    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime, maxMessageTime);
 
     DataSchema modifiedDataSchema = getDataSchema("some other datasource");
 
     KinesisIndexTask taskFromStorageMismatchedDataSchema = createKinesisIndexTask(
-            "id2",
-            0,
-            new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of(
-                    SHARD_ID1,
-                    "3"
-            ), ImmutableSet.of()),
-            new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
-                    SHARD_ID1,
-                    KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
-            )),
-            minMessageTime,
-            maxMessageTime,
-            modifiedDataSchema
+        "id2",
+        0,
+        new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of(
+            SHARD_ID1,
+            "3"
+        ), ImmutableSet.of()),
+        new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
+            SHARD_ID1,
+            KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
+        )),
+        minMessageTime,
+        maxMessageTime,
+        modifiedDataSchema
     );
 
     EasyMock.expect(taskStorage.getTask("id2"))
@@ -3986,61 +3986,61 @@ public class KinesisSupervisorTest extends EasyMockSupport
     DateTime minMessageTime = DateTimes.nowUtc();
     DateTime maxMessageTime = DateTimes.nowUtc().plus(10000);
 
-    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime,maxMessageTime);
+    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime, maxMessageTime);
 
     KinesisSupervisorTuningConfig modifiedTuningConfig = new KinesisSupervisorTuningConfig(
-            null,
-            1000,
-            null,
-            null,
-            50000,
-            null,
-            new Period("P1Y"),
-            new File("/test"),
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null,
-            null,
-            numThreads,
-            TEST_CHAT_THREADS,
-            TEST_CHAT_RETRIES,
-            TEST_HTTP_TIMEOUT,
-            TEST_SHUTDOWN_TIMEOUT,
-            null,
-            null,
-            null,
-            5000,
-            null,
-            null,
-            null,
-            null,
-            42, // This property is different from tuningConfig
-            null,
-            null,
-            null,
-            null,
-            null
+        null,
+        1000,
+        null,
+        null,
+        50000,
+        null,
+        new Period("P1Y"),
+        new File("/test"),
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        null,
+        numThreads,
+        TEST_CHAT_THREADS,
+        TEST_CHAT_RETRIES,
+        TEST_HTTP_TIMEOUT,
+        TEST_SHUTDOWN_TIMEOUT,
+        null,
+        null,
+        null,
+        5000,
+        null,
+        null,
+        null,
+        null,
+        42, // This property is different from tuningConfig
+        null,
+        null,
+        null,
+        null,
+        null
     );
 
     KinesisIndexTask taskFromStorageMismatchedTuningConfig = createKinesisIndexTask(
-            "id3",
-            0,
-            new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of(
-                    SHARD_ID1,
-                    "3"
-            ), ImmutableSet.of()),
-            new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
-                    SHARD_ID1,
-                    KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
-            )),
-            minMessageTime,
-            maxMessageTime,
-            dataSchema,
-            modifiedTuningConfig
+        "id3",
+        0,
+        new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of(
+            SHARD_ID1,
+            "3"
+        ), ImmutableSet.of()),
+        new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
+            SHARD_ID1,
+            KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
+        )),
+        minMessageTime,
+        maxMessageTime,
+        dataSchema,
+        modifiedTuningConfig
     );
 
     EasyMock.expect(taskStorage.getTask("id3"))
@@ -4059,26 +4059,26 @@ public class KinesisSupervisorTest extends EasyMockSupport
     DateTime minMessageTime = DateTimes.nowUtc();
     DateTime maxMessageTime = DateTimes.nowUtc().plus(10000);
 
-    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime,maxMessageTime);
+    KinesisSupervisor supervisor = isCurrentSetup(minMessageTime, maxMessageTime);
 
     KinesisIndexTask taskFromStorageMismatchedPartitionsWithTaskGroup = createKinesisIndexTask(
-            "id4",
-            0,
-            new SeekableStreamStartSequenceNumbers<>(
-                    "stream",
-                    ImmutableMap.of(
-                            SHARD_ID1,
-                            "4" // this is the mismatch
-                    ),
-                    ImmutableSet.of()
+        "id4",
+        0,
+        new SeekableStreamStartSequenceNumbers<>(
+            "stream",
+            ImmutableMap.of(
+                SHARD_ID1,
+                "4" // this is the mismatch
             ),
-            new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
-                    SHARD_ID1,
-                    KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
-            )),
-            minMessageTime,
-            maxMessageTime,
-            dataSchema
+            ImmutableSet.of()
+        ),
+        new SeekableStreamEndSequenceNumbers<>("stream", ImmutableMap.of(
+            SHARD_ID1,
+            KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER
+        )),
+        minMessageTime,
+        maxMessageTime,
+        dataSchema
     );
 
     EasyMock.expect(taskStorage.getTask("id4"))


### PR DESCRIPTION

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #12398 .

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

The test case [ testIsTaskCurrent ](https://github.com/apache/druid/tree/master/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java#L3885) is testing the `supervisor.isTaskCurrent()` with 4 different scenarios (`taskFromStorage`, `taskFromStorageMismatchedDataSchema`,`taskFromStorageMismatchedTuningConfig`,`taskFromStorageMismatchedPartitionsWithTaskGroup`) in one single test case. In my humble opinion, it could be beneficial to separate the four scenarios into four individual test cases. Each test case will focus on one scenario. 

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

So in this PR, based on the discussion in #12398 , the [ `testIsTaskCurrent()` ](https://github.com/apache/druid/tree/master/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java#L3885) is replaced by four unit tests `testIsTaskCurrentTaskFromStorage()`, `testIsTaskCurrentTaskFromStorageMismatchedDataSchema()`, `testIsTaskCurrentTaskFromStorageMismatchedTuningConfig()`, `testIsTaskCurrentTaskFromStorageMismatchedPartitionsWithTaskGroup()`, and one setup function `isCurrentSetup()`.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added class in this PR
 * `KinesisSupervisorTest`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
   - [X] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
