### PR TITLE
draft: Task table query optimizations

### DIFF
--- a/core/src/main/java/org/apache/druid/indexer/TaskInfoLite.java
+++ b/core/src/main/java/org/apache/druid/indexer/TaskInfoLite.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexer;
+
+import com.google.common.base.Preconditions;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class is used to store task info that is only necessary to some status queries in the OverlordResource
+ */
+public class TaskInfoLite
+{
+  private final String id;
+  private final String groupId;
+  private final String type;
+  private final String dataSource;
+  private final TaskLocation location;
+  private final DateTime createdTime;
+  private final String status;
+  private final Long duration;
+  private final @Nullable String errorMsg;
+
+  public TaskInfoLite(
+      String id,
+      String groupId,
+      String type,
+      String dataSource,
+      TaskLocation location,
+      DateTime createdTime,
+      String status,
+      Long duration,
+      @Nullable String errorMsg
+  )
+  {
+    this.id = Preconditions.checkNotNull(id, "id");
+    this.groupId = Preconditions.checkNotNull(groupId, "groupId");
+    this.type = Preconditions.checkNotNull(type, "type");
+    this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
+    this.location = Preconditions.checkNotNull(location, "location");
+    this.createdTime = Preconditions.checkNotNull(createdTime, "createdTime");
+    this.status = Preconditions.checkNotNull(status, "status");
+    this.duration = Preconditions.checkNotNull(duration, "duration");
+    this.errorMsg = errorMsg;
+  }
+
+  public String getId()
+  {
+    return id;
+  }
+
+  public String getGroupId()
+  {
+    return groupId;
+  }
+
+  public String getType()
+  {
+    return type;
+  }
+
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+
+  public TaskLocation getLocation()
+  {
+    return location;
+  }
+
+  public DateTime getCreatedTime()
+  {
+    return createdTime;
+  }
+
+  public TaskState getStatus()
+  {
+    switch(status) {
+      case "SUCCESS":
+        return TaskState.SUCCESS;
+      case "FAILED":
+        return TaskState.FAILED;
+      case "RUNNING":
+      default:
+        return TaskState.RUNNING;
+    }
+  }
+
+  public Long getDuration()
+  {
+    return duration;
+  }
+
+  public String getErrorMsg() {
+    return errorMsg;
+  }
+}

--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -102,12 +103,24 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
       @Nullable String datasource
   );
 
+  default List<TaskInfoLite> getCompletedTaskInfoLite(
+      DateTime timestamp,
+      @Nullable Integer maxNumStatuses,
+      @Nullable String datasource
+  ) {
+    return Collections.emptyList();
+  }
+
   /**
    * Return {@link TaskInfo} objects for all active entries
    *
    * @return list of {@link TaskInfo}
    */
   List<TaskInfo<EntryType, StatusType>> getActiveTaskInfo(@Nullable String dataSource);
+
+  default List<TaskInfoLite> getActiveTaskInfoLite(@Nullable String dataSource) {
+    return Collections.emptyList();
+  }
 
   /**
    * Add a lock to the given entry

--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
@@ -21,6 +21,7 @@ package org.apache.druid.metadata;
 
 import com.google.common.base.Optional;
 import org.apache.druid.indexer.TaskInfo;
+import org.apache.druid.indexer.TaskInfoLite;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -80,6 +81,11 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
 
   @Nullable
   TaskInfo<EntryType, StatusType> getTaskInfo(String entryId);
+
+  @Nullable
+  default TaskInfoLite getTaskInfoLite(String entryId) {
+    return null;
+  }
 
   /**
    * Return up to {@code maxNumStatuses} {@link TaskInfo} objects for all inactive entries

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
@@ -29,6 +29,7 @@ import org.apache.druid.metadata.MetadataCASUpdate;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
 import org.apache.druid.metadata.SQLMetadataConnector;
+import org.eclipse.jetty.util.ajax.JSON;
 import org.postgresql.PGProperty;
 import org.postgresql.util.PSQLException;
 import org.skife.jdbi.v2.DBI;
@@ -45,6 +46,7 @@ public class PostgreSQLConnector extends SQLMetadataConnector
 {
   private static final Logger log = new Logger(PostgreSQLConnector.class);
   private static final String PAYLOAD_TYPE = "BYTEA";
+  private static final String JSON_PAYLOAD_TYPE = "JSONB";
   private static final String SERIAL_TYPE = "BIGSERIAL";
   private static final String QUOTE_STRING = "\\\"";
   private static final String PSQL_SERIALIZATION_FAILURE_MSG =
@@ -124,6 +126,12 @@ public class PostgreSQLConnector extends SQLMetadataConnector
   public String getPayloadType()
   {
     return PAYLOAD_TYPE;
+  }
+
+  @Override
+  public String getJsonPayloadType()
+  {
+    return JSON_PAYLOAD_TYPE;
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import org.apache.druid.indexer.TaskInfo;
+import org.apache.druid.indexer.TaskInfoLite;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.actions.TaskAction;
@@ -184,6 +185,13 @@ public class MetadataTaskStorage implements TaskStorage
   public TaskInfo<Task, TaskStatus> getTaskInfo(String taskId)
   {
     return handler.getTaskInfo(taskId);
+  }
+
+  @Nullable
+  @Override
+  public TaskInfoLite getTaskInfoLite(String taskId)
+  {
+    return handler.getTaskInfoLite(taskId);
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
@@ -228,6 +228,14 @@ public class MetadataTaskStorage implements TaskStorage
   }
 
   @Override
+  public List<TaskInfoLite> getActiveTaskInfoLite(@Nullable String dataSource)
+  {
+    return ImmutableList.copyOf(
+        handler.getActiveTaskInfoLite(dataSource)
+    );
+  }
+
+  @Override
   public List<TaskInfo<Task, TaskStatus>> getRecentlyCreatedAlreadyFinishedTaskInfo(
       @Nullable Integer maxTaskStatuses,
       @Nullable Duration durationBeforeNow,
@@ -236,6 +244,23 @@ public class MetadataTaskStorage implements TaskStorage
   {
     return ImmutableList.copyOf(
         handler.getCompletedTaskInfo(
+            DateTimes.nowUtc()
+                     .minus(durationBeforeNow == null ? config.getRecentlyFinishedThreshold() : durationBeforeNow),
+            maxTaskStatuses,
+            datasource
+        )
+    );
+  }
+
+  @Override
+  public List<TaskInfoLite> getRecentlyCreatedAlreadyFinishedTaskInfoLite(
+      @Nullable Integer maxTaskStatuses,
+      @Nullable Duration durationBeforeNow,
+      @Nullable String datasource
+  )
+  {
+    return ImmutableList.copyOf(
+        handler.getCompletedTaskInfoLite(
             DateTimes.nowUtc()
                      .minus(durationBeforeNow == null ? config.getRecentlyFinishedThreshold() : durationBeforeNow),
             maxTaskStatuses,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.overlord;
 
 import com.google.common.base.Optional;
 import org.apache.druid.indexer.TaskInfo;
+import org.apache.druid.indexer.TaskInfoLite;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.actions.TaskAction;
@@ -108,6 +109,11 @@ public interface TaskStorage
 
   @Nullable
   TaskInfo<Task, TaskStatus> getTaskInfo(String taskId);
+
+  @Nullable
+  default TaskInfoLite getTaskInfoLite(String taskId) {
+    return null;
+  }
 
   /**
    * Add an action taken by a task to the audit log.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
@@ -30,6 +30,7 @@ import org.apache.druid.metadata.EntryExistsException;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 
 public interface TaskStorage
@@ -161,6 +162,10 @@ public interface TaskStorage
    */
   List<TaskInfo<Task, TaskStatus>> getActiveTaskInfo(@Nullable String dataSource);
 
+  default List<TaskInfoLite> getActiveTaskInfoLite(@Nullable String dataSource) {
+    return Collections.emptyList();
+  }
+
   /**
    * Returns up to {@code maxTaskStatuses} {@link TaskInfo} objects of recently finished tasks as stored in the storage
    * facility. No particular order is guaranteed, but implementations are encouraged to return tasks in descending order
@@ -178,6 +183,14 @@ public interface TaskStorage
       @Nullable Duration durationBeforeNow,
       @Nullable String datasource
   );
+
+  default List<TaskInfoLite> getRecentlyCreatedAlreadyFinishedTaskInfoLite(
+      @Nullable Integer maxTaskStatuses,
+      @Nullable Duration durationBeforeNow,
+      @Nullable String datasource
+  ) {
+    return Collections.emptyList();
+  }
 
   /**
    * Returns a list of locks for a particular task.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -79,6 +79,19 @@ public class TaskStorageQueryAdapter
     return storage.getActiveTaskInfo(dataSource);
   }
 
+  public List<TaskInfoLite> getActiveTaskInfoLite(@Nullable String dataSource)
+  {
+    return storage.getActiveTaskInfoLite(dataSource);
+  }
+  public List<TaskInfoLite> getCompletedTaskInfoByCreatedTimeDurationLite(
+      @Nullable Integer maxTaskStatuses,
+      @Nullable Duration duration,
+      @Nullable String dataSource
+  )
+  {
+    return storage.getRecentlyCreatedAlreadyFinishedTaskInfoLite(maxTaskStatuses, duration, dataSource);
+  }
+
   public List<TaskInfo<Task, TaskStatus>> getCompletedTaskInfoByCreatedTimeDuration(
       @Nullable Integer maxTaskStatuses,
       @Nullable Duration duration,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.overlord;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import org.apache.druid.indexer.TaskInfo;
+import org.apache.druid.indexer.TaskInfoLite;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.actions.SegmentInsertAction;
 import org.apache.druid.indexing.common.actions.SegmentTransactionalInsertAction;
@@ -101,6 +102,12 @@ public class TaskStorageQueryAdapter
   public TaskInfo<Task, TaskStatus> getTaskInfo(String taskId)
   {
     return storage.getTaskInfo(taskId);
+  }
+
+  @Nullable
+  public TaskInfoLite getTaskInfoLite(String taskId)
+  {
+    return storage.getTaskInfoLite(taskId);
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -264,7 +264,17 @@ public class OverlordResource
   @Path("/task/{taskid}/status")
   @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(TaskResourceFilter.class)
-  public Response getTaskStatus(@PathParam("taskid") String taskid)
+  public Response getTaskStatus(
+      @PathParam("taskid") String taskid,
+      @QueryParam("lite") final Boolean isLite
+  )
+  {
+    return isLite != null && isLite
+           ? getTaskStatusLite(taskid)
+           : getTaskStatus(taskid);
+  }
+
+  protected Response getTaskStatusLite(String taskid)
   {
     final TaskInfoLite taskInfo = taskStorageQueryAdapter.getTaskInfoLite(taskid);
     TaskStatusResponse response = null;
@@ -331,12 +341,7 @@ public class OverlordResource
     return Response.status(status).entity(response).build();
   }
 
-  /*
-  @GET
-  @Path("/task/{taskid}/status")
-  @Produces(MediaType.APPLICATION_JSON)
-  @ResourceFilters(TaskResourceFilter.class)
-  public Response getTaskStatus(@PathParam("taskid") String taskid)
+  protected Response getTaskStatus(String taskid)
   {
     final TaskInfo<Task, TaskStatus> taskInfo = taskStorageQueryAdapter.getTaskInfo(taskid);
     TaskStatusResponse response = null;
@@ -402,7 +407,6 @@ public class OverlordResource
 
     return Response.status(status).entity(response).build();
   }
-  */
 
   @Deprecated
   @GET

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -447,7 +447,7 @@ public class OverlordResourceTest
         workerTaskRunnerQueryAdapter
     );
     List<TaskStatusPlus> responseObjects = (List<TaskStatusPlus>) overlordResource
-        .getTasks(null, null, null, null, null, req)
+        .getTasks(null, null, null, null, null, null, req)
         .getEntity();
     Assert.assertEquals(4, responseObjects.size());
   }
@@ -543,7 +543,7 @@ public class OverlordResourceTest
     );
 
     List<TaskStatusPlus> responseObjects = (List<TaskStatusPlus>) overlordResource
-        .getTasks(null, "allow", null, null, null, req)
+        .getTasks(null, "allow", null, null, null, null, req)
         .getEntity();
     Assert.assertEquals(7, responseObjects.size());
     Assert.assertEquals("id_5", responseObjects.get(0).getId());
@@ -610,6 +610,7 @@ public class OverlordResourceTest
             null,
             null,
             null,
+            null,
             req
         ).getEntity();
     Assert.assertEquals(1, responseObjects.size());
@@ -672,7 +673,7 @@ public class OverlordResourceTest
     );
 
     List<TaskStatusPlus> responseObjects = (List) overlordResource
-        .getTasks("running", "allow", null, null, null, req)
+        .getTasks("running", "allow", null, null, null, null, req)
         .getEntity();
 
     Assert.assertEquals(2, responseObjects.size());
@@ -737,7 +738,7 @@ public class OverlordResourceTest
     );
 
     List<TaskStatusPlus> responseObjects = (List<TaskStatusPlus>) overlordResource
-        .getTasks("pending", null, null, null, null, req)
+        .getTasks("pending", null, null, null, null, null, req)
         .getEntity();
 
     Assert.assertEquals(1, responseObjects.size());
@@ -784,7 +785,7 @@ public class OverlordResourceTest
         workerTaskRunnerQueryAdapter
     );
     List<TaskStatusPlus> responseObjects = (List<TaskStatusPlus>) overlordResource
-        .getTasks("complete", null, null, null, null, req)
+        .getTasks("complete", null, null, null, null, null, req)
         .getEntity();
     Assert.assertEquals(2, responseObjects.size());
     Assert.assertEquals("id_1", responseObjects.get(0).getId());
@@ -834,7 +835,7 @@ public class OverlordResourceTest
     );
     String interval = "2010-01-01_P1D";
     List<TaskStatusPlus> responseObjects = (List<TaskStatusPlus>) overlordResource
-        .getTasks("complete", null, interval, null, null, req)
+        .getTasks("complete", null, interval, null, null, null, req)
         .getEntity();
     Assert.assertEquals(2, responseObjects.size());
     Assert.assertEquals("id_2", responseObjects.get(0).getId());
@@ -879,7 +880,7 @@ public class OverlordResourceTest
         workerTaskRunnerQueryAdapter
     );
     List<TaskStatusPlus> responseObjects = (List<TaskStatusPlus>) overlordResource
-        .getTasks("complete", null, null, null, null, req)
+        .getTasks("complete", null, null, null, null, null, req)
         .getEntity();
     Assert.assertEquals(2, responseObjects.size());
     Assert.assertEquals("id_1", responseObjects.get(0).getId());
@@ -900,7 +901,7 @@ public class OverlordResourceTest
         workerTaskRunnerQueryAdapter
     );
     Object responseObject = overlordResource
-        .getTasks("blah", "ds_test", null, null, null, req)
+        .getTasks("blah", "ds_test", null, null, null, null, req)
         .getEntity();
     Assert.assertEquals(
         "Invalid state : blah, valid values are: [pending, waiting, running, complete]",

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -56,6 +56,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 {
   private static final Logger log = new Logger(SQLMetadataConnector.class);
   private static final String PAYLOAD_TYPE = "BLOB";
+  private static final String JSON_PAYLOAD_TYPE = "CLOB";
   private static final String COLLATION = "";
 
   static final int DEFAULT_MAX_TRIES = 10;
@@ -86,6 +87,11 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   public String getPayloadType()
   {
     return PAYLOAD_TYPE;
+  }
+
+  public String getJsonPayloadType()
+  {
+    return JSON_PAYLOAD_TYPE;
   }
 
   /**
@@ -334,13 +340,15 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 "CREATE TABLE %1$s (\n"
                 + "  id VARCHAR(255) NOT NULL,\n"
                 + "  created_date VARCHAR(255) NOT NULL,\n"
-                + "  datasource VARCHAR(255) %3$s NOT NULL,\n"
+                + "  datasource VARCHAR(255) %4$s NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
+                + "  payload_json %3$s NOT NULL,\n"
                 + "  status_payload %2$s NOT NULL,\n"
+                + "  status_payload_json %3$s NOT NULL,\n"
                 + "  active BOOLEAN NOT NULL DEFAULT FALSE,\n"
                 + "  PRIMARY KEY (id)\n"
                 + ")",
-                tableName, getPayloadType(), getCollation()
+                tableName, getPayloadType(), getJsonPayloadType(), getCollation()
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_active_created_date ON %1$s(active, created_date)", tableName)
         )

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -146,8 +146,10 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
       getConnector().retryWithHandle(
           (HandleCallback<Void>) handle -> {
             final String sql = StringUtils.format(
-                "INSERT INTO %s (id, created_date, datasource, payload, active, status_payload) "
-                + "VALUES (:id, :created_date, :datasource, :payload, :active, :status_payload)",
+                "INSERT INTO %s (id, created_date, datasource, payload, payload_json, active, status_payload, "
+                + "status_payload_json) "
+                + "VALUES (:id, :created_date, :datasource, :payload, CAST(:payload_json as jsonb), :active, "
+                + ":status_payload, CAST(:status_payload_json as jsonb))",
                 getEntryTable()
             );
             handle.createStatement(sql)
@@ -155,8 +157,10 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
                   .bind("created_date", timestamp.toString())
                   .bind("datasource", dataSource)
                   .bind("payload", jsonMapper.writeValueAsBytes(entry))
+                  .bind("payload_json", jsonMapper.writeValueAsString(entry))
                   .bind("active", active)
                   .bind("status_payload", jsonMapper.writeValueAsBytes(status))
+                  .bind("status_payload_json", jsonMapper.writeValueAsString(status))
                   .execute();
             return null;
           },

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -330,7 +330,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
     return query;
   }
 
-  private String getWhereClauseForActiveStatusesQuery(String dataSource)
+  protected String getWhereClauseForActiveStatusesQuery(String dataSource)
   {
     String sql = StringUtils.format("active = TRUE ");
     if (dataSource != null) {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Posting an early and rough draft of the work I've started a few weeks back, given that https://github.com/apache/druid/pull/12404 was also opened recently and was just brought to my attention. The PR here and https://github.com/apache/druid/pull/12404 share similar goals regarding the optimization of queries on the tasks endpoints. 

The approach I follow is a bit different, after I evaluated tradeoffs between adding new columns for specific subfields (as https://github.com/apache/druid/pull/12404 proposes) as well as writing queries that would deserialize the payload on the fly and this approach. 

In this PR the suggestion is to keep querying the payload columns, but select specific subfields after we effectively change the type of the columns to be JSONB instead of BYTEA. This change is currently applicable to the Postgres backend with a port to MySQL to be potentially possible as well, while support for the non-production backend of Derby doesn't seem straightforward at the moment (this partly explains why this PR lacks tests at the moment and for this reason is not ready for a full review). The PR also adds a query parameter to two task endpoints in order to get the specific fields required by the web console. 

Regarding the tradeoffs of this approach, here's a quick list of things I can think of: 

PROS: 
* We don't commit to the addition of extra columns that would require schema evolution in the future. They new payload columns should replace the old ones.
* Based on some basic experiments with roughly 80K tasks the storage was moderately increased (less than 20%) which might not be significant for this metadata table. 
* Querying the new columns to extract the json subfields is comparable to the current query execution times. 

CONS: 
* The fields that we are interested in are not elevated as first class columns and are kept embedded in the JSON payloads. 
* Storage and query times might still be slightly higher than adding the specific fields as individual columns. 

This PR is currently lacking code to migrate task history and tests. This is something I would add if we think this could be plausible approach. Also any new names are not necessarily final or well thought out suggestions.

Note that this PR is based off of the 0.22.1 branch but will rebase on top of `master` if any of the changes here are valuable. 

Also, please note that this is my first contribution to the Druid project and this PR probably reflects this fact in various ways. 

I'd appreciate some high level comments on the direction of this early draft and whether we think that it's an approach that we could follow or combine with the one proposed in https://github.com/apache/druid/pull/12404. 

cc @imply-cheddar @AmatyaAvadhanula @xvrl 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
