### PR TITLE
Web console: fix go to segments not working

### DIFF
--- a/web-console/src/views/datasources-view/datasources-view.tsx
+++ b/web-console/src/views/datasources-view/datasources-view.tsx
@@ -349,7 +349,7 @@ ORDER BY 1`;
 
     const datasourceFilter: Filter[] = [];
     if (props.initDatasource) {
-      datasourceFilter.push({ id: 'datasource', value: `"${props.initDatasource}"` });
+      datasourceFilter.push({ id: 'datasource', value: `=${props.initDatasource}` });
     }
 
     this.state = {

--- a/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
+++ b/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
@@ -217,7 +217,7 @@ exports[`IngestionView matches snapshot 1`] = `
           Array [
             Object {
               "id": "datasource",
-              "value": "datasource",
+              "value": "=datasource",
             },
           ]
         }
@@ -536,11 +536,11 @@ exports[`IngestionView matches snapshot 1`] = `
           Array [
             Object {
               "id": "group_id",
-              "value": "test",
+              "value": "=test",
             },
             Object {
               "id": "datasource",
-              "value": "datasource",
+              "value": "=datasource",
             },
           ]
         }

--- a/web-console/src/views/ingestion-view/ingestion-view.tsx
+++ b/web-console/src/views/ingestion-view/ingestion-view.tsx
@@ -219,11 +219,12 @@ ORDER BY "rank" DESC, "created_time" DESC`;
     super(props, context);
 
     const taskFilter: Filter[] = [];
-    if (props.taskGroupId) taskFilter.push({ id: 'group_id', value: props.taskGroupId });
-    if (props.datasourceId) taskFilter.push({ id: 'datasource', value: props.datasourceId });
+    if (props.taskGroupId) taskFilter.push({ id: 'group_id', value: `=${props.taskGroupId}` });
+    if (props.datasourceId) taskFilter.push({ id: 'datasource', value: `=${props.datasourceId}` });
 
     const supervisorFilter: Filter[] = [];
-    if (props.datasourceId) supervisorFilter.push({ id: 'datasource', value: props.datasourceId });
+    if (props.datasourceId)
+      supervisorFilter.push({ id: 'datasource', value: `=${props.datasourceId}` });
 
     this.state = {
       supervisorsState: QueryState.INIT,

--- a/web-console/src/views/segments-view/__snapshots__/segments-view.spec.tsx.snap
+++ b/web-console/src/views/segments-view/__snapshots__/segments-view.spec.tsx.snap
@@ -352,7 +352,7 @@ exports[`SegmentsView matches snapshot 1`] = `
         Array [
           Object {
             "id": "datasource",
-            "value": "\\"test\\"",
+            "value": "=test",
           },
         ]
       }

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -252,7 +252,7 @@ END AS "time_span"`,
     super(props, context);
 
     const segmentFilter: Filter[] = [];
-    if (props.datasource) segmentFilter.push({ id: 'datasource', value: `"${props.datasource}"` });
+    if (props.datasource) segmentFilter.push({ id: 'datasource', value: `=${props.datasource}` });
     if (props.onlyUnavailable) segmentFilter.push({ id: 'is_available', value: 'false' });
 
     this.state = {


### PR DESCRIPTION
Following https://github.com/apache/druid/pull/12489 the filter syntax was updated but the init filters that are used by functions like `goToSegment` were not updated. As a result right now clicking on the segments link in the datasource view takes you to the segments view but yields no results which is confusing.

<img width="232" alt="image" src="https://user-images.githubusercontent.com/177816/169219643-ffda101b-c14d-4d55-93f5-cffecb180ddd.png">
