### PR TITLE
fix regression with ipv4_match and prefixes

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressExprUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressExprUtils.java
@@ -68,6 +68,16 @@ public class IPv4AddressExprUtils
     return null;
   }
 
+  @Nullable
+  public static IPAddressString parseString(@Nullable String string)
+  {
+    IPAddressString ipAddressString = new IPAddressString(string, IPV4_ADDRESS_PARAMS);
+    if (ipAddressString.isIPv4()) {
+      return ipAddressString;
+    }
+    return null;
+  }
+
   /**
    * @return IPv4 address if the supplied integer is a valid IPv4 integer number.
    */

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.query.expression;
 
+import inet.ipaddr.AddressStringException;
+import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 import inet.ipaddr.ipv4.IPv4Address;
 import org.apache.druid.java.util.common.IAE;
@@ -71,71 +73,75 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
       throw new IAE(ExprUtils.createErrMsg(name(), "must have 2 arguments"));
     }
 
-    IPAddressString subnetInfo = getSubnetInfo(args);
-    Expr arg = args.get(0);
+    try {
+      final Expr arg = args.get(0);
+      final IPAddressString blockString = getSubnetInfo(args);
+      final IPAddress block = blockString.toAddress().toPrefixBlock();
 
-    class IPv4AddressMatchExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
-    {
-      private final IPAddressString subnetString;
-
-      private IPv4AddressMatchExpr(Expr arg, IPAddressString subnetString)
+      class IPv4AddressMatchExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
       {
-        super(FN_NAME, arg);
-        this.subnetString = subnetString;
-      }
-
-      @Nonnull
-      @Override
-      public ExprEval eval(final ObjectBinding bindings)
-      {
-        ExprEval eval = arg.eval(bindings);
-        boolean match;
-        switch (eval.type().getType()) {
-          case STRING:
-            match = isStringMatch(eval.asString());
-            break;
-          case LONG:
-            match = !eval.isNumericNull() && isLongMatch(eval.asLong());
-            break;
-          default:
-            match = false;
+        private IPv4AddressMatchExpr(Expr arg)
+        {
+          super(FN_NAME, arg);
         }
-        return ExprEval.ofLongBoolean(match);
+
+        @Nonnull
+        @Override
+        public ExprEval eval(final ObjectBinding bindings)
+        {
+          ExprEval eval = arg.eval(bindings);
+          boolean match;
+          switch (eval.type().getType()) {
+            case STRING:
+              match = isStringMatch(eval.asString());
+              break;
+            case LONG:
+              match = !eval.isNumericNull() && isLongMatch(eval.asLong());
+              break;
+            default:
+              match = false;
+          }
+          return ExprEval.ofLongBoolean(match);
+        }
+
+        private boolean isStringMatch(String stringValue)
+        {
+          IPAddressString iPv4Address = IPv4AddressExprUtils.parseString(stringValue);
+          return iPv4Address != null && blockString.prefixContains(iPv4Address);
+        }
+
+        private boolean isLongMatch(long longValue)
+        {
+          IPv4Address iPv4Address = IPv4AddressExprUtils.parse(longValue);
+          return iPv4Address != null && block.contains(iPv4Address);
+        }
+
+        @Override
+        public Expr visit(Shuttle shuttle)
+        {
+          return shuttle.visit(apply(shuttle.visitAll(args)));
+        }
+
+        @Nullable
+        @Override
+        public ExpressionType getOutputType(InputBindingInspector inspector)
+        {
+          return ExpressionType.LONG;
+        }
+
+        @Override
+        public String stringify()
+        {
+          return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(ARG_SUBNET).stringify());
+        }
       }
 
-      private boolean isStringMatch(String stringValue)
-      {
-        IPv4Address iPv4Address = IPv4AddressExprUtils.parse(stringValue);
-        return iPv4Address != null && subnetString.prefixContains(iPv4Address.toAddressString());
-      }
-
-      private boolean isLongMatch(long longValue)
-      {
-        IPv4Address iPv4Address = IPv4AddressExprUtils.parse(longValue);
-        return iPv4Address != null && subnetString.prefixContains(iPv4Address.toAddressString());
-      }
-
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
-      @Nullable
-      @Override
-      public ExpressionType getOutputType(InputBindingInspector inspector)
-      {
-        return ExpressionType.LONG;
-      }
-
-      @Override
-      public String stringify()
-      {
-        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(ARG_SUBNET).stringify());
-      }
+      return new IPv4AddressMatchExpr(arg);
     }
 
-    return new IPv4AddressMatchExpr(arg, subnetInfo);
+    catch (AddressStringException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private IPAddressString getSubnetInfo(List<Expr> args)

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
@@ -75,6 +75,8 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
 
     try {
       final Expr arg = args.get(0);
+      // we use 'blockString' for string matching with 'prefixContains' because we parse them into IPAddressString
+      // for longs, we convert into a prefix block use 'block' and 'contains' so avoid converting to IPAddressString
       final IPAddressString blockString = getSubnetInfo(args);
       final IPAddress block = blockString.toAddress().toPrefixBlock();
 
@@ -106,14 +108,14 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
 
         private boolean isStringMatch(String stringValue)
         {
-          IPAddressString iPv4Address = IPv4AddressExprUtils.parseString(stringValue);
-          return iPv4Address != null && blockString.prefixContains(iPv4Address);
+          IPAddressString addressString = IPv4AddressExprUtils.parseString(stringValue);
+          return addressString != null && blockString.prefixContains(addressString);
         }
 
         private boolean isLongMatch(long longValue)
         {
-          IPv4Address iPv4Address = IPv4AddressExprUtils.parse(longValue);
-          return iPv4Address != null && block.contains(iPv4Address);
+          IPv4Address address = IPv4AddressExprUtils.parse(longValue);
+          return address != null && block.contains(address);
         }
 
         @Override

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
@@ -106,13 +106,13 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
       private boolean isStringMatch(String stringValue)
       {
         IPv4Address iPv4Address = IPv4AddressExprUtils.parse(stringValue);
-        return iPv4Address != null && subnetString.contains(iPv4Address.toAddressString());
+        return iPv4Address != null && subnetString.prefixContains(iPv4Address.toAddressString());
       }
 
       private boolean isLongMatch(long longValue)
       {
         IPv4Address iPv4Address = IPv4AddressExprUtils.parse(longValue);
-        return iPv4Address != null && subnetString.contains(iPv4Address.toAddressString());
+        return iPv4Address != null && subnetString.prefixContains(iPv4Address.toAddressString());
       }
 
       @Override

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
@@ -184,6 +184,23 @@ public class IPv4AddressMatchExprMacroTest extends MacroTestBase
     Assert.assertFalse(eval(ExprEval.of("192.168.1.240").toExpr(), ExprEval.of("192.168.1.251/31").toExpr()));
     Assert.assertFalse(eval(ExprEval.of("192.168.1.250").toExpr(), ExprEval.of("192.168.1.251/32").toExpr()));
     Assert.assertTrue(eval(ExprEval.of("192.168.1.251").toExpr(), ExprEval.of("192.168.1.251/32").toExpr()));
+
+    Assert.assertTrue(eval(
+        ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.250").longValue()).toExpr(),
+        ExprEval.of("192.168.1.251/31").toExpr()
+    ));
+    Assert.assertFalse(eval(
+        ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.240").longValue()).toExpr(),
+        ExprEval.of("192.168.1.251/31").toExpr()
+    ));
+    Assert.assertFalse(eval(
+        ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.250").longValue()).toExpr(),
+        ExprEval.of("192.168.1.251/32").toExpr()
+    ));
+    Assert.assertTrue(eval(
+        ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.251").longValue()).toExpr(),
+        ExprEval.of("192.168.1.251/32").toExpr()
+    ));
   }
 
   private boolean eval(Expr... args)

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
@@ -177,6 +177,15 @@ public class IPv4AddressMatchExprMacroTest extends MacroTestBase
     Assert.assertTrue(eval(IPV4_BROADCAST, subnet));
   }
 
+  @Test
+  public void testMatchesPrefix()
+  {
+    Assert.assertTrue(eval(ExprEval.of("192.168.1.250").toExpr(), ExprEval.of("192.168.1.251/31").toExpr()));
+    Assert.assertFalse(eval(ExprEval.of("192.168.1.240").toExpr(), ExprEval.of("192.168.1.251/31").toExpr()));
+    Assert.assertFalse(eval(ExprEval.of("192.168.1.250").toExpr(), ExprEval.of("192.168.1.251/32").toExpr()));
+    Assert.assertTrue(eval(ExprEval.of("192.168.1.251").toExpr(), ExprEval.of("192.168.1.251/32").toExpr()));
+  }
+
   private boolean eval(Expr... args)
   {
     Expr expr = apply(Arrays.asList(args));


### PR DESCRIPTION
### Description
Follow up to #11634, this PR fixes a regression when matching some prefixes, which in cases like`ip_match('192.168.1.250', '192.168.1.251/31')` was now evaluating to false. The solution is to use `prefixContains` (when matching strings) instead of `contains`. Added tests to ensure that this behaves as it did previously and this evaluates to true. I've also modified long matching to instead of converting every long row from an `IPv4Address` to an `IPAddressString`, to instead use `toPrefixBlock` and `contains` on the block, which seems ~4x faster (see benchmarks in the comment, `longContainsUsingIpAddr` is using the new approach while `longContainsUsingIpAddrWithStrings` is the old).

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
