### PR TITLE
CVE suppression (#12535)

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -300,6 +300,11 @@
     <cve>CVE-2019-20445</cve>
     <cve>CVE-2021-37136</cve>
     <cve>CVE-2021-37137</cve>
+    <cve>CVE-2021-4104</cve>
+    <cve>CVE-2020-9493</cve>
+    <cve>CVE-2022-23307</cve>
+    <cve>CVE-2022-23305</cve>
+    <cve>CVE-2022-23302</cve>
   </suppress>
   <suppress>
        <!--
@@ -383,6 +388,7 @@
     <cve>CVE-2021-29943</cve>
     <cve>CVE-2021-27905</cve>
     <cve>CVE-2021-29262</cve>
+    <cve>CVE-2021-44548</cve>
   </suppress>
 
   <suppress>
@@ -480,6 +486,31 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.asynchttpclient/async-http-client-netty-utils@2.5.3$</packageUrl>
     <cve>CVE-2021-43138</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Jackson CVEs when processing objects of large depth. Consider updating -->
+    <notes><![CDATA[
+   file name: *jackson-*.jar
+   ]]></notes>
+    <cve>CVE-2020-36518</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Non-applicable CVE for gson -->
+    <notes><![CDATA[
+   file name: gson-*.jar
+   ]]></notes>
+    <cve>CVE-2022-25647</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Non-applicable CVE for jedis, since we don't use lua scripts -->
+    <notes><![CDATA[
+   file name: jedis-2.9.0.jar
+   ]]></notes>
+    <cve>CVE-2021-32626</cve>
+    <cve>CVE-2022-24735</cve>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
Backport #12535 to release 0.23.0


Suppress

1) Ambari -> ambari-metrics-common-2.7.0.0.0.jar -> CVE-2021-4104, CVE-2020-9493, CVE-2022-23307, CVE-2022-23305, CVE-2022-23302 

- The CVEs are being suppressed since Ambari hasn't been updated in a long time. Might consider eliminating this dependency in the future


2) GSON -> gson-\*.jar -> CVE-2022-25647

- This CVE only affects code using java serialization and doesn't affect druid. (https://github.com/google/gson/pull/1991#issuecomment-1121629844)


3) Jackson -> \*jackson-\*.jar -> CVE-2020-36518

- The issue may occur due to large object depth when using jackson. Suppressing for now. A jackson update to mitigate this is being considered as well. One such PR is https://github.com/apache/druid/pull/12411


4) Jedis -> jedis-2.9.0.jar -> CVE-2021-32626, CVE-2022-24735

- The Jedis vulnerabilities are due to lua script execution in Redis. This is not applicable to druid


5) Solr -> solr-solrj-7.7.1.jar -> CVE-2021-44548

- This CVE only affects Windows and is not applicable to druid
