### PR TITLE
[Backport] Updates default inputSegmentSizeBytes in Compaction config (#12534)

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -34,7 +34,8 @@ public class DataSourceCompactionConfig
 {
   /** Must be synced with Tasks.DEFAULT_MERGE_TASK_PRIORITY */
   public static final int DEFAULT_COMPACTION_TASK_PRIORITY = 25;
-  private static final long DEFAULT_INPUT_SEGMENT_SIZE_BYTES = Long.MAX_VALUE;
+  // Approx. 100TB. Chosen instead of Long.MAX_VALUE to avoid overflow on web-console and other clients
+  private static final long DEFAULT_INPUT_SEGMENT_SIZE_BYTES = 100_000_000_000_000L;
   private static final Period DEFAULT_SKIP_OFFSET_FROM_LATEST = new Period("P1D");
 
   private final String dataSource;

--- a/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
@@ -61,7 +61,7 @@ public class DataSourceCompactionConfigTest extends InitializedNullHandlingTest
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "dataSource",
         null,
-        500L,
+        null,
         null,
         new Period(3600),
         null,
@@ -77,7 +77,7 @@ public class DataSourceCompactionConfigTest extends InitializedNullHandlingTest
 
     Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
     Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assert.assertEquals(100_000_000_000_000L, fromJson.getInputSegmentSizeBytes());
     Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
     Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
     Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());


### PR DESCRIPTION
Backport of [12534](https://github.com/apache/druid/pull/12534) to 0.23.0.