### PR TITLE
object[] handling for DimensionHandlers for arrays

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -787,8 +787,8 @@ public class GroupByQuery extends BaseQuery<ResultRow>
         dimCompare = Comparators.<Comparable>naturalNullsFirst().compare(lhsArr, rhsArr);
       } else if (dimensionType.equals(ColumnType.LONG_ARRAY)
                  || dimensionType.equals(ColumnType.DOUBLE_ARRAY)) {
-        final ComparableList lhsArr = DimensionHandlerUtils.convertToList(lhsObj, dimensionType.getType());
-        final ComparableList rhsArr = DimensionHandlerUtils.convertToList(rhsObj, dimensionType.getType());
+        final ComparableList lhsArr = DimensionHandlerUtils.convertToList(lhsObj, dimensionType.getElementType().getType());
+        final ComparableList rhsArr = DimensionHandlerUtils.convertToList(rhsObj, dimensionType.getElementType().getType());
         dimCompare = Comparators.<Comparable>naturalNullsFirst().compare(lhsArr, rhsArr);
       } else {
         dimCompare = comparator.compare((String) lhsObj, (String) rhsObj);

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -787,8 +787,8 @@ public class GroupByQuery extends BaseQuery<ResultRow>
         dimCompare = Comparators.<Comparable>naturalNullsFirst().compare(lhsArr, rhsArr);
       } else if (dimensionType.equals(ColumnType.LONG_ARRAY)
                  || dimensionType.equals(ColumnType.DOUBLE_ARRAY)) {
-        final ComparableList lhsArr = DimensionHandlerUtils.convertToList(lhsObj);
-        final ComparableList rhsArr = DimensionHandlerUtils.convertToList(rhsObj);
+        final ComparableList lhsArr = DimensionHandlerUtils.convertToList(lhsObj, dimensionType.getType());
+        final ComparableList rhsArr = DimensionHandlerUtils.convertToList(rhsObj, dimensionType.getType());
         dimCompare = Comparators.<Comparable>naturalNullsFirst().compare(lhsArr, rhsArr);
       } else {
         dimCompare = comparator.compare((String) lhsObj, (String) rhsObj);

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1051,9 +1051,9 @@ public class RowBasedGrouperHelper
         } else if (fieldTypes.get(i - dimStart).equals(ColumnType.LONG_ARRAY)
                    || fieldTypes.get(i - dimStart).equals(ColumnType.DOUBLE_ARRAY)) {
           final ComparableList lhs = DimensionHandlerUtils.convertToList(key1.getKey()[i],
-                                                                         fieldTypes.get(i - dimStart).getType());
+                                                                         fieldTypes.get(i - dimStart).getElementType().getType());
           final ComparableList rhs = DimensionHandlerUtils.convertToList(key2.getKey()[i],
-                                                                         fieldTypes.get(i - dimStart).getType());
+                                                                         fieldTypes.get(i - dimStart).getElementType().getType());
           cmp = Comparators.<Comparable>naturalNullsFirst().compare(lhs, rhs);
         } else {
           cmp = Comparators.<Comparable>naturalNullsFirst().compare(
@@ -1131,8 +1131,8 @@ public class RowBasedGrouperHelper
 
           cmp = ComparableList.compareWithComparator(
               comparator,
-              DimensionHandlerUtils.convertToList(lhs, fieldType.getType()),
-              DimensionHandlerUtils.convertToList(rhs, fieldType.getType())
+              DimensionHandlerUtils.convertToList(lhs, fieldType.getElementType().getType()),
+              DimensionHandlerUtils.convertToList(rhs, fieldType.getElementType().getType())
           );
 
         } else {

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -760,7 +760,8 @@ public class RowBasedGrouperHelper
             case DOUBLE:
               return (InputRawSupplierColumnSelectorStrategy<ColumnValueSelector>)
                   columnSelector ->
-                      () -> DimensionHandlerUtils.convertToList(columnSelector.getObject());
+                      () -> DimensionHandlerUtils.convertToList(columnSelector.getObject(),
+                                                                capabilities.getElementType().getType());
             default:
               throw new IAE(
                   "Cannot create query type helper from invalid type [%s]",
@@ -1049,8 +1050,10 @@ public class RowBasedGrouperHelper
           cmp = Comparators.<Comparable>naturalNullsFirst().compare(lhs, rhs);
         } else if (fieldTypes.get(i - dimStart).equals(ColumnType.LONG_ARRAY)
                    || fieldTypes.get(i - dimStart).equals(ColumnType.DOUBLE_ARRAY)) {
-          final ComparableList lhs = DimensionHandlerUtils.convertToList(key1.getKey()[i]);
-          final ComparableList rhs = DimensionHandlerUtils.convertToList(key2.getKey()[i]);
+          final ComparableList lhs = DimensionHandlerUtils.convertToList(key1.getKey()[i],
+                                                                         fieldTypes.get(i - dimStart).getType());
+          final ComparableList rhs = DimensionHandlerUtils.convertToList(key2.getKey()[i],
+                                                                         fieldTypes.get(i - dimStart).getType());
           cmp = Comparators.<Comparable>naturalNullsFirst().compare(lhs, rhs);
         } else {
           cmp = Comparators.<Comparable>naturalNullsFirst().compare(
@@ -1128,8 +1131,8 @@ public class RowBasedGrouperHelper
 
           cmp = ComparableList.compareWithComparator(
               comparator,
-              DimensionHandlerUtils.convertToList(lhs),
-              DimensionHandlerUtils.convertToList(rhs)
+              DimensionHandlerUtils.convertToList(lhs, fieldType.getType()),
+              DimensionHandlerUtils.convertToList(rhs, fieldType.getType())
           );
 
         } else {

--- a/processing/src/main/java/org/apache/druid/query/groupby/orderby/DefaultLimitSpec.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/orderby/DefaultLimitSpec.java
@@ -440,11 +440,12 @@ public class DefaultLimitSpec implements LimitSpec
   {
     Comparator arrayComparator = null;
     if (columnType.isArray()) {
+      final ValueType elementType = columnType.getElementType().getType();
       if (columnType.getElementType().isNumeric()) {
         arrayComparator = (Comparator<Object>) (o1, o2) -> ComparableList.compareWithComparator(
             comparator,
-            DimensionHandlerUtils.convertToList(o1),
-            DimensionHandlerUtils.convertToList(o2)
+            DimensionHandlerUtils.convertToList(o1, elementType),
+            DimensionHandlerUtils.convertToList(o2, elementType)
         );
       } else if (columnType.getElementType().equals(ColumnType.STRING)) {
         arrayComparator = (Comparator<Object>) (o1, o2) -> ComparableStringArray.compareWithComparator(

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -448,7 +448,7 @@ public final class DimensionHandlerUtils
     if (obj instanceof List) {
       return ComparableStringArray.of((String[]) ((List) obj).toArray(new String[0]));
     }
-    if(obj instanceof Object[]) {
+    if (obj instanceof Object[]) {
       Object[] objects = (Object[]) obj;
       String[] delegate = new String[objects.length];
       for (int i = 0; i < objects.length; i++) {
@@ -456,7 +456,11 @@ public final class DimensionHandlerUtils
       }
       return ComparableStringArray.of(delegate);
     }
-    throw new ISE("Unable to convert object of type[%s] to [%s]", obj.getClass().getName(), ComparableStringArray.class.getName());
+    throw new ISE(
+        "Unable to convert object of type[%s] to [%s]",
+        obj.getClass().getName(),
+        ComparableStringArray.class.getName()
+    );
   }
 
   public static int compareObjectsAsType(

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -409,7 +409,7 @@ public final class DimensionHandlerUtils
       case DOUBLE:
         return convertToListWithObjectFunction(obj, CONVERT_OBJECT_TO_DOUBLE_FUNCTION);
     }
-    throw new IAE("Unable to convert element of type[%s] to comparable list", elementType);
+    throw new ISE("Unable to convert object of type[%s] to [%s]", obj.getClass().getName(), ComparableList.class.getName());
   }
 
 
@@ -431,7 +431,7 @@ public final class DimensionHandlerUtils
       }
       return new ComparableList(delegateList);
     }
-    throw new ISE("Unable to convert type %s to %s", obj.getClass().getName(), ComparableList.class.getName());
+    throw new ISE("Unable to convert object of type[%s] to [%s]", obj.getClass().getName(), ComparableList.class.getName());
   }
 
 
@@ -444,19 +444,19 @@ public final class DimensionHandlerUtils
     if (obj instanceof ComparableStringArray) {
       return (ComparableStringArray) obj;
     }
-    if (obj instanceof String[]) {
-      return ComparableStringArray.of((String[]) obj);
-    }
     // Jackson converts the serialized array into a list. Converting it back to a string array
     if (obj instanceof List) {
       return ComparableStringArray.of((String[]) ((List) obj).toArray(new String[0]));
     }
-    Object[] objects = (Object[]) obj;
-    String[] delegate = new String[objects.length];
-    for (int i = 0; i < objects.length; i++) {
-      delegate[i] = convertObjectToString(objects[i]);
+    if(obj instanceof Object[]) {
+      Object[] objects = (Object[]) obj;
+      String[] delegate = new String[objects.length];
+      for (int i = 0; i < objects.length; i++) {
+        delegate[i] = convertObjectToString(objects[i]);
+      }
+      return ComparableStringArray.of(delegate);
     }
-    return ComparableStringArray.of(delegate);
+    throw new ISE("Unable to convert object of type[%s] to [%s]", obj.getClass().getName(), ComparableStringArray.class.getName());
   }
 
   public static int compareObjectsAsType(

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -69,10 +69,6 @@ public final class DimensionHandlerUtils
 
   public static final ConcurrentHashMap<String, DimensionHandlerProvider> DIMENSION_HANDLER_PROVIDERS = new ConcurrentHashMap<>();
 
-  private static final Function<Object, Long> CONVERT_OBJECT_TO_LONG_FUNCTION = o -> convertObjectToLong(o);
-  private static final Function<Object, Double> CONVERT_OBJECT_TO_DOUBLE_FUNCTION = o -> convertObjectToDouble(o);
-  private static final Function<Object, Float> CONVERT_OBJECT_TO_FLOAT_FUNCTION = o -> convertObjectToFloat(o);
-
   public static void registerDimensionHandlerProvider(String type, DimensionHandlerProvider provider)
   {
     DIMENSION_HANDLER_PROVIDERS.compute(type, (key, value) -> {
@@ -387,11 +383,11 @@ public final class DimensionHandlerUtils
           case STRING:
             return convertToComparableStringArray(obj);
           case LONG:
-            return convertToListWithObjectFunction(obj, CONVERT_OBJECT_TO_LONG_FUNCTION);
+            return convertToListWithObjectFunction(obj, DimensionHandlerUtils::convertObjectToLong);
           case FLOAT:
-            return convertToListWithObjectFunction(obj, CONVERT_OBJECT_TO_FLOAT_FUNCTION);
+            return convertToListWithObjectFunction(obj, DimensionHandlerUtils::convertObjectToFloat);
           case DOUBLE:
-            return convertToListWithObjectFunction(obj, CONVERT_OBJECT_TO_DOUBLE_FUNCTION);
+            return convertToListWithObjectFunction(obj, DimensionHandlerUtils::convertObjectToDouble);
         }
 
       default:
@@ -404,11 +400,11 @@ public final class DimensionHandlerUtils
   {
     switch (elementType) {
       case LONG:
-        return convertToListWithObjectFunction(obj, CONVERT_OBJECT_TO_LONG_FUNCTION);
+        return convertToListWithObjectFunction(obj, DimensionHandlerUtils::convertObjectToLong);
       case FLOAT:
-        return convertToListWithObjectFunction(obj, CONVERT_OBJECT_TO_FLOAT_FUNCTION);
+        return convertToListWithObjectFunction(obj, DimensionHandlerUtils::convertObjectToFloat);
       case DOUBLE:
-        return convertToListWithObjectFunction(obj, CONVERT_OBJECT_TO_DOUBLE_FUNCTION);
+        return convertToListWithObjectFunction(obj, DimensionHandlerUtils::convertObjectToDouble);
     }
     throw new ISE(
         "Unable to convert object of type[%s] to [%s]",

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -2056,6 +2056,141 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
 
 
     List<ResultRow> expectedResults = Arrays.asList(
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(78L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(97L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(109L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(110L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(112L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(113L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(114L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(118L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(119L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(120L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(121L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(126L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(135L)), "rows", 2L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(144L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(147L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(158L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(166L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1049L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1144L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1193L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1234L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1314L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1321L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1447L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1522L)), "rows", 1L)
+    );
+
+    Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, outer);
+    TestHelper.assertExpectedObjects(expectedResults, results, "long-groupby-arrays");
+  }
+
+  @Test
+  public void testGroupByWithLongArraysDesc()
+  {
+    if (config.getDefaultStrategy().equals(GroupByStrategySelector.STRATEGY_V1)) {
+      expectedException.expect(UnsupportedOperationException.class);
+      expectedException.expectMessage("GroupBy v1 only supports dimensions with an outputType of STRING");
+    }
+    cannotVectorize();
+    GroupByQuery outer = makeQueryBuilder()
+        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setVirtualColumns(new ExpressionVirtualColumn(
+            "v0",
+            "array(index)",
+            ColumnType.LONG_ARRAY,
+            ExprMacroTable.nil()
+        ))
+        .setDimensions(
+            new DefaultDimensionSpec("v0", "alias_outer", ColumnType.LONG_ARRAY)
+        )
+        .setLimitSpec(new DefaultLimitSpec(
+            ImmutableList.of(new OrderByColumnSpec(
+                "alias_outer",
+                OrderByColumnSpec.Direction.DESCENDING,
+                StringComparators.NUMERIC
+            )),
+            Integer.MAX_VALUE - 1
+        ))
+        .setAggregatorSpecs(
+            QueryRunnerTestHelper.ROWS_COUNT
+        )
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .build();
+
+
+    List<ResultRow> expectedResults = Arrays.asList(
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(78L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(97L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(109L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(110L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(112L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(113L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(114L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(118L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(119L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(120L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(121L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(126L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(135L)), "rows", 2L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(144L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(147L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(158L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(166L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1049L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1144L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1193L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1234L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1314L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1321L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1447L)), "rows", 1L),
+        makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1522L)), "rows", 1L)
+    );
+    // reversing list
+    Collections.reverse(expectedResults);
+    Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, outer);
+    TestHelper.assertExpectedObjects(expectedResults, results, "long-groupby-arrays");
+  }
+
+  @Test
+  public void testGroupByWithDoubleArrays()
+  {
+    if (config.getDefaultStrategy().equals(GroupByStrategySelector.STRATEGY_V1)) {
+      expectedException.expect(UnsupportedOperationException.class);
+      expectedException.expectMessage("GroupBy v1 only supports dimensions with an outputType of STRING");
+    }
+    cannotVectorize();
+    GroupByQuery outer = makeQueryBuilder()
+        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setVirtualColumns(new ExpressionVirtualColumn(
+            "v0",
+            "array(index)",
+            ColumnType.DOUBLE_ARRAY,
+            ExprMacroTable.nil()
+        ))
+        .setDimensions(
+            new DefaultDimensionSpec("v0", "alias_outer", ColumnType.DOUBLE_ARRAY)
+        )
+        .setLimitSpec(new DefaultLimitSpec(
+            ImmutableList.of(new OrderByColumnSpec(
+                "alias_outer",
+                OrderByColumnSpec.Direction.ASCENDING,
+                StringComparators.NUMERIC
+            )),
+            Integer.MAX_VALUE - 1
+        ))
+        .setAggregatorSpecs(
+            QueryRunnerTestHelper.ROWS_COUNT
+        )
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .build();
+
+
+    List<ResultRow> expectedResults = Arrays.asList(
         makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(78.622547)), "rows", 1L),
         makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(97.387433)), "rows", 1L),
         makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(109.705815)), "rows", 1L),
@@ -2083,13 +2218,13 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
         makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1447.34116)), "rows", 1L),
         makeRow(outer, "2011-04-01", "alias_outer", new ComparableList(ImmutableList.of(1522.043733)), "rows", 1L)
     );
-
     Iterable<ResultRow> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, outer);
     TestHelper.assertExpectedObjects(expectedResults, results, "long-groupby-arrays");
   }
 
+
   @Test
-  public void testGroupByWithLongArraysDesc()
+  public void testGroupByWithDoubleArraysDesc()
   {
     if (config.getDefaultStrategy().equals(GroupByStrategySelector.STRATEGY_V1)) {
       expectedException.expect(UnsupportedOperationException.class);
@@ -2102,11 +2237,11 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
         .setVirtualColumns(new ExpressionVirtualColumn(
             "v0",
             "array(index)",
-            ColumnType.LONG_ARRAY,
+            ColumnType.DOUBLE_ARRAY,
             ExprMacroTable.nil()
         ))
         .setDimensions(
-            new DefaultDimensionSpec("v0", "alias_outer", ColumnType.LONG_ARRAY)
+            new DefaultDimensionSpec("v0", "alias_outer", ColumnType.DOUBLE_ARRAY)
         )
         .setLimitSpec(new DefaultLimitSpec(
             ImmutableList.of(new OrderByColumnSpec(

--- a/processing/src/test/java/org/apache/druid/segment/DimensionHandlerUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/DimensionHandlerUtilsTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DoubleDimensionSchema;
 import org.apache.druid.data.input.impl.FloatDimensionSchema;
@@ -28,6 +29,9 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.data.ComparableList;
+import org.apache.druid.segment.data.ComparableStringArray;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -44,12 +48,19 @@ public class DimensionHandlerUtilsTest extends InitializedNullHandlingTest
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  private static final ComparableList<Long> LONG_COMPARABLE_LIST = new ComparableList<>(ImmutableList.of(1L, 2L));
+  private static final ComparableList<Double> DOUBLE_COMPARABLE_LIST = new ComparableList<>(ImmutableList.of(1.0, 2.0));
+  private static final ComparableList<Float> FLOAT_COMPARABLE_LIST = new ComparableList<>(ImmutableList.of(1F, 2F));
+  private static final ComparableStringArray COMPARABLE_STRING_ARRAY = ComparableStringArray.of("1", "2");
+  private static final ComparableStringArray COMPARABLE_STRING_ARRAY_DECIMAL = ComparableStringArray.of("1.0", "2.0");
+
   @BeforeClass
   public static void setupTests()
   {
     DimensionHandlerUtils.registerDimensionHandlerProvider(
         TYPE,
-        d -> new DoubleDimensionHandler(d) {
+        d -> new DoubleDimensionHandler(d)
+        {
           @Override
           public DimensionSchema getDimensionSchema(ColumnCapabilities capabilities)
           {
@@ -143,6 +154,169 @@ public class DimensionHandlerUtilsTest extends InitializedNullHandlingTest
     );
     Assert.assertTrue(handler instanceof LongDimensionHandler);
     Assert.assertTrue(handler.getDimensionSchema(capabilities) instanceof LongDimensionSchema);
+  }
+
+  @Test
+  public void testComparableLongList()
+  {
+    Assert.assertEquals(null, DimensionHandlerUtils.convertToList(null, ValueType.LONG));
+    Assert.assertEquals(
+        LONG_COMPARABLE_LIST,
+        DimensionHandlerUtils.convertToList(ImmutableList.of(1L, 2L), ValueType.LONG)
+    );
+    Assert.assertEquals(
+        LONG_COMPARABLE_LIST,
+        DimensionHandlerUtils.convertToList(
+            new ComparableList(ImmutableList.of(1L, 2L)),
+            ValueType.LONG
+        )
+    );
+
+    assertArrayCases(LONG_COMPARABLE_LIST, ValueType.LONG);
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Long] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1L, ValueType.LONG)
+    );
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Long] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1L, ValueType.ARRAY)
+    );
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Long] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1L, ValueType.STRING)
+    );
+  }
+
+  @Test
+  public void testComparableFloatList()
+  {
+    Assert.assertEquals(null, DimensionHandlerUtils.convertToList(null, ValueType.FLOAT));
+    Assert.assertEquals(
+        FLOAT_COMPARABLE_LIST,
+        DimensionHandlerUtils.convertToList(ImmutableList.of(1.0F, 2.0F), ValueType.FLOAT)
+    );
+    Assert.assertEquals(
+        FLOAT_COMPARABLE_LIST,
+        DimensionHandlerUtils.convertToList(
+            new ComparableList(ImmutableList.of(1.0F, 2.0F)),
+            ValueType.FLOAT
+        )
+    );
+
+    assertArrayCases(FLOAT_COMPARABLE_LIST, ValueType.FLOAT);
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Float] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1.0F, ValueType.FLOAT)
+    );
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Float] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1.0F, ValueType.ARRAY)
+    );
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Float] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1.0F, ValueType.STRING)
+    );
+  }
+
+  @Test
+  public void testComparableDoubleList()
+  {
+    Assert.assertEquals(null, DimensionHandlerUtils.convertToList(null, ValueType.DOUBLE));
+    Assert.assertEquals(
+        DOUBLE_COMPARABLE_LIST,
+        DimensionHandlerUtils.convertToList(ImmutableList.of(1.0D, 2.0D), ValueType.DOUBLE)
+    );
+    Assert.assertEquals(
+        DOUBLE_COMPARABLE_LIST,
+        DimensionHandlerUtils.convertToList(
+            new ComparableList(ImmutableList.of(1.0D, 2.0D)),
+            ValueType.DOUBLE
+        )
+    );
+
+    assertArrayCases(DOUBLE_COMPARABLE_LIST, ValueType.DOUBLE);
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Double] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1.0D, ValueType.DOUBLE)
+    );
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Double] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1.0D, ValueType.ARRAY)
+    );
+
+    Assert.assertThrows(
+        "Unable to convert object of type[Double] to [ComparableList]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToList(1.0D, ValueType.STRING)
+    );
+  }
+
+  @Test
+  public void testComparableStringArrayList()
+  {
+    Assert.assertEquals(null, DimensionHandlerUtils.convertToComparableStringArray(null));
+    Assert.assertEquals(
+        COMPARABLE_STRING_ARRAY,
+        DimensionHandlerUtils.convertToComparableStringArray(ImmutableList.of("1", "2"))
+    );
+
+    Assert.assertEquals(
+        COMPARABLE_STRING_ARRAY,
+        DimensionHandlerUtils.convertToComparableStringArray(new Object[]{1L, 2L})
+    );
+    Assert.assertEquals(
+        COMPARABLE_STRING_ARRAY,
+        DimensionHandlerUtils.convertToComparableStringArray(new Long[]{1L, 2L})
+    );
+    Assert.assertEquals(
+        COMPARABLE_STRING_ARRAY_DECIMAL,
+        DimensionHandlerUtils.convertToComparableStringArray(new String[]{"1.0", "2.0"})
+    );
+    Assert.assertEquals(
+        COMPARABLE_STRING_ARRAY_DECIMAL,
+        DimensionHandlerUtils.convertToComparableStringArray(new Double[]{1.0, 2.0})
+    );
+    Assert.assertEquals(
+        COMPARABLE_STRING_ARRAY_DECIMAL,
+        DimensionHandlerUtils.convertToComparableStringArray(new Float[]{1F, 2F})
+    );
+
+    Assert.assertThrows(
+        "Unable to convert object of type[String] to [ComparablComparableStringArray]",
+        ISE.class,
+        () -> DimensionHandlerUtils.convertToComparableStringArray("1")
+    );
+  }
+
+  private static void assertArrayCases(ComparableList expectedComparableList, ValueType elementType)
+  {
+    Assert.assertEquals(expectedComparableList, DimensionHandlerUtils.convertToList(new Object[]{1L, 2L}, elementType));
+    Assert.assertEquals(expectedComparableList, DimensionHandlerUtils.convertToList(new Long[]{1L, 2L}, elementType));
+    Assert.assertEquals(
+        expectedComparableList,
+        DimensionHandlerUtils.convertToList(new String[]{"1.0", "2.0"}, elementType)
+    );
+    Assert.assertEquals(
+        expectedComparableList,
+        DimensionHandlerUtils.convertToList(new Double[]{1.0, 2.0}, elementType)
+    );
+    Assert.assertEquals(expectedComparableList, DimensionHandlerUtils.convertToList(new Float[]{1F, 2F}, elementType));
   }
 
   private static class TestDimensionSchema extends DimensionSchema

--- a/processing/src/test/java/org/apache/druid/segment/TestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestHelper.java
@@ -416,9 +416,9 @@ public class TestHelper
             ExprEval.coerceListToArray((List) actualValue, true).rhs
         );
       } else if (expectedValue instanceof ComparableList && actualValue instanceof List) {
-        Assert.assertEquals(
-            ((ComparableList) expectedValue).getDelegate(),
-            (List) actualValue
+        Assert.assertArrayEquals(
+            ((ComparableList) expectedValue).getDelegate().toArray(new Object[0]),
+            ExprEval.coerceListToArray((List) actualValue, true).rhs
         );
       } else {
         Assert.assertEquals(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -2195,7 +2195,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                                                         .setQuerySegmentSpec(querySegmentSpec(Filtration.eternity()))
                                                         .setGranularity(Granularities.ALL)
                                                         .setInterval(querySegmentSpec(Filtration.eternity()))
-                                                        .setContext(QUERY_CONTEXT_DEFAULT)
+                                                        .setContext(QUERY_CONTEXT_NO_STRINGIFY_ARRAY)
                                                         .setDimensions(
                                                             new DefaultDimensionSpec("dim1", "d0"),
                                                             new DefaultDimensionSpec("dim2", "d1"),
@@ -2238,7 +2238,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                         .setQuerySegmentSpec(querySegmentSpec(Filtration.eternity()))
                         .setGranularity(Granularities.ALL)
                         .setInterval(querySegmentSpec(Filtration.eternity()))
-                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .setContext(QUERY_CONTEXT_NO_STRINGIFY_ARRAY)
                         .setDimensions(new DefaultDimensionSpec("_a0", "d0", ColumnType.LONG_ARRAY))
                         .setAggregatorSpecs(new CountAggregatorFactory("a0"))
                         .build()
@@ -2268,7 +2268,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                                                         .setQuerySegmentSpec(querySegmentSpec(Filtration.eternity()))
                                                         .setGranularity(Granularities.ALL)
                                                         .setInterval(querySegmentSpec(Filtration.eternity()))
-                                                        .setContext(QUERY_CONTEXT_DEFAULT)
+                                                        .setContext(QUERY_CONTEXT_NO_STRINGIFY_ARRAY)
                                                         .setDimensions(
                                                             new DefaultDimensionSpec("dim1", "d0"),
                                                             new DefaultDimensionSpec("dim2", "d1"),
@@ -2304,7 +2304,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                         .setQuerySegmentSpec(querySegmentSpec(Filtration.eternity()))
                         .setGranularity(Granularities.ALL)
                         .setInterval(querySegmentSpec(Filtration.eternity()))
-                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .setContext(QUERY_CONTEXT_NO_STRINGIFY_ARRAY)
                         .setDimensions(new DefaultDimensionSpec("_a0", "d0", ColumnType.STRING_ARRAY))
                         .setAggregatorSpecs(new CountAggregatorFactory("a0"))
                         .build()
@@ -2322,7 +2322,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
     requireMergeBuffers(3);
     cannotVectorize();
     testQuery(
-        "select cntarray, count(*) from ( select dim1, dim2, ARRAY_AGG(cnt) as cntarray from ( select dim1, dim2, dim3, cast( count(*) as VARCHAR ) as cnt from foo group by 1, 2, 3 ) group by 1, 2 ) group by 1",
+        "select cntarray, count(*) from ( select dim1, dim2, ARRAY_AGG(cnt) as cntarray from ( select dim1, dim2, dim3, cast( count(*) as DOUBLE ) as cnt from foo group by 1, 2, 3 ) group by 1, 2 ) group by 1",
         QUERY_CONTEXT_NO_STRINGIFY_ARRAY,
         ImmutableList.of(
             GroupByQuery
@@ -2335,7 +2335,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                                                 .setQuerySegmentSpec(querySegmentSpec(Filtration.eternity()))
                                                 .setGranularity(Granularities.ALL)
                                                 .setInterval(querySegmentSpec(Filtration.eternity()))
-                                                .setContext(QUERY_CONTEXT_DEFAULT)
+                                                .setContext(QUERY_CONTEXT_NO_STRINGIFY_ARRAY)
                                                 .setDimensions(
                                                     new DefaultDimensionSpec("dim1", "d0"),
                                                     new DefaultDimensionSpec("dim2", "d1"),
@@ -2371,7 +2371,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                 .setQuerySegmentSpec(querySegmentSpec(Filtration.eternity()))
                 .setGranularity(Granularities.ALL)
                 .setInterval(querySegmentSpec(Filtration.eternity()))
-                .setContext(QUERY_CONTEXT_DEFAULT)
+                .setContext(QUERY_CONTEXT_NO_STRINGIFY_ARRAY)
                 .setDimensions(new DefaultDimensionSpec("_a0", "d0", ColumnType.DOUBLE_ARRAY))
                 .setAggregatorSpecs(new CountAggregatorFactory("a0"))
                 .build()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -1069,15 +1069,15 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         useDefault ? ImmutableList.of(
-            new Object[]{ImmutableList.of(0.0), 4L},
-            new Object[]{ImmutableList.of(0.10000000149011612), 1L},
-            new Object[]{ImmutableList.of(1.0), 1L}
+            new Object[]{ImmutableList.of(0.0F), 4L},
+            new Object[]{ImmutableList.of(0.10000000149011612F), 1L},
+            new Object[]{ImmutableList.of(1.0F), 1L}
         ) :
         ImmutableList.of(
             new Object[]{Collections.singletonList(null), 3L},
-            new Object[]{ImmutableList.of(0.0), 1L},
-            new Object[]{ImmutableList.of(0.10000000149011612), 1L},
-            new Object[]{ImmutableList.of(1.0), 1L}
+            new Object[]{ImmutableList.of(0.0F), 1L},
+            new Object[]{ImmutableList.of(0.10000000149011612F), 1L},
+            new Object[]{ImmutableList.of(1.0F), 1L}
         )
     );
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->
### Description
Fixes a bug when running q's like 
```sql
 SELECT cntarray,
       Count(*)
FROM   (SELECT dim1,
               dim2,
               Array_agg(cnt) AS cntarray
        FROM   (SELECT dim1,
                       dim2,
                       dim3,
                       Count(*) AS cnt
                FROM   foo
                GROUP  BY 1,
                          2,
                          3)
        GROUP  BY 1,
                  2)
GROUP  BY 1  
```

This generates an error:
```
org.apache.druid.java.util.common.ISE: Unable to convert type [Ljava.lang.Object; to org.apache.druid.segment.data.ComparableList
        at org.apache.druid.segment.DimensionHandlerUtils.convertToList(DimensionHandlerUtils.java:405) ~[druid-xx]
```
Because it's an array of numbers it looks like it does the `convertToList` call, which looks like:
``` java
  @Nullable
  public static ComparableList convertToList(Object obj)
  {
    if (obj == null) {
      return null;
    }
    if (obj instanceof List) {
      return new ComparableList((List) obj);
    }
    if (obj instanceof ComparableList) {
      return (ComparableList) obj;
    }
    throw new ISE("Unable to convert type %s to %s", obj.getClass().getName(), ComparableList.class.getName());
  }
  ```
I.e. it doesn't know about arrays.  Added the array handling as part of this PR. 

Also, there is another code path that knows about arrays. but that has a typo. 
```java
Objects[] objects = (Objects[]) obj;
    String[] delegate = new String[objects.length];
    for (int i = 0; i < objects.length; i++) {
      delegate[i] = convertObjectToString(objects[i]);
    }
    return ComparableStringArray.of(delegate);
```

it should be `object[]` and not `objects[]`. 
Added test cases to handle this case along with the change. 

Thanks, @imply-cheddar for finding this bug. 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->



<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java`
 * `sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
