### PR TITLE
Suppress CVEs

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -253,6 +253,7 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.oauth-client/google\-oauth\-client@.*$</packageUrl>
     <cve>CVE-2020-7692</cve>
+    <cve>CVE-2021-22573</cve>
   </suppress>
   <suppress>
     <!--
@@ -286,6 +287,11 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/log4j/log4j@1.2.17$</packageUrl>
     <cve>CVE-2019-17571</cve>
+    <cve>CVE-2021-4104</cve>
+    <cve>CVE-2020-9493</cve>
+    <cve>CVE-2022-23307</cve>
+    <cve>CVE-2022-23305</cve>
+    <cve>CVE-2022-23302</cve>
   </suppress>
   <suppress>
     <!--
@@ -511,6 +517,14 @@
    ]]></notes>
     <cve>CVE-2021-32626</cve>
     <cve>CVE-2022-24735</cve>
+  </suppress>
+
+  <suppress>
+    <!-- pac4j-core-3.8.3 -->
+    <notes><![CDATA[
+   file name: pac4j-core-3.8.3.jar
+   ]]></notes>
+    <cve>CVE-2021-44878</cve>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
Suppress CVEs for

log4j-1.2.17.jar -> CVE-2021-4104, CVE-2020-9493, CVE-2022-23307, CVE-2022-23305, CVE-2022-23302
- Transitive dependency from Ranger and present in the latest version as well. Can be resolved in the future with an update to the unreleased version 3 of apache ranger.

google-oauth-client-1.26.0.jar -> CVE-2021-22573
- Druid is not a native app and it seems like only native apps are affected.

pac4j-core-3.8.3.jar: CVE-2021-44878
- Is an issue only when OpenId "none" algorithm is used, which is why it is not really severe and is unlikely to be an issue in the real world. Reference : https://www.pac4j.org/blog/cve_2021_44878_is_this_serious.html