### PR TITLE
Add error message for incorrectly ordered clause in sql

### DIFF
--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -36,6 +36,11 @@ SqlNode DruidSqlInsertEof() :
     <CLUSTERED> <BY>
     clusteredBy = ClusterItems()
   ]
+  {
+      if (clusteredBy != null && partitionedBy.lhs == null) {
+        throw new ParseException("CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.");
+      }
+  }
   // EOF is also present in SqlStmtEof but EOF is a special case and a single EOF can be consumed multiple times.
   // The reason for adding EOF here is to ensure that we create a DruidSqlInsert node after the syntax has been
   // validated and throw SQL syntax errors before performing validations in the DruidSqlInsert which can overshadow the

--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -38,7 +38,7 @@ SqlNode DruidSqlInsertEof() :
   ]
   {
       if (clusteredBy != null && partitionedBy.lhs == null) {
-        throw new ParseException("CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.");
+        throw new ParseException("CLUSTERED BY found before PARTITIONED BY. In druid, the CLUSTERED BY clause has to be specified after the PARTITIONED BY clause");
       }
   }
   // EOF is also present in SqlStmtEof but EOF is a special case and a single EOF can be consumed multiple times.

--- a/sql/src/main/codegen/includes/replace.ftl
+++ b/sql/src/main/codegen/includes/replace.ftl
@@ -56,6 +56,11 @@ SqlNode DruidSqlReplaceEof() :
       <CLUSTERED> <BY>
       clusteredBy = ClusterItems()
     ]
+    {
+        if (clusteredBy != null && partitionedBy.lhs == null) {
+          throw new ParseException("CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.");
+        }
+    }
     // EOF is also present in SqlStmtEof but EOF is a special case and a single EOF can be consumed multiple times.
     // The reason for adding EOF here is to ensure that we create a DruidSqlReplace node after the syntax has been
     // validated and throw SQL syntax errors before performing validations in the DruidSqlReplace which can overshadow the

--- a/sql/src/main/codegen/includes/replace.ftl
+++ b/sql/src/main/codegen/includes/replace.ftl
@@ -58,7 +58,7 @@ SqlNode DruidSqlReplaceEof() :
     ]
     {
         if (clusteredBy != null && partitionedBy.lhs == null) {
-          throw new ParseException("CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.");
+          throw new ParseException("CLUSTERED BY found before PARTITIONED BY. In druid, the CLUSTERED BY clause has to be specified after the PARTITIONED BY clause");
         }
     }
     // EOF is also present in SqlStmtEof but EOF is a special case and a single EOF can be consumed multiple times.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -349,6 +349,19 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
   }
 
   @Test
+  public void testInsertWithoutPartitionedByWithClusteredBy()
+  {
+    testIngestionQuery()
+        .sql(
+            "INSERT INTO druid.dst "
+            + "SELECT __time, FLOOR(m1) as floor_m1, dim1, CEIL(m2) as ceil_m2 FROM foo "
+            + "CLUSTERED BY 2, dim1 DESC, CEIL(m2)"
+        )
+        .expectValidationError(SqlPlanningException.class, "CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.")
+        .verify();
+  }
+
+  @Test
   public void testInsertWithPartitionedByAndClusteredBy()
   {
     // Test correctness of the query when both PARTITIONED BY and CLUSTERED BY clause is present

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -357,7 +357,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
             + "SELECT __time, FLOOR(m1) as floor_m1, dim1, CEIL(m2) as ceil_m2 FROM foo "
             + "CLUSTERED BY 2, dim1 DESC, CEIL(m2)"
         )
-        .expectValidationError(SqlPlanningException.class, "CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.")
+        .expectValidationError(SqlPlanningException.class, "CLUSTERED BY found before PARTITIONED BY. In druid, the CLUSTERED BY clause has to be specified after the PARTITIONED BY clause")
         .verify();
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteReplaceDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteReplaceDmlTest.java
@@ -406,7 +406,7 @@ public class CalciteReplaceDmlTest extends CalciteIngestionDmlTest
   {
     testIngestionQuery()
         .sql("REPLACE INTO dst OVERWRITE ALL SELECT __time, FLOOR(m1) as floor_m1, dim1 FROM foo CLUSTERED BY dim1")
-        .expectValidationError(SqlPlanningException.class, "CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.")
+        .expectValidationError(SqlPlanningException.class, "CLUSTERED BY found before PARTITIONED BY. In druid, the CLUSTERED BY clause has to be specified after the PARTITIONED BY clause")
         .verify();
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteReplaceDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteReplaceDmlTest.java
@@ -393,6 +393,24 @@ public class CalciteReplaceDmlTest extends CalciteIngestionDmlTest
   }
 
   @Test
+  public void testReplaceWithoutPartitionedBy()
+  {
+    testIngestionQuery()
+        .sql("REPLACE INTO dst OVERWRITE ALL SELECT __time, FLOOR(m1) as floor_m1, dim1 FROM foo")
+        .expectValidationError(SqlPlanningException.class, "REPLACE statements must specify PARTITIONED BY clause explicitly")
+        .verify();
+  }
+
+  @Test
+  public void testReplaceWithoutPartitionedByWithClusteredBy()
+  {
+    testIngestionQuery()
+        .sql("REPLACE INTO dst OVERWRITE ALL SELECT __time, FLOOR(m1) as floor_m1, dim1 FROM foo CLUSTERED BY dim1")
+        .expectValidationError(SqlPlanningException.class, "CLUSTERED BY clause found before PARTITIONED BY, the PARITITIONED BY clause has to be specified first before the CLUSTERED BY clause.")
+        .verify();
+  }
+
+  @Test
   public void testReplaceWithoutOverwriteClause()
   {
     testIngestionQuery()


### PR DESCRIPTION
In the case that the clustered by is before the partitioned by for an sql query, the error message is a bit confusing.

```insert into foo select * from bar clustered by dim1 partitioned by all```

```
Error: SQL parse failed

Encountered "PARTITIONED" at line 1, column 88.

Was expecting one of: <EOF> "," ... "ASC" ... "DESC" ... "NULLS" ... "." ... "NOT" ... "IN" ... "<" ... "<=" ... ">" ... ">=" ... "=" ... "<>" ... "!=" ... "BETWEEN" ... "LIKE" ... "SIMILAR" ... "+" ... "-" ... "*" ... "/" ... "%" ... "||" ... "AND" ... "OR" ... "IS" ... "MEMBER" ... "SUBMULTISET" ... "CONTAINS" ... "OVERLAPS" ... "EQUALS" ... "PRECEDES" ... "SUCCEEDS" ... "IMMEDIATELY" ... "MULTISET" ... "[" ... "FORMAT" ... "(" ... Less...

org.apache.calcite.sql.parser.SqlParseException
```

This is a bit confusing and adding a check could be added to throw a more user friendly message stating that the order should be reversed.

- Add error message for incorrectly ordered clause in sql
- Add unit tests to verify


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
