### PR TITLE
Add retention for file request logs

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -267,7 +267,7 @@ The `file` request logger stores daily request logs on disk.
 |--------|-----------|-------|
 |`druid.request.logging.dir`|Historical, Realtime and Broker processes maintain request logs of all of the requests they get (interaction is via POST, so normal request logs don’t generally capture information about the actual query), this specifies the directory to store the request logs in|none|
 |`druid.request.logging.filePattern`|[Joda datetime format](http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html) for each file|"yyyy-MM-dd'.log'"|
-| `druid.request.logging.durationToRetain`| Period to retain the request logs on disk. The period should be atleast longer than `P1D`.| none
+| `druid.request.logging.durationToRetain`| Period to retain the request logs on disk. The period should be at least longer than `P1D`.| none
 
 The format of request logs is TSV, one line per requests, with five fields: timestamp, remote\_addr, native\_query, query\_context, sql\_query.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -267,6 +267,7 @@ The `file` request logger stores daily request logs on disk.
 |--------|-----------|-------|
 |`druid.request.logging.dir`|Historical, Realtime and Broker processes maintain request logs of all of the requests they get (interaction is via POST, so normal request logs don’t generally capture information about the actual query), this specifies the directory to store the request logs in|none|
 |`druid.request.logging.filePattern`|[Joda datetime format](http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html) for each file|"yyyy-MM-dd'.log'"|
+| `druid.request.logging.durationToRetain`| Period to retain the request logs on disk. The period should be atleast longer than `P1D`.| none
 
 The format of request logs is TSV, one line per requests, with five fields: timestamp, remote\_addr, native\_query, query\_context, sql\_query.
 

--- a/server/src/main/java/org/apache/druid/server/log/FileRequestLoggerProvider.java
+++ b/server/src/main/java/org/apache/druid/server/log/FileRequestLoggerProvider.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.joda.time.Duration;
 
 import javax.validation.constraints.NotNull;
 import java.io.File;
@@ -54,6 +55,9 @@ public class FileRequestLoggerProvider implements RequestLoggerProvider
   @Json
   private ObjectMapper jsonMapper = null;
 
+  @JsonProperty
+  private Duration durationToRetain;
+
   @Override
   public RequestLogger get()
   {
@@ -61,7 +65,8 @@ public class FileRequestLoggerProvider implements RequestLoggerProvider
         jsonMapper,
         factory.create(1, "RequestLogger-%s"),
         dir,
-        filePattern
+        filePattern,
+        durationToRetain
     );
     log.debug(new Exception("Stack trace"), "Creating %s at", logger);
     return logger;

--- a/server/src/test/java/org/apache/druid/server/log/FileRequestLoggerTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/FileRequestLoggerTest.java
@@ -25,14 +25,17 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.server.RequestLogLine;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Date;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -44,7 +47,11 @@ public class FileRequestLoggerTest
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  @Test public void testLog() throws Exception
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testLog() throws Exception
   {
     ObjectMapper objectMapper = new ObjectMapper();
     DateTime dateTime = DateTimes.nowUtc();
@@ -52,11 +59,19 @@ public class FileRequestLoggerTest
     String nativeQueryLogString = dateTime + "\t" + HOST + "\t" + "native";
     String sqlQueryLogString = dateTime + "\t" + HOST + "\t" + "sql";
 
-    FileRequestLogger fileRequestLogger = new FileRequestLogger(objectMapper, scheduler, logDir, "yyyy-MM-dd'.log'");
+    FileRequestLogger fileRequestLogger = new FileRequestLogger(
+        objectMapper,
+        scheduler,
+        logDir,
+        "yyyy-MM-dd'.log'",
+        null
+    );
     fileRequestLogger.start();
 
     RequestLogLine nativeRequestLogLine = EasyMock.createMock(RequestLogLine.class);
-    EasyMock.expect(nativeRequestLogLine.getNativeQueryLine(EasyMock.anyObject())).andReturn(nativeQueryLogString).anyTimes();
+    EasyMock.expect(nativeRequestLogLine.getNativeQueryLine(EasyMock.anyObject()))
+            .andReturn(nativeQueryLogString)
+            .anyTimes();
     RequestLogLine sqlRequestLogLine = EasyMock.createMock(RequestLogLine.class);
     EasyMock.expect(sqlRequestLogLine.getSqlQueryLine(EasyMock.anyObject())).andReturn(sqlQueryLogString).anyTimes();
     EasyMock.replay(nativeRequestLogLine, sqlRequestLogLine);
@@ -68,5 +83,51 @@ public class FileRequestLoggerTest
     String logString = CharStreams.toString(Files.newBufferedReader(logFile.toPath(), StandardCharsets.UTF_8));
     Assert.assertTrue(logString.contains(nativeQueryLogString + "\n" + sqlQueryLogString + "\n"));
     fileRequestLogger.stop();
+  }
+
+  @Test
+  public void testLogRemove() throws Exception
+  {
+    ObjectMapper objectMapper = new ObjectMapper();
+    File logDir = temporaryFolder.newFolder();
+    DateTime dateTime = DateTimes.nowUtc();
+    String logString = dateTime + "\t" + HOST + "\t" + "logString";
+
+    File oldLogFile = new File(logDir, "2000-01-01.log");
+    com.google.common.io.Files.write("testOldLogContent", oldLogFile, StandardCharsets.UTF_8);
+    oldLogFile.setLastModified(new Date(0).getTime());
+    FileRequestLogger fileRequestLogger = new FileRequestLogger(
+        objectMapper,
+        scheduler,
+        logDir,
+        "yyyy-MM-dd'.log'",
+        Duration.standardDays(1)
+    );
+    fileRequestLogger.start();
+    RequestLogLine nativeRequestLogLine = EasyMock.createMock(RequestLogLine.class);
+    EasyMock.expect(nativeRequestLogLine.getNativeQueryLine(EasyMock.anyObject())).andReturn(logString).anyTimes();
+    EasyMock.replay(nativeRequestLogLine);
+    fileRequestLogger.logNativeQuery(nativeRequestLogLine);
+    File logFile = new File(logDir, dateTime.toString("yyyy-MM-dd'.log'"));
+    Thread.sleep(100);
+    Assert.assertFalse(oldLogFile.exists());
+    Assert.assertTrue(logFile.exists());
+    fileRequestLogger.stop();
+  }
+
+  @Test
+  public void testLogRemoveWithInvalidDuration() throws Exception
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("request logs retention period must be atleast P1D");
+    ObjectMapper objectMapper = new ObjectMapper();
+    File logDir = temporaryFolder.newFolder();
+    FileRequestLogger fileRequestLogger = new FileRequestLogger(
+        objectMapper,
+        scheduler,
+        logDir,
+        "yyyy-MM-dd'.log'",
+        Duration.standardHours(12)
+    );
   }
 }


### PR DESCRIPTION
### Description

This PR adds a new property `druid.request.logging.durationToRetain` that provides support to specify retention periods for request logs stored on disk. This property works only for the file-based request logger and the retention period must be at least 1 day so that it avoids deleting the request log for the current day. It is disabled by default to preserve existing behavior.

<hr>

##### Key changed/added classes in this PR
 * `FileRequestLogger`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
