### PR TITLE
Use a different repository to download sigar artifacts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <!-- Only used by core, but moved to root for parallel build dependency resolution -->
         <repository>
           <id>sigar</id>
-          <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/</url>
+          <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
JBoss repository seems to be down again and we have run into this before as well. This PR switches to a different repository in hope that availability is better for that repository. Eventually, we will have to get rid of sugar itself since it has not been upgraded in awhile. 

This PR has:
- [x] been self-reviewed.
