### PR TITLE
Suppress false CVE on druid-indexing-hadoop artifact

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -27,6 +27,7 @@
     <cve>CVE-2012-4449</cve>
     <cve>CVE-2017-3162</cve>
     <cve>CVE-2018-8009</cve>
+    <cve>CVE-2022-26612</cve>
   </suppress>
   <suppress>
     <!-- druid-processing.jar is mistaken for org.processing:processing -->


### PR DESCRIPTION
`druid-indexing-hadoop` is often mistaken as `Hadoop` artifact and gets flagged with some CVEs that only affect hadoop jars. 

This PR has:
- [x] been self-reviewed.