### PR TITLE
fix(druid-indexing): failed to get shardSpec for interval issue

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
@@ -39,6 +39,7 @@ import org.apache.druid.segment.realtime.appenderator.AppenderatorDriverAddResul
 import org.apache.druid.segment.realtime.appenderator.BatchAppenderatorDriver;
 import org.apache.druid.segment.realtime.appenderator.SegmentsAndCommitMetadata;
 import org.joda.time.Interval;
+import org.joda.time.chrono.ISOChronology;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -101,7 +102,7 @@ public class InputSourceProcessor
         // IndexTaskInputRowIteratorBuilder.absentBucketIntervalConsumer() ensures the interval will be present here
         Optional<Interval> optInterval = granularitySpec.bucketInterval(inputRow.getTimestamp());
         @SuppressWarnings("OptionalGetWithoutIsPresent")
-        final Interval interval = optInterval.get();
+        final Interval interval = optInterval.get().withChronology(ISOChronology.getInstanceUTC());
 
         final String sequenceName = sequenceNameFunction.getSequenceName(interval, inputRow);
         final AppenderatorDriverAddResult addResult = driver.add(inputRow, sequenceName);


### PR DESCRIPTION
### Description

when we index_parallel with spec

```json
{
    "type": "index_parallel",
    "spec": {
        ...
        "dataSchema": {
             ...
            "granularitySpec": {
                "rollup": true,
                "intervals": [
                    "2022-03-23T00:00:00.000+08:00/P1D"
                ],
                "queryGranularity": {
                    "type": "period",
                    "period": "P1D",
                    "timeZone": "Asia/Shanghai"
                },
                "segmentGranularity": {
                    "type": "period",
                    "period": "P1D",
                    "timeZone": "Asia/Shanghai"
                }
            }
        }
    }
}
```

the task failed at `partial_index_generic_merge` sub task with exception

```
SLF4J: Found binding in [jar:file:/opt/druid/lib/log4j-slf4j-impl-2.15.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/druid/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
2022-05-24T10:52:25,778 WARN [main] org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
2022-05-24T10:52:27,524 WARN [main] org.apache.druid.indexing.common.config.TaskConfig - Batch processing mode argument value is null or not valid:[null], defaulting to[CLOSED_SEGMENTS] 
2022-05-24T10:52:27,865 WARN [main] org.eclipse.jetty.server.handler.gzip.GzipHandler - minGzipSize of 0 is inefficient for short content, break even is size 23
2022-05-24T10:52:28,125 WARN [NodeRoleWatcher[COORDINATOR]] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider$NodeRoleWatcher - Ignored event type[CONNECTION_RECONNECTED] for node watcher of role[coordinator].
2022-05-24T10:52:48,511 WARN [task-runner-0-priority-0] org.apache.druid.indexing.input.DruidSegmentInputEntity - Could not clean temporary segment file: /druid/data/indexerTask/partial_index_generate_xapi-statistics_alaklohh_2022-05-24T10:52:23.380Z/work/indexing-tmp/xapi-statistics/2022-03-23T11:00:00.000Z_2022-03-23T12:00:00.000Z/2022-05-06T02:45:40.447Z/0
2022-05-24T10:52:48,514 ERROR [task-runner-0-priority-0] org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner - Exception while running task[AbstractTask{id='partial_index_generate_xapi-statistics_alaklohh_2022-05-24T10:52:23.380Z', groupId='index_parallel_xapi-statistics_eacjhgae_2022-05-24T10:30:20.878Z', taskResource=TaskResource{availabilityGroup='partial_index_generate_xapi-statistics_alaklohh_2022-05-24T10:52:23.380Z', requiredCapacity=1}, dataSource='xapi-statistics', context={forceTimeChunkLock=true, useLineageBasedSegmentAllocation=true}}]
org.apache.druid.java.util.common.ISE: Failed to get shardSpec for interval[2022-03-23T00:00:00.000+08:00/2022-03-24T00:00:00.000+08:00]
	at org.apache.druid.indexing.common.task.ShardSpecs.getShardSpec(ShardSpecs.java:57) ~[druid-indexing-service-0.22.1.jar:0.22.1]
	at org.apache.druid.indexing.common.task.NonLinearlyPartitionedSequenceNameFunction.getSequenceName(NonLinearlyPartitionedSequenceNameFunction.java:49) ~[druid-indexing-service-0.22.1.jar:0.22.1]
	at org.apache.druid.indexing.common.task.InputSourceProcessor.process(InputSourceProcessor.java:106) ~[druid-indexing-service-0.22.1.jar:0.22.1]
	at org.apache.druid.indexing.common.task.batch.parallel.PartialSegmentGenerateTask.generateSegments(PartialSegmentGenerateTask.java:187) ~[druid-indexing-service-0.22.1.jar:0.22.1]
	at org.apache.druid.indexing.common.task.batch.parallel.PartialSegmentGenerateTask.runTask(PartialSegmentGenerateTask.java:109) ~[druid-indexing-service-0.22.1.jar:0.22.1]
	at org.apache.druid.indexing.common.task.AbstractBatchIndexTask.run(AbstractBatchIndexTask.java:159) ~[druid-indexing-service-0.22.1.jar:0.22.1]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:471) [druid-indexing-service-0.22.1.jar:0.22.1]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:443) [druid-indexing-service-0.22.1.jar:0.22.1]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_275]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_275]
Finished peon task
```

After review the code and done some tests, I found intervalToNumberSharesOverride is a `Map<Interval[UTC], integer>`, but 

https://github.com/apache/druid/blob/master/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java#L104-L105

return a interval as `Interval[Asia/Shanghai]`, which is not the same index key and cause the exception.

I think it's safe to convert the interval timezone to UTC, so `getSequenceName` will return the right sequence name instead of throw the exception.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
