### PR TITLE
fix compression-strategy-test

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/data/CompressionStrategyTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressionStrategyTest.java
@@ -126,21 +126,15 @@ public class CompressionStrategyTest
                                                                .allocateOutBuffer(originalData.length, closer);
                 ByteBuffer compressionIn = compressionStrategy.getCompressor()
                                                               .allocateInBuffer(originalData.length, closer);
-                try {
-                  compressionIn.put(originalData);
-                  compressionIn.position(0);
-                  ByteBuffer compressed = compressionStrategy.getCompressor().compress(compressionIn, compressionOut);
-                  ByteBuffer output = compressionStrategy.getCompressor().allocateOutBuffer(originalData.length, closer);
-                  compressionStrategy.getDecompressor().decompress(compressed, compressed.remaining(), output);
-                  byte[] checkArray = new byte[DATA_SIZER];
-                  output.get(checkArray);
-                  Assert.assertArrayEquals("Uncompressed data does not match", originalData, checkArray);
-                  return true;
-                }
-                finally {
-                  ByteBufferUtils.free(compressionIn);
-                  ByteBufferUtils.free(compressionOut);
-                }
+                compressionIn.put(originalData);
+                compressionIn.position(0);
+                ByteBuffer compressed = compressionStrategy.getCompressor().compress(compressionIn, compressionOut);
+                ByteBuffer output = compressionStrategy.getCompressor().allocateOutBuffer(originalData.length, closer);
+                compressionStrategy.getDecompressor().decompress(compressed, compressed.remaining(), output);
+                byte[] checkArray = new byte[DATA_SIZER];
+                output.get(checkArray);
+                Assert.assertArrayEquals("Uncompressed data does not match", originalData, checkArray);
+                return true;
               }
           )
       );


### PR DESCRIPTION
Fixes an issue caused by a modification to `CompressionStrategyTest` in #12408 that was closing buffers allocated by the compression strategy instead of allowing the `Closer` to do it, leading to exceptions such as https://github.com/apache/druid/pull/12408#issuecomment-1140352022 appearing when running the tests. After making these changes, I am unable to trigger the issue anymore.