### PR TITLE
Add RowIdSupplier to ColumnSelectorFactory.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/ColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/ColumnSelectorFactory.java
@@ -53,4 +53,15 @@ public interface ColumnSelectorFactory extends ColumnInspector
   @Override
   @Nullable
   ColumnCapabilities getColumnCapabilities(String column);
+
+  /**
+   * Returns a {@link RowIdSupplier} that allows callers to detect whether the selectors returned by this
+   * factory have moved or not. Useful for selectors that wrap other selectors, such as virtual columns,
+   * as it allows them to cache their outputs.
+   */
+  @Nullable
+  default RowIdSupplier getRowIdSupplier()
+  {
+    return null;
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexColumnSelectorFactory.java
@@ -39,7 +39,7 @@ import java.util.function.Function;
  * It's counterpart for incremental index is {@link
  * org.apache.druid.segment.incremental.IncrementalIndexColumnSelectorFactory}.
  */
-public class QueryableIndexColumnSelectorFactory implements ColumnSelectorFactory
+public class QueryableIndexColumnSelectorFactory implements ColumnSelectorFactory, RowIdSupplier
 {
   private final QueryableIndex index;
   private final VirtualColumns virtualColumns;
@@ -191,6 +191,19 @@ public class QueryableIndexColumnSelectorFactory implements ColumnSelectorFactor
     } else {
       return null;
     }
+  }
+
+  @Nullable
+  @Override
+  public RowIdSupplier getRowIdSupplier()
+  {
+    return this;
+  }
+
+  @Override
+  public long getRowId()
+  {
+    return offset.getOffset();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/RowIdSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowIdSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+/**
+ * Returned by {@link ColumnSelectorFactory#getRowIdSupplier()}. Allows users of {@link ColumnSelectorFactory}
+ * to cache objects returned by their selectors.
+ */
+public interface RowIdSupplier
+{
+  /**
+   * A number that will never be returned from {@link #getRowId()}. Useful for initialization.
+   */
+  long INIT = -1;
+
+  /**
+   * Returns a number that uniquely identifies the current position of some underlying cursor. This is useful for
+   * caching: it is safe to assume nothing has changed in the selector as long as the row ID stays the same.
+   *
+   * Row IDs do not need to be contiguous or monotonic. They need not have any meaning. In particular: they may not
+   * be row *numbers* (row number 0 may have any arbitrary row ID).
+   *
+   * Valid row IDs are always nonnegative.
+   */
+  long getRowId();
+}

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexColumnSelectorFactory.java
@@ -25,6 +25,7 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.DimensionIndexer;
 import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.RowIdSupplier;
 import org.apache.druid.segment.SingleScanTimeDimensionSelector;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
@@ -37,7 +38,7 @@ import javax.annotation.Nullable;
  * The basic implementation of {@link ColumnSelectorFactory} over an {@link IncrementalIndex}. It's counterpart for
  * historical segments is {@link org.apache.druid.segment.QueryableIndexColumnSelectorFactory}.
  */
-class IncrementalIndexColumnSelectorFactory implements ColumnSelectorFactory
+class IncrementalIndexColumnSelectorFactory implements ColumnSelectorFactory, RowIdSupplier
 {
   private final IncrementalIndexStorageAdapter adapter;
   private final IncrementalIndex index;
@@ -132,5 +133,18 @@ class IncrementalIndexColumnSelectorFactory implements ColumnSelectorFactory
 
     // Use adapter.getColumnCapabilities instead of index.getCapabilities (see note in IncrementalIndexStorageAdapater)
     return adapter.getColumnCapabilities(columnName);
+  }
+
+  @Nullable
+  @Override
+  public RowIdSupplier getRowIdSupplier()
+  {
+    return this;
+  }
+
+  @Override
+  public long getRowId()
+  {
+    return rowHolder.get().getRowIndex();
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/virtual/BaseExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/BaseExpressionColumnValueSelector.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.virtual;
+
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.RowIdSupplier;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base class for many (although not all) {@code ColumnValueSelector<ExprEval>}.
+ */
+public abstract class BaseExpressionColumnValueSelector implements ColumnValueSelector<ExprEval>
+{
+  @Nullable
+  private final RowIdSupplier rowIdSupplier;
+  private long currentRowId = RowIdSupplier.INIT;
+  private ExprEval<?> currentEval;
+
+  protected BaseExpressionColumnValueSelector(@Nullable RowIdSupplier rowIdSupplier)
+  {
+    this.rowIdSupplier = rowIdSupplier;
+  }
+
+  @Override
+  public double getDouble()
+  {
+    // No assert for null handling as ExprEval already has it.
+    return computeCurrentEval().asDouble();
+  }
+
+  @Override
+  public float getFloat()
+  {
+    // No assert for null handling as ExprEval already has it.
+    return (float) computeCurrentEval().asDouble();
+  }
+
+  @Override
+  public long getLong()
+  {
+    // No assert for null handling as ExprEval already has it.
+    return computeCurrentEval().asLong();
+  }
+
+  @Override
+  public boolean isNull()
+  {
+    // It is possible for an expression to have a non-null String value, but be null when treated as long/float/double.
+    // Check specifically for numeric nulls, which matches the expected behavior of ColumnValueSelector.isNull.
+    return computeCurrentEval().isNumericNull();
+  }
+
+  @Nullable
+  @Override
+  public ExprEval<?> getObject()
+  {
+    return computeCurrentEval();
+  }
+
+  @Override
+  public Class<ExprEval> classOfObject()
+  {
+    return ExprEval.class;
+  }
+
+  @Override
+  public void inspectRuntimeShape(final RuntimeShapeInspector inspector)
+  {
+    inspector.visit("rowIdSupplier", this);
+  }
+
+  /**
+   * Implementations override this.
+   */
+  protected abstract ExprEval<?> eval();
+
+  /**
+   * Call {@link #eval()} or use {@code currentEval} as appropriate.
+   */
+  private ExprEval<?> computeCurrentEval()
+  {
+    if (rowIdSupplier == null) {
+      return eval();
+    } else {
+      final long rowId = rowIdSupplier.getRowId();
+
+      if (currentRowId != rowId) {
+        currentEval = eval();
+        currentRowId = rowId;
+      }
+
+      return currentEval;
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -40,6 +40,7 @@ import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.ConstantExprEvalSelector;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.NilColumnValueSelector;
+import org.apache.druid.segment.RowIdSupplier;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
@@ -143,6 +144,8 @@ public class ExpressionSelectors
       ExpressionPlan plan
   )
   {
+    final RowIdSupplier rowIdSupplier = columnSelectorFactory.getRowIdSupplier();
+
     if (plan.is(ExpressionPlan.Trait.SINGLE_INPUT_SCALAR)) {
       final String column = plan.getSingleInputName();
       final ColumnType inputType = plan.getSingleInputType();
@@ -150,12 +153,14 @@ public class ExpressionSelectors
         return new SingleLongInputCachingExpressionColumnValueSelector(
             columnSelectorFactory.makeColumnValueSelector(column),
             plan.getExpression(),
-            !ColumnHolder.TIME_COLUMN_NAME.equals(column) // __time doesn't need an LRU cache since it is sorted.
+            !ColumnHolder.TIME_COLUMN_NAME.equals(column), // __time doesn't need an LRU cache since it is sorted.
+            rowIdSupplier
         );
       } else if (inputType.is(ValueType.STRING)) {
         return new SingleStringInputCachingExpressionColumnValueSelector(
             columnSelectorFactory.makeDimensionSelector(new DefaultDimensionSpec(column, column, ColumnType.STRING)),
-            plan.getExpression()
+            plan.getExpression(),
+            rowIdSupplier
         );
       }
     }
@@ -169,11 +174,11 @@ public class ExpressionSelectors
     // if any unknown column input types, fall back to an expression selector that examines input bindings on a
     // per row basis
     if (plan.any(ExpressionPlan.Trait.UNKNOWN_INPUTS, ExpressionPlan.Trait.INCOMPLETE_INPUTS)) {
-      return new RowBasedExpressionColumnValueSelector(plan, bindings);
+      return new RowBasedExpressionColumnValueSelector(plan, bindings, rowIdSupplier);
     }
 
     // generic expression value selector for fully known input types
-    return new ExpressionColumnValueSelector(plan.getAppliedExpression(), bindings);
+    return new ExpressionColumnValueSelector(plan.getAppliedExpression(), bindings, rowIdSupplier);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputCachingExpressionColumnValueSelector.java
@@ -28,9 +28,9 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
-import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.RowIdSupplier;
 import org.apache.druid.segment.data.IndexedInts;
 
 import javax.annotation.Nullable;
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
  * Like {@link ExpressionColumnValueSelector}, but caches results for the first CACHE_SIZE dictionary IDs of
  * a string column. Must only be used on selectors with dictionaries.
  */
-public class SingleStringInputCachingExpressionColumnValueSelector implements ColumnValueSelector<ExprEval>
+public class SingleStringInputCachingExpressionColumnValueSelector extends BaseExpressionColumnValueSelector
 {
   private static final int CACHE_SIZE = 1000;
 
@@ -53,9 +53,12 @@ public class SingleStringInputCachingExpressionColumnValueSelector implements Co
 
   public SingleStringInputCachingExpressionColumnValueSelector(
       final DimensionSelector selector,
-      final Expr expression
+      final Expr expression,
+      @Nullable final RowIdSupplier rowIdSupplier
   )
   {
+    super(rowIdSupplier);
+
     // Verify expression has just one binding.
     if (expression.analyzeInputs().getRequiredBindings().size() != 1) {
       throw new ISE("Expected expression with just one binding");
@@ -81,45 +84,13 @@ public class SingleStringInputCachingExpressionColumnValueSelector implements Co
   @Override
   public void inspectRuntimeShape(final RuntimeShapeInspector inspector)
   {
+    super.inspectRuntimeShape(inspector);
     inspector.visit("selector", selector);
     inspector.visit("expression", expression);
   }
 
   @Override
-  public double getDouble()
-  {
-    // No Assert for null handling as ExprEval already have it.
-    return eval().asDouble();
-  }
-
-  @Override
-  public float getFloat()
-  {
-    // No Assert for null handling as ExprEval already have it.
-    return (float) eval().asDouble();
-  }
-
-  @Override
-  public long getLong()
-  {
-    // No Assert for null handling as ExprEval already have it.
-    return eval().asLong();
-  }
-
-  @Nullable
-  @Override
-  public ExprEval getObject()
-  {
-    return eval();
-  }
-
-  @Override
-  public Class<ExprEval> classOfObject()
-  {
-    return ExprEval.class;
-  }
-
-  private ExprEval eval()
+  protected ExprEval<?> eval()
   {
     final IndexedInts row = selector.getRow();
 

--- a/processing/src/main/java/org/apache/druid/segment/virtual/VirtualizedColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/VirtualizedColumnSelectorFactory.java
@@ -24,7 +24,10 @@ import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.RowIdSupplier;
 import org.apache.druid.segment.VirtualColumns;
+
+import javax.annotation.Nullable;
 
 /**
  * {@link ColumnSelectorFactory} which can create selectors for both virtual and non-virtual columns
@@ -60,5 +63,12 @@ public class VirtualizedColumnSelectorFactory extends VirtualizedColumnInspector
     } else {
       return baseFactory.makeColumnValueSelector(columnName);
     }
+  }
+
+  @Nullable
+  @Override
+  public RowIdSupplier getRowIdSupplier()
+  {
+    return baseFactory.getRowIdSupplier();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/VirtualColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/VirtualColumnsTest.java
@@ -56,6 +56,11 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -67,6 +72,12 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock
+  public ColumnSelectorFactory baseColumnSelectorFactory;
 
   @Test
   public void testExists()
@@ -197,24 +208,35 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("No such virtual column[bar]");
 
-    virtualColumns.makeColumnValueSelector("bar", null);
+    virtualColumns.makeColumnValueSelector("bar", baseColumnSelectorFactory);
   }
 
   @Test
   public void testMakeSelectors()
   {
+    Mockito.when(baseColumnSelectorFactory.getRowIdSupplier()).thenReturn(null);
+
     final VirtualColumns virtualColumns = makeVirtualColumns();
-    final BaseObjectColumnValueSelector objectSelector = virtualColumns.makeColumnValueSelector("expr", null);
+    final BaseObjectColumnValueSelector objectSelector = virtualColumns.makeColumnValueSelector(
+        "expr",
+        baseColumnSelectorFactory
+    );
     final DimensionSelector dimensionSelector = virtualColumns.makeDimensionSelector(
         new DefaultDimensionSpec("expr", "x"),
-        null
+        baseColumnSelectorFactory
     );
     final DimensionSelector extractionDimensionSelector = virtualColumns.makeDimensionSelector(
         new ExtractionDimensionSpec("expr", "x", new BucketExtractionFn(1.0, 0.5)),
-        null
+        baseColumnSelectorFactory
     );
-    final BaseFloatColumnValueSelector floatSelector = virtualColumns.makeColumnValueSelector("expr", null);
-    final BaseLongColumnValueSelector longSelector = virtualColumns.makeColumnValueSelector("expr", null);
+    final BaseFloatColumnValueSelector floatSelector = virtualColumns.makeColumnValueSelector(
+        "expr",
+        baseColumnSelectorFactory
+    );
+    final BaseLongColumnValueSelector longSelector = virtualColumns.makeColumnValueSelector(
+        "expr",
+        baseColumnSelectorFactory
+    );
 
     Assert.assertEquals(1L, objectSelector.getObject());
     Assert.assertEquals("1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
@@ -227,13 +249,22 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   public void testMakeSelectorsWithDotSupport()
   {
     final VirtualColumns virtualColumns = makeVirtualColumns();
-    final BaseObjectColumnValueSelector objectSelector = virtualColumns.makeColumnValueSelector("foo.5", null);
+    final BaseObjectColumnValueSelector objectSelector = virtualColumns.makeColumnValueSelector(
+        "foo.5",
+        baseColumnSelectorFactory
+    );
     final DimensionSelector dimensionSelector = virtualColumns.makeDimensionSelector(
         new DefaultDimensionSpec("foo.5", "x"),
-        null
+        baseColumnSelectorFactory
     );
-    final BaseFloatColumnValueSelector floatSelector = virtualColumns.makeColumnValueSelector("foo.5", null);
-    final BaseLongColumnValueSelector longSelector = virtualColumns.makeColumnValueSelector("foo.5", null);
+    final BaseFloatColumnValueSelector floatSelector = virtualColumns.makeColumnValueSelector(
+        "foo.5",
+        baseColumnSelectorFactory
+    );
+    final BaseLongColumnValueSelector longSelector = virtualColumns.makeColumnValueSelector(
+        "foo.5",
+        baseColumnSelectorFactory
+    );
 
     Assert.assertEquals(5L, objectSelector.getObject());
     Assert.assertEquals("5", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
@@ -245,13 +276,22 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   public void testMakeSelectorsWithDotSupportBaseNameOnly()
   {
     final VirtualColumns virtualColumns = makeVirtualColumns();
-    final BaseObjectColumnValueSelector objectSelector = virtualColumns.makeColumnValueSelector("foo", null);
+    final BaseObjectColumnValueSelector objectSelector = virtualColumns.makeColumnValueSelector(
+        "foo",
+        baseColumnSelectorFactory
+    );
     final DimensionSelector dimensionSelector = virtualColumns.makeDimensionSelector(
         new DefaultDimensionSpec("foo", "x"),
-        null
+        baseColumnSelectorFactory
     );
-    final BaseFloatColumnValueSelector floatSelector = virtualColumns.makeColumnValueSelector("foo", null);
-    final BaseLongColumnValueSelector longSelector = virtualColumns.makeColumnValueSelector("foo", null);
+    final BaseFloatColumnValueSelector floatSelector = virtualColumns.makeColumnValueSelector(
+        "foo",
+        baseColumnSelectorFactory
+    );
+    final BaseLongColumnValueSelector longSelector = virtualColumns.makeColumnValueSelector(
+        "foo",
+        baseColumnSelectorFactory
+    );
 
     Assert.assertEquals(-1L, objectSelector.getObject());
     Assert.assertEquals("-1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));


### PR DESCRIPTION
This enables virtual columns to cache their outputs in case they are
called multiple times on the same underlying row. This is common for
numeric selectors, where the common pattern is to call isNull() and
then follow with getLong(), getFloat(), or getDouble(). Here, output
caching reduces the number of expression evals by half.

A similar thing is already possible for vector selectors via
ReadableVectorInspector.getId.