### PR TITLE
CompressionUtils: Increase gzip buffer size.

### DIFF
--- a/core/src/main/java/org/apache/druid/utils/CompressionUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/CompressionUtils.java
@@ -72,6 +72,7 @@ public class CompressionUtils
   private static final String ZIP_SUFFIX = ".zip";
   private static final String SNAPPY_SUFFIX = ".sz";
   private static final String ZSTD_SUFFIX = ".zst";
+  private static final int GZIP_BUFFER_SIZE = 8192; // Default is 512
 
   /**
    * Zip the contents of directory into the file indicated by outputZipFile. Sub directories are skipped
@@ -370,7 +371,8 @@ public class CompressionUtils
             // so we estimate about 1KiB to work around available == 0 bug in GZIPInputStream
             return otherAvailable == 0 ? 1 << 10 : otherAvailable;
           }
-        }
+        },
+        GZIP_BUFFER_SIZE
     );
   }
 


### PR DESCRIPTION
The default of 512 bytes is quite small for a buffer size. On my machine (M1 Mac) I got a 15% speedup by increasing it to 8 KB. Increases beyond 8 KB did not yield any change in performance.