### PR TITLE
fix backwards compatibility for explicit null columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -337,7 +337,7 @@ public class IndexMergerV9 implements IndexMerger
           ColumnDescriptor columnDesc = ColumnDescriptor
               .builder()
               .setValueType(dimCapabilities.get(i).getType())
-              .addSerde(new NullColumnPartSerde(indexMergeResult.rowCount))
+              .addSerde(new NullColumnPartSerde(indexMergeResult.rowCount, indexSpec.getBitmapSerdeFactory()))
               .build();
           makeColumn(v9Smoosher, mergedDimensions.get(i), columnDesc);
         }

--- a/processing/src/test/java/org/apache/druid/segment/serde/NullColumnPartSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/serde/NullColumnPartSerdeTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.segment.column.ColumnBuilder;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class NullColumnPartSerdeTest extends InitializedNullHandlingTest
   {
     final ObjectMapper mapper = new DefaultObjectMapper();
 
-    final NullColumnPartSerde partSerde = new NullColumnPartSerde(10);
+    final NullColumnPartSerde partSerde = new NullColumnPartSerde(10, new RoaringBitmapSerdeFactory(null));
     final String json = mapper.writeValueAsString(partSerde);
     Assert.assertEquals(partSerde, mapper.readValue(json, ColumnPartSerde.class));
   }
@@ -48,7 +49,7 @@ public class NullColumnPartSerdeTest extends InitializedNullHandlingTest
   @Test
   public void testDeserializer()
   {
-    final NullColumnPartSerde partSerde = new NullColumnPartSerde(10);
+    final NullColumnPartSerde partSerde = new NullColumnPartSerde(10, new RoaringBitmapSerdeFactory(null));
     final ColumnBuilder builder = new ColumnBuilder().setType(ValueType.DOUBLE);
     partSerde.getDeserializer().read(Mockito.mock(ByteBuffer.class), builder, Mockito.mock(ColumnConfig.class));
     final ColumnCapabilities columnCapabilities = builder.build().getCapabilities();


### PR DESCRIPTION
Adds back `bitmapSerdeFactory` to JSON of `NullColumnPartSerde` for backwards compatibility so 0.23 can read segments generated by newer versions, see https://github.com/apache/druid/pull/12388#issuecomment-1140387984 for additional details