### PR TITLE
Add validation for invalid partitioned by granularities

### DIFF
--- a/sql/src/main/codegen/config.fmpp
+++ b/sql/src/main/codegen/config.fmpp
@@ -55,9 +55,7 @@ data: {
       "org.apache.calcite.sql.SqlNode"
       "org.apache.calcite.sql.SqlInsert"
       "org.apache.druid.java.util.common.granularity.Granularity"
-      "org.apache.druid.java.util.common.granularity.GranularityType"
       "org.apache.druid.java.util.common.granularity.Granularities"
-      "org.apache.druid.java.util.common.IAE"
       "org.apache.druid.sql.calcite.parser.DruidSqlInsert"
       "org.apache.druid.sql.calcite.parser.DruidSqlParserUtils"
     ]

--- a/sql/src/main/codegen/config.fmpp
+++ b/sql/src/main/codegen/config.fmpp
@@ -55,7 +55,9 @@ data: {
       "org.apache.calcite.sql.SqlNode"
       "org.apache.calcite.sql.SqlInsert"
       "org.apache.druid.java.util.common.granularity.Granularity"
+      "org.apache.druid.java.util.common.granularity.GranularityType"
       "org.apache.druid.java.util.common.granularity.Granularities"
+      "org.apache.druid.java.util.common.IAE"
       "org.apache.druid.sql.calcite.parser.DruidSqlInsert"
       "org.apache.druid.sql.calcite.parser.DruidSqlParserUtils"
     ]

--- a/sql/src/main/codegen/includes/common.ftl
+++ b/sql/src/main/codegen/includes/common.ftl
@@ -65,11 +65,7 @@ org.apache.druid.java.util.common.Pair<Granularity, String> PartitionGranularity
     e = Expression(ExprContext.ACCEPT_SUB_QUERY)
     {
       granularity = DruidSqlParserUtils.convertSqlNodeToGranularityThrowingParseExceptions(e);
-      if(!GranularityType.isStandard(granularity))
-      {
-        throw new IAE("The granularity specified in PARTITIONED BY is not supported. "
-        + "Please use a standard granularity.");
-      }
+      DruidSqlParserUtils.throwIfUnsupportedGranularityInPartitionedBy(granularity);
       unparseString = e.toString();
     }
   )

--- a/sql/src/main/codegen/includes/common.ftl
+++ b/sql/src/main/codegen/includes/common.ftl
@@ -65,6 +65,11 @@ org.apache.druid.java.util.common.Pair<Granularity, String> PartitionGranularity
     e = Expression(ExprContext.ACCEPT_SUB_QUERY)
     {
       granularity = DruidSqlParserUtils.convertSqlNodeToGranularityThrowingParseExceptions(e);
+      if(!GranularityType.isStandard(granularity))
+      {
+        throw new IAE("The granularity specified in PARTITIONED BY is not supported. "
+        + "Please use a standard granularity.");
+      }
       unparseString = e.toString();
     }
   )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
@@ -431,7 +431,7 @@ public class DruidSqlParserUtils
           Arrays.stream(GranularityType.values())
                 .filter(granularityType -> !granularityType.equals(GranularityType.NONE))
                 .map(Enum::name)
-                .map(String::toLowerCase)
+                .map(StringUtils::toLowerCase)
                 .collect(Collectors.joining(", "))
       );
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
@@ -32,8 +32,10 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOrderBy;
 import org.apache.calcite.sql.SqlTimestampLiteral;
 import org.apache.calcite.tools.ValidationException;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.java.util.common.granularity.GranularityType;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.filter.AndDimFilter;
@@ -56,6 +58,7 @@ import org.joda.time.base.AbstractInterval;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -412,5 +415,25 @@ public class DruidSqlParserUtils
     Timestamp sqlTimestamp = Timestamp.valueOf(((SqlTimestampLiteral) sqlNode).toFormattedString());
     ZonedDateTime zonedTimestamp = sqlTimestamp.toLocalDateTime().atZone(timeZone.toTimeZone().toZoneId());
     return String.valueOf(zonedTimestamp.toInstant().toEpochMilli());
+  }
+
+  /**
+   * Throws an IAE with appropriate message if the granularity supplied is not present in
+   * {@link org.apache.druid.java.util.common.granularity.Granularities}. It also filters out NONE as it is not a valid
+   * granularity that can be supplied in PARTITIONED BY
+   */
+  public static void throwIfUnsupportedGranularityInPartitionedBy(Granularity granularity)
+  {
+    if (!GranularityType.isStandard(granularity)) {
+      throw new IAE(
+          "The granularity specified in PARTITIONED BY is not supported. "
+          + "Please use an equivalent of these granularities: %s.",
+          Arrays.stream(GranularityType.values())
+                .filter(granularityType -> !granularityType.equals(GranularityType.NONE))
+                .map(Enum::name)
+                .map(String::toLowerCase)
+                .collect(Collectors.joining(", "))
+      );
+    }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParserUtils.java
@@ -34,7 +34,6 @@ import org.apache.calcite.sql.SqlTimestampLiteral;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
-import org.apache.druid.java.util.common.granularity.GranularityType;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.filter.AndDimFilter;
@@ -160,11 +159,7 @@ public class DruidSqlParserUtils
       catch (IllegalArgumentException e) {
         throw new ParseException(StringUtils.format("%s is an invalid period string", granularitySqlNode.toString()));
       }
-      Granularity granularity = new PeriodGranularity(period, null, null);
-      if (!GranularityType.isStandard(granularity)) {
-        throw new ParseException("The granularity specified in PARTITIONED BY is not supported. Please use a supported standard granularity.");
-      }
-      return granularity;
+      return new PeriodGranularity(period, null, null);
 
     } else if ("FLOOR".equalsIgnoreCase(operatorName)) { // If the floor function is of form FLOOR(__time TO DAY)
       SqlNode granularitySqlNode = operandList.get(1);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -744,11 +744,12 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
   {
     testIngestionQuery()
         .sql("insert into foo1 select __time, dim1 FROM foo partitioned by time_floor(__time, 'PT2H')")
-        .expectValidationError(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(SqlPlanningException.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                "The granularity specified in PARTITIONED BY is not supported. Please use a supported standard granularity."))
-                               )
+        .expectValidationError(
+            CoreMatchers.allOf(
+                CoreMatchers.instanceOf(SqlPlanningException.class),
+                ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
+                    "The granularity specified in PARTITIONED BY is not supported. Please use a standard granularity."))
+            )
         )
         .verify();
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -748,7 +748,9 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
             CoreMatchers.allOf(
                 CoreMatchers.instanceOf(SqlPlanningException.class),
                 ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                    "The granularity specified in PARTITIONED BY is not supported. Please use a standard granularity."))
+                    "The granularity specified in PARTITIONED BY is not supported. "
+                    + "Please use an equivalent of these granularities: second, minute, five_minute, ten_minute, "
+                    + "fifteen_minute, thirty_minute, hour, six_hour, day, week, month, quarter, year, all."))
             )
         )
         .verify();


### PR DESCRIPTION
### Description

This PR is in continuation to https://github.com/apache/druid/pull/12580 and rejects the ingest queries with `PARTITIONED BY` granularities that are not supported. For example queries with`PARTITIONED BY` clause set to `TIME_FLOOR(__time, 'PT2H')` are rejected in the validation layer itself. Unit tests for the same have been added.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
