### PR TITLE
Use newer linux release for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 
 language: java
 
-dist: xenial
+dist: focal
 
 jdk:
   - openjdk8


### PR DESCRIPTION
All builds are failing right now due to https://travis-ci.community/t/install-of-openjdk-8-failing-on-xenial-builds/13043

Switching to a different ubuntu flavor will hopefully work 🤞 