### PR TITLE
Add remedial information in error message when type is unknown

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
@@ -784,7 +784,7 @@ public class GroupByBenchmark
     QueryRunner<ResultRow> theRunner = new FinalizeResultsQueryRunner<>(
         toolChest.mergeResults(
             new SerializingQueryRunner<>(
-                new DefaultObjectMapper(new SmileFactory()),
+                new DefaultObjectMapper(new SmileFactory(), null),
                 ResultRow.class,
                 toolChest.mergeResults(
                     factory.mergeRunners(state.executorService, makeMultiRunners(state))

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
@@ -308,7 +308,7 @@ public class DatasourceOptimizerTest extends CuratorTestBase
     final SmileFactory smileFactory = new SmileFactory();
     smileFactory.configure(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT, false);
     smileFactory.delegateToTextual(true);
-    final ObjectMapper retVal = new DefaultObjectMapper(smileFactory);
+    final ObjectMapper retVal = new DefaultObjectMapper(smileFactory, "broker");
     retVal.getFactory().setCodec(retVal);
     return retVal;
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -62,7 +63,7 @@ public class StringSketchTest
 
   public static class SerializationDeserializationTest
   {
-    private static final ObjectMapper OBJECT_MAPPER = new JacksonModule().smileMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new JacksonModule().smileMapper(new Properties());
 
     @Test
     public void serializesDeserializes()

--- a/processing/src/main/java/org/apache/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/org/apache/druid/jackson/DefaultObjectMapper.java
@@ -105,10 +105,10 @@ public class DefaultObjectMapper extends ObjectMapper
                                         String failureMsg)
         throws IOException
     {
-      String msg = String.format("Please make sure to load all the necessary extensions and jars on '%s' service " +
-              "that have '%s' type. " +
+      String msg = String.format("Please make sure to load all the necessary extensions and jars " +
+              "with type '%s' on '%s' service. " +
               "Could not resolve type id '%s' as a subtype of %s",
-          serviceName, subTypeId, subTypeId, ClassUtil.getTypeDescription(baseType));
+          subTypeId, serviceName, subTypeId, ClassUtil.getTypeDescription(baseType));
       throw InvalidTypeIdException.from(ctxt.getParser(), extraFailureMessage(msg, failureMsg), baseType, subTypeId);
     }
 

--- a/processing/src/main/java/org/apache/druid/jackson/DefaultObjectMapper.java
+++ b/processing/src/main/java/org/apache/druid/jackson/DefaultObjectMapper.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nullable;
 
@@ -90,13 +91,19 @@ public class DefaultObjectMapper extends ObjectMapper
    * A custom implementation of {@link #DeserializationProblemHandler} to add custom error message so
    * that users know how to troubleshoot unknown type ids.
    */
-  private static class DefaultDeserializationProblemHandler extends DeserializationProblemHandler
+  static class DefaultDeserializationProblemHandler extends DeserializationProblemHandler
   {
     private final String serviceName;
 
     public DefaultDeserializationProblemHandler(@Nullable String serviceName)
     {
       this.serviceName = serviceName == null ? "unknown" : serviceName;
+    }
+
+    @VisibleForTesting
+    String getServiceName()
+    {
+      return serviceName;
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/jackson/JacksonModule.java
+++ b/processing/src/main/java/org/apache/druid/jackson/JacksonModule.java
@@ -24,9 +24,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import com.google.inject.Binder;
+import com.google.inject.Inject;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import com.google.inject.name.Named;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.JsonNonNull;
@@ -36,6 +38,14 @@ import org.apache.druid.guice.annotations.Smile;
  */
 public class JacksonModule implements Module
 {
+  private String serviceName;
+
+  @Inject
+  public void setServiceName(@Named("serviceName") String serviceName)
+  {
+    this.serviceName = serviceName;
+  }
+
   @Override
   public void configure(Binder binder)
   {
@@ -45,7 +55,7 @@ public class JacksonModule implements Module
   @Provides @LazySingleton @Json
   public ObjectMapper jsonMapper()
   {
-    return new DefaultObjectMapper();
+    return new DefaultObjectMapper(serviceName);
   }
 
   /**
@@ -54,7 +64,7 @@ public class JacksonModule implements Module
   @Provides @LazySingleton @JsonNonNull
   public ObjectMapper jsonMapperOnlyNonNullValue()
   {
-    return new DefaultObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    return new DefaultObjectMapper(serviceName).setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 
   @Provides @LazySingleton @Smile
@@ -63,7 +73,7 @@ public class JacksonModule implements Module
     final SmileFactory smileFactory = new SmileFactory();
     smileFactory.configure(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT, false);
     smileFactory.delegateToTextual(true);
-    final ObjectMapper retVal = new DefaultObjectMapper(smileFactory);
+    final ObjectMapper retVal = new DefaultObjectMapper(smileFactory, serviceName);
     retVal.getFactory().setCodec(retVal);
     return retVal;
   }

--- a/processing/src/test/java/org/apache/druid/jackson/DefaultObjectMapperTest.java
+++ b/processing/src/test/java/org/apache/druid/jackson/DefaultObjectMapperTest.java
@@ -19,12 +19,15 @@
 
 package org.apache.druid.jackson;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.guava.Yielders;
+import org.apache.druid.query.Query;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
@@ -66,5 +69,20 @@ public class DefaultObjectMapperTest
         "[\"a\",\"b\",null,\"1970-01-01T00:00:00.002Z\",5,\"UTC\",\"c\"]",
         mapper.writeValueAsString(Yielders.each(sequence))
     );
+  }
+
+  @Test
+  public void testUnknownType() throws JsonProcessingException
+  {
+    DefaultObjectMapper objectMapper = new DefaultObjectMapper("testService");
+    try {
+      objectMapper.readValue("{\"queryType\":\"random\",\"name\":\"does-not-matter\"}", Query.class);
+    } catch (InvalidTypeIdException e) {
+      String message = e.getMessage();
+      Assert.assertTrue(message, message.startsWith("Please make sure to load all the necessary extensions and " +
+          "jars with type 'random' on 'testService' service."));
+      return;
+    }
+    Assert.fail("We expect InvalidTypeIdException to be thrown");
   }
 }

--- a/processing/src/test/java/org/apache/druid/jackson/JacksonModuleTest.java
+++ b/processing/src/test/java/org/apache/druid/jackson/JacksonModuleTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.jackson;
+
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.util.LinkedNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class JacksonModuleTest
+{
+  @Test
+  public void testNullServiceNameInProperties()
+  {
+    JacksonModule module = new JacksonModule();
+    verifyUnknownServiceName((DefaultObjectMapper) module.jsonMapper(new Properties()));
+    verifyUnknownServiceName((DefaultObjectMapper) module.smileMapper(new Properties()));
+    verifyUnknownServiceName((DefaultObjectMapper) module.jsonMapperOnlyNonNullValue(new Properties()));
+  }
+
+  @Test
+  public void testNullProperties()
+  {
+    JacksonModule module = new JacksonModule();
+    verifyUnknownServiceName((DefaultObjectMapper) module.jsonMapper(null));
+    verifyUnknownServiceName((DefaultObjectMapper) module.smileMapper(null));
+    verifyUnknownServiceName((DefaultObjectMapper) module.jsonMapperOnlyNonNullValue(null));
+  }
+
+  @Test
+  public void testServiceNameInProperties()
+  {
+    JacksonModule module = new JacksonModule();
+    Properties properties = new Properties();
+    properties.setProperty("druid.service", "myService_1");
+    verifyServiceName((DefaultObjectMapper) module.jsonMapper(properties), "myService_1");
+    properties.setProperty("druid.service", "myService_2");
+    verifyServiceName((DefaultObjectMapper) module.smileMapper(properties), "myService_2");
+    properties.setProperty("druid.service", "myService_3");
+    verifyServiceName((DefaultObjectMapper) module.jsonMapperOnlyNonNullValue(properties), "myService_3");
+  }
+
+  private void verifyUnknownServiceName(DefaultObjectMapper objectMapper)
+  {
+    verifyServiceName(objectMapper, "unknown");
+  }
+
+  private void verifyServiceName(DefaultObjectMapper objectMapper, String expectedServiceName)
+  {
+    LinkedNode<DeserializationProblemHandler> handlers = objectMapper.getDeserializationConfig().getProblemHandlers();
+    Assert.assertNull(handlers.next());
+    DefaultObjectMapper.DefaultDeserializationProblemHandler handler =
+        (DefaultObjectMapper.DefaultDeserializationProblemHandler) handlers.value();
+    Assert.assertEquals(expectedServiceName, handler.getServiceName());
+  }
+}

--- a/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
@@ -698,7 +698,7 @@ public class BrokerServerViewTest extends CuratorTestBase
     final SmileFactory smileFactory = new SmileFactory();
     smileFactory.configure(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT, false);
     smileFactory.delegateToTextual(true);
-    final ObjectMapper retVal = new DefaultObjectMapper(smileFactory);
+    final ObjectMapper retVal = new DefaultObjectMapper(smileFactory, "broker");
     retVal.getFactory().setCodec(retVal);
     return retVal;
   }

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTestUtils.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTestUtils.java
@@ -87,7 +87,7 @@ public final class CachingClusteredClientTestUtils
   public static ObjectMapper createObjectMapper()
   {
     final SmileFactory factory = new SmileFactory();
-    final ObjectMapper objectMapper = new DefaultObjectMapper(factory);
+    final ObjectMapper objectMapper = new DefaultObjectMapper(factory, "broker");
     factory.setCodec(objectMapper);
     return objectMapper;
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6384,7 +6384,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 )
             )
         ),
-        "SELECT FLOOR(__time to day), COUNT(distinct city), COUNT(distinct user) FROM druid.visits GROUP BY 1",
+        "SELECT TIME_FLOOR(__time, 'PT1D'), COUNT(distinct city), COUNT(distinct user) FROM druid.visits GROUP BY 1",
         CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(
             GroupByQuery.builder()


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Often users are submitting queries, and ingestion specs that work only if the relevant extension is not loaded. However, the error is too technical for the users and doesn't suggest them to check for missing extensions. This PR modifies the error message so users can at least check their settings before assuming that the error is because of a bug. 

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

Added `DefaultDeserializationProblemHandler` that lets us control what exception is thrown for unknown types. This is registered only for `DefaultObjectMapper`



<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
