### PR TITLE
Make default query context show up in sql query logs

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
@@ -35,6 +35,7 @@ import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryInterruptedException;
@@ -93,6 +94,7 @@ public class SqlLifecycle
   private final RequestLogger requestLogger;
   private final QueryScheduler queryScheduler;
   private final AuthConfig authConfig;
+  private final DefaultQueryConfig defaultQueryConfig;
   private final long startMs;
   private final long startNs;
 
@@ -120,7 +122,7 @@ public class SqlLifecycle
       RequestLogger requestLogger,
       QueryScheduler queryScheduler,
       AuthConfig authConfig,
-      long startMs,
+      DefaultQueryConfig defaultQueryConfig, long startMs,
       long startNs
   )
   {
@@ -129,6 +131,7 @@ public class SqlLifecycle
     this.requestLogger = requestLogger;
     this.queryScheduler = queryScheduler;
     this.authConfig = authConfig;
+    this.defaultQueryConfig = defaultQueryConfig;
     this.startMs = startMs;
     this.startNs = startNs;
     this.parameters = Collections.emptyList();
@@ -144,6 +147,7 @@ public class SqlLifecycle
     transition(State.NEW, State.INITIALIZED);
     this.sql = sql;
     this.queryContext = contextWithSqlId(queryContext);
+    this.queryContext.addDefaultParams(defaultQueryConfig.getContext());
     return sqlQueryId();
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlLifecycle.java
@@ -122,7 +122,8 @@ public class SqlLifecycle
       RequestLogger requestLogger,
       QueryScheduler queryScheduler,
       AuthConfig authConfig,
-      DefaultQueryConfig defaultQueryConfig, long startMs,
+      DefaultQueryConfig defaultQueryConfig,
+      long startMs,
       long startNs
   )
   {

--- a/sql/src/main/java/org/apache/druid/sql/SqlLifecycleFactory.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlLifecycleFactory.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql;
 import com.google.inject.Inject;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.server.QueryScheduler;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.security.AuthConfig;
@@ -35,6 +36,7 @@ public class SqlLifecycleFactory
   private final RequestLogger requestLogger;
   private final QueryScheduler queryScheduler;
   private final AuthConfig authConfig;
+  private final DefaultQueryConfig defaultQueryConfig;
 
   @Inject
   public SqlLifecycleFactory(
@@ -42,7 +44,8 @@ public class SqlLifecycleFactory
       ServiceEmitter emitter,
       RequestLogger requestLogger,
       QueryScheduler queryScheduler,
-      AuthConfig authConfig
+      AuthConfig authConfig,
+      DefaultQueryConfig defaultQueryConfig
   )
   {
     this.plannerFactory = plannerFactory;
@@ -50,6 +53,7 @@ public class SqlLifecycleFactory
     this.requestLogger = requestLogger;
     this.queryScheduler = queryScheduler;
     this.authConfig = authConfig;
+    this.defaultQueryConfig = defaultQueryConfig;
   }
 
   public SqlLifecycle factorize()
@@ -60,6 +64,7 @@ public class SqlLifecycleFactory
         requestLogger,
         queryScheduler,
         authConfig,
+        defaultQueryConfig,
         System.currentTimeMillis(),
         System.nanoTime()
     );

--- a/sql/src/main/java/org/apache/druid/sql/SqlLifecycleFactory.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlLifecycleFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.sql;
 
+import com.google.common.base.Supplier;
 import com.google.inject.Inject;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -45,7 +46,7 @@ public class SqlLifecycleFactory
       RequestLogger requestLogger,
       QueryScheduler queryScheduler,
       AuthConfig authConfig,
-      DefaultQueryConfig defaultQueryConfig
+      Supplier<DefaultQueryConfig> defaultQueryConfig
   )
   {
     this.plannerFactory = plannerFactory;
@@ -53,7 +54,7 @@ public class SqlLifecycleFactory
     this.requestLogger = requestLogger;
     this.queryScheduler = queryScheduler;
     this.authConfig = authConfig;
-    this.defaultQueryConfig = defaultQueryConfig;
+    this.defaultQueryConfig = defaultQueryConfig.get();
   }
 
   public SqlLifecycle factorize()

--- a/sql/src/test/java/org/apache/druid/sql/SqlLifecycleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlLifecycleTest.java
@@ -99,18 +99,23 @@ public class SqlLifecycleTest
   @Test
   public void testDefaultQueryContextIsApplied()
   {
-
     SqlLifecycle lifecycle = sqlLifecycleFactory.factorize();
+    // lifecycle should not have a query context is there on it when created/factorized
+    Assert.assertNull(lifecycle.getQueryContext());
     final String sql = "select 1 + ?";
     final Map<String, Object> queryContext = ImmutableMap.of(QueryContexts.BY_SEGMENT_KEY, "true");
-    lifecycle.initialize(sql, new QueryContext(queryContext));
+    QueryContext testQueryContext = new QueryContext(queryContext);
+    // default query context isn't applied to query context until lifecycle is initialized
+    for (String defaultContextKey : defaultQueryConfig.getContext().keySet()) {
+      Assert.assertFalse(testQueryContext.getMergedParams().containsKey(defaultContextKey));
+    }
+    lifecycle.initialize(sql, testQueryContext);
     Assert.assertEquals(SqlLifecycle.State.INITIALIZED, lifecycle.getState());
     Assert.assertEquals(2, lifecycle.getQueryContext().getMergedParams().size());
-    // should contain only query id, not bySegment since it is not valid for SQL
+    // should lifecycle should contain default query context values after initialization
     for (String defaultContextKey : defaultQueryConfig.getContext().keySet()) {
       Assert.assertTrue(lifecycle.getQueryContext().getMergedParams().containsKey(defaultContextKey));
     }
-
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/SqlLifecycleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlLifecycleTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.sql;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.calcite.avatica.SqlType;
@@ -78,7 +79,7 @@ public class SqlLifecycleTest
         requestLogger,
         QueryStackTests.DEFAULT_NOOP_SCHEDULER,
         new AuthConfig(),
-        defaultQueryConfig
+        Suppliers.ofInstance(defaultQueryConfig)
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.sql.avatica;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -30,6 +32,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import org.apache.calcite.avatica.AvaticaClientRuntimeException;
@@ -215,7 +218,7 @@ public abstract class DruidAvaticaHandlerTest extends CalciteTestBase
                       .toProvider(QuerySchedulerProvider.class)
                       .in(LazySingleton.class);
                 binder.bind(QueryMakerFactory.class).to(NativeQueryMakerFactory.class);
-                binder.bind(DefaultQueryConfig.class).toInstance(new DefaultQueryConfig(ImmutableMap.of()));
+                binder.bind(new TypeLiteral<Supplier<DefaultQueryConfig>>(){}).toInstance(Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of())));
               }
             }
         )
@@ -238,6 +241,8 @@ public abstract class DruidAvaticaHandlerTest extends CalciteTestBase
     propertiesLosAngeles.setProperty(BaseQuery.SQL_QUERY_ID, DUMMY_SQL_QUERY_ID);
     clientLosAngeles = DriverManager.getConnection(url, propertiesLosAngeles);
   }
+
+
 
   @After
   public void tearDown() throws Exception

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -49,6 +49,7 @@ import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.BaseQuery;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.server.QueryLifecycleFactory;
 import org.apache.druid.server.QueryScheduler;
@@ -214,6 +215,7 @@ public abstract class DruidAvaticaHandlerTest extends CalciteTestBase
                       .toProvider(QuerySchedulerProvider.class)
                       .in(LazySingleton.class);
                 binder.bind(QueryMakerFactory.class).to(NativeQueryMakerFactory.class);
+                binder.bind(DefaultQueryConfig.class).toInstance(new DefaultQueryConfig(ImmutableMap.of()));
               }
             }
         )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -845,7 +845,8 @@ public class CalciteTests
         new ServiceEmitter("dummy", "dummy", new NoopEmitter()),
         new NoopRequestLogger(),
         QueryStackTests.DEFAULT_NOOP_SCHEDULER,
-        authConfig
+        authConfig,
+        new DefaultQueryConfig(ImmutableMap.of())
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -846,7 +846,7 @@ public class CalciteTests
         new NoopRequestLogger(),
         QueryStackTests.DEFAULT_NOOP_SCHEDULER,
         authConfig,
-        new DefaultQueryConfig(ImmutableMap.of())
+        Suppliers.ofInstance(new DefaultQueryConfig(ImmutableMap.of()))
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.sql.guice;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;

--- a/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
@@ -199,7 +199,6 @@ public class SqlModuleTest
               binder.bind(QueryScheduler.class)
                     .toProvider(QuerySchedulerProvider.class)
                     .in(LazySingleton.class);
-              binder.bind(DefaultQueryConfig.class).toInstance(new DefaultQueryConfig(ImmutableMap.of()));
             },
             new SqlModule(props),
             new TestViewManagerModule()

--- a/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql.guice;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -198,6 +199,7 @@ public class SqlModuleTest
               binder.bind(QueryScheduler.class)
                     .toProvider(QuerySchedulerProvider.class)
                     .in(LazySingleton.class);
+              binder.bind(DefaultQueryConfig.class).toInstance(new DefaultQueryConfig(ImmutableMap.of()));
             },
             new SqlModule(props),
             new TestViewManagerModule()

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -46,6 +46,7 @@ import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.BaseQuery;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryContexts;
@@ -255,12 +256,14 @@ public class SqlResourceTest extends CalciteTestBase
     };
     final ServiceEmitter emitter = new NoopServiceEmitter();
     final AuthConfig authConfig = new AuthConfig();
+    final DefaultQueryConfig defaultQueryConfig = new DefaultQueryConfig(ImmutableMap.of());
     sqlLifecycleFactory = new SqlLifecycleFactory(
         plannerFactory,
         emitter,
         testRequestLogger,
         scheduler,
-        authConfig
+        authConfig,
+        defaultQueryConfig
     )
     {
       @Override
@@ -1776,7 +1779,7 @@ public class SqlResourceTest extends CalciteTestBase
         SettableSupplier<Function<Sequence<Object[]>, Sequence<Object[]>>> sequenceMapFnSupplier
     )
     {
-      super(plannerFactory, emitter, requestLogger, queryScheduler, authConfig, startMs, startNs);
+      super(plannerFactory, emitter, requestLogger, queryScheduler, authConfig, new DefaultQueryConfig(ImmutableMap.of()), startMs, startNs);
       this.validateAndAuthorizeLatchSupplier = validateAndAuthorizeLatchSupplier;
       this.planLatchSupplier = planLatchSupplier;
       this.executeLatchSupplier = executeLatchSupplier;

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -263,7 +264,7 @@ public class SqlResourceTest extends CalciteTestBase
         testRequestLogger,
         scheduler,
         authConfig,
-        defaultQueryConfig
+        Suppliers.ofInstance(defaultQueryConfig)
     )
     {
       @Override


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes an issue where when you look at the sql query request logs emitted via an emitter or logged would be missing default query context values set in runtime.properties

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Added DefaultQueryConfig to SqlLifecycle ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

This was chosen because while the default query context is added as part of QueryLifecycle it was never added as part of the sql lifecycle meaning it wouldn't show up in the logs or when emitted via an emitter. Since this is a duplicate value with the values being added at QueryLifecycle there should no worries about the eventual double write of default query context values

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `SqlLifecycle`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
