### PR TITLE
Bump up druid version in docker compose for 0.23.0

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - ZOO_MY_ID=1
 
   coordinator:
-    image: apache/druid:0.22.0
+    image: apache/druid:0.23.0
     container_name: coordinator
     volumes:
       - druid_shared:/opt/shared
@@ -65,7 +65,7 @@ services:
       - environment
 
   broker:
-    image: apache/druid:0.22.0
+    image: apache/druid:0.23.0
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
@@ -81,7 +81,7 @@ services:
       - environment
 
   historical:
-    image: apache/druid:0.22.0
+    image: apache/druid:0.23.0
     container_name: historical
     volumes:
       - druid_shared:/opt/shared
@@ -98,7 +98,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:0.22.0
+    image: apache/druid:0.23.0
     container_name: middlemanager
     volumes:
       - druid_shared:/opt/shared
@@ -116,7 +116,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:0.22.0
+    image: apache/druid:0.23.0
     container_name: router
     volumes:
       - router_var:/opt/druid/var


### PR DESCRIPTION
Bumping up to correct druid version for 0.23.0

This PR has:
- [x] been self-reviewed
