### PR TITLE
NettyHttpClient: Replace ReadTimeoutException with our own exception.

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
@@ -26,7 +26,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;

--- a/core/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
@@ -319,9 +319,9 @@ public class NettyHttpClient extends AbstractHttpClient
             }
 
             if (event.getCause() instanceof ReadTimeoutException) {
-              // ReadTimeoutException is a singleton with a misleading stack trace. No point including it: instead,
-              // we replace it with our own exception.
-              retVal.setException(new RE("[%s] Read timed out", requestDesc));
+              // ReadTimeoutException thrown by ReadTimeoutHandler is a singleton with a misleading stack trace.
+              // No point including it: instead, we replace it with a fresh exception.
+              retVal.setException(new ReadTimeoutException(StringUtils.format("[%s] Read timed out", requestDesc)));
             } else {
               retVal.setException(event.getCause());
             }


### PR DESCRIPTION
It may also be a good idea to wrap non-ReadTimeoutExceptions, to provide additional context to _all_ exceptions. But I thought we could start here.