### PR TITLE
Fix thread-unsafe emitter usage in SeekableStreamSupervisorStateTest.

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -1371,17 +1372,22 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
   private static class TestEmitter extends NoopServiceEmitter
   {
+    @GuardedBy("events")
     private final List<Event> events = new ArrayList<>();
 
     @Override
     public void emit(Event event)
     {
-      events.add(event);
+      synchronized (events) {
+        events.add(event);
+      }
     }
 
     public List<Event> getEvents()
     {
-      return events;
+      synchronized (events) {
+        return ImmutableList.copyOf(events);
+      }
     }
   }
 }


### PR DESCRIPTION
The TestEmitter is used from different threads without concurrency control. This patch makes the emitter thread-safe.

I think this fixes #12649, since:

1. Without the patch, the test generally fails once every 10–20 runs on my machine. With the patch, I've done 200 runs and it hasn't failed yet.
2. It's believable that the ConcurrentModificationException is due to the thread-unsafe emitter.