### PR TITLE
Make sure that we always use the local disk cache for Authz data.

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
@@ -195,17 +195,17 @@ public class CoordinatorPollingBasicAuthenticatorCacheManager implements BasicAu
           commonCacheConfig.getMaxSyncRetries()
       );
     }
-    catch (Exception e) {
-      LOG.makeAlert(e, "Encountered exception while fetching user map for authenticator [%s]", prefix).emit();
+    catch (Throwable t) {
+      LOG.makeAlert(t, "Encountered exception while fetching user map for authenticator [%s]", prefix).emit();
       if (isInit) {
         if (commonCacheConfig.getCacheDirectory() != null) {
           try {
             LOG.info("Attempting to load user map snapshot from disk.");
             return loadUserMapFromDisk(prefix);
           }
-          catch (Exception e2) {
-            e2.addSuppressed(e);
-            LOG.makeAlert(e2, "Encountered exception while loading user map snapshot for authenticator [%s]", prefix)
+          catch (Throwable t2) {
+            t2.addSuppressed(t);
+            LOG.makeAlert(t2, "Encountered exception while loading user map snapshot for authenticator [%s]", prefix)
                .emit();
           }
         }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
@@ -333,17 +333,17 @@ public class CoordinatorPollingBasicAuthorizerCacheManager implements BasicAutho
           commonCacheConfig.getMaxSyncRetries()
       );
     }
-    catch (Exception e) {
-      LOG.makeAlert(e, "Encountered exception while fetching user and role map for authorizer [%s]", prefix).emit();
+    catch (Throwable t) {
+      LOG.makeAlert(t, "Encountered exception while fetching user and role map for authorizer [%s]", prefix).emit();
       if (isInit) {
         if (commonCacheConfig.getCacheDirectory() != null) {
           try {
             LOG.info("Attempting to load user map snapshot from disk.");
             return loadUserAndRoleMapFromDisk(prefix);
           }
-          catch (Exception e2) {
-            e2.addSuppressed(e);
-            LOG.makeAlert(e2, "Encountered exception while loading user-role map snapshot for authorizer [%s]", prefix)
+          catch (Throwable t2) {
+            t2.addSuppressed(t);
+            LOG.makeAlert(t2, "Encountered exception while loading user-role map snapshot for authorizer [%s]", prefix)
                .emit();
           }
         }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

`CoordinatorPollingBasicAuthenticatorCacheManager` and its `Authorizer` counterpart are running inside every daemon, fetching `/druid-ext/basic-security/authentication/db/%s/cachedSerializedUserMap` data and cache them on local disk.

When Coordinator is under heavy load, this remote call can break and fail the daemon. Specifically with Peon, since it goes up and down on every subtask ingestion, this failure can results in a failed ingestion. And that's unfortunate considering that Middle Manager already saved perfectly good Authz cache data on local disk.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
This patch makes absolutely sure that any kind of failure will force the daemon to load the local cache on disk.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `CoordinatorPollingBasicAuthenticatorCacheManager`
 * `CoordinatorPollingBasicAuthorizerCacheManager`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
