### PR TITLE
Overlord & Coordinator are able to delegate to followers.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
@@ -32,6 +32,7 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
 import org.apache.druid.indexing.overlord.config.DefaultTaskConfig;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
+import org.apache.druid.indexing.overlord.config.TaskMasterConfig;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
 import org.apache.druid.indexing.overlord.helpers.OverlordHelperManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
@@ -57,6 +58,8 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 {
   private static final EmittingLogger log = new EmittingLogger(TaskMaster.class);
 
+  private final TaskMasterConfig config;
+
   private final DruidLeaderSelector overlordLeaderSelector;
   private final DruidLeaderSelector.Listener leadershipListener;
 
@@ -80,6 +83,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
   public TaskMaster(
       final TaskLockConfig taskLockConfig,
       final TaskQueueConfig taskQueueConfig,
+      final TaskMasterConfig taskMasterConfig,
       final DefaultTaskConfig defaultTaskConfig,
       final TaskLockbox taskLockbox,
       final TaskStorage taskStorage,
@@ -94,6 +98,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
       @IndexingService final DruidLeaderSelector overlordLeaderSelector
   )
   {
+    this.config = taskMasterConfig;
     this.supervisorManager = supervisorManager;
     this.taskActionClientFactory = taskActionClientFactory;
 
@@ -230,6 +235,11 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
   public String getCurrentLeader()
   {
     return overlordLeaderSelector.getCurrentLeader();
+  }
+
+  public TaskMasterConfig getConfig()
+  {
+    return config;
   }
 
   public Optional<TaskRunner> getTaskRunner()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskMasterConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskMasterConfig.java
@@ -1,0 +1,22 @@
+package org.apache.druid.indexing.overlord.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TaskMasterConfig {
+    @JsonProperty
+    private boolean delegateRequestsToFollowers;
+
+    @JsonCreator
+    public TaskMasterConfig(
+        @JsonProperty("delegateRequestsToFollowers") final Boolean delegateRequestsToFollowers
+    )
+    {
+      this.delegateRequestsToFollowers = delegateRequestsToFollowers == null ? false : delegateRequestsToFollowers;
+    }
+
+    public boolean getDelegateRequestsToFollowers()
+    {
+      return delegateRequestsToFollowers;
+    }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskMasterConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskMasterConfig.java
@@ -1,22 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.indexing.overlord.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class TaskMasterConfig {
-    @JsonProperty
-    private boolean delegateRequestsToFollowers;
+public class TaskMasterConfig
+{
+  @JsonProperty
+  private boolean delegateRequestsToFollowers;
 
-    @JsonCreator
-    public TaskMasterConfig(
-        @JsonProperty("delegateRequestsToFollowers") final Boolean delegateRequestsToFollowers
-    )
-    {
-      this.delegateRequestsToFollowers = delegateRequestsToFollowers == null ? false : delegateRequestsToFollowers;
-    }
+  @JsonCreator
+  public TaskMasterConfig(
+      @JsonProperty("delegateRequestsToFollowers") final Boolean delegateRequestsToFollowers
+  )
+  {
+    this.delegateRequestsToFollowers = delegateRequestsToFollowers == null ? false : delegateRequestsToFollowers;
+  }
 
-    public boolean getDelegateRequestsToFollowers()
-    {
-      return delegateRequestsToFollowers;
-    }
+  public boolean getDelegateRequestsToFollowers()
+  {
+    return delegateRequestsToFollowers;
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
@@ -67,6 +67,10 @@ public class OverlordRedirectInfo implements RedirectInfo
       return true;
     }
 
+    if (!taskMaster.getConfig().getDelegateRequestsToFollowers()) {
+      return false;
+    }
+
     if (requestURI != null) {
       // If the pattern matched exactly, return true
       if (LOCAL_GET_PATHS.contains(requestURI)) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
@@ -43,10 +43,7 @@ public class OverlordRedirectInfo implements RedirectInfo
       "/druid/indexer/v1/task/*/log",
       "/druid/indexer/v1/task/*/reports",
       "/druid/indexer/v1/task/*/segments",
-      "/druid/indexer/v1/worker",
-      "/druid/indexer/v1/worker/history",
-      "/druid/indexer/v1/tasks",
-      "/druid/indexer/v1/*Tasks"
+      "/druid/indexer/v1/worker/history"
   );
 
   private final TaskMaster taskMaster;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
@@ -42,7 +42,11 @@ public class OverlordRedirectInfo implements RedirectInfo
   private static final Set<String> LOCAL_GET_PATHS = ImmutableSet.of(
       "/druid/indexer/v1/task/*/log",
       "/druid/indexer/v1/task/*/reports",
-      "/druid/indexer/v1/task/*/segments"
+      "/druid/indexer/v1/task/*/segments",
+      "/druid/indexer/v1/worker",
+      "/druid/indexer/v1/worker/history",
+      "/druid/indexer/v1/tasks",
+      "/druid/indexer/v1/*Tasks"
   );
 
   private final TaskMaster taskMaster;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
@@ -56,6 +56,7 @@ import org.apache.druid.indexing.overlord.WorkerTaskRunnerQueryAdapter;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
 import org.apache.druid.indexing.overlord.config.DefaultTaskConfig;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
+import org.apache.druid.indexing.overlord.config.TaskMasterConfig;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
 import org.apache.druid.indexing.overlord.helpers.OverlordHelperManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
@@ -176,6 +177,7 @@ public class OverlordTest
     taskMaster = new TaskMaster(
         new TaskLockConfig(),
         new TaskQueueConfig(null, new Period(1), null, new Period(10)),
+        new TaskMasterConfig(false),
         new DefaultTaskConfig(),
         taskLockbox,
         taskStorage,

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -408,6 +408,11 @@ public class DruidCoordinator
     return compactSegments.getAutoCompactionSnapshot();
   }
 
+  public DruidCoordinatorConfig getConfig()
+  {
+    return config;
+  }
+
   public CoordinatorDynamicConfig getDynamicConfigs()
   {
     return CoordinatorDynamicConfig.current(configManager);

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -143,4 +143,9 @@ public abstract class DruidCoordinatorConfig
     return true;
   }
 
+  @Config("druid.coordinator.delegateRequestsToFollowers")
+  public boolean getDelegateRequestsToFollowers()
+  {
+    return false;
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorRedirectInfo.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorRedirectInfo.java
@@ -64,6 +64,10 @@ public class CoordinatorRedirectInfo implements RedirectInfo
       return true;
     }
 
+    if (!coordinator.getConfig().getDelegateRequestsToFollowers()) {
+      return false;
+    }
+
     if (requestURI != null) {
       // If the pattern matched exactly, return true
       if (LOCAL_GET_PATHS.contains(requestURI)) {

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorRedirectInfo.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorRedirectInfo.java
@@ -39,8 +39,8 @@ public class CoordinatorRedirectInfo implements RedirectInfo
   );
 
   private static final Set<String> LOCAL_GET_PATHS = ImmutableSet.of(
-    "/druid-ext/basic-security/authentication/db",
-    "/druid-ext/basic-security/authorization/db"
+      "/druid-ext/basic-security/authentication/db/*",
+      "/druid-ext/basic-security/authorization/db/*"
   );
 
   private final DruidCoordinator coordinator;

--- a/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
@@ -71,6 +71,10 @@ public class RedirectFilter implements Filter
 
     if (redirectInfo.doLocal(request.getRequestURI())) {
       chain.doFilter(request, response);
+
+    } else if (request.getMethod().equalsIgnoreCase("GET") && redirectInfo.doLocalGet(request.getRequestURI())) {
+      chain.doFilter(request, response);
+
     } else {
       URL url = redirectInfo.getRedirectURL(request.getQueryString(), request.getRequestURI());
       log.debug("Forwarding request to [%s]", url);

--- a/server/src/main/java/org/apache/druid/server/http/RedirectInfo.java
+++ b/server/src/main/java/org/apache/druid/server/http/RedirectInfo.java
@@ -27,5 +27,7 @@ public interface RedirectInfo
 {
   boolean doLocal(String requestURI);
 
+  boolean doLocalGet(String requestURI);
+
   URL getRedirectURL(String queryString, String requestURI);
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -49,6 +49,7 @@ public class DruidCoordinatorConfigTest
     Assert.assertEquals(Duration.millis(50), config.getLoadQueuePeonRepeatDelay());
     Assert.assertTrue(config.getCompactionSkipLockedIntervals());
     Assert.assertFalse(config.getCoordinatorKillIgnoreDurationToRetain());
+    Assert.assertFalse(config.getDelegateRequestsToFollowers());
 
     //with non-defaults
     Properties props = new Properties();
@@ -64,6 +65,7 @@ public class DruidCoordinatorConfigTest
     props.setProperty("druid.coordinator.loadqueuepeon.repeatDelay", "PT0.100s");
     props.setProperty("druid.coordinator.compaction.skipLockedIntervals", "false");
     props.setProperty("druid.coordinator.kill.ignoreDurationToRetain", "true");
+    props.setProperty("druid.coordinator.delegateRequestsToFollowers", "true");
 
     factory = Config.createFactory(props);
     config = factory.build(DruidCoordinatorConfig.class);
@@ -78,6 +80,7 @@ public class DruidCoordinatorConfigTest
     Assert.assertEquals(Duration.millis(100), config.getLoadQueuePeonRepeatDelay());
     Assert.assertFalse(config.getCompactionSkipLockedIntervals());
     Assert.assertTrue(config.getCoordinatorKillIgnoreDurationToRetain());
+    Assert.assertTrue(config.getDelegateRequestsToFollowers());
 
     // Test negative druid.coordinator.kill.durationToRetain now that it is valid.
     props = new Properties();

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -723,6 +723,49 @@ public class DruidCoordinatorTest extends CuratorTestBase
   }
 
   @Test
+  public void testGetConfig()
+  {
+    CoordinatorDynamicConfig dynamicConfig = EasyMock.createNiceMock(CoordinatorDynamicConfig.class);
+    EasyMock.expect(dynamicConfig.getBalancerComputeThreads()).andReturn(5).times(2);
+    EasyMock.expect(dynamicConfig.getBalancerComputeThreads()).andReturn(10).once();
+
+    JacksonConfigManager configManager = EasyMock.createNiceMock(JacksonConfigManager.class);
+    EasyMock.expect(
+        configManager.watch(
+            EasyMock.eq(CoordinatorDynamicConfig.CONFIG_KEY),
+            EasyMock.anyObject(Class.class),
+            EasyMock.anyObject()
+        )
+    ).andReturn(new AtomicReference(dynamicConfig)).anyTimes();
+
+    DruidCoordinator c = new DruidCoordinator(
+        druidCoordinatorConfig,
+        null,
+        configManager,
+        null,
+        null,
+        null,
+        () -> null,
+        null,
+        scheduledExecutorFactory,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new CoordinatorCustomDutyGroups(ImmutableSet.of()),
+        null,
+        null,
+        null,
+        null,
+        ZkEnablementConfig.ENABLED
+    );
+
+    Assert.assertEquals(druidCoordinatorConfig, c.getConfig());
+  }
+
+  @Test
   public void testBalancerThreadNumber()
   {
     CoordinatorDynamicConfig dynamicConfig = EasyMock.createNiceMock(CoordinatorDynamicConfig.class);

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -84,6 +84,7 @@ import org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningCo
 import org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningStrategy;
 import org.apache.druid.indexing.overlord.config.DefaultTaskConfig;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
+import org.apache.druid.indexing.overlord.config.TaskMasterConfig;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
 import org.apache.druid.indexing.overlord.helpers.OverlordHelper;
 import org.apache.druid.indexing.overlord.helpers.TaskLogAutoCleaner;
@@ -188,6 +189,7 @@ public class CliOverlord extends ServerRunnable
             JsonConfigProvider.bind(binder, "druid.indexer.task", TaskConfig.class);
             JsonConfigProvider.bind(binder, "druid.indexer.task.default", DefaultTaskConfig.class);
             JsonConfigProvider.bind(binder, "druid.indexer.auditlog", TaskAuditLogConfig.class);
+            JsonConfigProvider.bind(binder, "druid.indexer.taskMaster", TaskMasterConfig.class);
 
             binder.bind(TaskMaster.class).in(ManageLifecycle.class);
             binder.bind(TaskCountStatsProvider.class).to(TaskMaster.class);

--- a/services/src/main/java/org/apache/druid/cli/CoordinatorOverlordRedirectInfo.java
+++ b/services/src/main/java/org/apache/druid/cli/CoordinatorOverlordRedirectInfo.java
@@ -51,6 +51,14 @@ public class CoordinatorOverlordRedirectInfo implements RedirectInfo
   }
 
   @Override
+  public boolean doLocalGet(String requestURI)
+  {
+    return isOverlordRequest(requestURI) ?
+           overlordRedirectInfo.doLocalGet(requestURI) :
+           coordinatorRedirectInfo.doLocalGet(requestURI);
+  }
+
+  @Override
   public URL getRedirectURL(String queryString, String requestURI)
   {
     return isOverlordRequest(requestURI) ?


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Coordinator/Overlord <strike>is currently a single point of failure</strike> has a vertical scalability problem. I think it's time for them to start delegating to their followers.

There are some `GET` requests that can be delegated safely, in my opinion. Example:
* GET /druid-ext/basic-security/authentication/db/*
* GET /druid-ext/basic-security/authorization/db/*
* GET /druid/indexer/v1/task/*/log
* GET /druid/indexer/v1/task/*/reports
* GET /druid/indexer/v1/task/*/segments

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

This PR allows Druid to scale better horizontally.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

Inside `RedirectFilter` I added a condition to check if request is a GET request and if it satisfy a certain pattern. If yes, then let the current running server handles it.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `*RedirectInfo`
 * `RedirectFilter`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
