### PR TITLE
Cleanup changes pulled out of PR #12368

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ target
 .settings/
 .vscode
 *.log
-*.DS_Store
+.DS_Store
 _site
 dependency-reduced-pom.xml
 LICENSE.BINARY
@@ -21,7 +21,8 @@ NOTICE.BINARY
 README.BINARY
 README
 *.lock
-**/.pmd
-**/.pmdruleset.xml
+.pmd
+.pmdruleset.xml
 .java-version
 integration-tests/gen-scripts/
+bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ env:
     - DOCKER_IP=127.0.0.1  # for integration tests
     - MVN="mvn -B"
     - > # Various options to make execution of maven goals faster (e.g., mvn install)
-      MAVEN_SKIP="-Pskip-static-checks -Ddruid.console.skip=true -Dmaven.javadoc.skip=true"
-    - MAVEN_SKIP_TESTS="-Pskip-tests"
+      MAVEN_SKIP="-P skip-static-checks -Ddruid.console.skip=true -Dmaven.javadoc.skip=true"
+    - MAVEN_SKIP_TESTS="-P skip-tests"
 
 addons:
   apt:
@@ -46,7 +46,7 @@ addons:
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
-install: ./check_test_suite.py && travis_terminate 0  || echo 'Running maven install...' && MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+install: ./check_test_suite.py && travis_terminate 0  || echo 'Running Maven install...' && MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
 # There are 3 stages of tests
 # 1. Tests - phase 1

--- a/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
+++ b/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
@@ -61,7 +61,7 @@ public class LifecycleModule implements Module
    * is materialized and injected, meaning that objects are not actually instantiated in dependency order.
    * Registering with the LifecyceModule, on the other hand, will instantiate the objects after the normal object
    * graph has already been instantiated, meaning that objects will be created in dependency order and this will
-   * only actually instantiate something that wasn't actually dependend upon.
+   * only actually instantiate something that wasn't actually depended upon.
    *
    * @param clazz the class to instantiate
    * @return this, for chaining.

--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageConnectorConfig.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageConnectorConfig.java
@@ -22,6 +22,7 @@ package org.apache.druid.metadata;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.StringUtils;
 
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -48,6 +49,30 @@ public class MetadataStorageConnectorConfig
 
   @JsonProperty("dbcp")
   private Properties dbcpProperties;
+
+  public static MetadataStorageConnectorConfig create(
+      String connectUri,
+      String user,
+      String password,
+      Map<String, Object> properties
+  )
+  {
+    MetadataStorageConnectorConfig config = new MetadataStorageConnectorConfig();
+    if (connectUri != null) {
+      config.connectURI = connectUri;
+    }
+    if (user != null) {
+      config.user = user;
+    }
+    if (password != null) {
+      config.passwordProvider = () -> password;
+    }
+    if (properties != null) {
+      config.dbcpProperties = new Properties();
+      config.dbcpProperties.putAll(properties);
+    }
+    return config;
+  }
 
   @JsonProperty
   public boolean isCreateTables()

--- a/core/src/test/java/org/apache/druid/metadata/MetadataStorageConnectorConfigTest.java
+++ b/core/src/test/java/org/apache/druid/metadata/MetadataStorageConnectorConfigTest.java
@@ -20,10 +20,12 @@
 package org.apache.druid.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 
 public class MetadataStorageConnectorConfigTest
@@ -186,5 +188,20 @@ public class MetadataStorageConnectorConfigTest
     Properties dbcpProperties = config.getDbcpProperties();
     Assert.assertEquals(dbcpProperties.getProperty("maxConnLifetimeMillis"), "1200000");
     Assert.assertEquals(dbcpProperties.getProperty("defaultQueryTimeout"), "30000");
+  }
+
+  @Test
+  public void testCreate()
+  {
+    Map<String, Object> props = ImmutableMap.of("key", "value");
+    MetadataStorageConnectorConfig config = MetadataStorageConnectorConfig.create(
+        "connectURI",
+        "user",
+        "pwd",
+        props);
+    Assert.assertEquals("connectURI", config.getConnectURI());
+    Assert.assertEquals("user", config.getUser());
+    Assert.assertEquals("pwd", config.getPassword());
+    Assert.assertEquals(1, config.getDbcpProperties().size());
   }
 }

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -20,11 +20,11 @@
 #
 
 # NOTE: this is a 'run' script for the stock tarball
-# It takes 1 required argument (the name of the service,
+# It takes one required argument (the name of the service,
 # e.g. 'broker', 'historical' etc). Any additional arguments
 # are passed to that service.
 #
-# It accepts 'JAVA_OPTS' as an environment variable
+# This script accepts JAVA_OPTS as an environment variable
 #
 # Additional env vars:
 # - DRUID_LOG4J -- set the entire log4j.xml verbatim

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -60,19 +60,24 @@ public class MySQLConnector extends SQLMetadataConnector
   )
   {
     super(config, dbTables);
-    log.info("Loading \"MySQL\" metadata connector driver %s", driverConfig.getDriverClassName());
-    tryLoadDriverClass(driverConfig.getDriverClassName(), true);
+    this.dbi = createDBI(config.get(), driverConfig, connectorSslConfig, getValidationQuery());
 
     if (driverConfig.getDriverClassName().contains("mysql")) {
       myTransientExceptionClass = tryLoadDriverClass(MYSQL_TRANSIENT_EXCEPTION_CLASS_NAME, false);
     } else {
       myTransientExceptionClass = null;
     }
+  }
 
-    final BasicDataSource datasource = getDatasource();
+  public static DBI createDBI(MetadataStorageConnectorConfig config, MySQLConnectorDriverConfig driverConfig, MySQLConnectorSslConfig connectorSslConfig, String validationQuery)
+  {
+    log.info("Loading \"MySQL\" metadata connector driver %s", driverConfig.getDriverClassName());
+    tryLoadDriverClass(driverConfig.getDriverClassName(), true);
+
+    final BasicDataSource datasource = makeDatasource(config, validationQuery);
     // MySQL driver is classloader isolated as part of the extension
     // so we need to help JDBC find the driver
-    datasource.setDriverClassLoader(getClass().getClassLoader());
+    datasource.setDriverClassLoader(MySQLConnector.class.getClassLoader());
     datasource.setDriverClassName(driverConfig.getDriverClassName());
     datasource.addConnectionProperty("useSSL", String.valueOf(connectorSslConfig.isUseSSL()));
     if (connectorSslConfig.isUseSSL()) {
@@ -140,9 +145,10 @@ public class MySQLConnector extends SQLMetadataConnector
     // use double-quotes for quoting columns, so we can write SQL that works with most databases
     datasource.setConnectionInitSqls(ImmutableList.of("SET sql_mode='ANSI_QUOTES'"));
 
-    this.dbi = new DBI(datasource);
+    DBI dbi = new DBI(datasource);
 
     log.info("Configured MySQL as metadata storage");
+    return dbi;
   }
 
   @Override
@@ -245,10 +251,10 @@ public class MySQLConnector extends SQLMetadataConnector
   }
 
   @Nullable
-  private Class<?> tryLoadDriverClass(String className, boolean failIfNotFound)
+  private static Class<?> tryLoadDriverClass(String className, boolean failIfNotFound)
   {
     try {
-      return Class.forName(className, false, getClass().getClassLoader());
+      return Class.forName(className, false, MySQLConnector.class.getClassLoader());
     }
     catch (ClassNotFoundException e) {
       if (failIfNotFound) {

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorDriverConfig.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorDriverConfig.java
@@ -20,13 +20,25 @@
 package org.apache.druid.metadata.storage.mysql;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
 
 import java.util.Objects;
 
 public class MySQLConnectorDriverConfig
 {
+  public static final String MYSQL_DRIVER = "com.mysql.jdbc.Driver";
+
   @JsonProperty
-  private String driverClassName = "com.mysql.jdbc.Driver";
+  private String driverClassName = MYSQL_DRIVER;
+
+  public static MySQLConnectorDriverConfig create(String driverClassName)
+  {
+    MySQLConnectorDriverConfig config = new MySQLConnectorDriverConfig();
+    if (!Strings.isNullOrEmpty(driverClassName)) {
+      config.driverClassName = driverClassName;
+    }
+    return config;
+  }
 
   @JsonProperty
   public String getDriverClassName()

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorDriverConfigTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorDriverConfigTest.java
@@ -22,6 +22,8 @@ package org.apache.druid.metadata.storage.mysql;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class MySQLConnectorDriverConfigTest
 {
   @Test
@@ -32,5 +34,14 @@ public class MySQLConnectorDriverConfigTest
                   .usingGetClass()
                   .withNonnullFields("driverClassName")
                   .verify();
+  }
+
+  @Test
+  public void testCreate()
+  {
+    MySQLConnectorDriverConfig config = MySQLConnectorDriverConfig.create(null);
+    assertEquals(MySQLConnectorDriverConfig.MYSQL_DRIVER, config.getDriverClassName());
+    config = MySQLConnectorDriverConfig.create("myDriver");
+    assertEquals("myDriver", config.getDriverClassName());
   }
 }

--- a/server/src/main/java/org/apache/druid/client/FilteredHttpServerInventoryViewProvider.java
+++ b/server/src/main/java/org/apache/druid/client/FilteredHttpServerInventoryViewProvider.java
@@ -36,20 +36,20 @@ public class FilteredHttpServerInventoryViewProvider implements FilteredServerIn
   @JacksonInject
   @NotNull
   @EscalatedClient
-  HttpClient httpClient = null;
+  HttpClient httpClient;
 
   @JacksonInject
   @NotNull
   @Smile
-  ObjectMapper smileMapper = null;
+  ObjectMapper smileMapper;
 
   @JacksonInject
   @NotNull
-  HttpServerInventoryViewConfig config = null;
+  HttpServerInventoryViewConfig config;
 
   @JacksonInject
   @NotNull
-  private DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = null;
+  private DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
 
   @Override
   public HttpServerInventoryView get()

--- a/server/src/main/java/org/apache/druid/curator/CuratorConfig.java
+++ b/server/src/main/java/org/apache/druid/curator/CuratorConfig.java
@@ -28,6 +28,8 @@ import javax.validation.constraints.Min;
 
 public class CuratorConfig
 {
+  public static final String CONFIG_PREFIX = "druid.zk.service";
+
   static final String HOST = "host";
   @JsonProperty(HOST)
   private String zkHosts = "localhost";
@@ -55,6 +57,13 @@ public class CuratorConfig
 
   @JsonProperty("authScheme")
   private String authScheme = "digest";
+
+  public static CuratorConfig create(String hosts)
+  {
+    CuratorConfig config = new CuratorConfig();
+    config.zkHosts = hosts;
+    return config;
+  }
 
   public String getZkHosts()
   {

--- a/server/src/main/java/org/apache/druid/curator/ExhibitorConfig.java
+++ b/server/src/main/java/org/apache/druid/curator/ExhibitorConfig.java
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public class ExhibitorConfig
 {
+  static final String CONFIG_PREFIX = "druid.exhibitor.service";
+
   @JsonProperty
   private List<String> hosts = new ArrayList<>();
 
@@ -47,6 +49,15 @@ public class ExhibitorConfig
   @JsonProperty
   @Min(0)
   private int pollingMs = 10000;
+
+  public static ExhibitorConfig create(List<String> hosts)
+  {
+    ExhibitorConfig config = new ExhibitorConfig();
+    if (hosts != null) {
+      config.hosts = hosts;
+    }
+    return config;
+  }
 
   public List<String> getHosts()
   {
@@ -72,5 +83,4 @@ public class ExhibitorConfig
   {
     return pollingMs;
   }
-
 }

--- a/server/src/main/java/org/apache/druid/curator/ZkEnablementConfig.java
+++ b/server/src/main/java/org/apache/druid/curator/ZkEnablementConfig.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 
 public class ZkEnablementConfig
 {
-  private static final String PROP_KEY_ENABLED = StringUtils.format("%s.enabled", CuratorModule.CURATOR_CONFIG_PREFIX);
+  private static final String PROP_KEY_ENABLED = StringUtils.format("%s.enabled", CuratorConfig.CONFIG_PREFIX);
 
   public static final ZkEnablementConfig ENABLED = new ZkEnablementConfig(true);
 

--- a/server/src/main/java/org/apache/druid/curator/cache/PathChildrenCacheFactory.java
+++ b/server/src/main/java/org/apache/druid/curator/cache/PathChildrenCacheFactory.java
@@ -65,18 +65,10 @@ public class PathChildrenCacheFactory
   {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = ThreadUtils.newThreadFactory("PathChildrenCache");
 
-    private boolean cacheData;
-    private boolean compressed;
+    private boolean cacheData = true;
+    private boolean compressed = false;
     private ExecutorService exec;
-    private boolean shutdownExecutorOnClose;
-
-    public Builder()
-    {
-      cacheData = true;
-      compressed = false;
-      exec = null;
-      shutdownExecutorOnClose = true;
-    }
+    private boolean shutdownExecutorOnClose = true;
 
     public Builder withCacheData(boolean cacheData)
     {

--- a/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
+++ b/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
@@ -246,12 +246,12 @@ public class CuratorDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvide
               break;
             }
             default: {
-              log.warn("Ignored event type[%s] for node watcher of role[%s].", event.getType(), nodeRole.getJsonName());
+              log.warn("Ignored event type [%s] for node watcher of role [%s].", event.getType(), nodeRole.getJsonName());
             }
           }
         }
         catch (Exception ex) {
-          log.error(ex, "Unknown error in node watcher of role[%s].", nodeRole.getJsonName());
+          log.error(ex, "Unknown error in node watcher of role [%s].", nodeRole.getJsonName());
         }
       }
     }

--- a/server/src/main/java/org/apache/druid/discovery/BaseNodeRoleWatcher.java
+++ b/server/src/main/java/org/apache/druid/discovery/BaseNodeRoleWatcher.java
@@ -120,7 +120,7 @@ public class BaseNodeRoleWatcher
     synchronized (lock) {
       if (!nodeRole.equals(druidNode.getNodeRole())) {
         LOGGER.error(
-            "Node[%s] of role[%s] addition ignored due to mismatched role (expected role[%s]).",
+            "Node [%s] of role [%s] addition ignored due to mismatched role (expected role [%s]).",
             druidNode.getDruidNode().getUriToUse(),
             druidNode.getNodeRole().getJsonName(),
             nodeRole.getJsonName()
@@ -128,7 +128,7 @@ public class BaseNodeRoleWatcher
         return;
       }
 
-      LOGGER.info("Node[%s] of role[%s] detected.", druidNode.getDruidNode().getUriToUse(), nodeRole.getJsonName());
+      LOGGER.info("Node [%s] of role [%s] detected.", druidNode.getDruidNode().getUriToUse(), nodeRole.getJsonName());
 
       addNode(druidNode);
     }
@@ -153,7 +153,7 @@ public class BaseNodeRoleWatcher
       }
     } else {
       LOGGER.error(
-          "Node[%s] of role[%s] discovered but existed already [%s].",
+          "Node [%s] of role [%s] discovered but existed already [%s].",
           druidNode.getDruidNode().getUriToUse(),
           nodeRole.getJsonName(),
           prev
@@ -166,7 +166,7 @@ public class BaseNodeRoleWatcher
     synchronized (lock) {
       if (!nodeRole.equals(druidNode.getNodeRole())) {
         LOGGER.error(
-            "Node[%s] of role[%s] removal ignored due to mismatched role (expected role[%s]).",
+            "Node [%s] of role [%s] removal ignored due to mismatched role (expected role [%s]).",
             druidNode.getDruidNode().getUriToUse(),
             druidNode.getNodeRole().getJsonName(),
             nodeRole.getJsonName()
@@ -174,7 +174,7 @@ public class BaseNodeRoleWatcher
         return;
       }
 
-      LOGGER.info("Node[%s] of role[%s] went offline.", druidNode.getDruidNode().getUriToUse(), nodeRole.getJsonName());
+      LOGGER.info("Node [%s] of role [%s] went offline.", druidNode.getDruidNode().getUriToUse(), nodeRole.getJsonName());
 
       removeNode(druidNode);
     }
@@ -187,7 +187,7 @@ public class BaseNodeRoleWatcher
 
     if (prev == null) {
       LOGGER.error(
-          "Noticed disappearance of unknown druid node [%s] of role[%s].",
+          "Noticed disappearance of unknown druid node [%s] of role [%s].",
           druidNode.getDruidNode().getUriToUse(),
           druidNode.getNodeRole().getJsonName()
       );
@@ -200,7 +200,7 @@ public class BaseNodeRoleWatcher
       for (DruidNodeDiscovery.Listener listener : nodeListeners) {
         safeSchedule(
             () -> listener.nodesRemoved(nodeRemoved),
-            "Exception occured in nodeRemoved(node[%s] of role[%s]) in listener [%s].",
+            "Exception occured in nodeRemoved(node [%s] of role [%s]) in listener [%s].",
             druidNode.getDruidNode().getUriToUse(),
             druidNode.getNodeRole().getJsonName(),
             listener
@@ -219,12 +219,15 @@ public class BaseNodeRoleWatcher
         return;
       }
 
-      LOGGER.info("Node watcher of role[%s] is now initialized.", nodeRole.getJsonName());
+      // It is important to take a snapshot here as list of nodes might change by the time listeners process
+      // the changes.
+      List<DiscoveryDruidNode> currNodes = Lists.newArrayList(nodes.values());
+      LOGGER.info(
+          "Node watcher of role [%s] is now initialized with %d nodes.",
+          nodeRole.getJsonName(),
+          currNodes.size());
 
       for (DruidNodeDiscovery.Listener listener : nodeListeners) {
-        // It is important to take a snapshot here as list of nodes might change by the time listeners process
-        // the changes.
-        List<DiscoveryDruidNode> currNodes = Lists.newArrayList(nodes.values());
         safeSchedule(
             () -> {
               listener.nodesAdded(currNodes);

--- a/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
+++ b/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
@@ -51,7 +51,7 @@ public class DiscoveryDruidNode
 
   /**
    * Map of service name -> DruidServices.
-   * This map has only the DruidServices that is understandable.
+   * This map has only the DruidServices that are understandable.
    * It means, if there is some DruidService not understandable found while converting rawServices to services,
    * that DruidService will be ignored and not stored in this map.
    *

--- a/server/src/main/java/org/apache/druid/initialization/Initialization.java
+++ b/server/src/main/java/org/apache/druid/initialization/Initialization.java
@@ -449,7 +449,7 @@ public class Initialization
     return Guice.createInjector(Modules.override(intermediateModules).with(extensionModules.getModules()));
   }
 
-  private static class ModuleList
+  public static class ModuleList
   {
     private final Injector baseInjector;
     private final Set<NodeRole> nodeRoles;
@@ -468,7 +468,7 @@ public class Initialization
       this.modules = new ArrayList<>();
     }
 
-    private List<Module> getModules()
+    public List<Module> getModules()
     {
       return Collections.unmodifiableList(modules);
     }

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -189,14 +189,14 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             public Void withHandle(Handle handle)
             {
               if (!tableExists(handle, tableName)) {
-                log.info("Creating table[%s]", tableName);
+                log.info("Creating table [%s]", tableName);
                 final Batch batch = handle.createBatch();
                 for (String s : sql) {
                   batch.add(s);
                 }
                 batch.execute();
               } else {
-                log.info("Table[%s] already exists", tableName);
+                log.info("Table [%s] already exists", tableName);
               }
               return null;
             }
@@ -646,10 +646,8 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     return config.get();
   }
 
-  protected BasicDataSource getDatasource()
+  protected static BasicDataSource makeDatasource(MetadataStorageConnectorConfig connectorConfig, String validationQuery)
   {
-    MetadataStorageConnectorConfig connectorConfig = getConfig();
-
     BasicDataSource dataSource;
 
     try {
@@ -669,10 +667,15 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     String uri = connectorConfig.getConnectURI();
     dataSource.setUrl(uri);
 
-    dataSource.setValidationQuery(getValidationQuery());
+    dataSource.setValidationQuery(validationQuery);
     dataSource.setTestOnBorrow(true);
 
     return dataSource;
+  }
+
+  protected BasicDataSource getDatasource()
+  {
+    return makeDatasource(getConfig(), getValidationQuery());
   }
 
   protected final <T> T inReadOnlyTransaction(

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManagerConfig.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManagerConfig.java
@@ -26,6 +26,8 @@ import org.joda.time.Period;
  */
 public class SegmentsMetadataManagerConfig
 {
+  public static final String CONFIG_PREFIX = "druid.manager.segments";
+
   @JsonProperty
   private Period pollDuration = new Period("PT1M");
 

--- a/server/src/test/java/org/apache/druid/curator/CuratorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/curator/CuratorConfigTest.java
@@ -23,6 +23,8 @@ import org.apache.druid.guice.JsonConfigTesterBase;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class CuratorConfigTest extends JsonConfigTesterBase<CuratorConfig>
 {
   @Test
@@ -41,5 +43,22 @@ public class CuratorConfigTest extends JsonConfigTesterBase<CuratorConfig>
     Assert.assertEquals("test-zk-user", config.getZkUser());
     Assert.assertEquals("test-zk-pwd", config.getZkPwd());
     Assert.assertEquals("auth", config.getAuthScheme());
+  }
+
+  @Test
+  public void testCreate()
+  {
+    CuratorConfig config = CuratorConfig.create("foo:2181,bar:2181");
+    Assert.assertEquals("foo:2181,bar:2181", config.getZkHosts());
+    Assert.assertEquals(false, config.getEnableAcl());
+    Assert.assertNull(config.getZkUser());
+    Assert.assertEquals("digest", config.getAuthScheme());
+  }
+
+  @Test
+  public void testExhibitorCreate()
+  {
+    ExhibitorConfig config = ExhibitorConfig.create(Arrays.asList("foo:2181", "bar:2181"));
+    Assert.assertEquals(2, config.getHosts().size());
   }
 }

--- a/server/src/test/java/org/apache/druid/curator/CuratorModuleTest.java
+++ b/server/src/test/java/org/apache/druid/curator/CuratorModuleTest.java
@@ -48,10 +48,10 @@ import java.util.Properties;
 
 public final class CuratorModuleTest
 {
-  private static final String CURATOR_HOST_KEY = CuratorModule.CURATOR_CONFIG_PREFIX + "." + CuratorConfig.HOST;
+  private static final String CURATOR_HOST_KEY = CuratorConfig.CONFIG_PREFIX + "." + CuratorConfig.HOST;
   private static final String CURATOR_CONNECTION_TIMEOUT_MS_KEY =
-      CuratorModule.CURATOR_CONFIG_PREFIX + "." + CuratorConfig.CONNECTION_TIMEOUT_MS;
-  private static final String EXHIBITOR_HOSTS_KEY = CuratorModule.EXHIBITOR_CONFIG_PREFIX + ".hosts";
+      CuratorConfig.CONFIG_PREFIX + "." + CuratorConfig.CONNECTION_TIMEOUT_MS;
+  private static final String EXHIBITOR_HOSTS_KEY = ExhibitorConfig.CONFIG_PREFIX + ".hosts";
 
   @Rule
   public final ExpectedSystemExit exit = ExpectedSystemExit.none();
@@ -164,7 +164,7 @@ public final class CuratorModuleTest
   public void ignoresDeprecatedCuratorConfigProperties()
   {
     Properties props = new Properties();
-    String deprecatedPropName = CuratorModule.CURATOR_CONFIG_PREFIX + ".terminateDruidProcessOnConnectFail";
+    String deprecatedPropName = CuratorConfig.CONFIG_PREFIX + ".terminateDruidProcessOnConnectFail";
     props.setProperty(deprecatedPropName, "true");
     Injector injector = newInjector(props);
 

--- a/server/src/test/java/org/apache/druid/curator/CuratorTestBase.java
+++ b/server/src/test/java/org/apache/druid/curator/CuratorTestBase.java
@@ -59,7 +59,6 @@ public class CuratorTestBase
         .retryPolicy(new RetryOneTime(1))
         .compressionProvider(new PotentiallyGzippedCompressionProvider(true))
         .build();
-
   }
 
   protected void setupZNodeForServer(DruidServer server, ZkPathsConfig zkPathsConfig, ObjectMapper jsonMapper)

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -186,7 +186,7 @@ public class CliCoordinator extends ServerRunnable
 
             binder.bind(MetadataStorage.class).toProvider(MetadataStorageProvider.class);
 
-            JsonConfigProvider.bind(binder, "druid.manager.segments", SegmentsMetadataManagerConfig.class);
+            JsonConfigProvider.bind(binder, SegmentsMetadataManagerConfig.CONFIG_PREFIX, SegmentsMetadataManagerConfig.class);
             JsonConfigProvider.bind(binder, "druid.manager.rules", MetadataRuleManagerConfig.class);
             JsonConfigProvider.bind(binder, "druid.manager.lookups", LookupCoordinatorManagerConfig.class);
             JsonConfigProvider.bind(binder, "druid.coordinator.balancer", BalancerStrategyFactory.class);

--- a/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
@@ -125,6 +125,11 @@ public abstract class GuiceRunnable implements Runnable
 
   public Lifecycle initLifecycle(Injector injector)
   {
+    return initLifecycle(injector, log);
+  }
+
+  public static Lifecycle initLifecycle(Injector injector, Logger log)
+  {
     try {
       final Lifecycle lifecycle = injector.getInstance(Lifecycle.class);
       final StartupLoggingConfig startupLoggingConfig = injector.getInstance(StartupLoggingConfig.class);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -1074,7 +1074,7 @@ public class SystemSchema extends AbstractSchema
 
       if (responseHolder.getStatus().getCode() != HttpServletResponse.SC_OK) {
         throw new RE(
-            "Failed to talk to leader node at [%s]. Error code[%d], description[%s].",
+            "Failed to talk to leader node at [%s]. Error code [%d], description [%s].",
             query,
             responseHolder.getStatus().getCode(),
             responseHolder.getStatus().getReasonPhrase()


### PR DESCRIPTION
The [new IT PR](https://github.com/apache/druid/pull/12368/files#) has struggled to get a clean build due to the complexity and flakiness of the Druid build system. It is ironic that the attempt to fix the ITs has been stymied by the fragility of the existing ITs. Out of desperation, the big PR is being broken up into smaller chunks. This one provides the myriad cleanup tasks done in that PR.
The cleanup is of two kinds:

* Just general cleanup: fixing misspellings, etc.
* Allowing the use of some of Druid's "JSON config" objects in tests.

The general cleanup is self-explanatory. The JSON configs are odd beasts: there is no way to create one via code; only using the JSON config mechanism that populates the instance dynamically from a provided set of properties. While that is great in production, it does make it very hard to create the config in tests. Since we do, in fact, want to test, this PR alters a few of these configs to provide a constructor or factory method.

Further, the config key used for properties tends to reside in the consumer of those properties. If we do want to create one in tests, using the property mechanism, we have to copy/paste that key. To make life a bit easier here, this PR moves the key to a constant inside the config object itself (but only for those configs used by the IT PR.)

The ITs want to create a Guice instance for "client" use, not for use in a Druid server. The existing ITs jump though some amazing hoops to do this. The new ones take a somewhat different path. To make this possible, a few of the formerly-private bits related to Guice initialization are now exposed for use by tests.

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
