### PR TITLE
Revert "SqlSegmentsMetadataQuery: Fix OVERLAPS for wide target segments"

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -233,25 +233,12 @@ public class SqlSegmentsMetadataQuery
             )
         );
 
-        if (i != intervals.size() - 1) {
+        if (i == intervals.size() - 1) {
+          sb.append(")");
+        } else {
           sb.append(" OR ");
         }
       }
-
-      if (matchMode == IntervalMode.OVERLAPS) {
-        // Segments with both endpoints outside 0000/10000 may overlap the search intervals but not match the
-        // generated SQL conditions. We need to add one more OR condition to catch all of these.
-        sb.append(
-            StringUtils.format(
-                " OR start < %2$s OR %1$send%1$s >= %3$s",
-                connector.getQuoteString(),
-                ":minmatch",
-                ":maxmatch"
-            )
-        );
-      }
-
-      sb.append(")");
     }
 
     final Query<Map<String, Object>> sql = handle
@@ -260,17 +247,12 @@ public class SqlSegmentsMetadataQuery
         .bind("used", used)
         .bind("dataSource", dataSource);
 
-    if (compareAsString && !intervals.isEmpty()) {
+    if (compareAsString) {
       final Iterator<Interval> iterator = intervals.iterator();
       for (int i = 0; iterator.hasNext(); i++) {
-        final Interval interval = iterator.next();
-        sql.bind(StringUtils.format("start%d", i), interval.getStart().toString());
-        sql.bind(StringUtils.format("end%d", i), interval.getEnd().toString());
-      }
-
-      if (matchMode == IntervalMode.OVERLAPS) {
-        sql.bind("minmatch", "0000-"); // '-' is lexicographically lower than '0' so this catches negative-year starts
-        sql.bind("maxmatch", "10000-"); // Catches end points at 10000 or after
+        Interval interval = iterator.next();
+        sql.bind(StringUtils.format("start%d", i), interval.getStart().toString())
+           .bind(StringUtils.format("end%d", i), interval.getEnd().toString());
       }
     }
 
@@ -287,8 +269,7 @@ public class SqlSegmentsMetadataQuery
               } else {
                 // Must re-check that the interval matches, even if comparing as string, because the *segment interval*
                 // might not be string-comparable. (Consider a query interval like "2000-01-01/3000-01-01" and a
-                // segment interval like "20010/20011". Consider also a segment interval with endpoints prior to
-                // year 0000 or after year 9999.)
+                // segment interval like "20010/20011".)
                 for (Interval interval : intervals) {
                   if (matchMode.apply(interval, dataSegment.getInterval())) {
                     return true;

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -254,42 +254,6 @@ public class IndexerSQLMetadataStorageCoordinatorTest
       100
   );
 
-  private final DataSegment eternityRangeSegment1 = new DataSegment(
-      "eternity1",
-      Intervals.ETERNITY,
-      "zversion",
-      ImmutableMap.of(),
-      ImmutableList.of("dim1"),
-      ImmutableList.of("m1"),
-      new NumberedShardSpec(0, 1),
-      9,
-      100
-  );
-
-  private final DataSegment halfEternityRangeSegment1 = new DataSegment(
-      "halfEternity",
-      new Interval(DateTimes.MIN, DateTimes.of("1970")),
-      "zversion",
-      ImmutableMap.of(),
-      ImmutableList.of("dim1"),
-      ImmutableList.of("m1"),
-      new NumberedShardSpec(0, 1),
-      9,
-      100
-  );
-
-  private final DataSegment halfEternityRangeSegment2 = new DataSegment(
-      "halfEternity",
-      new Interval(DateTimes.of("1970"), DateTimes.MAX),
-      "zversion",
-      ImmutableMap.of(),
-      ImmutableList.of("dim1"),
-      ImmutableList.of("m1"),
-      new NumberedShardSpec(0, 1),
-      9,
-      100
-  );
-
   private final Set<DataSegment> SEGMENTS = ImmutableSet.of(defaultSegment, defaultSegment2);
   private final AtomicLong metadataUpdateCounter = new AtomicLong();
   private final AtomicLong segmentTableDropUpdateCounter = new AtomicLong();
@@ -1164,74 +1128,6 @@ public class IndexerSQLMetadataStorageCoordinatorTest
             coordinator.retrieveUnusedSegmentsForInterval(
                 defaultSegment.getDataSource(),
                 defaultSegment.getInterval().withEnd(defaultSegment.getInterval().getEnd().plusYears(1))
-            )
-        )
-    );
-  }
-
-  @Test
-  public void testUsedEternitySegmentEternityFilter() throws IOException
-  {
-    coordinator.announceHistoricalSegments(ImmutableSet.of(eternityRangeSegment1));
-
-    Assert.assertEquals(
-        ImmutableSet.of(eternityRangeSegment1),
-        ImmutableSet.copyOf(
-            coordinator.retrieveUsedSegmentsForIntervals(
-                eternityRangeSegment1.getDataSource(),
-                Intervals.ONLY_ETERNITY,
-                Segments.ONLY_VISIBLE
-            )
-        )
-    );
-  }
-
-  @Test
-  public void testUsedEternitySegment2000Filter() throws IOException
-  {
-    coordinator.announceHistoricalSegments(ImmutableSet.of(eternityRangeSegment1));
-
-    Assert.assertEquals(
-        ImmutableSet.of(eternityRangeSegment1),
-        ImmutableSet.copyOf(
-            coordinator.retrieveUsedSegmentsForIntervals(
-                eternityRangeSegment1.getDataSource(),
-                Collections.singletonList(Intervals.of("2000/2030")),
-                Segments.ONLY_VISIBLE
-            )
-        )
-    );
-  }
-
-  @Test
-  public void testUsedHalfEternitySegmentEternityFilter() throws IOException
-  {
-    coordinator.announceHistoricalSegments(ImmutableSet.of(halfEternityRangeSegment1, halfEternityRangeSegment2));
-
-    Assert.assertEquals(
-        ImmutableSet.of(halfEternityRangeSegment1, halfEternityRangeSegment2),
-        ImmutableSet.copyOf(
-            coordinator.retrieveUsedSegmentsForIntervals(
-                halfEternityRangeSegment1.getDataSource(),
-                Intervals.ONLY_ETERNITY,
-                Segments.ONLY_VISIBLE
-            )
-        )
-    );
-  }
-
-  @Test
-  public void testUsedHalfEternitySegment2000Filter() throws IOException
-  {
-    coordinator.announceHistoricalSegments(ImmutableSet.of(halfEternityRangeSegment1, halfEternityRangeSegment2));
-
-    Assert.assertEquals(
-        ImmutableSet.of(halfEternityRangeSegment2),
-        ImmutableSet.copyOf(
-            coordinator.retrieveUsedSegmentsForIntervals(
-                halfEternityRangeSegment1.getDataSource(),
-                Collections.singletonList(Intervals.of("2000/2030")),
-                Segments.ONLY_VISIBLE
             )
         )
     );


### PR DESCRIPTION
This reverts commit 8fbf92e047f792ff1c69bf67d14784ac55eee88f (PR #12600).

While that patch fixed a correctness bug, it also introduced a performance regression: the number of segments returned from the metadata store to Druid servers increases substantially. We observed significant slowdowns on Overlord APIs as a result of this.

The main problem is that 4-digit, 5-digit, 6-digit, etc, years are all jumbled up when sorted lexicographically. We can't write a range filter (such that metadata store indexes can be used) without also potentially returning a bunch of extra records that need to be filtered out on the Overlord.

I can't see a good way to solve the original correctness bug while maintaining performance, other than introducing bigint-typed versions of `start` and `end`. So I think we'll need to do that, unless someone else has a better idea.