### PR TITLE
Add some debug tips for debugging peons

### DIFF
--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -69,13 +69,20 @@ Before running or debugging the apps, you should do a `mvn clean install -Pdist 
 
 You may also add `-Ddruid.console.skip=true` to the command if you're focusing on backend servers instead of frontend project. This option saves great building time.
 
-## Debugging Running Druid from Intellij
+## Debug a running Druid cluster using Intellij
 Intellij IDEA debugger can attach to a local or remote Java process (Druid process). 
-First, you must enable debugging in the application.
-For Druid services (such as Overlord, Coordinator, etc), include the following as JVM config `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<PORT>` where `<PORT>` is any available port.
-For the peons (workers on Middle Manager), include the following `agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0` in runtime properties `druid.indexer.runner.javaOpts` of the Middle Manager. Note that `address=0` will tell the debugger to assign ephemeral port.
-Once the above is done, you can attach the debugger to the running process by creating a Remote configuration in the Run/Debug Configurations dialog of Intellij (see: https://www.jetbrains.com/help/idea/tutorial-remote-debug.html#debugger_rc). Note that you must set the port value to that of the JVM argument above.
-For the peons (workers on Middle Manager), you can find the assigned ephemeral port by checking the first line of the task log.
+Follow these steps to debug a Druid process using the IntelliJ IDEA debugger.
+1. Enable debugging in the Druid process
+    1. For Druid services (such as Overlord, Coordinator, etc), include the following as JVM config `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<PORT>` where `<PORT>` is any available port. Note that different port values should be chosen for each Druid service.
+    2. For the peons (workers on Middlemanager), include the following `agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0` in runtime properties `druid.indexer.runner.javaOpts` of the Middle Manager. Note that `address=0` will tell the debugger to assign ephemeral port.
+2. Find the port assigned to the Druid process.
+    1. For Druid services, the port value is what you chose in the JVM argument of step 1i above. The port value can also be found in the first line of each Druid service log.
+    2. For the peons (workers on Middlemanager), you can find the assigned ephemeral port by checking the first line of the task log.
+3. Attach Intellij IDEA debugger to the running process
+    1. Create a Remote configuration in the Run/Debug Configurations dialog of Intellij (see: https://www.jetbrains.com/help/idea/tutorial-remote-debug.html#debugger_rc)
+    2. Set the port value using the value from step 2 for the Druid service and/or peon (worker on Middlemanager) that you want to debug
+    3. Start (debug) the above remote configuration
+    4. Repeat step 3i to 3iii for each Druid service and/or peon (worker on Middlemanager) that you want to debug
 
 ## XML App Def
 You can configure application definitions in XML for import into IntelliJ. Below are a few examples. These should be placed in an XML file in `.idea/runConfigurations` in the Druid source code.

--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -69,6 +69,14 @@ Before running or debugging the apps, you should do a `mvn clean install -Pdist 
 
 You may also add `-Ddruid.console.skip=true` to the command if you're focusing on backend servers instead of frontend project. This option saves great building time.
 
+## Debugging Running Druid from Intellij
+Intellij IDEA debugger can attach to a local or remote Java process (Druid process). 
+First, you must enable debugging in the application.
+For Druid services (such as Overlord, Coordinator, etc), include the following as JVM config `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<PORT>` where `<PORT>` is any available port.
+For the peons (workers on Middle Manager), include the following `agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0` in runtime properties `druid.indexer.runner.javaOpts` of the Middle Manager. Note that `address=0` will tell the debugger to assign ephemeral port.
+Once the above is done, you can attach the debugger to the running process by creating a Remote configuration in the Run/Debug Configurations dialog of Intellij (see: https://www.jetbrains.com/help/idea/tutorial-remote-debug.html#debugger_rc). Note that you must set the port value to that of the JVM argument above.
+For the peons (workers on Middle Manager), you can find the assigned ephemeral port by checking the first line of the task log.
+
 ## XML App Def
 You can configure application definitions in XML for import into IntelliJ. Below are a few examples. These should be placed in an XML file in `.idea/runConfigurations` in the Druid source code.
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -212,6 +212,7 @@ For your convenience, Druid processes running inside Docker have been debugging 
 | Historical | 5007 |
 | Middlemanager | 5008 |
 | Overlord | 5009 |
+| Peons (Workers on Middle Manager) |  Ephemeral port assigned by debugger (check task log for port assigned to each task)
 
 You can use remote debugger(such as via IntelliJ IDEA's Remote Configuration) to debug the corresponding Druid process at above port.
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -212,7 +212,7 @@ For your convenience, Druid processes running inside Docker have been debugging 
 | Historical | 5007 |
 | Middlemanager | 5008 |
 | Overlord | 5009 |
-| Peons (Workers on Middle Manager) |  Ephemeral port assigned by debugger (check task log for port assigned to each task)
+| Peons (Workers on Middlemanager) |  Ephemeral port assigned by debugger (check task log for port assigned to each task) |
 
 You can use remote debugger(such as via IntelliJ IDEA's Remote Configuration) to debug the corresponding Druid process at above port.
 

--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -27,7 +27,7 @@ SERVICE_DRUID_JAVA_OPTS=-server -Xmx64m -Xms64m -XX:+UseG1GC -agentlib:jdwp=tran
 druid_host=druid-middlemanager
 druid_server_http_numThreads=100
 druid_storage_storageDirectory=/shared/storage
-druid_indexer_runner_javaOptsArray=["-server", "agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0", ""-Xmx256m", "-Xms256m", "-XX:NewSize=128m", "-XX:MaxNewSize=128m", "-XX:+UseG1GC", "-Duser.timezone=UTC", "-Dfile.encoding=UTF-8", "-Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml"]
+druid_indexer_runner_javaOptsArray=["-server", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0", "-Xmx256m", "-Xms256m", "-XX:NewSize=128m", "-XX:MaxNewSize=128m", "-XX:+UseG1GC", "-Duser.timezone=UTC", "-Dfile.encoding=UTF-8", "-Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml"]
 
 druid_indexer_fork_property_druid_processing_buffer_sizeBytes=25000000
 druid_indexer_fork_property_druid_processing_numThreads=1

--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -27,7 +27,7 @@ SERVICE_DRUID_JAVA_OPTS=-server -Xmx64m -Xms64m -XX:+UseG1GC -agentlib:jdwp=tran
 druid_host=druid-middlemanager
 druid_server_http_numThreads=100
 druid_storage_storageDirectory=/shared/storage
-druid_indexer_runner_javaOptsArray=["-server", "-Xmx256m", "-Xms256m", "-XX:NewSize=128m", "-XX:MaxNewSize=128m", "-XX:+UseG1GC", "-Duser.timezone=UTC", "-Dfile.encoding=UTF-8", "-Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml"]
+druid_indexer_runner_javaOptsArray=["-server", "agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0", ""-Xmx256m", "-Xms256m", "-XX:NewSize=128m", "-XX:MaxNewSize=128m", "-XX:+UseG1GC", "-Duser.timezone=UTC", "-Dfile.encoding=UTF-8", "-Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml"]
 
 druid_indexer_fork_property_druid_processing_buffer_sizeBytes=25000000
 druid_indexer_fork_property_druid_processing_numThreads=1


### PR DESCRIPTION
Add some debug tips for debugging peons

### Description

- Add some debug tips for debugging peons
- Enable (open debug ports) for peons on Integration tests Druid cluster by default

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
