### PR TITLE
Add support for optional region, endpoint url, and endpoint signing region for s3 for ingestion

### DIFF
--- a/docs/ingestion/native-batch-input-source.md
+++ b/docs/ingestion/native-batch-input-source.md
@@ -158,6 +158,10 @@ Properties Object:
 |secretAccessKey|The [Password Provider](../operations/password-provider.md) or plain text string of this S3 InputSource's secret key|None|yes if accessKeyId is given|
 |assumeRoleArn|AWS ARN of the role to assume [see](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html). **assumeRoleArn** can be used either with the ingestion spec AWS credentials or with the default S3 credentials|None|no|
 |assumeRoleExternalId|A unique identifier that might be required when you assume a role in another account [see](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)|None|no|
+|region|The AWS Region|None|no|
+|endpointUrl|The service endpoint|None|no|
+|endpointSigningRegion|The region to use for SigV4 signing of requests|None|no|
+
 
 > **Note:** If `accessKeyId` and `secretAccessKey` are not given, the default [S3 credentials provider chain](../development/extensions-core/s3.md#s3-authentication-methods) is used.
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceConfig.java
@@ -42,13 +42,22 @@ public class S3InputSourceConfig
   private PasswordProvider accessKeyId;
   @JsonProperty
   private PasswordProvider secretAccessKey;
+  @JsonProperty
+  private String region;
+  @JsonProperty
+  private String endpointUrl;
+  @JsonProperty
+  private String endpointSigningRegion;
 
   @JsonCreator
   public S3InputSourceConfig(
       @JsonProperty("accessKeyId") @Nullable PasswordProvider accessKeyId,
       @JsonProperty("secretAccessKey") @Nullable PasswordProvider secretAccessKey,
       @JsonProperty("assumeRoleArn") @Nullable String assumeRoleArn,
-      @JsonProperty("assumeRoleExternalId") @Nullable String assumeRoleExternalId
+      @JsonProperty("assumeRoleExternalId") @Nullable String assumeRoleExternalId,
+      @JsonProperty("region") @Nullable String region,
+      @JsonProperty("endpointUrl") @Nullable String endpointUrl,
+      @JsonProperty("endpointSigningRegion") @Nullable String endpointSigningRegion
   )
   {
     this.assumeRoleArn = assumeRoleArn;
@@ -57,6 +66,9 @@ public class S3InputSourceConfig
       this.accessKeyId = Preconditions.checkNotNull(accessKeyId, "accessKeyId cannot be null if secretAccessKey is given");
       this.secretAccessKey = Preconditions.checkNotNull(secretAccessKey, "secretAccessKey cannot be null if accessKeyId is given");
     }
+    this.region = region;
+    this.endpointUrl = endpointUrl;
+    this.endpointSigningRegion = endpointSigningRegion;
   }
 
   @Nullable
@@ -83,6 +95,24 @@ public class S3InputSourceConfig
     return secretAccessKey;
   }
 
+  @Nullable
+  public String getRegion()
+  {
+    return region;
+  }
+
+  @Nullable
+  public String getEndpointUrl()
+  {
+    return endpointUrl;
+  }
+
+  @Nullable
+  public String getEndpointSigningRegion()
+  {
+    return endpointSigningRegion;
+  }
+
   @JsonIgnore
   public boolean isCredentialsConfigured()
   {
@@ -94,10 +124,13 @@ public class S3InputSourceConfig
   public String toString()
   {
     return "S3InputSourceConfig{" +
-           "accessKeyId=" + accessKeyId +
+           "assumeRoleArn='" + assumeRoleArn + '\'' +
+           ", assumeRoleExternalId='" + assumeRoleExternalId + '\'' +
+           ", accessKeyId=" + accessKeyId +
            ", secretAccessKey=" + secretAccessKey +
-           ", assumeRoleArn=" + assumeRoleArn +
-           ", assumeRoleExternalId=" + assumeRoleExternalId +
+           ", region='" + region + '\'' +
+           ", endpointUrl='" + endpointUrl + '\'' +
+           ", endpointSigningRegion='" + endpointSigningRegion + '\'' +
            '}';
   }
 
@@ -111,15 +144,26 @@ public class S3InputSourceConfig
       return false;
     }
     S3InputSourceConfig that = (S3InputSourceConfig) o;
-    return Objects.equals(accessKeyId, that.accessKeyId) &&
+    return Objects.equals(assumeRoleArn, that.assumeRoleArn) &&
+           Objects.equals(assumeRoleExternalId, that.assumeRoleExternalId) &&
+           Objects.equals(accessKeyId, that.accessKeyId) &&
            Objects.equals(secretAccessKey, that.secretAccessKey) &&
-           Objects.equals(assumeRoleArn, that.assumeRoleArn) &&
-           Objects.equals(assumeRoleExternalId, that.assumeRoleExternalId);
+           Objects.equals(region, that.region) &&
+           Objects.equals(endpointUrl, that.endpointUrl) &&
+           Objects.equals(endpointSigningRegion, that.endpointSigningRegion);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(accessKeyId, secretAccessKey, assumeRoleArn, assumeRoleExternalId);
+    return Objects.hash(
+        assumeRoleArn,
+        assumeRoleExternalId,
+        accessKeyId,
+        secretAccessKey,
+        region,
+        endpointUrl,
+        endpointSigningRegion
+    );
   }
 }

--- a/website/.spelling
+++ b/website/.spelling
@@ -175,6 +175,7 @@ Redis
 S3
 SDK
 SIGAR
+SigV4
 SPNEGO
 SqlInputSource
 SQLServer
@@ -266,6 +267,8 @@ druid–kubernetes-extensions
 e.g.
 encodings
 endian
+endpointSigningRegion
+endpointUrl
 enum
 expr
 failover


### PR DESCRIPTION
Add support for optional region, endpoint url, and endpoint signing region for s3 for ingestion 

### Description

Cloud InputSource (such as S3, etc.) should be able to support taking in configs optionally in order to be able to read from multiple buckets/location. This is in order to use different region and/or endpoint url than the default (i.e. the one provided in the common runtime property) and also to be able to use different region and/or endpoint url for each ingestion.

Motivation:
This address the proposal https://github.com/apache/druid/issues/9305 and due to popular demand from the community

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
