### PR TITLE
Fix skipTests build flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1936,8 +1936,7 @@
             <activeByDefault>false</activeByDefault>
           </activation>
           <properties>
-            <skipUTs>true</skipUTs> <!-- Skip only UTs -->
-            <skipITs>true</skipITs> <!-- ITs are also behind a profile -->
+            <skipTests>true</skipTests> <!-- skips both UTs and ITs -->
             <jacoco.skip>true</jacoco.skip>
           </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,9 @@
              the "new" integration tests. To skip just the unit tests (but run the
              new integration tests by setting the required profile), use -DskipUTs=true.
              -->
-        <skipUTs>false</skipUTs>
-        <skipITs>false</skipITs>
+        <skipTests>false</skipTests>
+        <skipUTs>${skipTests}</skipUTs>
+        <skipITs>${skipTests}</skipITs>
     </properties>
 
     <modules>

--- a/web-console/pom.xml
+++ b/web-console/pom.xml
@@ -45,6 +45,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <configuration>
           <skip>${druid.console.skip}</skip>
+          <skipTests>${skipUTs}</skipTests>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Fixes the `-DskipTests` flag to skip UTs and ITs when given via command line
For console, added the change since I think the tests (test-console goal) are launched by the frontend plugin which doesn't understand `skipUTs` flag. 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
