### PR TITLE
fix bug when rewriting sql virtual column registry

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/VirtualColumnRegistry.java
@@ -29,9 +29,9 @@ import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -200,8 +200,8 @@ public class VirtualColumnRegistry
 
   public void visitAllSubExpressions(DruidExpression.DruidExpressionShuttle shuttle)
   {
-    final Queue<Map.Entry<String, ExpressionAndTypeHint>> toVisit = new LinkedList<>(virtualColumnsByName.entrySet());
-    while(!toVisit.isEmpty()) {
+    final Queue<Map.Entry<String, ExpressionAndTypeHint>> toVisit = new ArrayDeque<>(virtualColumnsByName.entrySet());
+    while (!toVisit.isEmpty()) {
       final Map.Entry<String, ExpressionAndTypeHint> entry = toVisit.poll();
       final String key = entry.getKey();
       final ExpressionAndTypeHint wrapped = entry.getValue();


### PR DESCRIPTION
### Description
Fixes a bug in #12241 from a simple mistake I made that results in modifying the Map that is being iterated over ending up in a `ConcurrentModificationException`. The added test fails to plan due to this error prior to the changes in this PR, with one of these in the stack trace:

```
Caused by: java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1469)
	at java.util.HashMap$EntryIterator.next(HashMap.java:1503)
	at java.util.HashMap$EntryIterator.next(HashMap.java:1501)
	at org.apache.druid.sql.calcite.rel.VirtualColumnRegistry.visitAllSubExpressions(VirtualColumnRegistry.java:212)
	at org.apache.druid.sql.calcite.rel.DruidQuery.getVirtualColumns(DruidQuery.java:643)
```

I tried to fix this by using `replaceAll`, but still saw the exception, so ended up just copying everything to a new collection and going through them that way.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
