### PR TITLE
fix DruidSchema issue where datasources with no segments can become stuck in tables list indefinitely

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITBroadcastJoinQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITBroadcastJoinQueryTest.java
@@ -39,8 +39,6 @@ import org.apache.druid.tests.indexer.AbstractIndexerTest;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
-import java.util.concurrent.Callable;
-
 @Test(groups = TestNGGroup.QUERY)
 @Guice(moduleFactory = DruidTestModuleFactory.class)
 public class ITBroadcastJoinQueryTest extends AbstractIndexerTest
@@ -133,18 +131,6 @@ public class ITBroadcastJoinQueryTest extends AbstractIndexerTest
 
     finally {
       closer.close();
-
-      coordinator.unloadSegmentsForDataSource(BROADCAST_JOIN_DATASOURCE);
-      ITRetryUtil.retryUntilFalse(
-          new Callable<Boolean>()
-          {
-            @Override
-            public Boolean call()
-            {
-              return coordinator.areSegmentsLoaded(BROADCAST_JOIN_DATASOURCE);
-            }
-          }, "Segment Unloading"
-      );
 
       // query metadata until druid schema is refreshed and datasource is no longer available
       ITRetryUtil.retryUntilTrue(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -77,6 +77,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1197,6 +1198,17 @@ public class DruidSchemaTest extends DruidSchemaTestCommon
         RowSignature.builder().add("a", ColumnType.STRING).add("count", ColumnType.LONG).build(),
         signature
     );
+  }
+
+  @Test
+  public void testStaleDatasourceRefresh() throws IOException
+  {
+    Set<SegmentId> segments = new HashSet<>();
+    Set<String> datasources = new HashSet<>();
+    datasources.add("wat");
+    Assert.assertNull(schema.getTable("wat"));
+    schema.refresh(segments, datasources);
+    Assert.assertNull(schema.getTable("wat"));
   }
 
   private static DataSegment newSegment(String datasource, int partitionId)


### PR DESCRIPTION
### Description
This PR fixes an issue where datasources with no segments can become effectively stuck `DruidSchema` in a stale state if they are in the 'needs refresh' list after all segments have been removed. This meant that the datasource would be more or less permanently in `INFORMATION_SCHEMA.TABLES` until new segment activity takes place for such a datasource, which might be never if it was completely dropped, meaning the table would be present until the broker was restarted.

This is the source of the `ITBroadcastJoinQueryTest` flakiness, since depending on if the table was in the refresh list or not seemed to be the determining factor on whether or not the test flaked out or not. 

In the failure case, the broker would have a log message like this:
```
2022-06-30T23:40:59,164 INFO [DruidSchema-Cache-0] org.apache.druid.sql.calcite.schema.DruidSchema - global dataSource [broadcast_join_wikipedia_test] has new signature: {}
```

which was the clue I was looking for that trouble was afoot. There is probably an alternative way to fix this by removing stuff from the refresh list, but this way seemed to work well enough and ensures that we shouldn't ever run into stale tables by giving us another out to remove them.

Since making this change I have been unable to trigger the failure locally, so will run through travis a few times to ensure it is indeed fixed. None of the changes made to `ITBroadcastJoinQueryTest` were in fact necessary, I just modified it to more aggressively drop the segments so that the test would run a little quicker rather than waiting on the load rules to drop them.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.
